### PR TITLE
Test: verify site workflow does not trigger for test-only changes

### DIFF
--- a/tests/test_kitaru.py
+++ b/tests/test_kitaru.py
@@ -5,3 +5,12 @@ import kitaru
 
 def test_package_imports() -> None:
     assert kitaru.__name__ == "kitaru"
+
+
+def test_package_has_version() -> None:
+    """Verify the package exposes a version via importlib.metadata."""
+    from importlib.metadata import version
+
+    v = version("kitaru")
+    assert v
+    assert "." in v


### PR DESCRIPTION
Throwaway PR to verify `site.yml` path filters work correctly.

This PR only changes `tests/test_kitaru.py` — the Site workflow should **not** run.
Will be closed after verification.