### PR TITLE
Make landing site mobile-friendly across all breakpoints

### DIFF
--- a/site/src/components/Architecture.astro
+++ b/site/src/components/Architecture.astro
@@ -177,6 +177,15 @@
 
     .arch-layer-note {
       text-align: left;
+      white-space: normal;
     }
+
+    .arch-layer-label {
+      white-space: normal;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .arch-layer { padding: 12px 14px; }
   }
 </style>

--- a/site/src/components/CodingAgent.astro
+++ b/site/src/components/CodingAgent.astro
@@ -418,6 +418,21 @@
       height: 24px;
     }
   }
+
+  @media (max-width: 480px) {
+    .timeline-wrapper { padding-left: 24px; }
+    .tl-dot { left: -20px; width: 20px; height: 20px; font-size: 0.6rem; }
+    .tl-fn { font-size: 0.75rem; }
+    .tl-badge { font-size: 0.6rem; padding: 2px 6px; }
+    .tl-meta { font-size: 0.68rem; }
+    .tl-dispatch { padding: 10px; }
+    .tl-dispatch-label { font-size: 0.62rem; }
+    .tl-dispatch-pills { gap: 4px; }
+    .tl-dispatch-pill { font-size: 0.62rem; padding: 2px 6px; }
+    .replay-callout { padding: 12px 14px; }
+    .replay-icon { font-size: 1rem; }
+    .replay-text { font-size: 0.75rem; }
+  }
 </style>
 
 <script>

--- a/site/src/components/Features.astro
+++ b/site/src/components/Features.astro
@@ -546,6 +546,13 @@
       height: 160px;
     }
   }
+
+  @media (max-width: 480px) {
+    .feature-visual { height: 140px; }
+    .feature-card h3 { font-size: 1rem; }
+    .feature-card p { font-size: 0.82rem; }
+    .feature-text { padding: 16px; }
+  }
 </style>
 
 <script>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -298,6 +298,32 @@ coding_agent.<span class="fn">deploy</span>(<span class="str">"Fix login bug"</s
       max-width: 100%;
     }
   }
+
+  @media (max-width: 900px) {
+    .hero-left, .hero-right {
+      min-width: 0;
+      overflow: hidden;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .hero-section {
+      padding-top: 72px !important;
+      padding-bottom: 40px !important;
+    }
+
+    .hero-grid { gap: 28px; }
+
+    .hero-badge { font-size: 0.7rem; margin-bottom: 20px; }
+
+    .code-pre {
+      font-size: 0.7rem;
+      padding: 16px 14px;
+      line-height: 1.6;
+    }
+
+    .code-tab { font-size: 0.62rem; padding: 3px 10px; }
+  }
 </style>
 
 <script>

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -69,6 +69,12 @@
     .nav-links { gap: 16px; }
     .nav-links a:not(.nav-cta) { display: none; }
   }
+
+  @media (max-width: 480px) {
+    .nav { padding: 0 16px; }
+    .nav-brand svg { height: 18px; }
+    .nav-cta { font-size: 12px; padding: 7px 14px; }
+  }
 </style>
 
 <script>

--- a/site/src/components/ZeroToProduction.astro
+++ b/site/src/components/ZeroToProduction.astro
@@ -181,6 +181,14 @@
   @media (max-width: 768px) {
     .deploy-grid {
       grid-template-columns: 1fr;
+      gap: 24px;
     }
+  }
+
+  @media (max-width: 480px) {
+    .terminal-body { padding: 14px 12px; font-size: 0.72rem; }
+    .you-get ul { gap: 14px; }
+    .you-get li strong { font-size: 0.82rem; }
+    .you-get li span { font-size: 0.78rem; }
   }
 </style>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -118,6 +118,7 @@ body::before {
 .section-inner {
   max-width: 1200px;
   margin: 0 auto;
+  overflow: hidden;
 }
 
 .section-eyebrow {
@@ -180,4 +181,19 @@ body::before {
    ═══════════════════════════════════════════════════ */
 @media (max-width: 768px) {
   .cta-input-row { flex-direction: column; }
+}
+
+@media (max-width: 600px) {
+  /* Tighten section padding on phones — inline styles use 80px/100px */
+  section {
+    padding-top: 48px !important;
+    padding-bottom: 48px !important;
+    padding-left: 16px !important;
+    padding-right: 16px !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .section-title { font-size: clamp(24px, 6vw, 32px); }
+  .section-desc { font-size: 15px; }
 }


### PR DESCRIPTION
Add responsive CSS for 480px, 600px, 768px, and 900px breakpoints:
- Global: overflow hidden on section-inner, tighter section padding on phones
- Nav: smaller logo and CTA button on small screens
- Hero: single-column grid below 900px, prevent code block overflow
- Architecture: word-wrap labels at 700px, tighter padding at 480px
- Features: smaller visual height and text at 480px
- CodingAgent: smaller timeline dots and fonts at 480px
- ZeroToProduction: single-column grid and smaller terminal text