### PR TITLE
Add Docs link to navigation bar

### DIFF
--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -18,6 +18,7 @@
     </svg>
   </a>
   <div class="nav-links">
+    <a href="/docs">Docs</a>
     <a href="#features">Features</a>
     <a href="#how">How it works</a>
     <a href="#cta" class="nav-cta">Get early access</a>


### PR DESCRIPTION
Links to kitaru.ai/docs in the top nav, before Features and How it works.