### PR TITLE
Add Monty sandbox support and runnable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Kitaru is under active development. The core SDK primitives are implemented and 
 - **Execution management** — `KitaruClient` for inspecting executions (`get`, `list`, `latest`, `logs`), replaying from checkpoints/waits (`replay`), same-execution recovery (`retry`), cancellation (`cancel`), and artifact browsing/loading
 - **Secrets** — `kitaru secrets set/show/list/delete` for managing credentials (private by default, create-or-update semantics)
 - **LLM calls** — `kitaru.llm()` with LiteLLM backend, automatic prompt/response capture, usage/cost/latency metadata, and local model aliases (`kitaru model register/list`)
+- **Sandboxed Python execution** — `kitaru.sandbox()` opens Monty-backed stateful Python sessions, with pause/resume support around `kitaru.wait(...)`
 - **Error handling** — Typed exception hierarchy (`KitaruContextError`, `KitaruExecutionError`, `KitaruUserCodeError`, etc.) with failure journaling via `execution.failure` and per-checkpoint `checkpoint.attempts`
 - **Execution CLI** — `kitaru run`, `kitaru executions get/list/logs/input/replay/retry/resume/cancel` for full lifecycle management from the terminal
 - **Durable wait/resume** — `kitaru.wait(...)` pauses a flow until external input arrives via `client.executions.input(...)` / `client.executions.resume(...)`
@@ -66,6 +67,7 @@ The `examples/` directory contains runnable workflows showcasing each feature. I
 ```bash
 uv sync --extra local              # Core examples
 uv sync --extra local --extra mcp  # MCP server example
+uv sync --extra sandbox            # Monty sandbox support
 ```
 
 | Example | File | What it demonstrates |
@@ -76,6 +78,7 @@ uv sync --extra local --extra mcp  # MCP server example
 | Configuration | `examples/flow_with_configuration.py` | `kitaru.configure()` with precedence resolution |
 | Execution management | `examples/client_execution_management.py` | `KitaruClient` for inspecting and managing executions |
 | LLM calls | `examples/flow_with_llm.py` | `kitaru.llm()` with model aliases and metadata capture |
+| Sandboxes | `examples/monty_sandbox.py` | execution-scoped `kitaru.sandbox()` state surviving `kitaru.wait()` / resume |
 | Wait/resume | `examples/wait_and_resume.py` | `kitaru.wait()` and external input via client |
 | Replay/overrides | `examples/replay_with_overrides.py` | replay from checkpoint boundaries with `checkpoint.*` overrides |
 | PydanticAI adapter | `examples/pydantic_ai_adapter.py` | `wrap(agent)` with child-event lineage, run summaries, and capture policy |
@@ -125,6 +128,11 @@ kitaru log-store show         Show effective global runtime log backend
 kitaru log-store set <backend> --endpoint <url> [--api-key <secret>]
 kitaru log-store reset        Clear global runtime log backend override
 
+kitaru sandbox set monty [--max-duration-secs <seconds>] [--max-memory-mb <mb>]
+kitaru sandbox show
+kitaru sandbox test
+kitaru sandbox reset
+
 kitaru secrets set <name> --KEY=value [--KEY=value ...]
 kitaru secrets show <name-or-id> [--show-values]
 kitaru secrets list
@@ -146,6 +154,7 @@ Requires Python 3.11+, [uv](https://docs.astral.sh/uv/), and [just](https://gith
 uv sync                            # Install dependencies
 uv sync --extra local              # Include local ZenML runtime components
 uv sync --extra mcp                # Include MCP server dependencies
+uv sync --extra sandbox            # Include Monty sandbox support
 uv sync --extra local --extra mcp  # Local runtime + MCP tools
 just --list                        # Show all available recipes
 just check             # Run all checks (format, lint, typecheck, typos, yaml)

--- a/docs/content/docs/getting-started/configuration.mdx
+++ b/docs/content/docs/getting-started/configuration.mdx
@@ -31,6 +31,7 @@ import kitaru
 
 kitaru.configure(
     stack="local",
+    sandbox="monty",
     cache=False,
     retries=1,
     image=kitaru.ImageSettings(
@@ -62,9 +63,9 @@ In this example, resolved retries are `3`.
 ## Precedence (highest to lowest)
 
 1. Invocation-time overrides (`my_flow.run(..., stack="prod")`)
-2. Flow decorator defaults (`@flow(stack="prod")`)
+2. Flow decorator defaults (`@flow(stack="prod", sandbox="monty")`)
 3. `kitaru.configure(...)`
-4. Environment variables (`KITARU_STACK`, `KITARU_SERVER_URL`, etc.)
+4. Environment variables (`KITARU_STACK`, `KITARU_SANDBOX`, `KITARU_SERVER_URL`, etc.)
 5. Project config (`pyproject.toml` under `[tool.kitaru]`)
 6. Global user config (active stack and connection defaults)
 7. Built-in defaults (`local` stack, `cache=True`, `retries=0`)
@@ -77,6 +78,7 @@ Execution settings:
 - `KITARU_CACHE`
 - `KITARU_RETRIES`
 - `KITARU_IMAGE` (JSON object or plain image string)
+- `KITARU_SANDBOX` (`monty` or a JSON object)
 
 Connection settings:
 
@@ -97,7 +99,43 @@ base_image = "python:3.12-slim"
 
 [tool.kitaru.image.environment]
 OPENAI_API_KEY = "{{ OPENAI_KEY }}"
+
+[tool.kitaru.sandbox]
+provider = "monty"
+
+[tool.kitaru.sandbox.monty]
+max_duration_secs = 1.0
+max_memory_mb = 64
+type_check = true
 ```
+
+## Sandbox configuration
+
+Monty-backed sandbox sessions are configured through the same precedence chain as
+stack, image, cache, and retries. You can set them in Python:
+
+```python
+import kitaru
+
+kitaru.configure(
+    sandbox={
+        "provider": "monty",
+        "monty": {"max_memory_mb": 128, "max_duration_secs": 2.0},
+    }
+)
+```
+
+Or through the CLI:
+
+```bash
+kitaru sandbox set monty --max-duration-secs 2 --max-memory-mb 128
+kitaru sandbox show
+```
+
+Kitaru resolves the sandbox config at flow submission time and propagates the
+resolved value into remote execution environments. That way a replayed or remote
+run uses the same sandbox settings even if your local machine config changes
+later.
 
 ## Automatic package injection
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -18,7 +18,7 @@ instead of starting over.
 <Callout type="info">
   Kitaru is in early development. Core SDK primitives are now available
   (`@flow`, `@checkpoint`, `kitaru.log()`, `kitaru.save()`,
-  `kitaru.load()`, `kitaru.configure()`), plus stack selection helpers
+  `kitaru.load()`, `kitaru.configure()`, `kitaru.sandbox()`), plus stack selection helpers
   (`list_stacks`, `current_stack`, `use_stack`), an MCP server (`kitaru-mcp`),
   and a Claude Code authoring skill available via the plugin marketplace.
 </Callout>
@@ -32,7 +32,9 @@ Kitaru **0.1.0** includes:
 - Artifact persistence + cross-execution reads with `kitaru.save()` / `kitaru.load()`
 - CLI connection commands (`login`, `logout`, `status`, `info`)
 - Runtime configuration defaults via `kitaru.configure(...)`
+- Monty-backed sandbox sessions via `kitaru.sandbox()`
 - Stack selection commands (`stack list/current/use`)
+- Global sandbox commands (`sandbox set/show/test/reset`)
 - Global runtime log-store commands (`log-store set/show/reset`)
 - Agent-native integrations: MCP server + Claude Code plugin marketplace skill
 - Project infrastructure (CI, testing, linting, type checking)

--- a/examples/monty_sandbox.py
+++ b/examples/monty_sandbox.py
@@ -1,0 +1,479 @@
+"""Phase 20 example: keep Monty sandbox state alive across wait/resume.
+
+This example demonstrates an execution-scoped ``kitaru.sandbox()`` session
+remembering Python state across a ``kitaru.wait()`` suspension/resume boundary.
+It is intended as a practical local verification workflow before you open a PR
+for the Monty sandbox feature.
+
+Setup:
+
+    uv sync --extra local --extra sandbox
+
+Optional preflight:
+
+    kitaru sandbox set monty
+    kitaru sandbox test
+
+Run in auto mode (single terminal):
+
+    uv run python -m examples.monty_sandbox --mode auto
+
+Run in interactive mode (two terminals):
+
+    uv run python -m examples.monty_sandbox --mode interactive
+
+Auto mode finds the pending wait and resolves it for you via ``KitaruClient``.
+Interactive mode prints the exact ``kitaru executions input`` / ``resume``
+commands you can run in another terminal.
+"""
+
+import argparse
+import threading
+import time
+from contextlib import suppress
+from typing import Any, TypedDict
+
+import kitaru
+from kitaru import checkpoint, flow
+from kitaru.client import Execution, ExecutionStatus, KitaruClient
+
+_WAIT_DISCOVERY_TIMEOUT_SECONDS = 900.0
+
+
+class _StartState(TypedDict):
+    """Shared state between the starter thread and the main thread."""
+
+    handle: Any | None
+    error: Exception | None
+
+
+class _SandboxSnapshot(TypedDict):
+    """User-visible values captured from one sandbox call."""
+
+    counter: int
+    draft: str
+
+
+class _SandboxWorkflowResult(TypedDict):
+    """Stable result payload returned by the sandbox example flow."""
+
+    approved: bool
+    before_wait: _SandboxSnapshot
+    after_wait: _SandboxSnapshot | None
+
+
+def _prime_zenml_runtime() -> None:
+    """Force ZenML's lazy store initialization on the current thread."""
+    from zenml.client import Client
+
+    _ = Client().zen_store
+
+
+@checkpoint
+def finalize_sandbox_result(
+    approved: bool,
+    before_wait: dict[str, Any],
+    after_wait: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Return one explicit terminal artifact for the example result."""
+    return {
+        "approved": approved,
+        "before_wait": before_wait,
+        "after_wait": after_wait,
+    }
+
+
+@flow(
+    sandbox={
+        "provider": "monty",
+        "monty": {"max_duration_secs": 5.0, "max_memory_mb": 128},
+    }
+)
+def monty_sandbox_flow(topic: str) -> dict[str, Any]:
+    """Run stateful sandbox code before and after a durable wait boundary."""
+    session = kitaru.sandbox(name="scratchpad")
+    before_wait = session.run_code(
+        """
+counter = 40
+draft = f"Draft for {topic}"
+{
+    "counter": counter,
+    "draft": draft,
+}
+""".strip(),
+        inputs={"topic": topic},
+        name="before_wait",
+    )
+
+    approved = kitaru.wait(
+        schema=bool,
+        name="approve_sandbox_resume",
+        question=f"Resume the sandbox workflow for {topic}?",
+        metadata={"topic": topic},
+    )
+    if not approved:
+        return finalize_sandbox_result(
+            approved=False,
+            before_wait=before_wait.value,
+            after_wait=None,
+        )
+
+    after_wait = session.run_code(
+        """
+counter += 2
+{
+    "counter": counter,
+    "draft": draft,
+}
+""".strip(),
+        name="after_wait",
+    )
+    return finalize_sandbox_result(
+        approved=True,
+        before_wait=before_wait.value,
+        after_wait=after_wait.value,
+    )
+
+
+def _coerce_snapshot(value: Any, *, label: str) -> _SandboxSnapshot:
+    """Validate one sandbox snapshot and normalize it into a stable shape."""
+    if not isinstance(value, dict):
+        raise RuntimeError(
+            f"Expected {label} to be a dict, got {type(value).__name__}."
+        )
+
+    counter = value.get("counter")
+    draft = value.get("draft")
+    if not isinstance(counter, int):
+        raise RuntimeError(f"Expected {label}['counter'] to be an int.")
+    if not isinstance(draft, str):
+        raise RuntimeError(f"Expected {label}['draft'] to be a str.")
+
+    return {
+        "counter": counter,
+        "draft": draft,
+    }
+
+
+def _coerce_workflow_result(value: Any) -> _SandboxWorkflowResult:
+    """Validate the flow result before printing or asserting on it."""
+    if not isinstance(value, dict):
+        raise RuntimeError(
+            "Expected monty_sandbox_flow() to return a dict result payload."
+        )
+
+    approved = value.get("approved")
+    if not isinstance(approved, bool):
+        raise RuntimeError("Expected result['approved'] to be a bool.")
+
+    before_wait = _coerce_snapshot(value.get("before_wait"), label="before_wait")
+    after_wait_raw = value.get("after_wait")
+    after_wait = None
+    if after_wait_raw is not None:
+        after_wait = _coerce_snapshot(after_wait_raw, label="after_wait")
+
+    return {
+        "approved": approved,
+        "before_wait": before_wait,
+        "after_wait": after_wait,
+    }
+
+
+def _find_pending_wait_for_topic(
+    *,
+    client: KitaruClient,
+    topic: str,
+) -> tuple[str, str] | None:
+    """Return ``(exec_id, wait_id)`` for the matching topic metadata."""
+    executions = client.executions.list(flow="monty_sandbox_flow", limit=20)
+    for execution in executions:
+        detailed_execution = client.executions.get(execution.exec_id)
+        pending_wait = detailed_execution.pending_wait
+        if pending_wait is None:
+            continue
+        if pending_wait.metadata.get("topic") != topic:
+            continue
+        return detailed_execution.exec_id, pending_wait.wait_id
+    return None
+
+
+def _watch_and_print_unblock_commands(
+    *,
+    client: KitaruClient,
+    topic: str,
+    stop_event: threading.Event,
+) -> None:
+    """Watch for a pending wait and print manual unblock commands once."""
+    printed = False
+    while not stop_event.is_set() and not printed:
+        found = _find_pending_wait_for_topic(client=client, topic=topic)
+        if found is not None:
+            exec_id, wait_id = found
+            print("\n⏸️  Flow is waiting and the sandbox session has been snapshotted.")
+            print("Run these commands in another terminal to continue:\n")
+            print(f"kitaru executions input {exec_id} --wait {wait_id} --value true")
+            print(f"kitaru executions resume {exec_id}\n")
+            print("(Use --value false to stop before the post-wait sandbox step.)\n")
+            printed = True
+            break
+        time.sleep(1.0)
+
+
+def _start_flow_in_background(topic: str) -> tuple[threading.Thread, _StartState]:
+    """Start the flow in a background thread to avoid local ``run()`` blocking."""
+    state: _StartState = {"handle": None, "error": None}
+
+    def _runner() -> None:
+        try:
+            state["handle"] = monty_sandbox_flow.run(topic, cache=False)
+        except Exception as exc:  # pragma: no cover - surfaced via state
+            state["error"] = exc
+
+    thread = threading.Thread(
+        target=_runner,
+        name="kitaru-monty-sandbox-example",
+        daemon=True,
+    )
+    thread.start()
+    return thread, state
+
+
+def _wait_for_pending_wait(
+    *,
+    client: KitaruClient,
+    topic: str,
+    start_state: _StartState,
+    timeout_seconds: float = _WAIT_DISCOVERY_TIMEOUT_SECONDS,
+) -> tuple[str, str]:
+    """Wait until this run reaches waiting state and return ``(exec_id, wait_id)``."""
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        start_error = start_state["error"]
+        if start_error is not None:
+            raise RuntimeError(
+                "Flow run failed before reaching a wait condition."
+            ) from start_error
+
+        found = _find_pending_wait_for_topic(client=client, topic=topic)
+        if found is not None:
+            return found
+
+        time.sleep(0.5)
+
+    raise TimeoutError(
+        "Timed out waiting for execution to reach a pending wait after "
+        f"{timeout_seconds:.0f}s. On remote stacks, first-run image builds can "
+        "take several minutes before the flow reaches wait()."
+    )
+
+
+def _wait_for_terminal_execution(
+    *,
+    client: KitaruClient,
+    exec_id: str,
+    timeout_seconds: int = 120,
+) -> Execution:
+    """Poll execution state until it reaches a terminal status."""
+    deadline = time.time() + timeout_seconds
+    while time.time() <= deadline:
+        execution = client.executions.get(exec_id)
+        if execution.status in {
+            ExecutionStatus.COMPLETED,
+            ExecutionStatus.FAILED,
+            ExecutionStatus.CANCELLED,
+        }:
+            return execution
+        time.sleep(1)
+
+    raise TimeoutError(
+        f"Execution {exec_id!r} did not finish within {timeout_seconds}s."
+    )
+
+
+def _result_from_execution(execution: Execution) -> _SandboxWorkflowResult:
+    """Load the final example result from the explicit terminal checkpoint."""
+    finalize_checkpoint = next(
+        (
+            checkpoint
+            for checkpoint in execution.checkpoints
+            if checkpoint.name == "finalize_sandbox_result"
+        ),
+        None,
+    )
+    if finalize_checkpoint is None:
+        raise RuntimeError(
+            "Expected checkpoint 'finalize_sandbox_result' was not found."
+        )
+    if not finalize_checkpoint.artifacts:
+        raise RuntimeError(
+            "The finalize_sandbox_result checkpoint has no artifacts to load."
+        )
+    return _coerce_workflow_result(finalize_checkpoint.artifacts[0].load())
+
+
+def run_workflow(
+    topic: str | None = None,
+    *,
+    approve: bool = True,
+    wait_discovery_timeout_seconds: float = _WAIT_DISCOVERY_TIMEOUT_SECONDS,
+) -> tuple[str, str, _SandboxWorkflowResult]:
+    """Run the sandbox example and auto-resolve its pending wait via the client."""
+    resolved_topic = topic or f"monty-sandbox-{int(time.time())}"
+    client = KitaruClient()
+    _prime_zenml_runtime()
+
+    starter_thread, start_state = _start_flow_in_background(resolved_topic)
+    exec_id, wait_id = _wait_for_pending_wait(
+        client=client,
+        topic=resolved_topic,
+        start_state=start_state,
+        timeout_seconds=wait_discovery_timeout_seconds,
+    )
+
+    execution_after_input = client.executions.input(
+        exec_id,
+        wait=wait_id,
+        value=approve,
+    )
+
+    with suppress(kitaru.KitaruStateError):
+        client.executions.resume(exec_id)
+
+    starter_thread.join(timeout=60.0)
+    if starter_thread.is_alive():
+        raise TimeoutError(
+            "Timed out waiting for the background flow run call to finish."
+        )
+    if start_state["error"] is not None:
+        raise RuntimeError("Background flow start failed.") from start_state["error"]
+
+    execution = _wait_for_terminal_execution(client=client, exec_id=exec_id)
+    if execution.status is not ExecutionStatus.COMPLETED:
+        raise RuntimeError(
+            f"Execution {exec_id} finished with status {execution.status.value!r}."
+        )
+
+    result = _result_from_execution(execution)
+    return exec_id, execution_after_input.status.value, result
+
+
+def run_workflow_interactive(
+    topic: str | None = None,
+) -> tuple[str, _SandboxWorkflowResult]:
+    """Run the workflow in the main thread and print manual unblock commands."""
+    resolved_topic = topic or f"monty-sandbox-{int(time.time())}"
+    client = KitaruClient()
+    _prime_zenml_runtime()
+    stop_event = threading.Event()
+
+    watcher = threading.Thread(
+        target=_watch_and_print_unblock_commands,
+        kwargs={
+            "client": client,
+            "topic": resolved_topic,
+            "stop_event": stop_event,
+        },
+        name="kitaru-monty-sandbox-watcher",
+        daemon=True,
+    )
+    watcher.start()
+
+    print("Starting interactive sandbox wait/resume workflow...")
+    print("Keep this terminal open; execute the printed commands in another terminal.")
+
+    handle = monty_sandbox_flow.run(resolved_topic, cache=False)
+    print(f"Execution ID: {handle.exec_id}")
+
+    try:
+        execution = _wait_for_terminal_execution(client=client, exec_id=handle.exec_id)
+        if execution.status is not ExecutionStatus.COMPLETED:
+            raise RuntimeError(
+                "Execution "
+                f"{handle.exec_id} finished with status "
+                f"{execution.status.value!r}."
+            )
+        result = _result_from_execution(execution)
+    finally:
+        stop_event.set()
+        watcher.join(timeout=2.0)
+
+    return handle.exec_id, result
+
+
+def _print_result_summary(
+    *,
+    execution_id: str,
+    result: _SandboxWorkflowResult,
+    status_after_input: str | None = None,
+) -> None:
+    """Render the example result as a short story-like summary."""
+    print(f"Execution ID: {execution_id}")
+    if status_after_input is not None:
+        print(f"Status after input: {status_after_input}")
+    print(f"Approved: {result['approved']}")
+    print(f"Before wait counter: {result['before_wait']['counter']}")
+
+    after_wait = result["after_wait"]
+    if after_wait is None:
+        print("After wait counter: not resumed")
+        print(f"Remembered draft before wait: {result['before_wait']['draft']}")
+        return
+
+    print(f"After wait counter: {after_wait['counter']}")
+    print(f"Remembered draft: {after_wait['draft']}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser for example execution modes."""
+    parser = argparse.ArgumentParser(
+        description="Monty sandbox wait/resume workflow example."
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["interactive", "auto"],
+        default="auto",
+        help="auto resolves the wait itself; interactive prints manual commands.",
+    )
+    parser.add_argument(
+        "--topic",
+        default=None,
+        help="Optional topic label. Defaults to a timestamp-based unique topic.",
+    )
+    parser.add_argument(
+        "--approve",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Auto-mode approval value (`--approve` / `--no-approve`).",
+    )
+    parser.add_argument(
+        "--wait-timeout",
+        type=float,
+        default=_WAIT_DISCOVERY_TIMEOUT_SECONDS,
+        help="Auto-mode wait-discovery timeout in seconds.",
+    )
+    return parser
+
+
+def main() -> None:
+    """Run the example as a script."""
+    args = _build_parser().parse_args()
+
+    if args.mode == "interactive":
+        execution_id, result = run_workflow_interactive(topic=args.topic)
+        _print_result_summary(execution_id=execution_id, result=result)
+        return
+
+    execution_id, status_after_input, result = run_workflow(
+        topic=args.topic,
+        approve=args.approve,
+        wait_discovery_timeout_seconds=args.wait_timeout,
+    )
+    _print_result_summary(
+        execution_id=execution_id,
+        status_after_input=status_after_input,
+        result=result,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ pydantic-ai = [
 mcp = [
     "mcp>=1.26.0",
 ]
+sandbox = [
+    "pydantic-monty>=0.0.8",
+]
 
 [project.scripts]
 kitaru = "kitaru.cli:cli"
@@ -68,6 +71,7 @@ dev = [
     "pytest-xdist[psutil]",
     "griffe>=1.13.0,<2.0.0",
     "griffe-typingdoc>=0.2.8,<1.0.0",
+    "pydantic-monty>=0.0.8",
     "pydantic-ai-slim>=0.2.0",
 ]
 

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -148,15 +148,19 @@ def _get_description(app: Any) -> str:
     return ""
 
 
+def _command_name(value: Any) -> str:
+    """Normalize a Cyclopts command name or key into its visible leaf name."""
+    name_parts: tuple[str, ...] = value if isinstance(value, tuple) else (str(value),)
+    return name_parts[-1]
+
+
 def build_command_tree(
     app: Any,
     parent_invocation: str = "",
+    registered_name: Any | None = None,
 ) -> CommandDoc:
     """Recursively build a normalized command tree from a cyclopts App."""
-    name_parts: tuple[str, ...] = (
-        app.name if isinstance(app.name, tuple) else (str(app.name),)
-    )
-    name = name_parts[-1]
+    name = _command_name(registered_name if registered_name is not None else app.name)
     invocation = f"{parent_invocation} {name}".strip() if parent_invocation else name
     slug = name
 
@@ -180,8 +184,14 @@ def build_command_tree(
 
     # Recurse into subcommands
     subcommands: list[CommandDoc] = []
-    for _cmd_name, sub_app in sorted(registered.items()):
-        subcommands.append(build_command_tree(sub_app, parent_invocation=invocation))
+    for cmd_name, sub_app in sorted(registered.items()):
+        subcommands.append(
+            build_command_tree(
+                sub_app,
+                parent_invocation=invocation,
+                registered_name=cmd_name,
+            )
+        )
 
     return CommandDoc(
         slug=slug,

--- a/src/kitaru/__init__.py
+++ b/src/kitaru/__init__.py
@@ -29,6 +29,7 @@ Current status:
   Kitaru exception hierarchy with failure journaling (`Execution.failure`,
   `CheckpointCall.attempts`).
 - Implemented: replay support (`KitaruClient.executions.replay(...)`).
+- Implemented: Monty-backed sandbox sessions via ``sandbox()``.
 
 The CLI also supports global runtime log-store configuration via
 ``kitaru log-store set/show/reset``, stack selection via
@@ -59,6 +60,13 @@ from kitaru.errors import (
     KitaruExecutionError,
     KitaruFeatureNotAvailableError,
     KitaruRuntimeError,
+    KitaruSandboxCapabilityError,
+    KitaruSandboxConfigurationError,
+    KitaruSandboxError,
+    KitaruSandboxExecutionError,
+    KitaruSandboxNotConfiguredError,
+    KitaruSandboxProviderError,
+    KitaruSandboxSessionError,
     KitaruStateError,
     KitaruUsageError,
     KitaruUserCodeError,
@@ -67,6 +75,12 @@ from kitaru.errors import (
 from kitaru.flow import FlowHandle, flow
 from kitaru.llm import llm
 from kitaru.logging import log
+from kitaru.sandbox import (
+    SandboxCapabilities,
+    SandboxExecutionResult,
+    SandboxSession,
+    sandbox,
+)
 from kitaru.wait import wait
 
 __all__ = [
@@ -82,10 +96,20 @@ __all__ = [
     "KitaruExecutionError",
     "KitaruFeatureNotAvailableError",
     "KitaruRuntimeError",
+    "KitaruSandboxCapabilityError",
+    "KitaruSandboxConfigurationError",
+    "KitaruSandboxError",
+    "KitaruSandboxExecutionError",
+    "KitaruSandboxNotConfiguredError",
+    "KitaruSandboxProviderError",
+    "KitaruSandboxSessionError",
     "KitaruStateError",
     "KitaruUsageError",
     "KitaruUserCodeError",
     "KitaruWaitValidationError",
+    "SandboxCapabilities",
+    "SandboxExecutionResult",
+    "SandboxSession",
     "StackInfo",
     "checkpoint",
     "configure",
@@ -96,6 +120,7 @@ __all__ = [
     "llm",
     "load",
     "log",
+    "sandbox",
     "save",
     "use_stack",
     "wait",

--- a/src/kitaru/cli.py
+++ b/src/kitaru/cli.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from importlib.metadata import version as get_version
 from pathlib import Path
 from types import ModuleType
-from typing import Annotated, Any, Protocol, runtime_checkable
+from typing import Annotated, Any, Literal, Protocol, runtime_checkable
 from urllib.parse import urlparse
 
 import cyclopts
@@ -35,7 +35,11 @@ from kitaru.client import Execution, ExecutionStatus, KitaruClient, LogEntry
 from kitaru.config import (
     KITARU_PROJECT_ENV,
     ModelAliasEntry,
+    MontySandboxSettings,
     ResolvedLogStore,
+    ResolvedSandboxConfig,
+    SandboxConfig,
+    SandboxProviderKind,
     StackInfo,
     _kitaru_config_dir,
     _read_runtime_connection_config,
@@ -44,8 +48,11 @@ from kitaru.config import (
     login_to_server,
     register_model_alias,
     reset_global_log_store,
+    reset_global_sandbox_config,
     resolve_log_store,
+    resolve_sandbox_config,
     set_global_log_store,
+    set_global_sandbox_config,
 )
 from kitaru.config import (
     current_stack as get_current_stack,
@@ -57,6 +64,7 @@ from kitaru.config import (
     use_stack as set_active_stack,
 )
 from kitaru.runtime import _submission_observer
+from kitaru.sandbox import run_sandbox_smoke_test
 from kitaru.terminal import (
     LiveExecutionRenderer,
     _suppress_zenml_console,
@@ -101,11 +109,16 @@ executions_app = cyclopts.App(
     name="executions",
     help="Inspect and manage flow executions.",
 )
+sandbox_app = cyclopts.App(
+    name="sandbox",
+    help="Manage sandbox provider settings and verify sandbox runtime access.",
+)
 app.command(log_store_app)
 app.command(stack_app)
 app.command(secrets_app)
 app.command(model_app)
 app.command(executions_app)
+app.command(sandbox_app)
 
 
 @dataclass
@@ -623,6 +636,26 @@ def _log_store_detail(snapshot: ResolvedLogStore) -> str:
         return f"Effective backend: {snapshot.backend}"
 
     return f"Effective backend: {snapshot.backend} (from {snapshot.source} settings)"
+
+
+def _sandbox_rows(snapshot: ResolvedSandboxConfig | None) -> list[tuple[str, str]]:
+    """Build label/value rows for `kitaru sandbox show`."""
+    if snapshot is None:
+        return [("Provider", "not configured")]
+
+    sdk_installed = "yes"
+    try:
+        importlib.import_module("pydantic_monty")
+    except ImportError:
+        sdk_installed = "no"
+
+    return [
+        ("Provider", snapshot.provider.value),
+        ("Max duration", f"{snapshot.monty.max_duration_secs:g}s"),
+        ("Max memory", f"{snapshot.monty.max_memory_mb} MB"),
+        ("Type check", "enabled" if snapshot.monty.type_check else "disabled"),
+        ("SDK installed", sdk_installed),
+    ]
 
 
 def _log_store_mismatch_details(
@@ -1265,6 +1298,97 @@ def reset() -> None:
         "Cleared global log-store override.",
         detail=_log_store_detail(snapshot),
     )
+
+
+@sandbox_app.command(name="set")
+def sandbox_set(
+    provider: Annotated[
+        Literal["monty"],
+        Parameter(help="Sandbox provider to persist globally."),
+    ],
+    *,
+    max_duration_secs: Annotated[
+        float,
+        Parameter(help="Maximum Python execution duration for one sandbox call."),
+    ] = 1.0,
+    max_memory_mb: Annotated[
+        int,
+        Parameter(help="Maximum memory budget for the Monty sandbox."),
+    ] = 64,
+    type_check: Annotated[
+        bool,
+        Parameter(help="Persist whether static type checking should be requested."),
+    ] = True,
+) -> None:
+    """Persist the global sandbox provider configuration."""
+    del provider
+    try:
+        set_global_sandbox_config(
+            SandboxConfig(
+                provider=SandboxProviderKind.MONTY,
+                monty=MontySandboxSettings(
+                    max_duration_secs=max_duration_secs,
+                    max_memory_mb=max_memory_mb,
+                    type_check=type_check,
+                ),
+            )
+        )
+    except ValueError as exc:
+        _exit_with_error(str(exc))
+
+    resolved = resolve_sandbox_config()
+    if resolved is None:
+        _exit_with_error("Sandbox configuration was saved but could not be resolved.")
+        return
+
+    _print_success(
+        "Saved sandbox configuration.",
+        detail=(
+            f"Provider: {SandboxProviderKind.MONTY.value} | "
+            f"max_duration_secs={resolved.monty.max_duration_secs:g} | "
+            f"max_memory_mb={resolved.monty.max_memory_mb} | "
+            f"type_check={str(resolved.monty.type_check).lower()}"
+        ),
+    )
+
+
+@sandbox_app.command(name="show")
+def sandbox_show() -> None:
+    """Show the effective sandbox configuration for the current process."""
+    try:
+        snapshot = resolve_sandbox_config()
+    except ValueError as exc:
+        _exit_with_error(str(exc))
+    _emit_snapshot("Kitaru sandbox", _sandbox_rows(snapshot))
+
+
+@sandbox_app.command(name="reset")
+def sandbox_reset() -> None:
+    """Clear the persisted sandbox configuration."""
+    reset_global_sandbox_config()
+    _print_success("Cleared sandbox configuration.")
+
+
+@sandbox_app.command(name="test")
+def sandbox_test() -> None:
+    """Run a small sandbox smoke test against the resolved provider config."""
+    try:
+        snapshot = resolve_sandbox_config()
+    except ValueError as exc:
+        _exit_with_error(str(exc))
+
+    if snapshot is None:
+        _exit_with_error(
+            "No sandbox provider is configured. Run `kitaru sandbox set monty` first."
+        )
+        return
+
+    try:
+        run_sandbox_smoke_test(snapshot)
+    except Exception as exc:
+        _exit_with_error(str(exc))
+
+    _print_success("Sandbox test passed.")
 
 
 @stack_app.command

--- a/src/kitaru/config.py
+++ b/src/kitaru/config.py
@@ -18,6 +18,7 @@ import re
 import tomllib
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal
 from unittest.mock import patch
@@ -63,9 +64,11 @@ KITARU_STACK_ENV = "KITARU_STACK"
 KITARU_CACHE_ENV = "KITARU_CACHE"
 KITARU_RETRIES_ENV = "KITARU_RETRIES"
 KITARU_IMAGE_ENV = "KITARU_IMAGE"
+KITARU_SANDBOX_ENV = "KITARU_SANDBOX"
 KITARU_SERVER_URL_ENV = "KITARU_SERVER_URL"
 KITARU_AUTH_TOKEN_ENV = "KITARU_AUTH_TOKEN"
 KITARU_PROJECT_ENV = "KITARU_PROJECT"
+_KITARU_RESOLVED_SANDBOX_ENV = "KITARU_INTERNAL_SANDBOX_CONFIG"
 
 FROZEN_EXECUTION_SPEC_METADATA_KEY = "kitaru_execution_spec"
 
@@ -249,6 +252,7 @@ class _KitaruGlobalConfig(BaseModel):
     version: int = 1
     log_store: LogStoreOverride | None = None
     model_registry: ModelRegistryConfig | None = None
+    sandbox: SandboxConfig | None = None
 
 
 class StackInfo(BaseModel):
@@ -325,11 +329,73 @@ class ImageSettings(BaseModel):
 ImageInput = str | DockerSettings | Mapping[str, Any] | ImageSettings
 
 
+class SandboxProviderKind(StrEnum):
+    """Known sandbox providers."""
+
+    MONTY = "monty"
+
+
+class MontySandboxSettings(BaseModel):
+    """Provider-specific configuration for Monty."""
+
+    max_duration_secs: float | None = None
+    max_memory_mb: int | None = None
+    type_check: bool | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("max_duration_secs")
+    @classmethod
+    def _validate_max_duration_secs(cls, value: float | None) -> float | None:
+        if value is None:
+            return None
+        if value <= 0:
+            raise ValueError("Monty max_duration_secs must be > 0.")
+        return value
+
+    @field_validator("max_memory_mb")
+    @classmethod
+    def _validate_max_memory_mb(cls, value: int | None) -> int | None:
+        if value is None:
+            return None
+        if value <= 0:
+            raise ValueError("Monty max_memory_mb must be > 0.")
+        return value
+
+
+class SandboxConfig(BaseModel):
+    """Sandbox configuration layer before defaults are resolved."""
+
+    provider: SandboxProviderKind | None = None
+    monty: MontySandboxSettings | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ResolvedMontySandboxSettings(BaseModel):
+    """Fully resolved Monty sandbox settings."""
+
+    max_duration_secs: float
+    max_memory_mb: int
+    type_check: bool
+
+
+class ResolvedSandboxConfig(BaseModel):
+    """Fully resolved sandbox configuration."""
+
+    provider: SandboxProviderKind
+    monty: ResolvedMontySandboxSettings
+
+
+SandboxInput = SandboxConfig | SandboxProviderKind | str | Mapping[str, Any]
+
+
 class KitaruConfig(BaseModel):
     """Unified Kitaru configuration model."""
 
     stack: str | None = None
     image: ImageSettings | None = None
+    sandbox: SandboxConfig | None = None
     cache: bool | None = None
     retries: int | None = None
     server_url: str | None = None
@@ -369,12 +435,18 @@ class KitaruConfig(BaseModel):
     def _coerce_image_input(cls, value: Any) -> Any:
         return _coerce_image_input(value)
 
+    @field_validator("sandbox", mode="before")
+    @classmethod
+    def _coerce_sandbox_value(cls, value: Any) -> Any:
+        return _coerce_sandbox_input(value)
+
 
 class ResolvedExecutionConfig(BaseModel):
     """Fully resolved execution settings for a flow run."""
 
     stack: str | None = None
     image: ImageSettings | None = None
+    sandbox: ResolvedSandboxConfig | None = None
     cache: bool
     retries: int
 
@@ -467,6 +539,32 @@ def _coerce_image_input(value: Any) -> ImageSettings | None:
     )
 
 
+def _coerce_sandbox_input(value: Any) -> SandboxConfig | None:
+    """Coerce supported sandbox inputs into :class:`SandboxConfig`."""
+    if value is None:
+        return None
+    if isinstance(value, SandboxConfig):
+        return value
+    if isinstance(value, SandboxProviderKind):
+        return SandboxConfig(provider=value)
+    if isinstance(value, str):
+        normalized_value = value.strip()
+        if not normalized_value:
+            raise ValueError("Sandbox configuration cannot be empty.")
+        try:
+            parsed_value = json.loads(normalized_value)
+        except json.JSONDecodeError:
+            return SandboxConfig(provider=normalized_value)
+        return SandboxConfig.model_validate(parsed_value)
+    if isinstance(value, Mapping):
+        return SandboxConfig.model_validate(dict(value))
+
+    raise TypeError(
+        "Unsupported sandbox configuration type. Expected str, dict, "
+        "SandboxConfig, SandboxProviderKind, or None."
+    )
+
+
 def _merge_image_settings(
     *,
     base: ImageSettings | None,
@@ -509,6 +607,85 @@ def _merge_image_settings(
             else base.replicate_local_python_environment
         ),
     )
+
+
+def _merge_monty_sandbox_settings(
+    *,
+    base: MontySandboxSettings | None,
+    override: MontySandboxSettings,
+) -> MontySandboxSettings:
+    """Merge one layer of Monty settings onto another."""
+    if base is None:
+        return override
+
+    return MontySandboxSettings(
+        max_duration_secs=(
+            override.max_duration_secs
+            if override.max_duration_secs is not None
+            else base.max_duration_secs
+        ),
+        max_memory_mb=(
+            override.max_memory_mb
+            if override.max_memory_mb is not None
+            else base.max_memory_mb
+        ),
+        type_check=(
+            override.type_check if override.type_check is not None else base.type_check
+        ),
+    )
+
+
+def _merge_sandbox_config(
+    *,
+    base: SandboxConfig | None,
+    override: SandboxConfig,
+) -> SandboxConfig:
+    """Merge a higher-precedence sandbox config over a lower-precedence one."""
+    if base is None:
+        return override
+
+    merged_monty = base.monty
+    if override.monty is not None:
+        merged_monty = _merge_monty_sandbox_settings(
+            base=merged_monty,
+            override=override.monty,
+        )
+
+    return SandboxConfig(
+        provider=override.provider if override.provider is not None else base.provider,
+        monty=merged_monty,
+    )
+
+
+def _resolve_sandbox_config(
+    sandbox_config: SandboxConfig | None,
+) -> ResolvedSandboxConfig | None:
+    """Resolve sandbox config defaults into a concrete provider config."""
+    if sandbox_config is None:
+        return None
+
+    provider = sandbox_config.provider
+    if provider is None:
+        if sandbox_config.monty is None:
+            return None
+        provider = SandboxProviderKind.MONTY
+
+    if provider == SandboxProviderKind.MONTY:
+        monty = sandbox_config.monty or MontySandboxSettings()
+        return ResolvedSandboxConfig(
+            provider=provider,
+            monty=ResolvedMontySandboxSettings(
+                max_duration_secs=(
+                    1.0 if monty.max_duration_secs is None else monty.max_duration_secs
+                ),
+                max_memory_mb=(
+                    64 if monty.max_memory_mb is None else monty.max_memory_mb
+                ),
+                type_check=(True if monty.type_check is None else monty.type_check),
+            ),
+        )
+
+    raise ValueError(f"Unsupported sandbox provider: {provider!r}")
 
 
 def _parse_bool_env(name: str, value: str) -> bool:
@@ -593,6 +770,10 @@ def _read_execution_env_config() -> KitaruConfig:
             parsed_image = stripped_image
         values["image"] = parsed_image
 
+    raw_sandbox = os.environ.get(KITARU_SANDBOX_ENV)
+    if raw_sandbox is not None:
+        values["sandbox"] = raw_sandbox
+
     return KitaruConfig.model_validate(values)
 
 
@@ -622,7 +803,13 @@ def _read_global_execution_config() -> KitaruConfig:
     except Exception:
         active_stack_name = None
 
-    return KitaruConfig(stack=active_stack_name)
+    global_config = _read_kitaru_global_config()
+    return KitaruConfig(
+        stack=active_stack_name,
+        sandbox=global_config.sandbox.model_copy(deep=True)
+        if global_config.sandbox is not None
+        else None,
+    )
 
 
 def _extract_store_token(store: Any) -> str | None:
@@ -690,9 +877,28 @@ def _merge_execution_layer(
         if merged_image.is_empty():
             merged_image = None
 
+    merged_sandbox = resolved.sandbox
+    if layer.sandbox is not None:
+        merged_sandbox = _resolve_sandbox_config(
+            _merge_sandbox_config(
+                base=(
+                    SandboxConfig(
+                        provider=resolved.sandbox.provider,
+                        monty=MontySandboxSettings.model_validate(
+                            resolved.sandbox.monty.model_dump(mode="python")
+                        ),
+                    )
+                    if resolved.sandbox is not None
+                    else None
+                ),
+                override=layer.sandbox,
+            )
+        )
+
     return ResolvedExecutionConfig(
         stack=layer.stack if layer.stack is not None else resolved.stack,
         image=merged_image,
+        sandbox=merged_sandbox,
         cache=layer.cache if layer.cache is not None else resolved.cache,
         retries=layer.retries if layer.retries is not None else resolved.retries,
     )
@@ -724,6 +930,7 @@ def resolve_execution_config(
     resolved = ResolvedExecutionConfig(
         stack=None,
         image=None,
+        sandbox=None,
         cache=True,
         retries=0,
     )
@@ -738,6 +945,20 @@ def resolve_execution_config(
         resolved = _merge_execution_layer(resolved, layer)
 
     return resolved
+
+
+def resolve_sandbox_config(
+    *,
+    decorator_overrides: KitaruConfig | None = None,
+    invocation_overrides: KitaruConfig | None = None,
+    start_dir: Path | None = None,
+) -> ResolvedSandboxConfig | None:
+    """Resolve only the sandbox configuration using execution precedence."""
+    return resolve_execution_config(
+        decorator_overrides=decorator_overrides,
+        invocation_overrides=invocation_overrides,
+        start_dir=start_dir,
+    ).sandbox
 
 
 def resolve_connection_config(
@@ -1286,6 +1507,40 @@ def reset_global_log_store() -> ResolvedLogStore:
     return resolve_log_store()
 
 
+def get_global_sandbox_config() -> SandboxConfig | None:
+    """Read the persisted global sandbox config without applying precedence."""
+    global_config = _read_kitaru_global_config()
+    if global_config.sandbox is None:
+        return None
+    return global_config.sandbox.model_copy(deep=True)
+
+
+def set_global_sandbox_config(
+    sandbox: SandboxInput,
+) -> SandboxConfig:
+    """Persist a global sandbox configuration."""
+    resolved_sandbox = _coerce_sandbox_input(sandbox)
+    if resolved_sandbox is None:
+        raise ValueError("Sandbox configuration cannot be empty.")
+
+    def _mutate(global_config: _KitaruGlobalConfig) -> None:
+        global_config.sandbox = resolved_sandbox
+
+    updated = _update_kitaru_global_config(_mutate)
+    if updated.sandbox is None:
+        raise RuntimeError("Sandbox configuration was not persisted.")
+    return updated.sandbox
+
+
+def reset_global_sandbox_config() -> None:
+    """Clear the persisted global sandbox configuration."""
+
+    def _mutate(global_config: _KitaruGlobalConfig) -> None:
+        global_config.sandbox = None
+
+    _update_kitaru_global_config(_mutate)
+
+
 def _read_model_registry_config() -> ModelRegistryConfig:
     """Read the local model registry from global config."""
     global_config = _read_kitaru_global_config()
@@ -1597,13 +1852,14 @@ def configure(
     *,
     stack: str | None | object = _UNSET,
     image: ImageInput | None | object = _UNSET,
+    sandbox: SandboxInput | None | object = _UNSET,
     cache: bool | None | object = _UNSET,
     retries: int | None | object = _UNSET,
     project: str | None | object = _UNSET,
 ) -> KitaruConfig:
     """Set process-local runtime defaults.
 
-    Execution-level fields (``stack``, ``image``, ``cache``, ``retries``)
+    Execution-level fields (``stack``, ``image``, ``sandbox``, ``cache``, ``retries``)
     update the execution precedence chain.  The ``project`` field updates
     the connection precedence chain and is intended as an internal /
     testing escape hatch — it is not a normal user-facing setting.
@@ -1611,6 +1867,7 @@ def configure(
     Args:
         stack: Default stack name/ID override.
         image: Default image settings override.
+        sandbox: Default sandbox configuration override.
         cache: Default cache behavior override.
         retries: Default retry-count override.
         project: Project override (internal/testing). Set to ``None``
@@ -1632,6 +1889,12 @@ def configure(
             candidate_execution.pop("image", None)
         else:
             candidate_execution["image"] = _coerce_image_input(image)
+
+    if sandbox is not _UNSET:
+        if sandbox is None:
+            candidate_execution.pop("sandbox", None)
+        else:
+            candidate_execution["sandbox"] = _coerce_sandbox_input(sandbox)
 
     if cache is not _UNSET:
         if cache is None:

--- a/src/kitaru/errors.py
+++ b/src/kitaru/errors.py
@@ -82,6 +82,34 @@ class KitaruFeatureNotAvailableError(KitaruError, NotImplementedError):
     """Raised when a documented API is intentionally not implemented yet."""
 
 
+class KitaruSandboxError(KitaruError):
+    """Base class for sandbox-specific failures."""
+
+
+class KitaruSandboxConfigurationError(KitaruUsageError, KitaruSandboxError):
+    """Raised when sandbox configuration is invalid."""
+
+
+class KitaruSandboxCapabilityError(KitaruUsageError, KitaruSandboxError):
+    """Raised when a sandbox provider lacks a requested capability."""
+
+
+class KitaruSandboxNotConfiguredError(KitaruStateError, KitaruSandboxError):
+    """Raised when sandbox APIs are used without an active provider."""
+
+
+class KitaruSandboxSessionError(KitaruStateError, KitaruSandboxError):
+    """Raised when a sandbox session is invalid or no longer usable."""
+
+
+class KitaruSandboxExecutionError(KitaruRuntimeError, KitaruSandboxError):
+    """Raised when sandboxed code execution fails."""
+
+
+class KitaruSandboxProviderError(KitaruRuntimeError, KitaruSandboxError):
+    """Raised when the sandbox provider itself fails."""
+
+
 _DIVERGENCE_HINTS: Final[tuple[str, ...]] = (
     "diverg",
     "durable call sequence",
@@ -182,6 +210,13 @@ __all__ = [
     "KitaruFeatureNotAvailableError",
     "KitaruLogRetrievalError",
     "KitaruRuntimeError",
+    "KitaruSandboxCapabilityError",
+    "KitaruSandboxConfigurationError",
+    "KitaruSandboxError",
+    "KitaruSandboxExecutionError",
+    "KitaruSandboxNotConfiguredError",
+    "KitaruSandboxProviderError",
+    "KitaruSandboxSessionError",
     "KitaruStateError",
     "KitaruUsageError",
     "KitaruUserCodeError",

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -24,9 +24,12 @@ from zenml.pipelines.pipeline_decorator import pipeline
 from zenml.pipelines.pipeline_definition import Pipeline
 
 from kitaru.config import (
+    _KITARU_RESOLVED_SANDBOX_ENV,
     ImageInput,
     ImageSettings,
     KitaruConfig,
+    ResolvedSandboxConfig,
+    SandboxInput,
     build_frozen_execution_spec,
     image_settings_to_docker_settings,
     persist_frozen_execution_spec,
@@ -44,7 +47,11 @@ from kitaru.errors import (
     traceback_last_line,
 )
 from kitaru.replay import build_replay_plan
-from kitaru.runtime import _flow_scope, _notify_submission_observer
+from kitaru.runtime import (
+    _flow_scope,
+    _notify_submission_observer,
+    _submission_sandbox_config,
+)
 
 ImageSetting = ImageInput
 
@@ -157,7 +164,9 @@ def _to_retry_config(retries: int) -> StepRetryConfig | None:
 
 
 def _build_settings(
+    *,
     image: ImageSettings | None,
+    sandbox: ResolvedSandboxConfig | None,
 ) -> dict[str, DockerSettings]:
     """Build ZenML settings payload for flow execution.
 
@@ -170,13 +179,23 @@ def _build_settings(
     Returns:
         Pipeline settings dictionary.
     """
-    return {DOCKER_SETTINGS_KEY: image_settings_to_docker_settings(image)}
+    docker_settings = image_settings_to_docker_settings(image)
+    if sandbox is not None:
+        environment = dict(docker_settings.environment or {})
+        environment[_KITARU_RESOLVED_SANDBOX_ENV] = sandbox.model_dump_json(
+            exclude_none=True
+        )
+        docker_settings = docker_settings.model_copy(
+            update={"environment": environment}
+        )
+    return {DOCKER_SETTINGS_KEY: docker_settings}
 
 
 def _build_execution_overrides(
     *,
     stack: str | None = None,
     image: ImageSetting | None = None,
+    sandbox: SandboxInput | None = None,
     cache: bool | None = None,
     retries: int | None = None,
 ) -> KitaruConfig:
@@ -186,6 +205,8 @@ def _build_execution_overrides(
         values["stack"] = stack
     if image is not None:
         values["image"] = image
+    if sandbox is not None:
+        values["sandbox"] = sandbox
     if cache is not None:
         values["cache"] = cache
     if retries is not None:
@@ -506,6 +527,7 @@ class _FlowDefinition:
         *,
         stack: str | None,
         image: ImageSetting | None,
+        sandbox: SandboxInput | None,
         cache: bool | None,
         retries: int | None,
     ) -> None:
@@ -515,6 +537,7 @@ class _FlowDefinition:
             func: User flow function.
             stack: Default stack override.
             image: Default image settings.
+            sandbox: Default sandbox settings.
             cache: Default cache behavior.
             retries: Default retry count.
         """
@@ -522,6 +545,7 @@ class _FlowDefinition:
         self._decorator_config = _build_execution_overrides(
             stack=stack,
             image=image,
+            sandbox=sandbox,
             cache=cache,
             retries=retries,
         )
@@ -554,6 +578,7 @@ class _FlowDefinition:
         *args: Any,
         stack: str | None = None,
         image: ImageSetting | None = None,
+        sandbox: SandboxInput | None = None,
         cache: bool | None = None,
         retries: int | None = None,
         **kwargs: Any,
@@ -564,6 +589,7 @@ class _FlowDefinition:
             *args: Flow input args.
             stack: Optional stack override.
             image: Optional image override.
+            sandbox: Optional sandbox override.
             cache: Optional cache override.
             retries: Optional retry override.
             **kwargs: Flow input kwargs.
@@ -577,6 +603,7 @@ class _FlowDefinition:
             invocation_overrides=_build_execution_overrides(
                 stack=stack,
                 image=image,
+                sandbox=sandbox,
                 cache=cache,
                 retries=retries,
             ),
@@ -590,6 +617,7 @@ class _FlowDefinition:
         overrides: dict[str, Any] | None = None,
         stack: str | None = None,
         image: ImageSetting | None = None,
+        sandbox: SandboxInput | None = None,
         cache: bool | None = None,
         retries: int | None = None,
         **flow_inputs: Any,
@@ -602,6 +630,7 @@ class _FlowDefinition:
             overrides: Optional `checkpoint.*` and `wait.*` override map.
             stack: Optional stack override for the replay run.
             image: Optional image override for the replay run.
+            sandbox: Optional sandbox override for the replay run.
             cache: Optional cache override for the replay run.
             retries: Optional retry override for the replay run.
             **flow_inputs: Optional flow input overrides.
@@ -633,6 +662,7 @@ class _FlowDefinition:
             invocation_overrides=_build_execution_overrides(
                 stack=stack,
                 image=image,
+                sandbox=sandbox,
                 cache=cache,
                 retries=retries,
             ),
@@ -645,10 +675,16 @@ class _FlowDefinition:
         configured_pipeline = self._pipeline.with_options(
             enable_cache=resolved_execution.cache,
             retry=_to_retry_config(_normalize_retries(resolved_execution.retries)),
-            settings=_build_settings(resolved_execution.image),
+            settings=_build_settings(
+                image=resolved_execution.image,
+                sandbox=resolved_execution.sandbox,
+            ),
         )
 
-        with _temporary_active_stack(resolved_execution.stack):
+        with (
+            _temporary_active_stack(resolved_execution.stack),
+            _submission_sandbox_config(resolved_execution.sandbox),
+        ):
             try:
                 replayed_run = configured_pipeline.replay(
                     pipeline_run=original_run.id,
@@ -718,10 +754,16 @@ class _FlowDefinition:
         configured_pipeline = self._pipeline.with_options(
             enable_cache=resolved_execution.cache,
             retry=_to_retry_config(_normalize_retries(resolved_execution.retries)),
-            settings=_build_settings(resolved_execution.image),
+            settings=_build_settings(
+                image=resolved_execution.image,
+                sandbox=resolved_execution.sandbox,
+            ),
         )
 
-        with _temporary_active_stack(resolved_execution.stack):
+        with (
+            _temporary_active_stack(resolved_execution.stack),
+            _submission_sandbox_config(resolved_execution.sandbox),
+        ):
             run = configured_pipeline(*args, **kwargs)
 
         if run is None:
@@ -738,6 +780,7 @@ class _FlowDefinition:
         *args: Any,
         stack: str | None = None,
         image: ImageSetting | None = None,
+        sandbox: SandboxInput | None = None,
         cache: bool | None = None,
         retries: int | None = None,
         **kwargs: Any,
@@ -750,6 +793,7 @@ class _FlowDefinition:
             *args: Flow input args.
             stack: Optional stack override.
             image: Optional image override.
+            sandbox: Optional sandbox override.
             cache: Optional cache override.
             retries: Optional retry override.
             **kwargs: Flow input kwargs.
@@ -761,6 +805,7 @@ class _FlowDefinition:
             *args,
             stack=stack,
             image=image,
+            sandbox=sandbox,
             cache=cache,
             retries=retries,
             **kwargs,
@@ -776,6 +821,7 @@ def flow(
     *,
     stack: str | None = None,
     image: ImageSetting | None = None,
+    sandbox: SandboxInput | None = None,
     cache: bool | None = None,
     retries: int | None = None,
 ) -> Callable[[Callable[..., Any]], _FlowDefinition]: ...
@@ -786,6 +832,7 @@ def flow(
     *,
     stack: str | None = None,
     image: ImageSetting | None = None,
+    sandbox: SandboxInput | None = None,
     cache: bool | None = None,
     retries: int | None = None,
 ) -> _FlowDefinition | Callable[[Callable[..., Any]], _FlowDefinition]:
@@ -805,6 +852,7 @@ def flow(
         func: Optional function for bare decorator use.
         stack: Default execution stack.
         image: Default image settings.
+        sandbox: Default sandbox settings.
         cache: Optional cache override (when omitted, lower-precedence config
             sources apply and eventually default to ``True``).
         retries: Optional retry override (when omitted, lower-precedence config
@@ -819,6 +867,7 @@ def flow(
             target,
             stack=stack,
             image=image,
+            sandbox=sandbox,
             cache=cache,
             retries=retries,
         )

--- a/src/kitaru/runtime.py
+++ b/src/kitaru/runtime.py
@@ -6,15 +6,19 @@ It is not part of the public API surface.
 
 from __future__ import annotations
 
+import json
+import os
+import warnings
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Any, NoReturn
+from typing import Any, NoReturn, Protocol
 
 from zenml.execution.pipeline.dynamic.run_context import DynamicPipelineRunContext
 from zenml.steps.step_context import StepContext
 
+from kitaru.config import _KITARU_RESOLVED_SANDBOX_ENV, ResolvedSandboxConfig
 from kitaru.errors import KitaruFeatureNotAvailableError
 
 
@@ -24,6 +28,7 @@ class _FlowScope:
 
     name: str | None
     execution_id: str | None = None
+    sandbox_config: ResolvedSandboxConfig | None = None
 
 
 @dataclass(frozen=True)
@@ -48,6 +53,28 @@ _LLM_CALL_COUNTER: ContextVar[int] = ContextVar("kitaru_llm_call_counter", defau
 
 _SUBMISSION_OBSERVER: ContextVar[Callable[[str], None] | None] = ContextVar(
     "kitaru_submission_observer",
+    default=None,
+)
+_SUBMISSION_SANDBOX_CONFIG: ContextVar[ResolvedSandboxConfig | None] = ContextVar(
+    "kitaru_submission_sandbox_config",
+    default=None,
+)
+
+
+class _SandboxLifecycleManager(Protocol):
+    """Runtime hooks implemented by the sandbox subsystem."""
+
+    def close_checkpoint_scope(self, checkpoint_id: str | None) -> None: ...
+
+    def close_execution_scope(self, execution_id: str | None) -> None: ...
+
+    def before_wait(self, execution_id: str | None) -> None: ...
+
+    def after_wait(self, execution_id: str | None) -> None: ...
+
+
+_CURRENT_SANDBOX_MANAGER: ContextVar[_SandboxLifecycleManager | None] = ContextVar(
+    "kitaru_current_sandbox_manager",
     default=None,
 )
 
@@ -110,24 +137,63 @@ def _get_zenml_flow_name() -> str | None:
     return None
 
 
+def _sandbox_config_from_env() -> ResolvedSandboxConfig | None:
+    """Load a resolved sandbox config propagated through the runtime env."""
+    raw_value = os.environ.get(_KITARU_RESOLVED_SANDBOX_ENV)
+    if raw_value is None or not raw_value.strip():
+        return None
+    try:
+        return ResolvedSandboxConfig.model_validate_json(raw_value)
+    except Exception:
+        try:
+            return ResolvedSandboxConfig.model_validate(json.loads(raw_value))
+        except Exception:
+            warnings.warn(
+                "Ignoring invalid propagated sandbox configuration from "
+                f"{_KITARU_RESOLVED_SANDBOX_ENV}.",
+                stacklevel=2,
+            )
+            return None
+
+
 @contextmanager
 def _flow_scope(
     *,
     name: str | None,
     execution_id: str | None = None,
+    sandbox_config: ResolvedSandboxConfig | None = None,
 ) -> Iterator[None]:
     """Set flow runtime scope for the active execution context."""
     resolved_execution_id = (
         execution_id if execution_id is not None else _get_zenml_execution_id()
     )
+    resolved_sandbox_config = sandbox_config
+    if resolved_sandbox_config is None:
+        resolved_sandbox_config = _SUBMISSION_SANDBOX_CONFIG.get()
+    if resolved_sandbox_config is None:
+        resolved_sandbox_config = _sandbox_config_from_env()
     flow_token = _CURRENT_FLOW_SCOPE.set(
-        _FlowScope(name=name, execution_id=resolved_execution_id)
+        _FlowScope(
+            name=name,
+            execution_id=resolved_execution_id,
+            sandbox_config=resolved_sandbox_config,
+        )
     )
     llm_counter_token = _LLM_CALL_COUNTER.set(0)
     try:
         yield
     finally:
+        sandbox_manager = _CURRENT_SANDBOX_MANAGER.get()
+        if sandbox_manager is not None:
+            try:
+                sandbox_manager.close_execution_scope(resolved_execution_id)
+            except Exception as exc:
+                warnings.warn(
+                    f"Failed to close sandbox execution scope: {exc}",
+                    stacklevel=2,
+                )
         _LLM_CALL_COUNTER.reset(llm_counter_token)
+        _CURRENT_SANDBOX_MANAGER.set(None)
         _CURRENT_FLOW_SCOPE.reset(flow_token)
 
 
@@ -158,6 +224,15 @@ def _checkpoint_scope(
     try:
         yield
     finally:
+        sandbox_manager = _CURRENT_SANDBOX_MANAGER.get()
+        if sandbox_manager is not None:
+            try:
+                sandbox_manager.close_checkpoint_scope(resolved_checkpoint_id)
+            except Exception as exc:
+                warnings.warn(
+                    f"Failed to close sandbox checkpoint scope: {exc}",
+                    stacklevel=2,
+                )
         _LLM_CALL_COUNTER.reset(llm_counter_token)
         _CURRENT_CHECKPOINT_SCOPE.reset(checkpoint_token)
 
@@ -180,6 +255,17 @@ def _suspend_checkpoint_scope() -> Iterator[None]:
 def _get_current_flow() -> _FlowScope | None:
     """Get the currently active flow scope, if any."""
     return _CURRENT_FLOW_SCOPE.get()
+
+
+def _get_current_sandbox_config() -> ResolvedSandboxConfig | None:
+    """Return the sandbox config active in the current flow scope, if any."""
+    flow_scope = _get_current_flow()
+    if flow_scope is not None:
+        return flow_scope.sandbox_config
+    config = _SUBMISSION_SANDBOX_CONFIG.get()
+    if config is not None:
+        return config
+    return _sandbox_config_from_env()
 
 
 def _is_inside_flow() -> bool:
@@ -226,6 +312,48 @@ def _next_llm_call_name(prefix: str = "llm") -> str:
     next_index = _LLM_CALL_COUNTER.get() + 1
     _LLM_CALL_COUNTER.set(next_index)
     return f"{normalized_prefix}_{next_index}"
+
+
+@contextmanager
+def _submission_sandbox_config(
+    config: ResolvedSandboxConfig | None,
+) -> Iterator[None]:
+    """Temporarily install resolved sandbox config for flow submission."""
+    token = _SUBMISSION_SANDBOX_CONFIG.set(config)
+    try:
+        yield
+    finally:
+        _SUBMISSION_SANDBOX_CONFIG.reset(token)
+
+
+def _get_current_sandbox_manager() -> _SandboxLifecycleManager | None:
+    """Return the active sandbox runtime manager, if any."""
+    return _CURRENT_SANDBOX_MANAGER.get()
+
+
+def _set_current_sandbox_manager(
+    manager: _SandboxLifecycleManager | None,
+) -> _SandboxLifecycleManager | None:
+    """Install the active sandbox runtime manager and return the previous one."""
+    previous = _CURRENT_SANDBOX_MANAGER.get()
+    _CURRENT_SANDBOX_MANAGER.set(manager)
+    return previous
+
+
+def _sandbox_before_wait() -> None:
+    """Let the sandbox subsystem prepare active sessions before a wait."""
+    sandbox_manager = _CURRENT_SANDBOX_MANAGER.get()
+    if sandbox_manager is None:
+        return
+    sandbox_manager.before_wait(_get_current_execution_id())
+
+
+def _sandbox_after_wait() -> None:
+    """Let the sandbox subsystem restore active sessions after a wait."""
+    sandbox_manager = _CURRENT_SANDBOX_MANAGER.get()
+    if sandbox_manager is None:
+        return
+    sandbox_manager.after_wait(_get_current_execution_id())
 
 
 def _not_implemented(name: str) -> NoReturn:

--- a/src/kitaru/sandbox.py
+++ b/src/kitaru/sandbox.py
@@ -1,0 +1,969 @@
+"""Sandbox session support for Kitaru.
+
+Monty-backed sandbox sessions provide stateful Python execution that can pause
+and resume around ``kitaru.wait()``.
+"""
+
+import base64
+import re
+import time
+import zlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol, cast
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+from zenml.client import Client
+from zenml.enums import MetadataResourceTypes
+from zenml.models.v2.misc.run_metadata import RunMetadataResource
+
+from kitaru.artifacts import save
+from kitaru.checkpoint import checkpoint
+from kitaru.config import ResolvedSandboxConfig, SandboxProviderKind
+from kitaru.errors import (
+    KitaruContextError,
+    KitaruFeatureNotAvailableError,
+    KitaruSandboxCapabilityError,
+    KitaruSandboxExecutionError,
+    KitaruSandboxNotConfiguredError,
+    KitaruSandboxProviderError,
+    KitaruSandboxSessionError,
+)
+from kitaru.logging import log
+from kitaru.runtime import (
+    _get_current_checkpoint,
+    _get_current_execution_id,
+    _get_current_flow,
+    _get_current_sandbox_config,
+    _get_current_sandbox_manager,
+    _is_inside_checkpoint,
+    _is_inside_flow,
+    _next_llm_call_name,
+    _set_current_sandbox_manager,
+)
+
+_SANDBOX_STATE_METADATA_KEY = "kitaru_sandbox_state"
+_LOCAL_EXECUTION_SCOPE_ID = "__local_execution__"
+_LOCAL_CHECKPOINT_SCOPE_ID = "__local_checkpoint__"
+_SESSION_NAME_PATTERN = re.compile(r"\W+")
+
+
+class SandboxCapabilities(BaseModel):
+    """Feature flags exposed by a sandbox provider."""
+
+    supports_shell: bool
+    supports_filesystem: bool
+    supports_network: bool
+    supports_stateful_python: bool
+    supports_pause_resume: bool
+    supports_snapshots: bool
+
+
+class SandboxExecutionResult(BaseModel):
+    """Structured result returned from sandbox execution."""
+
+    call_name: str
+    provider: SandboxProviderKind
+    session_name: str
+    value: Any | None = None
+    stdout: str = ""
+    stderr: str = ""
+    duration_ms: float
+    stateful: bool = True
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class _SandboxBackendSession(Protocol):
+    """Provider-specific backend session interface."""
+
+    def run_code(
+        self,
+        code: str,
+        *,
+        inputs: Mapping[str, Any] | None = None,
+    ) -> SandboxExecutionResult: ...
+
+    def run_command(
+        self,
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> SandboxExecutionResult: ...
+
+    def dump(self) -> bytes | None: ...
+
+    def close(self) -> None: ...
+
+
+class _SandboxProvider(Protocol):
+    """Internal provider registry contract."""
+
+    def capabilities(self) -> SandboxCapabilities: ...
+
+    def open_session(
+        self,
+        *,
+        session_name: str,
+        scope: Literal["execution", "checkpoint"],
+        config: ResolvedSandboxConfig,
+        restored_snapshot: bytes | None = None,
+    ) -> _SandboxBackendSession: ...
+
+
+@dataclass
+class _SandboxSessionRecord:
+    """Internal tracked state for one session."""
+
+    scope: Literal["execution", "checkpoint"]
+    scope_id: str
+    session_name: str
+    backend: _SandboxBackendSession | None
+    status: Literal["active", "paused", "closed"]
+    call_index: int = 0
+    snapshot: bytes | None = None
+
+
+class SandboxSession:
+    """Public session handle used inside flows and checkpoints."""
+
+    def __init__(
+        self,
+        *,
+        manager: "_SandboxRuntimeManager",
+        name: str,
+        scope: Literal["execution", "checkpoint"],
+        scope_id: str,
+    ) -> None:
+        self.name = name
+        self.scope = scope
+        self._scope_id = scope_id
+        self._manager = manager
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        """Return the provider capability flags for this session."""
+        return self._manager.capabilities
+
+    def run_code(
+        self,
+        code: str,
+        *,
+        inputs: Mapping[str, Any] | None = None,
+        name: str | None = None,
+    ) -> SandboxExecutionResult:
+        """Execute Python code in the sandbox session."""
+        call_name = _normalize_call_name(name) or _next_llm_call_name("sandbox")
+        if _is_inside_checkpoint():
+            return self._manager.run_code(
+                scope=self.scope,
+                scope_id=self._scope_id,
+                session_name=self.name,
+                code=code,
+                inputs=inputs,
+                call_name=call_name,
+            )
+
+        request = _SandboxCodeRequest(
+            scope=self.scope,
+            scope_id=self._scope_id,
+            session_name=self.name,
+            code=code,
+            inputs=dict(inputs or {}),
+            call_name=call_name,
+        )
+        result = _sandbox_run_code_checkpoint_call(request)
+        if isinstance(result, SandboxExecutionResult):
+            return result
+
+        load = getattr(result, "load", None)
+        if callable(load):
+            result = load()
+
+        return SandboxExecutionResult.model_validate(result)
+
+    def run_command(
+        self,
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> SandboxExecutionResult:
+        """Execute a shell command in the sandbox session."""
+        return self._manager.run_command(
+            scope=self.scope,
+            scope_id=self._scope_id,
+            session_name=self.name,
+            command=command,
+            cwd=cwd,
+            env=env,
+        )
+
+    def pause(self) -> None:
+        """Pause this sandbox session."""
+        self._manager.pause_session(
+            scope=self.scope,
+            scope_id=self._scope_id,
+            session_name=self.name,
+        )
+
+    def resume(self) -> None:
+        """Resume this sandbox session if it is paused."""
+        self._manager.resume_session(
+            scope=self.scope,
+            scope_id=self._scope_id,
+            session_name=self.name,
+        )
+
+    def close(self) -> None:
+        """Close this sandbox session and mark the handle unusable."""
+        self._manager.close_session(
+            scope=self.scope,
+            scope_id=self._scope_id,
+            session_name=self.name,
+        )
+
+
+class _SandboxCodeRequest(BaseModel):
+    """Synthetic-checkpoint payload for flow-scope sandbox calls."""
+
+    scope: Literal["execution", "checkpoint"]
+    scope_id: str
+    session_name: str
+    code: str
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    call_name: str
+
+
+class _MontyBackendSession:
+    """Monty-backed stateful Python REPL session."""
+
+    def __init__(
+        self,
+        *,
+        session_name: str,
+        config: ResolvedSandboxConfig,
+        restored_snapshot: bytes | None = None,
+    ) -> None:
+        monty_module = _require_monty()
+        limits = {
+            "max_duration_secs": config.monty.max_duration_secs,
+            "max_memory_mb": config.monty.max_memory_mb,
+        }
+        self._session_name = session_name
+        self._config = config
+        self._repl: Any
+        if restored_snapshot is not None:
+            self._repl = monty_module.MontyRepl.load(restored_snapshot)
+        else:
+            self._repl = monty_module.MontyRepl(limits=limits)
+        self._runtime_error = monty_module.MontyRuntimeError
+        self._syntax_error = monty_module.MontySyntaxError
+        self._typing_error = monty_module.MontyTypingError
+
+    def run_code(
+        self,
+        code: str,
+        *,
+        inputs: Mapping[str, Any] | None = None,
+    ) -> SandboxExecutionResult:
+        stdout_chunks: list[str] = []
+        stderr_chunks: list[str] = []
+
+        def _print_callback(stream: str, chunk: str) -> None:
+            if stream == "stderr":
+                stderr_chunks.append(chunk)
+            else:
+                stdout_chunks.append(chunk)
+
+        started_at = time.perf_counter()
+        try:
+            value = self._repl.feed_run(
+                code,
+                inputs=dict(inputs) if inputs is not None else None,
+                print_callback=_print_callback,
+            )
+        except Exception as exc:
+            duration_ms = (time.perf_counter() - started_at) * 1000.0
+            display = _monty_error_display(exc)
+            error_message = display or str(exc)
+            if isinstance(
+                exc,
+                (
+                    self._runtime_error,
+                    self._syntax_error,
+                    self._typing_error,
+                ),
+            ):
+                raise KitaruSandboxExecutionError(error_message) from exc
+            raise KitaruSandboxProviderError(error_message) from exc
+
+        duration_ms = (time.perf_counter() - started_at) * 1000.0
+        return SandboxExecutionResult(
+            call_name="sandbox",
+            provider=SandboxProviderKind.MONTY,
+            session_name=self._session_name,
+            value=value,
+            stdout="".join(stdout_chunks),
+            stderr="".join(stderr_chunks),
+            duration_ms=duration_ms,
+            stateful=True,
+        )
+
+    def run_command(
+        self,
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> SandboxExecutionResult:
+        del cwd, env
+        raise KitaruSandboxCapabilityError(
+            "The Monty sandbox provider supports Python code execution only. "
+            f"It cannot run shell commands like {command!r}."
+        )
+
+    def dump(self) -> bytes | None:
+        """Serialize the in-memory REPL state."""
+        try:
+            return cast(bytes, self._repl.dump())
+        except Exception as exc:
+            raise KitaruSandboxProviderError(
+                f"Failed to snapshot Monty sandbox state: {exc}"
+            ) from exc
+
+    def close(self) -> None:
+        """Close the session handle."""
+        self._repl = None
+
+
+class _MontyProvider:
+    """Internal Monty provider entrypoint."""
+
+    def capabilities(self) -> SandboxCapabilities:
+        return SandboxCapabilities(
+            supports_shell=False,
+            supports_filesystem=False,
+            supports_network=False,
+            supports_stateful_python=True,
+            supports_pause_resume=True,
+            supports_snapshots=True,
+        )
+
+    def open_session(
+        self,
+        *,
+        session_name: str,
+        scope: Literal["execution", "checkpoint"],
+        config: ResolvedSandboxConfig,
+        restored_snapshot: bytes | None = None,
+    ) -> _SandboxBackendSession:
+        del scope
+        return _MontyBackendSession(
+            session_name=session_name,
+            config=config,
+            restored_snapshot=restored_snapshot,
+        )
+
+
+_PROVIDER_REGISTRY: dict[SandboxProviderKind, _SandboxProvider] = {
+    SandboxProviderKind.MONTY: _MontyProvider(),
+}
+
+
+class _SandboxRuntimeManager:
+    """Owns live sandbox sessions for the current flow execution."""
+
+    def __init__(
+        self,
+        config: ResolvedSandboxConfig,
+        execution_id: str | None,
+    ) -> None:
+        self._config = config
+        self._execution_id = execution_id
+        self._provider = _provider_for_config(config)
+        self._records: dict[tuple[str, str, str], _SandboxSessionRecord] = {}
+
+    @property
+    def capabilities(self) -> SandboxCapabilities:
+        return self._provider.capabilities()
+
+    def open_session_handle(
+        self,
+        *,
+        name: str,
+        scope: Literal["execution", "checkpoint"],
+        scope_id: str,
+    ) -> SandboxSession:
+        self._ensure_record(scope=scope, scope_id=scope_id, session_name=name)
+        return SandboxSession(
+            manager=self,
+            name=name,
+            scope=scope,
+            scope_id=scope_id,
+        )
+
+    def run_code(
+        self,
+        *,
+        scope: Literal["execution", "checkpoint"],
+        scope_id: str,
+        session_name: str,
+        code: str,
+        inputs: Mapping[str, Any] | None,
+        call_name: str | None,
+    ) -> SandboxExecutionResult:
+        record = self._ensure_record(
+            scope=scope,
+            scope_id=scope_id,
+            session_name=session_name,
+        )
+        if record.status == "paused":
+            self._restore_record(record)
+        if record.status == "closed":
+            raise KitaruSandboxSessionError(
+                f"Sandbox session {session_name!r} is closed."
+            )
+        if record.backend is None:
+            raise KitaruSandboxSessionError(
+                f"Sandbox session {session_name!r} is not available."
+            )
+
+        record.call_index += 1
+        resolved_call_name = call_name or _next_llm_call_name("sandbox")
+        input_artifact = _save_with_fallback(
+            f"{session_name}_{resolved_call_name}_input",
+            {"code": code, "inputs": dict(inputs or {})},
+            artifact_type="input",
+        )
+        try:
+            result = record.backend.run_code(code, inputs=inputs)
+            result.call_name = resolved_call_name
+            summary = {
+                "provider": self._config.provider,
+                "session_name": session_name,
+                "scope": scope,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "duration_ms": result.duration_ms,
+                "stateful": result.stateful,
+                "status": "completed",
+                "input_artifact": input_artifact,
+            }
+            if result.value is not None:
+                _save_with_fallback(
+                    f"{session_name}_{resolved_call_name}_value",
+                    result.value,
+                    artifact_type="output",
+                )
+            _save_with_fallback(
+                f"{session_name}_{resolved_call_name}_summary",
+                summary,
+                artifact_type="blob",
+            )
+            log(
+                sandbox_calls={
+                    resolved_call_name: {
+                        "provider": self._config.provider,
+                        "session_name": session_name,
+                        "scope": scope,
+                        "duration_ms": result.duration_ms,
+                        "status": "completed",
+                        "stdout_chars": len(result.stdout),
+                        "stderr_chars": len(result.stderr),
+                    }
+                }
+            )
+            self._persist_record(record)
+            return result
+        except Exception as exc:
+            summary = {
+                "provider": self._config.provider,
+                "session_name": session_name,
+                "scope": scope,
+                "stdout": "",
+                "stderr": str(exc),
+                "duration_ms": None,
+                "stateful": True,
+                "status": "failed",
+                "input_artifact": input_artifact,
+            }
+            _save_with_fallback(
+                f"{session_name}_{resolved_call_name}_summary",
+                summary,
+                artifact_type="blob",
+            )
+            log(
+                sandbox_calls={
+                    resolved_call_name: {
+                        "provider": self._config.provider,
+                        "session_name": session_name,
+                        "scope": scope,
+                        "duration_ms": None,
+                        "status": "failed",
+                        "stdout_chars": 0,
+                        "stderr_chars": len(str(exc)),
+                    }
+                }
+            )
+            raise
+
+    def run_command(
+        self,
+        *,
+        scope: Literal["execution", "checkpoint"],
+        scope_id: str,
+        session_name: str,
+        command: str,
+        cwd: str | None,
+        env: Mapping[str, str] | None,
+    ) -> SandboxExecutionResult:
+        record = self._ensure_record(
+            scope=scope,
+            scope_id=scope_id,
+            session_name=session_name,
+        )
+        if record.backend is None:
+            raise KitaruSandboxSessionError(
+                f"Sandbox session {session_name!r} is not available."
+            )
+        return record.backend.run_command(command, cwd=cwd, env=env)
+
+    def pause_session(
+        self,
+        *,
+        scope: Literal["execution", "checkpoint"],
+        scope_id: str,
+        session_name: str,
+    ) -> None:
+        record = self._ensure_record(
+            scope=scope,
+            scope_id=scope_id,
+            session_name=session_name,
+        )
+        self._pause_record(record)
+
+    def resume_session(
+        self,
+        *,
+        scope: Literal["execution", "checkpoint"],
+        scope_id: str,
+        session_name: str,
+    ) -> None:
+        record = self._ensure_record(
+            scope=scope,
+            scope_id=scope_id,
+            session_name=session_name,
+        )
+        self._restore_record(record)
+
+    def close_session(
+        self,
+        *,
+        scope: Literal["execution", "checkpoint"],
+        scope_id: str,
+        session_name: str,
+    ) -> None:
+        record = self._ensure_record(
+            scope=scope,
+            scope_id=scope_id,
+            session_name=session_name,
+        )
+        self._close_record(record)
+
+    def close_checkpoint_scope(self, checkpoint_id: str | None) -> None:
+        resolved_checkpoint_id = checkpoint_id or _LOCAL_CHECKPOINT_SCOPE_ID
+        for key, record in list(self._records.items()):
+            if (
+                record.scope == "checkpoint"
+                and record.scope_id == resolved_checkpoint_id
+            ):
+                self._close_record(record)
+                self._records.pop(key, None)
+
+    def close_execution_scope(self, execution_id: str | None) -> None:
+        resolved_execution_id = execution_id or _LOCAL_EXECUTION_SCOPE_ID
+        for key, record in list(self._records.items()):
+            if record.scope == "execution" and record.scope_id == resolved_execution_id:
+                self._close_record(record)
+                self._records.pop(key, None)
+
+    def before_wait(self, execution_id: str | None) -> None:
+        resolved_execution_id = execution_id or _LOCAL_EXECUTION_SCOPE_ID
+        for record in self._records.values():
+            if record.scope == "execution" and record.scope_id == resolved_execution_id:
+                self._pause_record(record)
+
+    def after_wait(self, execution_id: str | None) -> None:
+        resolved_execution_id = execution_id or _LOCAL_EXECUTION_SCOPE_ID
+        for record in self._records.values():
+            if record.scope == "execution" and record.scope_id == resolved_execution_id:
+                self._restore_record(record)
+
+    def _record_key(
+        self,
+        *,
+        scope: Literal["execution", "checkpoint"],
+        scope_id: str,
+        session_name: str,
+    ) -> tuple[str, str, str]:
+        return scope, scope_id, session_name
+
+    def _ensure_record(
+        self,
+        *,
+        scope: Literal["execution", "checkpoint"],
+        scope_id: str,
+        session_name: str,
+    ) -> _SandboxSessionRecord:
+        key = self._record_key(
+            scope=scope,
+            scope_id=scope_id,
+            session_name=session_name,
+        )
+        record = self._records.get(key)
+        if record is not None:
+            if record.status == "closed":
+                raise KitaruSandboxSessionError(
+                    f"Sandbox session {session_name!r} is closed."
+                )
+            return record
+
+        restored_snapshot: bytes | None = None
+        call_index = 0
+        if scope == "execution":
+            persisted = self._load_persisted_session_state(session_name)
+            if persisted is not None:
+                restored_snapshot = _decode_snapshot(persisted.get("snapshot"))
+                call_index = int(persisted.get("call_index") or 0)
+
+        backend = self._provider.open_session(
+            session_name=session_name,
+            scope=scope,
+            config=self._config,
+            restored_snapshot=restored_snapshot,
+        )
+        record = _SandboxSessionRecord(
+            scope=scope,
+            scope_id=scope_id,
+            session_name=session_name,
+            backend=backend,
+            status="active",
+            call_index=call_index,
+        )
+        self._records[key] = record
+        self._persist_record(record)
+        return record
+
+    def _pause_record(self, record: _SandboxSessionRecord) -> None:
+        if record.status == "closed" or record.status == "paused":
+            return
+        if record.backend is not None:
+            record.snapshot = record.backend.dump()
+            record.backend.close()
+            record.backend = None
+        record.status = "paused"
+        self._persist_record(record)
+
+    def _restore_record(self, record: _SandboxSessionRecord) -> None:
+        if record.status == "closed":
+            raise KitaruSandboxSessionError(
+                f"Sandbox session {record.session_name!r} is closed."
+            )
+        if record.status == "active":
+            return
+        if record.snapshot is None and record.scope == "execution":
+            persisted = self._load_persisted_session_state(record.session_name)
+            if persisted is not None:
+                record.snapshot = _decode_snapshot(persisted.get("snapshot"))
+                record.call_index = int(
+                    persisted.get("call_index") or record.call_index
+                )
+        record.backend = self._provider.open_session(
+            session_name=record.session_name,
+            scope=record.scope,
+            config=self._config,
+            restored_snapshot=record.snapshot,
+        )
+        record.snapshot = None
+        record.status = "active"
+        self._persist_record(record)
+
+    def _close_record(self, record: _SandboxSessionRecord) -> None:
+        if record.status == "closed":
+            return
+        if record.backend is not None:
+            record.backend.close()
+        record.backend = None
+        record.snapshot = None
+        record.status = "closed"
+        self._persist_record(record)
+
+    def _load_persisted_session_state(self, session_name: str) -> dict[str, Any] | None:
+        state = _load_execution_state(self._execution_id)
+        sessions = state.get("sessions", {})
+        raw_session = sessions.get(session_name)
+        if isinstance(raw_session, dict):
+            return raw_session
+        return None
+
+    def _persist_record(self, record: _SandboxSessionRecord) -> None:
+        if record.scope != "execution":
+            return
+        state = _load_execution_state(self._execution_id)
+        sessions = dict(state.get("sessions", {}))
+        sessions[record.session_name] = {
+            "provider": self._config.provider,
+            "status": record.status,
+            "scope": record.scope,
+            "call_index": record.call_index,
+            "encoding": "zlib+base64",
+            "snapshot": _encode_snapshot(record.snapshot),
+        }
+        state["version"] = 1
+        state["sessions"] = sessions
+        _persist_execution_state(self._execution_id, state)
+
+
+@checkpoint(type="sandbox_call")
+def _sandbox_run_code_checkpoint_call(
+    request: _SandboxCodeRequest,
+) -> dict[str, Any]:
+    """Execute a flow-scope sandbox call inside a synthetic checkpoint."""
+    manager = _require_runtime_manager()
+    return manager.run_code(
+        scope=request.scope,
+        scope_id=request.scope_id,
+        session_name=request.session_name,
+        code=request.code,
+        inputs=request.inputs,
+        call_name=request.call_name,
+    ).model_dump(mode="json")
+
+
+def _require_monty() -> Any:
+    """Import the optional Monty dependency with a helpful install hint."""
+    try:
+        import pydantic_monty
+
+        return pydantic_monty
+    except ImportError as exc:
+        raise KitaruFeatureNotAvailableError(
+            "Monty sandbox support requires the optional sandbox dependency. "
+            "Install it with `uv sync --extra sandbox`."
+        ) from exc
+
+
+def _provider_for_config(config: ResolvedSandboxConfig) -> _SandboxProvider:
+    """Resolve the registered provider implementation for a config."""
+    provider = _PROVIDER_REGISTRY.get(config.provider)
+    if provider is None:
+        raise KitaruSandboxProviderError(
+            f"No sandbox provider is registered for {config.provider.value!r}."
+        )
+    return provider
+
+
+def _ensure_runtime_manager() -> _SandboxRuntimeManager:
+    """Return the active runtime sandbox manager, creating it lazily."""
+    existing = _get_current_sandbox_manager()
+    if existing is not None:
+        return cast(_SandboxRuntimeManager, existing)
+    config = _get_current_sandbox_config()
+    if config is None:
+        raise KitaruSandboxNotConfiguredError(
+            "No sandbox provider is configured for this flow execution. Configure "
+            "one with `kitaru.configure(sandbox=...)`, `KITARU_SANDBOX`, or "
+            "`kitaru sandbox set ...`."
+        )
+    manager = _SandboxRuntimeManager(config, _get_current_execution_id())
+    _set_current_sandbox_manager(manager)
+    return manager
+
+
+def _require_runtime_manager() -> _SandboxRuntimeManager:
+    """Return the active runtime manager or raise a clear context error."""
+    if not _is_inside_flow():
+        raise KitaruContextError("sandbox() can only run inside a @flow.")
+    return _ensure_runtime_manager()
+
+
+def _normalize_session_name(name: str | None) -> str:
+    """Normalize user-provided session names into stable identifiers."""
+    candidate = "sandbox" if name is None else name.strip()
+    if not candidate:
+        raise KitaruSandboxSessionError("Sandbox session name cannot be empty.")
+    normalized = _SESSION_NAME_PATTERN.sub("_", candidate).strip("_")
+    if not normalized:
+        raise KitaruSandboxSessionError("Sandbox session name cannot be empty.")
+    return normalized
+
+
+def _normalize_call_name(name: str | None) -> str | None:
+    """Normalize an optional sandbox call name."""
+    if name is None:
+        return None
+    candidate = name.strip()
+    if not candidate:
+        raise KitaruSandboxSessionError("Sandbox call name cannot be empty.")
+    normalized = _SESSION_NAME_PATTERN.sub("_", candidate).strip("_")
+    if not normalized:
+        raise KitaruSandboxSessionError("Sandbox call name cannot be empty.")
+    return normalized
+
+
+def _save_with_fallback(name: str, value: Any, *, artifact_type: str) -> str:
+    """Persist an artifact, falling back to repr when serialization fails."""
+    try:
+        save(name, value, type=artifact_type)
+        return name
+    except Exception:
+        fallback_name = f"{name}_repr"
+        save(fallback_name, repr(value), type="blob")
+        return fallback_name
+
+
+def _monty_error_display(error: Exception) -> str | None:
+    """Render a Monty exception into human-readable text when possible."""
+    display = getattr(error, "display", None)
+    if not callable(display):
+        return None
+    for args in [(), ("traceback",), ("full",), ("msg",)]:
+        try:
+            rendered = display(*args)
+        except Exception:
+            continue
+        if isinstance(rendered, str) and rendered.strip():
+            return rendered
+    return None
+
+
+def _encode_snapshot(snapshot: bytes | None) -> str:
+    """Compress and encode a snapshot for metadata storage."""
+    if snapshot is None:
+        return ""
+    compressed = zlib.compress(snapshot)
+    return base64.b64encode(compressed).decode("ascii")
+
+
+def _decode_snapshot(snapshot: Any) -> bytes | None:
+    """Decode a snapshot from metadata storage."""
+    if not isinstance(snapshot, str) or not snapshot:
+        return None
+    try:
+        compressed = base64.b64decode(snapshot.encode("ascii"))
+        return zlib.decompress(compressed)
+    except Exception as exc:
+        raise KitaruSandboxSessionError(
+            "Stored sandbox snapshot could not be restored."
+        ) from exc
+
+
+def _load_execution_state(execution_id: str | None) -> dict[str, Any]:
+    """Load persisted execution-scoped sandbox state from run metadata."""
+    if execution_id is None:
+        return {"version": 1, "sessions": {}}
+    try:
+        run = Client().get_pipeline_run(
+            name_id_or_prefix=execution_id,
+            allow_name_prefix_match=False,
+            hydrate=True,
+        )
+    except Exception:
+        return {"version": 1, "sessions": {}}
+    metadata = getattr(run, "run_metadata", {}) or {}
+    state = metadata.get(_SANDBOX_STATE_METADATA_KEY)
+    if isinstance(state, dict):
+        return {
+            "version": state.get("version", 1),
+            "sessions": dict(state.get("sessions", {})),
+        }
+    return {"version": 1, "sessions": {}}
+
+
+def _persist_execution_state(execution_id: str | None, state: dict[str, Any]) -> None:
+    """Persist execution-scoped sandbox state to pipeline-run metadata."""
+    if execution_id is None:
+        return
+    try:
+        run_uuid = UUID(str(execution_id))
+    except ValueError:
+        return
+    Client().create_run_metadata(
+        metadata={_SANDBOX_STATE_METADATA_KEY: state},
+        resources=[
+            RunMetadataResource(
+                id=run_uuid,
+                type=MetadataResourceTypes.PIPELINE_RUN,
+            )
+        ],
+    )
+
+
+def sandbox(*, name: str | None = None) -> SandboxSession:
+    """Return a stateful sandbox session for the current flow/checkpoint."""
+    if not _is_inside_flow():
+        raise KitaruContextError("sandbox() can only run inside a @flow.")
+    manager = _ensure_runtime_manager()
+    normalized_name = _normalize_session_name(name)
+    if _is_inside_checkpoint():
+        checkpoint_scope = _get_current_checkpoint()
+        scope = "checkpoint"
+        scope_id = (
+            checkpoint_scope.checkpoint_id
+            if (
+                checkpoint_scope is not None
+                and checkpoint_scope.checkpoint_id is not None
+            )
+            else _LOCAL_CHECKPOINT_SCOPE_ID
+        )
+    else:
+        flow_scope = _get_current_flow()
+        scope = "execution"
+        scope_id = (
+            flow_scope.execution_id
+            if flow_scope is not None and flow_scope.execution_id is not None
+            else _LOCAL_EXECUTION_SCOPE_ID
+        )
+    return manager.open_session_handle(
+        name=normalized_name,
+        scope=scope,
+        scope_id=scope_id,
+    )
+
+
+def run_sandbox_smoke_test(config: ResolvedSandboxConfig) -> None:
+    """Run a minimal provider smoke test outside flow runtime context."""
+    provider = _provider_for_config(config)
+    backend = provider.open_session(
+        session_name="sandbox_test",
+        scope="execution",
+        config=config,
+    )
+    try:
+        backend.run_code("counter = 40")
+        snapshot = backend.dump()
+        backend.close()
+        backend = provider.open_session(
+            session_name="sandbox_test",
+            scope="execution",
+            config=config,
+            restored_snapshot=snapshot,
+        )
+        result = backend.run_code("counter + 2")
+        if result.value != 42:
+            raise KitaruSandboxProviderError(
+                f"Sandbox smoke test expected `42` after resume, got {result.value!r}."
+            )
+    finally:
+        backend.close()
+
+
+__all__ = [
+    "SandboxCapabilities",
+    "SandboxExecutionResult",
+    "SandboxSession",
+    "sandbox",
+]

--- a/src/kitaru/wait.py
+++ b/src/kitaru/wait.py
@@ -17,7 +17,12 @@ from kitaru.errors import (
     KitaruContextError,
     KitaruFeatureNotAvailableError,
 )
-from kitaru.runtime import _is_inside_checkpoint, _is_inside_flow
+from kitaru.runtime import (
+    _is_inside_checkpoint,
+    _is_inside_flow,
+    _sandbox_after_wait,
+    _sandbox_before_wait,
+)
 
 _WAIT_OUTSIDE_FLOW_ERROR = "wait() can only run inside a @flow."
 _WAIT_INSIDE_CHECKPOINT_ERROR = (
@@ -82,11 +87,17 @@ def wait(
 
     resolved_timeout = _DEFAULT_WAIT_TIMEOUT_SECONDS if timeout is None else timeout
     zenml_wait = _resolve_zenml_wait()
-    resolved_value, _ = zenml_wait(
-        schema=schema,
-        question=question,
-        timeout=resolved_timeout,
-        metadata=metadata,
-        key_prefix=name,
-    )
+    _sandbox_before_wait()
+    try:
+        resolved_value, _ = zenml_wait(
+            schema=schema,
+            question=question,
+            timeout=resolved_timeout,
+            metadata=metadata,
+            key_prefix=name,
+        )
+    except Exception:
+        _sandbox_after_wait()
+        raise
+    _sandbox_after_wait()
     return resolved_value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from zenml.constants import (
 )
 
 from kitaru.config import (
+    _KITARU_RESOLVED_SANDBOX_ENV,
     KITARU_AUTH_TOKEN_ENV,
     KITARU_CACHE_ENV,
     KITARU_IMAGE_ENV,
@@ -29,6 +30,7 @@ from kitaru.config import (
     KITARU_LOG_STORE_ENDPOINT_ENV,
     KITARU_PROJECT_ENV,
     KITARU_RETRIES_ENV,
+    KITARU_SANDBOX_ENV,
     KITARU_SERVER_URL_ENV,
     KITARU_STACK_ENV,
     _reset_runtime_configuration,
@@ -71,9 +73,11 @@ def isolated_zenml_global_config(
         KITARU_CACHE_ENV,
         KITARU_RETRIES_ENV,
         KITARU_IMAGE_ENV,
+        KITARU_SANDBOX_ENV,
         KITARU_SERVER_URL_ENV,
         KITARU_AUTH_TOKEN_ENV,
         KITARU_PROJECT_ENV,
+        _KITARU_RESOLVED_SANDBOX_ENV,
     ):
         monkeypatch.delenv(env_name, raising=False)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,7 @@ def test_help_flag_lists_available_commands(
         "model",
         "executions",
         "run",
+        "sandbox",
     ):
         assert command in output
 
@@ -1194,6 +1195,110 @@ def test_log_store_reset_reports_environment_override(
     output = capsys.readouterr().out
     assert "Cleared global log-store override." in output
     assert "Effective backend: datadog (from environment settings)" in output
+
+
+def test_sandbox_set_persists_config(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`kitaru sandbox set monty` should persist the global sandbox config."""
+    with (
+        patch("kitaru.cli.set_global_sandbox_config") as mock_set,
+        patch("kitaru.cli.resolve_sandbox_config") as mock_resolve,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        mock_set.return_value = SimpleNamespace(provider=SimpleNamespace(value="monty"))
+        mock_resolve.return_value = SimpleNamespace(
+            provider=SimpleNamespace(value="monty"),
+            monty=SimpleNamespace(
+                max_duration_secs=2.0,
+                max_memory_mb=128,
+                type_check=False,
+            ),
+        )
+        app(
+            [
+                "sandbox",
+                "set",
+                "monty",
+                "--max-duration-secs",
+                "2",
+                "--max-memory-mb",
+                "128",
+                "--type-check=false",
+            ]
+        )
+
+    assert exc_info.value.code == 0
+    mock_set.assert_called_once()
+    output = capsys.readouterr().out
+    assert "Saved sandbox configuration." in output
+    assert "Provider: monty" in output
+
+
+def test_sandbox_show_renders_snapshot(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`kitaru sandbox show` should print the resolved sandbox config."""
+    with (
+        patch("kitaru.cli.resolve_sandbox_config") as mock_resolve,
+        patch("kitaru.cli.importlib.import_module") as mock_import_module,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        mock_resolve.return_value = SimpleNamespace(
+            provider=SimpleNamespace(value="monty"),
+            monty=SimpleNamespace(
+                max_duration_secs=1.0,
+                max_memory_mb=64,
+                type_check=True,
+            ),
+        )
+        mock_import_module.return_value = object()
+        app(["sandbox", "show"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "Kitaru sandbox" in output
+    assert "Provider: monty" in output
+    assert "SDK installed: yes" in output
+
+
+def test_sandbox_reset_clears_override(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`kitaru sandbox reset` should clear persisted sandbox config."""
+    with (
+        patch("kitaru.cli.reset_global_sandbox_config") as mock_reset,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["sandbox", "reset"])
+
+    assert exc_info.value.code == 0
+    mock_reset.assert_called_once_with()
+    assert "Cleared sandbox configuration." in capsys.readouterr().out
+
+
+def test_sandbox_test_runs_smoke_check(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`kitaru sandbox test` should run the provider smoke test."""
+    with (
+        patch("kitaru.cli.resolve_sandbox_config") as mock_resolve,
+        patch("kitaru.cli.run_sandbox_smoke_test") as mock_smoke_test,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        mock_resolve.return_value = SimpleNamespace(
+            provider=SimpleNamespace(value="monty"),
+            monty=SimpleNamespace(
+                max_duration_secs=1.0,
+                max_memory_mb=64,
+                type_check=True,
+            ),
+        )
+        app(["sandbox", "test"])
+
+    assert exc_info.value.code == 0
+    mock_smoke_test.assert_called_once()
+    assert "Sandbox test passed." in capsys.readouterr().out
 
 
 def test_log_store_set_surfaces_validation_errors(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,27 +19,37 @@ from kitaru.config import (
     KITARU_LOG_STORE_ENDPOINT_ENV,
     KITARU_PROJECT_ENV,
     KITARU_RETRIES_ENV,
+    KITARU_SANDBOX_ENV,
     KITARU_SERVER_URL_ENV,
     KITARU_STACK_ENV,
     FrozenExecutionSpec,
     ImageSettings,
     KitaruConfig,
+    MontySandboxSettings,
     ResolvedConnectionConfig,
     ResolvedExecutionConfig,
+    ResolvedMontySandboxSettings,
+    ResolvedSandboxConfig,
+    SandboxConfig,
+    SandboxProviderKind,
     build_frozen_execution_spec,
     configure,
     current_stack,
+    get_global_sandbox_config,
     image_settings_to_docker_settings,
     list_model_aliases,
     list_stacks,
     persist_frozen_execution_spec,
     register_model_alias,
     reset_global_log_store,
+    reset_global_sandbox_config,
     resolve_connection_config,
     resolve_execution_config,
     resolve_log_store,
     resolve_model_selection,
+    resolve_sandbox_config,
     set_global_log_store,
+    set_global_sandbox_config,
     use_stack,
 )
 
@@ -447,6 +457,113 @@ def test_configure_project_independent_of_execution() -> None:
     assert exec_resolved.stack == "gpu-prod"
     assert exec_resolved.cache is False
     assert conn_resolved.project == "staging-project"
+
+
+def test_set_sandbox_persists_global_override() -> None:
+    """Sandbox settings should persist to Kitaru global config."""
+    snapshot = set_global_sandbox_config(
+        {
+            "provider": "monty",
+            "monty": {
+                "max_duration_secs": 2.5,
+                "max_memory_mb": 128,
+                "type_check": False,
+            },
+        }
+    )
+
+    assert snapshot.provider == SandboxProviderKind.MONTY
+    assert snapshot.monty is not None
+    assert snapshot.monty.max_duration_secs == 2.5
+    persisted = yaml_utils.read_yaml(str(_kitaru_config_path()))
+    assert persisted["sandbox"]["provider"] == "monty"
+    assert persisted["sandbox"]["monty"]["max_memory_mb"] == 128
+
+
+def test_reset_sandbox_clears_persisted_override() -> None:
+    """Reset should remove the persisted sandbox config."""
+    set_global_sandbox_config("monty")
+
+    reset_global_sandbox_config()
+
+    assert get_global_sandbox_config() is None
+
+
+def test_configure_sets_runtime_sandbox_defaults() -> None:
+    """configure should accept sandbox overrides in the execution layer."""
+    snapshot = configure(
+        sandbox={
+            "provider": "monty",
+            "monty": {"max_duration_secs": 3.0, "max_memory_mb": 96},
+        }
+    )
+
+    assert snapshot.sandbox is not None
+    assert snapshot.sandbox.provider == SandboxProviderKind.MONTY
+    assert snapshot.sandbox.monty is not None
+    assert snapshot.sandbox.monty.max_duration_secs == 3.0
+
+
+def test_resolve_execution_config_supports_sandbox_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """KITARU_SANDBOX should accept both simple and structured values."""
+    monkeypatch.setenv(
+        KITARU_SANDBOX_ENV,
+        '{"provider":"monty","monty":{"max_memory_mb":128}}',
+    )
+
+    resolved = resolve_execution_config()
+
+    assert resolved.sandbox == ResolvedSandboxConfig(
+        provider=SandboxProviderKind.MONTY,
+        monty=ResolvedMontySandboxSettings(
+            max_duration_secs=1.0,
+            max_memory_mb=128,
+            type_check=True,
+        ),
+    )
+
+
+def test_resolve_sandbox_config_follows_execution_precedence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sandbox settings should merge across config layers just like image settings."""
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text(
+        """
+[tool.kitaru.sandbox]
+provider = "monty"
+
+[tool.kitaru.sandbox.monty]
+max_duration_secs = 4.0
+max_memory_mb = 64
+type_check = false
+""".strip()
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(KITARU_SANDBOX_ENV, '{"monty":{"max_memory_mb":256}}')
+    configure(sandbox={"monty": {"type_check": True}})
+
+    resolved = resolve_sandbox_config(
+        decorator_overrides=KitaruConfig(
+            sandbox=SandboxConfig(monty=MontySandboxSettings(max_duration_secs=8.0))
+        ),
+        invocation_overrides=KitaruConfig(
+            sandbox=SandboxConfig(monty=MontySandboxSettings(max_memory_mb=512))
+        ),
+        start_dir=tmp_path,
+    )
+
+    assert resolved == ResolvedSandboxConfig(
+        provider=SandboxProviderKind.MONTY,
+        monty=ResolvedMontySandboxSettings(
+            max_duration_secs=8.0,
+            max_memory_mb=512,
+            type_check=True,
+        ),
+    )
 
 
 def test_global_connection_config_does_not_infer_project() -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -13,7 +13,13 @@ from zenml.config.docker_settings import DockerSettings
 from zenml.enums import ExecutionStatus
 from zenml.models import PipelineRunResponse
 
-from kitaru.config import ResolvedExecutionConfig
+from kitaru.config import (
+    _KITARU_RESOLVED_SANDBOX_ENV,
+    ResolvedExecutionConfig,
+    ResolvedMontySandboxSettings,
+    ResolvedSandboxConfig,
+    SandboxProviderKind,
+)
 from kitaru.errors import (
     FailureOrigin,
     KitaruStateError,
@@ -32,12 +38,14 @@ def _as_pipeline_run(run: _DummyRun) -> PipelineRunResponse:
 def _resolved_execution(
     *,
     stack: str | None = None,
+    sandbox: ResolvedSandboxConfig | None = None,
     cache: bool = True,
     retries: int = 0,
 ) -> ResolvedExecutionConfig:
     return ResolvedExecutionConfig(
         stack=stack,
         image=None,
+        sandbox=sandbox,
         cache=cache,
         retries=retries,
     )
@@ -308,6 +316,79 @@ def test_run_resolves_config_and_persists_frozen_spec() -> None:
         frozen_execution_spec=frozen_spec,
     )
     configured_pipeline.assert_called_once_with("payload")
+
+
+def test_run_injects_resolved_sandbox_config_into_docker_settings() -> None:
+    """Flow submission should propagate resolved sandbox config into env settings."""
+    run = _DummyRun(status=ExecutionStatus.RUNNING)
+    configured_pipeline = MagicMock(return_value=run)
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+    sandbox_config = ResolvedSandboxConfig(
+        provider=SandboxProviderKind.MONTY,
+        monty=ResolvedMontySandboxSettings(
+            max_duration_secs=2.0,
+            max_memory_mb=128,
+            type_check=False,
+        ),
+    )
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(sandbox=sandbox_config),
+        ),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.persist_frozen_execution_spec"),
+    ):
+        wrapped = flow(lambda: None)
+        wrapped.run()
+
+    docker_settings = base_pipeline.with_options.call_args.kwargs["settings"]["docker"]
+    assert docker_settings.environment is not None
+    assert _KITARU_RESOLVED_SANDBOX_ENV in docker_settings.environment
+    assert (
+        '"provider":"monty"'
+        in docker_settings.environment[_KITARU_RESOLVED_SANDBOX_ENV]
+    )
+
+
+def test_run_wraps_submission_with_runtime_sandbox_context() -> None:
+    """Flow submission should install resolved sandbox config in runtime context."""
+    run = _DummyRun(status=ExecutionStatus.RUNNING)
+    configured_pipeline = MagicMock(return_value=run)
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+    sandbox_config = ResolvedSandboxConfig(
+        provider=SandboxProviderKind.MONTY,
+        monty=ResolvedMontySandboxSettings(
+            max_duration_secs=1.0,
+            max_memory_mb=64,
+            type_check=True,
+        ),
+    )
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(sandbox=sandbox_config),
+        ),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch("kitaru.flow._submission_sandbox_config") as submission_sandbox_config,
+    ):
+        submission_sandbox_config.return_value.__enter__.return_value = None
+        submission_sandbox_config.return_value.__exit__.return_value = None
+        wrapped = flow(lambda: None)
+        wrapped.run()
+
+    submission_sandbox_config.assert_called_once_with(sandbox_config)
 
 
 def test_replay_submits_pipeline_replay_and_persists_frozen_spec() -> None:

--- a/tests/test_generate_cli_docs.py
+++ b/tests/test_generate_cli_docs.py
@@ -49,6 +49,7 @@ class TestBuildCommandTree:
             "logout",
             "model",
             "run",
+            "sandbox",
             "secrets",
             "stack",
             "status",
@@ -215,6 +216,7 @@ class TestWriteDocsTree:
             "logout",
             "model",
             "run",
+            "sandbox",
             "secrets",
             "stack",
             "status",
@@ -244,8 +246,16 @@ class TestWriteDocsTree:
             assert not (output_dir / command / "index.mdx").exists()
             assert not (output_dir / command / "meta.json").exists()
 
-        # executions, log-store, model, secrets, and stack have nested subcommands.
-        for command in ("executions", "log-store", "model", "secrets", "stack"):
+        # executions, log-store, model, sandbox, secrets, and stack
+        # have nested subcommands.
+        for command in (
+            "executions",
+            "log-store",
+            "model",
+            "sandbox",
+            "secrets",
+            "stack",
+        ):
             assert (output_dir / command / "index.mdx").exists()
             assert (output_dir / command / "meta.json").exists()
 
@@ -269,6 +279,10 @@ class TestWriteDocsTree:
         for command in ("list", "register"):
             assert (output_dir / "model" / f"{command}.mdx").exists()
             assert f"model/{command}.mdx" in files
+
+        for command in ("reset", "set", "show", "test"):
+            assert (output_dir / "sandbox" / f"{command}.mdx").exists()
+            assert f"sandbox/{command}.mdx" in files
 
         for command in ("delete", "list", "set", "show"):
             assert (output_dir / "secrets" / f"{command}.mdx").exists()

--- a/tests/test_kitaru.py
+++ b/tests/test_kitaru.py
@@ -55,6 +55,9 @@ class TestPublicExports:
     def test_kitaru_client_exists(self) -> None:
         assert hasattr(kitaru, "KitaruClient")
 
+    def test_sandbox_exists(self) -> None:
+        assert hasattr(kitaru, "sandbox")
+
     def test_all_exports_match(self) -> None:
         expected = {
             "FailureOrigin",
@@ -69,10 +72,20 @@ class TestPublicExports:
             "KitaruExecutionError",
             "KitaruFeatureNotAvailableError",
             "KitaruRuntimeError",
+            "KitaruSandboxCapabilityError",
+            "KitaruSandboxConfigurationError",
+            "KitaruSandboxError",
+            "KitaruSandboxExecutionError",
+            "KitaruSandboxNotConfiguredError",
+            "KitaruSandboxProviderError",
+            "KitaruSandboxSessionError",
             "KitaruStateError",
             "KitaruUsageError",
             "KitaruUserCodeError",
             "KitaruWaitValidationError",
+            "SandboxCapabilities",
+            "SandboxExecutionResult",
+            "SandboxSession",
             "StackInfo",
             "checkpoint",
             "configure",
@@ -84,6 +97,7 @@ class TestPublicExports:
             "load",
             "log",
             "save",
+            "sandbox",
             "use_stack",
             "wait",
         }

--- a/tests/test_phase20_sandbox_example.py
+++ b/tests/test_phase20_sandbox_example.py
@@ -1,0 +1,29 @@
+"""Integration test for the Phase 20 Monty sandbox example workflow."""
+
+from __future__ import annotations
+
+import pytest
+from examples.monty_sandbox import run_workflow
+
+from kitaru.errors import KitaruFeatureNotAvailableError
+from kitaru.wait import _resolve_zenml_wait
+
+
+def test_phase20_sandbox_example_runs_end_to_end() -> None:
+    """Verify sandbox state survives a wait/resume boundary in the example."""
+    pytest.importorskip("pydantic_monty")
+
+    try:
+        _resolve_zenml_wait()
+    except KitaruFeatureNotAvailableError:
+        pytest.skip("Installed ZenML build does not expose wait support yet.")
+
+    execution_id, status_after_input, result = run_workflow(topic="kitaru")
+
+    assert execution_id
+    assert status_after_input in {"running", "waiting", "completed"}
+    assert result["approved"] is True
+    assert result["before_wait"]["counter"] == 40
+    assert result["after_wait"] is not None
+    assert result["after_wait"]["counter"] == 42
+    assert result["before_wait"]["draft"] == result["after_wait"]["draft"]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -5,11 +5,22 @@ from __future__ import annotations
 from unittest.mock import patch
 from uuid import uuid4
 
+from kitaru.config import (
+    _KITARU_RESOLVED_SANDBOX_ENV,
+    ResolvedMontySandboxSettings,
+    ResolvedSandboxConfig,
+    SandboxProviderKind,
+)
 from kitaru.runtime import (
     _checkpoint_scope,
     _flow_scope,
+    _get_current_sandbox_config,
     _is_inside_checkpoint,
     _is_inside_flow,
+    _sandbox_after_wait,
+    _sandbox_before_wait,
+    _set_current_sandbox_manager,
+    _submission_sandbox_config,
     _suspend_checkpoint_scope,
 )
 from kitaru.wait import wait
@@ -85,3 +96,72 @@ def test_wait_runs_when_checkpoint_scope_is_suspended() -> None:
         _suspend_checkpoint_scope(),
     ):
         assert wait(name="approve") is True
+
+
+def test_flow_scope_reads_submission_sandbox_config() -> None:
+    """Flow scope should capture resolved sandbox config from submission context."""
+    sandbox_config = ResolvedSandboxConfig(
+        provider=SandboxProviderKind.MONTY,
+        monty=ResolvedMontySandboxSettings(
+            max_duration_secs=1.0,
+            max_memory_mb=64,
+            type_check=True,
+        ),
+    )
+
+    with _submission_sandbox_config(sandbox_config), _flow_scope(name="demo"):
+        assert _get_current_sandbox_config() == sandbox_config
+
+
+def test_flow_scope_reads_sandbox_config_from_env(monkeypatch) -> None:
+    """Flow scope should fall back to the propagated sandbox env var."""
+    sandbox_config = ResolvedSandboxConfig(
+        provider=SandboxProviderKind.MONTY,
+        monty=ResolvedMontySandboxSettings(
+            max_duration_secs=2.0,
+            max_memory_mb=128,
+            type_check=False,
+        ),
+    )
+    monkeypatch.setenv(
+        _KITARU_RESOLVED_SANDBOX_ENV,
+        sandbox_config.model_dump_json(exclude_none=True),
+    )
+
+    with _flow_scope(name="demo"):
+        assert _get_current_sandbox_config() == sandbox_config
+
+
+def test_wait_hooks_delegate_to_active_sandbox_manager() -> None:
+    """Runtime wait helpers should call the active sandbox manager when present."""
+
+    class _Manager:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str | None]] = []
+
+        def close_checkpoint_scope(self, checkpoint_id: str | None) -> None:
+            self.calls.append(("close_checkpoint_scope", checkpoint_id))
+
+        def close_execution_scope(self, execution_id: str | None) -> None:
+            self.calls.append(("close_execution_scope", execution_id))
+
+        def before_wait(self, execution_id: str | None) -> None:
+            self.calls.append(("before_wait", execution_id))
+
+        def after_wait(self, execution_id: str | None) -> None:
+            self.calls.append(("after_wait", execution_id))
+
+    sandbox_manager = _Manager()
+    _set_current_sandbox_manager(sandbox_manager)
+    execution_id, _ = _scope_ids()
+    try:
+        with _flow_scope(name="demo", execution_id=execution_id):
+            _sandbox_before_wait()
+            _sandbox_after_wait()
+    finally:
+        _set_current_sandbox_manager(None)
+
+    assert sandbox_manager.calls[:2] == [
+        ("before_wait", execution_id),
+        ("after_wait", execution_id),
+    ]

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,156 @@
+"""Tests for Kitaru sandbox sessions."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from kitaru.config import (
+    ResolvedMontySandboxSettings,
+    ResolvedSandboxConfig,
+    SandboxProviderKind,
+)
+from kitaru.errors import (
+    KitaruContextError,
+    KitaruSandboxCapabilityError,
+    KitaruSandboxNotConfiguredError,
+)
+from kitaru.runtime import _checkpoint_scope, _flow_scope
+from kitaru.sandbox import SandboxExecutionResult, run_sandbox_smoke_test, sandbox
+
+
+@pytest.fixture
+def resolved_sandbox() -> ResolvedSandboxConfig:
+    """Return a standard resolved Monty config for sandbox tests."""
+    return ResolvedSandboxConfig(
+        provider=SandboxProviderKind.MONTY,
+        monty=ResolvedMontySandboxSettings(
+            max_duration_secs=1.0,
+            max_memory_mb=64,
+            type_check=True,
+        ),
+    )
+
+
+def test_sandbox_requires_flow_context() -> None:
+    """sandbox() should fail outside a flow."""
+    with pytest.raises(KitaruContextError, match="inside a @flow"):
+        sandbox()
+
+
+def test_sandbox_requires_configured_provider() -> None:
+    """sandbox() should fail clearly when no provider is configured."""
+    with (
+        _flow_scope(name="demo"),
+        pytest.raises(
+            KitaruSandboxNotConfiguredError,
+            match="No sandbox provider",
+        ),
+    ):
+        sandbox()
+
+
+def test_sandbox_returns_execution_scoped_session(
+    resolved_sandbox: ResolvedSandboxConfig,
+) -> None:
+    """sandbox() should return an execution-scoped session in the flow body."""
+    with _flow_scope(name="demo", sandbox_config=resolved_sandbox):
+        session = sandbox(name="coding-loop")
+        same_name = sandbox(name="coding-loop")
+
+    assert session.scope == "execution"
+    assert session.name == "coding_loop"
+    assert same_name.name == "coding_loop"
+    assert session.capabilities.supports_stateful_python is True
+
+
+def test_sandbox_returns_checkpoint_scoped_session_inside_checkpoint(
+    resolved_sandbox: ResolvedSandboxConfig,
+) -> None:
+    """sandbox() should switch to checkpoint scope inside a checkpoint."""
+    with (
+        _flow_scope(name="demo", sandbox_config=resolved_sandbox),
+        _checkpoint_scope(name="step", checkpoint_type=None),
+    ):
+        session = sandbox(name="step-sandbox")
+
+    assert session.scope == "checkpoint"
+    assert session.name == "step_sandbox"
+
+
+def test_execution_scoped_run_code_uses_synthetic_checkpoint_dispatch(
+    resolved_sandbox: ResolvedSandboxConfig,
+) -> None:
+    """Flow-scope sandbox calls should route through the synthetic checkpoint helper."""
+    result = SandboxExecutionResult(
+        call_name="sandbox_1",
+        provider=SandboxProviderKind.MONTY,
+        session_name="sandbox",
+        value=2,
+        duration_ms=1.0,
+    )
+    with (
+        _flow_scope(name="demo", sandbox_config=resolved_sandbox),
+        patch(
+            "kitaru.sandbox._sandbox_run_code_checkpoint_call",
+            return_value=result,
+        ) as mock_call,
+    ):
+        session = sandbox()
+        resolved = session.run_code("1 + 1")
+
+    assert resolved.value == 2
+    mock_call.assert_called_once()
+
+
+def test_pause_and_resume_preserve_state(
+    resolved_sandbox: ResolvedSandboxConfig,
+) -> None:
+    """Monty-backed sessions should preserve REPL state across pause/resume."""
+    with (
+        _flow_scope(name="demo", sandbox_config=resolved_sandbox),
+        patch("kitaru.sandbox._save_with_fallback", return_value="artifact"),
+        patch("kitaru.sandbox.log"),
+        patch("kitaru.sandbox._sandbox_run_code_checkpoint_call") as mock_call,
+    ):
+        session = sandbox(name="math")
+
+        def _dispatch(request):
+            return session._manager.run_code(
+                scope=request.scope,
+                scope_id=request.scope_id,
+                session_name=request.session_name,
+                code=request.code,
+                inputs=request.inputs,
+                call_name=request.call_name,
+            )
+
+        mock_call.side_effect = _dispatch
+
+        session.run_code("x = 41")
+        session.pause()
+        session.resume()
+        result = session.run_code("x + 1")
+
+    assert result.value == 42
+
+
+def test_run_command_is_not_supported_for_monty(
+    resolved_sandbox: ResolvedSandboxConfig,
+) -> None:
+    """Monty should reject shell-style command execution."""
+    with _flow_scope(name="demo", sandbox_config=resolved_sandbox):
+        session = sandbox()
+        with pytest.raises(
+            KitaruSandboxCapabilityError,
+            match="cannot run shell commands",
+        ):
+            session.run_command("ls -la")
+
+
+def test_run_sandbox_smoke_test_works_with_monty(
+    resolved_sandbox: ResolvedSandboxConfig,
+) -> None:
+    """The standalone smoke test should verify pause/resume behavior."""
+    run_sandbox_smoke_test(resolved_sandbox)

--- a/uv.lock
+++ b/uv.lock
@@ -1089,12 +1089,16 @@ mcp = [
 pydantic-ai = [
     { name = "pydantic-ai-slim" },
 ]
+sandbox = [
+    { name = "pydantic-monty" },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "griffe" },
     { name = "griffe-typingdoc" },
     { name = "pydantic-ai-slim" },
+    { name = "pydantic-monty" },
     { name = "pytest" },
     { name = "pytest-clarity" },
     { name = "pytest-randomly" },
@@ -1112,17 +1116,19 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.26.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=0.2.0" },
+    { name = "pydantic-monty", marker = "extra == 'sandbox'", specifier = ">=0.0.8" },
     { name = "rich", specifier = ">=12.0.0" },
     { name = "zenml", extras = ["local"], git = "https://github.com/zenml-io/zenml.git?rev=feature%2Fkitaru" },
     { name = "zenml", extras = ["local"], marker = "extra == 'local'", specifier = ">=0.94.0" },
 ]
-provides-extras = ["local", "pydantic-ai", "mcp"]
+provides-extras = ["local", "pydantic-ai", "mcp", "sandbox"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "griffe", specifier = ">=1.13.0,<2.0.0" },
     { name = "griffe-typingdoc", specifier = ">=0.2.8,<1.0.0" },
     { name = "pydantic-ai-slim", specifier = ">=0.2.0" },
+    { name = "pydantic-monty", specifier = ">=0.0.8" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-clarity" },
     { name = "pytest-randomly" },
@@ -1798,6 +1804,62 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e6/1cae7cd39ab29f2eebc87c0a82c7ffcdfbe88492d2fb4afaaad91534e1ff/pydantic_graph-1.60.0.tar.gz", hash = "sha256:9710e457c2f8c113fd63629f05174e45bdca917d90c69ec8cf558649f995505f", size = 58492, upload-time = "2026-02-17T00:33:32.66Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/6c/ce1c0eca77c6efbf7c7168c05a244c2756bde876a52575f750471d522024/pydantic_graph-1.60.0-py3-none-any.whl", hash = "sha256:741fa1e48424b0def86079a01100ad0652e75882f0352cd157232b75ace468a5", size = 72345, upload-time = "2026-02-17T00:33:25.077Z" },
+]
+
+[[package]]
+name = "pydantic-monty"
+version = "0.0.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/bf/e9794b562c207406d8fda0cf4fea810943a5e8a85fe69e5505046179df16/pydantic_monty-0.0.8.tar.gz", hash = "sha256:8135e781a184f971825c1d2eb6d621598103e900f6e0d34291ff0bf35df6142f", size = 802646, upload-time = "2026-03-10T14:46:51.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/32/ac657c9e517665cc74bf47c326a2b9585b1ed0a9ebba5d624c8ad3cf3892/pydantic_monty-0.0.8-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b36cd5b8e380d9624a6929203a35e8e0d6e11b2bdb840553f0079000c1acf84e", size = 6700260, upload-time = "2026-03-10T14:45:19.034Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0b/042f23c8211cc74b508eb7a648f7dd3ce6b39ef6fb72ebd8f1f6c060f29b/pydantic_monty-0.0.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:82adee95051eab2b04d11e4a11e852eafa2d00d8adacf62176ec25bd0d3f6a7b", size = 6767968, upload-time = "2026-03-10T14:46:14.422Z" },
+    { url = "https://files.pythonhosted.org/packages/77/9a/c0d387b8b3ad6255645044afc8ac3f1cece7f8d91e819aaefeb738251634/pydantic_monty-0.0.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f7840f0e0d3933dc3c2f64402275d9176877ecbe565008dee657305f5c6e40f", size = 6502971, upload-time = "2026-03-10T14:46:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/58/ebda094d5ac8fbdd74dfc2041d7a04289fd13a9ad19accdf22841ef00d79/pydantic_monty-0.0.8-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5a904d8d489bb6494458364874af31a8a933f7b316234fd69b25edf6b0567b9", size = 6764397, upload-time = "2026-03-10T14:46:12.921Z" },
+    { url = "https://files.pythonhosted.org/packages/52/58/9a89b514b2953f85cc089149bcbc1ed4a79d9ee90cd6448ce85d71d04ece/pydantic_monty-0.0.8-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c44c7464c9286a8c39ee58bf45d0a477e2f281c49ce99796210874f58bbe52f7", size = 7325434, upload-time = "2026-03-10T14:46:01.563Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fe/cf2c8556589d11f85ab82ff1cc2ead3f1e70a1bdbc03e6b0648bf66186c7/pydantic_monty-0.0.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:94644e34771e4255772d41e31c30c9ab1f9df06860507cb5f47152760a15767d", size = 7530790, upload-time = "2026-03-10T14:45:11.566Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/56/b981e8e29e316d3f327142fc206c4d727ecaa1b875057110b3e754c1fc52/pydantic_monty-0.0.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70fa4aba236678a1d0b04e07300d404f2504351922b6aecec7aa4b4d84785d3e", size = 7297432, upload-time = "2026-03-10T14:46:36.305Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/4e/8b41a6e1461e52478d8ca3ef19db6e271c4b7f27e0073337b3f98e35d3a4/pydantic_monty-0.0.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8df1d1fa0deed81de60e43e3ab8c4a82f63998b6e04e535e681633b4eaff98b6", size = 7185726, upload-time = "2026-03-10T14:45:05.965Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/be/28f86c4c7679359c9a2fcd17392d7716550e87b8a4d381cf865bc1014a31/pydantic_monty-0.0.8-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f0344a975c59f5f35ca6c0c2b332d7d8d7c681449c5ce8849181ed05025b18c4", size = 6677665, upload-time = "2026-03-10T14:46:31.198Z" },
+    { url = "https://files.pythonhosted.org/packages/31/68/82374a2e8a832f72c65a4a26d20fdb756c089cbce0984d7153f70fbb05fb/pydantic_monty-0.0.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8aad6b5eee8d8c1dda9b63b6ea3b7c524b64b8c06ad49ba9cc015740c4f86c78", size = 7136490, upload-time = "2026-03-10T14:45:17.199Z" },
+    { url = "https://files.pythonhosted.org/packages/63/46/4b487728ed5a97341a21fd54a32ec11552757e843bb69983f72eae0caa41/pydantic_monty-0.0.8-cp311-cp311-win32.whl", hash = "sha256:d7e16a25b0066e34a2694dac157fc93971f80c67c4f1b47ad6e5049423141e6a", size = 6585220, upload-time = "2026-03-10T14:45:47.124Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d6/b2665d7590849969da9dbde08fdc1810f8ded7891d8fff3488ceb557eda2/pydantic_monty-0.0.8-cp311-cp311-win_amd64.whl", hash = "sha256:85cdec430afb4bbe1860aadf910c1b00832037ce08a2fb64e6012927a58ea14f", size = 7364044, upload-time = "2026-03-10T14:45:59.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/4f/7d7c7531be850469bccfbbf3cfede9e95d92b1d8e7b245d9dc77a599d6e4/pydantic_monty-0.0.8-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:025b380c0ed728bdf88e3ed60d5977498d4bb9da61cd81d9cabdaecce16f5755", size = 6699454, upload-time = "2026-03-10T14:46:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/35/074daa5fd92e4a5c1e49c8fae06036e194139feef9a51b4db82d0fee7e54/pydantic_monty-0.0.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:76846d77ebda3414beb8c9e5da9eaef722e06606dc0307613186d888e775dc51", size = 6743273, upload-time = "2026-03-10T14:46:16.184Z" },
+    { url = "https://files.pythonhosted.org/packages/55/0d/e6cb1e9e1c2e51501d8f7848c18803780164948e338350ab94769690f207/pydantic_monty-0.0.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b58149d6a8998ffed80f626c10bf0de7e65964aae1dfad80db8ecb00968fb1a", size = 6503552, upload-time = "2026-03-10T14:45:26.083Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a9/286f7eb6c95d7877f6f8b9bcbe26e2d988fa142cd77509e48e67302478bf/pydantic_monty-0.0.8-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1b99bb030ff8e95b160c11702b9a6823705b7dcc1a49a2c1dccc43c2538bfe27", size = 6765377, upload-time = "2026-03-10T14:45:14.472Z" },
+    { url = "https://files.pythonhosted.org/packages/74/76/85268f6305bc5b153be7c0860e69ce3b9ba916daa4a419f53d8a777e9a39/pydantic_monty-0.0.8-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b05b17fc2b8875e0efea047416fc0cd28a8018c040b25387454996b98540ccfc", size = 7324571, upload-time = "2026-03-10T14:45:48.786Z" },
+    { url = "https://files.pythonhosted.org/packages/11/6a/2855c6149f6ba3138c7bfb009c07d528e2df12802e3216928b1289bbf233/pydantic_monty-0.0.8-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97fa5deef4d8cdcf60a4d8a4e7a34099deae1ad4b33acc1c33ac2e1cc348a1c2", size = 7533828, upload-time = "2026-03-10T14:46:55.386Z" },
+    { url = "https://files.pythonhosted.org/packages/31/63/44b5bb5798323f7f735f5855a0d3f478d6852d9d1774427d77e31b5dbffb/pydantic_monty-0.0.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1aabd56af5db51c4af512142fe7ffc866b6a20dcd039a4aad5245ef42768f21", size = 7271978, upload-time = "2026-03-10T14:45:33.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/ce82eb571e45afbe3c0b9544fe3ebf93f841ec895fea0d39c9604a0a421f/pydantic_monty-0.0.8-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9782e58da29176a3fb0ce8ec808571d0be99c1e2ad167637225246e594e85f13", size = 7187140, upload-time = "2026-03-10T14:46:41.784Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/45/778bc260195ddb892f284c3cb8ab8cbcb0542e6a18f11b7e50a592b507ba/pydantic_monty-0.0.8-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ff7fb7ff3f4e830ef9b28a76e634219195b552c0dfed3471fb4910708db56221", size = 6677996, upload-time = "2026-03-10T14:46:03.163Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/02/8e8396b83d19ec70a09c24b0245177a595c2b7d6d092c6f6c7d3310b191c/pydantic_monty-0.0.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ce7222d923676900827e3951e65f854d65f50b65ed8c7a84011d3472773d51bf", size = 7136513, upload-time = "2026-03-10T14:45:52.179Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/53d06af74b82043be9c4960c38bbc255eeb3de9f2a4d450f942912630bb3/pydantic_monty-0.0.8-cp312-cp312-win32.whl", hash = "sha256:4cb59e1e7b1a3d573247a871a87c88506ce9fb68bbd7648598e171cf2f04747e", size = 6582168, upload-time = "2026-03-10T14:45:58.197Z" },
+    { url = "https://files.pythonhosted.org/packages/25/0f/55a16faf379139263ad852421734cb096390777d299ef7f185ec10404656/pydantic_monty-0.0.8-cp312-cp312-win_amd64.whl", hash = "sha256:45bf11e3b795cc470a91cbd7cfeb9d96f7a60387e8da146a11bf952b4371aba7", size = 7335422, upload-time = "2026-03-10T14:45:28.301Z" },
+    { url = "https://files.pythonhosted.org/packages/27/46/3268001a639052515d5a55ea2f1e087ae1e5f7aa9d7bc62c4808d731fff1/pydantic_monty-0.0.8-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f303f1d979213dcb365c69de3912daa70a32af019bb5ee86e086f584638974f2", size = 6698529, upload-time = "2026-03-10T14:45:39.712Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/22/28d6b7f8f7a1e0881c449310a6f2c8ee0cf85dc4434ae0f7e633dfcf5bcf/pydantic_monty-0.0.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b8cc698da6f7f11743df7c48b959eea000e8e30511c7e1318b67543e25985062", size = 6743849, upload-time = "2026-03-10T14:46:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ab/e3dfe057af472e4065297d69aea0cf30616d01366a29e02d0a2739f22b93/pydantic_monty-0.0.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90f6da093164e99012b49b39ba1e64c166ccd126128d114f9e2c66df6fb695c4", size = 6503266, upload-time = "2026-03-10T14:46:19.594Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/82/d3e9aa9bd9ac69b3584216166a189e11370913ffcbd2a57a5cac6ce2d4ba/pydantic_monty-0.0.8-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f2432ef62140554f5970991b7df41e064824741a807515658f91283c75669086", size = 6765032, upload-time = "2026-03-10T14:45:20.571Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9d/7ab11be8eff998bf9283c7bf444254cff5212f87fe3f2a9a2f7436cce6d7/pydantic_monty-0.0.8-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:99951afb4d722212c2ce85c303b5e87d50756adaff46817ad0e60e95eb1e5141", size = 7324673, upload-time = "2026-03-10T14:45:37.957Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a0/7f026ece228cc990e58aa27f2ce5af26d042baaa0186cb451f3e04ff0abe/pydantic_monty-0.0.8-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bdef70921b408378f9bc38bce4952d3c176b3f7833aa782068b310390901c516", size = 7533774, upload-time = "2026-03-10T14:46:24.265Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e7/72f250ffd005520ad8cdffb387241a9dd92fc70bcbdd769720918bd34495/pydantic_monty-0.0.8-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00b5dee7bef619e7661f77bef765f483605bcd2a79c6b8bf5c910afa1c93fc40", size = 7272179, upload-time = "2026-03-10T14:45:08.085Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7c/97c87c2a315ba4376bfb83197586365003005e01d6547df7f6d77b80d13f/pydantic_monty-0.0.8-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5f4c6f6fb2ebae0bc80520af71e1057055413ca96fd33f13f3c612a085e50fb8", size = 7186684, upload-time = "2026-03-10T14:46:49.833Z" },
+    { url = "https://files.pythonhosted.org/packages/09/42/2eea55906fee8bef7c1024bf2d35e2c301b15b562934731bdae25db448cb/pydantic_monty-0.0.8-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3ab3c558a648942d4d31e7f668d60d2a2e129751a3e8e9dc27b1e6d635e9e627", size = 6677272, upload-time = "2026-03-10T14:45:54.037Z" },
+    { url = "https://files.pythonhosted.org/packages/40/0a/066e53d4693b680e39080d3af4f234c1ff9976f7621b8a49dd2a41710431/pydantic_monty-0.0.8-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:782d686d217b537e6fa9047aa3444d67b3b7cc69bf6faf34078c992ceaeb1e9e", size = 7136493, upload-time = "2026-03-10T14:45:30.014Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c1/46dc300f87314aef883a57ae5a35ba45a463c09f64d3d9c9f0b620672734/pydantic_monty-0.0.8-cp313-cp313-win32.whl", hash = "sha256:ef0db454757cb92974890b11c7b0969d8c0d95944c821f6fc6cd23846d1d2aa4", size = 6581014, upload-time = "2026-03-10T14:46:07.886Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2a/cf156df19a1612ca5ddcbd982645e54c5485e83215d9532cc9aff791f854/pydantic_monty-0.0.8-cp313-cp313-win_amd64.whl", hash = "sha256:dbf8c7cfaff2b345f8c1bfba98fdc282e790fef5c601f37c8d5355ccd45073de", size = 7335041, upload-time = "2026-03-10T14:46:21.371Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/69/5bedc7ad67fdd9e4f04007477f5c414b54c51d47c5dfdd7abad4c78663aa/pydantic_monty-0.0.8-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:47990770ed74af1e8e2160a7dd925aa1e4fd1bf4ae9658ffd1cdc32eb5c8c6e8", size = 6700454, upload-time = "2026-03-10T14:45:56.247Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/35/06aaa9c766a83e7e95219bfb6cb88bd0a87803f85eb3f596b82da0cb3009/pydantic_monty-0.0.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9534f6236b3ebdd09f0f7d71e508e68736733d24cdda2a6c0a758914261c75e5", size = 6760180, upload-time = "2026-03-10T14:45:22.982Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b8/eaa4a4f0b3a1c343773317027bb5d1e11a1b0c1ad01d3f0921a7f547d346/pydantic_monty-0.0.8-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76c4ffd8275d520628732d82e7410e5f1f69ef5af274d676f1f2f9221fd85a34", size = 6504414, upload-time = "2026-03-10T14:45:12.984Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/79/dbb0875ad2b565d7ef1981feda4438ab743130f4031107aaadc9212488dd/pydantic_monty-0.0.8-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:badaa22749fa7a22ee2cb88f6deb48fc191cb2f41237dd630593259ed9f30b67", size = 6766768, upload-time = "2026-03-10T14:46:29.12Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cb/bd6bef8fa2cfe807dd5ef36ab8ce6d094ecdad0050cf57dec4c8a438d413/pydantic_monty-0.0.8-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e39104684eda1ae3c290e3a4369bef9d00f9b637be8515802bc1523fecb5160d", size = 7326073, upload-time = "2026-03-10T14:45:50.679Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/44/b64b6e2857519d5fdc66f74998019e585e5c3bf2cf8deb7b77419d29db2a/pydantic_monty-0.0.8-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2e5b3b11b794f82504bb6929f4101f0db84933986aee9b46ce7561add152e9", size = 7535251, upload-time = "2026-03-10T14:46:04.645Z" },
+    { url = "https://files.pythonhosted.org/packages/da/11/4e1524d94e33427990cffd74eaf94a023724c872f11d42ac90eebd74ccc0/pydantic_monty-0.0.8-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a94fc87b2a9b1b66a09f35b819b1c7e7da7702b21c923cdca21fa13129486b45", size = 7288739, upload-time = "2026-03-10T14:45:35.609Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7d/7e667c72c9742a6725b04d21faf50e8f552a0e23da9ca1cbeba891961c9a/pydantic_monty-0.0.8-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:70b7479e7bd47d274fbd6278a625289e71b1a4aad400f40c7a4a89fe9a50952c", size = 7189195, upload-time = "2026-03-10T14:46:09.399Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/3f/3243277e2c6bf4c3e4684fbc78c316a8965dbbb012b573b38978d8628bfc/pydantic_monty-0.0.8-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:48b8c9cb9a96a5f28b03669771368a444c8b50c758b6a5bd0d148fa02db3f65b", size = 6679333, upload-time = "2026-03-10T14:45:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/51/88152b89f5288e9d3cd28e71f79a6567421e20d8f00b0514b7819a29a8bb/pydantic_monty-0.0.8-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:b005f10798a1b58a12b5643f69a7b54208bd4965d16ca2bd21d13fca4d1a4f67", size = 7137771, upload-time = "2026-03-10T14:46:33.043Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/38/baf5a66ed72b931de7ce92251822d6ffb752582389ff4f4c853742cee029/pydantic_monty-0.0.8-cp314-cp314-win32.whl", hash = "sha256:b143bba29c274e15424a097af6ae85a1e81e6c2fb7184ee7a93fbf10997dbbd3", size = 6584038, upload-time = "2026-03-10T14:46:34.53Z" },
+    { url = "https://files.pythonhosted.org/packages/71/80/bfda690914fa15c68f8be9e824e62c4054118a9a72304735221446a89014/pydantic_monty-0.0.8-cp314-cp314-win_amd64.whl", hash = "sha256:f4bc9185bb5f37f3220a978889b4bc6f822a41ee4d5523c17eef4d869aca66e8", size = 7351170, upload-time = "2026-03-10T14:46:57.025Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed
- add Monty-backed sandbox support to Kitaru, including runtime/config/CLI wiring
- add a runnable sandbox example at `examples/monty_sandbox.py`
- add sandbox-focused tests plus example integration coverage
- document sandbox setup and example discoverability in the README/docs

## Why it was needed
Kitaru had the durable flow/checkpoint primitives and wait/resume support, but it was still missing a shipped sandbox capability for stateful Python execution across suspension boundaries. This PR adds the Monty provider and a concrete example users can run locally to verify the behavior.

## Key implementation decisions
- implement a provider-shaped sandbox runtime but ship only the Monty provider for now
- keep the public API as `kitaru.sandbox()` and route flow-scope sandbox calls through a synthetic checkpoint boundary for durability
- persist execution-scoped sandbox state across `kitaru.wait()` using runtime pause/resume hooks
- make the example self-contained with flow-level sandbox config and load its final result through the explicit terminal checkpoint artifact
- generate CLI docs from the registered Cyclopts command keys so subcommands like `sandbox reset` render correctly

## Reviewer focus areas
- `src/kitaru/sandbox.py` for runtime/session lifecycle and synthetic checkpoint behavior
- `src/kitaru/config.py`, `src/kitaru/flow.py`, `src/kitaru/runtime.py`, and `src/kitaru/wait.py` for config propagation and wait/resume integration
- `examples/monty_sandbox.py` for the user-facing workflow and local testability story
- CLI/docs/tests for completeness and ergonomics

## Verification
- `just check`
- `uv run pytest -n0 tests/test_phase20_sandbox_example.py tests/test_phase15_wait_example.py tests/test_sandbox.py -q`
