### PR TITLE
Add multi-arch Docker support (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,8 @@ jobs:
             --generate-notes
 
       # --- Docker image ---
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Log in to Docker Hub
@@ -215,6 +217,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           target: server
+          platforms: linux/amd64,linux/arm64
           push: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
           build-args: |
             ZENML_SERVER_TAG=0.94.1

--- a/Justfile
+++ b/Justfile
@@ -6,6 +6,9 @@ ZENML_SERVER_TAG := "0.94.1"
 DOCKER_REPO := "zenmldocker/kitaru"
 DOCKER_TAG := "latest"
 UI_TAG := "latest"
+# Set to "linux/amd64,linux/arm64" for multi-arch builds (requires QEMU + buildx).
+# Leave empty (default) to build for the native platform only.
+DOCKER_PLATFORM := ""
 
 # List available recipes
 default:
@@ -91,17 +94,37 @@ dev-image REPO="strickvl/kitaru-dev":
 #   just UI_TAG=v0.1.0 server-image            # specific UI release
 #   just DOCKER_TAG=v0.2.0 server-image        # specific image tag
 server-image:
-    docker build -f docker/Dockerfile --target server \
-        --build-arg ZENML_SERVER_TAG={{ ZENML_SERVER_TAG }} \
-        --build-arg KITARU_UI_TAG={{ UI_TAG }} \
-        -t kitaru-server .
-    docker tag kitaru-server {{ DOCKER_REPO }}:{{ DOCKER_TAG }}
-    @printf 'Server image built: {{ DOCKER_REPO }}:{{ DOCKER_TAG }}\n'
+    #!/usr/bin/env bash
+    set -euo pipefail
+    platform="{{ DOCKER_PLATFORM }}"
+    if [ -n "$platform" ]; then
+        docker buildx build -f docker/Dockerfile --target server \
+            --platform "$platform" \
+            --build-arg ZENML_SERVER_TAG={{ ZENML_SERVER_TAG }} \
+            --build-arg KITARU_UI_TAG={{ UI_TAG }} \
+            -t {{ DOCKER_REPO }}:{{ DOCKER_TAG }} \
+            --push .
+        printf 'Multi-arch server image pushed: {{ DOCKER_REPO }}:{{ DOCKER_TAG }} (%s)\n' "$platform"
+    else
+        docker build -f docker/Dockerfile --target server \
+            --build-arg ZENML_SERVER_TAG={{ ZENML_SERVER_TAG }} \
+            --build-arg KITARU_UI_TAG={{ UI_TAG }} \
+            -t kitaru-server .
+        docker tag kitaru-server {{ DOCKER_REPO }}:{{ DOCKER_TAG }}
+        printf 'Server image built: {{ DOCKER_REPO }}:{{ DOCKER_TAG }}\n'
+    fi
 
-# Build and push production server image
+# Build and push production server image.
+# Multi-arch builds (DOCKER_PLATFORM set) push during build; this is a no-op then.
 server-image-push: server-image
-    docker push {{ DOCKER_REPO }}:{{ DOCKER_TAG }}
-    @printf 'Server image pushed: {{ DOCKER_REPO }}:{{ DOCKER_TAG }}\n'
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -z "{{ DOCKER_PLATFORM }}" ]; then
+        docker push {{ DOCKER_REPO }}:{{ DOCKER_TAG }}
+        printf 'Server image pushed: {{ DOCKER_REPO }}:{{ DOCKER_TAG }}\n'
+    else
+        printf 'Multi-arch image already pushed during build.\n'
+    fi
 
 # Build dev server image for local UI testing.
 # Requires docker/kitaru-ui-dist/ to exist (copy from kitaru-ui/dist/).


### PR DESCRIPTION
## Summary

- Publish multi-platform Docker images (linux/amd64 + linux/arm64) so Mac/Apple Silicon users can pull and run the Kitaru server natively without emulation
- Add QEMU setup step + `platforms: linux/amd64,linux/arm64` to the release workflow's `docker/build-push-action`
- Add `DOCKER_PLATFORM` variable to the Justfile for opt-in multi-arch local builds via `docker buildx`; default remains native-platform-only for fast local iteration

## Test plan

- [ ] Verify release workflow YAML is valid (actionlint)
- [ ] Dry-run release to confirm multi-arch Docker build succeeds
- [ ] Confirm `just server-image` still works for default single-platform local builds
- [ ] Test `just DOCKER_PLATFORM="linux/amd64,linux/arm64" server-image` with buildx + QEMU
- [ ] Verify the base image `zenmldocker/zenml-server:0.94.1` supports arm64 (if not, upstream issue needed)

https://claude.ai/code/session_01KnRo2j238wM2bNB4JfrRHY