### PR TITLE
Show recovery hint after flow failure traceback

### DIFF
--- a/src/kitaru/_cli/_executions.py
+++ b/src/kitaru/_cli/_executions.py
@@ -13,6 +13,7 @@ from cyclopts import Parameter
 from kitaru._interface_errors import run_with_cli_error_boundary
 from kitaru.cli_output import CLIOutputFormat
 from kitaru.client import Execution, ExecutionStatus, LogEntry, PendingWait
+from kitaru.errors import build_recovery_command
 from kitaru.inspection import (
     serialize_execution,
     serialize_execution_summary,
@@ -309,19 +310,29 @@ def _follow_execution_logs(
             failure_reason = execution.status_reason or "execution failed"
             if execution.failure is not None:
                 failure_reason = execution.failure.message
+            recovery_cmd = build_recovery_command(
+                exec_id, status=ExecutionStatus.FAILED.value
+            )
             if output == CLIOutputFormat.JSON:
-                _emit_json_log_event(
-                    "terminal",
-                    {
-                        "status": ExecutionStatus.FAILED.value,
-                        "message": failure_reason,
-                    },
-                )
+                terminal_item: dict[str, Any] = {
+                    "status": ExecutionStatus.FAILED.value,
+                    "message": failure_reason,
+                }
+                if recovery_cmd:
+                    terminal_item["recovery_command"] = recovery_cmd
+                _emit_json_log_event("terminal", terminal_item)
             else:
                 _emit_control_message(
                     f"[Execution failed: {failure_reason}]",
                     output=output,
                 )
+                if recovery_cmd:
+                    _emit_control_message(
+                        "To retry this execution from the failed"
+                        " checkpoint, run:\n\n"
+                        f"  {recovery_cmd}",
+                        output=output,
+                    )
             return 1
         if execution.status == ExecutionStatus.CANCELLED:
             if output == CLIOutputFormat.JSON:

--- a/src/kitaru/_cli/_executions.py
+++ b/src/kitaru/_cli/_executions.py
@@ -13,7 +13,7 @@ from cyclopts import Parameter
 from kitaru._interface_errors import run_with_cli_error_boundary
 from kitaru.cli_output import CLIOutputFormat
 from kitaru.client import Execution, ExecutionStatus, LogEntry, PendingWait
-from kitaru.errors import build_recovery_command
+from kitaru.errors import build_recovery_command, format_recovery_hint
 from kitaru.inspection import (
     serialize_execution,
     serialize_execution_summary,
@@ -310,12 +310,11 @@ def _follow_execution_logs(
             failure_reason = execution.status_reason or "execution failed"
             if execution.failure is not None:
                 failure_reason = execution.failure.message
-            recovery_cmd = build_recovery_command(
-                exec_id, status=ExecutionStatus.FAILED.value
-            )
+            status_value = ExecutionStatus.FAILED.value
+            recovery_cmd = build_recovery_command(exec_id, status=status_value)
             if output == CLIOutputFormat.JSON:
                 terminal_item: dict[str, Any] = {
-                    "status": ExecutionStatus.FAILED.value,
+                    "status": status_value,
                     "message": failure_reason,
                 }
                 if recovery_cmd:
@@ -326,13 +325,9 @@ def _follow_execution_logs(
                     f"[Execution failed: {failure_reason}]",
                     output=output,
                 )
-                if recovery_cmd:
-                    _emit_control_message(
-                        "To retry this execution from the failed"
-                        " checkpoint, run:\n\n"
-                        f"  {recovery_cmd}",
-                        output=output,
-                    )
+                hint = format_recovery_hint(exec_id, status=status_value)
+                if hint:
+                    _emit_control_message(hint, output=output)
             return 1
         if execution.status == ExecutionStatus.CANCELLED:
             if output == CLIOutputFormat.JSON:

--- a/src/kitaru/errors.py
+++ b/src/kitaru/errors.py
@@ -202,7 +202,7 @@ def format_recovery_hint(exec_id: str, *, status: str) -> str | None:
     command = build_recovery_command(exec_id, status=status)
     if command is None:
         return None
-    return f"To retry this execution from the failed checkpoint, run:\n\n  {command}"
+    return f"To retry this failed execution, run:\n\n  {command}"
 
 
 __all__ = [

--- a/src/kitaru/errors.py
+++ b/src/kitaru/errors.py
@@ -172,6 +172,39 @@ def execution_error_from_failure(
     )
 
 
+def build_recovery_command(exec_id: str, *, status: str) -> str | None:
+    """Return the CLI recovery command appropriate for a given run status.
+
+    Args:
+        exec_id: Execution identifier.
+        status: Raw run status value (e.g. ``"failed"``).
+
+    Returns:
+        Copy-pasteable CLI command string, or ``None`` when no recovery
+        action is available for the status.
+    """
+    if status == "failed":
+        return f"kitaru executions retry {exec_id}"
+    return None
+
+
+def format_recovery_hint(exec_id: str, *, status: str) -> str | None:
+    """Format a user-facing recovery hint for a non-successful execution.
+
+    Args:
+        exec_id: Execution identifier.
+        status: Raw run status value.
+
+    Returns:
+        Multi-line hint string, or ``None`` when no recovery action
+        is available.
+    """
+    command = build_recovery_command(exec_id, status=status)
+    if command is None:
+        return None
+    return f"To retry this execution from the failed checkpoint, run:\n\n  {command}"
+
+
 __all__ = [
     "FailureOrigin",
     "KitaruBackendError",
@@ -186,8 +219,10 @@ __all__ = [
     "KitaruUsageError",
     "KitaruUserCodeError",
     "KitaruWaitValidationError",
+    "build_recovery_command",
     "classify_failure_origin",
     "execution_error_from_failure",
+    "format_recovery_hint",
     "traceback_exception_type",
     "traceback_last_line",
 ]

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -52,6 +52,7 @@ from kitaru.errors import (
     KitaruUsageError,
     classify_failure_origin,
     execution_error_from_failure,
+    format_recovery_hint,
     traceback_last_line,
 )
 from kitaru.replay import build_replay_plan
@@ -410,10 +411,16 @@ def _raise_for_unsuccessful_run(
     if traceback_tail:
         details.append(traceback_tail)
 
+    message = " ".join(details)
+
+    hint = format_recovery_hint(str(run.id), status=run.status.value)
+    if hint:
+        message = f"{message}\n\n{hint}"
+
     if failure_origin is None:
         failure_origin = _safe_classify_run_failure(run)
     raise execution_error_from_failure(
-        " ".join(details),
+        message,
         exec_id=str(run.id),
         status=run.status.value,
         origin=failure_origin,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -775,7 +775,7 @@ def test_executions_logs_follow_failure_shows_retry_hint(
     assert exc_info.value.code == 1
     output = capsys.readouterr().out
     assert "kitaru executions retry kr-456" in output
-    assert "To retry this execution" in output
+    assert "To retry this failed execution" in output
 
 
 def test_executions_logs_follow_failure_json_includes_recovery_command(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -750,6 +750,76 @@ def test_executions_logs_follow_failure_exits_non_zero(
     assert "[Execution failed: Checkpoint failed]" in output
 
 
+def test_executions_logs_follow_failure_shows_retry_hint(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--follow` should show a retry hint when execution fails."""
+    failed = _execution_stub(
+        exec_id="kr-456",
+        flow_name="content_pipeline",
+        status=ExecutionStatus.FAILED,
+        failure=SimpleNamespace(message="Checkpoint failed"),
+    )
+
+    fake_client = Mock()
+    fake_client.executions.logs.return_value = []
+    fake_client.executions.get.return_value = failed
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        patch("kitaru.cli.time.sleep"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "logs", "kr-456", "--follow", "--interval", "0.01"])
+
+    assert exc_info.value.code == 1
+    output = capsys.readouterr().out
+    assert "kitaru executions retry kr-456" in output
+    assert "To retry this execution" in output
+
+
+def test_executions_logs_follow_failure_json_includes_recovery_command(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--follow --output json` should include recovery_command in terminal event."""
+    failed = _execution_stub(
+        exec_id="kr-789",
+        flow_name="content_pipeline",
+        status=ExecutionStatus.FAILED,
+        failure=SimpleNamespace(message="Checkpoint failed"),
+    )
+
+    fake_client = Mock()
+    fake_client.executions.logs.return_value = []
+    fake_client.executions.get.return_value = failed
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        patch("kitaru.cli.time.sleep"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(
+            [
+                "executions",
+                "logs",
+                "kr-789",
+                "--follow",
+                "--interval",
+                "0.01",
+                "--output",
+                "json",
+            ]
+        )
+
+    assert exc_info.value.code == 1
+    output = capsys.readouterr().out
+    terminal_event = json.loads(output.strip())
+    assert terminal_event["event"] == "terminal"
+    assert terminal_event["item"]["recovery_command"] == (
+        "kitaru executions retry kr-789"
+    )
+
+
 def test_executions_logs_surfaces_backend_errors(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1210,8 +1210,14 @@ class TestRecoveryHintHelpers:
         assert "kitaru executions retry kr-abc" in hint
         assert "To retry" in hint
 
+    def test_build_recovery_command_returns_none_for_cancelled(self) -> None:
+        assert build_recovery_command("kr-abc", status="cancelled") is None
+
     def test_format_recovery_hint_returns_none_for_completed(self) -> None:
         assert format_recovery_hint("kr-abc", status="completed") is None
+
+    def test_format_recovery_hint_returns_none_for_cancelled(self) -> None:
+        assert format_recovery_hint("kr-abc", status="cancelled") is None
 
 
 def test_flow_handle_get_includes_retry_hint_on_failure() -> None:
@@ -1236,7 +1242,7 @@ def test_flow_handle_get_includes_retry_hint_on_failure() -> None:
 
     message = str(exc_info.value)
     assert f"kitaru executions retry {run_id}" in message
-    assert "To retry this execution" in message
+    assert "To retry this failed execution" in message
 
 
 def test_flow_handle_wait_includes_retry_hint_on_failure() -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -30,6 +30,8 @@ from kitaru.errors import (
     KitaruStateError,
     KitaruUsageError,
     KitaruUserCodeError,
+    build_recovery_command,
+    format_recovery_hint,
 )
 from kitaru.flow import (
     FlowHandle,
@@ -1186,3 +1188,76 @@ def test_flow_handle_wait_still_raises_when_classify_fails() -> None:
             "failure_origin": FailureOrigin.UNKNOWN.value,
         },
     )
+
+
+class TestRecoveryHintHelpers:
+    """Tests for the recovery hint formatting helpers in errors.py."""
+
+    def test_build_recovery_command_for_failed(self) -> None:
+        assert build_recovery_command("kr-abc", status="failed") == (
+            "kitaru executions retry kr-abc"
+        )
+
+    def test_build_recovery_command_returns_none_for_completed(self) -> None:
+        assert build_recovery_command("kr-abc", status="completed") is None
+
+    def test_build_recovery_command_returns_none_for_running(self) -> None:
+        assert build_recovery_command("kr-abc", status="running") is None
+
+    def test_format_recovery_hint_for_failed(self) -> None:
+        hint = format_recovery_hint("kr-abc", status="failed")
+        assert hint is not None
+        assert "kitaru executions retry kr-abc" in hint
+        assert "To retry" in hint
+
+    def test_format_recovery_hint_returns_none_for_completed(self) -> None:
+        assert format_recovery_hint("kr-abc", status="completed") is None
+
+
+def test_flow_handle_get_includes_retry_hint_on_failure() -> None:
+    """FlowHandle.get() error message should include a retry CLI hint."""
+    run_id = uuid4()
+    failed = _DummyRun(
+        status=ExecutionStatus.FAILED,
+        run_id=run_id,
+        status_reason="upstream failure",
+        traceback="Traceback\nValueError: boom",
+    )
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = failed
+
+    handle = FlowHandle(_as_pipeline_run(failed))
+    with (
+        patch("kitaru.flow.Client", return_value=client_mock),
+        patch("kitaru.flow.track"),
+        pytest.raises(KitaruUserCodeError, match="kitaru executions retry") as exc_info,
+    ):
+        handle.get()
+
+    message = str(exc_info.value)
+    assert f"kitaru executions retry {run_id}" in message
+    assert "To retry this execution" in message
+
+
+def test_flow_handle_wait_includes_retry_hint_on_failure() -> None:
+    """FlowHandle.wait() error message should include a retry CLI hint."""
+    run_id = uuid4()
+    failed = _DummyRun(
+        status=ExecutionStatus.FAILED,
+        run_id=run_id,
+        traceback="Traceback\nRuntimeError: connection lost",
+    )
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = failed
+
+    handle = FlowHandle(_as_pipeline_run(failed))
+    with (
+        patch("kitaru.flow.Client", return_value=client_mock),
+        patch("kitaru.flow.time.sleep"),
+        patch("kitaru.flow.track"),
+        pytest.raises(KitaruExecutionError) as exc_info,
+    ):
+        handle.wait()
+
+    message = str(exc_info.value)
+    assert f"kitaru executions retry {run_id}" in message


### PR DESCRIPTION
## Summary

Closes #114.

- When a flow execution fails, the user now sees an actionable CLI hint telling them how to recover
- The hint appears in both SDK error messages (`FlowHandle.wait()`/`get()`) and CLI follow-mode output (text and JSON)
- Uses `retry` (not `resume`) as the recovery command since `_raise_for_unsuccessful_run` is exclusively reached for `failed` runs

**Example SDK output:**
```
kitaru.errors.KitaruUserCodeError: Execution abc-123 finished with status 'failed'. ValueError: boom

To retry this failed execution, run:

  kitaru executions retry abc-123
```

**Example CLI follow-mode output:**
```
[Execution failed: Checkpoint failed]
To retry this failed execution, run:

  kitaru executions retry abc-123
```

**JSON follow-mode** adds an additive `recovery_command` field to the terminal event:
```json
{"event": "terminal", "item": {"status": "failed", "message": "...", "recovery_command": "kitaru executions retry abc-123"}}
```

## Changes

| File | Change |
|------|--------|
| `src/kitaru/errors.py` | New `build_recovery_command()` and `format_recovery_hint()` helpers |
| `src/kitaru/flow.py` | `_raise_for_unsuccessful_run()` appends hint to error message |
| `src/kitaru/_cli/_executions.py` | Follow-mode failure shows hint (text) / `recovery_command` (JSON) |
| `tests/test_flow.py` | 9 new tests (helper unit tests + FlowHandle integration) |
| `tests/test_cli.py` | 2 new tests (follow-mode text + JSON) |

## Test plan

- [x] `just check` passes (format, lint, typecheck, typos, yaml, actions, links)
- [x] `just test` passes (944 passed, 6 skipped; 1 pre-existing xdist flake in test_phase15)
- [x] New unit tests cover: failed hint, completed/running/cancelled no-hint, FlowHandle.get + wait integration, CLI text + JSON modes
- [x] Ran `/simplify` and `/pr-review-toolkit:review-pr` — addressed all findings