### PR TITLE
Use durable flow IDs for flow-scoped memory

### DIFF
--- a/examples/memory/flow_with_memory.py
+++ b/examples/memory/flow_with_memory.py
@@ -28,7 +28,7 @@ from kitaru import KitaruClient, checkpoint, flow, memory
 from kitaru.memory import MemoryEntry, MemoryScopeInfo
 
 FLOW_SCOPE = "repo_memory_demo"
-"""The flow scope name, derived from the ``@flow`` function name below."""
+"""The human-readable flow name, derived from the ``@flow`` function name below."""
 
 # ---------------------------------------------------------------------------
 # Checkpoints — the durable work units
@@ -296,6 +296,10 @@ def run_workflow(
 
     client = KitaruClient()
     execution_scope = handle.exec_id
+    execution = client.executions.get(handle.exec_id)
+    flow_scope_id = execution.flow_id
+    if flow_scope_id is None:
+        raise RuntimeError("Expected execution to expose a flow_id for flow memory.")
 
     # --- Post-flow detached execution-scope writes (annotation pattern) ---
     client.memories.set(
@@ -327,7 +331,7 @@ def run_workflow(
         scope=namespace_scope,
         scope_type="namespace",
     )
-    flow_entries = client.memories.list(scope=FLOW_SCOPE, scope_type="flow")
+    flow_entries = client.memories.list(scope=flow_scope_id, scope_type="flow")
     execution_entries = client.memories.list(
         scope=execution_scope,
         scope_type="execution",
@@ -363,13 +367,13 @@ def run_workflow(
 
     flow_summary_entry = client.memories.get(
         "summaries/latest",
-        scope=FLOW_SCOPE,
+        scope=flow_scope_id,
         scope_type="flow",
     )
     flow_summary_value = _load_value(client, flow_summary_entry)
     flow_summary_history = client.memories.history(
         "summaries/latest",
-        scope=FLOW_SCOPE,
+        scope=flow_scope_id,
         scope_type="flow",
     )
 
@@ -483,7 +487,8 @@ def run_workflow(
     return {
         "execution_id": execution_scope,
         "namespace_scope": namespace_scope,
-        "flow_scope": FLOW_SCOPE,
+        "flow_scope": flow_scope_id,
+        "flow_name": execution.flow_name or FLOW_SCOPE,
         "seed_snapshot": seed_snapshot,
         "flow_snapshot": flow_snapshot,
         "execution_snapshot": execution_snapshot,
@@ -541,7 +546,8 @@ def _render_text(
     lines.append("=== Memory Walkthrough ===")
     lines.append("")
     lines.append(f"Namespace scope: {snapshot['namespace_scope']}")
-    lines.append(f"Flow scope:      {snapshot['flow_scope']}")
+    lines.append(f"Flow name:       {snapshot['flow_name']}")
+    lines.append(f"Flow scope ID:   {snapshot['flow_scope']}")
     lines.append(f"Execution:       {snapshot['execution_id']}")
 
     # --- Seeding ---

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -534,8 +534,8 @@ def _map_execution(
     flow_id: str | None = None
     flow_name: str | None = None
     if run.pipeline is not None:
-        if getattr(run.pipeline, "id", None) is not None:
-            flow_id = str(run.pipeline.id)
+        raw_id = getattr(run.pipeline, "id", None)
+        flow_id = str(raw_id) if raw_id is not None else None
         flow_name = _normalize_flow_name(run.pipeline.name)
 
     original_exec_id: str | None = None

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -531,8 +531,11 @@ def _map_execution(
 
     metadata = _to_plain_dict(run.run_metadata)
 
+    flow_id: str | None = None
     flow_name: str | None = None
     if run.pipeline is not None:
+        if getattr(run.pipeline, "id", None) is not None:
+            flow_id = str(run.pipeline.id)
         flow_name = _normalize_flow_name(run.pipeline.name)
 
     original_exec_id: str | None = None
@@ -545,6 +548,7 @@ def _map_execution(
 
     return Execution(
         exec_id=str(run.id),
+        flow_id=flow_id,
         flow_name=flow_name,
         status=status,
         started_at=run.start_time,

--- a/src/kitaru/_client/_models.py
+++ b/src/kitaru/_client/_models.py
@@ -116,6 +116,7 @@ class Execution:
     """Public view of a Kitaru execution."""
 
     exec_id: str
+    flow_id: str | None
     flow_name: str | None
     status: ExecutionStatus
     started_at: datetime | None

--- a/src/kitaru/inspection.py
+++ b/src/kitaru/inspection.py
@@ -573,6 +573,7 @@ def serialize_execution_summary(execution: Execution) -> dict[str, Any]:
     """Serialize execution list-item details."""
     return {
         "exec_id": execution.exec_id,
+        "flow_id": execution.flow_id,
         "flow_name": execution.flow_name,
         "status": execution.status.value,
         "started_at": to_jsonable(execution.started_at, fallback_repr=True),

--- a/src/kitaru/memory.py
+++ b/src/kitaru/memory.py
@@ -587,7 +587,9 @@ def _resolve_execution_flow_context(
     return None
 
 
-def _resolve_active_flow_scope_context(scope: _MemoryScope) -> _ExecutionFlowContext | None:
+def _resolve_active_flow_scope_context(
+    scope: _MemoryScope,
+) -> _ExecutionFlowContext | None:
     """Resolve current runtime flow metadata for a flow-scoped write."""
     if scope.scope_type != "flow":
         return None

--- a/src/kitaru/memory.py
+++ b/src/kitaru/memory.py
@@ -335,9 +335,15 @@ def _implicit_flow_memory_scope(api_name: str) -> _MemoryScope:
 
     flow_scope = _get_current_flow()
     resolved_flow_id = _get_current_flow_id()
-    if flow_scope is None or resolved_flow_id is None:
+    if flow_scope is None:
         raise KitaruStateError(
-            f"{qualified_name} requires an active flow ID inside @flow."
+            f"{qualified_name} requires an active flow scope inside @flow."
+        )
+    if resolved_flow_id is None:
+        raise KitaruStateError(
+            f"{qualified_name} could not resolve a durable flow ID from the "
+            f"ZenML runtime. This typically means the pipeline has not been "
+            f"registered yet or the runtime context is not fully initialized."
         )
 
     return _MemoryScope(
@@ -621,6 +627,11 @@ def _memory_tags(
         _memory_key_tag(key),
         _memory_scope_type_tag(scope_type),
     ]
+    # Flow-ID tag is only added for execution-scoped entries as a cross-reference
+    # back to the parent flow.  For flow-scoped entries the scope itself *is*
+    # the flow ID (encoded in the kitaru:memory:scope:<id> tag), so a separate
+    # flow_id tag would be redundant.  Metadata still records flow_id/flow_name
+    # unconditionally for auditability.
     if scope_type == "execution" and flow_context is not None:
         tags.append(_memory_flow_id_tag(flow_context.flow_id))
     return tags

--- a/src/kitaru/memory.py
+++ b/src/kitaru/memory.py
@@ -48,6 +48,7 @@ from kitaru.errors import (
 from kitaru.runtime import (
     _get_current_execution_id,
     _get_current_flow,
+    _get_current_flow_id,
     _is_inside_checkpoint,
     _is_inside_flow,
 )
@@ -213,7 +214,7 @@ class _MemoryScope:
 
 @dataclass(frozen=True)
 class _ExecutionFlowContext:
-    """Resolved logical flow context for an execution-scoped memory write."""
+    """Resolved logical flow context for a memory write."""
 
     flow_id: str
     flow_name: str | None = None
@@ -329,17 +330,18 @@ def _require_memory_boundary(api_name: str) -> None:
 
 
 def _implicit_flow_memory_scope(api_name: str) -> _MemoryScope:
-    """Resolve the implicit flow-name-backed memory scope."""
+    """Resolve the implicit flow-ID-backed memory scope."""
     qualified_name = f"kitaru.memory.{api_name}()"
 
     flow_scope = _get_current_flow()
-    if flow_scope is None or flow_scope.name is None:
+    resolved_flow_id = _get_current_flow_id()
+    if flow_scope is None or resolved_flow_id is None:
         raise KitaruStateError(
-            f"{qualified_name} requires an active flow name inside @flow."
+            f"{qualified_name} requires an active flow ID inside @flow."
         )
 
     return _MemoryScope(
-        scope=_validate_memory_identifier(flow_scope.name, kind="scope"),
+        scope=_validate_memory_identifier(resolved_flow_id, kind="scope"),
         scope_type="flow",
     )
 
@@ -585,6 +587,24 @@ def _resolve_execution_flow_context(
     return None
 
 
+def _resolve_active_flow_scope_context(scope: _MemoryScope) -> _ExecutionFlowContext | None:
+    """Resolve current runtime flow metadata for a flow-scoped write."""
+    if scope.scope_type != "flow":
+        return None
+
+    flow_scope = _get_current_flow()
+    resolved_flow_id = _get_current_flow_id()
+    if flow_scope is None or resolved_flow_id is None:
+        return None
+    if resolved_flow_id != scope.scope:
+        return None
+
+    return _ExecutionFlowContext(
+        flow_id=resolved_flow_id,
+        flow_name=normalize_flow_name(flow_scope.name),
+    )
+
+
 def _memory_tags(
     scope: str,
     key: str,
@@ -599,7 +619,7 @@ def _memory_tags(
         _memory_key_tag(key),
         _memory_scope_type_tag(scope_type),
     ]
-    if flow_context is not None:
+    if scope_type == "execution" and flow_context is not None:
         tags.append(_memory_flow_id_tag(flow_context.flow_id))
     return tags
 
@@ -1256,6 +1276,8 @@ def _set_entry_impl(
                 scope=scope,
                 project=project,
             )
+        elif resolved_scope_type == "flow":
+            flow_context = _resolve_active_flow_scope_context(scope)
 
         created = _save_memory_artifact(
             client=client,
@@ -1482,6 +1504,8 @@ def _delete_impl(
                 scope=scope,
                 project=project,
             )
+        elif resolved_scope_type == "flow":
+            flow_context = _resolve_active_flow_scope_context(scope)
 
         tombstone = _save_memory_artifact(
             client=client,
@@ -1526,6 +1550,8 @@ def _write_compaction_record(
                 scope=scope,
                 project=project,
             )
+        elif scope.scope_type == "flow":
+            flow_context = _resolve_active_flow_scope_context(scope)
 
         _save_memory_artifact(
             client=client,

--- a/src/kitaru/runtime.py
+++ b/src/kitaru/runtime.py
@@ -84,7 +84,9 @@ def _get_zenml_flow_name() -> str | None:
 
     if run_context := DynamicPipelineRunContext.get():
         run_pipeline = getattr(getattr(run_context, "run", None), "pipeline", None)
-        if flow_name := _shared_normalize_flow_name(getattr(run_pipeline, "name", None)):
+        if flow_name := _shared_normalize_flow_name(
+            getattr(run_pipeline, "name", None)
+        ):
             return flow_name
 
         if flow_name := _shared_normalize_flow_name(
@@ -192,10 +194,10 @@ def _get_current_flow() -> _FlowScope | None:
 
 
 def _get_current_flow_id() -> str | None:
-    """Get the durable ID for the active flow from Kitaru or ZenML context."""
+    """Get the durable ID for the active flow, if any."""
     if (flow_scope := _get_current_flow()) and flow_scope.flow_id is not None:
         return flow_scope.flow_id
-    return _get_zenml_flow_id()
+    return None
 
 
 def _is_inside_flow() -> bool:

--- a/src/kitaru/runtime.py
+++ b/src/kitaru/runtime.py
@@ -24,6 +24,7 @@ class _FlowScope:
     """Internal runtime context for the currently executing flow."""
 
     name: str | None
+    flow_id: str | None = None
     execution_id: str | None = None
 
 
@@ -81,12 +82,33 @@ def _get_zenml_flow_name() -> str | None:
         if flow_name := _shared_normalize_flow_name(getattr(pipeline, "name", None)):
             return flow_name
 
-    if (run_context := DynamicPipelineRunContext.get()) and (
-        flow_name := _shared_normalize_flow_name(
+    if run_context := DynamicPipelineRunContext.get():
+        run_pipeline = getattr(getattr(run_context, "run", None), "pipeline", None)
+        if flow_name := _shared_normalize_flow_name(getattr(run_pipeline, "name", None)):
+            return flow_name
+
+        if flow_name := _shared_normalize_flow_name(
             getattr(run_context.pipeline, "name", None)
-        )
-    ):
-        return flow_name
+        ):
+            return flow_name
+
+    return None
+
+
+def _get_zenml_flow_id() -> str | None:
+    """Resolve the active flow ID from ZenML runtime contexts, if available."""
+    if step_context := StepContext.get():
+        pipeline = getattr(step_context.pipeline_run, "pipeline", None)
+        if flow_id := _to_optional_str(getattr(pipeline, "id", None)):
+            return flow_id
+
+    if run_context := DynamicPipelineRunContext.get():
+        run_pipeline = getattr(getattr(run_context, "run", None), "pipeline", None)
+        if flow_id := _to_optional_str(getattr(run_pipeline, "id", None)):
+            return flow_id
+
+        if flow_id := _to_optional_str(getattr(run_context.pipeline, "id", None)):
+            return flow_id
 
     return None
 
@@ -95,14 +117,20 @@ def _get_zenml_flow_name() -> str | None:
 def _flow_scope(
     *,
     name: str | None,
+    flow_id: str | None = None,
     execution_id: str | None = None,
 ) -> Iterator[None]:
     """Set flow runtime scope for the active execution context."""
+    resolved_flow_id = flow_id if flow_id is not None else _get_zenml_flow_id()
     resolved_execution_id = (
         execution_id if execution_id is not None else _get_zenml_execution_id()
     )
     flow_token = _CURRENT_FLOW_SCOPE.set(
-        _FlowScope(name=name, execution_id=resolved_execution_id)
+        _FlowScope(
+            name=name,
+            flow_id=resolved_flow_id,
+            execution_id=resolved_execution_id,
+        )
     )
     llm_counter_token = _LLM_CALL_COUNTER.set(0)
     try:
@@ -161,6 +189,13 @@ def _suspend_checkpoint_scope() -> Iterator[None]:
 def _get_current_flow() -> _FlowScope | None:
     """Get the currently active flow scope, if any."""
     return _CURRENT_FLOW_SCOPE.get()
+
+
+def _get_current_flow_id() -> str | None:
+    """Get the durable ID for the active flow from Kitaru or ZenML context."""
+    if (flow_scope := _get_current_flow()) and flow_scope.flow_id is not None:
+        return flow_scope.flow_id
+    return _get_zenml_flow_id()
 
 
 def _is_inside_flow() -> bool:

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -92,6 +92,7 @@ def sample_execution(
 
     return Execution(
         exec_id="kr-a8f3c2",
+        flow_id="flow-123",
         flow_name="content_pipeline",
         status=ExecutionStatus.WAITING,
         started_at=started_at,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -105,6 +105,7 @@ class _DummyRun:
         *,
         status: Any,
         flow_name: str,
+        flow_id: str | None = None,
         run_metadata: dict[str, Any] | None = None,
         steps: dict[str, _DummyStep] | None = None,
         stack_name: str | None = "local",
@@ -120,7 +121,7 @@ class _DummyRun:
         self.start_time = None
         self.end_time = None
         self.run_metadata = run_metadata or {}
-        self.pipeline = SimpleNamespace(name=flow_name)
+        self.pipeline = SimpleNamespace(name=flow_name, id=flow_id or uuid4())
         self.stack = SimpleNamespace(name=stack_name) if stack_name else None
         self.snapshot = snapshot
         self.original_run = None
@@ -489,6 +490,7 @@ def test_get_maps_execution_details() -> None:
         execution = client.executions.get(str(run.id))
 
     assert execution.exec_id == str(run.id)
+    assert execution.flow_id == str(run.pipeline.id)
     assert execution.flow_name == "content_flow"
     assert execution.status == ExecutionStatus.COMPLETED
     assert execution.frozen_execution_spec is not None

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -830,7 +830,13 @@ def test_flow_runtime_scope_sets_execution_id_from_zenml_run_context() -> None:
 
     with patch(
         "kitaru.runtime.DynamicPipelineRunContext.get",
-        return_value=SimpleNamespace(run=SimpleNamespace(id="exec-123")),
+        return_value=SimpleNamespace(
+            run=SimpleNamespace(
+                id="exec-123",
+                pipeline=SimpleNamespace(id="flow-abc", name="_user_flow"),
+            ),
+            pipeline=SimpleNamespace(id=None, name=None),
+        ),
     ):
         result = wrapped()
 
@@ -861,6 +867,8 @@ def test_flow_runtime_scope_keeps_execution_id_none_without_zenml_context() -> N
 
 
 def test_wrapped_flow_resets_memory_scope_between_invocations() -> None:
+    flow_id = "flow-reset-test"
+
     def first_flow() -> None:
         memory.configure(scope="repo_a")
         memory.list()
@@ -873,7 +881,15 @@ def test_wrapped_flow_resets_memory_scope_between_invocations() -> None:
 
     with (
         patch("kitaru.runtime.StepContext.get", return_value=None),
-        patch("kitaru.runtime.DynamicPipelineRunContext.get", return_value=None),
+        patch(
+            "kitaru.runtime.DynamicPipelineRunContext.get",
+            return_value=SimpleNamespace(
+                run=SimpleNamespace(
+                    pipeline=SimpleNamespace(id=flow_id, name="test_flow"),
+                ),
+                pipeline=SimpleNamespace(id=None, name=None),
+            ),
+        ),
         patch("kitaru.memory._memory_list_step", return_value=[]) as memory_list_step,
     ):
         wrapped_first()
@@ -881,7 +897,7 @@ def test_wrapped_flow_resets_memory_scope_between_invocations() -> None:
 
     assert memory_list_step.call_args_list == [
         call("repo_a", "namespace"),
-        call("second_flow", "flow"),
+        call(flow_id, "flow"),
     ]
 
 

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -208,6 +208,7 @@ def _sample_checkpoint_call() -> CheckpointCall:
 def _sample_execution() -> Execution:
     return Execution(
         exec_id="kr-123",
+        flow_id="flow-123",
         flow_name="content_pipeline",
         status=ExecutionStatus.WAITING,
         started_at=datetime(2026, 3, 14, 9, 55, tzinfo=UTC),
@@ -542,6 +543,7 @@ def test_serialize_execution_summary_contract() -> None:
 
     assert payload == {
         "exec_id": "kr-123",
+        "flow_id": "flow-123",
         "flow_name": "content_pipeline",
         "status": "waiting",
         "started_at": "2026-03-14T09:55:00+00:00",
@@ -568,6 +570,7 @@ def test_serialize_execution_contract() -> None:
 
     assert set(payload) == {
         "exec_id",
+        "flow_id",
         "flow_name",
         "status",
         "started_at",

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -218,6 +218,16 @@ def test_memory_rejects_invalid_flow_id_as_scope() -> None:
         memory.list()
 
 
+def test_memory_raises_when_flow_active_but_flow_id_missing() -> None:
+    """Flow scope without a resolvable flow ID should raise a diagnostic error."""
+    with (
+        _flow_scope(name="demo_flow"),
+        patch("kitaru.memory._get_current_flow_id", return_value=None),
+        pytest.raises(KitaruStateError, match="could not resolve a durable flow ID"),
+    ):
+        memory.list()
+
+
 def test_memory_configure_rejects_invalid_scope_before_dispatch() -> None:
     with (
         _flow_scope(name="demo_flow", flow_id=_runtime_flow_id("demo_flow")),

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -102,6 +102,11 @@ def _flow_memory_scope(name: str = "demo_flow") -> _MemoryScope:
     return _MemoryScope(scope=name, scope_type="flow")
 
 
+def _runtime_flow_id(name: str = "demo_flow") -> str:
+    """Return a deterministic flow ID string for runtime-scope tests."""
+    return f"flow-{name}"
+
+
 def _created_artifact_response(artifact_id: UUID | None = None) -> SimpleNamespace:
     """Build the lightweight response returned by ``save_artifact``."""
     return SimpleNamespace(id=artifact_id or uuid4())
@@ -169,7 +174,7 @@ def test_memory_apis_require_configured_scope_outside_flow(
 )
 def test_memory_apis_reject_checkpoint_context(call: Callable[[], object]) -> None:
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=_runtime_flow_id("demo_flow")),
         _checkpoint_scope(name="demo_checkpoint", checkpoint_type=None),
         pytest.raises(KitaruContextError, match=r"@checkpoint"),
     ):
@@ -186,7 +191,7 @@ def test_memory_configure_outside_flow_sets_process_default() -> None:
 
 def test_memory_configure_rejects_checkpoint_context() -> None:
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=_runtime_flow_id("demo_flow")),
         _checkpoint_scope(name="demo_checkpoint", checkpoint_type=None),
         pytest.raises(KitaruContextError, match=r"@checkpoint"),
     ):
@@ -196,7 +201,7 @@ def test_memory_configure_rejects_checkpoint_context() -> None:
 @pytest.mark.parametrize("bad_key", ["", " ", "bad:key", "bad key"])
 def test_memory_set_rejects_invalid_keys_before_dispatch(bad_key: str) -> None:
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=_runtime_flow_id("demo_flow")),
         patch("kitaru.memory._memory_set_step") as memory_set_step,
         pytest.raises(KitaruUsageError, match="Memory key"),
     ):
@@ -205,9 +210,9 @@ def test_memory_set_rejects_invalid_keys_before_dispatch(bad_key: str) -> None:
     memory_set_step.assert_not_called()
 
 
-def test_memory_rejects_invalid_flow_name_as_scope() -> None:
+def test_memory_rejects_invalid_flow_id_as_scope() -> None:
     with (
-        _flow_scope(name="bad:scope"),
+        _flow_scope(name="demo_flow", flow_id="bad:scope"),
         pytest.raises(KitaruUsageError, match="Memory scope"),
     ):
         memory.list()
@@ -215,7 +220,7 @@ def test_memory_rejects_invalid_flow_name_as_scope() -> None:
 
 def test_memory_configure_rejects_invalid_scope_before_dispatch() -> None:
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=_runtime_flow_id("demo_flow")),
         patch("kitaru.memory._memory_list_step") as memory_list_step,
         pytest.raises(KitaruUsageError, match="Memory scope"),
     ):
@@ -253,16 +258,17 @@ def test_memory_configure_cannot_infer_flowish_scope_outside_flow(
 
 def test_memory_set_dispatches_to_synthetic_step() -> None:
     payload = {"language": "en", "theme": "dark"}
+    flow_id = _runtime_flow_id("research_agent")
 
     with (
-        _flow_scope(name="research_agent"),
+        _flow_scope(name="research_agent", flow_id=flow_id),
         patch("kitaru.memory._memory_set_step") as memory_set_step,
     ):
         result = memory.set("user_preferences", payload)
 
     assert result is None
     memory_set_step.assert_called_once_with(
-        "research_agent",
+        flow_id,
         "flow",
         "user_preferences",
         payload,
@@ -289,8 +295,10 @@ def test_memory_set_outside_flow_dispatches_to_direct_impl() -> None:
 
 
 def test_memory_get_dispatches_to_synthetic_step() -> None:
+    flow_id = _runtime_flow_id("demo_flow")
+
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=flow_id),
         patch(
             "kitaru.memory._memory_get_step",
             return_value={"theme": "dark"},
@@ -299,7 +307,7 @@ def test_memory_get_dispatches_to_synthetic_step() -> None:
         result = memory.get("prefs", version=2)
 
     assert result == {"theme": "dark"}
-    memory_get_step.assert_called_once_with("demo_flow", "flow", "prefs", 2)
+    memory_get_step.assert_called_once_with(flow_id, "flow", "prefs", 2)
 
 
 def test_memory_get_outside_flow_dispatches_to_direct_impl() -> None:
@@ -325,9 +333,10 @@ def test_memory_get_outside_flow_dispatches_to_direct_impl() -> None:
 
 def test_memory_list_dispatches_to_synthetic_step() -> None:
     fake_entries = [_memory_entry(version=2)]
+    flow_id = _runtime_flow_id("demo_flow")
 
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=flow_id),
         patch(
             "kitaru.memory._memory_list_step",
             return_value=fake_entries,
@@ -336,7 +345,7 @@ def test_memory_list_dispatches_to_synthetic_step() -> None:
         result = memory.list()
 
     assert result == fake_entries
-    memory_list_step.assert_called_once_with("demo_flow", "flow")
+    memory_list_step.assert_called_once_with(flow_id, "flow")
 
 
 def test_memory_list_outside_flow_dispatches_to_direct_impl() -> None:
@@ -361,9 +370,10 @@ def test_memory_list_outside_flow_dispatches_to_direct_impl() -> None:
 
 def test_memory_history_dispatches_to_synthetic_step() -> None:
     fake_entries = [_memory_entry(version=3, is_deleted=True)]
+    flow_id = _runtime_flow_id("demo_flow")
 
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=flow_id),
         patch(
             "kitaru.memory._memory_history_step",
             return_value=fake_entries,
@@ -372,7 +382,7 @@ def test_memory_history_dispatches_to_synthetic_step() -> None:
         result = memory.history("prefs")
 
     assert result == fake_entries
-    memory_history_step.assert_called_once_with("demo_flow", "flow", "prefs")
+    memory_history_step.assert_called_once_with(flow_id, "flow", "prefs")
 
 
 def test_memory_history_outside_flow_dispatches_to_direct_impl() -> None:
@@ -398,9 +408,10 @@ def test_memory_history_outside_flow_dispatches_to_direct_impl() -> None:
 
 def test_memory_delete_dispatches_to_synthetic_step() -> None:
     fake_entry = _memory_entry(version=3, is_deleted=True)
+    flow_id = _runtime_flow_id("demo_flow")
 
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=flow_id),
         patch(
             "kitaru.memory._memory_delete_step",
             return_value=fake_entry,
@@ -409,7 +420,7 @@ def test_memory_delete_dispatches_to_synthetic_step() -> None:
         result = memory.delete("prefs")
 
     assert result == fake_entry
-    memory_delete_step.assert_called_once_with("demo_flow", "flow", "prefs")
+    memory_delete_step.assert_called_once_with(flow_id, "flow", "prefs")
 
 
 def test_memory_delete_outside_flow_dispatches_to_direct_impl() -> None:
@@ -442,7 +453,7 @@ def test_memory_configure_sets_namespace_scope_for_subsequent_calls() -> None:
     fake_entries = [_memory_entry(scope="my_repo", scope_type="namespace")]
 
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=_runtime_flow_id("demo_flow")),
         patch("kitaru.memory._memory_set_step") as memory_set_step,
         patch(
             "kitaru.memory._memory_get_step",
@@ -480,11 +491,12 @@ def test_memory_configure_sets_namespace_scope_for_subsequent_calls() -> None:
     memory_delete_step.assert_called_once_with("my_repo", "namespace", "prefs")
 
 
-def test_memory_configure_scope_type_flow_uses_current_flow_name() -> None:
-    fake_entries = [_memory_entry(scope="demo_flow", scope_type="flow")]
+def test_memory_configure_scope_type_flow_uses_current_flow_id() -> None:
+    flow_id = _runtime_flow_id("demo_flow")
+    fake_entries = [_memory_entry(scope=flow_id, scope_type="flow")]
 
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=flow_id),
         patch(
             "kitaru.memory._memory_list_step",
             return_value=fake_entries,
@@ -494,14 +506,36 @@ def test_memory_configure_scope_type_flow_uses_current_flow_name() -> None:
         result = memory.list()
 
     assert result == fake_entries
-    memory_list_step.assert_called_once_with("demo_flow", "flow")
+    memory_list_step.assert_called_once_with(flow_id, "flow")
+
+
+def test_memory_flow_scope_distinguishes_same_name_flows_by_id() -> None:
+    """Implicit flow scope should use durable flow IDs, not display names."""
+    first_flow_id = "flow-alpha-123"
+    second_flow_id = "flow-beta-456"
+
+    with patch("kitaru.memory._memory_set_step") as memory_set_step:
+        with _flow_scope(name="shared_flow_name", flow_id=first_flow_id):
+            memory.set("prefs", {"theme": "dark"})
+
+        with _flow_scope(name="shared_flow_name", flow_id=second_flow_id):
+            memory.set("prefs", {"theme": "light"})
+
+    assert memory_set_step.call_args_list == [
+        call(first_flow_id, "flow", "prefs", {"theme": "dark"}),
+        call(second_flow_id, "flow", "prefs", {"theme": "light"}),
+    ]
 
 
 def test_memory_configure_scope_type_execution_uses_execution_id() -> None:
     fake_entries = [_memory_entry(scope="exec-123", scope_type="execution")]
 
     with (
-        _flow_scope(name="demo_flow", execution_id="exec-123"),
+        _flow_scope(
+            name="demo_flow",
+            flow_id=_runtime_flow_id("demo_flow"),
+            execution_id="exec-123",
+        ),
         patch(
             "kitaru.memory._memory_list_step",
             return_value=fake_entries,
@@ -516,7 +550,7 @@ def test_memory_configure_scope_type_execution_uses_execution_id() -> None:
 
 def test_memory_configure_execution_scope_requires_execution_id() -> None:
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=_runtime_flow_id("demo_flow")),
         pytest.raises(KitaruStateError, match="active execution ID"),
     ):
         memory.configure(scope_type="execution")
@@ -527,7 +561,7 @@ def test_memory_configure_outside_flow_seeds_later_flow_session() -> None:
     memory.configure(scope="repo_seed")
 
     with (
-        _flow_scope(name="demo_flow"),
+        _flow_scope(name="demo_flow", flow_id=_runtime_flow_id("demo_flow")),
         memory._memory_scope_session(),
         patch(
             "kitaru.memory._memory_list_step",
@@ -546,7 +580,7 @@ def test_memory_configure_inside_flow_overrides_process_default_without_mutation
     memory.configure(scope="repo_seed")
 
     with (
-        _flow_scope(name="first_flow"),
+        _flow_scope(name="first_flow", flow_id=_runtime_flow_id("first_flow")),
         memory._memory_scope_session(),
         patch("kitaru.memory._memory_list_step", return_value=[]) as memory_list_step,
     ):
@@ -554,7 +588,7 @@ def test_memory_configure_inside_flow_overrides_process_default_without_mutation
         memory.list()
 
     with (
-        _flow_scope(name="second_flow"),
+        _flow_scope(name="second_flow", flow_id=_runtime_flow_id("second_flow")),
         memory._memory_scope_session(),
         patch("kitaru.memory._memory_list_step", return_value=[]) as memory_list_step_2,
     ):
@@ -679,6 +713,57 @@ def test_set_entry_impl_returns_created_memory_entry() -> None:
     assert entry.execution_id == str(created.producer_pipeline_run_id)
     assert entry.flow_id is None
     assert entry.flow_name is None
+
+
+def test_set_entry_impl_flow_scope_persists_flow_metadata_without_flow_tag() -> None:
+    payload = {"summary": "ready"}
+    flow_id = "flow-demo-123"
+    created = _memory_artifact(
+        scope=flow_id,
+        key="scratch",
+        version=1,
+        value=payload,
+        scope_type="flow",
+        flow_id=flow_id,
+        flow_name="repo_memory_demo",
+    )
+    client_mock = MagicMock()
+    client_mock.list_artifact_versions.return_value = _page()
+    client_mock.get_artifact_version.return_value = created
+
+    with (
+        _flow_scope(name="repo_memory_demo", flow_id=flow_id),
+        patch("kitaru.memory.Client", return_value=client_mock),
+        patch(
+            "kitaru.memory.save_artifact",
+            return_value=_created_artifact_response(created.id),
+        ) as save_artifact_mock,
+    ):
+        entry = _set_entry_impl(
+            _MemoryScope(scope=flow_id, scope_type="flow"),
+            "scratch",
+            payload,
+        )
+
+    save_artifact_mock.assert_called_once_with(
+        data=payload,
+        name=f"kitaru_mem:flow:{flow_id}:scratch",
+        artifact_type=ArtifactType.DATA,
+        tags=[
+            "kitaru:memory",
+            f"kitaru:memory:scope:{flow_id}",
+            "kitaru:memory:key:scratch",
+            "kitaru:memory:scope_type:flow",
+        ],
+        user_metadata={
+            "kitaru_memory_scope_type": "flow",
+            "kitaru_memory_deleted": False,
+            "kitaru_memory_flow_id": flow_id,
+            "kitaru_memory_flow_name": "repo_memory_demo",
+        },
+    )
+    assert entry.flow_id == flow_id
+    assert entry.flow_name == "repo_memory_demo"
 
 
 def test_set_entry_impl_execution_scope_indexes_detached_flow_context() -> None:

--- a/tests/test_phase20_memory_example.py
+++ b/tests/test_phase20_memory_example.py
@@ -56,6 +56,8 @@ def test_phase20_memory_example_runs_end_to_end(primed_zenml) -> None:
         snapshot = run_workflow(topic="memory-browser", namespace_scope=namespace_scope)
 
     execution_id = cast(str, snapshot["execution_id"])
+    flow_scope_id = cast(str, snapshot["flow_scope"])
+    flow_name = cast(str, snapshot["flow_name"])
     flow_snapshot = cast(dict[str, Any], snapshot["flow_snapshot"])
     execution_snapshot = cast(dict[str, Any], snapshot["execution_snapshot"])
     client_snapshot = cast(dict[str, Any], snapshot["client_snapshot"])
@@ -64,7 +66,8 @@ def test_phase20_memory_example_runs_end_to_end(primed_zenml) -> None:
 
     assert execution_id
     assert snapshot["namespace_scope"] == namespace_scope
-    assert snapshot["flow_scope"] == FLOW_SCOPE
+    assert flow_scope_id
+    assert flow_name == FLOW_SCOPE
 
     # --- Seed phase assertions ---
     assert "conventions/test_runner" in seed_snapshot["active_keys"]
@@ -128,7 +131,7 @@ def test_phase20_memory_example_runs_end_to_end(primed_zenml) -> None:
     # Flow scope
     flow_entry = client.memories.get(
         "summaries/latest",
-        scope=FLOW_SCOPE,
+        scope=flow_scope_id,
         scope_type="flow",
     )
     assert flow_entry is not None
@@ -138,10 +141,12 @@ def test_phase20_memory_example_runs_end_to_end(primed_zenml) -> None:
         entry.version
         for entry in client.memories.history(
             "summaries/latest",
-            scope=FLOW_SCOPE,
+            scope=flow_scope_id,
             scope_type="flow",
         )
     ] == [1]
+    assert flow_entry.flow_id == flow_scope_id
+    assert flow_entry.flow_name == FLOW_SCOPE
 
     # Execution scope — in-flow entries
     execution_entries = client.memories.list(
@@ -213,7 +218,7 @@ def test_phase20_memory_example_runs_end_to_end(primed_zenml) -> None:
     # Scopes
     scopes = _scope_map(cast(list[dict[str, Any]], client_snapshot["scopes"]))
     assert scopes[namespace_scope]["scope_type"] == "namespace"
-    assert scopes[FLOW_SCOPE]["scope_type"] == "flow"
+    assert scopes[flow_scope_id]["scope_type"] == "flow"
     assert scopes[execution_id]["scope_type"] == "execution"
 
     # --- Maintenance phase assertions ---
@@ -254,7 +259,8 @@ def test_phase20_memory_without_maintenance(primed_zenml) -> None:
     )
 
     assert snapshot["maintenance_snapshot"] is None
-    assert snapshot["flow_scope"] == FLOW_SCOPE
+    assert snapshot["flow_name"] == FLOW_SCOPE
+    assert snapshot["flow_scope"]
 
     # Core runtime claims still hold.
     seed = snapshot["seed_snapshot"]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -173,3 +173,40 @@ def test_flow_scope_resolves_flow_id_from_dynamic_run_context() -> None:
 
         assert current_flow is not None
         assert current_flow.flow_id == flow_id
+
+
+def test_flow_scope_resolves_flow_id_from_legacy_pipeline_attr() -> None:
+    """Fall back to run_context.pipeline.id when run.pipeline.id is unavailable."""
+    flow_id = str(uuid4())
+    run_context = type(
+        "DynamicRunContextStub",
+        (),
+        {
+            "run": type(
+                "RunStub",
+                (),
+                {
+                    "pipeline": type(
+                        "PipelineStub",
+                        (),
+                        {"id": None, "name": None},
+                    )()
+                },
+            )(),
+            "pipeline": type(
+                "LegacyPipelineStub",
+                (),
+                {"id": flow_id, "name": "demo_flow"},
+            )(),
+        },
+    )()
+
+    with (
+        patch("kitaru.runtime.StepContext.get", return_value=None),
+        patch("kitaru.runtime.DynamicPipelineRunContext.get", return_value=run_context),
+        _flow_scope(name="demo_flow"),
+    ):
+        current_flow = _get_current_flow()
+
+        assert current_flow is not None
+        assert current_flow.flow_id == flow_id

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 from kitaru.runtime import (
     _checkpoint_scope,
+    _get_current_flow,
     _flow_scope,
     _is_inside_checkpoint,
     _is_inside_flow,
@@ -22,10 +23,11 @@ def _scope_ids() -> tuple[str, str]:
 
 def test_suspend_checkpoint_scope_temporarily_clears_checkpoint_scope() -> None:
     """Checkpoint scope should be disabled only inside suspension context."""
+    flow_id = str(uuid4())
     execution_id, checkpoint_id = _scope_ids()
 
     with (
-        _flow_scope(name="demo_flow", execution_id=execution_id),
+        _flow_scope(name="demo_flow", flow_id=flow_id, execution_id=execution_id),
         _checkpoint_scope(
             name="demo_checkpoint",
             checkpoint_type=None,
@@ -35,6 +37,8 @@ def test_suspend_checkpoint_scope_temporarily_clears_checkpoint_scope() -> None:
     ):
         assert _is_inside_flow()
         assert _is_inside_checkpoint()
+        assert _get_current_flow() is not None
+        assert _get_current_flow().flow_id == flow_id
 
         with _suspend_checkpoint_scope():
             assert _is_inside_flow()
@@ -46,10 +50,11 @@ def test_suspend_checkpoint_scope_temporarily_clears_checkpoint_scope() -> None:
 
 def test_suspend_checkpoint_scope_restores_state_after_exception() -> None:
     """Checkpoint scope should be restored even when the body raises."""
+    flow_id = str(uuid4())
     execution_id, checkpoint_id = _scope_ids()
 
     with (
-        _flow_scope(name="demo_flow", execution_id=execution_id),
+        _flow_scope(name="demo_flow", flow_id=flow_id, execution_id=execution_id),
         _checkpoint_scope(
             name="demo_checkpoint",
             checkpoint_type=None,
@@ -68,13 +73,14 @@ def test_suspend_checkpoint_scope_restores_state_after_exception() -> None:
 
 def test_wait_runs_when_checkpoint_scope_is_suspended() -> None:
     """wait() should succeed once checkpoint scope is temporarily suspended."""
+    flow_id = str(uuid4())
     execution_id, checkpoint_id = _scope_ids()
 
     def mock_zenml_wait(**_: object) -> None:
         return None
 
     with (
-        _flow_scope(name="demo_flow", execution_id=execution_id),
+        _flow_scope(name="demo_flow", flow_id=flow_id, execution_id=execution_id),
         _checkpoint_scope(
             name="demo_checkpoint",
             checkpoint_type=None,
@@ -85,3 +91,84 @@ def test_wait_runs_when_checkpoint_scope_is_suspended() -> None:
         _suspend_checkpoint_scope(),
     ):
         assert wait(name="approve") is None
+
+
+def test_flow_scope_records_explicit_flow_id() -> None:
+    """Flow scope should preserve durable flow identity alongside display name."""
+    flow_id = str(uuid4())
+
+    with _flow_scope(name="demo_flow", flow_id=flow_id):
+        current_flow = _get_current_flow()
+
+        assert current_flow is not None
+        assert current_flow.name == "demo_flow"
+        assert current_flow.flow_id == flow_id
+
+
+def test_flow_scope_resolves_flow_id_from_step_context() -> None:
+    """Flow scope should resolve IDs from the active ZenML step context."""
+    flow_id = str(uuid4())
+    step_context = type(
+        "StepContextStub",
+        (),
+        {
+            "pipeline_run": type(
+                "PipelineRunStub",
+                (),
+                {
+                    "pipeline": type(
+                        "PipelineStub",
+                        (),
+                        {"id": flow_id, "name": "demo_flow"},
+                    )()
+                },
+            )()
+        },
+    )()
+
+    with (
+        patch("kitaru.runtime.StepContext.get", return_value=step_context),
+        patch("kitaru.runtime.DynamicPipelineRunContext.get", return_value=None),
+        _flow_scope(name="demo_flow"),
+    ):
+        current_flow = _get_current_flow()
+
+        assert current_flow is not None
+        assert current_flow.flow_id == flow_id
+
+
+def test_flow_scope_resolves_flow_id_from_dynamic_run_context() -> None:
+    """Flow scope should resolve IDs from the active ZenML run context."""
+    flow_id = str(uuid4())
+    run_context = type(
+        "DynamicRunContextStub",
+        (),
+        {
+            "run": type(
+                "RunStub",
+                (),
+                {
+                    "pipeline": type(
+                        "PipelineStub",
+                        (),
+                        {"id": flow_id, "name": "demo_flow"},
+                    )()
+                },
+            )(),
+            "pipeline": type(
+                "LegacyPipelineStub",
+                (),
+                {"id": None, "name": None},
+            )(),
+        },
+    )()
+
+    with (
+        patch("kitaru.runtime.StepContext.get", return_value=None),
+        patch("kitaru.runtime.DynamicPipelineRunContext.get", return_value=run_context),
+        _flow_scope(name="demo_flow"),
+    ):
+        current_flow = _get_current_flow()
+
+        assert current_flow is not None
+        assert current_flow.flow_id == flow_id

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -7,8 +7,8 @@ from uuid import uuid4
 
 from kitaru.runtime import (
     _checkpoint_scope,
-    _get_current_flow,
     _flow_scope,
+    _get_current_flow,
     _is_inside_checkpoint,
     _is_inside_flow,
     _suspend_checkpoint_scope,
@@ -37,8 +37,9 @@ def test_suspend_checkpoint_scope_temporarily_clears_checkpoint_scope() -> None:
     ):
         assert _is_inside_flow()
         assert _is_inside_checkpoint()
-        assert _get_current_flow() is not None
-        assert _get_current_flow().flow_id == flow_id
+        current = _get_current_flow()
+        assert current is not None
+        assert current.flow_id == flow_id
 
         with _suspend_checkpoint_scope():
             assert _is_inside_flow()


### PR DESCRIPTION
## Summary

- Switch flow-scoped memory from keying on the flow *name* (Python function name) to the durable flow *ID* (UUID assigned by ZenML when a pipeline is registered). This fixes a collision bug where two different flows sharing the same function name could read/write each other's memories.
- Add `flow_id` field to the `Execution` model, `_FlowScope` runtime context, and serialization surfaces so the ID is available throughout the stack.
- Add `_get_zenml_flow_id()` runtime resolver and `_resolve_active_flow_scope_context()` memory helper to support flow-ID-based scoping.
- Simplify `_get_current_flow_id()` to be a pure accessor of pre-resolved state (no re-resolution fallback), and clean up the `_mappers.py` flow-ID extraction.
- Improve error diagnostics: split the flow-ID guard into two checks so users can distinguish "not inside a flow" from "flow ID not yet resolved by ZenML runtime".

## Test plan

- [x] New test: `test_memory_flow_scope_distinguishes_same_name_flows_by_id` — verifies two flows with the same name but different IDs get separate memory scopes
- [x] New test: `test_set_entry_impl_flow_scope_persists_flow_metadata_without_flow_tag` — verifies flow-scoped writes persist flow metadata but omit the flow-ID tag (since the scope itself is the ID)
- [x] New tests: `test_flow_scope_records_explicit_flow_id`, `test_flow_scope_resolves_flow_id_from_step_context`, `test_flow_scope_resolves_flow_id_from_dynamic_run_context` — verify flow-ID resolution from various runtime contexts
- [x] New test: `test_memory_raises_when_flow_active_but_flow_id_missing` — verifies the diagnostic error when a flow is active but the ZenML runtime hasn't provided a pipeline ID
- [x] New test: `test_flow_scope_resolves_flow_id_from_legacy_pipeline_attr` — verifies the fallback resolution path via `DynamicPipelineRunContext.pipeline.id`
- [x] Updated all existing memory and runtime tests to supply flow IDs
- [x] `just check` passes (format, lint, typecheck, typos, yaml, actions lint, links)
- [x] `just test` passes (1155 passed, 1 skipped)