### PR TITLE
Improve flow observability metadata and MCP documentation

### DIFF
--- a/docs/content/docs/agent-native/mcp-server.mdx
+++ b/docs/content/docs/agent-native/mcp-server.mdx
@@ -87,6 +87,47 @@ Connection tools:
 - `kitaru_stacks_list`
 - `manage_stack`
 
+## Copy-paste prompts
+
+Use prompts like these in an MCP-capable assistant after you configure the
+Kitaru MCP server.
+
+Read-only status check:
+
+```text
+Check my Kitaru status and list the five latest executions. Summarize anything waiting for input.
+```
+
+Start and watch a flow:
+
+```text
+Run `examples/basic_flow/first_working_flow.py:research_agent` with topic="durable execution", then watch the execution until it finishes.
+```
+
+Resolve a waiting execution safely:
+
+```text
+Find executions waiting for input. If exactly one is waiting, show me the question and ask me for the value before calling the input tool.
+```
+
+Plan and run a replay:
+
+```text
+Replay the latest failed execution from the checkpoint before the failing one. Explain the replay plan before running it.
+```
+
+Inspect results from a completed execution:
+
+```text
+Get the latest completed execution and show me its response artifacts.
+```
+
+Manage a local stack:
+
+```text
+Create a local Kitaru stack named local-dev if it does not already exist, then show me the current Kitaru status.
+```
+
 ## Starting executions with `kitaru_executions_run`
 
 The `kitaru_executions_run` tool requires a `target` string in the format:

--- a/docs/content/docs/getting-started/installation.mdx
+++ b/docs/content/docs/getting-started/installation.mdx
@@ -39,6 +39,11 @@ uv add "kitaru[mcp,pydantic-ai,local]"
 # or: pip install "kitaru[mcp,pydantic-ai,local]"
 ```
 
+If you use Claude Code or another MCP-capable assistant, install
+`kitaru[mcp]` so your assistant can query executions, inspect logs and
+artifacts, provide input to waiting runs, and start replays through structured
+tool calls. See [MCP Server](/agent-native/mcp-server) for setup.
+
 ## Verify Installation
 
 <Tabs items={["uv project", "pip environment"]}>

--- a/src/kitaru/_config/_stacks.py
+++ b/src/kitaru/_config/_stacks.py
@@ -1979,7 +1979,9 @@ def classify_stack_deployment_type(
     try:
         hydrated_stack = client.get_stack(resolved_stack.id, hydrate=True)
     except Exception as exc:
-        raise KitaruBackendError("Unable to classify stack deployment type.") from exc
+        raise KitaruBackendError(
+            f"Unable to classify stack deployment type for '{selector}'."
+        ) from exc
 
     component_details = _stack_component_details_from_stack_model(
         hydrated_stack,

--- a/src/kitaru/_config/_stacks.py
+++ b/src/kitaru/_config/_stacks.py
@@ -1835,72 +1835,13 @@ def _stack_component_details_from_model(
     )
 
 
-def _infer_stack_details_type(
-    components: tuple[StackComponentDetails, ...],
-) -> _StackShowType:
-    """Infer a user-facing stack type from translated stack components."""
-    if any(
-        component.role == "runner"
-        and component.backend == GCP_VERTEX_ORCHESTRATOR_FLAVOR
-        for component in components
-    ):
-        return "vertex"
-
-    if any(
-        component.role == "runner"
-        and component.backend == AWS_SAGEMAKER_ORCHESTRATOR_FLAVOR
-        for component in components
-    ):
-        return "sagemaker"
-
-    if any(
-        component.role == "runner" and component.backend == AZUREML_ORCHESTRATOR_FLAVOR
-        for component in components
-    ):
-        return "azureml"
-
-    if any(
-        component.role == "runner" and component.backend == "kubernetes"
-        for component in components
-    ):
-        return "kubernetes"
-
-    if components and all(
-        component.role in {"runner", "storage"} for component in components
-    ):
-        backends = {
-            component.backend
-            for component in components
-            if component.backend is not None
-        }
-        if backends.issubset({"local"}):
-            return "local"
-
-    return "custom"
-
-
-def _show_stack_operation(
-    name_or_id: str,
+def _stack_component_details_from_stack_model(
+    stack_model: Any,
     *,
-    client_factory: Callable[[], Any] = Client,
-) -> StackDetails:
-    """Inspect one stack and translate its component metadata for CLI display."""
-    selector = _normalize_stack_selector(name_or_id)
-    client = client_factory()
-    resolved_stack = _resolve_stack_for_show(client, selector)
-
-    try:
-        hydrated_stack = client.get_stack(resolved_stack.id, hydrate=True)
-    except Exception as exc:
-        raise KitaruBackendError(
-            f"Unable to inspect stack '{selector}': {exc}"
-        ) from exc
-
-    active_stack_id = str(client.active_stack_model.id)
-    stack = _stack_info_from_model(hydrated_stack, active_stack_id=active_stack_id)
-    is_managed = _stack_is_managed(hydrated_stack)
-
-    raw_components = getattr(hydrated_stack, "components", None)
+    selector: str,
+) -> tuple[StackComponentDetails, ...]:
+    """Translate hydrated stack component metadata into Kitaru details."""
+    raw_components = getattr(stack_model, "components", None)
     if not isinstance(raw_components, Mapping):
         raise KitaruStateError(
             f"Stack '{selector}' returned malformed component metadata."
@@ -1961,7 +1902,120 @@ def _show_stack_operation(
                 _stack_component_details_from_model(component_type, component_model)
             )
 
-    component_details = tuple(ordered_components)
+    return tuple(ordered_components)
+
+
+def _infer_stack_details_type(
+    components: tuple[StackComponentDetails, ...],
+) -> _StackShowType:
+    """Infer a user-facing stack type from translated stack components."""
+    if any(
+        component.role == "runner"
+        and component.backend == GCP_VERTEX_ORCHESTRATOR_FLAVOR
+        for component in components
+    ):
+        return "vertex"
+
+    if any(
+        component.role == "runner"
+        and component.backend == AWS_SAGEMAKER_ORCHESTRATOR_FLAVOR
+        for component in components
+    ):
+        return "sagemaker"
+
+    if any(
+        component.role == "runner" and component.backend == AZUREML_ORCHESTRATOR_FLAVOR
+        for component in components
+    ):
+        return "azureml"
+
+    if any(
+        component.role == "runner" and component.backend == "kubernetes"
+        for component in components
+    ):
+        return "kubernetes"
+
+    if components and all(
+        component.role in {"runner", "storage"} for component in components
+    ):
+        backends = {
+            component.backend
+            for component in components
+            if component.backend is not None
+        }
+        if backends.issubset({"local"}):
+            return "local"
+
+    return "custom"
+
+
+def classify_stack_deployment_type(
+    name_or_id: str | None = None,
+    *,
+    client_factory: Callable[[], Any] = Client,
+) -> _StackShowType:
+    """Classify a stack using the same component translation as stack show.
+
+    Args:
+        name_or_id: Optional stack selector. When omitted, the active stack is
+            classified.
+        client_factory: Factory for a ZenML client.
+
+    Returns:
+        Low-cardinality stack deployment type.
+    """
+    client = client_factory()
+    if name_or_id is None:
+        resolved_stack = client.active_stack_model
+        selector = (
+            _normalize_stack_detail_value(getattr(resolved_stack, "id", None))
+            or _normalize_stack_detail_value(getattr(resolved_stack, "name", None))
+            or "<active stack>"
+        )
+    else:
+        selector = _normalize_stack_selector(name_or_id)
+        resolved_stack = _resolve_stack_for_show(client, selector)
+
+    try:
+        hydrated_stack = client.get_stack(resolved_stack.id, hydrate=True)
+    except Exception as exc:
+        raise KitaruBackendError("Unable to classify stack deployment type.") from exc
+
+    component_details = _stack_component_details_from_stack_model(
+        hydrated_stack,
+        selector=selector,
+    )
+    if not component_details or all(
+        component.backend is None for component in component_details
+    ):
+        raise KitaruStateError("Stack components did not include backend metadata.")
+    return _infer_stack_details_type(component_details)
+
+
+def _show_stack_operation(
+    name_or_id: str,
+    *,
+    client_factory: Callable[[], Any] = Client,
+) -> StackDetails:
+    """Inspect one stack and translate its component metadata for CLI display."""
+    selector = _normalize_stack_selector(name_or_id)
+    client = client_factory()
+    resolved_stack = _resolve_stack_for_show(client, selector)
+
+    try:
+        hydrated_stack = client.get_stack(resolved_stack.id, hydrate=True)
+    except Exception as exc:
+        raise KitaruBackendError(
+            f"Unable to inspect stack '{selector}': {exc}"
+        ) from exc
+
+    active_stack_id = str(client.active_stack_model.id)
+    stack = _stack_info_from_model(hydrated_stack, active_stack_id=active_stack_id)
+    is_managed = _stack_is_managed(hydrated_stack)
+    component_details = _stack_component_details_from_stack_model(
+        hydrated_stack,
+        selector=selector,
+    )
     return StackDetails(
         stack=stack,
         is_managed=is_managed,

--- a/src/kitaru/analytics.py
+++ b/src/kitaru/analytics.py
@@ -100,6 +100,22 @@ def resolve_zenml_version() -> str:
         return "unknown"
 
 
+def _safe_kitaru_version() -> str:
+    """Kitaru version with fallback — never raises."""
+    try:
+        return resolve_installed_version()
+    except Exception:
+        return "unknown"
+
+
+def _safe_zenml_version() -> str:
+    """ZenML version with fallback — never raises."""
+    try:
+        return resolve_zenml_version()
+    except Exception:
+        return "unknown"
+
+
 def track(event_name: AnalyticsEvent, metadata: dict[str, Any] | None = None) -> bool:
     """Track a Kitaru analytics event via ZenML's pipeline.
 
@@ -114,11 +130,11 @@ def track(event_name: AnalyticsEvent, metadata: dict[str, Any] | None = None) ->
 
     Silently returns False if analytics are disabled or if tracking fails.
     """
-    enriched_metadata = dict(metadata or {})
-    enriched_metadata["kitaru_version"] = resolve_installed_version()
-    enriched_metadata["zenml_version"] = resolve_zenml_version()
-
     try:
+        enriched_metadata = dict(metadata or {})
+        enriched_metadata["kitaru_version"] = _safe_kitaru_version()
+        enriched_metadata["zenml_version"] = _safe_zenml_version()
+
         from zenml.analytics import track as _zenml_track
 
         return _zenml_track(

--- a/src/kitaru/analytics.py
+++ b/src/kitaru/analytics.py
@@ -7,9 +7,13 @@ references the same canonical string.  Add new events to
 
 from __future__ import annotations
 
+import functools
+import importlib.metadata
 import logging
 from enum import StrEnum
 from typing import Any
+
+from kitaru._version import resolve_installed_version
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +91,15 @@ def set_source(suffix_or_source: str) -> None:
         )
 
 
+@functools.lru_cache(maxsize=1)
+def resolve_zenml_version() -> str:
+    """Resolve the installed ZenML version lazily."""
+    try:
+        return importlib.metadata.version("zenml")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
 def track(event_name: AnalyticsEvent, metadata: dict[str, Any] | None = None) -> bool:
     """Track a Kitaru analytics event via ZenML's pipeline.
 
@@ -95,13 +108,21 @@ def track(event_name: AnalyticsEvent, metadata: dict[str, Any] | None = None) ->
     ``StrEnum``, so it works as a ``str`` at the ZenML boundary while giving
     callers type-checked event names.
 
+    The caller metadata is copied before central Kitaru fields are added. This
+    keeps call sites from mutating shared dictionaries and makes
+    ``kitaru_version`` / ``zenml_version`` authoritative for every event.
+
     Silently returns False if analytics are disabled or if tracking fails.
     """
+    enriched_metadata = dict(metadata or {})
+    enriched_metadata["kitaru_version"] = resolve_installed_version()
+    enriched_metadata["zenml_version"] = resolve_zenml_version()
+
     try:
         from zenml.analytics import track as _zenml_track
 
         return _zenml_track(
-            event=event_name, metadata=metadata or {}
+            event=event_name, metadata=enriched_metadata
         )  # ZenML accepts Union[AnalyticsEvent, str]
     except Exception:
         logger.debug("Analytics tracking failed", exc_info=True)

--- a/src/kitaru/config.py
+++ b/src/kitaru/config.py
@@ -186,9 +186,6 @@ _delete_unshared_service_connectors_best_effort = (
 _resolve_stack_for_show = _config_stacks._resolve_stack_for_show
 _stack_component_details_from_model = _config_stacks._stack_component_details_from_model
 _infer_stack_details_type = _config_stacks._infer_stack_details_type
-_stack_component_details_from_stack_model = (
-    _config_stacks._stack_component_details_from_stack_model
-)
 _stack_info_from_model = _config_stacks._stack_info_from_model
 _iter_available_stacks = _config_stacks._iter_available_stacks
 

--- a/src/kitaru/config.py
+++ b/src/kitaru/config.py
@@ -186,6 +186,9 @@ _delete_unshared_service_connectors_best_effort = (
 _resolve_stack_for_show = _config_stacks._resolve_stack_for_show
 _stack_component_details_from_model = _config_stacks._stack_component_details_from_model
 _infer_stack_details_type = _config_stacks._infer_stack_details_type
+_stack_component_details_from_stack_model = (
+    _config_stacks._stack_component_details_from_stack_model
+)
 _stack_info_from_model = _config_stacks._stack_info_from_model
 _iter_available_stacks = _config_stacks._iter_available_stacks
 
@@ -475,6 +478,14 @@ def current_stack() -> StackInfo:
 def _list_stack_entries() -> list[_StackListEntry]:
     """List stacks with active + managed metadata for structured output."""
     return _config_stacks._list_stack_entries(client_factory=Client)
+
+
+def classify_stack_deployment_type(name_or_id: str | None = None) -> str:
+    """Classify a stack into Kitaru's low-cardinality deployment taxonomy."""
+    return _config_stacks.classify_stack_deployment_type(
+        name_or_id,
+        client_factory=Client,
+    )
 
 
 def _show_stack_operation(name_or_id: str) -> StackDetails:

--- a/src/kitaru/config.py
+++ b/src/kitaru/config.py
@@ -477,7 +477,9 @@ def _list_stack_entries() -> list[_StackListEntry]:
     return _config_stacks._list_stack_entries(client_factory=Client)
 
 
-def classify_stack_deployment_type(name_or_id: str | None = None) -> str:
+def classify_stack_deployment_type(
+    name_or_id: str | None = None,
+) -> _config_stacks._StackShowType:
     """Classify a stack into Kitaru's low-cardinality deployment taxonomy."""
     return _config_stacks.classify_stack_deployment_type(
         name_or_id,

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -559,14 +559,7 @@ class FlowHandle:
                 exc_info=True,
             )
 
-        try:
-            checkpoint_count = _checkpoint_count_from_run(run)
-        except Exception:
-            logger.debug(
-                "Failed to derive checkpoint count for terminal analytics.",
-                exc_info=True,
-            )
-            checkpoint_count = None
+        checkpoint_count = _checkpoint_count_from_run(run)
         if checkpoint_count is not None:
             metadata["checkpoint_count"] = checkpoint_count
             metadata["checkpoint_count_source"] = "hydrated_run_steps"

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -408,7 +408,8 @@ def _deployment_metadata_for_stack(stack_name_or_id: str | None) -> dict[str, st
         deployment_type = classify_stack_deployment_type(stack_name_or_id)
     except Exception:
         logger.debug(
-            "Failed to classify stack deployment type for analytics.",
+            "Failed to classify stack deployment type for analytics (selector=%r).",
+            stack_name_or_id,
             exc_info=True,
         )
         return {
@@ -784,16 +785,18 @@ class _FlowDefinition:
             settings=_build_settings(transport_image),
         )
 
-        deployment_metadata = _deployment_metadata_for_stack(resolved_execution.stack)
-        replay_metadata = {
-            "from_checkpoint": from_,
-            "replay_path": "flow_wrapper",
-            **deployment_metadata,
-        }
-        track(AnalyticsEvent.REPLAY_REQUESTED, replay_metadata)
-
-        observed_started_at = time.perf_counter()
         with _temporary_active_stack(resolved_execution.stack):
+            deployment_metadata = _deployment_metadata_for_stack(
+                resolved_execution.stack
+            )
+            replay_metadata = {
+                "from_checkpoint": from_,
+                "replay_path": "flow_wrapper",
+                **deployment_metadata,
+            }
+            track(AnalyticsEvent.REPLAY_REQUESTED, replay_metadata)
+
+            observed_started_at = time.perf_counter()
             try:
                 replayed_run = configured_pipeline.replay(
                     pipeline_run=original_run.id,
@@ -890,9 +893,11 @@ class _FlowDefinition:
             settings=_build_settings(transport_image),
         )
 
-        deployment_metadata = _deployment_metadata_for_stack(resolved_execution.stack)
-        observed_started_at = time.perf_counter()
         with _temporary_active_stack(resolved_execution.stack):
+            deployment_metadata = _deployment_metadata_for_stack(
+                resolved_execution.stack
+            )
+            observed_started_at = time.perf_counter()
             run = configured_pipeline(*args, **kwargs)
 
         if run is None:

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -10,8 +10,9 @@ import logging
 import sys
 import threading
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
+from datetime import datetime
 from functools import update_wrapper, wraps
 from typing import Any, cast, overload
 
@@ -39,6 +40,7 @@ from kitaru.config import (
     _read_env_model_registry,
     _read_model_registry_config,
     build_frozen_execution_spec,
+    classify_stack_deployment_type,
     image_settings_to_docker_settings,
     persist_frozen_execution_spec,
     resolve_connection_config,
@@ -395,6 +397,71 @@ def _safe_classify_run_failure(run: PipelineRunResponse) -> FailureOrigin:
         return FailureOrigin.UNKNOWN
 
 
+def _deployment_metadata_for_stack(stack_name_or_id: str | None) -> dict[str, str]:
+    """Return privacy-safe flow analytics deployment metadata.
+
+    The metadata deliberately contains only the coarse Kitaru-owned deployment
+    class and a diagnostic source. It never includes stack names, stack IDs,
+    project names, server URLs, or other user-controlled selectors.
+    """
+    try:
+        deployment_type = classify_stack_deployment_type(stack_name_or_id)
+    except Exception:
+        logger.debug(
+            "Failed to classify stack deployment type for analytics.",
+            exc_info=True,
+        )
+        return {
+            "kitaru_deployment_type": "unknown",
+            "deployment_type_source": "kitaru_stack_inference_failed",
+        }
+
+    return {
+        "kitaru_deployment_type": deployment_type,
+        "deployment_type_source": "kitaru_stack_inference",
+    }
+
+
+def _duration_metadata_from_run(
+    run: PipelineRunResponse,
+    *,
+    observed_started_at: float | None,
+) -> dict[str, Any]:
+    """Return best-effort terminal duration metadata for a run."""
+    start_time = getattr(run, "start_time", None)
+    end_time = getattr(run, "end_time", None)
+    if isinstance(start_time, datetime) and isinstance(end_time, datetime):
+        duration_seconds = max((end_time - start_time).total_seconds(), 0.0)
+        return {
+            "duration_seconds": round(duration_seconds, 3),
+            "duration_source": "backend_timestamps",
+        }
+
+    if observed_started_at is None:
+        return {}
+
+    duration_seconds = max(time.perf_counter() - observed_started_at, 0.0)
+    return {
+        "duration_seconds": round(duration_seconds, 3),
+        "duration_source": "sdk_observed",
+    }
+
+
+def _checkpoint_count_from_run(run: PipelineRunResponse) -> int | None:
+    """Return a best-effort count of hydrated run steps as checkpoint proxy."""
+    try:
+        hydrated_run = run.get_hydrated_version()
+        steps = getattr(hydrated_run, "steps", None)
+        if isinstance(steps, Mapping):
+            return len(steps)
+    except Exception:
+        logger.debug(
+            "Failed to derive checkpoint count for terminal analytics.",
+            exc_info=True,
+        )
+    return None
+
+
 def _raise_for_unsuccessful_run(
     run: PipelineRunResponse,
     *,
@@ -430,15 +497,29 @@ def _raise_for_unsuccessful_run(
 class FlowHandle:
     """Handle for a running or finished flow execution."""
 
-    def __init__(self, run: PipelineRunResponse) -> None:
+    def __init__(
+        self,
+        run: PipelineRunResponse,
+        *,
+        observed_started_at: float | None = None,
+        analytics_metadata: dict[str, Any] | None = None,
+    ) -> None:
         """Initialize a flow handle.
 
         Args:
             run: Initial pipeline run response.
+            observed_started_at: SDK-observed start time from ``time.perf_counter``.
+            analytics_metadata: Privacy-safe metadata captured at submission time.
         """
         self._run = run
         self._run_id = run.id
         self._terminal_event_emitted = False
+        self._observed_started_at = (
+            observed_started_at
+            if observed_started_at is not None
+            else time.perf_counter()
+        )
+        self._analytics_metadata = dict(analytics_metadata or {})
 
     @property
     def exec_id(self) -> str:
@@ -460,11 +541,36 @@ class FlowHandle:
         if self._terminal_event_emitted:
             return
         self._terminal_event_emitted = True
-        metadata: dict[str, Any] = {
-            "status": run.status.value,
-        }
+        metadata: dict[str, Any] = dict(self._analytics_metadata)
+        metadata["status"] = run.status.value
         if failure_origin is not None:
             metadata["failure_origin"] = failure_origin.value
+
+        try:
+            metadata.update(
+                _duration_metadata_from_run(
+                    run,
+                    observed_started_at=self._observed_started_at,
+                )
+            )
+        except Exception:
+            logger.debug(
+                "Failed to derive duration metadata for terminal analytics.",
+                exc_info=True,
+            )
+
+        try:
+            checkpoint_count = _checkpoint_count_from_run(run)
+        except Exception:
+            logger.debug(
+                "Failed to derive checkpoint count for terminal analytics.",
+                exc_info=True,
+            )
+            checkpoint_count = None
+        if checkpoint_count is not None:
+            metadata["checkpoint_count"] = checkpoint_count
+            metadata["checkpoint_count_source"] = "hydrated_run_steps"
+
         track(AnalyticsEvent.FLOW_TERMINAL, metadata)
 
     def wait(self) -> Any:
@@ -685,12 +791,15 @@ class _FlowDefinition:
             settings=_build_settings(transport_image),
         )
 
+        deployment_metadata = _deployment_metadata_for_stack(resolved_execution.stack)
         replay_metadata = {
             "from_checkpoint": from_,
             "replay_path": "flow_wrapper",
+            **deployment_metadata,
         }
         track(AnalyticsEvent.REPLAY_REQUESTED, replay_metadata)
 
+        observed_started_at = time.perf_counter()
         with _temporary_active_stack(resolved_execution.stack):
             try:
                 replayed_run = configured_pipeline.replay(
@@ -741,8 +850,15 @@ class _FlowDefinition:
             frozen_execution_spec=frozen_execution_spec,
         )
 
-        track(AnalyticsEvent.FLOW_REPLAYED, {"replay_path": "flow_wrapper"})
-        return FlowHandle(replayed_run)
+        track(
+            AnalyticsEvent.FLOW_REPLAYED,
+            {"replay_path": "flow_wrapper", **deployment_metadata},
+        )
+        return FlowHandle(
+            replayed_run,
+            observed_started_at=observed_started_at,
+            analytics_metadata=deployment_metadata,
+        )
 
     def _submit(
         self,
@@ -781,18 +897,24 @@ class _FlowDefinition:
             settings=_build_settings(transport_image),
         )
 
+        deployment_metadata = _deployment_metadata_for_stack(resolved_execution.stack)
+        observed_started_at = time.perf_counter()
         with _temporary_active_stack(resolved_execution.stack):
             run = configured_pipeline(*args, **kwargs)
 
         if run is None:
             raise KitaruRuntimeError("Flow execution did not produce a pipeline run.")
 
-        track(AnalyticsEvent.FLOW_SUBMITTED, {})
+        track(AnalyticsEvent.FLOW_SUBMITTED, deployment_metadata)
         persist_frozen_execution_spec(
             run_id=run.id,
             frozen_execution_spec=frozen_execution_spec,
         )
-        return FlowHandle(run)
+        return FlowHandle(
+            run,
+            observed_started_at=observed_started_at,
+            analytics_metadata=deployment_metadata,
+        )
 
 
 @overload

--- a/src/kitaru/llm.py
+++ b/src/kitaru/llm.py
@@ -658,7 +658,7 @@ def _execute_llm_call(request: _LLMRequest) -> str:
         AnalyticsEvent.LLM_CALLED,
         {
             "resolved_model": model_selection.resolved_model,
-            "model": model_selection.resolved_model,
+            "model": model_selection.resolved_model,  # dashboard compat alias
             "credential_source": credential_source,
             "mocked": is_mocked,
         },

--- a/src/kitaru/llm.py
+++ b/src/kitaru/llm.py
@@ -658,6 +658,7 @@ def _execute_llm_call(request: _LLMRequest) -> str:
         AnalyticsEvent.LLM_CALLED,
         {
             "resolved_model": model_selection.resolved_model,
+            "model": model_selection.resolved_model,
             "credential_source": credential_source,
             "mocked": is_mocked,
         },

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -106,6 +106,45 @@ def test_track_returns_false_when_zenml_tracking_fails() -> None:
         assert track(AnalyticsEvent.CLI_INVOKED, {"command": "status"}) is False
 
 
+def test_track_returns_false_when_version_enrichment_raises() -> None:
+    """Version resolution failures must not propagate to callers."""
+    with (
+        patch(
+            "kitaru.analytics.resolve_installed_version",
+            side_effect=RuntimeError("broken metadata"),
+        ),
+        patch("kitaru.analytics.resolve_zenml_version", return_value="4.5.6"),
+        patch("zenml.analytics.track", return_value=True) as track_mock,
+    ):
+        result = track(AnalyticsEvent.CLI_INVOKED, {"command": "status"})
+
+    assert result is True
+    sent_metadata = track_mock.call_args.kwargs["metadata"]
+    assert sent_metadata["kitaru_version"] == "unknown"
+    assert sent_metadata["zenml_version"] == "4.5.6"
+
+
+def test_track_returns_false_when_both_version_helpers_raise() -> None:
+    """Both version helpers failing should still track with unknown versions."""
+    with (
+        patch(
+            "kitaru.analytics.resolve_installed_version",
+            side_effect=RuntimeError("bad"),
+        ),
+        patch(
+            "kitaru.analytics.resolve_zenml_version",
+            side_effect=RuntimeError("bad"),
+        ),
+        patch("zenml.analytics.track", return_value=True) as track_mock,
+    ):
+        result = track(AnalyticsEvent.CLI_INVOKED, {"command": "status"})
+
+    assert result is True
+    sent_metadata = track_mock.call_args.kwargs["metadata"]
+    assert sent_metadata["kitaru_version"] == "unknown"
+    assert sent_metadata["zenml_version"] == "unknown"
+
+
 def test_flow_lifecycle_event_canonical_strings() -> None:
     """Flow-lifecycle events should carry the expected canonical strings."""
     assert AnalyticsEvent.FLOW_SUBMITTED == "Kitaru flow submitted"

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+from kitaru import analytics
 from kitaru.analytics import AnalyticsEvent, set_source, track
 
 
@@ -37,18 +38,72 @@ def test_set_source_accepts_full_kitaru_source() -> None:
     source_context_mock.set.assert_called_once_with("normalized:kitaru-mcp")
 
 
-def test_track_passes_metadata_through_unchanged() -> None:
-    """track() should delegate metadata without injecting interface fields."""
-    metadata = {"command": "status"}
+def test_track_enriches_metadata_with_authoritative_versions() -> None:
+    """track() should copy caller metadata and add central version fields."""
+    metadata = {
+        "command": "status",
+        "kitaru_version": "caller-value",
+        "zenml_version": "caller-value",
+    }
 
-    with patch("zenml.analytics.track", return_value=True) as track_mock:
+    with (
+        patch("kitaru.analytics.resolve_installed_version", return_value="1.2.3"),
+        patch("kitaru.analytics.resolve_zenml_version", return_value="4.5.6"),
+        patch("zenml.analytics.track", return_value=True) as track_mock,
+    ):
         result = track(AnalyticsEvent.CLI_INVOKED, metadata)
 
     assert result is True
+    track_mock.assert_called_once()
+    sent_metadata = track_mock.call_args.kwargs["metadata"]
+    assert sent_metadata == {
+        "command": "status",
+        "kitaru_version": "1.2.3",
+        "zenml_version": "4.5.6",
+    }
+    assert sent_metadata is not metadata
+    assert metadata == {
+        "command": "status",
+        "kitaru_version": "caller-value",
+        "zenml_version": "caller-value",
+    }
+
+
+def test_track_supports_metadata_none() -> None:
+    """track() should still work when callers have no metadata to add."""
+    with (
+        patch("kitaru.analytics.resolve_installed_version", return_value="1.2.3"),
+        patch("kitaru.analytics.resolve_zenml_version", return_value="4.5.6"),
+        patch("zenml.analytics.track", return_value=True) as track_mock,
+    ):
+        result = track(AnalyticsEvent.STATUS_VIEWED, None)
+
+    assert result is True
     track_mock.assert_called_once_with(
-        event=AnalyticsEvent.CLI_INVOKED,
-        metadata=metadata,
+        event=AnalyticsEvent.STATUS_VIEWED,
+        metadata={"kitaru_version": "1.2.3", "zenml_version": "4.5.6"},
     )
+
+
+def test_resolve_zenml_version_falls_back_to_unknown() -> None:
+    """Missing ZenML package metadata should produce the analytics fallback value."""
+    analytics.resolve_zenml_version.cache_clear()
+    with patch(
+        "kitaru.analytics.importlib.metadata.version",
+        side_effect=analytics.importlib.metadata.PackageNotFoundError,
+    ):
+        assert analytics.resolve_zenml_version() == "unknown"
+    analytics.resolve_zenml_version.cache_clear()
+
+
+def test_track_returns_false_when_zenml_tracking_fails() -> None:
+    """Analytics failures should never raise into user-facing code."""
+    with (
+        patch("kitaru.analytics.resolve_installed_version", return_value="1.2.3"),
+        patch("kitaru.analytics.resolve_zenml_version", return_value="4.5.6"),
+        patch("zenml.analytics.track", side_effect=RuntimeError("boom")),
+    ):
+        assert track(AnalyticsEvent.CLI_INVOKED, {"command": "status"}) is False
 
 
 def test_flow_lifecycle_event_canonical_strings() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,6 +62,7 @@ from kitaru.config import (
     _show_stack_operation,
     _StackComponent,
     build_frozen_execution_spec,
+    classify_stack_deployment_type,
     configure,
     create_stack,
     current_stack,
@@ -1115,6 +1116,106 @@ def test_list_stack_entries_include_managed_flag() -> None:
         ("default", False),
         ("dev", True),
     ]
+
+
+@pytest.mark.parametrize(
+    ("hydrated_stack", "expected_stack_type"),
+    [
+        (
+            _stack_model(
+                stack_id="stack-local-id",
+                name="local-dev",
+                components={
+                    StackComponentType.ORCHESTRATOR: [
+                        _stack_component("orc-id", "local-runner", flavor="local")
+                    ],
+                    StackComponentType.ARTIFACT_STORE: [
+                        _stack_component("art-id", "local-storage", flavor="local")
+                    ],
+                },
+            ),
+            "local",
+        ),
+        (
+            _kubernetes_stack_model(stack_id="stack-k8s-id", name="k8s-dev"),
+            "kubernetes",
+        ),
+        (_vertex_stack_model(stack_id="stack-vertex-id", name="vertex-dev"), "vertex"),
+        (
+            _sagemaker_stack_model(stack_id="stack-sagemaker-id", name="sagemaker-dev"),
+            "sagemaker",
+        ),
+        (_azureml_stack_model(stack_id="stack-azure-id", name="azure-dev"), "azureml"),
+        (
+            _stack_model(
+                stack_id="stack-custom-id",
+                name="custom-dev",
+                components={
+                    StackComponentType.ORCHESTRATOR: [
+                        _stack_component("orc-id", "custom-runner", flavor="airflow")
+                    ]
+                },
+            ),
+            "custom",
+        ),
+    ],
+)
+def test_classify_stack_deployment_type_matches_show_inference(
+    hydrated_stack: SimpleNamespace,
+    expected_stack_type: str,
+) -> None:
+    """Classification-only helper should share stack show's inferred taxonomy."""
+    stack_summary = _stack_model(
+        stack_id=hydrated_stack.id,
+        name=hydrated_stack.name,
+    )
+    client_mock = Mock()
+    client_mock.active_stack_model = stack_summary
+    client_mock.list_stacks.return_value = [stack_summary]
+    client_mock.get_stack.return_value = hydrated_stack
+
+    with patch("kitaru.config.Client", return_value=client_mock):
+        deployment_type = classify_stack_deployment_type(hydrated_stack.name)
+        details = _show_stack_operation(hydrated_stack.name)
+
+    assert deployment_type == expected_stack_type
+    assert details.stack_type == expected_stack_type
+
+
+def test_classify_stack_deployment_type_uses_active_stack_when_selector_omitted() -> (
+    None
+):
+    """Omitting a selector should classify the currently active stack."""
+    hydrated_stack = _kubernetes_stack_model(stack_id="stack-active-id", name="active")
+    client_mock = Mock()
+    client_mock.active_stack_model = hydrated_stack
+    client_mock.get_stack.return_value = hydrated_stack
+
+    with patch("kitaru.config.Client", return_value=client_mock):
+        deployment_type = classify_stack_deployment_type()
+
+    assert deployment_type == "kubernetes"
+    client_mock.get_stack.assert_called_once_with("stack-active-id", hydrate=True)
+
+
+def test_classify_stack_deployment_type_rejects_unclassifiable_components() -> None:
+    """Malformed component details should fail classification instead of custom."""
+    stack_summary = _stack_model(stack_id="stack-bad-id", name="bad")
+    hydrated_stack = _stack_model(
+        stack_id="stack-bad-id",
+        name="bad",
+        components={StackComponentType.ORCHESTRATOR: [SimpleNamespace()]},
+    )
+    client_mock = Mock()
+    client_mock.active_stack_model = stack_summary
+    client_mock.list_stacks.return_value = [stack_summary]
+    client_mock.get_stack.return_value = hydrated_stack
+
+    with (
+        patch("kitaru.config.Client", return_value=client_mock),
+        pytest.raises(KitaruStateError, match="backend metadata"),
+    ):
+        classify_stack_deployment_type("bad")
 
 
 def test_show_stack_operation_returns_local_stack_details() -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -37,6 +37,8 @@ from kitaru.errors import (
 )
 from kitaru.flow import (
     FlowHandle,
+    _checkpoint_count_from_run,
+    _duration_metadata_from_run,
     _inject_model_registry_env,
     _temporary_active_stack,
     _wrap_flow_entrypoint,
@@ -1295,6 +1297,105 @@ def test_flow_handle_wait_still_raises_when_classify_fails() -> None:
     assert "duration_seconds" not in metadata
     assert "checkpoint_count" not in metadata
     assert "checkpoint_count_source" not in metadata
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for analytics helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestDurationMetadataFromRun:
+    """Direct tests for _duration_metadata_from_run edge cases."""
+
+    def test_backend_timestamps_produce_backend_source(self) -> None:
+        start = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+        run = SimpleNamespace(
+            start_time=start,
+            end_time=start + timedelta(seconds=5.678),
+        )
+        result = _duration_metadata_from_run(
+            cast(PipelineRunResponse, run), observed_started_at=0.0
+        )
+        assert result == {
+            "duration_seconds": 5.678,
+            "duration_source": "backend_timestamps",
+        }
+
+    def test_negative_backend_duration_clamped_to_zero(self) -> None:
+        start = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
+        run = SimpleNamespace(
+            start_time=start,
+            end_time=start - timedelta(seconds=1),
+        )
+        result = _duration_metadata_from_run(
+            cast(PipelineRunResponse, run), observed_started_at=0.0
+        )
+        assert result["duration_seconds"] == 0.0
+        assert result["duration_source"] == "backend_timestamps"
+
+    def test_missing_timestamps_falls_back_to_sdk_observed(self) -> None:
+        run = SimpleNamespace(start_time=None, end_time=None)
+        with patch("kitaru.flow.time.perf_counter", return_value=15.0):
+            result = _duration_metadata_from_run(
+                cast(PipelineRunResponse, run), observed_started_at=10.0
+            )
+        assert result == {
+            "duration_seconds": 5.0,
+            "duration_source": "sdk_observed",
+        }
+
+    def test_no_timestamps_and_no_observed_returns_empty(self) -> None:
+        run = SimpleNamespace(start_time=None, end_time=None)
+        result = _duration_metadata_from_run(
+            cast(PipelineRunResponse, run), observed_started_at=None
+        )
+        assert result == {}
+
+    def test_non_datetime_timestamps_fall_back_to_sdk(self) -> None:
+        run = SimpleNamespace(start_time="not-a-datetime", end_time="also-not")
+        with patch("kitaru.flow.time.perf_counter", return_value=20.0):
+            result = _duration_metadata_from_run(
+                cast(PipelineRunResponse, run), observed_started_at=18.0
+            )
+        assert result["duration_source"] == "sdk_observed"
+
+    def test_missing_start_time_attr_falls_back(self) -> None:
+        run = SimpleNamespace()
+        result = _duration_metadata_from_run(
+            cast(PipelineRunResponse, run), observed_started_at=None
+        )
+        assert result == {}
+
+
+class TestCheckpointCountFromRun:
+    """Direct tests for _checkpoint_count_from_run edge cases."""
+
+    def test_returns_step_count_from_hydrated_run(self) -> None:
+        hydrated = SimpleNamespace(steps={"step_a": object(), "step_b": object()})
+        run = SimpleNamespace(get_hydrated_version=lambda: hydrated)
+        assert _checkpoint_count_from_run(cast(PipelineRunResponse, run)) == 2
+
+    def test_returns_none_when_steps_not_a_mapping(self) -> None:
+        hydrated = SimpleNamespace(steps="not-a-mapping")
+        run = SimpleNamespace(get_hydrated_version=lambda: hydrated)
+        assert _checkpoint_count_from_run(cast(PipelineRunResponse, run)) is None
+
+    def test_returns_none_when_steps_attr_missing(self) -> None:
+        hydrated = SimpleNamespace()
+        run = SimpleNamespace(get_hydrated_version=lambda: hydrated)
+        assert _checkpoint_count_from_run(cast(PipelineRunResponse, run)) is None
+
+    def test_returns_none_when_hydration_raises(self) -> None:
+        def explode() -> None:
+            raise RuntimeError("backend unavailable")
+
+        run = SimpleNamespace(get_hydrated_version=explode)
+        assert _checkpoint_count_from_run(cast(PipelineRunResponse, run)) is None
+
+    def test_returns_zero_for_empty_steps(self) -> None:
+        hydrated = SimpleNamespace(steps={})
+        run = SimpleNamespace(get_hydrated_version=lambda: hydrated)
+        assert _checkpoint_count_from_run(cast(PipelineRunResponse, run)) == 0
 
 
 class TestRecoveryHintHelpers:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1281,7 +1281,7 @@ def test_flow_handle_wait_still_raises_when_classify_fails() -> None:
         ),
         patch(
             "kitaru.flow._checkpoint_count_from_run",
-            side_effect=RuntimeError("bad steps"),
+            return_value=None,
         ),
         pytest.raises(KitaruExecutionError, match="finished with status"),
     ):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import sys
 import threading
+from contextlib import nullcontext
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock, call, patch
@@ -84,9 +86,13 @@ class _DummyRun:
         run_id: UUID | None = None,
         status_reason: str | None = None,
         traceback: str | None = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
     ) -> None:
         self.id = run_id or uuid4()
         self.status = status
+        self.start_time = start_time
+        self.end_time = end_time
         self.status_reason = status_reason
         self.exception_info = (
             SimpleNamespace(traceback=traceback) if traceback else None
@@ -887,6 +893,7 @@ def test_submit_emits_flow_submitted_event() -> None:
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
         patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
         patch("kitaru.flow.track") as track_mock,
     ):
         wrapped = flow(lambda x: x)
@@ -894,8 +901,50 @@ def test_submit_emits_flow_submitted_event() -> None:
 
     track_mock.assert_called_once_with(
         AnalyticsEvent.FLOW_SUBMITTED,
-        {},
+        {
+            "kitaru_deployment_type": "local",
+            "deployment_type_source": "kitaru_stack_inference",
+        },
     )
+
+
+def test_submit_classification_failure_does_not_break_flow_execution() -> None:
+    """Deployment classification failures should become unknown metadata only."""
+    run = _DummyRun(status=ExecutionStatus.RUNNING)
+    configured_pipeline = MagicMock(return_value=run)
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(stack="private-stack-name"),
+        ),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch("kitaru.flow._temporary_active_stack", return_value=nullcontext()),
+        patch(
+            "kitaru.flow.classify_stack_deployment_type",
+            side_effect=RuntimeError("backend unavailable"),
+        ),
+        patch("kitaru.flow.track") as track_mock,
+    ):
+        wrapped = flow(lambda x: x)
+        handle = wrapped.run(123)
+
+    assert isinstance(handle, FlowHandle)
+    track_mock.assert_called_once_with(
+        AnalyticsEvent.FLOW_SUBMITTED,
+        {
+            "kitaru_deployment_type": "unknown",
+            "deployment_type_source": "kitaru_stack_inference_failed",
+        },
+    )
+    metadata = track_mock.call_args.args[1]
+    assert "private-stack-name" not in metadata.values()
 
 
 def test_submit_does_not_emit_when_run_is_none() -> None:
@@ -914,6 +963,7 @@ def test_submit_does_not_emit_when_run_is_none() -> None:
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
         patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
         patch("kitaru.flow.track") as track_mock,
         pytest.raises(KitaruRuntimeError, match="did not produce"),
     ):
@@ -943,6 +993,7 @@ def test_replay_success_emits_requested_and_replayed_events() -> None:
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
         patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch("kitaru.flow.classify_stack_deployment_type", return_value="kubernetes"),
         patch(
             "kitaru.flow.build_replay_plan",
             return_value=ReplayPlan(
@@ -963,10 +1014,14 @@ def test_replay_success_emits_requested_and_replayed_events() -> None:
     assert requested_call.args[0] == AnalyticsEvent.REPLAY_REQUESTED
     assert requested_call.args[1]["replay_path"] == "flow_wrapper"
     assert requested_call.args[1]["from_checkpoint"] == "write"
+    assert requested_call.args[1]["kitaru_deployment_type"] == "kubernetes"
+    assert requested_call.args[1]["deployment_type_source"] == "kitaru_stack_inference"
 
     replayed_call = track_mock.call_args_list[1]
     assert replayed_call.args[0] == AnalyticsEvent.FLOW_REPLAYED
     assert replayed_call.args[1]["replay_path"] == "flow_wrapper"
+    assert replayed_call.args[1]["kitaru_deployment_type"] == "kubernetes"
+    assert replayed_call.args[1]["deployment_type_source"] == "kitaru_stack_inference"
 
 
 def test_replay_failure_emits_requested_then_failed_events() -> None:
@@ -987,6 +1042,7 @@ def test_replay_failure_emits_requested_then_failed_events() -> None:
         ),
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.classify_stack_deployment_type", return_value="kubernetes"),
         patch(
             "kitaru.flow.build_replay_plan",
             return_value=ReplayPlan(
@@ -1006,10 +1062,14 @@ def test_replay_failure_emits_requested_then_failed_events() -> None:
     assert track_mock.call_count == 2
     requested_call = track_mock.call_args_list[0]
     assert requested_call.args[0] == AnalyticsEvent.REPLAY_REQUESTED
+    assert requested_call.args[1]["kitaru_deployment_type"] == "kubernetes"
+    assert requested_call.args[1]["deployment_type_source"] == "kitaru_stack_inference"
 
     failed_call = track_mock.call_args_list[1]
     assert failed_call.args[0] == AnalyticsEvent.REPLAY_FAILED
     assert failed_call.args[1]["error_type"] == "RuntimeError"
+    assert failed_call.args[1]["kitaru_deployment_type"] == "kubernetes"
+    assert failed_call.args[1]["deployment_type_source"] == "kitaru_stack_inference"
     assert "failure_origin" in failed_call.args[1]
 
 
@@ -1031,6 +1091,7 @@ def test_replay_none_run_emits_replay_failed_with_runtime_origin() -> None:
         ),
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.classify_stack_deployment_type", return_value="kubernetes"),
         patch(
             "kitaru.flow.build_replay_plan",
             return_value=ReplayPlan(
@@ -1048,24 +1109,40 @@ def test_replay_none_run_emits_replay_failed_with_runtime_origin() -> None:
         wrapped.replay(str(source_run.id), from_="write")
 
     assert track_mock.call_count == 2
+    requested_call = track_mock.call_args_list[0]
+    assert requested_call.args[0] == AnalyticsEvent.REPLAY_REQUESTED
+    assert requested_call.args[1]["kitaru_deployment_type"] == "kubernetes"
+    assert requested_call.args[1]["deployment_type_source"] == "kitaru_stack_inference"
+
     failed_call = track_mock.call_args_list[1]
     assert failed_call.args[0] == AnalyticsEvent.REPLAY_FAILED
     assert failed_call.args[1]["error_type"] == "KitaruRuntimeError"
     assert failed_call.args[1]["failure_origin"] == FailureOrigin.RUNTIME.value
+    assert failed_call.args[1]["kitaru_deployment_type"] == "kubernetes"
+    assert failed_call.args[1]["deployment_type_source"] == "kitaru_stack_inference"
 
 
 def test_flow_handle_wait_emits_flow_terminal_on_success() -> None:
-    """FlowHandle.wait() should emit FLOW_TERMINAL when run completes."""
+    """FlowHandle.wait() should emit enriched FLOW_TERMINAL metadata."""
     run_id = uuid4()
+    started_at = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
     finished = _DummyRun(
         status=ExecutionStatus.COMPLETED,
         run_id=run_id,
         outputs=[("step", "output", 42)],
+        start_time=started_at,
+        end_time=started_at + timedelta(seconds=2.3456),
     )
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = finished
 
-    handle = FlowHandle(_as_pipeline_run(finished))
+    handle = FlowHandle(
+        _as_pipeline_run(finished),
+        analytics_metadata={
+            "kitaru_deployment_type": "local",
+            "deployment_type_source": "kitaru_stack_inference",
+        },
+    )
     with (
         patch("kitaru.flow.Client", return_value=client_mock),
         patch("kitaru.flow.time.sleep"),
@@ -1073,25 +1150,40 @@ def test_flow_handle_wait_emits_flow_terminal_on_success() -> None:
     ):
         handle.wait()
 
-    track_mock.assert_called_once_with(
-        AnalyticsEvent.FLOW_TERMINAL,
-        {"status": "completed"},
-    )
+    track_mock.assert_called_once()
+    assert track_mock.call_args.args[0] == AnalyticsEvent.FLOW_TERMINAL
+    metadata = track_mock.call_args.args[1]
+    assert metadata["status"] == "completed"
+    assert metadata["kitaru_deployment_type"] == "local"
+    assert metadata["deployment_type_source"] == "kitaru_stack_inference"
+    assert metadata["duration_seconds"] == 2.346
+    assert metadata["duration_source"] == "backend_timestamps"
+    assert metadata["checkpoint_count"] == 1
+    assert metadata["checkpoint_count_source"] == "hydrated_run_steps"
 
 
 def test_flow_handle_wait_emits_flow_terminal_on_failure() -> None:
     """FlowHandle.wait() should emit FLOW_TERMINAL with failure_origin on failure."""
     run_id = uuid4()
+    started_at = datetime(2026, 4, 11, 12, 0, tzinfo=UTC)
     failed = _DummyRun(
         status=ExecutionStatus.FAILED,
         run_id=run_id,
         status_reason="user error",
         traceback="Traceback\nValueError: boom",
+        start_time=started_at,
+        end_time=started_at + timedelta(seconds=1.0),
     )
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = failed
 
-    handle = FlowHandle(_as_pipeline_run(failed))
+    handle = FlowHandle(
+        _as_pipeline_run(failed),
+        analytics_metadata={
+            "kitaru_deployment_type": "kubernetes",
+            "deployment_type_source": "kitaru_stack_inference",
+        },
+    )
     with (
         patch("kitaru.flow.Client", return_value=client_mock),
         patch("kitaru.flow.time.sleep"),
@@ -1100,17 +1192,18 @@ def test_flow_handle_wait_emits_flow_terminal_on_failure() -> None:
     ):
         handle.wait()
 
-    track_mock.assert_called_once_with(
-        AnalyticsEvent.FLOW_TERMINAL,
-        {
-            "status": "failed",
-            "failure_origin": FailureOrigin.USER_CODE.value,
-        },
-    )
+    track_mock.assert_called_once()
+    assert track_mock.call_args.args[0] == AnalyticsEvent.FLOW_TERMINAL
+    metadata = track_mock.call_args.args[1]
+    assert metadata["status"] == "failed"
+    assert metadata["failure_origin"] == FailureOrigin.USER_CODE.value
+    assert metadata["kitaru_deployment_type"] == "kubernetes"
+    assert metadata["duration_seconds"] == 1.0
+    assert metadata["duration_source"] == "backend_timestamps"
 
 
 def test_flow_handle_get_emits_flow_terminal_on_success() -> None:
-    """FlowHandle.get() should emit FLOW_TERMINAL once."""
+    """FlowHandle.get() should fall back to SDK-observed duration."""
     run_id = uuid4()
     finished = _DummyRun(
         status=ExecutionStatus.COMPLETED,
@@ -1120,17 +1213,22 @@ def test_flow_handle_get_emits_flow_terminal_on_success() -> None:
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = finished
 
-    handle = FlowHandle(_as_pipeline_run(finished))
+    handle = FlowHandle(_as_pipeline_run(finished), observed_started_at=10.0)
     with (
         patch("kitaru.flow.Client", return_value=client_mock),
+        patch("kitaru.flow.time.perf_counter", return_value=12.345),
         patch("kitaru.flow.track") as track_mock,
     ):
         handle.get()
 
-    track_mock.assert_called_once_with(
-        AnalyticsEvent.FLOW_TERMINAL,
-        {"status": "completed"},
-    )
+    track_mock.assert_called_once()
+    assert track_mock.call_args.args[0] == AnalyticsEvent.FLOW_TERMINAL
+    metadata = track_mock.call_args.args[1]
+    assert metadata["status"] == "completed"
+    assert metadata["duration_seconds"] == 2.345
+    assert metadata["duration_source"] == "sdk_observed"
+    assert metadata["checkpoint_count"] == 1
+    assert metadata["checkpoint_count_source"] == "hydrated_run_steps"
 
 
 def test_flow_handle_terminal_event_emitted_only_once() -> None:
@@ -1177,17 +1275,26 @@ def test_flow_handle_wait_still_raises_when_classify_fails() -> None:
             "kitaru.flow._classify_run_failure",
             side_effect=RuntimeError("unexpected shape"),
         ),
+        patch(
+            "kitaru.flow._duration_metadata_from_run",
+            side_effect=RuntimeError("bad timestamps"),
+        ),
+        patch(
+            "kitaru.flow._checkpoint_count_from_run",
+            side_effect=RuntimeError("bad steps"),
+        ),
         pytest.raises(KitaruExecutionError, match="finished with status"),
     ):
         handle.wait()
 
-    track_mock.assert_called_once_with(
-        AnalyticsEvent.FLOW_TERMINAL,
-        {
-            "status": "failed",
-            "failure_origin": FailureOrigin.UNKNOWN.value,
-        },
-    )
+    track_mock.assert_called_once()
+    assert track_mock.call_args.args[0] == AnalyticsEvent.FLOW_TERMINAL
+    metadata = track_mock.call_args.args[1]
+    assert metadata["status"] == "failed"
+    assert metadata["failure_origin"] == FailureOrigin.UNKNOWN.value
+    assert "duration_seconds" not in metadata
+    assert "checkpoint_count" not in metadata
+    assert "checkpoint_count_source" not in metadata
 
 
 class TestRecoveryHintHelpers:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 import pytest
 
+from kitaru.analytics import AnalyticsEvent
 from kitaru.config import ResolvedModelSelection
 from kitaru.errors import (
     KitaruContextError,
@@ -41,6 +42,15 @@ def _simple_selection(
         resolved_model=model,
         secret=secret,
     )
+
+
+def _tracked_llm_metadata(track_mock: MagicMock) -> dict[str, object]:
+    """Return the analytics metadata emitted by one LLM call."""
+    track_mock.assert_called_once()
+    event, metadata = track_mock.call_args.args
+    assert event == AnalyticsEvent.LLM_CALLED
+    assert isinstance(metadata, dict)
+    return metadata
 
 
 @contextmanager
@@ -608,6 +618,70 @@ def test_llm_mock_response_works_with_unsupported_provider(
         output = llm("hello", model="gemini/gemini-2.0-flash", name="mock_call")
 
     assert output == "mocked"
+
+
+# ---------------------------------------------------------------------------
+# Analytics metadata
+# ---------------------------------------------------------------------------
+
+
+def test_llm_analytics_includes_model_alias_for_explicit_model() -> None:
+    """LLM analytics should expose `model` as an alias for `resolved_model`."""
+    fake_result = _ProviderCallResult(response_text="ok", usage=_LLMUsage())
+    with (
+        _llm_execution_scope(model_selection=_simple_selection("openai/gpt-4o-mini")),
+        patch("kitaru.llm._call_openai", return_value=fake_result),
+        patch("kitaru.analytics.track", return_value=True) as track_mock,
+    ):
+        llm(
+            "private prompt text",
+            model="openai/gpt-4o-mini",
+            system="private system text",
+            name="private_call_name",
+        )
+
+    metadata = _tracked_llm_metadata(track_mock)
+    assert metadata["resolved_model"] == "openai/gpt-4o-mini"
+    assert metadata["model"] == "openai/gpt-4o-mini"
+    assert metadata["model"] == metadata["resolved_model"]
+    assert "prompt" not in metadata
+    assert "system" not in metadata
+    assert "call_name" not in metadata
+    assert "name" not in metadata
+    assert "private prompt text" not in metadata.values()
+    assert "private system text" not in metadata.values()
+    assert "private_call_name" not in metadata.values()
+
+
+def test_llm_analytics_includes_model_alias_in_mock_alias_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mock/default-alias calls should still emit safe model metadata."""
+    monkeypatch.setenv("KITARU_LLM_MOCK_RESPONSE", "mocked")
+    model_selection = ResolvedModelSelection(
+        requested_model="fast",
+        alias="fast",
+        resolved_model="openai/gpt-4o-mini",
+        secret=None,
+    )
+
+    with (
+        _llm_execution_scope(model_selection=model_selection),
+        patch("kitaru.analytics.track", return_value=True) as track_mock,
+    ):
+        llm("private prompt text", name="private_call_name")
+
+    metadata = _tracked_llm_metadata(track_mock)
+    assert metadata["resolved_model"] == "openai/gpt-4o-mini"
+    assert metadata["model"] == "openai/gpt-4o-mini"
+    assert metadata["model"] == metadata["resolved_model"]
+    assert metadata["mocked"] is True
+    assert "prompt" not in metadata
+    assert "system" not in metadata
+    assert "call_name" not in metadata
+    assert "name" not in metadata
+    assert "private prompt text" not in metadata.values()
+    assert "private_call_name" not in metadata.values()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Richer flow lifecycle metadata**: Flow submission and terminal events now include deployment context, execution duration (with source attribution), and checkpoint counts — giving operators better visibility into where flows run and how they perform
- **Central version stamping**: Every event now carries `kitaru_version` and `zenml_version`, enriched inside the analytics boundary so version resolution failures never propagate to user code
- **LLM model compatibility**: Adds a `model` field alongside `resolved_model` to fix dashboard display issues for LLM call events
- **Stack classification helper**: Extracts `classify_stack_deployment_type()` from the stack display path so flow events can safely reuse the same taxonomy without coupling to the full stack-show operation
- **MCP documentation**: Adds copy-paste prompt examples to the MCP server docs and mentions the MCP extra earlier in the installation guide
- **Code cleanup**: Removes a redundant exception wrapper in `_track_terminal_once`, an unused private re-export in `config.py`, and tightens the return type on the public facade

## Key design decisions

- Deployment metadata is computed **inside the stack-binding lock** at submission/replay time and stored on `FlowHandle`, ensuring concurrent submissions record the correct stack and avoiding re-inference at terminal observation
- Duration uses backend timestamps when available, falls back to SDK-observed timing, and always includes `duration_source` so dashboards can distinguish the two
- All metadata enrichment (including version resolution) runs inside `track()`'s try/except boundary — broken package metadata produces `"unknown"` fallbacks, never user-visible errors
- Privacy: only coarse deployment classes are emitted — no stack names, IDs, server URLs, or user content

## Test plan

- [x] `just check` passes (format, lint, typecheck, typos, yaml, actions, links)
- [x] `just test` passes (1052 tests, 6 skipped)
- [x] `classify_stack_deployment_type` returns expected types for local/k8s/vertex/sagemaker/azureml stacks (parametrized test)
- [x] Terminal events include duration and checkpoint count when backend timestamps exist
- [x] Classification failures don't break flow submission
- [x] No private data (stack names, prompts) leaks into metadata
- [x] Version enrichment failures produce `"unknown"` fallbacks without raising
- [x] Direct edge-case tests for `_duration_metadata_from_run` (negative clamping, missing timestamps, non-datetime values)
- [x] Direct edge-case tests for `_checkpoint_count_from_run` (hydration failure, missing/empty steps)