### PR TITLE
Add click-to-expand lightbox for blog images

### DIFF
--- a/site/src/layouts/BlogPost.astro
+++ b/site/src/layouts/BlogPost.astro
@@ -136,6 +136,7 @@ const ogImageUrl = ogImage
     )}
   </main>
   <Footer />
+  <script src="../scripts/image-lightbox.ts"></script>
 </Base>
 
 <style>
@@ -258,6 +259,18 @@ const ogImageUrl = ogImage
     border-radius: 10px;
     display: block;
     border: 1px solid var(--color-border);
+  }
+
+  /* ── Click-to-expand affordance for blog images ── */
+  .blog-post-body :global(img.is-zoomable),
+  :global(.blog-post-image.is-zoomable) {
+    cursor: zoom-in;
+    transition: opacity 0.15s ease;
+  }
+
+  .blog-post-body :global(img.is-zoomable:hover),
+  :global(.blog-post-image.is-zoomable:hover) {
+    opacity: 0.92;
   }
 
   /* ── Body + TOC wrapper ── */
@@ -494,5 +507,66 @@ const ogImageUrl = ogImage
       margin-right: -16px;
       border-radius: 0;
     }
+  }
+</style>
+
+<style is:global>
+  /* Lightbox dialog is appended to <body> at runtime, so it lives outside
+     Astro's scoped styles. */
+  dialog.image-lightbox {
+    border: none;
+    padding: 0;
+    background: transparent;
+    max-width: 100vw;
+    max-height: 100vh;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  dialog.image-lightbox::backdrop {
+    background: rgba(15, 12, 10, 0.88);
+    backdrop-filter: blur(4px);
+  }
+
+  dialog.image-lightbox[open] {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .image-lightbox__img {
+    max-width: 96vw;
+    max-height: 92vh;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+    border-radius: 6px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  }
+
+  .image-lightbox__close {
+    position: fixed;
+    top: 16px;
+    right: 20px;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease;
+  }
+
+  .image-lightbox__close:hover,
+  .image-lightbox__close:focus-visible {
+    background: rgba(255, 255, 255, 0.25);
+    outline: none;
   }
 </style>

--- a/site/src/scripts/image-lightbox.ts
+++ b/site/src/scripts/image-lightbox.ts
@@ -1,0 +1,62 @@
+/**
+ * Click-to-expand lightbox for blog images.
+ *
+ * Targets the hero image and any `<img>` rendered inside the MDX article body.
+ * Avatars and other UI images outside `.blog-post` are intentionally excluded.
+ */
+
+const TARGET_SELECTOR = '.blog-post-image, .blog-post-body img';
+const ZOOMABLE_CLASS = 'is-zoomable';
+
+interface LightboxRefs {
+  dialog: HTMLDialogElement;
+  img: HTMLImageElement;
+}
+
+function buildLightbox(): LightboxRefs {
+  const dialog = document.createElement('dialog');
+  dialog.className = 'image-lightbox';
+  dialog.setAttribute('aria-label', 'Image preview');
+  dialog.innerHTML = `
+    <button type="button" class="image-lightbox__close" aria-label="Close image preview">&times;</button>
+    <img class="image-lightbox__img" alt="" />
+  `;
+  document.body.appendChild(dialog);
+
+  const img = dialog.querySelector<HTMLImageElement>('.image-lightbox__img')!;
+  const closeBtn = dialog.querySelector<HTMLButtonElement>('.image-lightbox__close')!;
+
+  // Backdrop region is the dialog itself; clicks on the inner image bubble up
+  // to here, so we filter by event.target to keep image clicks from closing.
+  dialog.addEventListener('click', (event) => {
+    if (event.target === dialog) dialog.close();
+  });
+  closeBtn.addEventListener('click', () => dialog.close());
+
+  return { dialog, img };
+}
+
+function init(): void {
+  const targets = document.querySelectorAll<HTMLImageElement>(TARGET_SELECTOR);
+  if (targets.length === 0) return;
+
+  targets.forEach((source) => source.classList.add(ZOOMABLE_CLASS));
+
+  const { dialog, img } = buildLightbox();
+
+  document.addEventListener('click', (event) => {
+    const source = (event.target as Element | null)?.closest<HTMLImageElement>(
+      `img.${ZOOMABLE_CLASS}`,
+    );
+    if (!source) return;
+    img.src = source.currentSrc || source.src;
+    img.alt = source.alt || '';
+    dialog.showModal();
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}


### PR DESCRIPTION
## Summary

Reader feedback on the [Kitaru-agents-have-memory blog post](https://kitaru.ai/blog/kitaru-agents-now-have-memory/) flagged that the embedded dashboard screenshots are too small to read in the article column, with no way to expand them. This PR adds a native `<dialog>`-based lightbox so any blog image opens to full viewport on click.

## What it does

- Click the hero image or any `<img>` inside `.blog-post-body` → opens a modal with the image at full size
- ESC, backdrop click, or the close button dismisses it
- Cursor changes to `zoom-in` on hover so the affordance is discoverable
- Avatars and UI chrome are excluded by selector

## Implementation notes

- Uses the native `<dialog>` element for free focus trapping, ESC handling, and the `::backdrop` pseudo-element — no lightbox library
- Single delegated click listener on `document` matches `.is-zoomable` images, so future MDX-injected images are picked up automatically
- Lightbox markup is appended to `<body>` at runtime, so its CSS lives in a separate `<style is:global>` block alongside the existing scoped styles in `BlogPost.astro`

## Test plan

- [x] `just site-build-only` succeeds
- [x] `just check` passes
- [ ] Verify on PR preview Worker: open a blog post, click the hero image, click a body image, confirm ESC + backdrop click close
- [ ] Confirm avatars in the author block are not zoomable
- [ ] Sanity check on mobile viewport