### PR TITLE
Fix SDK + CLI doc rendering bugs

### DIFF
--- a/docs/scripts/convert-sdk-docs.mjs
+++ b/docs/scripts/convert-sdk-docs.mjs
@@ -60,6 +60,13 @@ if (!rootModule) {
 const normalizedBase = baseUrl.replace(/\/+$/, "");
 const apiPrefix = `${normalizedBase}/reference/python`;
 
+// fumadocs-python's convert() renders mod.description (summary) but drops
+// mod.docstring (structured sections like Google-style "Example:" blocks)
+// for modules. Functions get both. Inline any module-level docstring items
+// into description so "Example:" / "Note:" / "Warning:" sections actually
+// render on module pages.
+inlineModuleDocstrings(mod);
+
 console.log(`Converting ${rootModule} API to MDX...`);
 const files = convert(mod, { baseUrl: apiPrefix });
 console.log(`Generated ${files.length} MDX file(s)`);
@@ -103,6 +110,56 @@ await write(files, { outDir: outputDir });
 await generateMetaFiles(files, outputDir);
 
 console.log(`Wrote ${files.length} MDX files + meta.json to ${outputDir}`);
+
+/**
+ * Inline a module's structured docstring items (admonitions, code, text)
+ * into its description field as markdown. Recurses into submodules.
+ *
+ * MUTATES the input: appends to `module.description` and clears
+ * `module.docstring` on every module in the tree.
+ *
+ * Griffe emits Google-style sections like `Example:` as admonition items
+ * on `mod.docstring`; fumadocs-python's module converter ignores that
+ * field (only `mod.description` is rendered). Without this, any "Example:"
+ * section on a module docstring silently disappears from the generated
+ * page. We render admonitions as `**Title**\n\n<body>` so fenced code
+ * blocks inside them stay intact.
+ */
+function inlineModuleDocstrings(module) {
+  const extra = renderDocstringItems(module.docstring);
+  if (extra) {
+    module.description = module.description
+      ? `${module.description}\n\n${extra}`
+      : extra;
+  }
+  // Clear so convert() doesn't try to re-render these on the module itself
+  module.docstring = [];
+
+  for (const sub of Object.values(module.modules ?? {})) {
+    inlineModuleDocstrings(sub);
+  }
+}
+
+// Deliberately not reusing fumadocs-python's internal convertDoc() (dist/index.js:96):
+// it's unexported, emits MDX <Callout> JSX (which wouldn't round-trip through
+// the downstream encodeText() call on description), and has a bug where `code`
+// items are console.log'd instead of emitted. Keeping this local + markdown-only.
+function renderDocstringItems(items) {
+  if (!items || items.length === 0) return "";
+  const parts = [];
+  for (const item of items) {
+    if (item.kind === "text" && item.value) {
+      parts.push(item.value);
+    } else if (item.kind === "admonition") {
+      const title = item.title || item.value?.annotation || "Note";
+      const body = item.value?.description ?? "";
+      parts.push(`**${title}**\n\n${body}`);
+    } else if (item.kind === "code" && item.value) {
+      parts.push("```\n" + item.value + "\n```");
+    }
+  }
+  return parts.filter(Boolean).join("\n\n");
+}
 
 /**
  * Flatten singleton module directories into flat files.

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -60,13 +60,6 @@ class CommandDoc:
     parameters: list[ParameterDoc] = field(default_factory=list)
     subcommands: list[CommandDoc] = field(default_factory=list)
 
-    @property
-    def description(self) -> str:
-        """Combined summary and body (used for subcommand tables)."""
-        if self.body:
-            return f"{self.summary} {self.body}".strip()
-        return self.summary
-
 
 # ---------------------------------------------------------------------------
 # Extraction — cyclopts introspection
@@ -419,7 +412,10 @@ def render_command_page(cmd: CommandDoc, *, is_root: bool = False) -> str:
         lines.append("| Command | Description |")
         lines.append("| --- | --- |")
         for sub in cmd.subcommands:
-            desc_text = _escape_mdx(sub.description) if sub.description else ""
+            # Use summary only: markdown tables can't contain block-level
+            # content, so a body with lists or code fences would break the
+            # table. The detail body is already on the subcommand's own page.
+            desc_text = _escape_mdx(sub.summary) if sub.summary else ""
             lines.append(f"| [`{sub.name}`](./{sub.slug}) | {desc_text} |")
         lines.append("")
 

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -54,10 +54,18 @@ class CommandDoc:
     slug: str
     name: str
     invocation: str
-    description: str
+    summary: str
+    body: str
     usage: str
     parameters: list[ParameterDoc] = field(default_factory=list)
     subcommands: list[CommandDoc] = field(default_factory=list)
+
+    @property
+    def description(self) -> str:
+        """Combined summary and body (used for subcommand tables)."""
+        if self.body:
+            return f"{self.summary} {self.body}".strip()
+        return self.summary
 
 
 # ---------------------------------------------------------------------------
@@ -231,28 +239,48 @@ def _extract_parameters(app: Any) -> list[ParameterDoc]:
     return params
 
 
-def _get_description(app: Any) -> str:
-    """Extract a description from a cyclopts App."""
-    if app.help:
-        # Take the first paragraph (before any Args: section)
-        lines: list[str] = []
-        for line in str(app.help).splitlines():
-            stripped = line.strip()
-            if stripped.lower().startswith(
-                ("args:", "arguments:", "returns:", "raises:")
-            ):
-                break
-            lines.append(stripped)
-        desc = " ".join(lines).strip()
-        if desc:
-            return desc
+def _get_description(app: Any) -> tuple[str, str]:
+    """Extract (summary, body) from a cyclopts App's docstring.
 
-    if app.default_command and callable(app.default_command):
-        doc = inspect.getdoc(app.default_command)
-        if doc:
-            return doc.split("\n\n")[0].strip()
+    Google-style docstrings lead with a one-line summary, followed by a
+    blank line and then optional detail paragraphs.  We surface the
+    summary as the page's frontmatter description (short subtitle) and
+    keep the remaining paragraphs as body prose.
+    """
+    raw = str(app.help) if app.help else ""
+    if not raw and app.default_command and callable(app.default_command):
+        raw = inspect.getdoc(app.default_command) or ""
+    if not raw:
+        return ("", "")
 
-    return ""
+    # Drop Args:/Returns:/Raises: sections — cyclopts renders these as
+    # parameter help separately.
+    kept_lines: list[str] = []
+    for line in raw.splitlines():
+        if (
+            line.strip()
+            .lower()
+            .startswith(("args:", "arguments:", "returns:", "raises:"))
+        ):
+            break
+        kept_lines.append(line)
+
+    text = "\n".join(kept_lines).strip()
+    if not text:
+        return ("", "")
+
+    # Split on the first blank line: summary vs detail paragraphs.
+    parts = text.split("\n\n", 1)
+    summary = " ".join(parts[0].split()).strip()
+    body = ""
+    if len(parts) == 2:
+        body_paragraphs = [
+            " ".join(para.split()).strip()
+            for para in parts[1].split("\n\n")
+            if para.strip()
+        ]
+        body = "\n\n".join(body_paragraphs)
+    return (summary, body)
 
 
 def build_command_tree(
@@ -267,7 +295,7 @@ def build_command_tree(
     invocation = f"{parent_invocation} {name}".strip() if parent_invocation else name
     slug = name
 
-    description = _get_description(app)
+    summary, body = _get_description(app)
 
     params = _extract_parameters(app)
     registered = getattr(app, "_registered_commands", {})
@@ -283,7 +311,8 @@ def build_command_tree(
         slug=slug,
         name=name,
         invocation=invocation,
-        description=description,
+        summary=summary,
+        body=body,
         usage=usage,
         parameters=params,
         subcommands=subcommands,
@@ -310,7 +339,7 @@ def render_command_page(cmd: CommandDoc, *, is_root: bool = False) -> str:
 
     # Frontmatter
     title = "CLI Reference" if is_root else cmd.invocation
-    desc = cmd.description or f"Reference for the `{cmd.invocation}` command."
+    desc = cmd.summary or f"Reference for the `{cmd.invocation}` command."
     # Escape YAML special characters in description
     safe_desc = desc.replace('"', '\\"')
     lines.append("---")
@@ -319,9 +348,11 @@ def render_command_page(cmd: CommandDoc, *, is_root: bool = False) -> str:
     lines.append("---")
     lines.append("")
 
-    # Description
-    if cmd.description:
-        lines.append(_escape_mdx(cmd.description))
+    # FumaDocs renders the frontmatter description as the page subtitle.
+    # Detail paragraphs (if any) go in the body as normal prose so long
+    # descriptions don't become a wall of text under the h1.
+    if cmd.body:
+        lines.append(_escape_mdx(cmd.body))
         lines.append("")
 
     # Usage

--- a/src/kitaru/__init__.py
+++ b/src/kitaru/__init__.py
@@ -6,8 +6,8 @@ replayable, and observable. Decorate your orchestration function with
 ``@flow`` and your work units with ``@checkpoint`` to get automatic
 durability.
 
-Example::
-
+Example:
+    ```python
     from kitaru import flow, checkpoint
 
     @checkpoint
@@ -18,6 +18,7 @@ Example::
     def my_agent(url: str) -> str:
         data = fetch_data(url)
         return data.upper()
+    ```
 
 Current status:
 

--- a/src/kitaru/artifacts.py
+++ b/src/kitaru/artifacts.py
@@ -5,8 +5,8 @@
 
 Both are valid only inside a checkpoint.
 
-Example::
-
+Example:
+    ```python
     from kitaru import checkpoint
 
     @checkpoint
@@ -20,6 +20,7 @@ Example::
     def refine(exec_id: str) -> str:
         old_sources = kitaru.load(exec_id, "sources")
         return improve(old_sources)
+    ```
 """
 
 from __future__ import annotations

--- a/src/kitaru/checkpoint.py
+++ b/src/kitaru/checkpoint.py
@@ -293,18 +293,20 @@ def checkpoint(
 ) -> _CheckpointDefinition | Callable[[Callable[..., Any]], _CheckpointDefinition]:
     """Mark a function as a durable checkpoint.
 
-    Can be used as a bare decorator or with arguments::
+    Can be used as a bare decorator or with arguments:
 
-        from kitaru import checkpoint
+    ```python
+    from kitaru import checkpoint
 
-        @checkpoint
-        def my_step(): ...
+    @checkpoint
+    def my_step(): ...
 
-        @checkpoint(retries=3, type="llm_call")
-        def my_step(): ...
+    @checkpoint(retries=3, type="llm_call")
+    def my_step(): ...
 
-        @checkpoint(runtime="isolated")
-        def heavy_step(): ...
+    @checkpoint(runtime="isolated")
+    def heavy_step(): ...
+    ```
 
     Args:
         func: Optional function for bare decorator use.

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -3,13 +3,14 @@
 `KitaruClient` provides a programmatic API for inspecting and managing
 executions, artifacts, and memories outside flow bodies.
 
-Example::
-
+Example:
+    ```python
     from kitaru import KitaruClient
 
     client = KitaruClient()
     execution = client.executions.get("exec-123")
     print(execution.status)
+    ```
 """
 
 from __future__ import annotations

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -940,15 +940,17 @@ def flow(
 ) -> _FlowDefinition | Callable[[Callable[..., Any]], _FlowDefinition]:
     """Mark a function as a durable flow.
 
-    Can be used as a bare decorator or with arguments::
+    Can be used as a bare decorator or with arguments:
 
-        @flow
-        def my_flow(...):
-            ...
+    ```python
+    @flow
+    def my_flow(...):
+        ...
 
-        @flow(stack="prod", retries=2)
-        def my_other_flow(...):
-            ...
+    @flow(stack="prod", retries=2)
+    def my_other_flow(...):
+        ...
+    ```
 
     Args:
         func: Optional function for bare decorator use.

--- a/src/kitaru/logging.py
+++ b/src/kitaru/logging.py
@@ -5,8 +5,8 @@ checkpoint or execution. It is context-sensitive: inside a checkpoint
 it attaches to that checkpoint; inside a flow but outside a checkpoint
 it attaches to the execution.
 
-Example::
-
+Example:
+    ```python
     from kitaru import checkpoint
 
     @checkpoint
@@ -18,6 +18,7 @@ Example::
             model=response.model,
         )
         return response.text
+    ```
 """
 
 from __future__ import annotations

--- a/tests/test_generate_cli_docs.py
+++ b/tests/test_generate_cli_docs.py
@@ -184,7 +184,8 @@ class TestRenderCommandPage:
             slug="kitaru",
             name="kitaru",
             invocation="kitaru",
-            description="Test description.",
+            summary="Test description.",
+            body="",
             usage="kitaru",
         )
         page = render_command_page(cmd, is_root=True)
@@ -197,7 +198,8 @@ class TestRenderCommandPage:
             slug="kitaru",
             name="kitaru",
             invocation="kitaru",
-            description="Test.",
+            summary="Test.",
+            body="",
             usage="kitaru",
         )
         page = render_command_page(cmd, is_root=True)
@@ -210,7 +212,8 @@ class TestRenderCommandPage:
             slug="kitaru",
             name="kitaru",
             invocation="kitaru",
-            description="Test.",
+            summary="Test.",
+            body="",
             usage="kitaru",
         )
         page = render_command_page(cmd, is_root=True)
@@ -223,18 +226,35 @@ class TestRenderCommandPage:
             slug="serve",
             name="serve",
             invocation="kitaru serve",
-            description="Start server.",
+            summary="Start server.",
+            body="",
             usage="kitaru serve",
         )
         page = render_command_page(cmd, is_root=False)
         assert "## Global Flags" not in page
+
+    def test_body_renders_below_frontmatter(self) -> None:
+        cmd = CommandDoc(
+            slug="compact",
+            name="compact",
+            invocation="kitaru memory compact",
+            summary="Summarize memory values.",
+            body="Use --key for single-key mode or --keys for multi-key mode.",
+            usage="kitaru memory compact [OPTIONS]",
+        )
+        page = render_command_page(cmd, is_root=False)
+        assert 'description: "Summarize memory values."' in page
+        assert "Use --key for single-key mode" in page
+        # Body text should appear exactly once (summary stays in frontmatter only)
+        assert page.count("Summarize memory values.") == 1
 
     def test_renders_parameters_table(self) -> None:
         cmd = CommandDoc(
             slug="serve",
             name="serve",
             invocation="kitaru serve",
-            description="Start.",
+            summary="Start.",
+            body="",
             usage="kitaru serve [OPTIONS]",
             parameters=[
                 ParameterDoc(
@@ -257,14 +277,16 @@ class TestRenderCommandPage:
             slug="run",
             name="run",
             invocation="kitaru agent run",
-            description="Run an agent.",
+            summary="Run an agent.",
+            body="",
             usage="kitaru agent run",
         )
         cmd = CommandDoc(
             slug="agent",
             name="agent",
             invocation="kitaru agent",
-            description="Manage agents.",
+            summary="Manage agents.",
+            body="",
             usage="kitaru agent COMMAND",
             subcommands=[child],
         )
@@ -277,7 +299,8 @@ class TestRenderCommandPage:
             slug="test",
             name="test",
             invocation="test",
-            description="Uses <angle> and {braces}.",
+            summary="Summary.",
+            body="Uses <angle> and {braces}.",
             usage="test",
         )
         page = render_command_page(cmd, is_root=False)
@@ -556,14 +579,16 @@ class TestRenderMeta:
                 slug="serve",
                 name="serve",
                 invocation="kitaru serve",
-                description="",
+                summary="",
+                body="",
                 usage="",
             ),
             CommandDoc(
                 slug="agent",
                 name="agent",
                 invocation="kitaru agent",
-                description="",
+                summary="",
+                body="",
                 usage="",
             ),
         ]

--- a/tests/test_generate_cli_docs.py
+++ b/tests/test_generate_cli_docs.py
@@ -13,6 +13,7 @@ import pytest
 from generate_cli_docs import (
     CommandDoc,
     ParameterDoc,
+    _get_description,
     build_command_tree,
     render_command_page,
     render_meta,
@@ -36,6 +37,75 @@ def output_dir() -> Generator[Path]:
     shutil.rmtree(d, ignore_errors=True)
 
 
+class TestGetDescription:
+    """Tests for docstring summary/body extraction."""
+
+    @staticmethod
+    def _app(help_text: str | None = None, default_doc: str | None = None) -> object:
+        """Build a minimal cyclopts-shaped app for `_get_description()`."""
+        from types import SimpleNamespace
+
+        default_command = None
+        if default_doc is not None:
+
+            def fn() -> None:
+                """placeholder"""
+
+            fn.__doc__ = default_doc
+            default_command = fn
+        return SimpleNamespace(help=help_text, default_command=default_command)
+
+    def test_no_help_and_no_default_command(self) -> None:
+        assert _get_description(self._app()) == ("", "")
+
+    def test_summary_only(self) -> None:
+        app = self._app("Start the local server.")
+        assert _get_description(app) == ("Start the local server.", "")
+
+    def test_summary_plus_body(self) -> None:
+        app = self._app("Summary line.\n\nDetail paragraph explaining the nuance.")
+        assert _get_description(app) == (
+            "Summary line.",
+            "Detail paragraph explaining the nuance.",
+        )
+
+    def test_multiple_body_paragraphs_preserved(self) -> None:
+        app = self._app("Summary.\n\nFirst detail paragraph.\n\nSecond paragraph.")
+        summary, body = _get_description(app)
+        assert summary == "Summary."
+        assert body == "First detail paragraph.\n\nSecond paragraph."
+
+    def test_args_section_stripped_from_body(self) -> None:
+        app = self._app(
+            "Summary.\n\nDetail explaining flags.\n\n"
+            "Args:\n    foo: the foo parameter.\n    bar: the bar parameter."
+        )
+        summary, body = _get_description(app)
+        assert summary == "Summary."
+        assert body == "Detail explaining flags."
+
+    def test_docstring_is_only_args_section(self) -> None:
+        app = self._app("Args:\n    foo: the foo parameter.")
+        assert _get_description(app) == ("", "")
+
+    def test_returns_section_also_stripped(self) -> None:
+        app = self._app("Summary.\n\nReturns:\n    int: the result.")
+        assert _get_description(app) == ("Summary.", "")
+
+    def test_falls_back_to_default_command_docstring(self) -> None:
+        app = self._app(default_doc="Fallback summary.\n\nFallback body.")
+        assert _get_description(app) == (
+            "Fallback summary.",
+            "Fallback body.",
+        )
+
+    def test_collapses_hard_wrapped_summary_whitespace(self) -> None:
+        app = self._app("Summary that is\nhard-wrapped across\nmultiple lines.")
+        summary, body = _get_description(app)
+        assert summary == "Summary that is hard-wrapped across multiple lines."
+        assert body == ""
+
+
 class TestBuildCommandTree:
     """Tests for cyclopts command tree extraction."""
 
@@ -45,7 +115,7 @@ class TestBuildCommandTree:
         tree = build_command_tree(app)
         assert tree.name == "kitaru"
         assert tree.invocation == "kitaru"
-        assert tree.description
+        assert tree.summary
 
     def test_root_has_current_subcommands(self) -> None:
         from kitaru.cli import app
@@ -245,8 +315,11 @@ class TestRenderCommandPage:
         page = render_command_page(cmd, is_root=False)
         assert 'description: "Summarize memory values."' in page
         assert "Use --key for single-key mode" in page
-        # Body text should appear exactly once (summary stays in frontmatter only)
+        # Guard against duplication in both directions:
+        # - summary must stay in frontmatter only (not copied to body)
+        # - body must stay in body only (not promoted to frontmatter)
         assert page.count("Summarize memory values.") == 1
+        assert page.count("Use --key for single-key mode") == 1
 
     def test_renders_parameters_table(self) -> None:
         cmd = CommandDoc(
@@ -293,6 +366,31 @@ class TestRenderCommandPage:
         page = render_command_page(cmd, is_root=False)
         assert "## Commands" in page
         assert "[`run`](./run)" in page
+
+    def test_subcommand_table_omits_body(self) -> None:
+        # Markdown tables can't contain block-level content, so the child's
+        # body must NEVER appear in the parent's subcommand table — only
+        # its summary. The body stays on the child's own page.
+        child = CommandDoc(
+            slug="compact",
+            name="compact",
+            invocation="kitaru memory compact",
+            summary="Summarize memory values.",
+            body="Use --key for single-key mode.",
+            usage="kitaru memory compact [OPTIONS]",
+        )
+        parent = CommandDoc(
+            slug="memory",
+            name="memory",
+            invocation="kitaru memory",
+            summary="Manage memory.",
+            body="",
+            usage="kitaru memory COMMAND",
+            subcommands=[child],
+        )
+        page = render_command_page(parent, is_root=False)
+        assert "Summarize memory values." in page
+        assert "Use --key for single-key mode" not in page
 
     def test_escapes_mdx_special_chars(self) -> None:
         cmd = CommandDoc(


### PR DESCRIPTION
## Summary

Two reference-docs rendering bugs that made generated pages look broken:

- **SDK pages**: module-level docstrings used RST's `Example::` literal-block syntax. Griffe's Google parser passed them through as plain text, and fumadocs-python's module converter only emits `mod.description` (summary) — it silently drops `mod.docstring` (structured admonitions). Result: Example code blocks on module pages like `/reference/python/artifacts` rendered as run-on text like `Example:: from kitaru import checkpoint @checkpoint def research...`.
- **CLI pages**: every command's frontmatter description was the entire first paragraph of its docstring, *and* the same text was rendered in the body. FumaDocs already shows frontmatter description as the page subtitle, so long commands like `kitaru memory compact` showed ~100-word blob twice.

## Fix

**SDK**:
- Convert six source docstrings (`__init__`, `artifacts`, `checkpoint`, `client`, `flow`, `logging`) from RST `Example::` → Markdown `Example:` with fenced ` ```python ` blocks. These also read better via `help()` in a terminal.
- Patch `docs/scripts/convert-sdk-docs.mjs`: new `inlineModuleDocstrings()` walks the module tree and folds `mod.docstring` admonitions into `mod.description` as markdown before calling fumadocs-python's `convert()`. Functions already render their docstrings correctly; this closes the equivalent gap for modules.

**CLI**:
- `scripts/generate_cli_docs.py` splits each command's docstring on the Google-style summary/detail boundary. Summary → frontmatter `description` (short, good for `<meta description>` + page subtitle). Detail paragraphs → body prose.
- Subcommand tables in parent pages (e.g. `/cli/memory/index.mdx`) render only the child's summary — markdown tables can't contain block-level content, so any future body with a list or code fence would have silently produced malformed MDX.

## Review-driven improvements (second commit)

- Deleted the derived `CommandDoc.description` @property — after switching tables to `sub.summary`, the shim had no consumers. One source of truth: `summary` + `body`, period.
- Added direct `_get_description()` unit coverage: 9 parametrized cases for empty input, summary-only, multi-paragraph bodies, `Args:`/`Returns:` section stripping, `default_command` fallback, and whitespace normalization. Prevents silent degradation on future refactors of the split logic.
- Strengthened `test_body_renders_below_frontmatter` to also assert the body substring count == 1 (guards the inverse duplication).
- Added `test_subcommand_table_omits_body` pinning the table-only-uses-summary contract.

## Review notes

- Code-reuse review flagged that fumadocs-python has an internal `convertDoc()` that does similar admonition handling. Deliberately not reused: it's unexported, emits MDX `<Callout>` JSX that wouldn't round-trip through the downstream `encodeText()` call, and has a vendor bug where `code` items are `console.log`'d instead of emitted. Documented inline.
- `inlineModuleDocstrings()` mutates its input recursively — called exactly once, right before `convert()`, on the parsed JSON. Documented in the JSDoc.
- Node-side snapshot tests for `inlineModuleDocstrings` / `renderDocstringItems` were deferred — the repo has no JS test harness today (biome is lint-only). Filed as a separate issue.

## Test plan

- [x] `just fix` — clean
- [x] `just check` — all checks pass (format, lint, typecheck, typos, yaml, actions, links)
- [x] `just test` — 1291 passed, 1 skipped (+ 10 new tests)
- [x] Manual preview of `/docs/reference/python/artifacts` — Example section renders with syntax-highlighted Python block
- [x] Manual preview of `/docs/cli/memory/compact` — frontmatter shows short summary, detail paragraph renders as body prose
- [x] Manual preview of `/docs/cli/memory` subcommand table — compact row shows clean one-line summary instead of 100-word blob
- [x] Manual preview of `/docs/cli/memory/get` and other single-sentence commands — unchanged (no body content)