### PR TITLE
Add `/roadmap` and `/community` redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
   <a href="https://pypi.org/project/kitaru/"><img alt="PyPI" src="https://img.shields.io/pypi/v/kitaru?color=blue"></a>
   <a href="https://pypi.org/project/kitaru/"><img alt="Python" src="https://img.shields.io/pypi/pyversions/kitaru"></a>
   <a href="https://github.com/zenml-io/kitaru/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/zenml-io/kitaru"></a>
-  <a href="https://zenml.io/slack"><img alt="Slack" src="https://img.shields.io/badge/chat-on%20slack-blueviolet"></a>
 </p>
 
 <p align="center">
@@ -188,11 +187,10 @@ all PRs should target it.
 
 ## Community and support
 
-- [Slack](https://zenml.io/slack) — chat with the team and other users
-- [GitHub Discussions](https://kitaru.ai/community) — questions and conversations
-- [GitHub Issues](https://github.com/zenml-io/kitaru/issues) — bug reports and feature requests
-- [Roadmap](https://kitaru.ai/roadmap) — see what we're building next
-- [kitaru.ai](https://kitaru.ai) — landing page and docs
+- [Discussions](https://kitaru.ai/community) — ask questions, share ideas
+- [Issues](https://github.com/zenml-io/kitaru/issues) — report bugs, request features
+- [Roadmap](https://kitaru.ai/roadmap) — see what's coming next
+- [Docs](https://kitaru.ai/docs) — guides and reference
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@
   <a href="https://kitaru.ai/docs">Docs</a> &middot;
   <a href="#quick-start">Quick Start</a> &middot;
   <a href="https://kitaru.ai/docs/getting-started/examples">Examples</a> &middot;
-  <a href="GETTING_STARTED.md">Getting Started Guide</a>
+  <a href="GETTING_STARTED.md">Getting Started Guide</a> &middot;
+  <a href="https://kitaru.ai/roadmap">Roadmap</a> &middot;
+  <a href="https://kitaru.ai/community">Community</a>
 </p>
 
 ---
@@ -187,7 +189,9 @@ all PRs should target it.
 ## Community and support
 
 - [Slack](https://zenml.io/slack) — chat with the team and other users
+- [GitHub Discussions](https://kitaru.ai/community) — questions and conversations
 - [GitHub Issues](https://github.com/zenml-io/kitaru/issues) — bug reports and feature requests
+- [Roadmap](https://kitaru.ai/roadmap) — see what we're building next
 - [kitaru.ai](https://kitaru.ai) — landing page and docs
 
 ## License

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -11,6 +11,8 @@ export default defineConfig({
   redirects: {
     '/banner': { status: 302, destination: '/' },
     '/onepager': { status: 302, destination: '/' },
+    '/roadmap': { status: 302, destination: 'https://github.com/orgs/zenml-io/projects/5' },
+    '/community': { status: 302, destination: 'https://github.com/zenml-io/kitaru/discussions' },
   },
   integrations: [sitemap(), mdx()],
   markdown: {

--- a/site/src/components/Cta.astro
+++ b/site/src/components/Cta.astro
@@ -26,7 +26,7 @@
         </button>
       </div>
       <div class="cta-links">
-        <a href="/docs" class="btn-accent">Read the docs</a>
+        <a href="/get-started" class="btn-accent">Get started</a>
         <a href="https://github.com/zenml-io/kitaru" target="_blank" rel="noopener" class="btn-secondary-dark">
           Star on GitHub
         </a>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -38,11 +38,11 @@
     </div>
 
     <div class="hero-buttons" data-reveal data-reveal-delay="4">
-      <a href="https://github.com/zenml-io/kitaru" target="_blank" rel="noopener" class="btn-primary hero-gh-btn">
+      <a href="/get-started" class="btn-primary">Get started</a>
+      <a href="https://github.com/zenml-io/kitaru" target="_blank" rel="noopener" class="btn-secondary hero-gh-btn">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
         View on GitHub
       </a>
-      <a href="/docs" class="btn-secondary">Read the docs</a>
     </div>
   </div>
 </section>

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -24,7 +24,7 @@
     <a href="/blog">Blog</a>
     <a href="/docs/getting-started/examples">Examples</a>
     <a href="/#how-it-works">Features</a>
-    <a href="/docs" class="nav-cta">Get started</a>
+    <a href="/get-started" class="nav-cta">Get started</a>
   </div>
 
   <!-- Mobile hamburger button -->
@@ -46,7 +46,7 @@
     <a href="/blog" tabindex="-1">Blog</a>
     <a href="/docs/getting-started/examples" tabindex="-1">Examples</a>
     <a href="/#how-it-works" tabindex="-1">Features</a>
-    <a href="/docs" class="nav-mobile-cta" tabindex="-1">Get started</a>
+    <a href="/get-started" class="nav-mobile-cta" tabindex="-1">Get started</a>
   </div>
 </nav>
 

--- a/site/src/lib/segment.ts
+++ b/site/src/lib/segment.ts
@@ -1,0 +1,20 @@
+export const SEGMENT_WRITE_KEY = 'MMarT0XoV4LJH8wR7wpmkTbF7txc9Bsg';
+
+/** Send a single call to Segment's HTTP Tracking API. */
+export async function segmentCall(
+  endpoint: 'identify' | 'track',
+  body: Record<string, unknown>,
+): Promise<void> {
+  const resp = await fetch(`https://api.segment.io/v1/${endpoint}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${btoa(SEGMENT_WRITE_KEY + ':')}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    console.error(`[segment:${endpoint}] ${resp.status}: ${text}`);
+  }
+}

--- a/site/src/pages/api/get-started.ts
+++ b/site/src/pages/api/get-started.ts
@@ -1,0 +1,110 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = false;
+
+/** Send a single call to Segment's HTTP Tracking API. */
+async function segmentCall(
+  endpoint: 'identify' | 'track',
+  writeKey: string,
+  body: Record<string, unknown>,
+): Promise<void> {
+  const resp = await fetch(`https://api.segment.io/v1/${endpoint}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${btoa(writeKey + ':')}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    console.error(`[segment:${endpoint}] ${resp.status}: ${text}`);
+  }
+}
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  try {
+    const data = await request.json();
+    const name = data.name?.trim();
+    const company = data.company?.trim();
+    const email = data.email?.trim().toLowerCase();
+
+    if (!name) {
+      return new Response(JSON.stringify({ error: 'Name is required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (!company) {
+      return new Response(JSON.stringify({ error: 'Company is required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (!email || !email.includes('@')) {
+      return new Response(JSON.stringify({ error: 'Invalid email' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const runtime = (locals as any).runtime;
+    const env = runtime?.env;
+    const kv = env?.WAITLIST_KV;
+
+    if (!kv) {
+      return new Response(JSON.stringify({ error: 'KV not configured' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    await kv.put(email, JSON.stringify({
+      name,
+      company,
+      email,
+      timestamp: new Date().toISOString(),
+      source: 'get-started',
+    }));
+
+    // Send identify + track to Segment server-side (fire-and-forget)
+    const segmentKey = env?.SEGMENT_WRITE_KEY;
+    if (segmentKey) {
+      const referer = request.headers.get('referer') ?? '';
+      const userAgent = request.headers.get('user-agent') ?? '';
+      const segmentContext = { page: { url: referer }, userAgent };
+
+      const identifyCall = segmentCall('identify', segmentKey, {
+        userId: email,
+        traits: { name, company, email },
+        context: segmentContext,
+      });
+      const trackCall = segmentCall('track', segmentKey, {
+        userId: email,
+        event: 'Get Started Signup',
+        properties: {
+          name,
+          company,
+          email,
+          source: 'get-started',
+          formType: 'get-started',
+        },
+        context: segmentContext,
+      });
+
+      runtime.ctx.waitUntil(Promise.all([identifyCall, trackCall]));
+    }
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: 'Server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/site/src/pages/api/get-started.ts
+++ b/site/src/pages/api/get-started.ts
@@ -1,26 +1,7 @@
 import type { APIRoute } from 'astro';
+import { segmentCall } from '../../lib/segment';
 
 export const prerender = false;
-
-/** Send a single call to Segment's HTTP Tracking API. */
-async function segmentCall(
-  endpoint: 'identify' | 'track',
-  writeKey: string,
-  body: Record<string, unknown>,
-): Promise<void> {
-  const resp = await fetch(`https://api.segment.io/v1/${endpoint}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Basic ${btoa(writeKey + ':')}`,
-    },
-    body: JSON.stringify(body),
-  });
-  if (!resp.ok) {
-    const text = await resp.text();
-    console.error(`[segment:${endpoint}] ${resp.status}: ${text}`);
-  }
-}
 
 export const POST: APIRoute = async ({ request, locals }) => {
   try {
@@ -52,7 +33,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
     const runtime = (locals as any).runtime;
     const env = runtime?.env;
-    const kv = env?.WAITLIST_KV;
+    const kv = env?.GET_STARTED_KV;
 
     if (!kv) {
       return new Response(JSON.stringify({ error: 'KV not configured' }), {
@@ -70,32 +51,29 @@ export const POST: APIRoute = async ({ request, locals }) => {
     }));
 
     // Send identify + track to Segment server-side (fire-and-forget)
-    const segmentKey = env?.SEGMENT_WRITE_KEY;
-    if (segmentKey) {
-      const referer = request.headers.get('referer') ?? '';
-      const userAgent = request.headers.get('user-agent') ?? '';
-      const segmentContext = { page: { url: referer }, userAgent };
+    const referer = request.headers.get('referer') ?? '';
+    const userAgent = request.headers.get('user-agent') ?? '';
+    const segmentContext = { page: { url: referer }, userAgent };
 
-      const identifyCall = segmentCall('identify', segmentKey, {
-        userId: email,
-        traits: { name, company, email },
-        context: segmentContext,
-      });
-      const trackCall = segmentCall('track', segmentKey, {
-        userId: email,
-        event: 'Get Started Signup',
-        properties: {
-          name,
-          company,
-          email,
-          source: 'get-started',
-          formType: 'get-started',
-        },
-        context: segmentContext,
-      });
+    const identifyCall = segmentCall('identify', {
+      userId: email,
+      traits: { name, company, email },
+      context: segmentContext,
+    });
+    const trackCall = segmentCall('track', {
+      userId: email,
+      event: 'Get Started Signup',
+      properties: {
+        name,
+        company,
+        email,
+        source: 'get-started',
+        formType: 'get-started',
+      },
+      context: segmentContext,
+    });
 
-      runtime.ctx.waitUntil(Promise.all([identifyCall, trackCall]));
-    }
+    runtime.ctx.waitUntil(Promise.all([identifyCall, trackCall]));
 
     return new Response(JSON.stringify({ ok: true }), {
       status: 200,

--- a/site/src/pages/get-started.astro
+++ b/site/src/pages/get-started.astro
@@ -20,15 +20,14 @@ import Footer from '../components/Footer.astro';
           From zero to production agents in <span class="gs-accent">4&nbsp;weeks</span> — on&nbsp;us.
         </h1>
         <p class="gs-subtitle">
-          Our team will deploy Kitaru on your infrastructure, run your first durable flow, migrate existing agent code, and benchmark performance. Completely free.
+          Our engineers pair with your team to deploy Kitaru, migrate your agent code, and prove it works — on your infrastructure, with your data. No cost, no commitment.
         </p>
       </div>
     </section>
 
     <section class="gs-form-section" id="signup">
       <div class="gs-form-inner" data-reveal>
-        <h2>Start your free onboarding</h2>
-        <p class="gs-form-subtitle">Tell us a bit about yourself and we'll reach out within one business day.</p>
+        <h2>Talk to us</h2>
 
         <form id="getStartedForm" class="gs-form" novalidate>
           <div class="gs-field">
@@ -55,31 +54,84 @@ import Footer from '../components/Footer.astro';
       </div>
     </section>
 
+    <section class="gs-why">
+      <div class="gs-why-inner" data-reveal>
+        <div class="gs-why-item">
+          <strong>Free</strong> — No cost, no contract. We invest our time because every deployment makes Kitaru better.
+        </div>
+        <div class="gs-why-item">
+          <strong>Production-ready</strong> — Your actual infrastructure, your security policies, your data. Not a demo.
+        </div>
+        <div class="gs-why-item">
+          <strong>Battle-tested</strong> — Built by the ZenML team, who spent 5 years shipping ML infra for Adeo, Rivian, and JetBrains.
+        </div>
+        <div class="gs-why-item">
+          <strong>Yours to keep</strong> — Open source, Apache 2.0. Everything we set up belongs to you. Zero lock-in.
+        </div>
+      </div>
+    </section>
+
     <section class="gs-steps">
       <div class="gs-steps-header" data-reveal>
         <h2>What you get in 4 weeks</h2>
-        <p class="gs-steps-subtitle">Powered by 5 years of ZenML MLOps experience and hundreds of production deployments.</p>
+        <p class="gs-steps-subtitle">Powered by 5 years of ZenML MLOps experience, hundreds of production deployments, and a team that's shipped LLMOps and agent infrastructure for enterprise teams.</p>
       </div>
       <div class="gs-steps-grid">
         <div class="gs-step-card" data-reveal>
           <div class="gs-step-number">1</div>
           <h3>Deploy on your infra</h3>
-          <p>We deploy Kitaru on your cloud (AWS, GCP, Azure) or on-prem — you keep full control of your data and compute.</p>
+          <p>We deploy Kitaru on your cloud (AWS, GCP, Azure) or on-prem. We handle Kubernetes, networking, and storage config so your team doesn't have to context-switch.</p>
+          <span class="gs-step-time">Week 1</span>
         </div>
         <div class="gs-step-card" data-reveal data-reveal-delay="1">
           <div class="gs-step-number">2</div>
-          <h3>Run your first flow</h3>
-          <p>Build and run a durable agent flow end-to-end with checkpoints, replay, and observability from day one.</p>
+          <h3>Build a durable agent</h3>
+          <p>We pair-program a real agent workflow with your team — checkpoints, human-in-the-loop waits, LLM calls, and replay. Not a toy demo; something you'll actually ship.</p>
+          <span class="gs-step-time">Week 2</span>
         </div>
         <div class="gs-step-card" data-reveal data-reveal-delay="2">
           <div class="gs-step-number">3</div>
-          <h3>Migrate your code</h3>
-          <p>We help migrate your existing agent code to Kitaru primitives — no rewrites, just thin wrappers around your Python.</p>
+          <h3>Migrate your agents</h3>
+          <p>We take one of your production agents — LangChain, CrewAI, PydanticAI, or custom — and make it durable. No rewrites; thin decorators around your existing Python.</p>
+          <span class="gs-step-time">Week 3</span>
         </div>
         <div class="gs-step-card" data-reveal data-reveal-delay="3">
           <div class="gs-step-number">4</div>
           <h3>Benchmark</h3>
-          <p>Compare reliability, cost, and latency before and after. See exactly what durable execution changes for your agents.</p>
+          <p>Compare reliability, cost, and latency before and after. You get a written report showing exactly what durable execution changed for your agents.</p>
+          <span class="gs-step-time">Week 4</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="gs-faq">
+      <div class="gs-faq-inner">
+        <h2 data-reveal>Frequently asked questions</h2>
+        <div class="gs-faq-list">
+          <details class="gs-faq-item" data-reveal>
+            <summary>Is this really free? What's the catch?</summary>
+            <p>There is no catch. Kitaru is open source and we don't charge for this program. We do it because every real-world deployment teaches us something, and teams that go through onboarding tend to become long-term users and contributors. If you eventually need managed hosting or enterprise support, we offer that too — but there's zero obligation.</p>
+          </details>
+          <details class="gs-faq-item" data-reveal>
+            <summary>What kind of agents does Kitaru work with?</summary>
+            <p>Any Python-based agent — LangChain, CrewAI, PydanticAI, custom code, or raw API calls. Kitaru is framework-agnostic. It wraps your existing control flow with durable execution primitives. If your agent runs in Python, it works with Kitaru.</p>
+          </details>
+          <details class="gs-faq-item" data-reveal>
+            <summary>How much engineering time does our team need to invest?</summary>
+            <p>Roughly 2-4 hours per week for one engineer. We do the heavy lifting — infra setup, code migration, debugging. Your engineer joins pair-programming sessions and reviews PRs so the knowledge transfers to your team.</p>
+          </details>
+          <details class="gs-faq-item" data-reveal>
+            <summary>What clouds and infrastructure do you support?</summary>
+            <p>AWS, GCP, and Azure with Kubernetes. We also support on-prem Kubernetes clusters. Kitaru runs anywhere you can run a container — we just need cluster access and a storage backend (S3, GCS, or Azure Blob).</p>
+          </details>
+          <details class="gs-faq-item" data-reveal>
+            <summary>What happens after the 4 weeks?</summary>
+            <p>You have a working production deployment, migrated agent code, and a benchmark report. Your team keeps everything — it's your infrastructure, your code, your Kitaru instance. We offer optional ongoing support and managed hosting if you want it, but you're fully self-sufficient after onboarding.</p>
+          </details>
+          <details class="gs-faq-item" data-reveal>
+            <summary>Do you need access to our data or models?</summary>
+            <p>No. Kitaru runs on your infrastructure and your data never leaves your environment. We need cluster access to deploy and debug, but we don't need to see your training data, prompts, or model outputs. We can work under NDA if needed.</p>
+          </details>
         </div>
       </div>
     </section>
@@ -120,84 +172,6 @@ import Footer from '../components/Footer.astro';
     color: var(--color-secondary);
     max-width: 560px;
     margin: 0 auto;
-  }
-
-  /* ── Steps ── */
-  .gs-steps {
-    padding: 40px clamp(24px, 5vw, 80px) 120px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 40px;
-  }
-
-  .gs-steps-header {
-    text-align: center;
-    max-width: 560px;
-  }
-
-  .gs-steps-header h2 {
-    font-size: clamp(1.6rem, 3vw, 2.2rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
-    color: var(--color-primary);
-    margin: 0 0 12px;
-  }
-
-  .gs-steps-subtitle {
-    font-size: 0.95rem;
-    color: var(--color-secondary);
-    line-height: 1.55;
-    margin: 0;
-  }
-
-  .gs-steps-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 24px;
-    max-width: 1000px;
-    width: 100%;
-  }
-
-  .gs-step-card {
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    border-radius: 12px;
-    padding: 28px 24px;
-    transition: border-color 0.3s, box-shadow 0.3s;
-  }
-
-  .gs-step-card:hover {
-    border-color: oklch(0.65 0.16 45 / 0.3);
-    box-shadow: 0 0 0 3px oklch(0.65 0.16 45 / 0.06);
-  }
-
-  .gs-step-number {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 36px;
-    height: 36px;
-    border-radius: 50%;
-    background: var(--color-accent);
-    color: var(--color-dark-bg);
-    font-weight: 700;
-    font-size: 0.95rem;
-    margin-bottom: 16px;
-  }
-
-  .gs-step-card h3 {
-    font-size: 1.05rem;
-    font-weight: 600;
-    color: var(--color-primary);
-    margin: 0 0 8px;
-  }
-
-  .gs-step-card p {
-    font-size: 0.9rem;
-    line-height: 1.55;
-    color: var(--color-secondary);
-    margin: 0;
   }
 
   /* ── Form section ── */
@@ -307,9 +281,199 @@ import Footer from '../components/Footer.astro';
     margin: 0;
   }
 
+  /* ── Why list ── */
+  .gs-why {
+    padding: 0 clamp(24px, 5vw, 80px) 80px;
+    display: flex;
+    justify-content: center;
+  }
+
+  .gs-why-inner {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px 40px;
+    max-width: 720px;
+    width: 100%;
+  }
+
+  .gs-why-item {
+    font-size: 0.9rem;
+    line-height: 1.55;
+    color: var(--color-secondary);
+  }
+
+  .gs-why-item strong {
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  /* ── Steps ── */
+  .gs-steps {
+    padding: 40px clamp(24px, 5vw, 80px) 80px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 40px;
+  }
+
+  .gs-steps-header {
+    text-align: center;
+    max-width: 560px;
+  }
+
+  .gs-steps-header h2 {
+    font-size: clamp(1.6rem, 3vw, 2.2rem);
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    color: var(--color-primary);
+    margin: 0 0 12px;
+  }
+
+  .gs-steps-subtitle {
+    font-size: 0.95rem;
+    color: var(--color-secondary);
+    line-height: 1.55;
+    margin: 0;
+  }
+
+  .gs-steps-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 24px;
+    max-width: 1000px;
+    width: 100%;
+  }
+
+  .gs-step-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 28px 24px;
+    transition: border-color 0.3s, box-shadow 0.3s;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .gs-step-card:hover {
+    border-color: oklch(0.65 0.16 45 / 0.3);
+    box-shadow: 0 0 0 3px oklch(0.65 0.16 45 / 0.06);
+  }
+
+  .gs-step-number {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    color: var(--color-dark-bg);
+    font-weight: 700;
+    font-size: 0.95rem;
+    margin-bottom: 16px;
+  }
+
+  .gs-step-card h3 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--color-primary);
+    margin: 0 0 8px;
+  }
+
+  .gs-step-card p {
+    font-size: 0.85rem;
+    line-height: 1.55;
+    color: var(--color-secondary);
+    margin: 0;
+    flex: 1;
+  }
+
+  .gs-step-time {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-accent);
+    margin-top: 14px;
+    letter-spacing: 0.02em;
+  }
+
+  /* ── FAQ ── */
+  .gs-faq {
+    padding: 40px clamp(24px, 5vw, 80px) 120px;
+    display: flex;
+    justify-content: center;
+  }
+
+  .gs-faq-inner {
+    max-width: 680px;
+    width: 100%;
+  }
+
+  .gs-faq-inner h2 {
+    font-size: clamp(1.6rem, 3vw, 2.2rem);
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    color: var(--color-primary);
+    margin: 0 0 32px;
+    text-align: center;
+  }
+
+  .gs-faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .gs-faq-item {
+    border-top: 1px solid var(--color-border);
+    padding: 0;
+  }
+
+  .gs-faq-item:last-child {
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .gs-faq-item summary {
+    padding: 20px 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-primary);
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .gs-faq-item summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .gs-faq-item summary::after {
+    content: '+';
+    font-size: 1.3rem;
+    font-weight: 300;
+    color: var(--color-muted);
+    flex-shrink: 0;
+    transition: transform 0.2s;
+  }
+
+  .gs-faq-item[open] summary::after {
+    content: '\2212';
+  }
+
+  .gs-faq-item p {
+    font-size: 0.9rem;
+    line-height: 1.65;
+    color: var(--color-secondary);
+    margin: 0;
+    padding: 0 0 20px;
+  }
+
   /* ── Responsive ── */
   @media (max-width: 768px) {
-    .gs-hero { padding: 120px 24px 48px; }
+    .gs-hero { padding: 120px 24px 0; }
 
     .gs-steps-grid {
       grid-template-columns: repeat(2, 1fr);
@@ -317,14 +481,20 @@ import Footer from '../components/Footer.astro';
   }
 
   @media (max-width: 480px) {
-    .gs-hero { padding: 100px 16px 36px; }
+    .gs-hero { padding: 100px 16px 0; }
     .gs-headline { font-size: clamp(2rem, 7vw, 2.6rem); }
+
+    .gs-why-inner {
+      grid-template-columns: 1fr;
+    }
 
     .gs-steps-grid {
       grid-template-columns: 1fr;
     }
 
-    .gs-form-section { padding: 40px 16px 80px; }
+
+    .gs-form-section { padding: 16px 16px 60px; }
+    .gs-faq { padding: 40px 16px 80px; }
   }
 </style>
 

--- a/site/src/pages/get-started.astro
+++ b/site/src/pages/get-started.astro
@@ -1,0 +1,382 @@
+---
+import Base from '../layouts/Base.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<Base
+  title="Get Started | Kitaru"
+  description="Free white-glove onboarding: deploy Kitaru on your infra, run your first flow, migrate your code, and benchmark — in 4 weeks."
+>
+  <Nav />
+  <main id="main-content">
+    <section class="gs-hero">
+      <div class="gs-hero-inner" data-reveal>
+        <span class="pill-badge">
+          <span class="pulse-dot"></span>
+          Free onboarding program
+        </span>
+        <h1 class="gs-headline">
+          From zero to production agents in <span class="gs-accent">4&nbsp;weeks</span> — on&nbsp;us.
+        </h1>
+        <p class="gs-subtitle">
+          Our team will deploy Kitaru on your infrastructure, run your first durable flow, migrate existing agent code, and benchmark performance. Completely free.
+        </p>
+      </div>
+    </section>
+
+    <section class="gs-form-section" id="signup">
+      <div class="gs-form-inner" data-reveal>
+        <h2>Start your free onboarding</h2>
+        <p class="gs-form-subtitle">Tell us a bit about yourself and we'll reach out within one business day.</p>
+
+        <form id="getStartedForm" class="gs-form" novalidate>
+          <div class="gs-field">
+            <label for="gs-name">Name</label>
+            <input type="text" id="gs-name" name="name" required autocomplete="name" placeholder="Jane Smith" />
+          </div>
+          <div class="gs-field">
+            <label for="gs-company">Company</label>
+            <input type="text" id="gs-company" name="company" required autocomplete="organization" placeholder="Acme Inc." />
+          </div>
+          <div class="gs-field">
+            <label for="gs-email">Work email</label>
+            <input type="email" id="gs-email" name="email" required autocomplete="email" placeholder="jane@acme.com" />
+          </div>
+          <button type="submit" class="btn-accent gs-submit">Get started</button>
+          <p class="gs-error" id="gsError" aria-live="polite"></p>
+        </form>
+
+        <div id="gsSuccess" class="gs-success" hidden>
+          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--color-accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="9 12 12 15 16 10"/></svg>
+          <h3>You're in!</h3>
+          <p>We'll be in touch within one business day to kick off your onboarding.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="gs-steps">
+      <div class="gs-steps-header" data-reveal>
+        <h2>What you get in 4 weeks</h2>
+        <p class="gs-steps-subtitle">Powered by 5 years of ZenML MLOps experience and hundreds of production deployments.</p>
+      </div>
+      <div class="gs-steps-grid">
+        <div class="gs-step-card" data-reveal>
+          <div class="gs-step-number">1</div>
+          <h3>Deploy on your infra</h3>
+          <p>We deploy Kitaru on your cloud (AWS, GCP, Azure) or on-prem — you keep full control of your data and compute.</p>
+        </div>
+        <div class="gs-step-card" data-reveal data-reveal-delay="1">
+          <div class="gs-step-number">2</div>
+          <h3>Run your first flow</h3>
+          <p>Build and run a durable agent flow end-to-end with checkpoints, replay, and observability from day one.</p>
+        </div>
+        <div class="gs-step-card" data-reveal data-reveal-delay="2">
+          <div class="gs-step-number">3</div>
+          <h3>Migrate your code</h3>
+          <p>We help migrate your existing agent code to Kitaru primitives — no rewrites, just thin wrappers around your Python.</p>
+        </div>
+        <div class="gs-step-card" data-reveal data-reveal-delay="3">
+          <div class="gs-step-number">4</div>
+          <h3>Benchmark</h3>
+          <p>Compare reliability, cost, and latency before and after. See exactly what durable execution changes for your agents.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+</Base>
+
+<style>
+  /* ── Hero ── */
+  .gs-hero {
+    padding: 160px clamp(24px, 5vw, 80px) 0;
+    text-align: center;
+    display: flex;
+    justify-content: center;
+  }
+
+  .gs-hero-inner {
+    max-width: 720px;
+  }
+
+  .gs-headline {
+    font-size: clamp(2.4rem, 5vw, 4rem);
+    font-weight: 700;
+    line-height: 1.1;
+    letter-spacing: -0.04em;
+    margin: 24px 0 20px;
+    color: var(--color-primary);
+  }
+
+  .gs-accent {
+    color: var(--color-accent);
+  }
+
+  .gs-subtitle {
+    font-size: clamp(1rem, 1.6vw, 1.15rem);
+    font-weight: 300;
+    line-height: 1.65;
+    color: var(--color-secondary);
+    max-width: 560px;
+    margin: 0 auto;
+  }
+
+  /* ── Steps ── */
+  .gs-steps {
+    padding: 40px clamp(24px, 5vw, 80px) 120px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 40px;
+  }
+
+  .gs-steps-header {
+    text-align: center;
+    max-width: 560px;
+  }
+
+  .gs-steps-header h2 {
+    font-size: clamp(1.6rem, 3vw, 2.2rem);
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    color: var(--color-primary);
+    margin: 0 0 12px;
+  }
+
+  .gs-steps-subtitle {
+    font-size: 0.95rem;
+    color: var(--color-secondary);
+    line-height: 1.55;
+    margin: 0;
+  }
+
+  .gs-steps-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 24px;
+    max-width: 1000px;
+    width: 100%;
+  }
+
+  .gs-step-card {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 28px 24px;
+    transition: border-color 0.3s, box-shadow 0.3s;
+  }
+
+  .gs-step-card:hover {
+    border-color: oklch(0.65 0.16 45 / 0.3);
+    box-shadow: 0 0 0 3px oklch(0.65 0.16 45 / 0.06);
+  }
+
+  .gs-step-number {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    color: var(--color-dark-bg);
+    font-weight: 700;
+    font-size: 0.95rem;
+    margin-bottom: 16px;
+  }
+
+  .gs-step-card h3 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--color-primary);
+    margin: 0 0 8px;
+  }
+
+  .gs-step-card p {
+    font-size: 0.9rem;
+    line-height: 1.55;
+    color: var(--color-secondary);
+    margin: 0;
+  }
+
+  /* ── Form section ── */
+  .gs-form-section {
+    padding: 16px clamp(24px, 5vw, 80px) 80px;
+    display: flex;
+    justify-content: center;
+  }
+
+  .gs-form-inner {
+    max-width: 480px;
+    width: 100%;
+    text-align: center;
+  }
+
+  .gs-form-inner h2 {
+    font-size: clamp(1.6rem, 3vw, 2.2rem);
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    color: var(--color-primary);
+    margin: 0 0 8px;
+  }
+
+  .gs-form-subtitle {
+    font-size: 0.95rem;
+    color: var(--color-secondary);
+    margin: 0 0 32px;
+    line-height: 1.5;
+  }
+
+  .gs-form {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    text-align: left;
+  }
+
+  .gs-field label {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--color-primary);
+    margin-bottom: 6px;
+  }
+
+  .gs-field input {
+    width: 100%;
+    padding: 12px 16px;
+    font-size: 0.95rem;
+    font-family: var(--font-ui);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-surface);
+    color: var(--color-primary);
+    transition: border-color 0.2s, box-shadow 0.2s;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  .gs-field input::placeholder {
+    color: var(--color-muted);
+  }
+
+  .gs-field input:focus {
+    border-color: var(--color-accent);
+    box-shadow: 0 0 0 3px oklch(0.65 0.16 45 / 0.1);
+  }
+
+  .gs-submit {
+    width: 100%;
+    justify-content: center;
+    margin-top: 4px;
+  }
+
+  .gs-submit:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+  }
+
+  .gs-error {
+    font-size: 0.85rem;
+    color: oklch(0.55 0.2 25);
+    margin: 0;
+    min-height: 1.2em;
+  }
+
+  /* ── Success state ── */
+  .gs-success {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 40px 0;
+  }
+
+  .gs-success h3 {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--color-primary);
+    margin: 0;
+  }
+
+  .gs-success p {
+    font-size: 0.95rem;
+    color: var(--color-secondary);
+    margin: 0;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 768px) {
+    .gs-hero { padding: 120px 24px 48px; }
+
+    .gs-steps-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (max-width: 480px) {
+    .gs-hero { padding: 100px 16px 36px; }
+    .gs-headline { font-size: clamp(2rem, 7vw, 2.6rem); }
+
+    .gs-steps-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .gs-form-section { padding: 40px 16px 80px; }
+  }
+</style>
+
+<script>
+  const form = document.getElementById('getStartedForm') as HTMLFormElement | null;
+  const errorEl = document.getElementById('gsError');
+  const successEl = document.getElementById('gsSuccess');
+
+  form?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    if (errorEl) errorEl.textContent = '';
+
+    const name = (form.querySelector('#gs-name') as HTMLInputElement).value.trim();
+    const company = (form.querySelector('#gs-company') as HTMLInputElement).value.trim();
+    const email = (form.querySelector('#gs-email') as HTMLInputElement).value.trim();
+
+    if (!name || !company || !email) {
+      if (errorEl) errorEl.textContent = 'All fields are required.';
+      return;
+    }
+
+    if (!email.includes('@')) {
+      if (errorEl) errorEl.textContent = 'Please enter a valid email address.';
+      return;
+    }
+
+    const submitBtn = form.querySelector('button[type="submit"]') as HTMLButtonElement;
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Submitting...';
+
+    try {
+      const resp = await fetch('/api/get-started', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, company, email }),
+      });
+
+      const result = await resp.json();
+
+      if (!resp.ok) {
+        if (errorEl) errorEl.textContent = result.error || 'Something went wrong. Please try again.';
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Get started';
+        return;
+      }
+
+      form.hidden = true;
+      if (successEl) successEl.hidden = false;
+    } catch {
+      if (errorEl) errorEl.textContent = 'Network error. Please try again.';
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Get started';
+    }
+  });
+</script>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,3 +10,7 @@ not_found_handling = "404-page"
 [[kv_namespaces]]
 binding = "WAITLIST_KV"
 id = "7a952406df5543418f0cb8c4552ee65f"
+
+[[kv_namespaces]]
+binding = "GET_STARTED_KV"
+id = "a6a7c01a20c841b092649453ef2e0365"


### PR DESCRIPTION
                                                                                                                                                                         
  Added a lead-gen page at /get-started with a free white-glove onboarding program pitch — deploy Kitaru on your infra, run first flow, migrate code, benchmark, all in 4
   weeks.                                                                                                                                                                
                                                                                                                                                                         
  What changed:                                                                
  - New /get-started page with hero, signup form (name/company/email), and 4-step value prop cards
  - New /api/get-started API route — stores signups in a dedicated Cloudflare KV namespace and fires Segment identify + track events                                     
  - Homepage hero CTA is now "Get started" (primary) + "View on GitHub" (secondary)                                                 
  - Nav "Get started" links point to /get-started instead of /docs                                                                                                       
  - Bottom CTA updated to "Get started" + "Star on GitHub"                                                                                                               
  - Extracted shared Segment write key + helper into site/src/lib/segment.ts so the key lives in one place (server-side)                                                 
                                                                                                                                                                         
  Infra notes:                                                                                                                                                           
  - New KV namespace GET_STARTED_KV added to wrangler.toml — already created in Cloudflare
  - Segment uses the same write key as the existing client-side snippet, no new secrets needed                                                                           
  - Existing waitlist route untouched                                                         
                                                                                                                                                                         
  Preview: https://kitaru-site-preview-159.zenml-migration.workers.dev/get-started/