### PR TITLE
Fix docs sitemap and llms.txt to include /docs basePath

### DIFF
--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -7,7 +7,7 @@ export async function GET() {
   lines.push('# Documentation');
   lines.push('');
   for (const page of source.getPages()) {
-    lines.push(`- [${page.data.title}](${page.url}): ${page.data.description}`);
+    lines.push(`- [${page.data.title}](/docs${page.url}): ${page.data.description}`);
   }
   return new Response(lines.join('\n'));
 }

--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -9,7 +9,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     { url: `${baseUrl}/docs`, lastModified: new Date() },
     ...source.getPages().map((page) => ({
-      url: `${baseUrl}${page.url}`,
+      url: `${baseUrl}/docs${page.url}`,
       lastModified: new Date(),
     })),
   ];

--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -6,11 +6,8 @@ export const revalidate = false;
 const baseUrl = 'https://kitaru.ai';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [
-    { url: `${baseUrl}/docs`, lastModified: new Date() },
-    ...source.getPages().map((page) => ({
-      url: `${baseUrl}/docs${page.url}`,
-      lastModified: new Date(),
-    })),
-  ];
+  return source.getPages().map((page) => ({
+    url: `${baseUrl}/docs${page.url}`,
+    lastModified: new Date(),
+  }));
 }


### PR DESCRIPTION
## Summary

- Google Search Console flagged `https://kitaru.ai/cli` and `https://kitaru.ai/reference/python/errors/KitaruError` as `Server error (5xx)`. Investigation confirmed this is a **live** bug, not a stale crawl: 143 of 144 URLs in the docs sitemap were missing the `/docs` basePath, so every advertised URL 500'd on the deployed Cloudflare Worker.
- Root cause: FumaDocs' `source.getPages()` returns content-relative paths (e.g. `/cli`), but Next.js's `basePath: '/docs'` config serves the pages at `/docs/cli`. `docs/app/sitemap.ts` and `docs/app/llms.txt/route.ts` both emitted URLs without the prefix.
- Fix: prepend `/docs` to `page.url` in both files.
- Cleanup: removed a vestigial hardcoded `${baseUrl}/docs` sitemap entry that only existed as a workaround for the same bug. Now that every `page.url` is correctly prefixed, the index page (`page.url === '/'`) already produces the canonical `https://kitaru.ai/docs/` URL.

## Commits

1. `d0cf0f4` — Fix docs sitemap and llms.txt to include /docs basePath
2. `c69a180` — Remove redundant hardcoded /docs sitemap entry

## Verification

**Local rebuild:**
- `out/sitemap.xml`: 143/143 URLs correctly under `/docs`, only canonical `https://kitaru.ai/docs/` for the index (no duplicate)
- `out/llms.txt`: 143/143 links correctly under `/docs`

**Preview deploy (https://kitaru-site-preview-172.zenml-migration.workers.dev):**
- `/docs/cli/` → 200 (no regression)
- `/docs/reference/python/errors/KitaruError/` → 200 (one of the two Google flagged; now serves correctly)
- `/docs/sitemap.xml`: all URLs correctly prefixed; no duplicate index entry after `c69a180`

## Areas to watch

- After merge + `site.yml` deploy, hit **VALIDATE FIX** in Search Console to request re-crawl of the flagged URLs.
- No changes to Astro's `/sitemap-0.xml` — it was already clean.
- Follow-up worth tracking separately: a build-output verification script (e.g. `docs/scripts/verify-build-output.mjs`) that asserts every URL in `out/sitemap.xml` is `/docs`-prefixed. Would catch this class of bug in CI. Out of scope here.