### PR TITLE
Add per-checkpoint `cache` override and telemetry for checkpoint invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `@checkpoint(cache=...)` per-checkpoint cache overrides (`True`/`False`/`None`) with updated configuration docs and telemetry indicating whether checkpoint cache was explicitly configured
+
 ## [0.4.1] - 2026-04-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- `@checkpoint(cache=...)` per-checkpoint cache overrides (`True`/`False`/`None`) with updated configuration docs and telemetry indicating whether checkpoint cache was explicitly configured
+- `@checkpoint(cache=...)` per-checkpoint cache overrides (`True`/`False`/`None`) with updated configuration docs
+
+### Fixed
+- Execution-level cache no longer defaults to `True`, so `@checkpoint(cache=False)` is preserved through ZenML compilation when no flow-level cache is explicitly configured
 
 ## [0.4.1] - 2026-04-16
 

--- a/docs/content/docs/guides/configuration.mdx
+++ b/docs/content/docs/guides/configuration.mdx
@@ -87,7 +87,7 @@ The important distinction is:
 
 ## Checkpoint cache overrides
 
-You can now set cache behavior at checkpoint granularity:
+You can set cache behavior at checkpoint granularity:
 
 ```python
 from kitaru import checkpoint, flow
@@ -96,16 +96,20 @@ from kitaru import checkpoint, flow
 def always_fresh(topic: str) -> str:
     ...
 
-@flow(cache=True)
+@flow
 def my_flow(topic: str) -> str:
     return always_fresh(topic)
 ```
 
-When both are set, checkpoint-level cache takes precedence for that checkpoint:
+- `@checkpoint(cache=False)` disables cache for that checkpoint.
+- `@checkpoint(cache=True)` enables cache for that checkpoint.
+- Omitting `cache` defers to the execution-level setting (or the orchestrator default).
 
-1. `@checkpoint(cache=...)` (when set)
-2. flow-level cache (`@flow(cache=...)` or `my_flow.run(cache=...)`)
-3. lower-precedence defaults (`kitaru.configure`, env vars, project config, built-ins)
+For mixed cache behavior in one flow, leave execution-level cache unset and
+configure `cache` only on the checkpoints that need different behavior. If you
+set cache at execution level (`KITARU_CACHE`, `kitaru.configure(cache=...)`,
+`@flow(cache=...)`, or `my_flow.run(cache=...)`), that value is treated as an
+execution-wide override for the run and replaces any checkpoint-level setting.
 
 ## Environment variables
 
@@ -190,7 +194,7 @@ active. Secret values such as `KITARU_AUTH_TOKEN` and
 4. Environment variables (`KITARU_STACK`, `KITARU_SERVER_URL`, etc.)
 5. Project config (`pyproject.toml` under `[tool.kitaru]`)
 6. Persisted active stack fallback plus global user config (for example connection defaults)
-7. Built-in defaults (`cache=True`, `retries=0`)
+7. Built-in defaults (`retries=0`; cache is left unset so per-checkpoint cache settings and orchestrator defaults apply)
 
 In practice, `stack` starts unset in the built-in defaults and is then resolved
 from the persisted active stack when one is available.

--- a/docs/content/docs/guides/configuration.mdx
+++ b/docs/content/docs/guides/configuration.mdx
@@ -85,6 +85,28 @@ The important distinction is:
 - `my_flow.run(stack="...")` overrides both for one execution
 - none of those change the persisted active stack selected by `kitaru stack use ...`
 
+## Checkpoint cache overrides
+
+You can now set cache behavior at checkpoint granularity:
+
+```python
+from kitaru import checkpoint, flow
+
+@checkpoint(cache=False)
+def always_fresh(topic: str) -> str:
+    ...
+
+@flow(cache=True)
+def my_flow(topic: str) -> str:
+    return always_fresh(topic)
+```
+
+When both are set, checkpoint-level cache takes precedence for that checkpoint:
+
+1. `@checkpoint(cache=...)` (when set)
+2. flow-level cache (`@flow(cache=...)` or `my_flow.run(cache=...)`)
+3. lower-precedence defaults (`kitaru.configure`, env vars, project config, built-ins)
+
 ## Environment variables
 
 Kitaru's public env-var surface uses `KITARU_*` names.

--- a/src/kitaru/_config/_core.py
+++ b/src/kitaru/_config/_core.py
@@ -160,7 +160,7 @@ class ResolvedExecutionConfig(BaseModel):
 
     stack: str | None = None
     image: ImageSettings | None = None
-    cache: bool
+    cache: bool | None = None
     retries: int
 
     @field_validator("stack")

--- a/src/kitaru/_config/_env.py
+++ b/src/kitaru/_config/_env.py
@@ -279,7 +279,7 @@ def resolve_execution_config_impl(
         ResolvedExecutionConfig(
             stack=None,
             image=None,
-            cache=True,
+            cache=None,
             retries=0,
         ),
         (

--- a/src/kitaru/analytics.py
+++ b/src/kitaru/analytics.py
@@ -62,6 +62,7 @@ class AnalyticsEvent(StrEnum):
     STACK_ACTIVATED = "Kitaru stack activated"
     MODEL_ALIAS_REGISTERED = "Kitaru model alias registered"
     LOG_STORE_CONFIGURED = "Kitaru log store configured"
+    CHECKPOINT_INVOKED = "Kitaru checkpoint invoked"
     CLEAN_COMPLETED = "Kitaru clean completed"
     INFO_VIEWED = "Kitaru info viewed"
     INFO_EXPORTED = "Kitaru info exported"

--- a/src/kitaru/checkpoint.py
+++ b/src/kitaru/checkpoint.py
@@ -24,6 +24,7 @@ from kitaru._source_aliases import (
     build_checkpoint_source_alias,
     callable_name,
 )
+from kitaru.analytics import AnalyticsEvent, track
 from kitaru.errors import KitaruContextError, KitaruUsageError
 from kitaru.runtime import (
     _checkpoint_scope,
@@ -174,12 +175,14 @@ class _CheckpointDefinition:
         retries: int,
         checkpoint_type: str | None,
         runtime: StepRuntime | str | None,
+        cache: bool | None,
     ) -> None:
         """Initialize a Kitaru checkpoint wrapper."""
         self._func = func
         self._checkpoint_type = checkpoint_type
         self._default_retries = _normalize_retries(retries)
         self._runtime = _normalize_runtime(runtime)
+        self._cache = cache
 
         wrapped_entrypoint = _wrap_entrypoint(
             func,
@@ -195,6 +198,7 @@ class _CheckpointDefinition:
         self._step = step(
             name=registration_name,
             retry=_to_retry_config(self._default_retries),
+            enable_cache=self._cache,
             extra=_build_checkpoint_extra(checkpoint_type),
             step_type=_to_step_type(checkpoint_type),
             runtime=self._runtime,
@@ -228,6 +232,16 @@ class _CheckpointDefinition:
         if not DynamicPipelineRunContext.is_active() or not _is_inside_flow():
             raise KitaruContextError(_CHECKPOINT_CONCURRENT_OUTSIDE_FLOW_ERROR)
 
+    def _track_invocation(self, *, method: str) -> None:
+        """Emit checkpoint-level telemetry for invocation surfaces."""
+        track(
+            AnalyticsEvent.CHECKPOINT_INVOKED,
+            {
+                "method": method,
+                "cache_explicitly_set": self._cache is not None,
+            },
+        )
+
     def __call__(
         self,
         *args: Any,
@@ -237,6 +251,7 @@ class _CheckpointDefinition:
     ) -> Any:
         """Call the checkpoint with context guardrails."""
         self._assert_call_allowed()
+        self._track_invocation(method="call")
         return self._step(*args, id=id, after=after, **kwargs)
 
     def submit(
@@ -248,6 +263,7 @@ class _CheckpointDefinition:
     ) -> Any:
         """Submit the checkpoint concurrently inside a running flow."""
         self._assert_submit_allowed()
+        self._track_invocation(method="submit")
         return self._step.submit(*args, id=id, after=after, **kwargs)
 
     def map(
@@ -258,6 +274,7 @@ class _CheckpointDefinition:
     ) -> Any:
         """Map checkpoint invocations inside a running flow."""
         self._assert_submit_allowed()
+        self._track_invocation(method="map")
         return self._step.map(*args, after=after, **kwargs)
 
     def product(
@@ -268,6 +285,7 @@ class _CheckpointDefinition:
     ) -> Any:
         """Map checkpoint invocations as a cartesian product in a running flow."""
         self._assert_submit_allowed()
+        self._track_invocation(method="product")
         return self._step.product(*args, after=after, **kwargs)
 
 
@@ -281,6 +299,7 @@ def checkpoint(
     retries: int = 0,
     type: str | None = None,
     runtime: str | None = None,
+    cache: bool | None = None,
 ) -> Callable[[Callable[..., Any]], _CheckpointDefinition]: ...
 
 
@@ -290,6 +309,7 @@ def checkpoint(
     retries: int = 0,
     type: str | None = None,
     runtime: str | None = None,
+    cache: bool | None = None,
 ) -> _CheckpointDefinition | Callable[[Callable[..., Any]], _CheckpointDefinition]:
     """Mark a function as a durable checkpoint.
 
@@ -317,6 +337,9 @@ def checkpoint(
             the checkpoint runs in its own container on remote orchestrators
             that support it. ``None`` (the default) lets the orchestrator
             decide.
+        cache: Optional per-checkpoint cache override. ``True`` enables cache
+            for this checkpoint, ``False`` disables it, and ``None`` defers to
+            higher-level flow/default cache behavior.
 
     Returns:
         The wrapped checkpoint object or a decorator that returns it.
@@ -329,6 +352,7 @@ def checkpoint(
             retries=retries,
             checkpoint_type=checkpoint_type,
             runtime=runtime,
+            cache=cache,
         )
 
     if func is not None:

--- a/src/kitaru/checkpoint.py
+++ b/src/kitaru/checkpoint.py
@@ -10,7 +10,7 @@ import sys
 from collections.abc import Callable, Sequence
 from contextlib import ExitStack
 from functools import update_wrapper, wraps
-from typing import Any, cast, overload
+from typing import Any, Literal, cast, overload
 
 from zenml.config.retry_config import StepRetryConfig
 from zenml.enums import StepRuntime, StepType
@@ -37,6 +37,8 @@ from kitaru.runtime import (
     _get_zenml_flow_name,
     _is_inside_flow,
 )
+
+CheckpointSurface = Literal["call", "submit", "map", "product"]
 
 _CHECKPOINT_OUTSIDE_FLOW_ERROR = "Checkpoints can only run inside a @flow."
 _CHECKPOINT_NESTED_ERROR = (
@@ -183,6 +185,7 @@ class _CheckpointDefinition:
         self._default_retries = _normalize_retries(retries)
         self._runtime = _normalize_runtime(runtime)
         self._cache = cache
+        self._cache_explicitly_set = cache is not None
 
         wrapped_entrypoint = _wrap_entrypoint(
             func,
@@ -232,13 +235,13 @@ class _CheckpointDefinition:
         if not DynamicPipelineRunContext.is_active() or not _is_inside_flow():
             raise KitaruContextError(_CHECKPOINT_CONCURRENT_OUTSIDE_FLOW_ERROR)
 
-    def _track_invocation(self, *, method: str) -> None:
+    def _track_invocation(self, *, method: CheckpointSurface) -> None:
         """Emit checkpoint-level telemetry for invocation surfaces."""
         track(
             AnalyticsEvent.CHECKPOINT_INVOKED,
             {
                 "method": method,
-                "cache_explicitly_set": self._cache is not None,
+                "cache_explicitly_set": self._cache_explicitly_set,
             },
         )
 
@@ -251,8 +254,9 @@ class _CheckpointDefinition:
     ) -> Any:
         """Call the checkpoint with context guardrails."""
         self._assert_call_allowed()
+        result = self._step(*args, id=id, after=after, **kwargs)
         self._track_invocation(method="call")
-        return self._step(*args, id=id, after=after, **kwargs)
+        return result
 
     def submit(
         self,
@@ -263,8 +267,9 @@ class _CheckpointDefinition:
     ) -> Any:
         """Submit the checkpoint concurrently inside a running flow."""
         self._assert_submit_allowed()
+        result = self._step.submit(*args, id=id, after=after, **kwargs)
         self._track_invocation(method="submit")
-        return self._step.submit(*args, id=id, after=after, **kwargs)
+        return result
 
     def map(
         self,
@@ -274,8 +279,9 @@ class _CheckpointDefinition:
     ) -> Any:
         """Map checkpoint invocations inside a running flow."""
         self._assert_submit_allowed()
+        result = self._step.map(*args, after=after, **kwargs)
         self._track_invocation(method="map")
-        return self._step.map(*args, after=after, **kwargs)
+        return result
 
     def product(
         self,
@@ -285,8 +291,9 @@ class _CheckpointDefinition:
     ) -> Any:
         """Map checkpoint invocations as a cartesian product in a running flow."""
         self._assert_submit_allowed()
+        result = self._step.product(*args, after=after, **kwargs)
         self._track_invocation(method="product")
-        return self._step.product(*args, after=after, **kwargs)
+        return result
 
 
 @overload
@@ -339,7 +346,8 @@ def checkpoint(
             decide.
         cache: Optional per-checkpoint cache override. ``True`` enables cache
             for this checkpoint, ``False`` disables it, and ``None`` defers to
-            higher-level flow/default cache behavior.
+            higher-level flow/default cache behavior. Useful for forcing one
+            expensive step to re-run while the rest of the flow stays cached.
 
     Returns:
         The wrapped checkpoint object or a decorator that returns it.

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -37,6 +37,7 @@ from kitaru.config import (
     ImageSettings,
     KitaruConfig,
     ModelRegistryConfig,
+    ResolvedExecutionConfig,
     _read_env_model_registry,
     _read_model_registry_config,
     build_frozen_execution_spec,
@@ -170,6 +171,27 @@ def _build_settings(
         Pipeline settings dictionary.
     """
     return {DOCKER_SETTINGS_KEY: image_settings_to_docker_settings(image)}
+
+
+def _build_pipeline_options(
+    *,
+    resolved_execution: ResolvedExecutionConfig,
+    transport_image: ImageSettings | None,
+) -> dict[str, Any]:
+    """Build kwargs for ``Pipeline.with_options(...)``.
+
+    ``enable_cache`` is only forwarded when the user explicitly configured
+    cache at some execution layer. Passing a concrete bool here makes ZenML's
+    compiler overwrite every step's ``enable_cache``, which would clobber any
+    ``@checkpoint(cache=...)`` overrides.
+    """
+    options: dict[str, Any] = {
+        "retry": _to_retry_config(_normalize_retries(resolved_execution.retries)),
+        "settings": _build_settings(transport_image),
+    }
+    if resolved_execution.cache is not None:
+        options["enable_cache"] = resolved_execution.cache
+    return options
 
 
 def _inject_model_registry_env(
@@ -781,9 +803,10 @@ class _FlowDefinition:
             model_registry=effective_model_registry,
         )
         configured_pipeline = self._pipeline.with_options(
-            enable_cache=resolved_execution.cache,
-            retry=_to_retry_config(_normalize_retries(resolved_execution.retries)),
-            settings=_build_settings(transport_image),
+            **_build_pipeline_options(
+                resolved_execution=resolved_execution,
+                transport_image=transport_image,
+            )
         )
 
         with _temporary_active_stack(resolved_execution.stack):
@@ -889,9 +912,10 @@ class _FlowDefinition:
             model_registry=effective_model_registry,
         )
         configured_pipeline = self._pipeline.with_options(
-            enable_cache=resolved_execution.cache,
-            retry=_to_retry_config(_normalize_retries(resolved_execution.retries)),
-            settings=_build_settings(transport_image),
+            **_build_pipeline_options(
+                resolved_execution=resolved_execution,
+                transport_image=transport_image,
+            )
         )
 
         with _temporary_active_stack(resolved_execution.stack):

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -181,6 +181,7 @@ def test_feature_adoption_event_canonical_strings() -> None:
     assert AnalyticsEvent.STACK_ACTIVATED == "Kitaru stack activated"
     assert AnalyticsEvent.MODEL_ALIAS_REGISTERED == "Kitaru model alias registered"
     assert AnalyticsEvent.LOG_STORE_CONFIGURED == "Kitaru log store configured"
+    assert AnalyticsEvent.CHECKPOINT_INVOKED == "Kitaru checkpoint invoked"
 
 
 def test_adapter_event_canonical_strings() -> None:

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -13,6 +13,7 @@ import pytest
 from zenml.config.retry_config import StepRetryConfig
 from zenml.enums import StepRuntime, StepType
 
+from kitaru.analytics import AnalyticsEvent
 from kitaru.checkpoint import checkpoint
 from kitaru.errors import KitaruContextError, KitaruUsageError
 from kitaru.runtime import (
@@ -68,6 +69,7 @@ def _build_checkpoint(
     retries: int = 0,
     checkpoint_type: str | None = None,
     runtime: StepRuntime | str | None = None,
+    cache: bool | None = None,
 ) -> tuple[Any, dict[str, Any]]:
     """Create a checkpoint with a fake ZenML step decorator."""
     captured: dict[str, Any] = {}
@@ -76,12 +78,14 @@ def _build_checkpoint(
         *,
         name: str | None = None,
         retry: StepRetryConfig | None,
+        enable_cache: bool | None = None,
         extra: dict[str, Any],
         step_type: StepType | None = None,
         runtime: StepRuntime | None = None,
     ) -> Any:
         captured["name"] = name
         captured["retry"] = retry
+        captured["enable_cache"] = enable_cache
         captured["extra"] = extra
         captured["step_type"] = step_type
         captured["runtime"] = runtime
@@ -94,9 +98,12 @@ def _build_checkpoint(
         return _decorate
 
     with patch("kitaru.checkpoint.step", side_effect=_fake_step):
-        wrapped = checkpoint(retries=retries, type=checkpoint_type, runtime=runtime)(
-            func
-        )
+        wrapped = checkpoint(
+            retries=retries,
+            type=checkpoint_type,
+            runtime=runtime,
+            cache=cache,
+        )(func)
 
     return wrapped, captured
 
@@ -148,6 +155,21 @@ def test_checkpoint_maps_retries_and_type_to_step_config() -> None:
 def test_checkpoint_allows_zero_retries_without_retry_config() -> None:
     _, captured = _build_checkpoint(lambda: "ok", retries=0)
     assert captured["retry"] is None
+
+
+def test_checkpoint_forwards_cache_true_to_zenml_step() -> None:
+    _, captured = _build_checkpoint(lambda: "ok", cache=True)
+    assert captured["enable_cache"] is True
+
+
+def test_checkpoint_forwards_cache_false_to_zenml_step() -> None:
+    _, captured = _build_checkpoint(lambda: "ok", cache=False)
+    assert captured["enable_cache"] is False
+
+
+def test_checkpoint_omitted_cache_forwards_none() -> None:
+    _, captured = _build_checkpoint(lambda: "ok")
+    assert captured["enable_cache"] is None
 
 
 def test_well_known_types_map_to_step_type() -> None:
@@ -238,6 +260,44 @@ def test_checkpoint_rejects_invalid_runtime_string() -> None:
 def test_checkpoint_rejects_invalid_runtime_type() -> None:
     with pytest.raises(KitaruUsageError, match="Unsupported checkpoint runtime"):
         checkpoint(runtime=123)(lambda: None)  # type: ignore[arg-type]
+
+
+def test_checkpoint_call_tracks_cache_explicitly_set_flag() -> None:
+    wrapped, captured = _build_checkpoint(lambda: "ok", cache=False)
+
+    with (
+        _zenml_contexts(compilation_active=True, flow_active=True),
+        patch("kitaru.checkpoint.track") as track_mock,
+    ):
+        wrapped()
+
+    assert captured["step"].call_args is not None
+    track_mock.assert_called_once_with(
+        AnalyticsEvent.CHECKPOINT_INVOKED,
+        {
+            "method": "call",
+            "cache_explicitly_set": True,
+        },
+    )
+
+
+def test_checkpoint_call_tracks_cache_not_set_flag() -> None:
+    wrapped, captured = _build_checkpoint(lambda: "ok")
+
+    with (
+        _zenml_contexts(compilation_active=True, flow_active=True),
+        patch("kitaru.checkpoint.track") as track_mock,
+    ):
+        wrapped()
+
+    assert captured["step"].call_args is not None
+    track_mock.assert_called_once_with(
+        AnalyticsEvent.CHECKPOINT_INVOKED,
+        {
+            "method": "call",
+            "cache_explicitly_set": False,
+        },
+    )
 
 
 def test_checkpoint_rejects_call_outside_flow_context() -> None:

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -32,9 +32,30 @@ class _FakeStep:
 
     def __init__(self, func: Callable[..., Any]) -> None:
         self._func = func
-        self.call_args: tuple[tuple[Any, ...], dict[str, Any]] | None = None
-        self.submit_args: tuple[tuple[Any, ...], dict[str, Any]] | None = None
-        self.submit_result: object = object()
+        self.args: dict[str, tuple[tuple[Any, ...], dict[str, Any]]] = {}
+        self.results: dict[str, object] = {
+            "submit": object(),
+            "map": object(),
+            "product": object(),
+        }
+        self.side_effects: dict[str, BaseException] = {}
+        # Orders surface calls relative to the telemetry mock for post-step
+        # assertions.
+        self.events: list[str] = []
+
+    @property
+    def call_args(self) -> tuple[tuple[Any, ...], dict[str, Any]] | None:
+        return self.args.get("call")
+
+    @property
+    def submit_args(self) -> tuple[tuple[Any, ...], dict[str, Any]] | None:
+        return self.args.get("submit")
+
+    def _record_and_raise(self, surface: str) -> None:
+        self.events.append(surface)
+        exc = self.side_effects.get(surface)
+        if exc is not None:
+            raise exc
 
     def __call__(
         self,
@@ -43,7 +64,8 @@ class _FakeStep:
         after: Any = None,
         **kwargs: Any,
     ) -> Any:
-        self.call_args = (args, {"id": id, "after": after, **kwargs})
+        self.args["call"] = (args, {"id": id, "after": after, **kwargs})
+        self._record_and_raise("call")
         return self._func(*args, **kwargs)
 
     def submit(
@@ -53,14 +75,19 @@ class _FakeStep:
         after: Any = None,
         **kwargs: Any,
     ) -> object:
-        self.submit_args = (args, {"id": id, "after": after, **kwargs})
-        return self.submit_result
+        self.args["submit"] = (args, {"id": id, "after": after, **kwargs})
+        self._record_and_raise("submit")
+        return self.results["submit"]
 
     def map(self, *args: Any, after: Any = None, **kwargs: Any) -> object:
-        return ("map", args, after, kwargs)
+        self.args["map"] = (args, {"after": after, **kwargs})
+        self._record_and_raise("map")
+        return self.results["map"]
 
     def product(self, *args: Any, after: Any = None, **kwargs: Any) -> object:
-        return ("product", args, after, kwargs)
+        self.args["product"] = (args, {"after": after, **kwargs})
+        self._record_and_raise("product")
+        return self.results["product"]
 
 
 def _build_checkpoint(
@@ -262,42 +289,89 @@ def test_checkpoint_rejects_invalid_runtime_type() -> None:
         checkpoint(runtime=123)(lambda: None)  # type: ignore[arg-type]
 
 
-def test_checkpoint_call_tracks_cache_explicitly_set_flag() -> None:
-    wrapped, captured = _build_checkpoint(lambda: "ok", cache=False)
+def _invoke_surface(wrapped: Any, method: str) -> None:
+    """Invoke a checkpoint surface by name for parametrized tests."""
+    if method == "call":
+        wrapped()
+    elif method == "submit":
+        wrapped.submit()
+    elif method == "map":
+        wrapped.map([1, 2])
+    elif method == "product":
+        wrapped.product([1, 2])
+    else:
+        raise AssertionError(f"unknown surface: {method}")
+
+
+@pytest.mark.parametrize("method", ["call", "submit", "map", "product"])
+@pytest.mark.parametrize(
+    ("cache", "explicitly_set"),
+    [(True, True), (False, True), (None, False)],
+)
+def test_checkpoint_surface_tracks_invocation_after_step(
+    method: str, cache: bool | None, explicitly_set: bool
+) -> None:
+    """Every public checkpoint surface must emit telemetry post-step."""
+    wrapped, captured = _build_checkpoint(lambda *a, **kw: "ok", cache=cache)
+
+    contexts = (
+        _zenml_contexts(compilation_active=True, flow_active=True)
+        if method == "call"
+        else _zenml_contexts(dynamic_run_active=True, flow_active=True)
+    )
+
+    with contexts, patch("kitaru.checkpoint.track") as track_mock:
+        _invoke_surface(wrapped, method)
+
+    track_mock.assert_called_once_with(
+        AnalyticsEvent.CHECKPOINT_INVOKED,
+        {"method": method, "cache_explicitly_set": explicitly_set},
+    )
+    # Telemetry must fire AFTER the underlying ZenML surface, matching the
+    # post-success convention used by FLOW_SUBMITTED / LLM_CALLED. Tracking
+    # before the call would leak events on failed submissions.
+    assert captured["step"].events == [method]
+
+
+@pytest.mark.parametrize("method", ["call", "submit", "map", "product"])
+def test_checkpoint_surface_does_not_track_when_step_raises(method: str) -> None:
+    """Failures from the underlying ZenML surface must suppress telemetry."""
+    wrapped, captured = _build_checkpoint(lambda *a, **kw: "ok")
+    fake_step: _FakeStep = captured["step"]
+    fake_step.side_effects[method] = RuntimeError("boom")
+
+    contexts = (
+        _zenml_contexts(compilation_active=True, flow_active=True)
+        if method == "call"
+        else _zenml_contexts(dynamic_run_active=True, flow_active=True)
+    )
 
     with (
-        _zenml_contexts(compilation_active=True, flow_active=True),
+        contexts,
         patch("kitaru.checkpoint.track") as track_mock,
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        _invoke_surface(wrapped, method)
+
+    track_mock.assert_not_called()
+
+
+def test_checkpoint_does_not_track_when_called_outside_flow_context() -> None:
+    """Guardrail rejections must not leak analytics events."""
+    wrapped, _ = _build_checkpoint(lambda: "ok")
+
+    with (
+        _zenml_contexts(
+            compilation_active=False,
+            step_active=False,
+            dynamic_run_active=False,
+        ),
+        patch("kitaru.checkpoint.track") as track_mock,
+        pytest.raises(KitaruContextError, match=r"inside a @flow"),
     ):
         wrapped()
 
-    assert captured["step"].call_args is not None
-    track_mock.assert_called_once_with(
-        AnalyticsEvent.CHECKPOINT_INVOKED,
-        {
-            "method": "call",
-            "cache_explicitly_set": True,
-        },
-    )
-
-
-def test_checkpoint_call_tracks_cache_not_set_flag() -> None:
-    wrapped, captured = _build_checkpoint(lambda: "ok")
-
-    with (
-        _zenml_contexts(compilation_active=True, flow_active=True),
-        patch("kitaru.checkpoint.track") as track_mock,
-    ):
-        wrapped()
-
-    assert captured["step"].call_args is not None
-    track_mock.assert_called_once_with(
-        AnalyticsEvent.CHECKPOINT_INVOKED,
-        {
-            "method": "call",
-            "cache_explicitly_set": False,
-        },
-    )
+    track_mock.assert_not_called()
 
 
 def test_checkpoint_rejects_call_outside_flow_context() -> None:
@@ -390,7 +464,7 @@ def test_submit_rejects_nested_checkpoint_calls() -> None:
 def test_submit_returns_zenml_future_object() -> None:
     wrapped, captured = _build_checkpoint(lambda: "ok")
     expected_future = object()
-    captured["step"].submit_result = expected_future
+    captured["step"].results["submit"] = expected_future
 
     with _zenml_contexts(
         step_active=False,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3801,6 +3801,21 @@ def test_resolve_execution_config_rejects_invalid_cache_env(
         resolve_execution_config()
 
 
+def test_resolve_execution_config_default_cache_is_unset() -> None:
+    """With no cache configured anywhere, resolved cache must be None.
+
+    A concrete default would become a run-level enable_cache override at
+    compile time and clobber per-checkpoint cache settings.
+    """
+    with patch(
+        "kitaru.config.current_stack",
+        return_value=SimpleNamespace(name="global-stack"),
+    ):
+        resolved = resolve_execution_config()
+
+    assert resolved.cache is None
+
+
 def test_resolve_execution_config_supports_string_image_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -18,6 +18,7 @@ from zenml.models import PipelineRunResponse
 
 from kitaru import memory
 from kitaru.analytics import AnalyticsEvent
+from kitaru.checkpoint import checkpoint
 from kitaru.config import (
     KITARU_MODEL_REGISTRY_ENV,
     ImageSettings,
@@ -38,6 +39,7 @@ from kitaru.errors import (
 )
 from kitaru.flow import (
     FlowHandle,
+    _build_pipeline_options,
     _checkpoint_count_from_run,
     _duration_metadata_from_run,
     _inject_model_registry_env,
@@ -56,7 +58,7 @@ def _as_pipeline_run(run: _DummyRun) -> PipelineRunResponse:
 def _resolved_execution(
     *,
     stack: str | None = None,
-    cache: bool = True,
+    cache: bool | None = None,
     retries: int = 0,
 ) -> ResolvedExecutionConfig:
     return ResolvedExecutionConfig(
@@ -227,7 +229,6 @@ def test_flow_decorator_creates_wrapper_with_run() -> None:
     assert isinstance(handle, FlowHandle)
     call_kwargs = base_pipeline.with_options.call_args
     assert call_kwargs == call(
-        enable_cache=True,
         retry=None,
         settings={
             "docker": DockerSettings(
@@ -236,6 +237,86 @@ def test_flow_decorator_creates_wrapper_with_run() -> None:
             )
         },
     )
+    # Unset execution-level cache must not be forwarded as enable_cache, because
+    # ZenML's compiler treats any concrete run-level enable_cache as a per-step
+    # override that overwrites @checkpoint(cache=...) settings.
+    assert "enable_cache" not in call_kwargs.kwargs
+
+
+def test_build_pipeline_options_omits_enable_cache_when_unset() -> None:
+    options = _build_pipeline_options(
+        resolved_execution=_resolved_execution(cache=None),
+        transport_image=None,
+    )
+    assert "enable_cache" not in options
+
+
+@pytest.mark.parametrize("cache_value", [True, False])
+def test_build_pipeline_options_forwards_explicit_cache(
+    cache_value: bool,
+) -> None:
+    options = _build_pipeline_options(
+        resolved_execution=_resolved_execution(cache=cache_value),
+        transport_image=None,
+    )
+    assert options["enable_cache"] is cache_value
+
+
+def test_checkpoint_cache_survives_pipeline_with_options_when_execution_unset() -> None:
+    """Mixed ``@checkpoint(cache=...)`` values must survive ``with_options``.
+
+    A concrete ``enable_cache`` passed at run level would be applied per-step
+    during ZenML compilation and overwrite the decorator-set value; the flow
+    therefore omits ``enable_cache`` entirely when execution cache is unset.
+    """
+
+    @checkpoint(cache=False)
+    def never_cache() -> int:
+        return 1
+
+    @checkpoint(cache=True)
+    def always_cache() -> int:
+        return 2
+
+    @flow
+    def mixed_flow() -> int:
+        return never_cache() + always_cache()
+
+    assert never_cache._step.enable_cache is False
+    assert always_cache._step.enable_cache is True
+
+    options = _build_pipeline_options(
+        resolved_execution=_resolved_execution(cache=None),
+        transport_image=None,
+    )
+    configured = mixed_flow._pipeline.with_options(**options)
+    assert configured.configuration.enable_cache is None
+
+
+@pytest.mark.parametrize("cache_value", [True, False])
+def test_flow_run_forwards_explicit_cache_to_with_options(
+    cache_value: bool,
+) -> None:
+    run = _DummyRun(status=ExecutionStatus.RUNNING)
+    configured_pipeline = MagicMock(return_value=run)
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(cache=cache_value),
+        ),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.persist_frozen_execution_spec"),
+    ):
+        flow(lambda x: x).run(123)
+
+    call_kwargs = base_pipeline.with_options.call_args
+    assert call_kwargs.kwargs["enable_cache"] is cache_value
 
 
 def test_flow_registers_pipeline_source_alias_for_dynamic_reload() -> None:


### PR DESCRIPTION
### Motivation

Ship `@checkpoint(cache=...)` correctly. As originally submitted, a per-checkpoint cache setting was silently overwritten during ZenML compilation, so the decorator's main selling point didn't actually work end-to-end. Also realign checkpoint telemetry with the rest of the SDK (post-success, all four invocation surfaces covered) and give the event a privacy-safe payload.

### What was broken

`ResolvedExecutionConfig.cache` was a required `bool` seeded at `True`, so flow submission always passed a concrete `enable_cache` into `Pipeline.with_options(...)`. ZenML's compiler treats a non-None run-level `enable_cache` as a per-step override:

```python
# zenml/config/compiler.py::_apply_run_configuration
if config.enable_cache is not None:
    for invocation in pipeline.invocations.values():
        invocation.step.configure(enable_cache=config.enable_cache)
```

That loop clobbered whatever the `@checkpoint(cache=...)` decorator had set at step-definition time. The runtime `is_setting_enabled(step, pipeline)` resolver correctly gives step-level precedence, but by the time it runs the step value has already been replaced.

### Fix

Represent "cache not explicitly configured" as `None` and stop forwarding it to ZenML when unset:

- `ResolvedExecutionConfig.cache: bool | None = None` (was required `bool`).
- `_config/_env.py` seeds resolution with `cache=None` instead of `cache=True`.
- New `flow._build_pipeline_options(...)` helper used by both `_submit` and `replay` omits `enable_cache` from `with_options(...)` when `resolved_execution.cache is None`.

Explicit flow/run/env-level cache still behaves as a run-wide override, matching ZenML's documented contract. Only the accidental built-in `True` is removed.

### Checkpoint API

- `@checkpoint(cache=True)` enables cache for that checkpoint.
- `@checkpoint(cache=False)` disables cache for that checkpoint.
- `@checkpoint(cache=None)` (default) defers to the execution-level setting or the orchestrator default.

Docstring explains the "force one expensive step to re-run while the rest of the flow stays cached" use case. Config guide rewritten to describe the new precedence semantics accurately.

### Telemetry

Adds `AnalyticsEvent.CHECKPOINT_INVOKED` with payload `{method, cache_explicitly_set}` — no content, paths, or user-supplied identifiers, per the analytics policy in CLAUDE.md.

Telemetry fires **after** the underlying step call succeeds on all four surfaces (`__call__`, `submit`, `map`, `product`), matching the post-success convention used by `FLOW_SUBMITTED` (`flow.py:907`) and `LLM_CALLED` (`llm.py:643`). Calls rejected by the context guardrails or ZenML do not emit events.

### Testing

- New compile-level regression test (`test_checkpoint_cache_survives_pipeline_with_options_when_execution_unset`) builds a real flow with mixed `@checkpoint(cache=True)` / `@checkpoint(cache=False)` checkpoints, applies `_build_pipeline_options(cache=None)`, and asserts step-level cache settings survive onto the configured pipeline.
- Parametrized unit coverage for `_build_pipeline_options` (unset vs explicit cache).
- Parametrized telemetry matrix over `call`/`submit`/`map`/`product` × `cache=True|False|None`, with explicit ordering assertion that telemetry fires after the underlying step surface.
- Failure-path parametrized test: telemetry is suppressed when the underlying step raises.
- Guardrail-ordering test: patching `track` + calling outside a flow context raises `KitaruContextError` with `track.assert_not_called()`.
- New `test_resolve_execution_config_default_cache_is_unset` pins the `None` seed.

Full `just check` passes; full `just test` reports `1311 passed, 8 skipped`.

### Changelog

Split into `Added` (the `@checkpoint(cache=...)` API) and `Fixed` (the execution-level default no longer clobbering it).