### PR TITLE
Add public `kitaru.get_secret()` API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,4 @@ src/kitaru/_ui/bundle_manifest.json
 .codex/*
 !.codex/skills/
 AGENTS.override.md
+.agents/skills/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- `kitaru.get_secret()` and the public `Secret` model for exact, Kitaru-native secret reads in Python code without importing ZenML directly
 - `@checkpoint(cache=...)` per-checkpoint cache overrides (`True`/`False`/`None`) with updated configuration docs
 
 ### Fixed

--- a/docs/content/docs/guides/secrets-and-model-registration.mdx
+++ b/docs/content/docs/guides/secrets-and-model-registration.mdx
@@ -137,19 +137,20 @@ exported in the process, Kitaru uses the environment value.
 
 ## 6) Non-LLM secrets
 
-The walkthrough above covers the fully user-facing LLM path that Kitaru supports
-today.
+The walkthrough above covers the fully automatic LLM path: alias-linked
+credentials are loaded for `kitaru.llm()` when the provider environment variable
+is not already set.
 
-If you need a secret for some other external service inside a checkpoint, see
-[Manage Secrets](/guides/secrets) for the current advanced low-level
-pattern.
+If you need a secret for some other external service, call
+`kitaru.get_secret()` inside the flow or checkpoint that needs the credential.
+See [Manage Secrets](/guides/secrets) for an example.
 
 ## Related pages
 
 <Cards>
   <Card
     title="Manage Secrets"
-    description="Secret CRUD commands and the current low-level non-LLM pattern"
+    description="Secret CRUD commands and explicit non-LLM secret reads"
     href="/guides/secrets"
   />
   <Card

--- a/docs/content/docs/guides/secrets.mdx
+++ b/docs/content/docs/guides/secrets.mdx
@@ -60,36 +60,35 @@ kitaru secrets list
 kitaru secrets delete openai-creds
 ```
 
-## Use a secret inside a checkpoint (current low-level pattern)
+## Use a secret inside a checkpoint
 
-Today, Kitaru only auto-resolves linked secrets for `kitaru.llm()`.
-
-If you need credentials for some other external service, the current pattern is
-to load the secret explicitly inside your checkpoint or flow function body:
+Kitaru auto-resolves linked secrets for `kitaru.llm()`. If you need credentials
+for some other external service, load the secret explicitly with
+`kitaru.get_secret()` inside your checkpoint or flow function body:
 
 ```python
-from zenml.client import Client
-
-from kitaru import checkpoint
+from kitaru import checkpoint, get_secret
 
 
 @checkpoint
 def call_external_service() -> str:
-    secret = Client().get_secret(
-        name_id_or_prefix="github-creds",
-        allow_partial_name_match=False,
-        allow_partial_id_match=False,
-    )
-    token = secret.secret_values["GITHUB_TOKEN"]
+    secret = get_secret("github-creds")
+    token = secret.get("GITHUB_TOKEN")
+    if token is None:
+        raise RuntimeError("Secret `github-creds` is missing GITHUB_TOKEN.")
     return f"Loaded token with length {len(token)}"
 ```
+
+`get_secret()` performs an exact lookup by secret name or ID. It returns a
+Kitaru `Secret` model with `.name`, `.id`, `.values: dict[str, str]`, and
+`.get("KEY")` for optional access.
 
 Keep the lookup inside the function body so it happens in the actual runtime
 context. Do not load secrets at import time.
 
 <Callout type="warning">
-  This is the current low-level pattern. Kitaru does not yet expose a general
-  `get_secret()` helper in its public Python API.
+  Secret values are raw credentials. Avoid logging `secret.values` or returning
+  raw secret values from checkpoints unless that is explicitly intended.
 </Callout>
 
 ## Related reference pages

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -263,6 +263,20 @@ fi
 run_test "kitaru clean project --dry-run" $UV_RUN kitaru clean project --dry-run
 
 # ---------------------------------------------------------------------------
+# Secret API
+# ---------------------------------------------------------------------------
+section_header "Secret API"
+
+SMOKE_SECRET_NAME="kitaru-smoke-creds"
+run_test "kitaru secrets set smoke secret" \
+    $UV_RUN kitaru secrets set "$SMOKE_SECRET_NAME" --SMOKE_TOKEN=smoke-value
+run_test "SDK get_secret()" \
+    env SMOKE_SECRET_NAME="$SMOKE_SECRET_NAME" \
+    $UV_RUN python -c 'import os; from kitaru import get_secret; s = get_secret(os.environ["SMOKE_SECRET_NAME"]); assert s.get("SMOKE_TOKEN") == "smoke-value"'
+run_test "kitaru secrets delete smoke secret" \
+    $UV_RUN kitaru secrets delete "$SMOKE_SECRET_NAME"
+
+# ---------------------------------------------------------------------------
 # Core SDK flows
 # ---------------------------------------------------------------------------
 section_header "Core SDK flows"

--- a/src/kitaru/__init__.py
+++ b/src/kitaru/__init__.py
@@ -23,7 +23,7 @@ Example:
 Current status:
 
 - Implemented: ``@flow``, ``@checkpoint``, ``kitaru.log()``,
-  ``save()``, ``load()``, ``wait()``, ``llm()``,
+  ``save()``, ``load()``, ``wait()``, ``llm()``, ``get_secret()``,
   ``memory.configure/set/get/list/history/delete()``, ``connect()``,
   ``configure()``, stack lifecycle helpers (``list_stacks()``,
   ``current_stack()``, ``use_stack()``, ``create_stack()``,
@@ -93,6 +93,7 @@ from kitaru.errors import (
 from kitaru.flow import FlowHandle, flow
 from kitaru.llm import llm
 from kitaru.logging import log
+from kitaru.secrets import Secret, get_secret
 from kitaru.wait import wait
 
 __all__ = [
@@ -113,6 +114,7 @@ __all__ = [
     "KitaruUsageError",
     "KitaruUserCodeError",
     "KitaruWaitValidationError",
+    "Secret",
     "StackInfo",
     "checkpoint",
     "configure",
@@ -121,6 +123,7 @@ __all__ = [
     "current_stack",
     "delete_stack",
     "flow",
+    "get_secret",
     "list_stacks",
     "llm",
     "load",

--- a/src/kitaru/_cli/_secrets.py
+++ b/src/kitaru/_cli/_secrets.py
@@ -6,12 +6,14 @@ import re
 from typing import Annotated, Any
 
 from cyclopts import Parameter
-from zenml.exceptions import EntityExistsError, ZenKeyError
+from zenml.exceptions import EntityExistsError
 from zenml.models import SecretResponse
 
 from kitaru._interface_errors import run_with_cli_error_boundary
 from kitaru.cli_output import CLIOutputFormat
+from kitaru.errors import KitaruRuntimeError, KitaruUsageError
 from kitaru.inspection import serialize_secret_detail, serialize_secret_summary
+from kitaru.secrets import _get_secret_response_exact
 
 from . import secrets_app
 from ._helpers import (
@@ -109,14 +111,8 @@ def _parse_secret_assignments(raw_assignments: list[str]) -> dict[str, str]:
 def _resolve_secret_exact(client: Any, name_or_id: str) -> SecretResponse:
     """Fetch one secret by exact name or exact ID."""
     try:
-        return client.get_secret(
-            name_id_or_prefix=name_or_id,
-            allow_partial_name_match=False,
-            allow_partial_id_match=False,
-        )
-    except KeyError as exc:
-        raise ValueError(f"Secret `{name_or_id}` was not found.") from exc
-    except ZenKeyError as exc:
+        return _get_secret_response_exact(name_or_id, client=client)
+    except (KitaruRuntimeError, KitaruUsageError) as exc:
         raise ValueError(str(exc)) from exc
 
 

--- a/src/kitaru/analytics.py
+++ b/src/kitaru/analytics.py
@@ -58,6 +58,7 @@ class AnalyticsEvent(StrEnum):
     MEMORY_COMPACTED = "Kitaru memory compacted"
     MEMORY_REINDEX_RUN = "Kitaru memory reindex run"
     SECRET_UPSERTED = "Kitaru secret upserted"
+    SECRET_READ = "Kitaru secret read"
     STACK_CREATED = "Kitaru stack created"
     STACK_ACTIVATED = "Kitaru stack activated"
     MODEL_ALIAS_REGISTERED = "Kitaru model alias registered"

--- a/src/kitaru/llm.py
+++ b/src/kitaru/llm.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
-from zenml.client import Client
 
 from kitaru._safe_save import _safe_save
 from kitaru.artifacts import save
@@ -29,6 +28,7 @@ from kitaru.errors import (
 )
 from kitaru.logging import log
 from kitaru.runtime import _is_inside_checkpoint, _is_inside_flow, _next_llm_call_name
+from kitaru.secrets import _read_secret_values
 
 _LLM_OUTSIDE_FLOW_ERROR = "kitaru.llm() can only be called inside a @flow."
 _MOCK_RESPONSE_ENV = "KITARU_LLM_MOCK_RESPONSE"
@@ -174,42 +174,6 @@ def _parse_provider_target(resolved_model: str) -> _ProviderTarget:
 # ---------------------------------------------------------------------------
 # Credential resolution
 # ---------------------------------------------------------------------------
-
-
-def _read_secret_values(secret_name: str) -> dict[str, str]:
-    """Read secret key/value pairs from ZenML for env injection."""
-    try:
-        secret = Client().get_secret(
-            name_id_or_prefix=secret_name,
-            allow_partial_name_match=False,
-            allow_partial_id_match=False,
-        )
-    except KeyError as exc:
-        raise KitaruRuntimeError(f"Secret `{secret_name}` was not found.") from exc
-    except Exception as exc:
-        raise KitaruBackendError(
-            f"Failed to load secret `{secret_name}` for kitaru.llm(): {exc}"
-        ) from exc
-
-    secret_values = getattr(secret, "secret_values", None)
-    if not isinstance(secret_values, Mapping) or not secret_values:
-        raise KitaruRuntimeError(
-            f"Secret `{secret_name}` does not contain readable key/value pairs."
-        )
-    normalized_values: dict[str, str] = {}
-    for key, value in secret_values.items():
-        key_string = str(key).strip()
-        if not key_string:
-            continue
-        if value is None:
-            continue
-        normalized_values[key_string] = str(value)
-
-    if not normalized_values:
-        raise KitaruRuntimeError(
-            f"Secret `{secret_name}` does not contain non-empty values."
-        )
-    return normalized_values
 
 
 def _resolve_credential_overlay(

--- a/src/kitaru/secrets.py
+++ b/src/kitaru/secrets.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 from zenml.client import Client as _ZenMLClient
 from zenml.exceptions import ZenKeyError as _ZenMLKeyError
 
-import kitaru.analytics as _analytics
-from kitaru.analytics import AnalyticsEvent as _AnalyticsEvent
+from kitaru.analytics import AnalyticsEvent, track
 from kitaru.errors import KitaruBackendError, KitaruRuntimeError, KitaruUsageError
 
 
@@ -70,7 +69,6 @@ def _get_secret_response_exact(
     name_or_id: str,
     *,
     client: Any | None = None,
-    client_factory: Callable[[], Any] | None = None,
 ) -> Any:
     """Fetch one backend secret response by exact name or exact ID.
 
@@ -78,9 +76,6 @@ def _get_secret_response_exact(
         name_or_id: Secret name or ID to fetch.
         client: Optional already-created backend client. CLI code passes this
             to preserve its existing client lifecycle and tests.
-        client_factory: Factory used when ``client`` is not provided. Defaults
-            to the current backend client object, so tests can patch the module
-            symbol normally.
 
     Returns:
         The raw backend secret response.
@@ -93,9 +88,7 @@ def _get_secret_response_exact(
     normalized_name_or_id = _normalize_name_or_id(name_or_id)
 
     try:
-        resolved_client = (
-            client if client is not None else (client_factory or _ZenMLClient)()
-        )
+        resolved_client = client if client is not None else _ZenMLClient()
         return resolved_client.get_secret(
             name_id_or_prefix=normalized_name_or_id,
             allow_partial_name_match=False,
@@ -119,9 +112,7 @@ def _secret_from_response(secret_response: Any) -> Secret:
         raise KitaruBackendError("Backend returned a secret without a readable name.")
 
     raw_id = getattr(secret_response, "id", None)
-    if raw_id is None:
-        raise KitaruBackendError(f"Backend returned secret `{name}` without an ID.")
-    secret_id = str(raw_id)
+    secret_id = str(raw_id) if raw_id is not None else ""
     if not secret_id:
         raise KitaruBackendError(f"Backend returned secret `{name}` without an ID.")
 
@@ -135,12 +126,12 @@ def _secret_from_response(secret_response: Any) -> Secret:
 def _read_secret_values(secret_name: str) -> dict[str, str]:
     """Read non-empty secret key/value pairs for internal credential injection."""
     secret_response = _get_secret_response_exact(secret_name)
-    secret = _secret_from_response(secret_response)
-    if not secret.values:
+    values = _normalize_secret_values(secret_response, display_name=secret_name)
+    if not values:
         raise KitaruRuntimeError(
             f"Secret `{secret_name}` does not contain readable key/value pairs."
         )
-    return dict(secret.values)
+    return values
 
 
 def get_secret(name_or_id: str) -> Secret:
@@ -161,7 +152,7 @@ def get_secret(name_or_id: str) -> Secret:
     """
     secret_response = _get_secret_response_exact(name_or_id)
     secret = _secret_from_response(secret_response)
-    _analytics.track(_AnalyticsEvent.SECRET_READ, {"key_count": len(secret.values)})
+    track(AnalyticsEvent.SECRET_READ, {"key_count": len(secret.values)})
     return secret
 
 

--- a/src/kitaru/secrets.py
+++ b/src/kitaru/secrets.py
@@ -1,0 +1,168 @@
+"""Public helpers for reading Kitaru-managed secrets."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+from zenml.client import Client as _ZenMLClient
+from zenml.exceptions import ZenKeyError as _ZenMLKeyError
+
+import kitaru.analytics as _analytics
+from kitaru.analytics import AnalyticsEvent as _AnalyticsEvent
+from kitaru.errors import KitaruBackendError, KitaruRuntimeError, KitaruUsageError
+
+
+class Secret(BaseModel):
+    """Kitaru-native view of a stored secret.
+
+    The model intentionally exposes only stable Kitaru SDK fields and hides the
+    underlying backend response object.
+
+    Attributes:
+        name: Secret name.
+        id: Backend secret ID, normalized to a string.
+        values: Readable secret key/value pairs, normalized to strings.
+    """
+
+    name: str
+    id: str
+    values: dict[str, str]
+
+    model_config = ConfigDict(frozen=True)
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        """Return a secret value by key, or a default when the key is absent."""
+        return self.values.get(key, default)
+
+
+def _normalize_name_or_id(name_or_id: str) -> str:
+    """Normalize and validate a secret name or ID input."""
+    normalized = name_or_id.strip()
+    if not normalized:
+        raise KitaruUsageError("Secret name or ID cannot be empty.")
+    return normalized
+
+
+def _normalize_secret_values(
+    secret_response: Any, *, display_name: str
+) -> dict[str, str]:
+    """Convert backend secret values into Kitaru's public string mapping."""
+    raw_values = getattr(secret_response, "secret_values", None)
+    if not isinstance(raw_values, Mapping):
+        raise KitaruRuntimeError(
+            f"Secret `{display_name}` does not contain readable key/value pairs."
+        )
+
+    normalized_values: dict[str, str] = {}
+    for key, value in raw_values.items():
+        key_string = str(key).strip()
+        if not key_string:
+            continue
+        if value is None:
+            continue
+        normalized_values[key_string] = str(value)
+    return normalized_values
+
+
+def _get_secret_response_exact(
+    name_or_id: str,
+    *,
+    client: Any | None = None,
+    client_factory: Callable[[], Any] | None = None,
+) -> Any:
+    """Fetch one backend secret response by exact name or exact ID.
+
+    Args:
+        name_or_id: Secret name or ID to fetch.
+        client: Optional already-created backend client. CLI code passes this
+            to preserve its existing client lifecycle and tests.
+        client_factory: Factory used when ``client`` is not provided. Defaults
+            to the current backend client object, so tests can patch the module
+            symbol normally.
+
+    Returns:
+        The raw backend secret response.
+
+    Raises:
+        KitaruUsageError: If ``name_or_id`` is empty.
+        KitaruRuntimeError: If the secret is not found.
+        KitaruBackendError: If the backend lookup fails unexpectedly.
+    """
+    normalized_name_or_id = _normalize_name_or_id(name_or_id)
+
+    try:
+        resolved_client = (
+            client if client is not None else (client_factory or _ZenMLClient)()
+        )
+        return resolved_client.get_secret(
+            name_id_or_prefix=normalized_name_or_id,
+            allow_partial_name_match=False,
+            allow_partial_id_match=False,
+        )
+    except (KeyError, _ZenMLKeyError) as exc:
+        raise KitaruRuntimeError(
+            f"Secret `{normalized_name_or_id}` was not found."
+        ) from exc
+    except Exception as exc:
+        raise KitaruBackendError(
+            f"Failed to load secret `{normalized_name_or_id}`: {exc}"
+        ) from exc
+
+
+def _secret_from_response(secret_response: Any) -> Secret:
+    """Convert a backend secret response into Kitaru's public Secret model."""
+    raw_name = getattr(secret_response, "name", None)
+    name = str(raw_name).strip() if raw_name is not None else ""
+    if not name:
+        raise KitaruBackendError("Backend returned a secret without a readable name.")
+
+    raw_id = getattr(secret_response, "id", None)
+    if raw_id is None:
+        raise KitaruBackendError(f"Backend returned secret `{name}` without an ID.")
+    secret_id = str(raw_id)
+    if not secret_id:
+        raise KitaruBackendError(f"Backend returned secret `{name}` without an ID.")
+
+    return Secret(
+        name=name,
+        id=secret_id,
+        values=_normalize_secret_values(secret_response, display_name=name),
+    )
+
+
+def _read_secret_values(secret_name: str) -> dict[str, str]:
+    """Read non-empty secret key/value pairs for internal credential injection."""
+    secret_response = _get_secret_response_exact(secret_name)
+    secret = _secret_from_response(secret_response)
+    if not secret.values:
+        raise KitaruRuntimeError(
+            f"Secret `{secret_name}` does not contain readable key/value pairs."
+        )
+    return dict(secret.values)
+
+
+def get_secret(name_or_id: str) -> Secret:
+    """Read a stored secret by exact name or ID.
+
+    Args:
+        name_or_id: Secret name or ID. Partial name and partial ID matches are
+            disabled so the lookup resolves exactly one intended secret.
+
+    Returns:
+        A Kitaru-native ``Secret`` model with normalized string values.
+
+    Raises:
+        KitaruUsageError: If ``name_or_id`` is empty.
+        KitaruRuntimeError: If the secret is not found or has unreadable values.
+        KitaruBackendError: If the backend lookup returns an invalid response or
+            fails unexpectedly.
+    """
+    secret_response = _get_secret_response_exact(name_or_id)
+    secret = _secret_from_response(secret_response)
+    _analytics.track(_AnalyticsEvent.SECRET_READ, {"key_count": len(secret.values)})
+    return secret
+
+
+__all__ = ["Secret", "get_secret"]

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -177,6 +177,7 @@ def test_feature_adoption_event_canonical_strings() -> None:
     assert AnalyticsEvent.MEMORY_COMPACTED == "Kitaru memory compacted"
     assert AnalyticsEvent.MEMORY_REINDEX_RUN == "Kitaru memory reindex run"
     assert AnalyticsEvent.SECRET_UPSERTED == "Kitaru secret upserted"
+    assert AnalyticsEvent.SECRET_READ == "Kitaru secret read"
     assert AnalyticsEvent.STACK_CREATED == "Kitaru stack created"
     assert AnalyticsEvent.STACK_ACTIVATED == "Kitaru stack activated"
     assert AnalyticsEvent.MODEL_ALIAS_REGISTERED == "Kitaru model alias registered"

--- a/tests/test_generate_sdk_docs.py
+++ b/tests/test_generate_sdk_docs.py
@@ -290,6 +290,17 @@ class TestExtractApi:
             "use_stack",
         }.issubset(config_funcs)
 
+    def test_filtered_extraction_includes_secret_api(self) -> None:
+        raw = extract_api("kitaru")
+        filtered = _filter_module(raw, is_root=True)
+        secrets_module = filtered.get("modules", {}).get("secrets", {})
+
+        assert "Secret" in secrets_module.get("classes", {})
+        assert "Client" not in secrets_module.get("classes", {})
+        assert "ZenKeyError" not in secrets_module.get("classes", {})
+        assert "get_secret" in secrets_module.get("functions", {})
+        assert "_get_secret_response_exact" not in secrets_module.get("functions", {})
+
     def test_filtered_extraction_excludes_private_reference_modules(self) -> None:
         raw = extract_api("kitaru")
         filtered = _filter_module(raw, is_root=True)

--- a/tests/test_kitaru.py
+++ b/tests/test_kitaru.py
@@ -37,6 +37,12 @@ class TestPublicExports:
     def test_load_exists(self) -> None:
         assert hasattr(kitaru, "load")
 
+    def test_secret_exists(self) -> None:
+        assert hasattr(kitaru, "Secret")
+
+    def test_get_secret_exists(self) -> None:
+        assert hasattr(kitaru, "get_secret")
+
     def test_log_exists(self) -> None:
         assert hasattr(kitaru, "log")
 
@@ -83,6 +89,7 @@ class TestPublicExports:
             "KitaruUsageError",
             "KitaruUserCodeError",
             "KitaruWaitValidationError",
+            "Secret",
             "StackInfo",
             "checkpoint",
             "configure",
@@ -91,6 +98,7 @@ class TestPublicExports:
             "current_stack",
             "delete_stack",
             "flow",
+            "get_secret",
             "list_stacks",
             "llm",
             "memory",

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,116 @@
+"""Tests for Kitaru's public secret-read API."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from kitaru.analytics import AnalyticsEvent
+from kitaru.errors import KitaruBackendError, KitaruRuntimeError, KitaruUsageError
+from kitaru.secrets import Secret, _read_secret_values, get_secret
+
+
+def test_get_secret_fetches_exact_secret_and_normalizes_values() -> None:
+    """Public secret reads should exact-match and return a Kitaru model."""
+    client = Mock()
+    client.get_secret.return_value = SimpleNamespace(
+        name="openai-creds",
+        id=123,
+        secret_values={
+            "OPENAI_API_KEY": "sk-123",
+            "COUNT": 3,
+            "": "skip-empty-key",
+            "NONE": None,
+        },
+    )
+
+    with (
+        patch("kitaru.secrets._ZenMLClient", return_value=client),
+        patch("kitaru.secrets._analytics.track") as track_mock,
+    ):
+        secret = get_secret(" openai-creds ")
+
+    client.get_secret.assert_called_once_with(
+        name_id_or_prefix="openai-creds",
+        allow_partial_name_match=False,
+        allow_partial_id_match=False,
+    )
+    assert secret == Secret(
+        name="openai-creds",
+        id="123",
+        values={"OPENAI_API_KEY": "sk-123", "COUNT": "3"},
+    )
+    assert secret.get("OPENAI_API_KEY") == "sk-123"
+    assert secret.get("MISSING") is None
+    assert secret.get("MISSING", "fallback") == "fallback"
+    track_mock.assert_called_once_with(AnalyticsEvent.SECRET_READ, {"key_count": 2})
+
+
+def test_get_secret_rejects_empty_name() -> None:
+    """Empty names should fail before Kitaru contacts the backend."""
+    with pytest.raises(KitaruUsageError, match="Secret name or ID cannot be empty"):
+        get_secret("   ")
+
+
+def test_get_secret_maps_missing_secret_to_runtime_error() -> None:
+    """Backend not-found errors should become Kitaru runtime errors."""
+    client = Mock()
+    client.get_secret.side_effect = KeyError("missing")
+
+    with (
+        patch("kitaru.secrets._ZenMLClient", return_value=client),
+        pytest.raises(KitaruRuntimeError, match="Secret `github-creds` was not found"),
+    ):
+        get_secret("github-creds")
+
+
+def test_get_secret_maps_backend_failure_to_backend_error() -> None:
+    """Unexpected backend failures should not leak raw client errors."""
+    client = Mock()
+    client.get_secret.side_effect = RuntimeError("offline")
+
+    with (
+        patch("kitaru.secrets._ZenMLClient", return_value=client),
+        pytest.raises(KitaruBackendError, match="Failed to load secret `github-creds`"),
+    ):
+        get_secret("github-creds")
+
+
+def test_get_secret_rejects_unreadable_values() -> None:
+    """A malformed backend response should not become a public Secret."""
+    client = Mock()
+    client.get_secret.return_value = SimpleNamespace(
+        name="github-creds",
+        id="secret-id",
+        secret_values=None,
+    )
+
+    with (
+        patch("kitaru.secrets._ZenMLClient", return_value=client),
+        pytest.raises(
+            KitaruRuntimeError,
+            match="Secret `github-creds` does not contain readable key/value pairs",
+        ),
+    ):
+        get_secret("github-creds")
+
+
+def test_read_secret_values_rejects_empty_normalized_values() -> None:
+    """Internal credential reads should still require at least one usable value."""
+    client = Mock()
+    client.get_secret.return_value = SimpleNamespace(
+        name="empty-creds",
+        id="secret-id",
+        secret_values={"": "skip", "NONE": None},
+    )
+
+    with (
+        patch("kitaru.secrets._ZenMLClient", return_value=client),
+        pytest.raises(
+            KitaruRuntimeError,
+            match="Secret `empty-creds` does not contain readable key/value pairs",
+        ),
+    ):
+        _read_secret_values("empty-creds")

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -28,7 +28,7 @@ def test_get_secret_fetches_exact_secret_and_normalizes_values() -> None:
 
     with (
         patch("kitaru.secrets._ZenMLClient", return_value=client),
-        patch("kitaru.secrets._analytics.track") as track_mock,
+        patch("kitaru.secrets.track") as track_mock,
     ):
         secret = get_secret(" openai-creds ")
 


### PR DESCRIPTION
Closes #179.

## Summary

Adds a public Python API for reading Kitaru-managed secrets, so user code no longer has to import `zenml.client.Client` directly:

```python
from kitaru import get_secret

token = get_secret("github-creds").get("GITHUB_TOKEN")
```

- New `kitaru.Secret` Pydantic model and `kitaru.get_secret(name_or_id)` helper, both re-exported from the package root.
- Internal secret-read logic is centralized in `src/kitaru/secrets.py`; `kitaru.llm()` and `kitaru secrets` CLI commands now delegate to shared helpers (`_read_secret_values`, `_get_secret_response_exact`) instead of duplicating lookup code.
- `kitaru.llm()` keeps its env-first credential precedence and the CLI `_resolve_secret_exact` seam is preserved for existing test patches.
- Docs under `docs/content/docs/guides/secrets.mdx` now show the new pattern; `secrets-and-model-registration.mdx` stops pointing users at the ZenML client for non-LLM secrets.

## Design notes

- `get_secret()` does exact-match only (no partial name/ID matching) and returns a frozen `Secret` with normalized string values. Empty/`None` values are filtered out so `.values` is a clean `dict[str, str]`.
- Errors are mapped to Kitaru's typed hierarchy: `KitaruUsageError` for empty input, `KitaruRuntimeError` for not-found / unreadable, `KitaruBackendError` for unexpected backend failures.
- Adds a `SECRET_READ` analytics event with only a `key_count` integer — no key names or values are tracked.

## Scope vs. issue #179

Issue #179 also sketched richer semantics: ambiguity resolution when `private=None`, a `required_keys=` parameter, and failing when `has_missing_values` is set. This PR intentionally ships the minimal slice (`get_secret(name_or_id) -> Secret`) so users can stop importing `zenml.client`. The richer spec is a good follow-up once we see how `get_secret()` gets used in practice — the current shape leaves room for keyword-only additions without breaking callers.

## Code-review pass

Before opening the PR I ran the `simplify` skill over the branch and pulled in three changes:

- `_read_secret_values` now bypasses the `Secret` model on the `kitaru.llm()` hot path and calls `_normalize_secret_values` directly.
- Dropped the unused `client_factory` parameter on `_get_secret_response_exact` (tests already patch `_ZenMLClient` at the module level).
- Aligned the analytics imports with the rest of the SDK (`from kitaru.analytics import AnalyticsEvent, track`) and collapsed a duplicated id-empty check in `_secret_from_response`.

## Test plan

- [x] `just check` (format, lint, ty, typos, yaml, actions, links)
- [x] `just test` — 1319 passed, 9 skipped (optional extras)
- [x] `tests/test_secrets.py` — 6 new tests covering exact lookup, normalization, empty-input rejection, not-found mapping, backend-failure mapping, and internal-read emptiness guard
- [x] `tests/test_generate_sdk_docs.py` — confirms the `kitaru.secrets` module exposes `Secret` + `get_secret` in generated SDK docs and hides zenml imports
- [x] Smoke test updated: `kitaru secrets set` → SDK `get_secret()` round-trip → `kitaru secrets delete`