### PR TITLE
Make `release.yml` idempotent for partial-failure recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,15 +58,6 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check tag status (dispatch only)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
-            echo "::warning::Tag v$VERSION already exists — recovery mode (downstream steps will skip pre-existing artifacts)"
-          else
-            echo "Tag v$VERSION does not exist yet — normal release flow"
-          fi
-
       # --- Checkout ---
       - name: Checkout develop (dispatch)
         if: github.event_name == 'workflow_dispatch'
@@ -122,6 +113,29 @@ jobs:
           else
             git commit -m "Release $VERSION"
           fi
+
+      # --- Capture authoritative RELEASE_SHA for this release ---
+      # The v$VERSION tag, if it exists, is the immutable source of truth for
+      # which commit owns this version. A recovery dispatch must run on the
+      # exact same commit; otherwise PyPI, Docker, Helm, and the tag would
+      # diverge (split-brain release).
+      - name: Verify release SHA consistency
+        run: |
+          RELEASE_SHA=$(git rev-parse HEAD)
+          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
+            git fetch origin "refs/tags/v$VERSION:refs/tags/v$VERSION" --force
+            TAG_SHA=$(git rev-list -n 1 "v$VERSION")
+            if [ "$TAG_SHA" != "$RELEASE_SHA" ]; then
+              echo "::error::Tag v$VERSION pins SHA $TAG_SHA but workflow HEAD is $RELEASE_SHA."
+              echo "::error::A recovery dispatch must run on the same commit the tag points to."
+              echo "::error::Either dispatch a different version, or check out $TAG_SHA and retry."
+              exit 1
+            fi
+            echo "Tag v$VERSION matches HEAD ($RELEASE_SHA) — recovery-safe"
+          else
+            echo "No existing tag for v$VERSION — normal release flow"
+          fi
+          echo "RELEASE_SHA=$RELEASE_SHA" >> "$GITHUB_ENV"
 
       # --- Verify version matches (tag push only) ---
       - name: Verify tag matches pyproject.toml version
@@ -202,42 +216,87 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run != 'true' }}
         run: |
           REMOTE_DEVELOP=$(git ls-remote origin refs/heads/develop | awk '{print $1}')
-          LOCAL_HEAD=$(git rev-parse HEAD)
-          if [ "$REMOTE_DEVELOP" = "$LOCAL_HEAD" ]; then
-            echo "origin/develop is already at $LOCAL_HEAD — recovery mode, skipping push"
+          if [ "$REMOTE_DEVELOP" = "$RELEASE_SHA" ]; then
+            echo "origin/develop is at RELEASE_SHA $RELEASE_SHA — skipping push"
+          elif git merge-base --is-ancestor "$RELEASE_SHA" "$REMOTE_DEVELOP"; then
+            echo "origin/develop ($REMOTE_DEVELOP) already contains RELEASE_SHA $RELEASE_SHA — skipping push"
           else
-            git push origin HEAD:develop
+            git push origin "$RELEASE_SHA:refs/heads/develop"
           fi
 
       # --- Create release branch and update main (skip on dry-run) ---
+      # Both guards are identity-based: we only touch refs if they're missing
+      # or already at RELEASE_SHA. Divergent state triggers a hard error rather
+      # than silently overwriting an archival branch or rewinding main.
       - name: Create release branch
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
         run: |
-          git checkout -B "release/$VERSION"
-          git push --force origin "release/$VERSION"
+          REMOTE_SHA=$(git ls-remote --heads origin "refs/heads/release/$VERSION" | awk '{print $1}')
+          if [ -z "$REMOTE_SHA" ]; then
+            git push origin "$RELEASE_SHA:refs/heads/release/$VERSION"
+            echo "Created release/$VERSION at $RELEASE_SHA"
+          elif [ "$REMOTE_SHA" = "$RELEASE_SHA" ]; then
+            echo "release/$VERSION is already at RELEASE_SHA $RELEASE_SHA — skipping"
+          else
+            echo "::error::release/$VERSION exists at $REMOTE_SHA but expected $RELEASE_SHA."
+            echo "::error::Archival release branches are immutable; manual intervention required."
+            exit 1
+          fi
       - name: Update main to release
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
-        run: git push --force origin "release/$VERSION:main"
+        run: |
+          REMOTE_MAIN=$(git ls-remote origin refs/heads/main | awk '{print $1}')
+          if [ "$REMOTE_MAIN" = "$RELEASE_SHA" ]; then
+            echo "origin/main is already at RELEASE_SHA $RELEASE_SHA — skipping"
+          elif git merge-base --is-ancestor "$REMOTE_MAIN" "$RELEASE_SHA"; then
+            git push --force origin "$RELEASE_SHA:refs/heads/main"
+            echo "Fast-forwarded main to $RELEASE_SHA"
+          else
+            echo "::error::origin/main ($REMOTE_MAIN) is not an ancestor of RELEASE_SHA $RELEASE_SHA."
+            echo "::error::Force-pushing would rewind main to an older release. Manual intervention required."
+            exit 1
+          fi
 
       # --- Tag (dispatch only, skip on dry-run) ---
+      # The upstream "Verify release SHA consistency" step guarantees that if
+      # v$VERSION exists, it already points to RELEASE_SHA. So here we only
+      # need to create + push the tag when it does not yet exist.
       - name: Create and push tag
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run != 'true' }}
         run: |
           if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
-            echo "Tag v$VERSION already exists on origin — recovery mode, skipping"
+            echo "Tag v$VERSION already exists at RELEASE_SHA $RELEASE_SHA — skipping"
           else
-            git tag "v$VERSION"
+            git tag "v$VERSION" "$RELEASE_SHA"
             git push origin "v$VERSION"
           fi
 
       # --- GitHub Release (skip on dry-run) ---
+      # If the release already exists, verify it's attached to v$VERSION and
+      # fill in any missing dist/* assets (a previous run could have created
+      # the release and then died mid-upload).
       - name: Create GitHub Release
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if gh release view "v$VERSION" >/dev/null 2>&1; then
-            echo "GitHub Release v$VERSION already exists — recovery mode, skipping"
+            EXISTING_TAG=$(gh release view "v$VERSION" --json tagName --jq .tagName)
+            if [ "$EXISTING_TAG" != "v$VERSION" ]; then
+              echo "::error::Release v$VERSION is attached to tag $EXISTING_TAG, expected v$VERSION"
+              exit 1
+            fi
+            echo "Release v$VERSION exists — filling in any missing dist/* assets"
+            existing_assets=$(gh release view "v$VERSION" --json assets --jq '.assets[].name')
+            for f in dist/*; do
+              name=$(basename "$f")
+              if echo "$existing_assets" | grep -Fxq "$name"; then
+                echo "  asset already uploaded: $name"
+              else
+                echo "  uploading missing asset: $name"
+                gh release upload "v$VERSION" "$f"
+              fi
+            done
           else
             gh release create "v$VERSION" dist/* \
               --title "v$VERSION" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,13 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check tag does not already exist (dispatch only)
+      - name: Check tag status (dispatch only)
         if: github.event_name == 'workflow_dispatch'
         run: |
           if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
-            echo "::error::Tag v$VERSION already exists"
-            exit 1
+            echo "::warning::Tag v$VERSION already exists — recovery mode (downstream steps will skip pre-existing artifacts)"
+          else
+            echo "Tag v$VERSION does not exist yet — normal release flow"
           fi
 
       # --- Checkout ---
@@ -103,8 +104,12 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           DATE=$(date +%Y-%m-%d)
-          sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $DATE/" CHANGELOG.md
-          echo "Updated CHANGELOG.md for $VERSION ($DATE)"
+          if grep -q "^## \[$VERSION\] - " CHANGELOG.md; then
+            echo "CHANGELOG.md already has a section for $VERSION — skipping"
+          else
+            sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $DATE/" CHANGELOG.md
+            echo "Updated CHANGELOG.md for $VERSION ($DATE)"
+          fi
       - name: Update lockfile
         if: github.event_name == 'workflow_dispatch'
         run: uv lock
@@ -112,7 +117,11 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           git add pyproject.toml CHANGELOG.md uv.lock
-          git commit -m "Release $VERSION"
+          if git diff --cached --quiet; then
+            echo "No release changes to commit — recovery mode"
+          else
+            git commit -m "Release $VERSION"
+          fi
 
       # --- Verify version matches (tag push only) ---
       - name: Verify tag matches pyproject.toml version
@@ -171,6 +180,8 @@ jobs:
       - name: Publish to PyPI
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+        with:
+          skip-existing: true
       - name: Wait for PyPI availability
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
         run: |
@@ -189,14 +200,21 @@ jobs:
       # --- Push release commit to develop (dispatch only, skip on dry-run) ---
       - name: Push release commit to develop
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run != 'true' }}
-        run: git push origin HEAD:develop
+        run: |
+          REMOTE_DEVELOP=$(git ls-remote origin refs/heads/develop | awk '{print $1}')
+          LOCAL_HEAD=$(git rev-parse HEAD)
+          if [ "$REMOTE_DEVELOP" = "$LOCAL_HEAD" ]; then
+            echo "origin/develop is already at $LOCAL_HEAD — recovery mode, skipping push"
+          else
+            git push origin HEAD:develop
+          fi
 
       # --- Create release branch and update main (skip on dry-run) ---
       - name: Create release branch
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
         run: |
-          git checkout -b "release/$VERSION"
-          git push origin "release/$VERSION"
+          git checkout -B "release/$VERSION"
+          git push --force origin "release/$VERSION"
       - name: Update main to release
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
         run: git push --force origin "release/$VERSION:main"
@@ -205,8 +223,12 @@ jobs:
       - name: Create and push tag
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run != 'true' }}
         run: |
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
+          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
+            echo "Tag v$VERSION already exists on origin — recovery mode, skipping"
+          else
+            git tag "v$VERSION"
+            git push origin "v$VERSION"
+          fi
 
       # --- GitHub Release (skip on dry-run) ---
       - name: Create GitHub Release
@@ -214,9 +236,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v$VERSION" dist/* \
-            --title "v$VERSION" \
-            --generate-notes
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "GitHub Release v$VERSION already exists — recovery mode, skipping"
+          else
+            gh release create "v$VERSION" dist/* \
+              --title "v$VERSION" \
+              --generate-notes
+          fi
 
       # --- Docker image ---
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,36 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # --- Determine checkout ref (dispatch only) ---
+      # Normally checks out `develop`. If v$VERSION already exists on origin,
+      # this is a partial-recovery dispatch and we must check out that tag so
+      # the rest of the workflow runs against the canonical release commit —
+      # otherwise the SHA consistency check would fail, and the error message
+      # telling operators to "check out $TAG_SHA and retry" wouldn't be
+      # actionable from workflow_dispatch. Uses the full repo URL because
+      # `origin` isn't configured until after actions/checkout runs.
+      - name: Determine checkout ref (dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        id: ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/v$VERSION" --silent 2>/dev/null; then
+            echo "Tag v$VERSION exists — recovery mode, checking out tag"
+            echo "ref=refs/tags/v$VERSION" >> "$GITHUB_OUTPUT"
+            echo "TAG_EXISTS_AT_START=true" >> "$GITHUB_ENV"
+          else
+            echo "No existing tag — normal release flow, checking out develop"
+            echo "ref=develop" >> "$GITHUB_OUTPUT"
+            echo "TAG_EXISTS_AT_START=false" >> "$GITHUB_ENV"
+          fi
+
       # --- Checkout ---
-      - name: Checkout develop (dispatch)
+      - name: Checkout (dispatch)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: develop
+          ref: ${{ steps.ref.outputs.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout tagged commit (tag push)
@@ -122,18 +146,28 @@ jobs:
       - name: Verify release SHA consistency
         run: |
           RELEASE_SHA=$(git rev-parse HEAD)
-          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
+          # Dispatch trigger pre-populates $TAG_EXISTS_AT_START. Tag-push trigger
+          # skipped the dispatch-only probe, but by definition the tag exists.
+          if [ -z "${TAG_EXISTS_AT_START:-}" ]; then
+            TAG_EXISTS_AT_START=true
+          fi
+          if [ "$TAG_EXISTS_AT_START" = "true" ]; then
             git fetch origin "refs/tags/v$VERSION:refs/tags/v$VERSION" --force
             TAG_SHA=$(git rev-list -n 1 "v$VERSION")
             if [ "$TAG_SHA" != "$RELEASE_SHA" ]; then
               echo "::error::Tag v$VERSION pins SHA $TAG_SHA but workflow HEAD is $RELEASE_SHA."
-              echo "::error::A recovery dispatch must run on the same commit the tag points to."
-              echo "::error::Either dispatch a different version, or check out $TAG_SHA and retry."
+              echo "::error::The workflow must run on the same commit the tag points to."
+              echo "::error::Dispatch a different version, or check out $TAG_SHA and retry."
               exit 1
             fi
             echo "Tag v$VERSION matches HEAD ($RELEASE_SHA) — recovery-safe"
           else
             echo "No existing tag for v$VERSION — normal release flow"
+          fi
+          if ! grep -q "^## \[$VERSION\] - " CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing a '## [$VERSION] - YYYY-MM-DD' section."
+            echo "::error::The release commit is incomplete — add the changelog entry before retrying."
+            exit 1
           fi
           echo "RELEASE_SHA=$RELEASE_SHA" >> "$GITHUB_ENV"
 
@@ -190,6 +224,23 @@ jobs:
       - name: List build artifacts
         run: ls -lh dist/
 
+      # --- Tag (dispatch only, skip on dry-run) ---
+      # Push the tag BEFORE PyPI so that any later failure leaves a durable
+      # anchor: a subsequent recovery dispatch will find the tag, check out
+      # its SHA, and pass the consistency check. Without this, a mid-workflow
+      # failure after PyPI upload but before tag push would leave PyPI with
+      # artifacts from one commit and no immutable ref to anchor the next run
+      # to the same commit (split-brain release risk).
+      - name: Create and push tag
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run != 'true' }}
+        run: |
+          if [ "$TAG_EXISTS_AT_START" = "true" ]; then
+            echo "Tag v$VERSION already exists at RELEASE_SHA $RELEASE_SHA — skipping"
+          else
+            git tag "v$VERSION" "$RELEASE_SHA"
+            git push origin "v$VERSION"
+          fi
+
       # --- Publish (skip on dry-run) ---
       - name: Publish to PyPI
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
@@ -218,10 +269,24 @@ jobs:
           REMOTE_DEVELOP=$(git ls-remote origin refs/heads/develop | awk '{print $1}')
           if [ "$REMOTE_DEVELOP" = "$RELEASE_SHA" ]; then
             echo "origin/develop is at RELEASE_SHA $RELEASE_SHA — skipping push"
-          elif git merge-base --is-ancestor "$RELEASE_SHA" "$REMOTE_DEVELOP"; then
-            echo "origin/develop ($REMOTE_DEVELOP) already contains RELEASE_SHA $RELEASE_SHA — skipping push"
           else
-            git push origin "$RELEASE_SHA:refs/heads/develop"
+            # Distinguish "not ancestor" (exit 1) from fatal git errors (exit 128).
+            set +e
+            git merge-base --is-ancestor "$RELEASE_SHA" "$REMOTE_DEVELOP"
+            ancestor_status=$?
+            set -e
+            case "$ancestor_status" in
+              0)
+                echo "origin/develop ($REMOTE_DEVELOP) already contains RELEASE_SHA $RELEASE_SHA — skipping push"
+                ;;
+              1)
+                git push origin "$RELEASE_SHA:refs/heads/develop"
+                ;;
+              *)
+                echo "::error::Ancestry check failed (exit $ancestor_status) for origin/develop ($REMOTE_DEVELOP) vs RELEASE_SHA $RELEASE_SHA"
+                exit 1
+                ;;
+            esac
           fi
 
       # --- Create release branch and update main (skip on dry-run) ---
@@ -248,60 +313,71 @@ jobs:
           REMOTE_MAIN=$(git ls-remote origin refs/heads/main | awk '{print $1}')
           if [ "$REMOTE_MAIN" = "$RELEASE_SHA" ]; then
             echo "origin/main is already at RELEASE_SHA $RELEASE_SHA — skipping"
-          elif git merge-base --is-ancestor "$REMOTE_MAIN" "$RELEASE_SHA"; then
-            git push --force origin "$RELEASE_SHA:refs/heads/main"
-            echo "Fast-forwarded main to $RELEASE_SHA"
           else
-            echo "::error::origin/main ($REMOTE_MAIN) is not an ancestor of RELEASE_SHA $RELEASE_SHA."
-            echo "::error::Force-pushing would rewind main to an older release. Manual intervention required."
-            exit 1
-          fi
-
-      # --- Tag (dispatch only, skip on dry-run) ---
-      # The upstream "Verify release SHA consistency" step guarantees that if
-      # v$VERSION exists, it already points to RELEASE_SHA. So here we only
-      # need to create + push the tag when it does not yet exist.
-      - name: Create and push tag
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run != 'true' }}
-        run: |
-          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
-            echo "Tag v$VERSION already exists at RELEASE_SHA $RELEASE_SHA — skipping"
-          else
-            git tag "v$VERSION" "$RELEASE_SHA"
-            git push origin "v$VERSION"
+            set +e
+            git merge-base --is-ancestor "$REMOTE_MAIN" "$RELEASE_SHA"
+            ancestor_status=$?
+            set -e
+            case "$ancestor_status" in
+              0)
+                git push --force origin "$RELEASE_SHA:refs/heads/main"
+                echo "Fast-forwarded main to $RELEASE_SHA"
+                ;;
+              1)
+                echo "::error::origin/main ($REMOTE_MAIN) is not an ancestor of RELEASE_SHA $RELEASE_SHA."
+                echo "::error::Force-pushing would rewind main to an older release. Manual intervention required."
+                exit 1
+                ;;
+              *)
+                echo "::error::Ancestry check failed (exit $ancestor_status) for origin/main ($REMOTE_MAIN) vs RELEASE_SHA $RELEASE_SHA"
+                exit 1
+                ;;
+            esac
           fi
 
       # --- GitHub Release (skip on dry-run) ---
-      # If the release already exists, verify it's attached to v$VERSION and
-      # fill in any missing dist/* assets (a previous run could have created
-      # the release and then died mid-upload).
+      # If the release already exists, verify it's attached to v$VERSION, then
+      # check each expected dist/* asset. Present assets are SHA256-compared
+      # against the local build; matching assets are skipped, mismatched assets
+      # fail loudly (never silently overwrite), and missing assets get uploaded.
       - name: Create GitHub Release
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "v$VERSION" >/dev/null 2>&1; then
-            EXISTING_TAG=$(gh release view "v$VERSION" --json tagName --jq .tagName)
-            if [ "$EXISTING_TAG" != "v$VERSION" ]; then
-              echo "::error::Release v$VERSION is attached to tag $EXISTING_TAG, expected v$VERSION"
-              exit 1
-            fi
-            echo "Release v$VERSION exists — filling in any missing dist/* assets"
-            existing_assets=$(gh release view "v$VERSION" --json assets --jq '.assets[].name')
-            for f in dist/*; do
-              name=$(basename "$f")
-              if echo "$existing_assets" | grep -Fxq "$name"; then
-                echo "  asset already uploaded: $name"
-              else
-                echo "  uploading missing asset: $name"
-                gh release upload "v$VERSION" "$f"
-              fi
-            done
-          else
+          release_json=$(gh release view "v$VERSION" --json tagName,assets 2>/dev/null) || release_json=""
+          if [ -z "$release_json" ]; then
             gh release create "v$VERSION" dist/* \
               --title "v$VERSION" \
               --generate-notes
+            exit 0
           fi
+          existing_tag=$(echo "$release_json" | jq -r '.tagName')
+          if [ "$existing_tag" != "v$VERSION" ]; then
+            echo "::error::Release v$VERSION is attached to tag $existing_tag, expected v$VERSION"
+            exit 1
+          fi
+          echo "Release v$VERSION exists — reconciling dist/* assets by SHA256"
+          mkdir -p existing-assets
+          existing_assets=$(echo "$release_json" | jq -r '.assets[].name')
+          for f in dist/*; do
+            name=$(basename "$f")
+            if echo "$existing_assets" | grep -Fxq "$name"; then
+              gh release download "v$VERSION" --pattern "$name" --dir existing-assets --clobber
+              local_hash=$(sha256sum "$f" | awk '{print $1}')
+              remote_hash=$(sha256sum "existing-assets/$name" | awk '{print $1}')
+              if [ "$local_hash" = "$remote_hash" ]; then
+                echo "  asset matches local build: $name"
+              else
+                echo "::error::Release asset $name hash mismatch (remote=$remote_hash local=$local_hash)."
+                echo "::error::The existing asset was built from a different commit. Manual intervention required."
+                exit 1
+              fi
+            else
+              echo "  uploading missing asset: $name"
+              gh release upload "v$VERSION" "$f"
+            fi
+          done
 
       # --- Docker image ---
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary

During the v0.5.0 release, branch protection on `develop` rejected the workflow's push-to-develop step (GitHub Actions' `GITHUB_TOKEN` can't bypass admin-protected rules). Result: `kitaru==0.5.0` published to PyPI, but the tag / main update / Docker / Helm steps all got skipped, leaving a partial state.

This PR makes every mutating step in `release.yml` safe to re-run from any partial state, using **SHA-identity checks (not existence checks)** to eliminate the split-brain release risk where different runs could silently assemble one version from different commits.

## Key design: identity, not existence, anchored as early as possible

1. **Pre-checkout** — if `v$VERSION` already exists on origin (partial recovery), the workflow checks out the tag instead of `develop`, so the rest of the workflow runs against the canonical release commit. Uses `gh api` so no auth token is threaded through a shell URL.
2. **Tag-before-PyPI** — the tag is created **before** PyPI publish, not after. This makes the tag the durable identity anchor from the first moment any external artifact is published. Without this, a failure after PyPI but before tag push would leave PyPI with artifacts from one commit and no immutable ref to anchor the next run.
3. **"Verify release SHA consistency"** — captures `$RELEASE_SHA` from HEAD, cross-checks against the tag if it exists, and verifies the CHANGELOG has a `## [$VERSION]` section. Any divergence fails loudly.
4. Every downstream guard (`push-to-develop`, `release/$VERSION`, `main`, GitHub Release assets) compares against `$RELEASE_SHA` — not "does this exist?".

## Changes

| Step | Guard behavior |
|---|---|
| **Determine checkout ref** (new, dispatch only) | If `v$VERSION` exists, check out the tag; else `develop`. Caches `$TAG_EXISTS_AT_START` to avoid re-probing downstream. |
| **Verify release SHA consistency** (new) | Captures `$RELEASE_SHA`; verifies it matches `v$VERSION` tag if present; requires CHANGELOG section exists. Runs on both trigger events. |
| Update CHANGELOG.md | Skip if `## [VERSION]` section already present. |
| Commit release changes | Skip if `git diff --cached --quiet`. |
| **Create and push tag** (moved before PyPI) | Create only when tag is missing; skips otherwise. Now anchors identity before any external artifact is published. |
| Publish to PyPI | `skip-existing: true` — now safe because the tag upstream guarantees SHA consistency. |
| Push release commit to develop | Skip if `origin/develop` already contains `$RELEASE_SHA` in its history. Distinguishes `merge-base --is-ancestor` exit 1 (not ancestor) from exit 128 (fatal git error). |
| Create release branch | Create if missing; skip if at `$RELEASE_SHA`; **error** if diverged. |
| Update main to release | Fast-forward only if `main` is an ancestor of `$RELEASE_SHA`; **error** if main is ahead (would rewind). Same `set +e` + exit-code `case` pattern. |
| Create GitHub Release | Create if missing. If exists: verify tag attachment; for each `dist/*` asset, SHA256-compare against the existing one — matching = skip, mismatched = **error**, missing = upload. Three `gh release view` calls collapsed into one `--json tagName,assets`. |

## Review feedback addressed

This PR has been through two rounds of review.

**First review** (on the initial existence-only guards) identified split-brain risk. Addressed in commit `d584511` by introducing `$RELEASE_SHA` and identity comparisons.

**Second review** (on the identity guards) identified that:
- PyPI publishes before the tag existed, so split-brain was still possible pre-tag.
- Existing-tag recovery path's "check out and retry" error was not actionable via workflow_dispatch.
- GitHub Release asset repair trusted filename only.
- CHANGELOG invariant wasn't verified.
- `git merge-base --is-ancestor` conflated exit 1 with exit 128.

All five addressed in commit `a1ca913`:
- Tag creation moved before PyPI publish.
- Dispatch checkout-ref is now tag-aware via `gh api`.
- Asset repair does SHA256 comparison before skipping.
- CHANGELOG section presence is a hard invariant.
- Ancestry checks use `set +e` + `case` on exit status.

## Test plan

- [ ] CI on this PR passes all 6 required checks on `develop` base.
- [ ] After merge, dispatch with version=0.5.0 to fill in the missing v0.5.0 Docker image and Helm chart. The consistency check should pass (tag matches HEAD), PyPI publish skip-existing, all existing refs should no-op, Docker + Helm should build and push.
- [ ] `zenmldocker/kitaru:0.5.0` exists on Docker Hub afterward.
- [ ] Helm chart is published to ECR Public afterward.

## Follow-up not in this PR

Branch protection on `develop` still blocks the Actions token's push. That's a separate follow-up — add `github-actions[bot]` (or a dedicated deploy key/PAT) to the "Allow bypass" list in the `develop` branch protection rule. Without that, any future normal release with a new version bump commit will still hit the same rejection at the push-to-develop step.

This PR just ensures that when we do fix branch protection, recovery completes cleanly — and that any *future* partial-state recovery can't silently produce a split-brain release.