### PR TITLE
Add zizmor workflow security scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 env:
   ZENML_ANALYTICS_OPT_IN: false
   ZENML_LOGGING_VERBOSITY: INFO
@@ -31,7 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - uses: crate-ci/typos@5745f2a8dd91cd7b684680e2e10a2b388ba6e5cf  # v1
+      - uses: crate-ci/typos@cf5f1c29a8ac336af8568821ec41919923b05a83  # v1.45.1
   typecheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/image-optimiser.yml
+++ b/.github/workflows/image-optimiser.yml
@@ -8,10 +8,11 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-permissions:
-  contents: write
+permissions: {}
 jobs:
   build:
+    permissions:
+      contents: write
     # Only run on non-draft PRs within the same repository.
     if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft
       == false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: pypi
+    environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true' && 'dry-run' || 'pypi' }}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,44 +20,55 @@ on:
         default: false
   push:
     tags: [v*]
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 concurrency:
   group: release
   cancel-in-progress: false
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true' && '' || 'pypi' }}
+    environment: pypi
+    permissions:
+      contents: write
+      id-token: write
     steps:
       # --- Determine version and trigger mode ---
-      - name: Set version from dispatch
-        if: github.event_name == 'workflow_dispatch'
-        run: echo "VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
-      - name: Set version from tag
-        if: github.event_name == 'push'
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
-
-      # --- Validate version ---
-      - name: Validate semver format
+      - name: Determine and validate version
+        env:
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
-            echo "::error::Invalid version format: $VERSION (expected semver like 1.2.3 or 1.2.3-rc.1)"
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION_CANDIDATE="$DISPATCH_VERSION"
+          else
+            VERSION_CANDIDATE="${GITHUB_REF_NAME#v}"
+          fi
+          if ! printf '%s' "$VERSION_CANDIDATE" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Invalid version format: $VERSION_CANDIDATE (expected semver like 1.2.3 or 1.2.3-rc.1)"
             exit 1
           fi
+          printf 'VERSION=%s\n' "$VERSION_CANDIDATE" >> "$GITHUB_ENV"
       - name: Set Kitaru UI tag
-        run: |
-          INPUT_TAG="${{ github.event.inputs.kitaru-ui-tag }}"
-          if [ -n "$INPUT_TAG" ]; then
-            echo "KITARU_UI_TAG=$INPUT_TAG" >> "$GITHUB_ENV"
-          else
-            LATEST_TAG=$(gh release view --repo zenml-io/kitaru-ui --json tagName -q '.tagName')
-            echo "Using latest Kitaru UI release: $LATEST_TAG"
-            echo "KITARU_UI_TAG=$LATEST_TAG" >> "$GITHUB_ENV"
-          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ github.event.inputs.kitaru-ui-tag }}
+        run: |
+          set -euo pipefail
+          validate_tag() {
+            local tag="$1"
+            if ! printf '%s' "$tag" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then
+              echo "::error::Invalid Kitaru UI tag: $tag"
+              exit 1
+            fi
+          }
+          if [ -n "$INPUT_TAG" ]; then
+            KITARU_UI_TAG_VALUE="$INPUT_TAG"
+          else
+            KITARU_UI_TAG_VALUE=$(gh release view --repo zenml-io/kitaru-ui --json tagName -q '.tagName')
+            echo "Using latest Kitaru UI release: $KITARU_UI_TAG_VALUE"
+          fi
+          validate_tag "$KITARU_UI_TAG_VALUE"
+          printf 'KITARU_UI_TAG=%s\n' "$KITARU_UI_TAG_VALUE" >> "$GITHUB_ENV"
       # --- Determine checkout ref (dispatch only) ---
       # Normally checks out `develop`. If v$VERSION already exists on origin,
       # this is a partial-recovery dispatch and we must check out that tag so
@@ -74,12 +85,12 @@ jobs:
         run: |
           if gh api "repos/${{ github.repository }}/git/ref/tags/v$VERSION" --silent 2>/dev/null; then
             echo "Tag v$VERSION exists — recovery mode, checking out tag"
-            echo "ref=refs/tags/v$VERSION" >> "$GITHUB_OUTPUT"
-            echo "TAG_EXISTS_AT_START=true" >> "$GITHUB_ENV"
+            printf 'ref=refs/tags/v%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
+            printf 'TAG_EXISTS_AT_START=true\n' >> "$GITHUB_ENV"
           else
             echo "No existing tag — normal release flow, checking out develop"
-            echo "ref=develop" >> "$GITHUB_OUTPUT"
-            echo "TAG_EXISTS_AT_START=false" >> "$GITHUB_ENV"
+            printf 'ref=develop\n' >> "$GITHUB_OUTPUT"
+            printf 'TAG_EXISTS_AT_START=false\n' >> "$GITHUB_ENV"
           fi
 
       # --- Checkout ---
@@ -90,11 +101,13 @@ jobs:
           ref: ${{ steps.ref.outputs.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Checkout tagged commit (tag push)
         if: github.event_name == 'push'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # --- Configure git ---
       - name: Configure git identity
@@ -107,6 +120,7 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           python-version: '3.12'
+          enable-cache: false
 
       # --- Bump version (dispatch only, skip in recovery mode) ---
       # In recovery mode (tag already exists) we checked out the tag itself,
@@ -178,7 +192,7 @@ jobs:
             echo "::error::The release commit is incomplete — add the changelog entry before retrying."
             exit 1
           fi
-          echo "RELEASE_SHA=$RELEASE_SHA" >> "$GITHUB_ENV"
+          printf 'RELEASE_SHA=%s\n' "$RELEASE_SHA" >> "$GITHUB_ENV"
 
       # --- Verify version matches (tag push only) ---
       - name: Verify tag matches pyproject.toml version
@@ -194,7 +208,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --extra mcp
       - name: Check typos
-        uses: crate-ci/typos@5745f2a8dd91cd7b684680e2e10a2b388ba6e5cf  # v1
+        uses: crate-ci/typos@cf5f1c29a8ac336af8568821ec41919923b05a83  # v1.45.1
       - name: Lint
         run: |
           uv run ruff check .
@@ -242,12 +256,16 @@ jobs:
       # to the same commit (split-brain release risk).
       - name: Create and push tag
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          AUTHENTICATED_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           if [ "$TAG_EXISTS_AT_START" = "true" ]; then
             echo "Tag v$VERSION already exists at RELEASE_SHA $RELEASE_SHA — skipping"
           else
             git tag "v$VERSION" "$RELEASE_SHA"
-            git push origin "v$VERSION"
+            git push "$AUTHENTICATED_REMOTE" "v$VERSION"
           fi
 
       # --- Publish (skip on dry-run) ---
@@ -274,7 +292,11 @@ jobs:
       # --- Push release commit to develop (dispatch only, skip on dry-run) ---
       - name: Push release commit to develop
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          AUTHENTICATED_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           REMOTE_DEVELOP=$(git ls-remote origin refs/heads/develop | awk '{print $1}')
           if [ "$REMOTE_DEVELOP" = "$RELEASE_SHA" ]; then
             echo "origin/develop is at RELEASE_SHA $RELEASE_SHA — skipping push"
@@ -289,7 +311,7 @@ jobs:
                 echo "origin/develop ($REMOTE_DEVELOP) already contains RELEASE_SHA $RELEASE_SHA — skipping push"
                 ;;
               1)
-                git push origin "$RELEASE_SHA:refs/heads/develop"
+                git push "$AUTHENTICATED_REMOTE" "$RELEASE_SHA:refs/heads/develop"
                 ;;
               *)
                 echo "::error::Ancestry check failed (exit $ancestor_status) for origin/develop ($REMOTE_DEVELOP) vs RELEASE_SHA $RELEASE_SHA"
@@ -304,10 +326,14 @@ jobs:
       # than silently overwriting an archival branch or rewinding main.
       - name: Create release branch
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          AUTHENTICATED_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           REMOTE_SHA=$(git ls-remote --heads origin "refs/heads/release/$VERSION" | awk '{print $1}')
           if [ -z "$REMOTE_SHA" ]; then
-            git push origin "$RELEASE_SHA:refs/heads/release/$VERSION"
+            git push "$AUTHENTICATED_REMOTE" "$RELEASE_SHA:refs/heads/release/$VERSION"
             echo "Created release/$VERSION at $RELEASE_SHA"
           elif [ "$REMOTE_SHA" = "$RELEASE_SHA" ]; then
             echo "release/$VERSION is already at RELEASE_SHA $RELEASE_SHA — skipping"
@@ -318,7 +344,11 @@ jobs:
           fi
       - name: Update main to release
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          AUTHENTICATED_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           REMOTE_MAIN=$(git ls-remote origin refs/heads/main | awk '{print $1}')
           if [ "$REMOTE_MAIN" = "$RELEASE_SHA" ]; then
             echo "origin/main is already at RELEASE_SHA $RELEASE_SHA — skipping"
@@ -329,7 +359,7 @@ jobs:
             set -e
             case "$ancestor_status" in
               0)
-                git push --force origin "$RELEASE_SHA:refs/heads/main"
+                git push --force-with-lease=refs/heads/main:"$REMOTE_MAIN" "$AUTHENTICATED_REMOTE" "$RELEASE_SHA:refs/heads/main"
                 echo "Fast-forwarded main to $RELEASE_SHA"
                 ;;
               1)
@@ -442,7 +472,7 @@ jobs:
       - name: Login to Amazon ECR Public (Helm)
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
         id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78  # v2
+        uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78  # v2.1.2
         with:
           mask-password: 'true'
           registry-type: public

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - site/**
       - docs/**
@@ -14,9 +15,7 @@ on:
       - wrangler.toml
   pull_request_target:
     types: [closed]
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 concurrency:
   group: site-${{ github.event_name == 'pull_request' && github.event.pull_request.number
     || github.ref }}
@@ -25,6 +24,9 @@ jobs:
   build-deploy:
     if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       HAS_CF_SECRETS: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
     steps:
@@ -34,6 +36,8 @@ jobs:
 
       # --- Generate docs content (Python-only generators) ---
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          enable-cache: false
       - run: uv sync --frozen
       - run: uv run python scripts/generate_cli_docs.py
       - run: uv run python scripts/generate_changelog_docs.py
@@ -42,13 +46,10 @@ jobs:
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb  # v6.0.0
         with:
           version: 10.33.0
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version-file: docs/.node-version
-          cache: pnpm
-          cache-dependency-path: |
-            docs/pnpm-lock.yaml
-            site/pnpm-lock.yaml
+          package-manager-cache: false
       - run: pnpm install --frozen-lockfile
         working-directory: docs
 
@@ -82,7 +83,7 @@ jobs:
       - name: Deploy production
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name
           == 'workflow_dispatch'
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65  # v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65  # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -95,7 +96,7 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name
           == github.repository && env.HAS_CF_SECRETS == 'true'
         id: preview
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65  # v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65  # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -105,7 +106,7 @@ jobs:
       # --- Sticky PR comment with preview URL ---
       - name: Comment preview URL
         if: steps.preview.outcome == 'success'
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
         with:
           header: site-preview
           message: |
@@ -116,14 +117,19 @@ jobs:
             | **Branch** | `${{ github.head_ref }}` |
             | **Commit** | `${{ github.sha }}` |
 
-  # --- Clean up preview Worker when PR closes ---
+  # --- Clean up preview Worker when same-repo PR closes ---
   cleanup-preview:
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name
+      == github.repository
     runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      HAS_CF_SECRETS: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
     steps:
       - name: Delete preview Worker
+        if: env.HAS_CF_SECRETS == 'true'
         continue-on-error: true
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65  # v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65  # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,6 +11,8 @@ concurrency:
   # New commit on branch cancels running workflows of the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   spellcheck:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
@@ -21,7 +23,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Spelling checker
-        uses: crate-ci/typos@2361394247a38536a5f2376a05181ca001dd9e26  # v1.17.0
+        uses: crate-ci/typos@cf5f1c29a8ac336af8568821ec41919923b05a83  # v1.45.1
         with:
           files: .
           config: ./.typos.toml

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,62 @@
+---
+name: GitHub Actions Security Analysis
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - .github/workflows/**
+      - .github/zizmor.yml
+      - .github/dependabot.yml
+  pull_request:
+    paths:
+      - .github/workflows/**
+      - .github/zizmor.yml
+      - .github/dependabot.yml
+  # Weekly safety net to catch drift from new zizmor releases (Monday 3am UTC).
+  schedule:
+    - cron: 0 3 * * 1
+  workflow_dispatch:
+permissions: {}
+jobs:
+  zizmor:
+    name: Scan workflows with zizmor
+    runs-on: ubuntu-latest
+    # Only run on the main repo, not forks (scheduled runs would fail on forks).
+    if: github.repository == 'zenml-io/kitaru'
+    permissions:
+      contents: read
+      actions: read
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+      - name: Run zizmor
+        run: |
+          echo "============================================================"
+          echo "🔒 Zizmor: GitHub Actions Security Scanner"
+          echo "============================================================"
+          echo ""
+          echo "This check scans workflow files for security issues like:"
+          echo "  • Unpinned actions (supply chain risk)"
+          echo "  • SHA/version comment mismatches"
+          echo "  • Template injection vulnerabilities"
+          echo "  • Excessive token permissions"
+          echo ""
+          echo "This workflow intentionally uses 'uvx zizmor' without a package"
+          echo "version pin so CI runs the latest released zizmor version."
+          echo ""
+          echo "📖 To run locally and see detailed output:"
+          echo ""
+          echo "    GH_TOKEN=\$(gh auth token) uvx zizmor --config=.github/zizmor.yml .github/workflows/ .github/dependabot.yml"
+          echo ""
+          echo "📖 Documentation: https://docs.zizmor.sh/"
+          echo "📖 Config: .github/zizmor.yml"
+          echo "============================================================"
+          echo ""
+          uvx zizmor --format=github --config=.github/zizmor.yml .github/workflows/ .github/dependabot.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+---
+# Kitaru's zizmor policy:
+# - Fix GitHub Actions security findings whenever practical.
+# - Keep this file limited to narrow, documented exceptions.
+# - Do not copy broad suppressions from the larger ZenML monorepo config.
+rules:
+  # dangerous-triggers: site.yml uses pull_request_target only for preview
+  # cleanup on closed same-repo PRs. The cleanup job does not checkout or run
+  # PR-controlled code; it only deletes a deterministic Cloudflare Worker name.
+  dangerous-triggers:
+    ignore: [site.yml:3]

--- a/Justfile
+++ b/Justfile
@@ -54,6 +54,11 @@ yaml-check:
 actions-lint:
     actionlint
 
+# Audit GitHub Actions workflows with zizmor. For richer online checks, run:
+#   GH_TOKEN=$(gh auth token) just zizmor
+zizmor:
+    uvx zizmor --config=.github/zizmor.yml .github/workflows/ .github/dependabot.yml
+
 # Check links in markdown files — offline only (requires lychee: brew install lychee)
 links:
     lychee --offline --root-dir . --exclude-path '.venv' --exclude-path 'docs/node_modules' --exclude-path 'site/node_modules' --exclude-path 'design' './**/*.md'


### PR DESCRIPTION
## Summary

- Add a dedicated GitHub Actions Security Analysis workflow that runs the latest released `zizmor` via `uvx`.
- Add a minimal Kitaru-specific `.github/zizmor.yml` with one documented cleanup-only `pull_request_target` exception.
- Harden existing workflows with explicit permissions, safer release input handling, non-persisted release checkouts, explicit release push authentication, cache-poisoning fixes, and refreshed `crate-ci/typos` action pins.
- Add `just zizmor` for local workflow security scans.

## Why

This adds automated GitHub Actions security auditing so workflow hardening does not rely on one-off manual checks. It follows the same general shape as the ZenML repository setup, but keeps Kitaru's config narrower and fixes findings directly where practical.

Closes #78.

## Validation

- `uv run yamlfix --check .github/`
- `actionlint`
- `GH_TOKEN=$(gh auth token) timeout 120 uvx zizmor --no-progress --format=plain --config=.github/zizmor.yml .github/workflows/ .github/dependabot.yml`
- `GH_TOKEN=$(gh auth token) just zizmor`
- `uvx typos .github Justfile`
- `git diff --check`

## Reviewer focus

- `release.yml` push authentication after setting `persist-credentials: false` on checkout.
- `site.yml` preview cleanup: the `pull_request_target` job is intentionally retained for closed-PR cleanup, but it has no checkout, no GitHub token permissions, and only acts on same-repo PRs.
