### PR TITLE
Combine kitaru-vs-{temporal,dbos,restate} comparisons + drop competitorTagline

### DIFF
--- a/site/public/compare/dbos.svg
+++ b/site/public/compare/dbos.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none">
+  <rect width="40" height="40" rx="8" fill="#E6F0FF"/>
+  <text x="20" y="26" text-anchor="middle" font-family="DM Sans, system-ui, sans-serif" font-size="16" font-weight="700" fill="#1E3A8A">D</text>
+</svg>

--- a/site/public/compare/restate.svg
+++ b/site/public/compare/restate.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none">
+  <rect width="40" height="40" rx="8" fill="#EDE9F6"/>
+  <path d="M12 13 L19 20 L12 27" stroke="#2B2460" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M21 13 L28 20 L21 27" stroke="#2B2460" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/site/public/compare/temporal.svg
+++ b/site/public/compare/temporal.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" fill="none" aria-hidden="true">
+  <ellipse cx="20" cy="20" rx="17.5" ry="5.5" stroke="#1A1714" stroke-width="2.2"/>
+  <ellipse cx="20" cy="20" rx="5.5" ry="17.5" stroke="#1A1714" stroke-width="2.2"/>
+</svg>

--- a/site/src/components/compare/CodeCompare.astro
+++ b/site/src/components/compare/CodeCompare.astro
@@ -100,6 +100,8 @@ const {
     font-size: 13px;
     line-height: 1.6;
     background: transparent !important;
+    border: 0 !important;
+    border-radius: 0 !important;
     overflow-x: auto;
   }
   .codecompare-code :global(code) {

--- a/site/src/components/compare/CodePane.astro
+++ b/site/src/components/compare/CodePane.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * CodePane — single syntax-highlighted code pane.
+ *
+ * Use inside a FeatureWithGraphic `graphic` slot when a feature row should
+ * pair prose with a code block instead of a custom graphic.
+ */
+import { Code } from 'astro:components';
+import type { ThemeRegistrationRaw } from 'shiki';
+import kitaruLight from '../../styles/kitaru-light.json';
+
+interface Props {
+  code: string;
+  lang?: string;
+}
+
+const { code, lang = 'python' } = Astro.props;
+---
+
+<article class="codepane">
+  <Code code={code} lang={lang} theme={kitaruLight as ThemeRegistrationRaw} />
+</article>
+
+<style>
+  .codepane {
+    width: 100%;
+    border: 1px solid oklch(0.85 0.08 60);
+    border-radius: 12px;
+    background: var(--color-surface);
+    overflow: hidden;
+  }
+  .codepane :global(pre) {
+    margin: 0;
+    padding: 20px;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    line-height: 1.6;
+    background: transparent !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    overflow-x: auto;
+  }
+  .codepane :global(code) {
+    font-family: inherit;
+  }
+</style>

--- a/site/src/components/compare/ComparisonHero.astro
+++ b/site/src/components/compare/ComparisonHero.astro
@@ -4,9 +4,8 @@ interface Props {
   description: string;
   competitor: string;
   competitorLogo?: string;
-  competitorTagline?: string;
 }
-const { title, description, competitor, competitorLogo, competitorTagline } = Astro.props;
+const { title, description, competitor, competitorLogo } = Astro.props;
 ---
 
 <header class="chero">
@@ -30,8 +29,6 @@ const { title, description, competitor, competitorLogo, competitorTagline } = As
         <span class="chero-name">{competitor}</span>
       </span>
     </div>
-
-    {competitorTagline && <p class="chero-tagline">{competitorTagline}</p>}
 
     <h1 class="chero-title">{title}</h1>
     <p class="chero-desc">{description}</p>
@@ -106,14 +103,6 @@ const { title, description, competitor, competitorLogo, competitorTagline } = As
     font-style: italic;
     font-size: 20px;
     color: var(--color-muted);
-  }
-  .chero-tagline {
-    font-size: 15px;
-    line-height: 1.55;
-    color: var(--color-muted);
-    max-width: 560px;
-    margin: 0 auto 24px;
-    font-style: italic;
   }
   .chero-title {
     font-size: clamp(32px, 4.4vw, 48px);

--- a/site/src/components/compare/FeatureWithGraphic.astro
+++ b/site/src/components/compare/FeatureWithGraphic.astro
@@ -8,12 +8,13 @@
  */
 interface Props {
   title: string;
-  image: string;
+  image?: string;
   imageAlt?: string;
   reverse?: boolean;
 }
 
 const { title, image, imageAlt = '', reverse = false } = Astro.props;
+const hasGraphic = Astro.slots.has('graphic');
 ---
 
 <section class:list={["feature-graphic", { "feature-graphic--reverse": reverse }]} data-reveal>
@@ -25,7 +26,7 @@ const { title, image, imageAlt = '', reverse = false } = Astro.props;
       </div>
     </div>
     <div class="feature-graphic-media">
-      <img src={image} alt={imageAlt} loading="lazy" decoding="async" />
+      {hasGraphic ? <slot name="graphic" /> : image && <img src={image} alt={imageAlt} loading="lazy" decoding="async" />}
     </div>
   </div>
 </section>

--- a/site/src/components/compare/graphics/dbos/ArtifactVersioning.astro
+++ b/site/src/components/compare/graphics/dbos/ArtifactVersioning.astro
@@ -1,0 +1,261 @@
+---
+---
+
+<figure class="fig">
+  <div class="tree tree--a">
+    <div class="head">
+      <span class="exec">exec_id 9f2a</span>
+      <span class="ts">today · 14:02</span>
+    </div>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint research</span>
+        <span class="cost">$0.03</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">brief.json</span>
+        <span class="version">v3</span>
+      </div>
+    </div>
+    <svg class="conn" viewBox="0 0 6 14" aria-hidden="true"><path d="M3 0 L3 14" /></svg>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint draft</span>
+        <span class="cost">$0.08</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">draft.md</span>
+        <span class="version">v3</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="diff">
+    <span class="diff-label">diff</span>
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M8 4 L4 8 L8 12" />
+      <path d="M16 12 L20 16 L16 20" />
+      <path d="M4 8 L20 8 M20 16 L4 16" />
+    </svg>
+    <span class="diff-sub">across runs</span>
+  </div>
+
+  <div class="tree tree--b">
+    <div class="head">
+      <span class="exec">exec_id 7c1b</span>
+      <span class="ts">Mon · 11:47</span>
+    </div>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint research</span>
+        <span class="cost">$0.04</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">brief.json</span>
+        <span class="version version--old">v1</span>
+      </div>
+    </div>
+    <svg class="conn" viewBox="0 0 6 14" aria-hidden="true"><path d="M3 0 L3 14" /></svg>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint draft</span>
+        <span class="cost">$0.09</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">draft.md</span>
+        <span class="version version--old">v1</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="contrast">
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M4 6 L20 6 M4 12 L20 12 M4 18 L20 18" />
+    </svg>
+    <span><strong>DBOS:</strong> step I/O is persisted in Postgres to resume workflows. It isn't surfaced as versioned, cross-run artifacts with a dedicated diff view.</span>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 96px 1fr;
+    gap: 8px;
+    align-items: start;
+    margin: 0;
+    padding: 0;
+  }
+
+  .tree {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    background: var(--color-surface);
+    padding: 14px 14px 16px;
+  }
+  .tree--b {
+    opacity: 0.88;
+    background: var(--color-surface-warm);
+  }
+
+  .head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--color-border-light);
+  }
+  .exec {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-accent);
+  }
+  .tree--b .exec { color: var(--color-muted); }
+  .ts {
+    font-size: 10.5px;
+    color: var(--color-muted);
+  }
+
+  .step {
+    padding: 8px 10px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 6px;
+    background: var(--color-surface-warm);
+  }
+  .tree--b .step { background: var(--color-surface); }
+
+  .step-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+  .cp {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+  .cost {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-muted);
+    padding: 2px 6px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-light);
+    border-radius: 3px;
+  }
+  .artifacts {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .artifact {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    padding: 3px 8px;
+    background: var(--color-accent-light);
+    color: var(--color-accent-deep);
+    border-radius: 4px;
+  }
+  .version {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 700;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: var(--color-accent);
+    color: var(--color-surface);
+    letter-spacing: 0.03em;
+  }
+  .version--old {
+    background: var(--color-border-light);
+    color: var(--color-muted);
+  }
+  .conn {
+    display: block;
+    width: 6px;
+    height: 14px;
+    margin: 2px auto;
+    fill: none;
+    stroke: var(--color-border);
+    stroke-width: 1.5;
+  }
+
+  .diff {
+    align-self: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding-top: 60px;
+  }
+  .diff-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--color-accent);
+    padding: 3px 8px;
+    background: var(--color-accent-light);
+    border-radius: 3px;
+    text-transform: uppercase;
+  }
+  .diff svg {
+    width: 28px;
+    height: 28px;
+    fill: none;
+    stroke: var(--color-accent);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .diff-sub {
+    font-size: 9.5px;
+    color: var(--color-muted);
+    text-align: center;
+    margin-top: 2px;
+  }
+
+  .contrast {
+    grid-column: 1 / -1;
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    margin-top: 6px;
+    padding: 10px 12px;
+    background: var(--color-surface-warm);
+    border-left: 2px solid var(--color-muted);
+    border-radius: 4px;
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+  .contrast svg {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    margin-top: 2px;
+    fill: none;
+    stroke: var(--color-muted);
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    opacity: 0.6;
+  }
+  .contrast strong {
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  @media (max-width: 560px) {
+    .fig {
+      grid-template-columns: 1fr;
+    }
+    .diff { padding-top: 0; flex-direction: row; gap: 10px; }
+    .diff svg { transform: rotate(90deg); }
+    .contrast { grid-column: auto; }
+  }
+</style>

--- a/site/src/components/compare/graphics/dbos/LLMPrimitive.astro
+++ b/site/src/components/compare/graphics/dbos/LLMPrimitive.astro
@@ -1,0 +1,202 @@
+---
+---
+
+<figure class="fig">
+  <div class="dbos-row">
+    <span class="tag tag--muted">DBOS · @DBOS.step</span>
+    <div class="opaque">
+      <code>openai.chat.completions.create(prompt=&hellip;)</code>
+      <span class="dim">OTel traces via instrumentation. You own alias resolution and secrets.</span>
+    </div>
+  </div>
+
+  <div class="record">
+    <div class="record-head">
+      <span class="tag tag--accent">Kitaru · kitaru.llm()</span>
+      <span class="mono exec">checkpoint: research · exec_id 9f2a&hellip;</span>
+    </div>
+
+    <div class="mono-call">
+      <span class="fn">kitaru.llm</span>(<span class="str">prompt</span>, <span class="str">model=</span><span class="val">"fast"</span>)
+    </div>
+
+    <dl class="fields">
+      <div>
+        <dt>prompt</dt>
+        <dd class="mono">Research: Durable agents&hellip;</dd>
+      </div>
+      <div>
+        <dt>response</dt>
+        <dd class="mono">Durable execution keeps&hellip;</dd>
+      </div>
+      <div class="row">
+        <div class="chip">
+          <span class="chip-k">tokens</span><span class="chip-v">1,247</span>
+        </div>
+        <div class="chip">
+          <span class="chip-k">latency</span><span class="chip-v">2.8s</span>
+        </div>
+        <div class="chip">
+          <span class="chip-k">cost</span><span class="chip-v">$0.028</span>
+        </div>
+      </div>
+    </dl>
+
+    <div class="replay">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M3 12 A9 9 0 1 0 6 5 L3 8 M3 3 L3 8 L8 8" />
+      </svg>
+      <span>Logs roll up under the enclosing checkpoint. No separate LLM pipeline.</span>
+    </div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    margin: 0;
+    padding: 0;
+  }
+  .tag {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 3px 8px;
+    border-radius: 4px;
+  }
+  .tag--muted {
+    background: var(--color-border-light);
+    color: var(--color-muted);
+  }
+  .tag--accent {
+    background: var(--color-accent-light);
+    color: var(--color-accent-deep);
+  }
+
+  .dbos-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px 14px;
+    border: 1px dashed var(--color-border);
+    border-radius: 10px;
+    background: var(--color-surface-warm);
+  }
+  .opaque {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .opaque code {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+  .opaque .dim {
+    font-size: 11px;
+    color: var(--color-muted);
+    font-style: italic;
+  }
+
+  .record {
+    padding: 16px 18px 18px;
+    border: 1px solid var(--color-accent);
+    border-radius: 12px;
+    background: var(--color-surface);
+    box-shadow: 0 1px 0 var(--color-border);
+  }
+  .record-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+  }
+  .exec {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-muted);
+  }
+  .mono-call {
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    color: var(--color-primary);
+    padding: 10px 12px;
+    border-radius: 6px;
+    background: var(--color-bg);
+    margin-bottom: 12px;
+  }
+  .fn { color: var(--color-accent); font-weight: 600; }
+  .str { color: var(--color-secondary); }
+  .val { color: var(--color-accent-deep); }
+
+  .fields { margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+  .fields > div { display: grid; grid-template-columns: 70px 1fr; gap: 10px; align-items: center; }
+  .fields dt {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin: 0;
+  }
+  .fields dd {
+    margin: 0;
+    font-size: 12.5px;
+    color: var(--color-primary);
+    padding: 6px 10px;
+    background: var(--color-accent-light);
+    border-radius: 4px;
+  }
+  .fields .mono {
+    font-family: var(--font-mono);
+  }
+
+  .fields > div.row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 5px 10px;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: var(--color-surface);
+    font-size: 11px;
+  }
+  .chip-k { color: var(--color-muted); font-weight: 600; text-transform: uppercase; font-size: 9.5px; letter-spacing: 0.05em; }
+  .chip-v {
+    font-family: var(--font-mono);
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  .replay {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid var(--color-border-light);
+    font-size: 11.5px;
+    color: var(--color-secondary);
+  }
+  .replay svg {
+    width: 14px;
+    height: 14px;
+    fill: none;
+    stroke: var(--color-accent);
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+</style>

--- a/site/src/components/compare/graphics/dbos/NamedDeployments.astro
+++ b/site/src/components/compare/graphics/dbos/NamedDeployments.astro
@@ -1,0 +1,225 @@
+---
+---
+
+<figure class="fig">
+  <div class="panel panel--competitor">
+    <div class="panel-head">
+      <span class="panel-label">DBOS</span>
+      <span class="panel-sub">Queue + schedule shape</span>
+    </div>
+    <div class="primitives">
+      <div class="prim">
+        <span class="prim-key">@DBOS.scheduled("0 * * * *")</span>
+        <span class="prim-val">cron on the workflow</span>
+      </div>
+      <div class="prim">
+        <span class="prim-key">Queue("work", concurrency=8)</span>
+        <span class="prim-val">concurrency + dedup</span>
+      </div>
+      <div class="prim prim--muted">
+        <span class="prim-key">workflow_id = uuid4()</span>
+        <span class="prim-val">you assign it; app code starts the run</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel--kitaru">
+    <div class="panel-head">
+      <span class="panel-label panel-label--accent">Kitaru</span>
+      <span class="panel-sub">Named, versioned deployment with tag routing</span>
+    </div>
+    <div class="deployment">
+      <div class="dep-head">
+        <span class="mono name">review_flow</span>
+        <span class="mono version">@v3</span>
+      </div>
+      <div class="tags">
+        <span class="tag tag--default">default</span>
+        <span class="tag">staging</span>
+        <span class="tag tag--muted">preview</span>
+      </div>
+    </div>
+    <div class="invokes">
+      <div class="invoke-label">Invoke by name</div>
+      <div class="invoke-chips">
+        <span class="chip">CLI</span>
+        <span class="chip">SDK</span>
+        <span class="chip">MCP</span>
+        <span class="chip">curl</span>
+      </div>
+    </div>
+    <div class="auth">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <rect x="5" y="11" width="14" height="10" rx="2" />
+        <path d="M8 11 V7 a4 4 0 0 1 8 0 V11" />
+      </svg>
+      <span>Workspace-scoped keys. No per-deployment tokens to rotate.</span>
+    </div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 0;
+    padding: 0;
+  }
+  .panel {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 16px 16px 18px;
+    background: var(--color-surface);
+    display: flex;
+    flex-direction: column;
+  }
+  .panel--competitor { background: var(--color-surface-warm); }
+  .panel--kitaru { border-color: var(--color-accent); }
+
+  .panel-head { margin-bottom: 14px; }
+  .panel-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 4px;
+  }
+  .panel-label--accent { color: var(--color-accent); }
+  .panel-sub {
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+
+  .primitives {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .prim {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 10px 12px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 8px;
+    background: var(--color-surface);
+  }
+  .prim--muted { opacity: 0.85; border-style: dashed; }
+  .prim-key {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--color-primary);
+  }
+  .prim-val {
+    font-size: 11px;
+    color: var(--color-secondary);
+  }
+
+  .deployment {
+    padding: 12px 14px;
+    border: 1px solid var(--color-accent);
+    border-radius: 10px;
+    background: var(--color-surface);
+    margin-bottom: 12px;
+  }
+  .dep-head {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 10px;
+  }
+  .mono {
+    font-family: var(--font-mono);
+  }
+  .name {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+  .version {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--color-accent);
+  }
+
+  .tags {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .tag {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    font-weight: 600;
+    padding: 3px 9px;
+    border-radius: 999px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: var(--color-primary);
+  }
+  .tag--default {
+    background: var(--color-accent);
+    color: var(--color-surface);
+    border-color: var(--color-accent);
+  }
+  .tag--muted {
+    color: var(--color-muted);
+    background: var(--color-surface-warm);
+  }
+
+  .invokes {
+    margin-bottom: 12px;
+  }
+  .invoke-label {
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 6px;
+  }
+  .invoke-chips {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .chip {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    padding: 5px 10px;
+    border-radius: 6px;
+    background: var(--color-accent-light);
+    color: var(--color-accent-deep);
+    border: 1px solid var(--color-border-light);
+  }
+
+  .auth {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: auto;
+    padding-top: 10px;
+    border-top: 1px solid var(--color-border-light);
+    font-size: 11.5px;
+    color: var(--color-secondary);
+  }
+  .auth svg {
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+    fill: none;
+    stroke: var(--color-accent);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  @media (max-width: 560px) {
+    .fig { grid-template-columns: 1fr; }
+  }
+</style>

--- a/site/src/components/compare/graphics/dbos/StackDeployment.astro
+++ b/site/src/components/compare/graphics/dbos/StackDeployment.astro
@@ -1,0 +1,232 @@
+---
+---
+
+<figure class="fig">
+  <div class="panel panel--competitor">
+    <div class="panel-head">
+      <span class="panel-label">DBOS</span>
+      <span class="panel-sub">Library embedded in your Python service</span>
+    </div>
+    <div class="stack">
+      <div class="card">
+        <span class="mono dim">your_app.py</span>
+        <span class="mono accent">import DBOS</span>
+      </div>
+      <svg class="arrow" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 4 L12 20 M6 14 L12 20 L18 14" />
+      </svg>
+      <div class="card card--soft">
+        <span class="mono primary">deploy anywhere Python deploys</span>
+        <span class="mono dim">your container · your VM · your FaaS</span>
+      </div>
+      <svg class="arrow" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 4 L12 20 M6 14 L12 20 L18 14" />
+      </svg>
+      <div class="db">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <ellipse cx="12" cy="5" rx="8" ry="3" />
+          <path d="M4 5 L4 19 A8 3 0 0 0 20 19 L20 5" />
+          <path d="M4 12 A8 3 0 0 0 20 12" />
+        </svg>
+        <span class="mono">your Postgres</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel--kitaru">
+    <div class="panel-head">
+      <span class="panel-label panel-label--accent">Kitaru</span>
+      <span class="panel-sub">Stack-targeted deploy, one config swap</span>
+    </div>
+    <div class="flow">
+      <div class="cmd">
+        <span class="mono accent">kitaru build</span>
+        <span class="mono dim">package flow as container</span>
+      </div>
+      <svg class="arrow" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 4 L12 20 M6 14 L12 20 L18 14" />
+      </svg>
+      <div class="cmd">
+        <span class="mono accent">kitaru deploy --stack sagemaker</span>
+      </div>
+    </div>
+    <div class="targets">
+      <div class="target">
+        <span class="target-key">K8s</span>
+        <span class="target-val">kubernetes</span>
+      </div>
+      <div class="target">
+        <span class="target-key">AWS</span>
+        <span class="target-val">SageMaker</span>
+      </div>
+      <div class="target">
+        <span class="target-key">GCP</span>
+        <span class="target-val">Vertex AI</span>
+      </div>
+      <div class="target">
+        <span class="target-key">Az</span>
+        <span class="target-val">AzureML</span>
+      </div>
+    </div>
+    <div class="bucket">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M4 8 L20 8 L18.5 20 L5.5 20 Z M4 8 L6 4 L18 4 L20 8" />
+      </svg>
+      <span class="mono">artifacts in your own S3 · GCS · Azure Blob</span>
+    </div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 0;
+    padding: 0;
+  }
+  .panel {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 16px 16px 18px;
+    background: var(--color-surface);
+    display: flex;
+    flex-direction: column;
+  }
+  .panel--competitor { background: var(--color-surface-warm); }
+  .panel--kitaru { border-color: var(--color-accent); }
+
+  .panel-head { margin-bottom: 14px; }
+  .panel-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 4px;
+  }
+  .panel-label--accent { color: var(--color-accent); }
+  .panel-sub {
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+
+  .stack, .flow {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+  }
+
+  .card, .cmd {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 10px 12px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 8px;
+    background: var(--color-surface);
+  }
+  .card--soft { background: var(--color-surface-warm); border-style: dashed; }
+  .cmd { background: var(--color-bg); }
+
+  .mono {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+  }
+  .primary { color: var(--color-primary); font-weight: 600; }
+  .accent { color: var(--color-accent); font-weight: 600; }
+  .dim { color: var(--color-muted); }
+
+  .arrow {
+    width: 16px;
+    height: 16px;
+    align-self: center;
+    fill: none;
+    stroke: var(--color-muted);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .db {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-bg);
+  }
+  .db svg {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    fill: none;
+    stroke: var(--color-secondary);
+    stroke-width: 1.5;
+    stroke-linejoin: round;
+  }
+  .db .mono {
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  .targets {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 6px;
+    margin: 10px 0 8px;
+  }
+  .target {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 7px 10px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 6px;
+    background: var(--color-surface-warm);
+  }
+  .target-key {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    font-weight: 700;
+    color: var(--color-accent);
+    letter-spacing: 0.02em;
+  }
+  .target-val {
+    font-size: 11px;
+    color: var(--color-primary);
+    font-weight: 500;
+  }
+
+  .bucket {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--color-accent);
+    border-radius: 8px;
+    background: var(--color-accent-light);
+    margin-top: auto;
+  }
+  .bucket svg {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    fill: none;
+    stroke: var(--color-accent);
+    stroke-width: 1.5;
+    stroke-linejoin: round;
+  }
+  .bucket .mono {
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  @media (max-width: 560px) {
+    .fig { grid-template-columns: 1fr; }
+    .targets { grid-template-columns: 1fr 1fr; }
+  }
+</style>

--- a/site/src/components/compare/graphics/langgraph/SandboxSecurity.astro
+++ b/site/src/components/compare/graphics/langgraph/SandboxSecurity.astro
@@ -1,0 +1,175 @@
+---
+---
+
+<figure class="fig">
+  <div class="panel panel--competitor">
+    <div class="panel-head">
+      <span class="panel-label">LangSmith · packaged security</span>
+      <span class="panel-sub">Isolation bundled with the runtime</span>
+    </div>
+
+    <div class="block">
+      <span class="block-title">LangSmith Sandboxes</span>
+      <span class="block-sub">microVM isolation · Deep Agents integration</span>
+    </div>
+    <div class="block">
+      <span class="block-title">Auth proxy</span>
+      <span class="block-sub">secrets never enter the sandbox</span>
+    </div>
+    <div class="block">
+      <span class="block-title">OpenTelemetry tracing</span>
+      <span class="block-sub">native to the platform</span>
+    </div>
+
+    <div class="foot">Usable isolation story out of the box.</div>
+  </div>
+
+  <div class="panel panel--kitaru">
+    <div class="panel-head">
+      <span class="panel-label panel-label--accent">Kitaru · configurable boundary</span>
+      <span class="panel-sub">Policy at each execution boundary</span>
+    </div>
+
+    <div class="api">
+      <span class="api-call"><span class="fn">@checkpoint</span>(runtime=<span class="str">"isolated"</span>)</span>
+      <span class="api-sub">separate pod / job on your stack</span>
+    </div>
+
+    <div class="rows">
+      <div class="row">
+        <span class="rkey">Sandbox</span>
+        <span class="rval">bring your own provider</span>
+      </div>
+      <div class="row">
+        <span class="rkey">Secrets</span>
+        <span class="rval">your secret manager</span>
+      </div>
+      <div class="row">
+        <span class="rkey">Tracing</span>
+        <span class="rval">OTel, pointed at your backend</span>
+      </div>
+    </div>
+
+    <div class="foot foot--accent">Runtime exposes the boundary. Policy stays with your platform.</div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 0;
+    padding: 0;
+  }
+  .panel {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 16px 16px 14px;
+    background: var(--color-surface);
+    display: flex;
+    flex-direction: column;
+  }
+  .panel--competitor { background: var(--color-surface-warm); }
+  .panel--kitaru { border-color: var(--color-accent); }
+
+  .panel-head { margin-bottom: 14px; }
+  .panel-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 4px;
+  }
+  .panel-label--accent { color: var(--color-accent); }
+  .panel-sub {
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+
+  .block {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 10px 12px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 8px;
+    background: var(--color-surface);
+    margin-bottom: 8px;
+  }
+  .block-title {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+  .block-sub {
+    font-size: 11px;
+    color: var(--color-secondary);
+  }
+
+  .api {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 12px;
+    border: 1px solid var(--color-accent);
+    border-radius: 8px;
+    background: var(--color-accent-light);
+    margin-bottom: 10px;
+  }
+  .api-call {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--color-primary);
+  }
+  .fn { color: var(--color-accent); font-weight: 700; }
+  .str { color: var(--color-accent-deep); }
+  .api-sub {
+    font-size: 11px;
+    color: var(--color-secondary);
+  }
+
+  .rows {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 10px;
+  }
+  .row {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 7px 12px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 6px;
+    background: var(--color-surface-warm);
+  }
+  .rkey {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+  .rval {
+    font-size: 11px;
+    color: var(--color-secondary);
+    text-align: right;
+  }
+
+  .foot {
+    margin-top: auto;
+    font-size: 11px;
+    color: var(--color-muted);
+    font-style: italic;
+  }
+  .foot--accent {
+    color: var(--color-accent-deep);
+    font-style: normal;
+    font-weight: 500;
+  }
+
+  @media (max-width: 560px) {
+    .fig { grid-template-columns: 1fr; }
+  }
+</style>

--- a/site/src/components/compare/graphics/langgraph/SandboxSecurity.astro
+++ b/site/src/components/compare/graphics/langgraph/SandboxSecurity.astro
@@ -10,7 +10,7 @@
 
     <div class="block">
       <span class="block-title">LangSmith Sandboxes</span>
-      <span class="block-sub">microVM isolation · Deep Agents integration</span>
+      <span class="block-sub">ephemeral, locked-down environments</span>
     </div>
     <div class="block">
       <span class="block-title">Auth proxy</span>

--- a/site/src/components/compare/graphics/langgraph/SelfHostVsPackaged.astro
+++ b/site/src/components/compare/graphics/langgraph/SelfHostVsPackaged.astro
@@ -1,0 +1,189 @@
+---
+---
+
+<figure class="fig">
+  <div class="panel panel--competitor">
+    <div class="panel-head">
+      <span class="panel-label">LangSmith · packaged platform</span>
+      <span class="panel-sub">Runtime + infra bundled as a managed product</span>
+    </div>
+    <div class="bundle">
+      <div class="bundle-title">LangSmith Deployment</div>
+      <div class="bundle-pills">
+        <span class="pill">runtime</span>
+        <span class="pill">sandboxes</span>
+        <span class="pill">auth proxy</span>
+        <span class="pill">tracing</span>
+        <span class="pill">hosted infra</span>
+      </div>
+    </div>
+    <div class="ext">
+      <span class="ext-label">Control plane</span>
+      <span class="ext-val">hosted by LangChain</span>
+    </div>
+    <div class="foot">One product. Everything inside the box.</div>
+  </div>
+
+  <div class="panel panel--kitaru">
+    <div class="panel-head">
+      <span class="panel-label panel-label--accent">Kitaru · self-hosted primitive</span>
+      <span class="panel-sub">Single service, your infra, your data</span>
+    </div>
+
+    <div class="stack">
+      <div class="stack-row stack-row--accent">
+        <span class="mono skey">kitaru-server</span>
+        <span class="sval">single service · Helm-deployable</span>
+      </div>
+      <div class="stack-row">
+        <span class="mono skey">S3 / GCS / Azure Blob</span>
+        <span class="sval">artifacts in your own bucket</span>
+      </div>
+      <div class="stack-row">
+        <span class="mono skey">workspace auth</span>
+        <span class="sval">scoped, no per-deployment tokens</span>
+      </div>
+      <div class="stack-row">
+        <span class="mono skey">your cloud</span>
+        <span class="sval">AWS · GCP · Azure · Kubernetes</span>
+      </div>
+    </div>
+
+    <div class="foot foot--accent">No mandatory hosted control plane in the data path.</div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 0;
+    padding: 0;
+  }
+  .panel {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 16px 16px 14px;
+    background: var(--color-surface);
+    display: flex;
+    flex-direction: column;
+  }
+  .panel--competitor { background: var(--color-surface-warm); }
+  .panel--kitaru { border-color: var(--color-accent); }
+
+  .panel-head { margin-bottom: 14px; }
+  .panel-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 4px;
+  }
+  .panel-label--accent { color: var(--color-accent); }
+  .panel-sub {
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+
+  .bundle {
+    border: 1px solid var(--color-border-light);
+    border-radius: 8px;
+    padding: 12px;
+    background: var(--color-surface);
+    margin-bottom: 10px;
+  }
+  .bundle-title {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-primary);
+    margin-bottom: 8px;
+  }
+  .bundle-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 9px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 999px;
+    background: var(--color-surface-warm);
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--color-secondary);
+  }
+
+  .ext {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 12px;
+    border: 1px dashed var(--color-border);
+    border-radius: 6px;
+    background: transparent;
+    margin-bottom: 10px;
+  }
+  .ext-label {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .ext-val {
+    font-size: 11px;
+    color: var(--color-secondary);
+  }
+
+  .stack {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 10px;
+  }
+  .stack-row {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 12px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 6px;
+    background: var(--color-surface-warm);
+  }
+  .stack-row--accent {
+    border-color: var(--color-accent);
+    background: var(--color-accent-light);
+  }
+  .skey {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+  .stack-row--accent .skey { color: var(--color-accent); }
+  .sval {
+    font-size: 10.5px;
+    color: var(--color-secondary);
+  }
+
+  .foot {
+    margin-top: auto;
+    font-size: 11px;
+    color: var(--color-muted);
+    font-style: italic;
+  }
+  .foot--accent {
+    color: var(--color-accent-deep);
+    font-style: normal;
+    font-weight: 500;
+  }
+
+  @media (max-width: 560px) {
+    .fig { grid-template-columns: 1fr; }
+  }
+</style>

--- a/site/src/components/compare/graphics/langgraph/VersionedDeployments.astro
+++ b/site/src/components/compare/graphics/langgraph/VersionedDeployments.astro
@@ -1,0 +1,244 @@
+---
+---
+
+<figure class="fig">
+  <div class="panel panel--competitor">
+    <div class="panel-head">
+      <span class="panel-label">LangSmith · packaged endpoints</span>
+      <span class="panel-sub">Protocol surface bundled with the runtime</span>
+    </div>
+    <div class="proto-grid">
+      <span class="proto">MCP</span>
+      <span class="proto">A2A</span>
+      <span class="proto">Agent Protocol</span>
+      <span class="proto">HITL</span>
+      <span class="proto">Memory APIs</span>
+    </div>
+    <div class="foot">Endpoints as part of the packaged runtime.</div>
+  </div>
+
+  <div class="panel panel--kitaru">
+    <div class="panel-head">
+      <span class="panel-label panel-label--accent">Kitaru · immutable versioned snapshots</span>
+      <span class="panel-sub">Tag routing, not redeploys</span>
+    </div>
+
+    <div class="flow">
+      <span class="mono flow-name">research_flow</span>
+      <div class="versions">
+        <span class="ver">v1</span>
+        <span class="ver">v2</span>
+        <span class="ver ver--current">v3</span>
+        <span class="ver ver--current">v4</span>
+      </div>
+    </div>
+
+    <div class="tags">
+      <div class="tag-row">
+        <span class="tag tag--default">default</span>
+        <span class="tag-arrow">→</span>
+        <span class="mono tag-ver">v4</span>
+      </div>
+      <div class="tag-row">
+        <span class="tag tag--canary">canary</span>
+        <span class="tag-arrow">→</span>
+        <span class="mono tag-ver">v3</span>
+      </div>
+    </div>
+
+    <div class="invokes">
+      <div class="invoke-title">Invoke via</div>
+      <div class="invoke-pills">
+        <span class="ipill">CLI</span>
+        <span class="ipill">Python SDK</span>
+        <span class="ipill">MCP</span>
+        <span class="ipill">curl</span>
+      </div>
+    </div>
+
+    <div class="foot foot--accent">Promotion = tag move. Workspace-scoped auth.</div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 0;
+    padding: 0;
+  }
+  .panel {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 16px 16px 14px;
+    background: var(--color-surface);
+    display: flex;
+    flex-direction: column;
+  }
+  .panel--competitor { background: var(--color-surface-warm); }
+  .panel--kitaru { border-color: var(--color-accent); }
+
+  .panel-head { margin-bottom: 14px; }
+  .panel-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 4px;
+  }
+  .panel-label--accent { color: var(--color-accent); }
+  .panel-sub {
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+
+  .proto-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 10px;
+  }
+  .proto {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 12px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 999px;
+    background: var(--color-surface);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-primary);
+  }
+
+  .flow {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 8px;
+    background: var(--color-surface-warm);
+    margin-bottom: 8px;
+  }
+  .flow-name {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+  .versions {
+    display: flex;
+    gap: 6px;
+  }
+  .ver {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 34px;
+    padding: 3px 8px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 6px;
+    background: var(--color-surface);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-muted);
+  }
+  .ver--current {
+    border-color: var(--color-accent);
+    background: var(--color-accent-light);
+    color: var(--color-accent);
+    font-weight: 700;
+  }
+
+  .tags {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    margin-bottom: 10px;
+  }
+  .tag-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 6px;
+    background: var(--color-surface);
+  }
+  .tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 9px;
+    border-radius: 999px;
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: lowercase;
+  }
+  .tag--default {
+    background: var(--color-accent);
+    color: white;
+  }
+  .tag--canary {
+    background: var(--color-accent-light);
+    color: var(--color-accent-deep);
+    border: 1px solid var(--color-accent);
+  }
+  .tag-arrow {
+    font-size: 13px;
+    color: var(--color-muted);
+  }
+  .tag-ver {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+
+  .invokes {
+    margin-bottom: 10px;
+  }
+  .invoke-title {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 5px;
+  }
+  .invoke-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+  }
+  .ipill {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 9px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 999px;
+    background: var(--color-surface-warm);
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--color-secondary);
+  }
+
+  .foot {
+    margin-top: auto;
+    font-size: 11px;
+    color: var(--color-muted);
+    font-style: italic;
+  }
+  .foot--accent {
+    color: var(--color-accent-deep);
+    font-style: normal;
+    font-weight: 500;
+  }
+
+  @media (max-width: 560px) {
+    .fig { grid-template-columns: 1fr; }
+  }
+</style>

--- a/site/src/components/compare/graphics/pydantic-ai/DifferentQuestions.astro
+++ b/site/src/components/compare/graphics/pydantic-ai/DifferentQuestions.astro
@@ -1,0 +1,157 @@
+---
+---
+
+<figure class="fig">
+  <div class="panel panel--competitor">
+    <div class="panel-head">
+      <span class="panel-label">Pydantic AI · harness</span>
+      <span class="panel-sub">How the agent thinks</span>
+    </div>
+    <div class="quote">
+      <div class="quote-mark" aria-hidden="true">?</div>
+      <div class="quote-text">
+        How do I write a typed, ergonomic agent loop with first-class tools and structured outputs?
+      </div>
+    </div>
+    <div class="concerns">
+      <span class="chip">typed I/O</span>
+      <span class="chip">tool calls</span>
+      <span class="chip">structured outputs</span>
+      <span class="chip">streaming</span>
+    </div>
+    <div class="foot">Scope: a single agent invocation.</div>
+  </div>
+
+  <div class="panel panel--kitaru">
+    <div class="panel-head">
+      <span class="panel-label panel-label--accent">Kitaru · runtime</span>
+      <span class="panel-sub">How the agent runs over time and infra</span>
+    </div>
+    <div class="quote quote--accent">
+      <div class="quote-mark quote-mark--accent" aria-hidden="true">?</div>
+      <div class="quote-text">
+        Once this agent exists, how does it survive crashes, resume after a human approves, replay from failure, version its deployments, and plug into my infra?
+      </div>
+    </div>
+    <div class="concerns">
+      <span class="chip chip--accent">durability</span>
+      <span class="chip chip--accent">replay</span>
+      <span class="chip chip--accent">wait / resume</span>
+      <span class="chip chip--accent">versioning</span>
+      <span class="chip chip--accent">placement</span>
+    </div>
+    <div class="foot foot--accent">Scope: a long-lived production workload.</div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 0;
+    padding: 0;
+  }
+  .panel {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 16px 16px 14px;
+    background: var(--color-surface);
+    display: flex;
+    flex-direction: column;
+  }
+  .panel--competitor { background: var(--color-surface-warm); }
+  .panel--kitaru { border-color: var(--color-accent); }
+
+  .panel-head { margin-bottom: 14px; }
+  .panel-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 4px;
+  }
+  .panel-label--accent { color: var(--color-accent); }
+  .panel-sub {
+    display: block;
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+
+  .quote {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    padding: 12px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 8px;
+    background: var(--color-surface);
+    margin-bottom: 10px;
+  }
+  .quote--accent {
+    border-color: var(--color-accent);
+    background: var(--color-accent-light);
+  }
+  .quote-mark {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--color-muted);
+    color: var(--color-surface);
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 700;
+  }
+  .quote-mark--accent { background: var(--color-accent); }
+  .quote-text {
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--color-primary);
+    font-style: italic;
+  }
+
+  .concerns {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-bottom: 10px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 3px 9px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 999px;
+    background: var(--color-surface-warm);
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--color-secondary);
+  }
+  .chip--accent {
+    border-color: var(--color-accent);
+    background: var(--color-accent-light);
+    color: var(--color-accent-deep);
+  }
+
+  .foot {
+    margin-top: auto;
+    font-size: 11px;
+    color: var(--color-muted);
+    font-style: italic;
+  }
+  .foot--accent {
+    color: var(--color-accent-deep);
+    font-style: normal;
+    font-weight: 500;
+  }
+
+  @media (max-width: 560px) {
+    .fig { grid-template-columns: 1fr; }
+  }
+</style>

--- a/site/src/components/compare/graphics/pydantic-ai/WhatKitaruAddsOnTop.astro
+++ b/site/src/components/compare/graphics/pydantic-ai/WhatKitaruAddsOnTop.astro
@@ -1,0 +1,175 @@
+---
+---
+
+<figure class="fig">
+  <div class="layer layer--kitaru">
+    <div class="layer-head">
+      <span class="layer-label">Kitaru · runtime</span>
+      <span class="layer-sub">Adds on top — no agent rewrite</span>
+    </div>
+    <div class="caps">
+      <div class="cap">
+        <span class="mono ckey">durable execution</span>
+        <span class="cval">crash &rarr; replay · cached checkpoints, no re-burn</span>
+      </div>
+      <div class="cap">
+        <span class="mono ckey">kitaru.wait()</span>
+        <span class="cval">pause, release compute, resume hours later</span>
+      </div>
+      <div class="cap">
+        <span class="mono ckey">flow.deploy()</span>
+        <span class="cval">immutable versioned snapshots · tag routing</span>
+      </div>
+      <div class="cap">
+        <span class="mono ckey">artifact lineage</span>
+        <span class="cval">typed artifacts per checkpoint · cross-run diff</span>
+      </div>
+      <div class="cap">
+        <span class="mono ckey">@checkpoint(runtime="isolated")</span>
+        <span class="cval">per-step pod / job on K8s, AWS, GCP, Azure</span>
+      </div>
+      <div class="cap">
+        <span class="mono ckey">self-hosted</span>
+        <span class="cval">Helm service · artifacts in your own bucket</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="connector" aria-hidden="true">
+    <div class="connector-pill">
+      <span class="connector-arrow">&darr;</span>
+      <span class="connector-label">wraps</span>
+    </div>
+  </div>
+
+  <div class="layer layer--competitor">
+    <div class="layer-head">
+      <span class="layer-label layer-label--muted">Pydantic AI · harness</span>
+      <span class="layer-sub">Your existing agent, unchanged</span>
+    </div>
+    <div class="adapter">
+      <span class="mono adapter-key">KitaruAgent(Agent(...))</span>
+      <span class="adapter-sub">first-class adapter &middot; model + tool calls as child events</span>
+    </div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin: 0;
+    padding: 0;
+  }
+
+  .layer {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 16px 16px 14px;
+    background: var(--color-surface);
+  }
+  .layer--kitaru {
+    border-color: var(--color-accent);
+    background: var(--color-accent-light);
+  }
+  .layer--competitor {
+    background: var(--color-surface-warm);
+  }
+
+  .layer-head {
+    margin-bottom: 12px;
+  }
+  .layer-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+    margin-bottom: 4px;
+  }
+  .layer-label--muted { color: var(--color-muted); }
+  .layer-sub {
+    display: block;
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+
+  .caps {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+  .cap {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 9px 11px;
+    border: 1px solid var(--color-accent);
+    border-radius: 8px;
+    background: var(--color-surface);
+  }
+  .ckey {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    font-weight: 700;
+    color: var(--color-accent);
+  }
+  .cval {
+    font-size: 10.5px;
+    line-height: 1.4;
+    color: var(--color-secondary);
+  }
+
+  .connector {
+    display: flex;
+    justify-content: center;
+  }
+  .connector-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 12px;
+    border: 1px solid var(--color-accent);
+    border-radius: 999px;
+    background: var(--color-accent-light);
+  }
+  .connector-arrow {
+    font-size: 13px;
+    line-height: 1;
+    color: var(--color-accent);
+    font-weight: 700;
+  }
+  .connector-label {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+  }
+
+  .adapter {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 10px 12px;
+    border: 1px dashed var(--color-border);
+    border-radius: 8px;
+    background: var(--color-surface);
+  }
+  .adapter-key {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+  .adapter-sub {
+    font-size: 11px;
+    color: var(--color-secondary);
+  }
+
+  @media (max-width: 560px) {
+    .caps { grid-template-columns: 1fr; }
+  }
+</style>

--- a/site/src/components/compare/graphics/restate/AgentShapedRuntime.astro
+++ b/site/src/components/compare/graphics/restate/AgentShapedRuntime.astro
@@ -1,0 +1,191 @@
+---
+---
+
+<figure class="fig">
+  <div class="panel panel--competitor">
+    <div class="panel-head">
+      <span class="panel-label">Restate · app-shaped</span>
+      <span class="panel-sub">Handlers for services, state, and workflows</span>
+    </div>
+    <div class="handlers">
+      <div class="handler">
+        <span class="mono hkey">service</span>
+        <span class="hval">RPC-shaped durable handlers</span>
+      </div>
+      <div class="handler">
+        <span class="mono hkey">virtual object</span>
+        <span class="hval">keyed per-entity state, strongly consistent</span>
+      </div>
+      <div class="handler">
+        <span class="mono hkey">workflow</span>
+        <span class="hval">long-running, journaled, resumable</span>
+      </div>
+    </div>
+    <div class="foot">Durability primitives, built for app workloads.</div>
+  </div>
+
+  <div class="panel panel--kitaru">
+    <div class="panel-head">
+      <span class="panel-label panel-label--accent">Kitaru · agent-shaped</span>
+      <span class="panel-sub">Primitives for LLM, wait, memory, artifacts</span>
+    </div>
+
+    <div class="wrap">
+      <span class="mono wrap-label">@flow</span>
+      <span class="wrap-sub">wraps your agent</span>
+    </div>
+
+    <div class="prims">
+      <div class="prim prim--accent">
+        <span class="mono pkey">kitaru.llm()</span>
+        <span class="pval">alias-resolved keys · per-call token/latency logging</span>
+      </div>
+      <div class="prim">
+        <span class="mono pkey">kitaru.wait()</span>
+        <span class="pval">compute-released human-in-the-loop</span>
+      </div>
+      <div class="prim">
+        <span class="mono pkey">kitaru.memory</span>
+        <span class="pval">typed scopes across runs</span>
+      </div>
+      <div class="prim">
+        <span class="mono pkey">@checkpoint</span>
+        <span class="pval">versioned artifacts per step</span>
+      </div>
+    </div>
+
+    <div class="foot foot--accent">PydanticAI adapter ships in the box.</div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 0;
+    padding: 0;
+  }
+  .panel {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 16px 16px 14px;
+    background: var(--color-surface);
+    display: flex;
+    flex-direction: column;
+  }
+  .panel--competitor { background: var(--color-surface-warm); }
+  .panel--kitaru { border-color: var(--color-accent); }
+
+  .panel-head { margin-bottom: 14px; }
+  .panel-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 4px;
+  }
+  .panel-label--accent { color: var(--color-accent); }
+  .panel-sub {
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+
+  .handlers {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 10px;
+  }
+  .handler {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 10px 12px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 8px;
+    background: var(--color-surface);
+  }
+  .hkey {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    font-weight: 700;
+    color: var(--color-primary);
+    text-transform: lowercase;
+  }
+  .hval {
+    font-size: 11px;
+    color: var(--color-secondary);
+  }
+
+  .wrap {
+    display: inline-flex;
+    align-self: flex-start;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    border: 1px solid var(--color-accent);
+    background: var(--color-accent-light);
+    border-radius: 999px;
+    margin-bottom: 10px;
+  }
+  .wrap-label {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-accent);
+  }
+  .wrap-sub {
+    font-size: 11px;
+    color: var(--color-secondary);
+  }
+
+  .prims {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 10px;
+  }
+  .prim {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 12px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 6px;
+    background: var(--color-surface-warm);
+  }
+  .prim--accent {
+    border-color: var(--color-accent);
+    background: var(--color-accent-light);
+  }
+  .pkey {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+  .prim--accent .pkey { color: var(--color-accent); }
+  .pval {
+    font-size: 10.5px;
+    color: var(--color-secondary);
+  }
+
+  .foot {
+    margin-top: auto;
+    font-size: 11px;
+    color: var(--color-muted);
+    font-style: italic;
+  }
+  .foot--accent {
+    color: var(--color-accent-deep);
+    font-style: normal;
+    font-weight: 500;
+  }
+
+  @media (max-width: 560px) {
+    .fig { grid-template-columns: 1fr; }
+  }
+</style>

--- a/site/src/components/compare/graphics/restate/ArtifactLineage.astro
+++ b/site/src/components/compare/graphics/restate/ArtifactLineage.astro
@@ -1,0 +1,257 @@
+---
+---
+
+<figure class="fig">
+  <div class="tree tree--a">
+    <div class="head">
+      <span class="exec">exec_id 9f2a</span>
+      <span class="ts">today · 14:02</span>
+    </div>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint research</span>
+        <span class="meta">1,247 tok · 2.8s</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">brief.json</span>
+        <span class="version">v3</span>
+      </div>
+    </div>
+    <svg class="conn" viewBox="0 0 6 14" aria-hidden="true"><path d="M3 0 L3 14" /></svg>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint draft</span>
+        <span class="meta">3,980 tok · 6.1s</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">draft.md</span>
+        <span class="version">v3</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="diff">
+    <span class="diff-label">diff</span>
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M8 4 L4 8 L8 12" />
+      <path d="M16 12 L20 16 L16 20" />
+      <path d="M4 8 L20 8 M20 16 L4 16" />
+    </svg>
+    <span class="diff-sub">across runs</span>
+  </div>
+
+  <div class="tree tree--b">
+    <div class="head">
+      <span class="exec">exec_id 7c1b</span>
+      <span class="ts">Mon · 11:47</span>
+    </div>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint research</span>
+        <span class="meta">1,112 tok · 2.4s</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">brief.json</span>
+        <span class="version version--old">v1</span>
+      </div>
+    </div>
+    <svg class="conn" viewBox="0 0 6 14" aria-hidden="true"><path d="M3 0 L3 14" /></svg>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint draft</span>
+        <span class="meta">4,215 tok · 6.8s</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">draft.md</span>
+        <span class="version version--old">v1</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="contrast">
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M4 6 L20 6 M4 12 L20 12 M4 18 L20 18" />
+    </svg>
+    <span><strong>Restate:</strong> handler progress is journaled; Virtual Object state is keyed per entity. Not surfaced as cross-run versioned artifacts with a diff view.</span>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 96px 1fr;
+    gap: 8px;
+    align-items: start;
+    margin: 0;
+    padding: 0;
+  }
+
+  .tree {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    background: var(--color-surface);
+    padding: 14px 14px 16px;
+  }
+  .tree--b {
+    opacity: 0.88;
+    background: var(--color-surface-warm);
+  }
+
+  .head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--color-border-light);
+  }
+  .exec {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-accent);
+  }
+  .tree--b .exec { color: var(--color-muted); }
+  .ts {
+    font-size: 10.5px;
+    color: var(--color-muted);
+  }
+
+  .step {
+    padding: 8px 10px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 6px;
+    background: var(--color-surface-warm);
+  }
+  .tree--b .step { background: var(--color-surface); }
+
+  .step-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+  .cp {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+  .meta {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--color-muted);
+  }
+  .artifacts {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .artifact {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    padding: 3px 8px;
+    background: var(--color-accent-light);
+    color: var(--color-accent-deep);
+    border-radius: 4px;
+  }
+  .version {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 700;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: var(--color-accent);
+    color: var(--color-surface);
+    letter-spacing: 0.03em;
+  }
+  .version--old {
+    background: var(--color-border-light);
+    color: var(--color-muted);
+  }
+  .conn {
+    display: block;
+    width: 6px;
+    height: 14px;
+    margin: 2px auto;
+    fill: none;
+    stroke: var(--color-border);
+    stroke-width: 1.5;
+  }
+
+  .diff {
+    align-self: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding-top: 60px;
+  }
+  .diff-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--color-accent);
+    padding: 3px 8px;
+    background: var(--color-accent-light);
+    border-radius: 3px;
+    text-transform: uppercase;
+  }
+  .diff svg {
+    width: 28px;
+    height: 28px;
+    fill: none;
+    stroke: var(--color-accent);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .diff-sub {
+    font-size: 9.5px;
+    color: var(--color-muted);
+    text-align: center;
+    margin-top: 2px;
+  }
+
+  .contrast {
+    grid-column: 1 / -1;
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    margin-top: 6px;
+    padding: 10px 12px;
+    background: var(--color-surface-warm);
+    border-left: 2px solid var(--color-muted);
+    border-radius: 4px;
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+  .contrast svg {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    margin-top: 2px;
+    fill: none;
+    stroke: var(--color-muted);
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    opacity: 0.6;
+  }
+  .contrast strong {
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  @media (max-width: 560px) {
+    .fig {
+      grid-template-columns: 1fr;
+    }
+    .diff { padding-top: 0; flex-direction: row; gap: 10px; }
+    .diff svg { transform: rotate(90deg); }
+    .contrast { grid-column: auto; }
+  }
+</style>

--- a/site/src/components/compare/graphics/restate/EmbeddedVsServerRegistered.astro
+++ b/site/src/components/compare/graphics/restate/EmbeddedVsServerRegistered.astro
@@ -19,7 +19,7 @@
     <div class="server-box">
       <div class="server-head">
         <span class="mono srv-name">restate-server</span>
-        <span class="srv-tag">Rust · Apache 2.0</span>
+        <span class="srv-tag">Rust · BSL 1.1</span>
       </div>
       <div class="server-body">
         <span class="srv-row">journal</span>

--- a/site/src/components/compare/graphics/restate/EmbeddedVsServerRegistered.astro
+++ b/site/src/components/compare/graphics/restate/EmbeddedVsServerRegistered.astro
@@ -1,0 +1,291 @@
+---
+---
+
+<figure class="fig">
+  <div class="panel panel--competitor">
+    <div class="panel-head">
+      <span class="panel-label">Restate · server-registered</span>
+      <span class="panel-sub">Request path flows through the server</span>
+    </div>
+
+    <div class="row row--caller">
+      <span class="node node--ghost">caller</span>
+    </div>
+
+    <svg class="conn" viewBox="0 0 100 24" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M50 0 L50 24 M45 18 L50 24 L55 18" />
+    </svg>
+
+    <div class="server-box">
+      <div class="server-head">
+        <span class="mono srv-name">restate-server</span>
+        <span class="srv-tag">Rust · Apache 2.0</span>
+      </div>
+      <div class="server-body">
+        <span class="srv-row">journal</span>
+        <span class="srv-row">routing</span>
+        <span class="srv-row">replay</span>
+      </div>
+    </div>
+
+    <svg class="conn" viewBox="0 0 100 24" preserveAspectRatio="none" aria-hidden="true">
+      <path d="M30 0 L30 24 M25 18 L30 24 L35 18" />
+      <path d="M70 0 L70 24 M65 18 L70 24 L75 18" />
+    </svg>
+
+    <div class="row row--handlers">
+      <span class="node">handler</span>
+      <span class="node">handler</span>
+    </div>
+
+    <div class="foot">Handlers register with the server. Every invocation crosses the server boundary.</div>
+  </div>
+
+  <div class="panel panel--kitaru">
+    <div class="panel-head">
+      <span class="panel-label panel-label--accent">Kitaru · embedded</span>
+      <span class="panel-sub">Flow runs in your process; server holds metadata</span>
+    </div>
+
+    <div class="proc">
+      <span class="proc-label">your python process</span>
+      <div class="proc-body">
+        <div class="deco">
+          <span class="mono deco-key">@flow</span>
+        </div>
+        <div class="deco">
+          <span class="mono deco-key">@checkpoint</span>
+        </div>
+        <div class="deco deco--accent">
+          <span class="mono deco-key">kitaru.llm()</span>
+        </div>
+      </div>
+      <span class="proc-foot">pip install kitaru · no server process in the request path</span>
+    </div>
+
+    <div class="meta-group">
+      <svg class="side" viewBox="0 0 60 40" preserveAspectRatio="none" aria-hidden="true">
+        <path d="M0 20 L60 20 M52 14 L60 20 L52 26" />
+      </svg>
+      <div class="meta">
+        <span class="meta-label">kitaru server</span>
+        <span class="meta-sub">metadata · UI · auth</span>
+      </div>
+    </div>
+
+    <div class="foot foot--accent">Server is for the metadata, not the request path.</div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 0;
+    padding: 0;
+  }
+  .panel {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 16px 16px 14px;
+    background: var(--color-surface);
+    display: flex;
+    flex-direction: column;
+  }
+  .panel--competitor { background: var(--color-surface-warm); }
+  .panel--kitaru { border-color: var(--color-accent); }
+
+  .panel-head { margin-bottom: 12px; }
+  .panel-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin-bottom: 4px;
+  }
+  .panel-label--accent { color: var(--color-accent); }
+  .panel-sub {
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+
+  .row {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+  }
+  .row--handlers { justify-content: space-around; }
+  .node {
+    display: inline-flex;
+    align-items: center;
+    padding: 5px 12px;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: var(--color-surface);
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--color-primary);
+  }
+  .node--ghost {
+    border-style: dashed;
+    color: var(--color-muted);
+  }
+
+  .conn {
+    display: block;
+    width: 100%;
+    height: 18px;
+    fill: none;
+    stroke: var(--color-border);
+    stroke-width: 1.2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .conn path { vector-effect: non-scaling-stroke; }
+
+  .server-box {
+    border: 1px solid var(--color-muted);
+    border-radius: 8px;
+    padding: 10px 12px;
+    background: var(--color-surface);
+    margin: 2px 0;
+  }
+  .server-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 6px;
+  }
+  .srv-name {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+  .srv-tag {
+    font-size: 9.5px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    padding: 2px 6px;
+    background: var(--color-border-light);
+    border-radius: 3px;
+  }
+  .server-body {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .srv-row {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--color-secondary);
+    padding: 2px 8px;
+    background: var(--color-bg);
+    border-radius: 3px;
+  }
+
+  .proc {
+    padding: 14px;
+    border: 1px solid var(--color-accent);
+    border-radius: 10px;
+    background: var(--color-accent-light);
+    margin-bottom: 12px;
+  }
+  .proc-label {
+    display: block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+    margin-bottom: 10px;
+  }
+  .proc-body {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    margin-bottom: 10px;
+  }
+  .deco {
+    padding: 6px 10px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 5px;
+    background: var(--color-surface);
+  }
+  .deco--accent {
+    border-color: var(--color-accent);
+  }
+  .deco-key {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--color-primary);
+  }
+  .deco--accent .deco-key {
+    color: var(--color-accent);
+  }
+  .proc-foot {
+    font-size: 10.5px;
+    color: var(--color-accent-deep);
+    font-style: italic;
+  }
+
+  .meta-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 10px;
+  }
+  .side {
+    flex-shrink: 0;
+    width: 32px;
+    height: 20px;
+    fill: none;
+    stroke: var(--color-border);
+    stroke-width: 1.2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .side path { vector-effect: non-scaling-stroke; }
+  .meta {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 8px 12px;
+    border: 1px dashed var(--color-border);
+    border-radius: 6px;
+    background: var(--color-surface);
+  }
+  .meta-label {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+  .meta-sub {
+    font-size: 10.5px;
+    color: var(--color-muted);
+  }
+
+  .foot {
+    margin-top: auto;
+    font-size: 11px;
+    color: var(--color-muted);
+    font-style: italic;
+  }
+  .foot--accent {
+    color: var(--color-accent-deep);
+    font-style: normal;
+    font-weight: 500;
+  }
+
+  @media (max-width: 560px) {
+    .fig { grid-template-columns: 1fr; }
+  }
+</style>

--- a/site/src/components/compare/graphics/restate/StackAbstraction.astro
+++ b/site/src/components/compare/graphics/restate/StackAbstraction.astro
@@ -1,0 +1,185 @@
+---
+---
+
+<figure class="fig">
+  <div class="top">
+    <div class="flow">
+      <span class="mono flow-name">review_flow</span>
+      <span class="flow-sub">one `@flow` decorator on your Python function</span>
+    </div>
+    <div class="switch">
+      <span class="switch-label">stack config</span>
+      <span class="switch-hint">switch backend without changing flow code</span>
+    </div>
+  </div>
+
+  <svg class="fan" viewBox="0 0 100 70" preserveAspectRatio="none" aria-hidden="true">
+    <path d="M50 0 L50 18 Q50 30 35 30 L16 30 Q8 30 8 42 L8 70" />
+    <path d="M50 0 L50 18 Q50 30 40 30 L32 30 Q26 30 26 42 L26 70" />
+    <path d="M50 0 L50 18 Q50 30 60 30 L68 30 Q74 30 74 42 L74 70" />
+    <path d="M50 0 L50 18 Q50 30 65 30 L84 30 Q92 30 92 42 L92 70" />
+  </svg>
+
+  <div class="targets">
+    <div class="target">
+      <span class="t-label">Kubernetes</span>
+      <span class="t-sub">any cluster</span>
+    </div>
+    <div class="target">
+      <span class="t-label">AWS</span>
+      <span class="t-sub">S3 + IAM + EKS</span>
+    </div>
+    <div class="target">
+      <span class="t-label">GCP</span>
+      <span class="t-sub">GCS + Vertex AI</span>
+    </div>
+    <div class="target">
+      <span class="t-label">Azure</span>
+      <span class="t-sub">Blob + AzureML</span>
+    </div>
+  </div>
+
+  <div class="contrast">
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M4 6 L20 6 M4 12 L20 12 M4 18 L20 18" />
+    </svg>
+    <span><strong>Restate:</strong> <code>restate-server</code> self-hosts on any of these; handlers deploy however you already deploy backend services. The runtime does not abstract the cloud backend for you.</span>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0;
+    margin: 0;
+    padding: 0;
+  }
+
+  .top {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 2px;
+  }
+  .flow {
+    border: 1px solid var(--color-accent);
+    border-radius: 12px;
+    padding: 12px 14px;
+    background: var(--color-accent-light);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .flow-name {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--color-accent);
+  }
+  .flow-sub {
+    font-size: 11px;
+    color: var(--color-accent-deep);
+  }
+  .switch {
+    border: 1px dashed var(--color-border);
+    border-radius: 12px;
+    padding: 12px 14px;
+    background: var(--color-surface);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .switch-label {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+  }
+  .switch-hint {
+    font-size: 11px;
+    color: var(--color-secondary);
+    font-style: italic;
+  }
+
+  .fan {
+    display: block;
+    width: 100%;
+    height: 50px;
+    margin: 0 0 4px;
+    fill: none;
+    stroke: var(--color-border);
+    stroke-width: 1.2;
+    stroke-linecap: round;
+  }
+  .fan path { vector-effect: non-scaling-stroke; }
+
+  .targets {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+  .target {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 9px 10px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 6px;
+    background: var(--color-surface-warm);
+    align-items: center;
+    text-align: center;
+  }
+  .t-label {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+  .t-sub {
+    font-size: 10px;
+    color: var(--color-muted);
+  }
+
+  .contrast {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    padding: 10px 12px;
+    background: var(--color-surface-warm);
+    border-left: 2px solid var(--color-muted);
+    border-radius: 4px;
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+  .contrast svg {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    margin-top: 2px;
+    fill: none;
+    stroke: var(--color-muted);
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    opacity: 0.6;
+  }
+  .contrast code {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--color-primary);
+    background: var(--color-surface);
+    padding: 1px 5px;
+    border-radius: 3px;
+  }
+  .contrast strong {
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  @media (max-width: 560px) {
+    .top { grid-template-columns: 1fr; }
+    .targets { grid-template-columns: repeat(2, 1fr); }
+  }
+</style>

--- a/site/src/components/compare/graphics/temporal/ArtifactLineage.astro
+++ b/site/src/components/compare/graphics/temporal/ArtifactLineage.astro
@@ -1,0 +1,258 @@
+---
+---
+
+<figure class="fig">
+  <div class="tree tree--b">
+    <div class="head">
+      <span class="exec">exec_id 7c1b</span>
+      <span class="ts">Mon · 11:47</span>
+      <span class="total">total $0.15</span>
+    </div>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint research</span>
+        <span class="cost">$0.04</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">brief.json</span>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint draft</span>
+        <span class="cost">$0.09</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">draft.md</span>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint review</span>
+        <span class="cost">$0.02</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">review.json</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="diff">
+    <span class="diff-label">kitaru.load()</span>
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M4 12 L20 12" />
+      <path d="M16 8 L20 12 L16 16" />
+    </svg>
+    <span class="diff-hint">reuses brief.json</span>
+  </div>
+
+  <div class="tree tree--a">
+    <div class="head">
+      <span class="exec">exec_id 9f2a</span>
+      <span class="ts">today · 14:02</span>
+      <span class="total">total $0.10</span>
+    </div>
+    <div class="step step--reused">
+      <div class="step-head">
+        <span class="cp">@checkpoint research</span>
+        <span class="badge-reused">loaded</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact artifact--reused">brief.json · from 7c1b</span>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint draft</span>
+        <span class="cost">$0.08</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">draft.md</span>
+      </div>
+    </div>
+    <div class="step">
+      <div class="step-head">
+        <span class="cp">@checkpoint review</span>
+        <span class="cost">$0.02</span>
+      </div>
+      <div class="artifacts">
+        <span class="artifact">review.json</span>
+      </div>
+    </div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 86px 1fr;
+    gap: 8px;
+    align-items: start;
+    margin: 0;
+    padding: 0;
+  }
+
+  .tree {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    background: var(--color-surface);
+    padding: 14px 14px 16px;
+  }
+  .tree--b { opacity: 0.82; }
+
+  .head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--color-border-light);
+  }
+  .exec {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-accent);
+  }
+  .ts {
+    font-size: 10.5px;
+    color: var(--color-muted);
+  }
+  .total {
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    font-weight: 700;
+    color: var(--color-primary);
+    padding: 2px 7px;
+    background: var(--color-accent-light);
+    border-radius: 4px;
+    width: 100%;
+    text-align: right;
+    margin-top: 2px;
+  }
+
+  .step {
+    padding: 8px 10px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 6px;
+    background: var(--color-surface-warm);
+  }
+  .step--reused {
+    border-color: var(--color-accent);
+    background: var(--color-accent-light);
+    border-style: dashed;
+  }
+  .badge-reused {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--color-accent-deep);
+    padding: 2px 6px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-accent);
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .artifact--reused {
+    background: var(--color-surface);
+    border: 1px dashed var(--color-accent);
+    color: var(--color-accent-deep);
+  }
+  .step-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+  .cp {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+  .cost {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-muted);
+    padding: 2px 6px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-light);
+    border-radius: 3px;
+  }
+  .artifacts {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .artifact {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    padding: 3px 8px;
+    background: var(--color-accent-light);
+    color: var(--color-accent-deep);
+    border-radius: 4px;
+  }
+  .step + .step {
+    margin-top: 18px;
+    position: relative;
+  }
+  .step + .step::before {
+    content: '';
+    position: absolute;
+    top: -16px;
+    left: 50%;
+    width: 0;
+    height: 14px;
+    border-left: 1.5px solid var(--color-border);
+  }
+
+  .diff {
+    align-self: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding-top: 60px;
+  }
+  .diff-hint {
+    font-size: 9.5px;
+    color: var(--color-muted);
+    font-style: italic;
+    text-align: center;
+    max-width: 80px;
+    line-height: 1.3;
+  }
+  .diff-label {
+    font-family: var(--font-mono);
+    font-size: 9.5px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: var(--color-accent);
+    padding: 2px 6px;
+    background: var(--color-accent-light);
+    border-radius: 3px;
+    white-space: nowrap;
+  }
+  .diff svg {
+    width: 24px;
+    height: 24px;
+    fill: none;
+    stroke: var(--color-accent);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  @media (max-width: 560px) {
+    .fig {
+      grid-template-columns: 1fr;
+    }
+    .diff { padding-top: 0; flex-direction: row; }
+    .diff svg { transform: rotate(90deg); }
+  }
+</style>

--- a/site/src/components/compare/graphics/temporal/DurableExecution.astro
+++ b/site/src/components/compare/graphics/temporal/DurableExecution.astro
@@ -1,0 +1,213 @@
+---
+---
+
+<figure class="fig">
+  <div class="panel panel--competitor">
+    <div class="panel-label">Temporal cluster</div>
+    <div class="panel-sub">Temporal Service + Workers</div>
+    <div class="cluster">
+      <svg class="mesh" preserveAspectRatio="none" viewBox="0 0 100 100" aria-hidden="true">
+        <path d="M16.67 40 L16.67 58 L83.33 58 L83.33 40" />
+        <path d="M50 40 L50 58" />
+        <path d="M50 58 L50 72" />
+      </svg>
+      <div class="node">Frontend</div>
+      <div class="node">History</div>
+      <div class="node">Matching</div>
+      <div class="db">Persistence DB <span class="db-sub">(your Postgres / MySQL / Cassandra)</span></div>
+      <div class="worker-node">Workers (your code)</div>
+    </div>
+  </div>
+
+  <div class="panel panel--kitaru">
+    <div class="panel-label">Kitaru + stack</div>
+    <div class="panel-sub">Kitaru server + stack storage</div>
+    <div class="stack">
+      <div class="card">
+        <span class="mono accent">@flow</span>
+        <span class="mono dim">review_flow</span>
+      </div>
+      <svg class="arrow" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 4 L12 20 M6 14 L12 20 L18 14" />
+      </svg>
+      <div class="card">
+        <span class="mono accent">@checkpoint</span>
+        <span class="mono dim">draft</span>
+      </div>
+      <svg class="arrow" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 4 L12 20 M6 14 L12 20 L18 14" />
+      </svg>
+      <div class="bucket">
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M4 8 L20 8 L18.5 20 L5.5 20 Z M4 8 L6 4 L18 4 L20 8" />
+        </svg>
+        <span class="mono">S3 · GCS · Blob</span>
+      </div>
+    </div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 0;
+    padding: 0;
+  }
+  .panel {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 18px 16px 20px;
+    background: var(--color-surface);
+    position: relative;
+  }
+  .panel--competitor { background: var(--color-surface-warm); }
+  .panel-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+  }
+  .panel--competitor .panel-label {
+    color: var(--color-muted);
+  }
+  .panel-sub {
+    font-size: 12px;
+    color: var(--color-secondary);
+    margin-bottom: 16px;
+  }
+
+  .cluster {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    padding-top: 4px;
+  }
+  .cluster .db {
+    grid-column: 1 / -1;
+    margin-top: 30px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-secondary);
+    text-align: center;
+    padding: 10px 12px;
+    border: 1px dashed var(--color-border);
+    border-radius: 8px;
+    background: var(--color-bg);
+    position: relative;
+    z-index: 1;
+  }
+  .cluster .db-sub {
+    display: block;
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--color-muted);
+    margin-top: 2px;
+    font-style: italic;
+  }
+  .cluster .worker-node {
+    grid-column: 1 / -1;
+    margin-top: 12px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-primary);
+    text-align: center;
+    padding: 8px 12px;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-surface);
+    position: relative;
+    z-index: 1;
+  }
+  .mesh {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    fill: none;
+    stroke: var(--color-border);
+    z-index: 0;
+  }
+  .mesh path {
+    vector-effect: non-scaling-stroke;
+    stroke-width: 1.2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .node {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-primary);
+    text-align: center;
+    padding: 8px 6px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    position: relative;
+    z-index: 1;
+  }
+  .stack {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
+    padding-top: 4px;
+  }
+  .card {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-surface);
+  }
+  .card .mono {
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+  .card .accent { color: var(--color-accent); font-weight: 600; }
+  .card .dim { color: var(--color-secondary); }
+  .arrow {
+    width: 16px;
+    height: 16px;
+    align-self: center;
+    fill: none;
+    stroke: var(--color-muted);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .bucket {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border: 1px solid var(--color-accent);
+    border-radius: 8px;
+    background: var(--color-accent-light);
+  }
+  .bucket svg {
+    width: 20px;
+    height: 20px;
+    fill: none;
+    stroke: var(--color-accent);
+    stroke-width: 1.5;
+    stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+  .bucket .mono {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  @media (max-width: 520px) {
+    .fig { grid-template-columns: 1fr; }
+  }
+</style>

--- a/site/src/components/compare/graphics/temporal/DurableMemory.astro
+++ b/site/src/components/compare/graphics/temporal/DurableMemory.astro
@@ -1,0 +1,233 @@
+---
+---
+
+<figure class="fig">
+  <div class="memory">
+    <div class="memory-head">
+      <span class="tag tag--accent">kitaru.memory</span>
+      <span class="scope-label">scope</span>
+      <span class="scope-val">namespace</span>
+      <span class="hint">versioned · persists across runs</span>
+    </div>
+    <ul class="entries">
+      <li>
+        <span class="ver">v3</span>
+        <span class="key">preferences.tone</span>
+        <span class="val">"formal, brief"</span>
+        <span class="ts">today · 14:02</span>
+      </li>
+      <li>
+        <span class="ver">v2</span>
+        <span class="key">preferences.tone</span>
+        <span class="val">"casual"</span>
+        <span class="ts">yesterday · 09:18</span>
+      </li>
+      <li>
+        <span class="ver ver--old">v1</span>
+        <span class="key">preferences.tone</span>
+        <span class="val">"neutral"</span>
+        <span class="ts">Mon · 11:47</span>
+      </li>
+    </ul>
+  </div>
+
+  <div class="runs">
+    <svg class="connectors" viewBox="0 0 480 70" aria-hidden="true" preserveAspectRatio="none">
+      <path d="M80 0 L80 30 Q80 50 100 50 L380 50 Q400 50 400 30 L400 0" />
+      <path d="M240 0 L240 50" />
+    </svg>
+    <div class="run">
+      <span class="exec">exec #1</span>
+      <span class="when">Mon</span>
+    </div>
+    <div class="run run--active">
+      <span class="exec">exec #2</span>
+      <span class="when">yesterday</span>
+    </div>
+    <div class="run">
+      <span class="exec">exec #3</span>
+      <span class="when">today</span>
+    </div>
+  </div>
+
+  <div class="contrast">
+    <span class="exec-badge">1 exec</span>
+    <span><strong>Temporal:</strong> workflow variables are scoped to one execution, reconstituted from event history.</span>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    margin: 0;
+    padding: 0;
+  }
+
+  .tag {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    padding: 3px 10px;
+    border-radius: 4px;
+  }
+  .tag--accent {
+    background: var(--color-accent);
+    color: var(--color-surface);
+  }
+
+  .memory {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    background: var(--color-surface);
+    padding: 16px 16px 6px;
+  }
+  .memory-head {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-bottom: 10px;
+  }
+  .scope-label {
+    font-size: 10.5px;
+    color: var(--color-muted);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-left: 4px;
+  }
+  .scope-val {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-accent-deep);
+  }
+  .hint {
+    font-size: 11px;
+    color: var(--color-muted);
+    font-style: italic;
+    margin-left: auto;
+  }
+
+  .entries { list-style: none; padding: 0; margin: 0; }
+  .entries li {
+    display: grid;
+    grid-template-columns: 38px 1fr auto auto;
+    gap: 12px;
+    align-items: center;
+    padding: 8px 4px;
+    border-bottom: 1px solid var(--color-border-light);
+    font-size: 12px;
+  }
+  .entries li:last-child { border-bottom: none; }
+  .ver {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--color-surface);
+    background: var(--color-accent);
+    padding: 2px 6px;
+    border-radius: 4px;
+    text-align: center;
+  }
+  .ver--old {
+    background: var(--color-border-light);
+    color: var(--color-muted);
+  }
+  .key {
+    font-family: var(--font-mono);
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+  .val {
+    font-family: var(--font-mono);
+    color: var(--color-secondary);
+    padding: 2px 8px;
+    background: var(--color-surface-warm);
+    border-radius: 3px;
+    font-size: 11px;
+  }
+  .ts {
+    font-size: 10.5px;
+    color: var(--color-muted);
+    white-space: nowrap;
+  }
+
+  .runs {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    padding-top: 14px;
+  }
+  .connectors {
+    position: absolute;
+    top: -6px;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 34px;
+    fill: none;
+    stroke: var(--color-border);
+    stroke-width: 1.5;
+    stroke-linecap: round;
+  }
+  .run {
+    position: relative;
+    padding: 10px 12px;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-surface);
+    text-align: center;
+    z-index: 1;
+  }
+  .run--active {
+    border-color: var(--color-accent);
+    background: var(--color-accent-light);
+  }
+  .run .exec {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-primary);
+  }
+  .run .when {
+    display: block;
+    font-size: 10.5px;
+    color: var(--color-muted);
+    margin-top: 2px;
+  }
+
+  .contrast {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    margin-top: 4px;
+    padding: 10px 12px;
+    background: var(--color-surface-warm);
+    border-left: 2px solid var(--color-muted);
+    border-radius: 4px;
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+  .exec-badge {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--color-muted);
+    padding: 2px 7px;
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    background: var(--color-surface);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .contrast strong {
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+</style>

--- a/site/src/components/compare/graphics/temporal/LLMCheckpoints.astro
+++ b/site/src/components/compare/graphics/temporal/LLMCheckpoints.astro
@@ -1,0 +1,201 @@
+---
+---
+
+<figure class="fig">
+  <div class="temporal-row">
+    <span class="tag tag--muted">Temporal Activity</span>
+    <div class="opaque">
+      <code>await call_openai(prompt)</code>
+      <span class="dim">unstructured by default · instrument it yourself</span>
+    </div>
+  </div>
+
+  <div class="record">
+    <div class="record-head">
+      <span class="tag tag--accent">Kitaru · @checkpoint</span>
+      <span class="mono exec">exec_id 9f2a&hellip;</span>
+    </div>
+
+    <div class="mono-call">
+      <span class="fn">kitaru.llm</span>(<span class="str">prompt</span>, <span class="str">model=</span><span class="val">"fast"</span>)
+    </div>
+
+    <dl class="fields">
+      <div>
+        <dt>prompt</dt>
+        <dd class="mono">Research: Durable agents&hellip;</dd>
+      </div>
+      <div>
+        <dt>response</dt>
+        <dd class="mono">Durable execution keeps&hellip;</dd>
+      </div>
+      <div class="row">
+        <div class="chip">
+          <span class="chip-k">tokens</span><span class="chip-v">1,247</span>
+        </div>
+        <div class="chip">
+          <span class="chip-k">latency</span><span class="chip-v">1.4s</span>
+        </div>
+        <div class="chip">
+          <span class="chip-k">model</span><span class="chip-v">fast → claude-sonnet-4-6</span>
+        </div>
+      </div>
+    </dl>
+
+    <div class="replay">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M3 12 A9 9 0 1 0 6 5 L3 8 M3 3 L3 8 L8 8" />
+      </svg>
+      <span>On replay, response is loaded from checkpoint. Provider isn't hit again.</span>
+    </div>
+  </div>
+</figure>
+
+<style>
+  .fig {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    margin: 0;
+    padding: 0;
+  }
+  .tag {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 3px 8px;
+    border-radius: 4px;
+  }
+  .tag--muted {
+    background: var(--color-border-light);
+    color: var(--color-muted);
+  }
+  .tag--accent {
+    background: var(--color-accent-light);
+    color: var(--color-accent-deep);
+  }
+
+  .temporal-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 12px 14px;
+    border: 1px dashed var(--color-border);
+    border-radius: 10px;
+    background: var(--color-surface-warm);
+  }
+  .opaque {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  .opaque code {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--color-secondary);
+  }
+  .opaque .dim {
+    font-size: 11px;
+    color: var(--color-muted);
+    font-style: italic;
+  }
+
+  .record {
+    padding: 16px 18px 18px;
+    border: 1px solid var(--color-accent);
+    border-radius: 12px;
+    background: var(--color-surface);
+    box-shadow: 0 1px 0 var(--color-border);
+  }
+  .record-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+  }
+  .exec {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-muted);
+  }
+  .mono-call {
+    font-family: var(--font-mono);
+    font-size: 12.5px;
+    color: var(--color-primary);
+    padding: 10px 12px;
+    border-radius: 6px;
+    background: var(--color-bg);
+    margin-bottom: 12px;
+  }
+  .fn { color: var(--color-accent); font-weight: 600; }
+  .str { color: var(--color-secondary); }
+  .val { color: var(--color-accent-deep); }
+
+  .fields { margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+  .fields > div:not(.row) { display: grid; grid-template-columns: 70px 1fr; gap: 10px; align-items: center; }
+  .fields dt {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--color-muted);
+    margin: 0;
+  }
+  .fields dd {
+    margin: 0;
+    font-size: 12.5px;
+    color: var(--color-primary);
+    padding: 6px 10px;
+    background: var(--color-accent-light);
+    border-radius: 4px;
+  }
+  .fields .mono {
+    font-family: var(--font-mono);
+  }
+
+  .row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 5px 10px;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: var(--color-surface);
+    font-size: 11px;
+  }
+  .chip-k { color: var(--color-muted); font-weight: 600; text-transform: uppercase; font-size: 9.5px; letter-spacing: 0.05em; }
+  .chip-v {
+    font-family: var(--font-mono);
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  .replay {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid var(--color-border-light);
+    font-size: 11.5px;
+    color: var(--color-secondary);
+  }
+  .replay svg {
+    width: 14px;
+    height: 14px;
+    fill: none;
+    stroke: var(--color-accent);
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    flex-shrink: 0;
+  }
+</style>

--- a/site/src/content.config.ts
+++ b/site/src/content.config.ts
@@ -22,7 +22,6 @@ const comparisons = defineCollection({
   schema: z.object({
     competitor: z.string(),
     competitorLogo: z.string().optional(),
-    competitorTagline: z.string(),
     title: z.string(),
     description: z.string(),
     cardSubtitle: z.string(),

--- a/site/src/content/comparisons/kitaru-vs-claude-agent-sdk.mdx
+++ b/site/src/content/comparisons/kitaru-vs-claude-agent-sdk.mdx
@@ -102,6 +102,18 @@ Kitaru captures artifacts from every `@checkpoint` automatically and links them 
   ]}
 />
 
+## How the two surfaces map
+
+| Concept | Claude Agent SDK | Kitaru |
+|---|---|---|
+| Execution boundary | Agent session / SDK loop | `@flow` + `@checkpoint` |
+| Durability unit | Session history on disk | Versioned artifacts per checkpoint |
+| Resumption | Rewinds file edits from Write / Edit / NotebookEdit | Replay from a specific checkpoint, cached work above it reused |
+| Human-in-the-loop | Tool approval prompts in the session | `kitaru.wait()` (compute released, survives crashes) |
+| Cross-run memory | Session-scoped conversation history | `kitaru.memory` with `namespace`, `flow`, or `execution` scopes |
+| Model access | Anthropic / Bedrock / Vertex / Azure AI Foundry paths | `kitaru.llm()` with alias-resolved providers + secrets |
+| Deployment | Container patterns you own and operate | Stack-based deploy to Kubernetes, AWS, GCP, Azure |
+
 ## Code comparison
 
 <CodeCompare
@@ -165,5 +177,5 @@ If you are running agents locally or in short interactive sessions, stick with w
 - [Talk to the team](/get-started) if you want help mapping an Agent SDK prototype to a production deployment
 
 <div class="compare-inline-cta">
-  <a href="/get-started" class="btn-primary">Get started with Kitaru</a>
+  <a href="/get-started" class="btn-primary">Get started</a>
 </div>

--- a/site/src/content/comparisons/kitaru-vs-claude-agent-sdk.mdx
+++ b/site/src/content/comparisons/kitaru-vs-claude-agent-sdk.mdx
@@ -1,7 +1,6 @@
 ---
 competitor: "Claude Agent SDK"
 competitorLogo: "/compare/claude-agent-sdk.svg"
-competitorTagline: "Build AI agents that autonomously read files, run commands, search the web, edit code, and more."
 title: "Kitaru vs Claude Agent SDK: The lifecycle layer for agents you build with Claude Agent SDK"
 description: "Kitaru and the Claude Agent SDK solve different problems. Keep the SDK, add Kitaru underneath for durable execution, artifact lineage, memory, and deployment on your own cloud."
 cardSubtitle: "Keep the SDK. Add durable execution, memory, and cloud-native deployment underneath."

--- a/site/src/content/comparisons/kitaru-vs-dbos.mdx
+++ b/site/src/content/comparisons/kitaru-vs-dbos.mdx
@@ -54,7 +54,7 @@ We built Kitaru around a different shape of work. An agent loop has expensive LL
 <FeatureWithGraphic title="LLM calls as a first-class primitive">
   <LLMPrimitive slot="graphic" />
 
-  In DBOS, an LLM call is something you make inside your own `@DBOS.step`. DBOS ships OpenTelemetry instrumentation for OpenAI, LiteLLM, and LangChain, so traces show up in Conductor. That gets you visibility. It doesn't get you a primitive. We built `kitaru.llm()` so the call itself is part of the runtime.
+  In DBOS, an LLM call is something you make inside your own `@DBOS.step`. DBOS can emit OpenTelemetry-compatible logs and traces for workflows and applications, so LLM visibility lands in Conductor if you wire up provider instrumentation yourself. That gets you visibility. It doesn't get you a primitive. We built `kitaru.llm()` so the call itself is part of the runtime.
 
   - **Alias-resolved secrets:** `kitaru.llm(prompt, model="fast")` resolves the model alias and injects the provider key from the active stack. The same call retargets from OpenAI to Anthropic to a self-hosted model without touching code.
   - **Per-checkpoint cost roll-up:** Latency, token counts, and cost land under the enclosing `@checkpoint` automatically. Run inspection shows you the cost of step 9 without a separate LLM logging pipeline.
@@ -119,7 +119,7 @@ We built Kitaru around a different shape of work. An agent loop has expensive LL
 | Workflow boundary | `@DBOS.workflow()` | `@flow` |
 | Durable step | `@DBOS.step()` | `@checkpoint` (ordinary Python) |
 | State backend | Postgres, alongside your OLTP data | Your own S3 / GCS / Azure Blob |
-| LLM call | Inside a `@DBOS.step` with OTel instrumentation | `kitaru.llm()` with alias-resolved keys and per-checkpoint cost |
+| LLM call | Inside a `@DBOS.step`; OTel-compatible traces and logs if you wire up provider instrumentation | `kitaru.llm()` with alias-resolved keys and per-checkpoint cost |
 | Pause / resume | `DBOS.send` / `DBOS.recv` messaging | `kitaru.wait()` with schema-validated input |
 | Cross-run state | Bring your own store | `kitaru.memory` with scopes |
 | Scheduling | `@DBOS.scheduled()` (cron) + `Queue` with concurrency + dedup | Stack scheduler, or periodic invocation at the call site |

--- a/site/src/content/comparisons/kitaru-vs-dbos.mdx
+++ b/site/src/content/comparisons/kitaru-vs-dbos.mdx
@@ -112,6 +112,19 @@ We built Kitaru around a different shape of work. An agent loop has expensive LL
   ]}
 />
 
+## How the two surfaces map
+
+| Concept | DBOS | Kitaru |
+|---|---|---|
+| Workflow boundary | `@DBOS.workflow()` | `@flow` |
+| Durable step | `@DBOS.step()` | `@checkpoint` (ordinary Python) |
+| State backend | Postgres, alongside your OLTP data | Your own S3 / GCS / Azure Blob |
+| LLM call | Inside a `@DBOS.step` with OTel instrumentation | `kitaru.llm()` with alias-resolved keys and per-checkpoint cost |
+| Pause / resume | `DBOS.send` / `DBOS.recv` messaging | `kitaru.wait()` with schema-validated input |
+| Cross-run state | Bring your own store | `kitaru.memory` with scopes |
+| Scheduling | `@DBOS.scheduled()` (cron) + `Queue` with concurrency + dedup | Stack scheduler, or periodic invocation at the call site |
+| Deployment | Library embedded in whatever Python app you already ship | Named, versioned deployments with tag routing |
+
 ## Code comparison
 
 <CodeCompare
@@ -183,16 +196,14 @@ def review_flow(topic: str) -> str:
 # from another process via DBOS.send.`}
 />
 
-<PullQuote
-  quote="If your durability problem is polyglot services against Postgres with a SOC 2 or HIPAA control plane on day one, DBOS is better-shaped for that workload. Be honest about which side you're on."
-/>
-
 ## Ready to try Kitaru?
 
-If your durability problem is shaped like a Python agent loop, Kitaru removes the glue layer you'd otherwise write on top of a general-purpose workflow engine.
+If your durability problem is polyglot services against Postgres with a SOC 2 or HIPAA control plane on day one, DBOS is better-shaped for that workload — be honest about which side you're on. If it's shaped like a Python agent loop (LLM calls, memory, artifacts, human/agent approval gates), Kitaru removes the glue layer you'd otherwise write on top of a general-purpose workflow engine.
 
-`pip install kitaru`, add `@flow` and `@checkpoint`, and run your first durable agent in minutes. Check [the docs](/docs) for how `@flow`, `@checkpoint`, `kitaru.llm()`, `wait()`, and replay compose.
+- Read [our documentation](/docs) and see how `@flow`, `@checkpoint`, `kitaru.llm()`, `wait()`, and artifact lineage compose
+- `pip install kitaru` and run your first durable agent in an afternoon
+- [Talk to our team](/get-started) if you want help mapping a DBOS workflow onto Kitaru primitives
 
 <div class="compare-inline-cta">
-  <a href="/get-started" class="btn-primary">Get Started</a>
+  <a href="/get-started" class="btn-primary">Get started</a>
 </div>

--- a/site/src/content/comparisons/kitaru-vs-dbos.mdx
+++ b/site/src/content/comparisons/kitaru-vs-dbos.mdx
@@ -1,0 +1,198 @@
+---
+competitor: "DBOS"
+competitorLogo: "/compare/dbos.svg"
+title: "Kitaru vs DBOS: Durable execution, shaped around Python agents"
+description: "DBOS and Kitaru both make code durable. DBOS is polyglot, Postgres-backed, and built for general app workflows. Kitaru is Python-first and shaped for agent loops: LLM calls, wait/resume, artifact lineage, and stack retargeting are primitives."
+cardSubtitle: "Durable execution, shaped around Python agents. LLM calls, memory, and artifacts in the box."
+ctaHeading: "Durable execution, shaped for your Python agent"
+order: 30
+ogImage: "https://assets.kitaru.ai/compare/9abe6a89/og-card.avif"
+---
+
+import WhenToUseEach from '../../components/compare/WhenToUseEach.astro';
+import ComparisonTable from '../../components/compare/ComparisonTable.astro';
+import CodeCompare from '../../components/compare/CodeCompare.astro';
+import FeatureWithGraphic from '../../components/compare/FeatureWithGraphic.astro';
+import PullQuote from '../../components/compare/PullQuote.astro';
+import LLMPrimitive from '../../components/compare/graphics/dbos/LLMPrimitive.astro';
+import ArtifactVersioning from '../../components/compare/graphics/dbos/ArtifactVersioning.astro';
+import StackDeployment from '../../components/compare/graphics/dbos/StackDeployment.astro';
+import NamedDeployments from '../../components/compare/graphics/dbos/NamedDeployments.astro';
+
+DBOS and Kitaru solve the same first-order problem. Code crashes, and you shouldn't start over. Both are durable-runtime libraries, both are Apache-2.0, both are self-hostable, both do checkpoint, replay, and resume. The honest differences start further down the stack.
+
+DBOS is a polyglot durable workflow library on Postgres. It was shaped for the workloads every backend team ships: order processing, payment sagas, document approval, transactional side effects. Workflow state sits alongside your OLTP data in the same database, and Conductor gives ops a UI for scheduled workflows and durable queues.
+
+We built Kitaru around a different shape of work. An agent loop has expensive LLM calls, tool runs measured in minutes, humans approving drafts hours later, and artifact outputs you want to inspect after the fact. So we put those in the box: `kitaru.llm()` with alias-resolved secrets and per-checkpoint cost, `wait()` as a typed primitive, versioned artifact lineage across runs, and stack-based deploy to Kubernetes, SageMaker, Vertex AI, or AzureML without a rewrite.
+
+<WhenToUseEach
+  kitaru={{
+    title: "Use Kitaru if you are",
+    items: [
+      "Building Python agents and want `@flow`, `@checkpoint`, `kitaru.llm()`, `wait()`, and replay as the base primitives, not patterns you hand-roll on top of steps",
+      "Replaying a failed run from the last good checkpoint without paying for the LLM calls that already succeeded upstream",
+      "Retargeting the same agent across Kubernetes, SageMaker, Vertex AI, or AzureML with one stack swap, not a rewrite",
+      "Wrapping an existing Python agent in durability, or using Kitaru's documented PydanticAI adapter, without rewriting the core agent logic",
+      "Writing agent loops with runtime branches, tool calls, and human-in-the-loop waits measured in hours or days",
+    ],
+  }}
+  competitor={{
+    title: "Use DBOS if you are",
+    items: [
+      "Running durable workflows across Python, TypeScript, Go, and Java services with one contract",
+      "Leaning on durable queues, cron schedules, and the Conductor UI for ops",
+      "Needing DBOS Conductor's managed workflow console, and on paid plans, SOC 2/HIPAA-compliant tooling",
+      "Already deep into Postgres and want durable state living in the same database as your app",
+    ],
+  }}
+/>
+
+<PullQuote
+  quote="DBOS was shaped for app workflows on Postgres. Kitaru was shaped for Python agent loops. Both are durable runtimes. The ergonomics diverge at the primitives each one ships."
+/>
+
+<FeatureWithGraphic title="LLM calls as a first-class primitive">
+  <LLMPrimitive slot="graphic" />
+
+  In DBOS, an LLM call is something you make inside your own `@DBOS.step`. DBOS ships OpenTelemetry instrumentation for OpenAI, LiteLLM, and LangChain, so traces show up in Conductor. That gets you visibility. It doesn't get you a primitive. We built `kitaru.llm()` so the call itself is part of the runtime.
+
+  - **Alias-resolved secrets:** `kitaru.llm(prompt, model="fast")` resolves the model alias and injects the provider key from the active stack. The same call retargets from OpenAI to Anthropic to a self-hosted model without touching code.
+  - **Per-checkpoint cost roll-up:** Latency, token counts, and cost land under the enclosing `@checkpoint` automatically. Run inspection shows you the cost of step 9 without a separate LLM logging pipeline.
+  - **Replay:** On replay, the captured response is loaded from the checkpoint. The provider isn't hit again unless the input changed.
+</FeatureWithGraphic>
+
+<FeatureWithGraphic title="Artifact versioning across every checkpoint" reverse={true}>
+  <ArtifactVersioning slot="graphic" />
+
+  Every `@checkpoint` in Kitaru persists its inputs and outputs as versioned artifacts. Not just cached for resumption. Referenced, diffed, loaded into the next run, inspected through the UI.
+
+  - **Cross-run lineage:** Outputs from yesterday's run are artifacts you can reference or diff against today's. DBOS step I/O is persisted in Postgres to resume a workflow. It isn't surfaced as versioned, cross-run artifacts with a dedicated diff view.
+  - **Payload shape:** Artifacts live in your own S3, GCS, or Azure Blob. When a checkpoint output is a 50MB model completion or a document bundle, that's the right storage. DBOS keeps durable state next to your OLTP data, which is the right call when durable state is transactional rows.
+  - **Same UI as the run:** Artifacts, checkpoints, logs, and costs show up in one place. No `psql` console required to reconstruct what the agent produced.
+</FeatureWithGraphic>
+
+<FeatureWithGraphic title="Stack-based deploy to your own cloud">
+  <StackDeployment slot="graphic" />
+
+  DBOS is a library. You deploy the Python app however you already deploy Python apps, and state lives in whatever Postgres you point it at. That's simple and portable. Kitaru treats "where does this run" as a stack, and a stack is the unit of retarget.
+
+  - **One config swap, four clouds:** `kitaru deploy --stack sagemaker` moves the same flow from your laptop to AWS SageMaker. Swap `sagemaker` for `kubernetes`, `vertex`, or `azureml` and the flow retargets without a rewrite.
+  - **Cloud integration for free:** IAM, GPU quotas, autoscaling, and the right object store are inherited from the target stack. Under DBOS, that's wiring you do yourself in the deployment tool of your choice.
+  - **Build once, serve once, deploy anywhere:** `kitaru build` packages the flow as a container. `kitaru serve` runs it locally with the full durability contract. `kitaru deploy` ships it to the remote stack. Same code path each time.
+</FeatureWithGraphic>
+
+<FeatureWithGraphic title="Named deployments you invoke by name" reverse={true}>
+  <NamedDeployments slot="graphic" />
+
+  DBOS gives you scheduled workflows and durable queues with concurrency limits and deduplication. That's the operational shape: queue a job, assign a workflow ID from your code, recover on failure. Kitaru ships a different shape: immutable versioned deployments you invoke by name.
+
+  - **Named, versioned, tag-routed:** A flow ships as `review_flow@v3`. Tags (`default`, `staging`, whatever you want) route traffic. Roll a new version forward by moving a tag, not redeploying every caller.
+  - **Invoke from anywhere:** CLI, Python SDK, MCP server, or the generated curl snippet. The dashboard gives you a handle the rest of your stack can call. DBOS workflows start from application code with a workflow ID you assign.
+  - **Workspace-scoped auth:** No per-deployment tokens to rotate when you ship a new version. Keys are scoped to the workspace, not the individual flow.
+  - **Scheduling is honest:** DBOS ships `@DBOS.scheduled()` with cron and `Queue` with concurrency + dedup. Kitaru stacks lean on the underlying cloud's scheduler or a periodic invocation at the call site. If cron and queues are your happy path, DBOS has a thicker story there.
+</FeatureWithGraphic>
+
+## What makes Kitaru unique
+
+<ComparisonTable
+  competitorLabel="DBOS"
+  rows={[
+    { feature: "Durable execution with checkpoint replay", kitaru: true, competitor: true },
+    { feature: "Replay skips completed steps without re-running LLM calls", kitaru: true, competitor: true },
+    { feature: "`kitaru.llm()` primitive with alias-resolved keys and per-checkpoint cost roll-up", kitaru: true, competitor: false },
+    { feature: "Artifact versioning across runs (diffable across executions)", kitaru: true, competitor: false },
+    { feature: "Typed `wait()` with schema-validated input", kitaru: true, competitor: false },
+    { feature: "Isolated checkpoints (`runtime=\"isolated\"`) for container-per-step on remote stacks", kitaru: true, competitor: false },
+    { feature: "Stack retarget to Kubernetes, SageMaker, Vertex AI, AzureML", kitaru: true, competitor: false },
+    { feature: "Named, versioned deployments with tag routing", kitaru: true, competitor: false },
+    { feature: "Documented framework adapter for PydanticAI (more coming)", kitaru: true, competitor: false },
+    { feature: "Polyglot SDKs (Python, TypeScript, Go, Java)", kitaru: false, competitor: true },
+    { feature: "Native cron scheduling and durable queues", kitaru: false, competitor: true },
+    { feature: "SOC 2 / HIPAA compliant managed control plane", kitaru: false, competitor: true },
+  ]}
+/>
+
+## Code comparison
+
+<CodeCompare
+  kitaruLabel="Kitaru"
+  competitorLabel="DBOS (Python SDK)"
+  kitaruCode={`from kitaru import flow, checkpoint, wait
+import kitaru
+
+@checkpoint
+def research(topic: str) -> str:
+    return kitaru.llm(
+        prompt=f"Research: {topic}. Return a brief.",
+        model="fast",
+    )
+
+@checkpoint
+def draft(brief: str) -> str:
+    return kitaru.llm(
+        prompt=f"Write a draft from this brief:\\n{brief}",
+        model="claude-sonnet-4-6",
+    )
+
+@flow
+def review_flow(topic: str) -> str:
+    brief = research(topic)
+    text = draft(brief)
+
+    approved = wait(
+        name="approve",
+        schema=bool,
+        question=f"Approve this draft?\\n\\n{text[:500]}",
+    )
+    return text if approved else "Rejected"
+
+review_flow.run("Durable agents")`}
+  competitorCode={`from dbos import DBOS
+import openai
+
+client = openai.OpenAI()
+
+@DBOS.step()
+def research(topic: str) -> str:
+    resp = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user",
+                   "content": f"Research: {topic}"}],
+    )
+    return resp.choices[0].message.content
+
+@DBOS.step()
+def draft(brief: str) -> str:
+    resp = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user",
+                   "content": f"Write a draft:\\n{brief}"}],
+    )
+    return resp.choices[0].message.content
+
+@DBOS.workflow()
+def review_flow(topic: str) -> str:
+    brief = research(topic)
+    text = draft(brief)
+
+    # Human approval via DBOS.send / recv messaging.
+    approved = DBOS.recv(timeout_seconds=86400)
+    return text if approved else "Rejected"
+
+# Plus: start the DBOS runtime, send approval
+# from another process via DBOS.send.`}
+/>
+
+<PullQuote
+  quote="If your durability problem is polyglot services against Postgres with a SOC 2 or HIPAA control plane on day one, DBOS is better-shaped for that workload. Be honest about which side you're on."
+/>
+
+## Ready to try Kitaru?
+
+If your durability problem is shaped like a Python agent loop, Kitaru removes the glue layer you'd otherwise write on top of a general-purpose workflow engine.
+
+`pip install kitaru`, add `@flow` and `@checkpoint`, and run your first durable agent in minutes. Check [the docs](/docs) for how `@flow`, `@checkpoint`, `kitaru.llm()`, `wait()`, and replay compose.
+
+<div class="compare-inline-cta">
+  <a href="/get-started" class="btn-primary">Get Started</a>
+</div>

--- a/site/src/content/comparisons/kitaru-vs-langgraph-deep-agents.mdx
+++ b/site/src/content/comparisons/kitaru-vs-langgraph-deep-agents.mdx
@@ -118,7 +118,7 @@ def critique(docs: Docs) -> str:
   Kitaru deploys each flow as an immutable, auto-incrementing versioned snapshot. Consumers invoke by flow name using CLI, Python SDK, MCP, or a generated curl command pinned to a resolved version. Tag routing (`default`, `canary`, or your own exclusive tags) makes promotion and rollback a tag move, not a redeploy. Auth is workspace-scoped with no per-deployment tokens.
 </FeatureWithGraphic>
 
-## What makes Kitaru different
+## What makes Kitaru unique
 
 <ComparisonTable
   competitorLabel="LangGraph / Deep Agents"
@@ -137,6 +137,18 @@ def critique(docs: Docs) -> str:
     { feature: "Hosted control plane option", kitaru: false, competitor: true },
   ]}
 />
+
+## How the two surfaces map
+
+| Concept | LangGraph / Deep Agents | Kitaru |
+|---|---|---|
+| Execution model | Graph of nodes and edges with typed state | Ordinary Python with `@flow` + `@checkpoint` |
+| Durable unit | A node, persisted by the checkpointer between supersteps | A checkpoint boundary around any Python call |
+| Durability scope | Inside the LangGraph graph | Framework-agnostic — any harness inside a checkpoint |
+| Pause / resume | Graph pause/resume via checkpointer | `kitaru.wait()` |
+| Sandboxing | LangSmith Sandboxes (microVM, packaged) | `@checkpoint(runtime="isolated")` on your configured stack |
+| Deployment | LangSmith Deployment (packaged runtime + auth proxy + tracing) | `flow.deploy()` — immutable, versioned, tag-routed |
+| Control plane | Hosted by LangSmith (or their on-prem option) | Self-hosted Helm service, artifacts in your own bucket |
 
 ## Code comparison
 
@@ -194,23 +206,14 @@ app = graph.compile(checkpointer=MemorySaver())
 # routing / deployment / versioning via LangSmith.`}
 />
 
-## When LangGraph is the better pick
-
-If everyone on your team has standardized on LangGraph or Deep Agents, likes the graph model, and is moving onto LangSmith Deployment as the packaged runtime + platform, Kitaru adds less. Use what you have.
-
-## When Kitaru is the better pick
-
-- Multiple harnesses across teams, and you want a single durable runtime underneath all of them.
-- Self-hosted, on-prem, or regulated-industry constraints that rule out a hosted control plane.
-- You want durable execution that is a *primitive*, not a product your org has to adopt top-to-bottom.
-- You already have auth, observability, and secrets infrastructure and don&rsquo;t want a packaged runtime duplicating them.
-
 ## Ready to try Kitaru?
 
-- Read the [harness, runtime, platform](/docs/concepts/harness-runtime-platform) and [execution architecture](/docs/concepts/execution-architecture) docs for the full framing.
-- `pip install kitaru` and wrap your first agent with `@flow` and `@checkpoint` in an afternoon.
-- [Talk to the team](/get-started) if you&rsquo;re sizing up a move away from a hosted control plane.
+If everyone on your team has standardized on LangGraph or Deep Agents and you're moving onto LangSmith Deployment as the packaged runtime and platform, use what you have — Kitaru adds less. If multiple harnesses live across your teams, or a hosted control plane is not an option, Kitaru gives you one self-hosted durable runtime underneath all of them.
+
+- Read the [harness, runtime, platform](/docs/concepts/harness-runtime-platform) docs and see how `@flow` and `@checkpoint` wrap any harness
+- `pip install kitaru` and wrap your first agent with `@flow` and `@checkpoint` in an afternoon
+- [Talk to our team](/get-started) if you want help mapping a LangGraph or LangSmith setup onto Kitaru primitives
 
 <div class="compare-inline-cta">
-  <a href="/get-started" class="btn-primary">Get started with Kitaru</a>
+  <a href="/get-started" class="btn-primary">Get started</a>
 </div>

--- a/site/src/content/comparisons/kitaru-vs-langgraph-deep-agents.mdx
+++ b/site/src/content/comparisons/kitaru-vs-langgraph-deep-agents.mdx
@@ -1,7 +1,6 @@
 ---
 competitor: "LangGraph & Deep Agents"
 competitorLogo: "/compare/langgraph-deep-agents.svg"
-competitorTagline: "Graph-native agent harness + runtime, with a packaged deployment platform via LangSmith."
 title: "Kitaru vs LangGraph & Deep Agents: durable runtime without adopting a harness"
 description: "LangGraph gives you a graph-native harness with built-in checkpointer. Kitaru gives you a framework-agnostic durable runtime that works across any Python harness your teams pick."
 cardSubtitle: "Keep your harness freedom. Add durable execution underneath whatever your teams pick."

--- a/site/src/content/comparisons/kitaru-vs-langgraph-deep-agents.mdx
+++ b/site/src/content/comparisons/kitaru-vs-langgraph-deep-agents.mdx
@@ -101,7 +101,7 @@ def critique(docs: Docs) -> str:
 <FeatureWithGraphic title="Sandbox and security" reverse={true}>
   <SandboxSecurity slot="graphic" />
 
-  LangSmith ships real security infrastructure: LangSmith Sandboxes (microVM isolation, Deep Agents integration), an auth proxy that keeps secrets out of the sandbox, and OpenTelemetry-native tracing. Adopt their stack and you get a usable isolation story out of the box.
+  LangSmith ships real security infrastructure: LangSmith Sandboxes provide ephemeral, locked-down environments for running untrusted code, and LangSmith Deployment adds authentication, monitoring, and tracing around deployed agents. Adopt their stack and you get a usable isolation story out of the box.
 
   Kitaru takes a different posture. `@checkpoint(runtime="isolated")` runs a checkpoint in a separate pod or job on the stack you configured. For stronger isolation, bring your own sandbox provider. Secrets come from your own secret manager. The runtime exposes execution boundaries; policy at those boundaries belongs to your platform.
 
@@ -146,7 +146,7 @@ def critique(docs: Docs) -> str:
 | Durable unit | A node, persisted by the checkpointer between supersteps | A checkpoint boundary around any Python call |
 | Durability scope | Inside the LangGraph graph | Framework-agnostic — any harness inside a checkpoint |
 | Pause / resume | Graph pause/resume via checkpointer | `kitaru.wait()` |
-| Sandboxing | LangSmith Sandboxes (microVM, packaged) | `@checkpoint(runtime="isolated")` on your configured stack |
+| Sandboxing | LangSmith Sandboxes (ephemeral, locked-down environments) | `@checkpoint(runtime="isolated")` on your configured stack |
 | Deployment | LangSmith Deployment (packaged runtime + auth proxy + tracing) | `flow.deploy()` — immutable, versioned, tag-routed |
 | Control plane | Hosted by LangSmith (or their on-prem option) | Self-hosted Helm service, artifacts in your own bucket |
 

--- a/site/src/content/comparisons/kitaru-vs-langgraph-deep-agents.mdx
+++ b/site/src/content/comparisons/kitaru-vs-langgraph-deep-agents.mdx
@@ -12,6 +12,11 @@ import WhenToUseEach from '../../components/compare/WhenToUseEach.astro';
 import ComparisonTable from '../../components/compare/ComparisonTable.astro';
 import CodeCompare from '../../components/compare/CodeCompare.astro';
 import PullQuote from '../../components/compare/PullQuote.astro';
+import FeatureWithGraphic from '../../components/compare/FeatureWithGraphic.astro';
+import CodePane from '../../components/compare/CodePane.astro';
+import SelfHostVsPackaged from '../../components/compare/graphics/langgraph/SelfHostVsPackaged.astro';
+import SandboxSecurity from '../../components/compare/graphics/langgraph/SandboxSecurity.astro';
+import VersionedDeployments from '../../components/compare/graphics/langgraph/VersionedDeployments.astro';
 
 LangGraph is a real durable runtime. Deep Agents is a strong opinionated harness on top of it. LangSmith Deployment packages both with sandboxes, auth proxy, tracing, and hosted infra. If you adopt that stack, you get a lot for free.
 
@@ -44,30 +49,25 @@ Kitaru is a different bet. Kitaru is a **framework-agnostic durable runtime**: `
   quote="LangGraph is a runtime inside one harness. Kitaru is a runtime across any harness."
 />
 
-## Graph-native vs Python-native
-
-LangGraph&rsquo;s checkpointer, resume, and time-travel are powerful &mdash; inside the graph/state-machine model. Your agent is a graph of nodes and edges, and LangGraph persists state between supersteps.
-
-Kitaru doesn&rsquo;t require a graph. `@checkpoint` marks the durable boundaries around ordinary Python function calls. That means the agent harness inside a checkpoint can be anything &mdash; a LangGraph graph invocation, a Pydantic AI agent, a Claude Agent SDK turn, or hand-written code that calls an LLM. The flow body stays Python:
-
-```python
-@flow
+<FeatureWithGraphic title="Graph-native vs Python-native">
+  <CodePane
+    slot="graphic"
+    code={`@flow
 def research_agent(topic: str) -> str:
     plan = checkpoint(make_plan)(topic)
     docs = checkpoint(retrieve)(plan)
-    return checkpoint(synthesize)(docs)
-```
+    return checkpoint(synthesize)(docs)`}
+  />
 
-No graph, no state schema, no nodes and edges. Just Python boundaries you can replay and resume.
+  LangGraph&rsquo;s checkpointer, resume, and time-travel are powerful &mdash; inside the graph/state-machine model. Your agent is a graph of nodes and edges, and LangGraph persists state between supersteps.
 
-## Harness freedom
+  Kitaru doesn&rsquo;t require a graph. `@checkpoint` marks the durable boundaries around ordinary Python function calls. That means the agent harness inside a checkpoint can be anything &mdash; a LangGraph graph invocation, a Pydantic AI agent, a Claude Agent SDK turn, or hand-written code that calls an LLM. The flow body stays Python: no graph, no state schema, no nodes and edges. Just Python boundaries you can replay and resume.
+</FeatureWithGraphic>
 
-Platform teams at larger orgs rarely get to pick one harness for everyone. One team wants Pydantic AI for its typing. Another picked Deep Agents for multi-agent patterns. A third wrote a loop against the Anthropic SDK. A fourth uses an internal framework that predates all of this.
-
-LangGraph&rsquo;s durability is strongest when everyone adopts LangGraph. Kitaru&rsquo;s is strongest when they don&rsquo;t have to.
-
-```python
-# Pydantic AI inside a Kitaru checkpoint
+<FeatureWithGraphic title="Harness freedom" reverse={true}>
+  <CodePane
+    slot="graphic"
+    code={`# Pydantic AI inside a Kitaru checkpoint
 @checkpoint
 def plan(topic: str) -> Plan:
     return pydantic_agent.run_sync(topic).output
@@ -80,34 +80,43 @@ def research(plan: Plan) -> Docs:
 # Claude Agent SDK inside a Kitaru checkpoint
 @checkpoint
 def critique(docs: Docs) -> str:
-    return asyncio.run(_claude_critique(docs))
-```
+    return asyncio.run(_claude_critique(docs))`}
+  />
 
-Same durability contract, three different harnesses, one runtime.
+  Platform teams at larger orgs rarely get to pick one harness for everyone. One team wants Pydantic AI for its typing. Another picked Deep Agents for multi-agent patterns. A third wrote a loop against the Anthropic SDK. A fourth uses an internal framework that predates all of this.
 
-## Self-host vs packaged platform
+  LangGraph&rsquo;s durability is strongest when everyone adopts LangGraph. Kitaru&rsquo;s is strongest when they don&rsquo;t have to. Same durability contract, three different harnesses, one runtime.
+</FeatureWithGraphic>
 
-LangSmith Deployment packages runtime + sandboxes + auth proxy + tracing into a managed product. That&rsquo;s genuinely useful if you want to offload the platform layer.
+<FeatureWithGraphic title="Self-host vs packaged platform">
+  <SelfHostVsPackaged slot="graphic" />
 
-Kitaru ships the runtime layer as a primitive you self-host. The Kitaru server is a single service deployable via Helm. Artifacts and state live in your own S3, GCS, or Azure Blob bucket. Auth is workspace-scoped. There is no mandatory hosted control plane in the path of your agent&rsquo;s data.
+  LangSmith Deployment packages runtime + sandboxes + auth proxy + tracing into a managed product. That&rsquo;s genuinely useful if you want to offload the platform layer.
 
-If your security team needs to know exactly where prompts, outputs, and artifacts live, &ldquo;in our own bucket&rdquo; is a shorter conversation than a data-residency addendum on a hosted control plane.
+  Kitaru ships the runtime layer as a primitive you self-host. The Kitaru server is a single service deployable via Helm. Artifacts and state live in your own S3, GCS, or Azure Blob bucket. Auth is workspace-scoped. There is no mandatory hosted control plane in the path of your agent&rsquo;s data.
 
-## Sandbox and security
+  If your security team needs to know exactly where prompts, outputs, and artifacts live, &ldquo;in our own bucket&rdquo; is a shorter conversation than a data-residency addendum on a hosted control plane.
+</FeatureWithGraphic>
 
-LangSmith ships real security infrastructure: LangSmith Sandboxes (microVM isolation, Deep Agents integration), an auth proxy that keeps secrets out of the sandbox, and OpenTelemetry-native tracing. Adopt their stack and you get a usable isolation story out of the box.
+<FeatureWithGraphic title="Sandbox and security" reverse={true}>
+  <SandboxSecurity slot="graphic" />
 
-Kitaru takes a different posture. `@checkpoint(runtime="isolated")` runs a checkpoint in a separate pod or job on the stack you configured. For stronger isolation, bring your own sandbox provider. Secrets come from your own secret manager. The runtime exposes execution boundaries; policy at those boundaries belongs to your platform.
+  LangSmith ships real security infrastructure: LangSmith Sandboxes (microVM isolation, Deep Agents integration), an auth proxy that keeps secrets out of the sandbox, and OpenTelemetry-native tracing. Adopt their stack and you get a usable isolation story out of the box.
 
-Two legitimate answers to the same problem: security packaged with the runtime, or security configurable at each execution boundary.
+  Kitaru takes a different posture. `@checkpoint(runtime="isolated")` runs a checkpoint in a separate pod or job on the stack you configured. For stronger isolation, bring your own sandbox provider. Secrets come from your own secret manager. The runtime exposes execution boundaries; policy at those boundaries belongs to your platform.
 
-## Versioned deployments
+  Two legitimate answers to the same problem: security packaged with the runtime, or security configurable at each execution boundary.
+</FeatureWithGraphic>
 
-Both products have strong deployment stories &mdash; with different shapes.
+<FeatureWithGraphic title="Versioned deployments">
+  <VersionedDeployments slot="graphic" />
 
-LangSmith Deployment exposes agent endpoints (MCP, A2A, Agent Protocol, HITL, memory APIs) as part of its packaged runtime.
+  Both products have strong deployment stories &mdash; with different shapes.
 
-Kitaru deploys each flow as an immutable, auto-incrementing versioned snapshot. Consumers invoke by flow name using CLI, Python SDK, MCP, or a generated curl command pinned to a resolved version. Tag routing (`default`, `canary`, or your own exclusive tags) makes promotion and rollback a tag move, not a redeploy. Auth is workspace-scoped with no per-deployment tokens.
+  LangSmith Deployment exposes agent endpoints (MCP, A2A, Agent Protocol, HITL, memory APIs) as part of its packaged runtime.
+
+  Kitaru deploys each flow as an immutable, auto-incrementing versioned snapshot. Consumers invoke by flow name using CLI, Python SDK, MCP, or a generated curl command pinned to a resolved version. Tag routing (`default`, `canary`, or your own exclusive tags) makes promotion and rollback a tag move, not a redeploy. Auth is workspace-scoped with no per-deployment tokens.
+</FeatureWithGraphic>
 
 ## What makes Kitaru different
 

--- a/site/src/content/comparisons/kitaru-vs-pydantic-ai.mdx
+++ b/site/src/content/comparisons/kitaru-vs-pydantic-ai.mdx
@@ -92,7 +92,7 @@ def review(case: dict) -> str:
   - **Self-hosted infrastructure.** The Kitaru server is a single Helm-deployed service. Artifacts and state live in your own S3 / GCS / Azure Blob bucket. No mandatory SaaS control plane.
 </FeatureWithGraphic>
 
-## What makes Kitaru different
+## What makes Kitaru unique
 
 <ComparisonTable
   competitorLabel="Pydantic AI"
@@ -111,6 +111,19 @@ def review(case: dict) -> str:
     { feature: "First-class adapter for the other", kitaru: true, competitor: false },
   ]}
 />
+
+## How the two surfaces map
+
+| Concept | Pydantic AI | Kitaru |
+|---|---|---|
+| Layer | Agent harness (how the agent thinks) | Durable runtime (how it runs over time and infra) |
+| Durable unit | — (not a durable runtime) | `@flow` + `@checkpoint` |
+| Composition | Standalone Pythonic agent | Pydantic AI agent wrapped by `KitaruAgent` adapter inside a `@checkpoint` |
+| Crash recovery | — | Replay from the last good checkpoint, cached work reused |
+| Long wait on a human | Blocking `input()` / your own polling | `kitaru.wait()` (compute released, survives crashes) |
+| Artifacts | — | Typed, versioned artifacts per checkpoint |
+| Versioning | — | Named versioned deployments with tag routing |
+| Deployment | Whatever Python service you wrap the agent in | Stack-based deploy to Kubernetes, AWS, GCP, Azure |
 
 ## Code comparison
 
@@ -163,23 +176,14 @@ def review_flow(case: dict) -> str:
 review_flow(case={"id": "C-001"})`}
 />
 
-## When to reach for Kitaru
-
-- The agent is becoming a **production workload**, not a notebook script.
-- A run can **take minutes to hours**, and you can&rsquo;t afford to re-run it on every crash.
-- A step sometimes needs a **human or another agent** to say yes, and you don&rsquo;t want a process sitting around paying for CPU while it waits.
-- You need to **version, roll out, and roll back** deployments without redeploying infrastructure.
-- You want **artifact-level audit trails**, not just log lines.
-- You need **self-hosted execution** on your own Kubernetes / cloud job backend.
-
-If none of that applies, Pydantic AI on its own is the right answer.
-
 ## Ready to try Kitaru?
 
-- Read the [Pydantic AI adapter docs](/docs/guides/pydantic-ai-adapter) for the composition pattern.
-- See the [harness, runtime, platform](/docs/concepts/harness-runtime-platform) page for the layer split.
-- `pip install kitaru` and wrap an existing Pydantic AI agent in `@flow` in an afternoon.
+If the Pydantic AI agent you wrote is still a notebook script or a short-lived interactive tool, Pydantic AI on its own is the right answer. If it's becoming a production workload — long-running, crash-surviving, approved by a human hours later, deployed on your own cloud — the durability layer is the stuff Kitaru ships in the box.
+
+- Read the [Pydantic AI adapter docs](/docs/guides/pydantic-ai-adapter) and see how `@flow` and `@checkpoint` wrap an existing agent
+- `pip install kitaru` and wrap your first Pydantic AI agent in an afternoon
+- [Talk to our team](/get-started) if you want help taking a Pydantic AI prototype to a production deployment
 
 <div class="compare-inline-cta">
-  <a href="/get-started" class="btn-primary">Get started with Kitaru</a>
+  <a href="/get-started" class="btn-primary">Get started</a>
 </div>

--- a/site/src/content/comparisons/kitaru-vs-pydantic-ai.mdx
+++ b/site/src/content/comparisons/kitaru-vs-pydantic-ai.mdx
@@ -37,7 +37,7 @@ They don&rsquo;t compete. They compose. Kitaru ships a [first-class Pydantic AI 
     title: "Use Pydantic AI if you are",
     items: [
       "Writing agent logic in Python and want type-safe inputs, outputs, and tools",
-      "Building short-lived or interactive agents where durable runtime is overkill",
+      "Building short-lived or interactive agents, or using Pydantic AI&rsquo;s own durable execution integrations (Temporal, DBOS, Prefect, Restate) where they fit your stack",
       "Prototyping an agent before deciding whether it needs a production runtime around it",
       "Happy with your existing orchestration and only need better agent ergonomics",
     ],
@@ -82,7 +82,7 @@ def review(case: dict) -> str:
 <FeatureWithGraphic title="What Kitaru adds on top">
   <WhatKitaruAddsOnTop slot="graphic" />
 
-  Pydantic AI doesn&rsquo;t try to do any of this. Kitaru does:
+  Pydantic AI is primarily an agent harness &mdash; it now documents durable execution through integrations with Temporal, DBOS, Prefect, and Restate. Kitaru&rsquo;s difference is that it ships the durable runtime layer Kitaru-natively:
 
   - **Durable execution.** A crash, pod eviction, or timeout doesn&rsquo;t send the run back to zero. Fix the bug, replay, and the completed checkpoints return cached output instead of re-burning tokens.
   - **Pause and resume.** `kitaru.wait()` suspends a flow, releases compute, and resumes minutes, hours, or days later when input lands from a human, another agent, a webhook, or a CLI call.
@@ -117,10 +117,10 @@ def review(case: dict) -> str:
 | Concept | Pydantic AI | Kitaru |
 |---|---|---|
 | Layer | Agent harness (how the agent thinks) | Durable runtime (how it runs over time and infra) |
-| Durable unit | — (not a durable runtime) | `@flow` + `@checkpoint` |
+| Durable unit | Agent run; durable execution via Temporal / DBOS / Prefect / Restate integrations | `@flow` + `@checkpoint` (Kitaru-native) |
 | Composition | Standalone Pythonic agent | Pydantic AI agent wrapped by `KitaruAgent` adapter inside a `@checkpoint` |
 | Crash recovery | — | Replay from the last good checkpoint, cached work reused |
-| Long wait on a human | Blocking `input()` / your own polling | `kitaru.wait()` (compute released, survives crashes) |
+| Long wait on a human | Deferred tools + HITL approval patterns; durable pause/resume depends on the chosen runtime integration | `kitaru.wait()` (compute released, survives crashes) |
 | Artifacts | — | Typed, versioned artifacts per checkpoint |
 | Versioning | — | Named versioned deployments with tag routing |
 | Deployment | Whatever Python service you wrap the agent in | Stack-based deploy to Kubernetes, AWS, GCP, Azure |

--- a/site/src/content/comparisons/kitaru-vs-pydantic-ai.mdx
+++ b/site/src/content/comparisons/kitaru-vs-pydantic-ai.mdx
@@ -1,7 +1,6 @@
 ---
 competitor: "Pydantic AI"
 competitorLogo: "/compare/pydantic-ai.svg"
-competitorTagline: "Type-safe, Pythonic agent framework from the Pydantic team."
 title: "Kitaru vs Pydantic AI: harness and runtime, composed"
 description: "Pydantic AI is how the agent thinks. Kitaru is how it runs reliably over time and infrastructure. Use both — there's a first-class adapter."
 cardSubtitle: "Build the agent with Pydantic AI. Run it reliably with Kitaru."

--- a/site/src/content/comparisons/kitaru-vs-pydantic-ai.mdx
+++ b/site/src/content/comparisons/kitaru-vs-pydantic-ai.mdx
@@ -12,6 +12,10 @@ import WhenToUseEach from '../../components/compare/WhenToUseEach.astro';
 import ComparisonTable from '../../components/compare/ComparisonTable.astro';
 import CodeCompare from '../../components/compare/CodeCompare.astro';
 import PullQuote from '../../components/compare/PullQuote.astro';
+import FeatureWithGraphic from '../../components/compare/FeatureWithGraphic.astro';
+import CodePane from '../../components/compare/CodePane.astro';
+import DifferentQuestions from '../../components/compare/graphics/pydantic-ai/DifferentQuestions.astro';
+import WhatKitaruAddsOnTop from '../../components/compare/graphics/pydantic-ai/WhatKitaruAddsOnTop.astro';
 
 Pydantic AI and Kitaru solve different problems at different layers. Pydantic AI is an **agent harness**: it&rsquo;s the best-in-class Pythonic library for writing type-safe agent logic &mdash; tool calling, structured outputs, dependency injection, streaming. Kitaru is a **durable runtime**: checkpoints, replay, resume, wait states, versioned deployments, artifact lineage, and self-hosted execution.
 
@@ -44,24 +48,18 @@ They don&rsquo;t compete. They compose. Kitaru ships a [first-class Pydantic AI 
   quote="Pydantic AI gives you a great way to write an agent. Kitaru gives you a great way to run one."
 />
 
-## Different questions
+<FeatureWithGraphic title="Different questions">
+  <DifferentQuestions slot="graphic" />
 
-Pydantic AI is asking:
+  Pydantic AI is asking: how do I write a typed, ergonomic agent loop with first-class tools and structured outputs? Kitaru is asking: once this agent exists, how does it survive crashes, resume after a human approves, replay from failure, version its deployments, and plug into my infra?
 
-> How do I write a typed, ergonomic agent loop with first-class tools and structured outputs?
+  In practice that means Pydantic AI lives *inside* a Kitaru checkpoint. Kitaru wraps the outer boundaries &mdash; where durability, replay, and execution placement matter.
+</FeatureWithGraphic>
 
-Kitaru is asking:
-
-> Once this agent exists, how does it survive crashes, resume after a human approves, replay from failure, version its deployments, and plug into my infra?
-
-In practice that means Pydantic AI lives *inside* a Kitaru checkpoint. Kitaru wraps the outer boundaries &mdash; where durability, replay, and execution placement matter.
-
-## Compose, don&rsquo;t replace
-
-Kitaru doesn&rsquo;t ask you to give up the Pydantic AI agent you already wrote. Wrap it in a checkpoint and you&rsquo;re done:
-
-```python
-from kitaru import flow, checkpoint, wait
+<FeatureWithGraphic title="Compose, don&rsquo;t replace" reverse={true}>
+  <CodePane
+    slot="graphic"
+    code={`from kitaru import flow, checkpoint, wait
 from kitaru.adapters.pydantic_ai import KitaruAgent
 from pydantic_ai import Agent
 
@@ -73,21 +71,26 @@ agent = KitaruAgent(
 def review(case: dict) -> str:
     first_pass = agent.run_sync(case).output
     approved = wait(name="approve", question=first_pass, schema=bool)
-    return first_pass if approved else "rejected"
-```
+    return first_pass if approved else "rejected"`}
+  />
 
-The adapter tracks every model request and tool call as a child event under the enclosing checkpoint, so replay, artifact lineage, and logs work at the grain of the agent&rsquo;s internal steps &mdash; not just the outer call.
+  Kitaru doesn&rsquo;t ask you to give up the Pydantic AI agent you already wrote. Wrap it in a checkpoint and you&rsquo;re done.
 
-## What Kitaru adds on top
+  The adapter tracks every model request and tool call as a child event under the enclosing checkpoint, so replay, artifact lineage, and logs work at the grain of the agent&rsquo;s internal steps &mdash; not just the outer call.
+</FeatureWithGraphic>
 
-Pydantic AI doesn&rsquo;t try to do any of this. Kitaru does:
+<FeatureWithGraphic title="What Kitaru adds on top">
+  <WhatKitaruAddsOnTop slot="graphic" />
 
-- **Durable execution.** A crash, pod eviction, or timeout doesn&rsquo;t send the run back to zero. Fix the bug, replay, and the completed checkpoints return cached output instead of re-burning tokens.
-- **Pause and resume.** `kitaru.wait()` suspends a flow, releases compute, and resumes minutes, hours, or days later when input lands from a human, another agent, a webhook, or a CLI call.
-- **Versioned deployments.** `flow.deploy()` captures an immutable snapshot. Consumers invoke by flow name; tag routing and rollback are a `kitaru flow tag` away.
-- **Artifact lineage.** Every checkpoint writes a typed, versioned artifact. Diff artifacts across runs, trace a bad output back to the specific step, and build audit trails without grepping logs.
-- **Execution placement.** `@checkpoint(runtime="isolated")` runs a specific step in its own pod or job on Kubernetes, AWS, GCP, Azure. Heavy or risky steps stay isolated; orchestration stays inline.
-- **Self-hosted infrastructure.** The Kitaru server is a single Helm-deployed service. Artifacts and state live in your own S3 / GCS / Azure Blob bucket. No mandatory SaaS control plane.
+  Pydantic AI doesn&rsquo;t try to do any of this. Kitaru does:
+
+  - **Durable execution.** A crash, pod eviction, or timeout doesn&rsquo;t send the run back to zero. Fix the bug, replay, and the completed checkpoints return cached output instead of re-burning tokens.
+  - **Pause and resume.** `kitaru.wait()` suspends a flow, releases compute, and resumes minutes, hours, or days later when input lands from a human, another agent, a webhook, or a CLI call.
+  - **Versioned deployments.** `flow.deploy()` captures an immutable snapshot. Consumers invoke by flow name; tag routing and rollback are a `kitaru flow tag` away.
+  - **Artifact lineage.** Every checkpoint writes a typed, versioned artifact. Diff artifacts across runs, trace a bad output back to the specific step, and build audit trails without grepping logs.
+  - **Execution placement.** `@checkpoint(runtime="isolated")` runs a specific step in its own pod or job on Kubernetes, AWS, GCP, Azure. Heavy or risky steps stay isolated; orchestration stays inline.
+  - **Self-hosted infrastructure.** The Kitaru server is a single Helm-deployed service. Artifacts and state live in your own S3 / GCS / Azure Blob bucket. No mandatory SaaS control plane.
+</FeatureWithGraphic>
 
 ## What makes Kitaru different
 

--- a/site/src/content/comparisons/kitaru-vs-restate.mdx
+++ b/site/src/content/comparisons/kitaru-vs-restate.mdx
@@ -2,7 +2,7 @@
 competitor: "Restate"
 competitorLogo: "/compare/restate.svg"
 title: "Kitaru vs Restate: Durable execution, shaped for Python agents"
-description: "Restate is a polyglot, open-source durable runtime for services, Virtual Objects, and workflows. Kitaru is a Python-native durable runtime shaped for agent loops, with typed artifact lineage and an opinionated cloud-stack abstraction."
+description: "Restate is a polyglot, source-available durable runtime for services, Virtual Objects, and workflows. Kitaru is a Python-native durable runtime shaped for agent loops, with typed artifact lineage and an opinionated cloud-stack abstraction."
 cardSubtitle: "Durable execution for Python agents, with agent-native primitives such as llm(), wait(), save()/load(), and memory."
 ctaHeading: "Durable execution, shaped for your Python agent"
 order: 60
@@ -19,7 +19,7 @@ import ArtifactLineage from '../../components/compare/graphics/restate/ArtifactL
 import StackAbstraction from '../../components/compare/graphics/restate/StackAbstraction.astro';
 import EmbeddedVsServerRegistered from '../../components/compare/graphics/restate/EmbeddedVsServerRegistered.astro';
 
-Restate is a serious durable runtime. Polyglot SDKs across TypeScript, Java, Kotlin, Go, Rust, and Python. Apache 2.0. Three handler shapes (services, Virtual Objects with keyed per-entity state and strongly-consistent access, and workflows), journaled execution, awakeables for human-in-the-loop, OpenTelemetry tracing, self-hostable on every major cloud. If your durability problem is polyglot and backend-services-shaped, Restate is the pragmatic answer. That's the honest thing to say up front.
+Restate is a serious durable runtime. Polyglot SDKs across TypeScript, Java, Kotlin, Go, Rust, and Python. BSL 1.1 runtime license, with Apache 2.0 as the change license after the change date. Three handler shapes (services, Virtual Objects with keyed per-entity state and strongly-consistent access, and workflows), journaled execution, awakeables for human-in-the-loop, OpenTelemetry tracing, self-hostable on every major cloud. If your durability problem is polyglot and backend-services-shaped, Restate is the pragmatic answer. That's the honest thing to say up front.
 
 Kitaru is narrower on purpose. We built it for Python agents, because that's the workload most teams we talk to are trying to ship right now. Today, it's increasingly obvious that every company running agents in production needs the same capabilities: a durable `llm()` call, wait/resume, typed versioned memory, artifact lineage across runs, human/agent approval gates, and a runtime that understands the cloud underneath it. Those don't come in the box with any general-purpose durable runtime. So we put them there.
 
@@ -95,7 +95,7 @@ Kitaru is narrower on purpose. We built it for Python agents, because that's the
   rows={[
     { feature: "Durable execution and replay", kitaru: true, competitor: true },
     { feature: "Human-in-the-loop waiting with compute released", kitaru: true, competitor: true },
-    { feature: "Self-hostable, Apache 2.0", kitaru: true, competitor: true },
+    { feature: "Self-hostable (Kitaru: Apache 2.0; Restate: BSL 1.1, Apache 2.0 as the change license)", kitaru: true, competitor: true },
     { feature: "OpenTelemetry tracing", kitaru: true, competitor: true },
     { feature: "Python-agent-shaped primitives (`kitaru.llm()`, `kitaru.wait()`, `kitaru.memory`)", kitaru: true, competitor: false },
     { feature: "Built-in LLM primitive with alias-resolved secrets and per-call token/latency logging", kitaru: true, competitor: false },

--- a/site/src/content/comparisons/kitaru-vs-restate.mdx
+++ b/site/src/content/comparisons/kitaru-vs-restate.mdx
@@ -193,5 +193,5 @@ We've spent five years building the MLOps-ready version of this problem space at
 - [Talk to our team](/get-started) if you want help mapping a Restate workflow or Virtual Object onto Kitaru primitives
 
 <div class="compare-inline-cta">
-  <a href="/get-started" class="btn-primary">Get Started</a>
+  <a href="/get-started" class="btn-primary">Get started</a>
 </div>

--- a/site/src/content/comparisons/kitaru-vs-restate.mdx
+++ b/site/src/content/comparisons/kitaru-vs-restate.mdx
@@ -1,0 +1,197 @@
+---
+competitor: "Restate"
+competitorLogo: "/compare/restate.svg"
+title: "Kitaru vs Restate: Durable execution, shaped for Python agents"
+description: "Restate is a polyglot, open-source durable runtime for services, Virtual Objects, and workflows. Kitaru is a Python-native durable runtime shaped for agent loops, with typed artifact lineage and an opinionated cloud-stack abstraction."
+cardSubtitle: "Durable execution for Python agents, with agent-native primitives such as llm(), wait(), save()/load(), and memory."
+ctaHeading: "Durable execution, shaped for your Python agent"
+order: 60
+ogImage: "https://assets.kitaru.ai/compare/4ff198fe/og-card.avif"
+---
+
+import WhenToUseEach from '../../components/compare/WhenToUseEach.astro';
+import ComparisonTable from '../../components/compare/ComparisonTable.astro';
+import CodeCompare from '../../components/compare/CodeCompare.astro';
+import FeatureWithGraphic from '../../components/compare/FeatureWithGraphic.astro';
+import PullQuote from '../../components/compare/PullQuote.astro';
+import AgentShapedRuntime from '../../components/compare/graphics/restate/AgentShapedRuntime.astro';
+import ArtifactLineage from '../../components/compare/graphics/restate/ArtifactLineage.astro';
+import StackAbstraction from '../../components/compare/graphics/restate/StackAbstraction.astro';
+import EmbeddedVsServerRegistered from '../../components/compare/graphics/restate/EmbeddedVsServerRegistered.astro';
+
+Restate is a serious durable runtime. Polyglot SDKs across TypeScript, Java, Kotlin, Go, Rust, and Python. Apache 2.0. Three handler shapes (services, Virtual Objects with keyed per-entity state and strongly-consistent access, and workflows), journaled execution, awakeables for human-in-the-loop, OpenTelemetry tracing, self-hostable on every major cloud. If your durability problem is polyglot and backend-services-shaped, Restate is the pragmatic answer. That's the honest thing to say up front.
+
+Kitaru is narrower on purpose. We built it for Python agents, because that's the workload most teams we talk to are trying to ship right now. Today, it's increasingly obvious that every company running agents in production needs the same capabilities: a durable `llm()` call, wait/resume, typed versioned memory, artifact lineage across runs, human/agent approval gates, and a runtime that understands the cloud underneath it. Those don't come in the box with any general-purpose durable runtime. So we put them there.
+
+<WhenToUseEach
+  kitaru={{
+    title: "Use Kitaru if you are",
+    items: [
+      "Running Python agents and want `kitaru.llm()`, `kitaru.wait()`, `kitaru.memory`, and artifact lineage as primitives, not glue code your platform team maintains forever",
+      "Deploying across Kubernetes, AWS, GCP, or Azure and want an opinionated stack abstraction where one config switches every flow's backend",
+      "Happy with embedded durability (`@flow` and `@checkpoint` on ordinary Python) rather than handlers that register with a separate server",
+      "Designing around dynamic agent loops: tool calls, conditional branches, human/agent approval gates, hours-long waits",
+    ],
+  }}
+  competitor={{
+    title: "Use Restate if you are",
+    items: [
+      "Running a polyglot services stack (TypeScript, Java, Kotlin, Go, Rust, Python) that needs one durability primitive across all of it",
+      "Doing durable RPC, sagas, or long-running backend workflows, not agent loops with LLM calls",
+      "Modeling keyed per-entity state with strongly-consistent access (chat sessions, orders, devices, users) as a first-class abstraction",
+      "Fine with running `restate-server` as infra and using awakeables / durable promises as the core HITL primitive",
+    ],
+  }}
+/>
+
+<PullQuote
+  quote="Restate adds durability to your services. Kitaru adds durability to your Python agents."
+/>
+
+<FeatureWithGraphic title="Agent-shaped vs app-shaped runtime">
+  <AgentShapedRuntime slot="graphic" />
+
+  Defaults tell you what a tool is actually for. Restate's defaults are services, Virtual Objects, and workflows. Real durability primitives, shaped for backend app workloads. Kitaru's defaults are `kitaru.llm()`, `kitaru.wait()`, `kitaru.memory`, and versioned artifacts per checkpoint. Different opinion about the workload, same commitment to durability.
+
+  - **In-the-box primitives:** `kitaru.llm()` resolves the model alias, injects the provider key, and logs prompt, response, latency, tokens, and model on every call. Restate's equivalent surface is services, Virtual Objects, workflows, and awakeables. Durability primitives, not agent primitives.
+  - **Framework adapters:** Kitaru ships a PydanticAI adapter, so wrapping an existing agent harness in `@flow` and `@checkpoint` is a five-minute job. Restate works alongside agent SDKs via generic wrappers.
+  - **Both can be bent to the other's shape.** What ships in the box tells you what the team was watching when they set the defaults.
+</FeatureWithGraphic>
+
+<FeatureWithGraphic title="Artifact lineage vs journal and Virtual Object state" reverse={true}>
+  <ArtifactLineage slot="graphic" />
+
+  Both tools persist state. The data models are different, and they're optimized for different shapes of work. Worth saying clearly.
+
+  - **Kitaru:** Every `@checkpoint` output lands as a typed, versioned artifact in your own S3, GCS, or Azure Blob bucket, linked to the execution record. Pick two runs, diff the artifacts at each checkpoint in the same UI. We took this straight from ZenML, where five years of ML work taught us that platform teams live or die on artifact lineage.
+  - **Restate:** Handler progress is journaled for deterministic replay. Virtual Objects expose keyed per-entity state with strongly-consistent access and single-writer semantics per object. That's the right shape for "the chat session", "the order", "the device".
+  - **Honest read:** VO-keyed per-entity state and versioned artifacts aren't two answers to the same question. They're two shapes of state, fit for different workloads.
+</FeatureWithGraphic>
+
+<FeatureWithGraphic title="Opinionated cloud-stack abstraction vs bring-your-own deployment">
+  <StackAbstraction slot="graphic" />
+
+  We spent five years at ZenML watching ML teams re-solve cloud topology for every new pipeline. Artifacts, secrets, compute, IAM: every cloud has its own version. JetBrains runs their AI globally on ZenML specifically to avoid re-solving this for every team. Same story is playing out for agent teams now. Kitaru's answer is to ship the stack abstraction in the runtime.
+
+  - **Kitaru:** Configure a stack once (AWS, GCP, Azure, Kubernetes). Every flow gets artifacts in your object store, secrets through the cloud's provider, orchestration on the chosen compute. Swap the stack to switch clouds without changing flow code.
+  - **Restate:** `restate-server` self-hosts on any of those clouds. That's a real feature. The wedge isn't where Restate can run, it's that the runtime doesn't abstract the cloud backend. You deploy handlers however you already deploy backend services.
+  - **The trade:** Polyglot backend teams often want exactly Restate's model. Python agent teams usually want the cloud topology handled by the runtime, not by the platform team for the tenth time.
+</FeatureWithGraphic>
+
+<FeatureWithGraphic title="Embedded library vs server-registered handlers" reverse={true}>
+  <EmbeddedVsServerRegistered slot="graphic" />
+
+  Both runtimes have a server. The wedge is whether your request path has to cross it.
+
+  - **Kitaru:** `pip install kitaru`, add `@flow` and `@checkpoint` to ordinary Python, your flow runs in your process. The Kitaru server stores execution metadata and powers the UI, CLI, and auth. It's not a proxy every invocation crosses.
+  - **Restate:** Handlers register with `restate-server`, and invocations flow through it. The server journals progress, routes requests, handles retries, and drives replay. That's not incidental; it's the durability model.
+  - **Selfishly, the Kitaru shape is what we want when we're shipping an agent.** Decorators on ordinary Python, flow runs where our code runs, metadata on the side. If your team wants server-mediated invocation by design, Restate's shape fits better.
+</FeatureWithGraphic>
+
+## What makes Kitaru unique
+
+<ComparisonTable
+  competitorLabel="Restate"
+  rows={[
+    { feature: "Durable execution and replay", kitaru: true, competitor: true },
+    { feature: "Human-in-the-loop waiting with compute released", kitaru: true, competitor: true },
+    { feature: "Self-hostable, Apache 2.0", kitaru: true, competitor: true },
+    { feature: "OpenTelemetry tracing", kitaru: true, competitor: true },
+    { feature: "Python-agent-shaped primitives (`kitaru.llm()`, `kitaru.wait()`, `kitaru.memory`)", kitaru: true, competitor: false },
+    { feature: "Built-in LLM primitive with alias-resolved secrets and per-call token/latency logging", kitaru: true, competitor: false },
+    { feature: "Typed, versioned artifact lineage per checkpoint (cross-run diff)", kitaru: true, competitor: false },
+    { feature: "Opinionated stack abstraction for Kubernetes, AWS, GCP, Azure", kitaru: true, competitor: false },
+    { feature: "Embedded library (no separate server process in the request path)", kitaru: true, competitor: false },
+    { feature: "Polyglot handler SDKs (TypeScript, Java, Kotlin, Go, Rust, Python)", kitaru: false, competitor: true },
+    { feature: "Virtual Objects: keyed per-entity state with strongly-consistent access", kitaru: false, competitor: true },
+    { feature: "Awakeables and durable promises as a primitive", kitaru: false, competitor: true },
+  ]}
+/>
+
+## How the two surfaces map
+
+| Concept | Restate | Kitaru |
+|---|---|---|
+| Durable unit | Handler (Service / Virtual Object / Workflow) | `@flow` + `@checkpoint` |
+| Durability mechanism | Journaled event log | Versioned artifacts per checkpoint |
+| Per-entity state | Virtual Object (keyed, strongly-consistent) | `kitaru.memory` scopes + artifact store |
+| Human-in-the-loop | Awakeable / durable promise | `kitaru.wait()` |
+| Invocation | Handler call via `restate-server` | `flow.run()`, `kitaru invoke`, CLI, SDK, MCP, curl |
+| Deployment model | Self-hosted `restate-server` + registered handlers | Stack abstraction for Kubernetes, AWS, GCP, Azure |
+| LLM call | Your code inside a journaled step | `kitaru.llm()` with alias, key injection, token/latency logging |
+
+## Code comparison
+
+<CodeCompare
+  kitaruLabel="Kitaru"
+  competitorLabel="Restate (Python SDK)"
+  kitaruCode={`import kitaru
+from kitaru import checkpoint, flow
+
+@checkpoint
+def research(topic: str) -> str:
+    return kitaru.llm(
+        prompt=f"Research: {topic}. Return a brief.",
+        model="fast",
+    )
+
+@checkpoint
+def draft(brief: str) -> str:
+    return kitaru.llm(
+        prompt=f"Write a draft from this brief:\\n{brief}",
+        model="fast",
+    )
+
+@flow
+def review_flow(topic: str) -> str:
+    brief = research(topic)
+    text = draft(brief)
+    approved = kitaru.wait(
+        name="approve_draft",
+        question="Approve draft?",
+        schema=bool,
+    )
+    return text if approved else "Rejected"
+
+review_flow.run("Durable agents")`}
+  competitorCode={`import restate
+
+review = restate.Workflow("ReviewWorkflow")
+
+@review.main()
+async def run(ctx: restate.WorkflowContext, topic: str) -> str:
+    # Journaled step. Non-deterministic work lives inside ctx.run().
+    brief = await ctx.run(
+        "research",
+        lambda: call_llm(f"Research: {topic}"),
+    )
+    text = await ctx.run(
+        "draft",
+        lambda: call_llm(f"Draft: {brief}"),
+    )
+
+    # Awakeable: durable promise resolved by an external caller.
+    approval_id, approval = ctx.awakeable()
+    send_approval_link(approval_id, text)
+    approved = await approval
+    return text if approved else "Rejected"
+
+app = restate.app([review])
+
+# Register the workflow with restate-server, deploy the handler,
+# and resolve the awakeable from wherever approvals come in.`}
+/>
+
+## Ready to try Kitaru?
+
+If your durability problem is shaped like a polyglot backend with keyed per-entity state, Restate is the right tool and I'd tell any team that. For Python agent work (LLM calls, memory, artifacts, human/agent approval gates), the glue code you'd write on top of a general-purpose durable runtime is the stuff we ship in the box.
+
+We've spent five years building the MLOps-ready version of this problem space at ZenML. Kitaru is that team two years into the agent version. Bet on us for agent infrastructure and you're betting on the group that's been doing this the whole time.
+
+- Read [our docs](/docs) and see how `@flow`, `@checkpoint`, `kitaru.llm()`, `kitaru.wait()`, and `kitaru.memory` compose
+- `pip install kitaru` and run your first durable agent in an afternoon
+- [Talk to our team](/get-started) if you want help mapping a Restate workflow or Virtual Object onto Kitaru primitives
+
+<div class="compare-inline-cta">
+  <a href="/get-started" class="btn-primary">Get Started</a>
+</div>

--- a/site/src/content/comparisons/kitaru-vs-temporal.mdx
+++ b/site/src/content/comparisons/kitaru-vs-temporal.mdx
@@ -1,0 +1,201 @@
+---
+competitor: "Temporal"
+competitorLogo: "/compare/temporal.svg"
+title: "Kitaru vs Temporal: Durable execution, built for AI agents"
+description: "Temporal is a general-purpose durable execution platform with seven official SDKs. Kitaru is an open-source runtime for durable Python agents, with built-in primitives for LLM calls, wait/resume, replay, memory, and artifact handling."
+cardSubtitle: "Durable execution for Python agents, with agent-native primitives such as llm(), wait(), save()/load(), and memory."
+ctaHeading: "The runtime layer underneath your Python agents"
+order: 20
+ogImage: "https://assets.kitaru.ai/compare/f26cf06e/og-card.avif"
+---
+
+import WhenToUseEach from '../../components/compare/WhenToUseEach.astro';
+import ComparisonTable from '../../components/compare/ComparisonTable.astro';
+import CodeCompare from '../../components/compare/CodeCompare.astro';
+import FeatureWithGraphic from '../../components/compare/FeatureWithGraphic.astro';
+import PullQuote from '../../components/compare/PullQuote.astro';
+import DurableExecution from '../../components/compare/graphics/temporal/DurableExecution.astro';
+import LLMCheckpoints from '../../components/compare/graphics/temporal/LLMCheckpoints.astro';
+import DurableMemory from '../../components/compare/graphics/temporal/DurableMemory.astro';
+import ArtifactLineage from '../../components/compare/graphics/temporal/ArtifactLineage.astro';
+
+Temporal is a general-purpose durable execution platform with seven official SDKs (Go, Java, Python, TypeScript, Ruby, PHP, and .NET). It has been in production for a decade and has the battle scars to show for it. If your durability problem is polyglot or mission-critical and not agent-shaped, Temporal's track record is the pragmatic choice.
+
+Kitaru is the runtime layer shaped for Python agents — the same durable execution story, narrower in scope, with agent primitives in the box. The glue code every agent team ends up writing on top of a general-purpose workflow engine (a durable `llm()` call, a versioned memory store, an artifact graph, an opinionated stack abstraction for Kubernetes, AWS, GCP, and Azure), we ship as first-class primitives.
+
+<WhenToUseEach
+  kitaru={{
+    title: "Use Kitaru if you are",
+    items: [
+      "Running Python agents and want LLM calls, memory, and artifact lineage as primitives instead of glue code",
+      "Replaying a run from a specific checkpoint without paying for the LLM calls above it again",
+      "Deploying into your own cloud (Kubernetes, SageMaker, Vertex AI, AzureML) and want one runtime that targets all of them",
+      "Designing around dynamic agent loops (tool calls, conditional branches, hours-long waits for humans)",
+    ],
+  }}
+  competitor={{
+    title: "Use Temporal if you are",
+    items: [
+      "Operating a polyglot fleet where Go, Java, and TypeScript services must share one durability contract",
+      "Running general workflows (billing, provisioning, ETL, saga patterns), not specifically agents",
+      "Leaning heavily on cron, namespacing, and a battle-tested service tier",
+    ],
+  }}
+/>
+
+<PullQuote
+  quote="Temporal makes failure irrelevant. Kitaru makes failure irrelevant for the specific shape of work an AI agent does."
+/>
+
+<FeatureWithGraphic title="A simpler ops model for agent workloads">
+  <DurableExecution slot="graphic" />
+
+  Temporal's durable execution relies on the Temporal Service plus Workers; you can self-host it or use Temporal Cloud. Kitaru uses a Kitaru server plus stack-backed storage and compute. Both provide durable recovery, but their operational models are different.
+
+  - **Service tier:** Temporal Server consists of Frontend, History, Matching, and Worker services, backed by a persistence database. Kitaru's server stores execution metadata, checkpoint state, and logs, while stack backends use storage such as S3, GCS, or Azure Blob depending on the runtime.
+  - **Determinism:** Temporal Workflow code must follow deterministic constraints, and non-deterministic work such as external calls belongs in Activities. Kitaru lets you wrap plain Python with `@flow` and `@checkpoint` and reuse checkpoint outputs on replay.
+  - **Replay cost:** Temporal caches Activity results via Workflow Event History — the difference is Kitaru's caching boundary is an ordinary Python function, not a deterministic Workflow/Activity split. `kitaru executions replay <exec_id> --from <checkpoint>` re-runs the flow from the top; checkpoints before the replay point return cached output, and the named checkpoint and anything after it re-execute — so you don't re-pay for the LLM calls above the replay point.
+</FeatureWithGraphic>
+
+<FeatureWithGraphic title="LLM calls as first-class checkpoints" reverse={true}>
+  <LLMCheckpoints slot="graphic" />
+
+  The LLM call is often the unit of cost, latency, and failure in an agent. In Temporal, LLM calls typically live in Activities. In Kitaru, `kitaru.llm()` is a built-in primitive.
+
+  - **Key handling:** In Temporal, API-key handling is part of your Activity or application code. In Kitaru, `kitaru.llm()` resolves model aliases and supports centralized secret handling.
+  - **Observability:** Temporal has a mature Web UI for workflow and activity visibility. What it leaves to you is the LLM-specific slice — prompt capture, token counts, latency, model identity. Kitaru captures prompt/response as artifacts and logs token counts, latency, and the resolved model on every `kitaru.llm()` call automatically. Cost accounting is glue you still write on top, but the raw material arrives for free.
+  - **Replay:** In Kitaru, the captured response is read from the checkpoint on replay. The provider isn't hit again unless the input changed.
+</FeatureWithGraphic>
+
+<FeatureWithGraphic title="Versioned durable memory, not workflow variables">
+  <DurableMemory slot="graphic" />
+
+  Temporal is a general-purpose workflow engine, so cross-run memory is an application concern — you bring your own store and plumb it through workflows. Kitaru is agent-shaped, so it ships a scoped memory primitive in the runtime. Same problem, different shape.
+
+  - **Scope:** Temporal durable state lives inside a workflow execution. In Kitaru, `kitaru.memory` is persisted with explicit `namespace`, `flow`, or `execution` scopes, so some memory can outlive a single run.
+  - **Escape hatch:** Anything that doesn't fit a KV shape goes through `kitaru.save()` / `kitaru.load()`, backed by the same artifact store.
+  - **Inspection:** Kitaru's Python surface exposes `set`, `get`, `list`, `history`, and `delete` on `kitaru.memory`, plus a `kitaru memory scope list` CLI command — so "what did I know last Tuesday?" is a documented call, not a workflow-variable archaeology job.
+</FeatureWithGraphic>
+
+<FeatureWithGraphic title="Artifact lineage across runs, not just event history" reverse={true}>
+  <ArtifactLineage slot="graphic" />
+
+  Temporal's Workflow Event History is a replay log, not an artifact store. Inspecting what a past workflow produced means threading your own artifact references through Activity return values. Kitaru persists checkpoint outputs as artifacts automatically and attaches them to the execution record.
+
+  - **Artifacts:** Kitaru stores each `@checkpoint` return value, plus prompt/response pairs from every `kitaru.llm()` call, as browsable artifacts on the execution.
+  - **Cross-run load:** A later run can pull an artifact from an earlier execution via `kitaru.load(exec_id, name)` from inside a `@checkpoint`. Artifact lineage across runs is a primitive, not something you build on top.
+  - **Inspection surface:** Executions, checkpoints, logs, and artifacts are exposed through the server, CLI, and client APIs — and every `kitaru.llm()` call contributes token counts, latency, and resolved model to the same record.
+</FeatureWithGraphic>
+
+## What makes Kitaru unique
+
+<ComparisonTable
+  rows={[
+    { feature: "Durable execution / recover after failure", kitaru: true, competitor: true },
+    { feature: "Recovery/replay avoids re-executing completed work after failure", kitaru: true, competitor: true },
+    { feature: "Prompt and token logging per `kitaru.llm()` call", kitaru: true, competitor: false },
+    { feature: "Versioned durable memory across runs", kitaru: true, competitor: false },
+    { feature: "Artifact lineage and run tracking across executions", kitaru: true, competitor: false },
+    { feature: "Opinionated stack abstraction for Kubernetes, AWS, GCP, Azure (configure once, every flow uses it)", kitaru: true, competitor: false },
+    { feature: "Durable human-in-the-loop waiting with no active compute", kitaru: true, competitor: true },
+    { feature: "Polyglot SDKs (Go, Java, TypeScript, Ruby, PHP, .NET)", kitaru: false, competitor: true },
+    { feature: "Native cron scheduling and namespacing", kitaru: false, competitor: true },
+    { feature: "Execution inspection, logs, and lifecycle control", kitaru: true, competitor: true },
+  ]}
+/>
+
+## How the two surfaces map
+
+| Concept | Temporal | Kitaru |
+|---|---|---|
+| Workflow boundary | `@workflow.defn` | `@flow` |
+| Durable step | Activity (non-deterministic) | `@checkpoint` (ordinary Python) |
+| Determinism requirement | Workflow must be deterministic | No determinism requirement on flow body |
+| Pause / resume | `wait_condition` + signal | `kitaru.wait()` |
+| Invocation | Workflow ID + start via client | `flow.run()`, `kitaru invoke`, CLI, SDK, MCP, curl |
+| Cross-run state | Bring your own store | `kitaru.memory` with scopes |
+| Artifacts | Thread through Activity returns | Automatic per-checkpoint artifact capture |
+
+## Code comparison
+
+<CodeCompare
+  kitaruLabel="Kitaru"
+  competitorLabel="Temporal (Python SDK)"
+  kitaruCode={`import kitaru
+from kitaru import checkpoint, flow
+
+@checkpoint
+def research(topic: str) -> str:
+    return kitaru.llm(
+        prompt=f"Research: {topic}. Return a brief.",
+        model="fast",
+    )
+
+@checkpoint
+def draft(brief: str) -> str:
+    return kitaru.llm(
+        prompt=f"Write a draft from this brief:\\n{brief}",
+        model="fast",
+    )
+
+@flow
+def review_flow(topic: str) -> str:
+    brief = research(topic)
+    text = draft(brief)
+    approved = kitaru.wait(
+        name="approve_draft",
+        question="Approve draft?",
+        schema=bool,
+    )
+    return text if approved else "Rejected"
+
+review_flow.run("Durable agents")`}
+  competitorCode={`from datetime import timedelta
+from temporalio import activity, workflow
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+@activity.defn
+async def research(topic: str) -> str:
+    return await call_llm(f"Research: {topic}")
+
+@activity.defn
+async def draft(brief: str) -> str:
+    return await call_llm(f"Write a draft:\\n{brief}")
+
+@workflow.defn
+class ReviewFlow:
+    def __init__(self) -> None:
+        self._approved: bool | None = None
+
+    @workflow.signal
+    def approve(self, ok: bool) -> None:
+        self._approved = ok
+
+    @workflow.run
+    async def run(self, topic: str) -> str:
+        brief = await workflow.execute_activity(
+            research, topic, start_to_close_timeout=timedelta(minutes=5)
+        )
+        text = await workflow.execute_activity(
+            draft, brief, start_to_close_timeout=timedelta(minutes=5)
+        )
+        await workflow.wait_condition(lambda: self._approved is not None)
+        return text if self._approved else "Rejected"
+
+# Run via: await client.execute_workflow(ReviewFlow.run, topic,
+#   id=..., task_queue=...); approval arrives via
+# client.get_workflow_handle(...).signal(ReviewFlow.approve, True).`}
+/>
+
+## Ready to try Kitaru?
+
+If your durability problem spans Go services, Java backends, and cron-scheduled ETL, Temporal is the tool. If it's shaped like a Python agent (LLM calls, memory, tool outputs, humans in the loop), Kitaru removes the glue layer you'd otherwise write on top.
+
+- Read [our documentation](/docs) and see how `@flow`, `@checkpoint`, `kitaru.llm`, and `kitaru.memory` work together
+- `pip install kitaru` and run your first durable agent in an afternoon
+- [Talk to our team](/get-started) if you want help mapping a Temporal agent workflow onto Kitaru primitives
+
+<div class="compare-inline-cta">
+  <a href="/get-started" class="btn-primary">Get Started</a>
+</div>

--- a/site/src/content/comparisons/kitaru-vs-temporal.mdx
+++ b/site/src/content/comparisons/kitaru-vs-temporal.mdx
@@ -197,5 +197,5 @@ If your durability problem spans Go services, Java backends, and cron-scheduled 
 - [Talk to our team](/get-started) if you want help mapping a Temporal agent workflow onto Kitaru primitives
 
 <div class="compare-inline-cta">
-  <a href="/get-started" class="btn-primary">Get Started</a>
+  <a href="/get-started" class="btn-primary">Get started</a>
 </div>

--- a/site/src/pages/compare/[slug].astro
+++ b/site/src/pages/compare/[slug].astro
@@ -25,7 +25,6 @@ const { Content } = await render(entry);
       description={entry.data.description}
       competitor={entry.data.competitor}
       competitorLogo={entry.data.competitorLogo}
-      competitorTagline={entry.data.competitorTagline}
     />
 
     <article class="compare-body">
@@ -92,18 +91,6 @@ const { Content } = await render(entry);
     font-size: 0.92em;
     color: var(--color-primary);
   }
-  /* Fenced code blocks (Shiki's astro-code output) get padding + border +
-     rounded corners so the block reads as a styled code block rather than
-     edge-to-edge text on a tinted background. */
-  .compare-body-inner :global(pre.astro-code),
-  .compare-body-inner :global(pre) {
-    padding: 20px 22px;
-    border-radius: 10px;
-    margin: 22px 0 26px;
-    border: 1px solid var(--color-border-light);
-    font-size: 14px;
-    line-height: 1.7;
-  }
   /* Clear any inherited background on code inside fenced blocks so Shiki's
      theme shows through without a doubled layer. */
   .compare-body-inner :global(pre code) {
@@ -117,6 +104,43 @@ const { Content } = await render(entry);
   }
   .compare-body-inner :global(a:hover) {
     text-decoration-thickness: 2px;
+  }
+
+  .compare-body-inner :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 24px 0 32px;
+    font-size: 15px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  .compare-body-inner :global(th) {
+    text-align: left;
+    padding: 12px 16px;
+    font-weight: 700;
+    font-size: 13px;
+    letter-spacing: 0.02em;
+    color: var(--color-primary);
+    background: var(--color-surface-warm);
+    border-bottom: 1px solid var(--color-border);
+  }
+  .compare-body-inner :global(td) {
+    padding: 12px 16px;
+    font-size: 15px;
+    line-height: 1.5;
+    color: var(--color-secondary);
+    border-bottom: 1px solid var(--color-border-light);
+    vertical-align: top;
+  }
+  .compare-body-inner :global(tr:last-child td) {
+    border-bottom: none;
+  }
+  .compare-body-inner :global(td:first-child) {
+    font-weight: 600;
+    color: var(--color-primary);
+    width: 28%;
   }
 
   .compare-footer-cta {
@@ -148,7 +172,7 @@ const { Content } = await render(entry);
 
   .compare-body-inner :global(.compare-inline-cta) {
     display: flex;
-    justify-content: center;
-    margin: 32px 0 8px;
+    justify-content: flex-start;
+    margin: 24px 0 8px;
   }
 </style>


### PR DESCRIPTION
## Summary

Combines previously-separate kitaru-vs-X comparison page work into a single branch and normalizes the shared schema/layout drift in one pass.

Supersedes #204 (Temporal), #211 (DBOS), #212 (Restate), and brings in the latest LangGraph + Pydantic AI alternating-layout rewrites from the still-open #214.

## What's in this PR

**Three new comparison pages:**
- `/compare/kitaru-vs-temporal` (4 graphic components)
- `/compare/kitaru-vs-dbos` (4 graphic components)
- `/compare/kitaru-vs-restate` (4 graphic components + new OG card)

**Two existing comparison pages refreshed to the new format:**
- `/compare/kitaru-vs-langgraph-deep-agents` (3 new graphics + CodePane)
- `/compare/kitaru-vs-pydantic-ai` (2 new graphics + CodePane)

**New shared building block:**
- `CodePane.astro` — code-block graphic for `FeatureWithGraphic`'s `graphic` slot.
- `CodeCompare.astro` — strip inner Shiki border/radius so the code block sits flush in its container.

**Schema change: remove `competitorTagline`.** Dropped from:
- Zod schema in `site/src/content.config.ts`
- `ComparisonHero.astro` (prop, render, `.chero-tagline` CSS)
- `[slug].astro` prop passing
- All six comparison mdx files. Hero now goes logos → title → description with no middle tagline.

**Shared infra changes applied once:**
- `FeatureWithGraphic.astro`: optional `graphic` named slot + optional `image` prop. Backward-compatible with existing image-based callers (CAS).
- `compare/[slug].astro`: removed hand-rolled fenced-code block styling, added markdown table styling, left-aligned inline CTA.

**Frontmatter normalization across all 6 comparison mdx files:**
```
competitor
competitorLogo
title
description
cardSubtitle
ctaHeading
order
ogImage (optional)
```

Also fixed an `order` collision (Restate was 40, conflicting with LangGraph — bumped to 60).

## Why combine?

Each open PR had a slightly different answer to "where does `competitorTagline` live" (required, optional, empty string) and "what's the graphic-slot variable called" (`hasGraphic` vs `hasGraphicSlot`). Merging them individually would have compounded the drift; one PR lets us pick a canonical shape for all 6 comparisons at once.

## Test plan

- [x] `pnpm build` succeeds; all 6 comparison pages generate
- [x] Local preview: all 6 `/compare/...` routes return 200
- [x] Restate OG image verified live at `https://assets.kitaru.ai/compare/4ff198fe/og-card.avif` (200 OK)
- [x] `competitorTagline` has zero survivors in `site/`
- [x] `/simplify` run locally — reuse/quality/efficiency reviews clean
- [ ] Reviewer sanity-check: visit each comparison page, confirm hero / graphics / footer render

## Closes / supersedes

- Closes #204 (Temporal)
- Closes #211 (DBOS)
- Closes #212 (Restate)
- Closes #214 (LangGraph / Pydantic AI alternating layouts — comparison pieces only; the non-comparison commits on that branch are out of scope and can still merge separately if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)