### PR TITLE
Fix replay frontier calculation

### DIFF
--- a/docs/content/docs/guides/replay-and-overrides.mdx
+++ b/docs/content/docs/guides/replay-and-overrides.mdx
@@ -5,8 +5,8 @@ description: Replay executions from checkpoints with flow and checkpoint overrid
 
 Replay creates a **new execution** from a previous one.
 
-Use replay when you want to keep earlier durable work and rerun only a suffix of
-your workflow.
+Use replay when you want to keep earlier durable work and rerun only the branch
+affected by your replay roots (`from_` plus override consumers).
 
 ## SDK replay
 
@@ -70,6 +70,13 @@ Examples:
 - `checkpoint.fetch_data`
 
 Any other prefix raises `KitaruUsageError`.
+
+Override behavior:
+
+- Overrides target checkpoint outputs (`checkpoint.<selector>`).
+- The overridden checkpoint must expose a single output.
+- Replay roots include the direct consumers of the overridden checkpoint output,
+  so replay re-executes from those consumers forward.
 
 ## Waits during replay
 

--- a/docs/content/docs/guides/replay-and-overrides.mdx
+++ b/docs/content/docs/guides/replay-and-overrides.mdx
@@ -5,8 +5,7 @@ description: Replay executions from checkpoints with flow and checkpoint overrid
 
 Replay creates a **new execution** from a previous one.
 
-Use replay when you want to keep earlier durable work and rerun only the branch
-affected by your replay roots (`from_` plus override consumers).
+Use replay when you want to keep earlier durable work and rerun only parts of your workflow.
 
 ## SDK replay
 
@@ -60,6 +59,16 @@ kitaru executions replay kr-a8f3c2 \
 
 If a selector is ambiguous, replay raises `KitaruStateError`.
 
+## What gets replayed
+
+Replay computes a set of replay roots, then re-executes those roots and their
+downstream descendants.
+
+- `from_` always contributes one replay root.
+- Each `checkpoint.<selector>` override adds replay roots at the direct
+  consumers of that checkpoint output.
+- Any checkpoint that is neither a replay root nor a downstream dependency is skipped.
+
 ## Override keys
 
 Replay override keys must start with `checkpoint.`.
@@ -75,8 +84,12 @@ Override behavior:
 
 - Overrides target checkpoint outputs (`checkpoint.<selector>`).
 - The overridden checkpoint must expose a single output.
-- Replay roots include the direct consumers of the overridden checkpoint output,
-  so replay re-executes from those consumers forward.
+- `checkpoint.<selector>` replaces that checkpoint output at each direct
+  consumer input; the source checkpoint itself is not forced to re-execute.
+- Replay roots include direct consumers of the overridden checkpoint output, so
+  replay re-executes from those consumers forward.
+- If an overridden checkpoint fans out to multiple direct consumers, replay
+  re-executes all those consumer branches.
 
 ## Waits during replay
 

--- a/examples/replay/README.md
+++ b/examples/replay/README.md
@@ -1,7 +1,7 @@
 # Replay example
 
 This group focuses on Kitaru's replay model: keep earlier durable work and rerun
-only the suffix you care about.
+only the downstream branch affected by your replay roots.
 
 ## Getting started
 
@@ -27,9 +27,11 @@ For the full catalog, see [../README.md](../README.md).
 
 Runs a three-step content pipeline (research → write draft → publish), then
 replays from `write_draft` while swapping the research checkpoint's cached
-output for edited notes. Checkpoints before the replay point return their
-cached results — no work wasted re-running `research`. Only `write_draft`
-and `publish` re-execute with the new input.
+output for edited notes. In this setup, the override is applied at
+`write_draft` (the direct consumer), and replay continues downstream from
+there. Checkpoints before that branch return cached results — no work wasted
+re-running `research`. Only `write_draft` and `publish` re-execute with the
+new input.
 
 This is the core value of durable execution: fix a mistake at step 3 without
 paying for steps 1 and 2 again.

--- a/src/kitaru/replay.py
+++ b/src/kitaru/replay.py
@@ -2,19 +2,12 @@
 
 This module translates Kitaru replay semantics (`from_` + overrides) into the
 ZenML replay inputs consumed by `Pipeline.replay(...)`.
-
-Ordering uses DAG topology derived from ``StepSpec.upstream_steps``, matching
-ZenML's own ``Compiler._get_sorted_invocations()`` strategy. Timestamps are
-used only as a last-resort fallback for legacy runs missing topology metadata.
 """
 
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import datetime
-from math import inf
 from typing import Any
 
 from zenml.models import PipelineRunResponse, StepRunResponse
@@ -22,7 +15,7 @@ from zenml.models import PipelineRunResponse, StepRunResponse
 from kitaru._source_aliases import (
     normalize_checkpoint_name as _normalize_checkpoint_name,
 )
-from kitaru.errors import KitaruRuntimeError, KitaruStateError, KitaruUsageError
+from kitaru.errors import KitaruStateError, KitaruUsageError
 
 _CHECKPOINT_OVERRIDE_PREFIX = "checkpoint."
 
@@ -38,122 +31,39 @@ class ReplayPlan:
 
 
 @dataclass(frozen=True)
-class _OrderedCheckpoint:
-    """One checkpoint invocation in DAG-topological order."""
+class _Checkpoint:
+    """Checkpoint metadata used during replay planning."""
 
-    index: int
     invocation_id: str
     call_id: str
     name: str
     step: StepRunResponse
 
 
-def _timestamp(value: datetime | None) -> float:
-    if value is None:
-        return inf
-    try:
-        return value.timestamp()
-    except Exception:
-        return inf
+def _checkpoint_invocation_id(step: StepRunResponse) -> str:
+    """Return invocation ID for a step, falling back to the step name."""
+    invocation_id = getattr(getattr(step, "spec", None), "invocation_id", None)
+    if not isinstance(invocation_id, str) or not invocation_id:
+        return step.name
+    return invocation_id
 
 
-def _topo_sort_steps(
-    steps: Mapping[str, StepRunResponse],
-) -> list[StepRunResponse]:
-    """Topologically sort steps using ``upstream_steps`` from step specs.
-
-    Within a topological layer, steps are sorted by invocation ID for
-    determinism. Falls back to timestamp ordering when upstream metadata
-    is missing from all steps.
-    """
-    step_list = list(steps.values())
-    if not step_list:
-        return []
-
-    # Build an invocation-keyed lookup. Steps are keyed by name in the run
-    # dict, but their spec carries the invocation_id used in upstream_steps.
-    by_invocation: dict[str, StepRunResponse] = {}
-    children: dict[str, list[str]] = defaultdict(list)
-    parent_count: dict[str, int] = {}
-    has_any_upstream = False
-
-    for step in step_list:
-        spec = getattr(step, "spec", None)
-        inv_id = getattr(spec, "invocation_id", None)
-        if not isinstance(inv_id, str) or not inv_id:
-            inv_id = step.name
-        by_invocation[inv_id] = step
-
-    for inv_id, step in by_invocation.items():
-        spec = getattr(step, "spec", None)
-        upstream: Sequence[str] = getattr(spec, "upstream_steps", None) or ()
-        # Only count parents that are actually present in this run.
-        valid_parents = [p for p in upstream if p in by_invocation]
-        parent_count[inv_id] = len(valid_parents)
-        if valid_parents:
-            has_any_upstream = True
-        for parent in valid_parents:
-            children[parent].append(inv_id)
-
-    if not has_any_upstream:
-        # No topology metadata — fall back to timestamp ordering.
-        return sorted(
-            step_list,
-            key=lambda s: (
-                _timestamp(s.start_time or s.end_time),
-                getattr(getattr(s, "spec", None), "invocation_id", s.name),
-            ),
-        )
-
-    # Kahn's algorithm with deterministic layer ordering.
-    sorted_steps: list[StepRunResponse] = []
-    layer = sorted(
-        [inv_id for inv_id, count in parent_count.items() if count == 0],
-    )
-
-    while layer:
-        for inv_id in layer:
-            sorted_steps.append(by_invocation[inv_id])
-
-        next_layer: list[str] = []
-        for inv_id in layer:
-            for child in children.get(inv_id, []):
-                parent_count[child] -= 1
-                if parent_count[child] == 0:
-                    next_layer.append(child)
-        layer = sorted(next_layer)
-
-    if len(sorted_steps) < len(by_invocation):
-        raise KitaruRuntimeError(
-            "Step dependency graph contains a cycle; cannot determine replay order."
-        )
-
-    return sorted_steps
-
-
-def _ordered_checkpoints(run: PipelineRunResponse) -> list[_OrderedCheckpoint]:
-    """Build checkpoint list in DAG-topological order."""
-    sorted_steps = _topo_sort_steps(run.steps)
-
-    ordered: list[_OrderedCheckpoint] = []
-    for index, step in enumerate(sorted_steps):
-        invocation_id = getattr(getattr(step, "spec", None), "invocation_id", None)
-        if not isinstance(invocation_id, str) or not invocation_id:
-            invocation_id = step.name
-
-        ordered.append(
-            _OrderedCheckpoint(
-                index=index,
-                invocation_id=invocation_id,
+def _checkpoints(run: PipelineRunResponse) -> list[_Checkpoint]:
+    """Build checkpoint metadata list from run steps."""
+    checkpoints: list[_Checkpoint] = []
+    for step in run.steps.values():
+        checkpoints.append(
+            _Checkpoint(
+                invocation_id=_checkpoint_invocation_id(step),
                 call_id=str(step.id),
                 name=_normalize_checkpoint_name(step.name),
                 step=step,
             )
         )
-    return ordered
+    return checkpoints
 
 
-def _available_checkpoint_selectors(checkpoints: Sequence[_OrderedCheckpoint]) -> str:
+def _available_checkpoint_selectors(checkpoints: Sequence[_Checkpoint]) -> str:
     names = sorted({checkpoint.name for checkpoint in checkpoints})
     if not names:
         return "none"
@@ -162,8 +72,8 @@ def _available_checkpoint_selectors(checkpoints: Sequence[_OrderedCheckpoint]) -
 
 def _resolve_checkpoint_selector(
     selector: str,
-    checkpoints: Sequence[_OrderedCheckpoint],
-) -> _OrderedCheckpoint:
+    checkpoints: Sequence[_Checkpoint],
+) -> _Checkpoint:
     matches = [
         checkpoint
         for checkpoint in checkpoints
@@ -216,7 +126,7 @@ def _iter_step_input_specs(step: StepRunResponse) -> Iterator[tuple[str, Any]]:
             yield input_name, input_spec
 
 
-def _single_checkpoint_output_name(checkpoint: _OrderedCheckpoint) -> str:
+def _single_checkpoint_output_name(checkpoint: _Checkpoint) -> str:
     try:
         output_names = list(checkpoint.step.regular_outputs)
     except Exception:
@@ -237,17 +147,13 @@ def _single_checkpoint_output_name(checkpoint: _OrderedCheckpoint) -> str:
 
 def _find_downstream_consumers(
     *,
-    source: _OrderedCheckpoint,
-    checkpoints: Sequence[_OrderedCheckpoint],
-) -> tuple[list[tuple[str, str]], list[int]]:
+    source: _Checkpoint,
+    checkpoints: Sequence[_Checkpoint],
+) -> list[tuple[str, str]]:
     output_name = _single_checkpoint_output_name(source)
 
     consumers: list[tuple[str, str]] = []
-    consumer_indices: list[int] = []
     for checkpoint in checkpoints:
-        if checkpoint.index <= source.index:
-            continue
-
         for input_name, input_spec in _iter_step_input_specs(checkpoint.step):
             upstream_name = getattr(input_spec, "step_name", None)
             upstream_output_name = getattr(input_spec, "output_name", None)
@@ -257,7 +163,6 @@ def _find_downstream_consumers(
                 continue
 
             consumers.append((checkpoint.invocation_id, input_name))
-            consumer_indices.append(checkpoint.index)
 
     if not consumers:
         raise KitaruStateError(
@@ -265,7 +170,51 @@ def _find_downstream_consumers(
             f"{source.name}."
         )
 
-    return consumers, consumer_indices
+    return consumers
+
+
+def _build_children_by_invocation(
+    checkpoints: Sequence[_Checkpoint],
+) -> dict[str, set[str]]:
+    """Build parent->children adjacency for checkpoints in this run."""
+    checkpoints_by_invocation = {
+        checkpoint.invocation_id: checkpoint for checkpoint in checkpoints
+    }
+    children_by_invocation: dict[str, set[str]] = {
+        invocation_id: set() for invocation_id in checkpoints_by_invocation
+    }
+
+    for checkpoint in checkpoints:
+        upstream_steps: Sequence[str] = (
+            getattr(getattr(checkpoint.step, "spec", None), "upstream_steps", None)
+            or ()
+        )
+        for upstream_invocation_id in upstream_steps:
+            if upstream_invocation_id not in checkpoints_by_invocation:
+                continue
+            children_by_invocation[upstream_invocation_id].add(checkpoint.invocation_id)
+
+    return children_by_invocation
+
+
+def _collect_descendants(
+    *,
+    roots: set[str],
+    children_by_invocation: Mapping[str, set[str]],
+) -> set[str]:
+    """Collect all transitive descendants for the provided roots."""
+    descendants: set[str] = set()
+    to_visit = list(roots)
+
+    while to_visit:
+        invocation_id = to_visit.pop()
+        for child_invocation_id in children_by_invocation.get(invocation_id, set()):
+            if child_invocation_id in descendants:
+                continue
+            descendants.add(child_invocation_id)
+            to_visit.append(child_invocation_id)
+
+    return descendants
 
 
 def _split_overrides(
@@ -311,6 +260,10 @@ def build_replay_plan(
 ) -> ReplayPlan:
     """Build a replay plan for a completed/paused execution.
 
+    Replay starts from the explicit ``from_`` checkpoint. For checkpoint
+    overrides, the direct consumers of each overridden source are added as
+    replay roots (the source itself is not forced to re-execute).
+
     Args:
         run: Source execution to replay from.
         from_: Checkpoint selector (checkpoint name, invocation ID, or call ID).
@@ -321,11 +274,10 @@ def build_replay_plan(
         A resolved replay plan.
 
     Raises:
-        KitaruStateError: If the plan would place a step in both
-            ``steps_to_skip`` and ``step_input_overrides``. ZenML's explicit
-            skip wins unconditionally and would silently discard the override.
+        KitaruStateError: If replay planning fails due to invalid run state.
+        KitaruUsageError: If replay planning fails due to invalid usage.
     """
-    checkpoints = _ordered_checkpoints(run)
+    checkpoints = _checkpoints(run)
     if not checkpoints:
         raise KitaruStateError(
             f"Execution '{run.id}' has no checkpoint history to replay."
@@ -339,26 +291,25 @@ def build_replay_plan(
     explicit_checkpoint = _resolve_checkpoint_selector(from_, checkpoints)
 
     step_input_overrides: dict[str, dict[str, Any]] = {}
-    frontier_candidates = [explicit_checkpoint.index]
+    replay_roots = {explicit_checkpoint.invocation_id}
 
     for selector, value in checkpoint_overrides.items():
         source = _resolve_checkpoint_selector(selector, checkpoints)
-        consumers, _consumer_indexes = _find_downstream_consumers(
+        consumers = _find_downstream_consumers(
             source=source,
             checkpoints=checkpoints,
         )
         for invocation_id, input_name in consumers:
             step_input_overrides.setdefault(invocation_id, {})[input_name] = value
-        # Anchor frontier at the source checkpoint, not the first consumer.
-        # This keeps the source out of steps_to_skip so ZenML re-executes it.
-        frontier_candidates.append(source.index)
+            replay_roots.add(invocation_id)
 
-    replay_frontier = min(frontier_candidates)
-    steps_to_skip = {
-        checkpoint.invocation_id
-        for checkpoint in checkpoints
-        if checkpoint.index < replay_frontier
-    }
+    children_by_invocation = _build_children_by_invocation(checkpoints)
+    steps_to_reexecute = replay_roots | _collect_descendants(
+        roots=replay_roots,
+        children_by_invocation=children_by_invocation,
+    )
+    all_steps = {checkpoint.invocation_id for checkpoint in checkpoints}
+    steps_to_skip = all_steps - steps_to_reexecute
 
     # Safety check: ZenML's explicit steps_to_skip wins unconditionally — it
     # does NOT check for step_input_overrides. If a step appears in both sets,

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -83,8 +83,8 @@ def test_build_replay_plan_skips_steps_before_checkpoint_selector() -> None:
     assert plan.step_input_overrides == {}
 
 
-def test_checkpoint_override_anchors_frontier_at_source_step() -> None:
-    """Checkpoint override frontier should use source.index, not consumer."""
+def test_checkpoint_override_reexecutes_override_source_path() -> None:
+    """Checkpoint overrides should replay from direct override consumers."""
     t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
     fetch = _step(
         name="fetch",
@@ -112,9 +112,9 @@ def test_checkpoint_override_anchors_frontier_at_source_step() -> None:
         overrides={"checkpoint.fetch": "edited research"},
     )
 
-    # source.index anchoring: fetch (index 0) is the frontier, so nothing is
-    # skipped. The override is injected on the consumer (write).
-    assert plan.steps_to_skip == set()
+    # Replay roots include publish (from_) and direct consumers of the override
+    # source (write). fetch remains skipped.
+    assert plan.steps_to_skip == {"fetch"}
     assert plan.step_input_overrides == {"write": {"research": "edited research"}}
 
 
@@ -141,19 +141,52 @@ def test_skip_override_disjointness_is_enforced() -> None:
         inputs_v2={"features": [_input_spec("transform", "output")]},
     )
 
-    # from_="train" means skip fetch and transform.
-    # But checkpoint.transform overrides inject into train, and the frontier
-    # from source.index (transform=1) should keep transform out of skip.
+    # from_="train" skips fetch/transform. Override on transform injects into
+    # train (already a replay root), so skip set remains unchanged.
     plan = build_replay_plan(
         run=_run(fetch, transform, train),
         from_="train",
         overrides={"checkpoint.transform": "new features"},
     )
 
-    # transform has step_input_overrides on its consumer (train), and
-    # source.index=1 means only fetch (index 0) is skipped.
+    assert plan.steps_to_skip == {"fetch", "transform"}
     assert "train" not in plan.steps_to_skip
     assert plan.step_input_overrides == {"train": {"features": "new features"}}
+
+
+def test_replay_from_branch_leaf_skips_unrelated_branch() -> None:
+    """Replay from a branch leaf should not re-execute sibling-branch work."""
+    t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
+    step_a = _step(
+        name="a",
+        invocation_id="a",
+        started_at=t0,
+    )
+    step_b = _step(
+        name="b",
+        invocation_id="b",
+        started_at=t0 + timedelta(seconds=1),
+        upstream_steps=["a"],
+        inputs_v2={"a_input": [_input_spec("a", "output")]},
+    )
+    step_c = _step(
+        name="c",
+        invocation_id="c",
+        started_at=t0 + timedelta(seconds=2),
+        upstream_steps=["b"],
+        inputs_v2={"b_input": [_input_spec("b", "output")]},
+    )
+    step_d = _step(
+        name="d",
+        invocation_id="d",
+        started_at=t0 + timedelta(seconds=3),
+        upstream_steps=["a"],
+        inputs_v2={"a_input": [_input_spec("a", "output")]},
+    )
+
+    plan = build_replay_plan(run=_run(step_a, step_b, step_c, step_d), from_="d")
+
+    assert plan.steps_to_skip == {"a", "b", "c"}
 
 
 def test_dag_ordering_not_timestamp_ordering() -> None:
@@ -187,8 +220,8 @@ def test_dag_ordering_not_timestamp_ordering() -> None:
     assert plan.steps_to_skip == {"extract"}
 
 
-def test_parallel_branches_ordered_deterministically() -> None:
-    """Parallel branches (no dependency) should get a deterministic order."""
+def test_replay_from_parallel_branch_only_skips_unrelated_peer() -> None:
+    """Replay should skip unrelated peer branch work."""
     t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
 
     branch_a = _step(
@@ -212,13 +245,41 @@ def test_parallel_branches_ordered_deterministically() -> None:
         },
     )
 
-    plan = build_replay_plan(
-        run=_run(branch_a, branch_b, merge),
-        from_="merge",
+    plan = build_replay_plan(run=_run(branch_a, branch_b, merge), from_="branch_a")
+
+    # Replaying from branch_a should not re-execute its sibling peer branch.
+    assert plan.steps_to_skip == {"branch_b"}
+
+
+def test_replay_from_parallel_branch_with_tied_start_times() -> None:
+    """Replay should be stable when peer branches share start times."""
+    t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
+
+    beta = _step(
+        name="beta",
+        invocation_id="beta",
+        started_at=t0,
+    )
+    alpha = _step(
+        name="alpha",
+        invocation_id="alpha",
+        started_at=t0,
+    )
+    merge = _step(
+        name="merge",
+        invocation_id="merge",
+        started_at=t0 + timedelta(seconds=20),
+        upstream_steps=["alpha", "beta"],
+        inputs_v2={
+            "a": [_input_spec("alpha", "output")],
+            "b": [_input_spec("beta", "output")],
+        },
     )
 
-    # branch_a and branch_b are in the same layer (no deps) — both skipped
-    assert plan.steps_to_skip == {"branch_a", "branch_b"}
+    plan = build_replay_plan(run=_run(beta, alpha, merge), from_="beta")
+
+    # Replaying from beta still skips the sibling alpha branch.
+    assert plan.steps_to_skip == {"alpha"}
 
 
 def test_wait_overrides_are_rejected() -> None:

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -189,6 +189,49 @@ def test_replay_from_branch_leaf_skips_unrelated_branch() -> None:
     assert plan.steps_to_skip == {"a", "b", "c"}
 
 
+def test_checkpoint_override_fanout_reexecutes_consumer_branches() -> None:
+    """Override fan-out re-executes every direct consumer branch."""
+    t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
+    step_a = _step(
+        name="a",
+        invocation_id="a",
+        started_at=t0,
+    )
+    step_b = _step(
+        name="b",
+        invocation_id="b",
+        started_at=t0 + timedelta(seconds=1),
+        upstream_steps=["a"],
+        inputs_v2={"a_input": [_input_spec("a", "output")]},
+    )
+    step_c = _step(
+        name="c",
+        invocation_id="c",
+        started_at=t0 + timedelta(seconds=2),
+        upstream_steps=["b"],
+        inputs_v2={"b_input": [_input_spec("b", "output")]},
+    )
+    step_d = _step(
+        name="d",
+        invocation_id="d",
+        started_at=t0 + timedelta(seconds=3),
+        upstream_steps=["a"],
+        inputs_v2={"a_input": [_input_spec("a", "output")]},
+    )
+
+    plan = build_replay_plan(
+        run=_run(step_a, step_b, step_c, step_d),
+        from_="d",
+        overrides={"checkpoint.a": "edited"},
+    )
+
+    assert plan.steps_to_skip == {"a"}
+    assert plan.step_input_overrides == {
+        "b": {"a_input": "edited"},
+        "d": {"a_input": "edited"},
+    }
+
+
 def test_dag_ordering_not_timestamp_ordering() -> None:
     """Steps should be ordered by DAG topology, not timestamps.
 


### PR DESCRIPTION
## What does this do?

Implemented and documented replay planning updates for branched DAGs and checkpoint overrides.

- Replay planning now uses graph reachability from replay roots, so replaying from a branch leaf only re-executes that branch’s downstream path.
- Override behavior is aligned with current semantics: checkpoint.<selector> injects into direct consumers, and replay roots include those consumers.
- Removed unnecessary ordering/index-based checkpoint plumbing from replay planning.
- Updated replay tests to match current behavior and added branch-focused regression coverage.
- Updated replay docs/example wording to describe branch-aware replay and consumer-based override behavior.

## How to test

Validation: uv run pytest tests/test_replay.py (all passing).
