### PR TITLE
Bump ZenML to 0.94.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   docker-smoke:
     runs-on: ubuntu-latest
     env:
-      ZENML_SERVER_TAG: 0.94.2
+      ZENML_SERVER_TAG: 0.94.3
       KITARU_UI_TAG: latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -447,7 +447,7 @@ jobs:
           target: server
           push: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
           build-args: |
-            ZENML_SERVER_TAG=0.94.1
+            ZENML_SERVER_TAG=0.94.3
             KITARU_UI_TAG=${{ env.KITARU_UI_TAG }}
             ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') && format('KITARU_VERSION={0}', env.VERSION) || '' }}
           tags: |

--- a/Justfile
+++ b/Justfile
@@ -2,7 +2,7 @@
 # Must match the ARG ZENML_SERVER_TAG default in docker/Dockerfile and
 # docker/Dockerfile.server-dev (those two are enforced by contract tests;
 # this Justfile value and the CI/release workflow values are not).
-ZENML_SERVER_TAG := "0.94.1"
+ZENML_SERVER_TAG := "0.94.3"
 DOCKER_REPO := "zenmldocker/kitaru"
 DOCKER_TAG := "latest"
 UI_TAG := "latest"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 # Published to: zenmldocker/kitaru
 
-ARG ZENML_SERVER_TAG=0.94.1
+ARG ZENML_SERVER_TAG=0.94.3
 
 FROM zenmldocker/zenml-server:${ZENML_SERVER_TAG} AS server
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -19,10 +19,10 @@ COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /uvx /bin/
 ENV UV_SYSTEM_PYTHON=1
 
 # Install kitaru from local source. Its pyproject.toml pulls
-# zenml[local]>=0.94.1 from PyPI automatically.
+# zenml[local]>=0.94.3 from PyPI automatically.
 COPY . /tmp/kitaru
 RUN cd /tmp/kitaru && uv pip install . && rm -rf /tmp/kitaru
 
 # Layer on cloud extras for remote artifact stores and connectors.
 RUN uv pip install \
-    "zenml[s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure]>=0.94.1"
+    "zenml[s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure]>=0.94.3"

--- a/docker/Dockerfile.server-dev
+++ b/docker/Dockerfile.server-dev
@@ -13,7 +13,7 @@
 #   4. Run:
 #        docker run -p 8080:8080 kitaru-server-dev
 
-ARG ZENML_SERVER_TAG=0.94.1
+ARG ZENML_SERVER_TAG=0.94.3
 
 FROM zenmldocker/zenml-server:${ZENML_SERVER_TAG} AS server
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://kitaru.ai/kitaru-logo.svg
 
 dependencies:
   - name: zenml
-    version: "0.94.1"
+    version: "0.94.3"
     repository: "oci://public.ecr.aws/zenml"
     alias: kitaru

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "cyclopts>=3.0",
     "pydantic>=2.0",
     "rich>=12.0.0",
-    "zenml[local]>=0.94.2",
+    "zenml[local]>=0.94.3",
 ]
 
 [project.optional-dependencies]
@@ -57,7 +57,7 @@ llm = [
     "kitaru[anthropic]",
 ]
 local = [
-    "zenml[server]>=0.94.2",
+    "zenml[server]>=0.94.3",
 ]
 pydantic-ai = [
     "pydantic-ai-slim>=1.75.0",
@@ -103,7 +103,7 @@ dev = [
     "ruff>=0.11",
     "ty>=0.0.1a7",
     "yamlfix",
-    "zenml[server]>=0.94.2",
+    "zenml[server]>=0.94.3",
     "pytest>=8.0",
     "pytest-randomly",
     "pytest-clarity",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,14 +97,19 @@ def isolated_zenml_global_config(
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setattr("click.get_app_dir", lambda app_name: str(config_dir))
 
+    repo_root = tmp_path / "isolated-repo"
+    repo_config_dir = repo_root / ".kitaru"
+    repo_config_dir.mkdir(parents=True)
+    (repo_config_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
+
     monkeypatch.setenv(ENV_ZENML_CONFIG_PATH, str(config_dir))
+    monkeypatch.setenv(ENV_ZENML_REPOSITORY_PATH, str(repo_root))
     monkeypatch.setenv("ZENML_ANALYTICS_OPT_IN", "false")
 
     for env_name in (
         ENV_ZENML_ACTIVE_PROJECT_ID,
         ENV_ZENML_ACTIVE_STACK_ID,
         ENV_ZENML_LOCAL_STORES_PATH,
-        ENV_ZENML_REPOSITORY_PATH,
         ENV_ZENML_SERVER,
         "ZENML_REPOSITORY_DIRECTORY_NAME",
     ):

--- a/tests/test_compliance_review_claude_agent.py
+++ b/tests/test_compliance_review_claude_agent.py
@@ -6,8 +6,10 @@ import asyncio
 import importlib
 from pathlib import Path
 from typing import Protocol
+from uuid import uuid4
 
 import pytest
+from zenml.client import Client
 
 from tests.compliance_review_fakes import (
     clear_compliance_review_modules,
@@ -19,6 +21,16 @@ from tests.compliance_review_fakes import (
 
 class _FakeSecret(Protocol):
     def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+def _materializer_uri_under_active_artifact_store(test_name: str) -> str:
+    artifact_store = Client().active_stack.artifact_store
+    artifact_store_root = Path(str(artifact_store.path))
+    materializer_uri = (
+        artifact_store_root / "test-compliance-review" / test_name / uuid4().hex
+    )
+    materializer_uri.mkdir(parents=True, exist_ok=True)
+    return str(materializer_uri)
 
 
 @pytest.fixture
@@ -245,6 +257,7 @@ def test_importing_claude_agent_does_not_lookup_secret_or_stack(
 def test_claude_agent_result_materializer_restores_transcript(
     tmp_path,
     claude_agent_module,
+    primed_zenml,
 ) -> None:
     """The example materializer should bundle and restore Claude JSONL state."""
     materializers = importlib.import_module("examples.compliance_review.materializers")
@@ -258,9 +271,12 @@ def test_claude_agent_result_materializer_restores_transcript(
     transcript_path = Path(result.transcript_path)
     original_transcript = transcript_path.read_text()
 
-    artifact_dir = tmp_path / "artifact"
-    artifact_dir.mkdir()
-    materializer = materializers.ClaudeAgentResultMaterializer(uri=str(artifact_dir))
+    del primed_zenml
+    materializer = materializers.ClaudeAgentResultMaterializer(
+        uri=_materializer_uri_under_active_artifact_store(
+            "test_claude_agent_result_materializer_restores_transcript"
+        )
+    )
 
     materializer.save(result)
     transcript_path.unlink()
@@ -322,6 +338,7 @@ def test_materializer_recomputes_transcript_path_on_different_home(
     monkeypatch,
     tmp_path,
     claude_agent_module,
+    primed_zenml,
 ) -> None:
     """Restore should land at the current host's path, not the saved one.
 
@@ -350,9 +367,12 @@ def test_materializer_recomputes_transcript_path_on_different_home(
     saved_transcript_path = result.transcript_path
     assert str(pod_a_home) in saved_transcript_path
 
-    artifact_dir = tmp_path / "artifact"
-    artifact_dir.mkdir()
-    materializer = materializers.ClaudeAgentResultMaterializer(uri=str(artifact_dir))
+    del primed_zenml
+    materializer = materializers.ClaudeAgentResultMaterializer(
+        uri=_materializer_uri_under_active_artifact_store(
+            "test_materializer_recomputes_transcript_path_on_different_home"
+        )
+    )
     materializer.save(result)
 
     pod_b_home = tmp_path / "pod_b_home"

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-04-20T13:30:48.101511129Z"
+exclude-newer = "2026-04-21T16:03:48.616809Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1173,8 +1173,8 @@ requires-dist = [
     { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=1.75.0" },
     { name = "rich", specifier = ">=12.0.0" },
     { name = "typing-extensions", marker = "extra == 'pydantic-ai'", specifier = ">=4.12" },
-    { name = "zenml", extras = ["local"], specifier = ">=0.94.2" },
-    { name = "zenml", extras = ["server"], marker = "extra == 'local'", specifier = ">=0.94.2" },
+    { name = "zenml", extras = ["local"], specifier = ">=0.94.3" },
+    { name = "zenml", extras = ["server"], marker = "extra == 'local'", specifier = ">=0.94.3" },
 ]
 provides-extras = ["openai", "anthropic", "llm", "local", "pydantic-ai", "claude-agent-sdk", "mcp"]
 
@@ -1193,7 +1193,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11" },
     { name = "ty", specifier = ">=0.0.1a7" },
     { name = "yamlfix" },
-    { name = "zenml", extras = ["server"], specifier = ">=0.94.2" },
+    { name = "zenml", extras = ["server"], specifier = ">=0.94.3" },
 ]
 
 [[package]]
@@ -2936,7 +2936,7 @@ wheels = [
 
 [[package]]
 name = "zenml"
-version = "0.94.2"
+version = "0.94.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
@@ -2955,9 +2955,9 @@ dependencies = [
     { name = "rich" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/38/1496321bbbacf82aa716afb74108a6aeb72fa958201f14af71d06ecaf1ac/zenml-0.94.2.tar.gz", hash = "sha256:e2bc7f245bb910b4cc4bd902cc2b0c7fa2fec4c1c004ea61f24b1aca3aac4efa", size = 7087286, upload-time = "2026-04-08T14:36:38.381Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/41/8f3aa68a00bbee24916d0256973cc61a4815672d9ee348cb0f8125b208ca/zenml-0.94.3.tar.gz", hash = "sha256:213115670540df182808179d96026a4c57537ba0838e5562a8442d40290137b9", size = 7134264, upload-time = "2026-04-24T13:40:12.38Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/92/f662ca3d9d797b26bdff1dfd5c976f3c83de1616e72d56ad495387e5377e/zenml-0.94.2-py3-none-any.whl", hash = "sha256:c88bbca1a708092d3cd6274af46b2ada1e76e72636d6d4fded819a155e760dfe", size = 8202437, upload-time = "2026-04-08T14:36:36.22Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/49/97827f97078bc67ad8f4dae20baf3b7a2b1d6ca8b2bff0927046be44b074/zenml-0.94.3-py3-none-any.whl", hash = "sha256:0ad07adf44d6736119e6b72a50ee3f9314e96f5b1152b76fd2b1f6810e59d142", size = 8274402, upload-time = "2026-04-24T13:40:09.698Z" },
 ]
 
 [package.optional-dependencies]
@@ -2974,6 +2974,7 @@ local = [
 server = [
     { name = "alembic" },
     { name = "bcrypt" },
+    { name = "cachetools" },
     { name = "croniter" },
     { name = "fastapi" },
     { name = "fastapi-utils" },


### PR DESCRIPTION
## What changed

- Bumped Kitaru's ZenML dependency and deployment pins to `0.94.3` across Python packaging, Docker defaults, Helm chart, Justfile, CI, and release workflow config.
- Updated test isolation so each pytest/xdist worker uses its own repository-local `.kitaru/config.yaml` instead of sharing the checkout marker.
- Updated the direct Claude compliance-review materializer tests to write test artifacts under the active ZenML artifact store root.

## Why it was needed

ZenML `0.94.3` tightened behavior around local config loading and artifact-store path validation. With the version bump applied, the full test suite failed because xdist workers could share and mutate the checkout's `.kitaru/config.yaml`, and because two unit tests used arbitrary temporary directories outside the active artifact store for direct materializer load/save checks.

## Key implementation decisions

- Kept the production `ClaudeAgentResultMaterializer` implementation unchanged and continued delegating Pydantic serialization to ZenML's `PydanticMaterializer`.
- Fixed the materializer failures at the test boundary by making the tests model real ZenML artifact placement.
- Isolated repository config in the shared test fixture, rather than adding per-test workarounds, because the failure moved between workers/tests under xdist.

## Reviewer Notes

Please focus on:

- `tests/conftest.py`: confirm the isolated repository root preserves source imports while preventing workers from touching the checkout `.kitaru/config.yaml`.
- `tests/test_compliance_review_claude_agent.py`: confirm the helper uses the active artifact store root only for direct unit-test materializer URIs and does not change production behavior.
- Version pin consistency across `pyproject.toml`, `uv.lock`, Dockerfiles, Helm, Justfile, CI, and release workflow files.

Useful local verification:

```bash
just check
just test
uv run pytest \
  tests/test_flow.py::test_submit_emits_flow_submitted_event \
  tests/test_phase12_llm_example.py \
  tests/test_compliance_review_claude_agent.py::test_claude_agent_result_materializer_restores_transcript \
  tests/test_compliance_review_claude_agent.py::test_materializer_recomputes_transcript_path_on_different_home \
  -vv
```

I ran `just check` and `just test` locally after the fixes; the full test suite passed with `1584 passed, 8 skipped`.
