### PR TITLE
Unify demo request formType metadata

### DIFF
--- a/site/src/lib/formTypes.ts
+++ b/site/src/lib/formTypes.ts
@@ -1,0 +1,6 @@
+export const FORM_TYPES = {
+  DEMO_REQUEST: 'demo-request',
+  WAITLIST: 'waitlist',
+} as const;
+
+export type FormType = typeof FORM_TYPES[keyof typeof FORM_TYPES];

--- a/site/src/pages/api/get-started.ts
+++ b/site/src/pages/api/get-started.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro';
+import { FORM_TYPES } from '../../lib/formTypes';
 import { segmentCall } from '../../lib/segment';
 
 export const prerender = false;
@@ -74,7 +75,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
       email,
       timestamp: new Date().toISOString(),
       source: 'book-a-demo',
-      formType: 'book-a-demo',
+      formType: FORM_TYPES.DEMO_REQUEST,
       product: 'kitaru',
       nextStep: 'cal-inline-booking',
     }));
@@ -97,7 +98,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         company,
         email,
         source: 'book-a-demo',
-        formType: 'book-a-demo',
+        formType: FORM_TYPES.DEMO_REQUEST,
         product: 'kitaru',
         nextStep: 'cal-inline-booking',
       },

--- a/site/src/pages/api/waitlist.ts
+++ b/site/src/pages/api/waitlist.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro';
+import { FORM_TYPES } from '../../lib/formTypes';
 
 export const prerender = false;
 
@@ -69,7 +70,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         properties: {
           email,
           source: 'landing-page',
-          formType: 'waitlist',
+          formType: FORM_TYPES.WAITLIST,
         },
         context: segmentContext,
       });

--- a/site/src/pages/book-a-demo.astro
+++ b/site/src/pages/book-a-demo.astro
@@ -925,6 +925,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
 </style>
 
 <script>
+  import { FORM_TYPES } from '../lib/formTypes';
   import { setupCardGlow } from '../scripts/card-glow';
 
   type CalQueueFn = ((...args: unknown[]) => void) & {
@@ -1073,7 +1074,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
         metadata: {
           product: 'kitaru',
           source: 'book-a-demo',
-          formType: 'book-a-demo',
+          formType: FORM_TYPES.DEMO_REQUEST,
           company: formData.company,
         },
       },


### PR DESCRIPTION
## What changed

- Standardized the Kitaru demo request `formType` metadata to `demo-request` so it matches the existing ZenML Segment/Attio convention.
- Kept `source: "book-a-demo"` intact so route/source attribution remains specific to the Kitaru page.
- Added shared `FORM_TYPES` constants for Kitaru site form metadata and reused them in the demo and waitlist flows.

## Why it was needed

Segment/Attio was receiving two tags for the same semantic lead type: Kitaru used `book-a-demo`, while ZenML used `demo-request`. This makes downstream tagging easier to confuse or accidentally split. The new shape keeps the useful distinction:

- `source`: where the lead came from, e.g. `book-a-demo`
- `formType`: what kind of lead/form it is, e.g. `demo-request`

## Key implementation decisions

- Changed only metadata values, not routes, copy, events, or form behavior.
- Centralized form type values in `site/src/lib/formTypes.ts` to reduce future string drift.
- Included the waitlist flow in the constant cleanup because it uses the same `formType` metadata contract.

## Reviewer Notes

Please check that this matches the expected Attio/Segment tagging convention.

Useful local checks:

```bash
# Confirm no old demo formType literal remains
rg "formType: ['\"]book-a-demo" site/src

# Confirm canonical values come from shared constants
rg "FORM_TYPES" site/src

# If site dependencies are installed
pnpm --dir site build
```

Validation performed:

- Formal review via RepoPrompt `context_builder`: no findings.
- `/simplify` reuse/quality/efficiency review: no functional issues.
- Confirmed there are no remaining raw `formType: 'book-a-demo'`, `formType: 'demo-request'`, or `formType: 'waitlist'` assignments in `site/src`.
- Build was attempted but could not run in the fresh worktree because `site/node_modules` is missing (`astro: command not found`).
