### PR TITLE
Handle runtime log version skew errors

### DIFF
--- a/src/kitaru/_client/_logs.py
+++ b/src/kitaru/_client/_logs.py
@@ -163,11 +163,17 @@ def _is_otel_log_retrieval_error(message: str) -> bool:
     return "otel" in lowered and "not implemented" in lowered
 
 
+def _is_log_endpoint_version_skew_error(message: str) -> bool:
+    """Return whether an error message points to incompatible log endpoints."""
+    return "zenml.log_stores" in message.lower()
+
+
 __all__ = [
     "_coerce_log_level",
     "_coerce_log_lineno",
     "_coerce_log_text",
     "_is_empty_log_result_error",
+    "_is_log_endpoint_version_skew_error",
     "_is_otel_log_retrieval_error",
     "_log_sort_key",
     "_map_runtime_log_entry",

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -52,6 +52,7 @@ from kitaru._client._logs import (
     _coerce_log_lineno,
     _coerce_log_text,
     _is_empty_log_result_error,
+    _is_log_endpoint_version_skew_error,
     _is_otel_log_retrieval_error,
     _log_sort_key,
     _map_runtime_log_entry,
@@ -432,6 +433,16 @@ class _ExecutionsAPI:
                 if endpoint_hint:
                     message += f" View them in your OTEL backend at: {endpoint_hint}."
                 raise KitaruLogRetrievalError(message) from exc
+
+            if _is_log_endpoint_version_skew_error(error_message):
+                raise KitaruLogRetrievalError(
+                    "Unable to retrieve runtime logs because the server log "
+                    "endpoint is incompatible with this Kitaru client. This "
+                    "usually means the client and server are running different "
+                    "Kitaru versions. Upgrade the server runtime or align the "
+                    "client and server versions, then retry `kitaru executions "
+                    "logs`."
+                ) from exc
 
             raise KitaruLogRetrievalError(
                 f"Failed to retrieve runtime logs for source '{source}': {exc}"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2767,6 +2767,54 @@ def test_logs_map_otel_retrieval_errors_to_kitaru_error() -> None:
             client.executions.logs(str(run.id))
 
 
+@pytest.mark.parametrize(
+    "backend_error",
+    [
+        ModuleNotFoundError("No module named 'zenml.log_stores'"),
+        RuntimeError("ModuleNotFoundError: No module named 'zenml.log_stores'"),
+    ],
+)
+def test_logs_map_version_skew_errors_to_actionable_kitaru_error(
+    backend_error: Exception,
+) -> None:
+    step = _DummyStep(
+        name="research",
+        status=ZenMLExecutionStatus.COMPLETED,
+        outputs={},
+    )
+    run = _DummyRun(
+        status=ZenMLExecutionStatus.RUNNING,
+        flow_name="flow_a",
+        steps={step.name: step},
+    )
+
+    fake_store = Mock()
+    fake_store.get.side_effect = backend_error
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch("kitaru.client._ExecutionsAPI._rest_store", return_value=fake_store),
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
+
+        client = KitaruClient()
+        with pytest.raises(KitaruLogRetrievalError) as exc_info:
+            client.executions.logs(str(run.id))
+
+    message = str(exc_info.value)
+    assert "incompatible" in message
+    assert "Upgrade the server runtime" in message
+    assert "ZenML" not in message
+    assert "zenml.log_stores" not in message
+    assert "No module named" not in message
+    assert "ModuleNotFoundError" not in message
+
+
 def test_logs_return_empty_list_when_backend_reports_no_entries() -> None:
     step = _DummyStep(
         name="research",


### PR DESCRIPTION
## What changed

- Detect the known older-server runtime log endpoint failure that reports `zenml.log_stores` as a missing module.
- Translate that failure into a Kitaru-branded compatibility error instead of surfacing the raw backend import error.
- Add regression coverage for both direct `ModuleNotFoundError` and string-wrapped remote error shapes.

Fixes #136.

## Why

When `kitaru executions logs <exec_id>` talks to an older/incompatible remote server, the backend can fail with an internal import error. Previously Kitaru wrapped that exception verbatim, so users saw a confusing implementation detail instead of an actionable next step.

The new message tells users that the server log endpoint is incompatible with their client and suggests aligning/upgrading client/server versions, without mentioning backend internals.

## Reviewer Notes

Please pay special attention to:

- `src/kitaru/client.py`: the new branch in `_ExecutionsAPI._fetch_log_payload()` should stay after the empty-log and OTEL-specific handling, but before the generic fallback.
- `src/kitaru/_client/_logs.py`: `_is_log_endpoint_version_skew_error()` intentionally detects only the known leaked module path to avoid broad string matching.
- `tests/test_client.py`: the regression test checks both that the new message is actionable and that it does **not** leak `ZenML`, `zenml.log_stores`, `No module named`, or `ModuleNotFoundError`.

To reproduce the original failure path locally, run the regression test added in this PR:

```bash
uv run pytest tests/test_client.py -k logs_map_version_skew_errors_to_actionable_kitaru_error -q
```

That test simulates the remote log endpoint raising the same older-server import failure reported in #136 and verifies the CLI/SDK-facing error text stays sanitized.

## Validation

```bash
uv run pytest tests/test_client.py -k "logs_map_version_skew or logs_map_otel_retrieval_errors or logs_return_empty_list_when_backend_reports_no_entries"
uv run pytest tests/test_cli.py -k "executions_logs_empty_state or executions_logs_surfaces_backend_errors"
just check
just test
```

Results:

- Focused client log tests: 4 passed
- Focused CLI log tests: 2 passed
- `just check`: passed
- `just test`: 1586 passed, 8 skipped
