### PR TITLE
Improve checkpoint output handle display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Checkpoint output handles now display Kitaru guidance to call `.load()` instead of leaking raw ZenML artifact metadata when stringified in flow bodies. (#127)
+
 ## [0.7.0] - 2026-04-24
 
 ### Added

--- a/src/kitaru/checkpoint.py
+++ b/src/kitaru/checkpoint.py
@@ -14,6 +14,7 @@ from typing import Any, Literal, cast, overload
 
 from zenml.config.retry_config import StepRetryConfig
 from zenml.enums import StepRuntime, StepType
+from zenml.execution.pipeline.dynamic.outputs import OutputArtifact
 from zenml.execution.pipeline.dynamic.run_context import DynamicPipelineRunContext
 from zenml.pipelines.compilation_context import PipelineCompilationContext
 from zenml.steps.step_context import StepContext
@@ -47,6 +48,39 @@ _CHECKPOINT_NESTED_ERROR = (
 _CHECKPOINT_CONCURRENT_OUTSIDE_FLOW_ERROR = (
     "Concurrent checkpoint execution is only available inside a running @flow."
 )
+_CHECKPOINT_OUTPUT_HANDLE_MESSAGE = (
+    "This is a Kitaru checkpoint output handle for `{checkpoint}.{output}`, "
+    "not the materialized value. Call `.load()` to materialize the value."
+)
+
+
+class _KitaruOutputArtifact(OutputArtifact):
+    """ZenML output artifact with a Kitaru-facing display string."""
+
+    def __str__(self) -> str:
+        """Return a short, helpful message instead of raw artifact metadata."""
+        return _CHECKPOINT_OUTPUT_HANDLE_MESSAGE.format(
+            checkpoint=self.step_name,
+            output=self.output_name,
+        )
+
+    def __repr__(self) -> str:
+        """Mirror ``str()`` for accidental repr conversions in user code."""
+        return str(self)
+
+
+def _with_kitaru_output_display(value: Any) -> Any:
+    """Attach Kitaru-friendly display behavior to exposed output handles."""
+    if isinstance(value, _KitaruOutputArtifact):
+        return value
+    if isinstance(value, OutputArtifact):
+        return _KitaruOutputArtifact.model_construct(
+            _fields_set=value.model_fields_set,
+            **value.__dict__,
+        )
+    if isinstance(value, tuple):
+        return tuple(_with_kitaru_output_display(item) for item in value)
+    return value
 
 
 def _register_checkpoint_source_alias(
@@ -256,7 +290,7 @@ class _CheckpointDefinition:
         self._assert_call_allowed()
         result = self._step(*args, id=id, after=after, **kwargs)
         self._track_invocation(method="call")
-        return result
+        return _with_kitaru_output_display(result)
 
     def submit(
         self,

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -16,6 +16,7 @@ from zenml.enums import StepRuntime, StepType
 from kitaru.analytics import AnalyticsEvent
 from kitaru.checkpoint import checkpoint
 from kitaru.errors import KitaruContextError, KitaruUsageError
+from kitaru.flow import flow
 from kitaru.runtime import (
     _flow_scope,
     _get_current_checkpoint,
@@ -599,3 +600,43 @@ def test_checkpoint_runtime_scope_restores_existing_flow_scope() -> None:
     assert _get_current_flow() is None
     assert not _is_inside_checkpoint()
     assert _get_current_checkpoint() is None
+
+
+def test_flow_body_output_handle_string_conversion_is_helpful(
+    primed_zenml: None,
+) -> None:
+    """Checkpoint output handles should display Kitaru guidance, not metadata."""
+    observed: dict[str, str] = {}
+
+    @checkpoint
+    def produce_issue_127_value():
+        return "hello"
+
+    @checkpoint
+    def consume_issue_127_value(value):
+        assert isinstance(value, str)
+        return f"{value}|{type(value).__name__}"
+
+    @flow
+    def issue_127_handle_display_flow():
+        handle = produce_issue_127_value()
+        downstream = consume_issue_127_value(handle)
+        observed.update(
+            {
+                "stringified": str(handle),
+                "repr": repr(handle),
+                "loaded": handle.load(),
+                "downstream": downstream.load(),
+            }
+        )
+
+    issue_127_handle_display_flow.run(cache=False)
+
+    assert observed["loaded"] == "hello"
+    assert observed["downstream"] == "hello|str"
+
+    for rendered in (observed["stringified"], observed["repr"]):
+        assert "Kitaru checkpoint output handle" in rendered
+        assert ".load()" in rendered
+        assert "ArtifactVersionResponse" not in rendered
+        assert "ZenML" not in rendered

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -5,18 +5,20 @@ from __future__ import annotations
 import sys
 from contextlib import contextmanager
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
 from kitaru.analytics import AnalyticsEvent
-from kitaru.config import ResolvedModelSelection
+from kitaru.config import ResolvedModelSelection, register_model_alias
 from kitaru.errors import (
     KitaruContextError,
     KitaruRuntimeError,
     KitaruUsageError,
 )
+from kitaru.flow import flow
 from kitaru.llm import (
     _LLMUsage,
     _parse_provider_target,
@@ -131,6 +133,37 @@ def test_llm_dispatches_through_synthetic_checkpoint_in_flow_scope() -> None:
     assert request.call_name == "outline"
     assert request.model == "fast"
     assert mock_synthetic.call_args.kwargs["id"] == "outline"
+
+
+def test_flow_body_llm_output_handle_string_conversion_is_helpful(
+    monkeypatch: pytest.MonkeyPatch,
+    primed_zenml: None,
+) -> None:
+    """Synthetic flow-body llm handles should share checkpoint handle display."""
+    register_model_alias("fast", model="openai/gpt-4o-mini")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("KITARU_LLM_MOCK_RESPONSE", "Mocked LLM response.")
+    observed: dict[str, str] = {}
+
+    @flow
+    def issue_127_llm_handle_display_flow():
+        handle = cast(Any, llm("hello", model="fast", name="issue_127_llm"))
+        observed.update(
+            {
+                "stringified": str(handle),
+                "repr": repr(handle),
+                "loaded": handle.load(),
+            }
+        )
+
+    issue_127_llm_handle_display_flow.run(cache=False)
+
+    assert observed["loaded"] == "Mocked LLM response."
+    for rendered in (observed["stringified"], observed["repr"]):
+        assert "Kitaru checkpoint output handle" in rendered
+        assert ".load()" in rendered
+        assert "ArtifactVersionResponse" not in rendered
+        assert "ZenML" not in rendered
 
 
 def test_llm_auto_names_calls_sequentially_within_flow_scope() -> None:


### PR DESCRIPTION
## What changed

- Added a Kitaru-facing display wrapper for checkpoint output handles returned from flow-body checkpoint calls.
- `str(handle)` / `repr(handle)` now show a short message telling users to call `.load()` instead of leaking raw ZenML artifact metadata.
- Added regression coverage for plain checkpoint output handles and synthetic flow-body `kitaru.llm()` handles.
- Added an Unreleased changelog entry.

Closes #127.

## Why it was needed

When a checkpoint returning a string was called inside a flow body, normal Python string conversion saw ZenML's dynamic `OutputArtifact` handle rather than the materialized string. That meant `print(summary)` produced `ArtifactVersionResponseBody(...)` metadata, which was confusing and leaked Kitaru's ZenML implementation details.

## Key implementation decisions

- Kept the change minimal: the handle is still an `OutputArtifact` subclass, so ZenML dependency wiring remains intact.
- Did not auto-load values during string conversion, avoiding hidden blocking/materialization work.
- Used Pydantic `model_construct()` to preserve the existing validated handle data without deep dump/revalidation.

## Reviewer Notes

Please focus on `src/kitaru/checkpoint.py`, especially `_with_kitaru_output_display(...)`, and confirm the wrapper stays narrow enough not to affect async `submit` / `map` / `product` future behavior.

Useful local checks:

```bash
just test tests/test_checkpoint.py tests/test_llm.py
just check
just test
```

This PR was validated with:

```text
just check                         # passed
just test tests/test_checkpoint.py tests/test_llm.py  # 84 passed
just test                          # 1586 passed, 8 skipped
```
