### PR TITLE
Prefill company in Cal demo booking

### DIFF
--- a/site/src/pages/book-a-demo.astro
+++ b/site/src/pages/book-a-demo.astro
@@ -1071,6 +1071,7 @@ const turnstileSiteKey = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
         useSlotsViewOnSmallScreen,
         name: formData.name,
         email: formData.email,
+        company: formData.company,
         metadata: {
           product: 'kitaru',
           source: 'book-a-demo',


### PR DESCRIPTION
## What changed

- Pass `company` as a top-level Cal inline embed `config` value on the Kitaru `/book-a-demo` flow.
- Keep the existing `metadata.company` value for downstream attribution/context.

## Why it was needed

Viola tested the deployed branch and found that Cal prefilled name and email, but not company.

The concrete cause was that name and email were passed as top-level Cal config values, while company was only passed inside `metadata`. Cal uses top-level `config` values for booking-form prefill; metadata is hidden context for payloads/webhooks and does not prefill the visible booking form.

## Key implementation decisions

- Made the smallest possible fix: one additional `company: formData.company` field next to `name` and `email`.
- Retained `metadata.company` so downstream consumers still receive company context.
- Did not change routes, event names, Segment metadata, form validation, or copy.

## Reviewer Notes

Please verify the Cal booking step now pre-fills all three user-entered fields:

1. Open `/book-a-demo`.
2. Submit name, company, and email.
3. Confirm the embedded Cal form has name, email, and company prefilled.

Relevant code path:

```ts
config: {
  name: formData.name,
  email: formData.email,
  company: formData.company,
  metadata: {
    company: formData.company,
  },
}
```

Validation performed:

```bash
cd site
pnpm install --frozen-lockfile
pnpm build
```

Build passed. Also confirmed the compiled bundle contains top-level `name`, `email`, and `company` before `metadata`.
