### PR TITLE
Guard against stale active stack fallback

### DIFF
--- a/src/kitaru/_cli/_status.py
+++ b/src/kitaru/_cli/_status.py
@@ -901,11 +901,16 @@ def status(output: OutputFormatOption = "text") -> None:
 def _write_info_file(
     snapshot: RuntimeSnapshot,
     file_path: str,
+    *,
+    include_provenance_details: bool = False,
 ) -> None:
     """Write serialized snapshot to a file, inferring format from extension."""
     path = Path(file_path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    data = serialize_runtime_snapshot(snapshot)
+    data = serialize_runtime_snapshot(
+        snapshot,
+        include_provenance_details=include_provenance_details,
+    )
     suffix = path.suffix.lower()
 
     if suffix in (".yaml", ".yml"):
@@ -996,7 +1001,11 @@ def info(
 
     if file is not None:
         run_with_cli_error_boundary(
-            lambda: _write_info_file(snapshot, file),
+            lambda: _write_info_file(
+                snapshot,
+                file,
+                include_provenance_details=include_provenance_details,
+            ),
             command=command,
             output=output_format,
             exit_with_error=_exit_with_error,
@@ -1021,7 +1030,10 @@ def info(
     if output_format == CLIOutputFormat.JSON:
         _emit_json_item(
             command,
-            serialize_runtime_snapshot(snapshot),
+            serialize_runtime_snapshot(
+                snapshot,
+                include_provenance_details=include_provenance_details,
+            ),
             output=output_format,
         )
         return

--- a/src/kitaru/_config/_active_context.py
+++ b/src/kitaru/_config/_active_context.py
@@ -249,8 +249,18 @@ def with_resolved_selection(
 def selection_resolved_via_fallback(
     provenance: ActiveConfigSelectionProvenance | None,
 ) -> bool:
-    """Return whether raw configured ID differs from the resolved resource ID."""
+    """Return whether a saved config ID resolved to a different resource.
+
+    Environment values are explicit overrides, and Kitaru/ZenML may accept a
+    human-readable name there before resolving it to a UUID. Treating that
+    name→UUID resolution as a saved-context fallback creates false alarms such
+    as ``KITARU_PROJECT=production`` resolving to the production project's ID.
+    The fallback warning is only for repo-local/global config values that ZenML
+    silently sanitized while loading.
+    """
     if provenance is None:
+        return False
+    if provenance.effective_source not in {"repo-local config", "global config"}:
         return False
     if provenance.effective_id is None or provenance.resolved_id is None:
         return False

--- a/src/kitaru/_config/_active_context.py
+++ b/src/kitaru/_config/_active_context.py
@@ -1,0 +1,300 @@
+"""Active stack/project provenance helpers.
+
+These helpers intentionally read the raw config files before constructing a
+ZenML ``Client``. The client may sanitize stale active stack/project IDs while
+it starts up, so diagnostics and safety checks need one "before" snapshot.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from zenml.client import Client
+from zenml.config.global_config import GlobalConfiguration
+from zenml.constants import (
+    CONFIG_FILE_NAME,
+    ENV_ZENML_ACTIVE_PROJECT_ID,
+    ENV_ZENML_ACTIVE_STACK_ID,
+)
+from zenml.utils import yaml_utils
+
+from kitaru._config._env import KITARU_STACK_ENV
+from kitaru._env import KITARU_PROJECT_ENV, KITARU_REPOSITORY_DIRECTORY_NAME
+
+logger = logging.getLogger(__name__)
+
+ProvenanceResource = Literal["active_stack", "active_project"]
+ProvenanceSource = Literal[
+    "environment",
+    "repo-local config",
+    "global config",
+    "unset",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class ActiveConfigSelectionProvenance:
+    """Raw and resolved provenance for an active stack/project selection."""
+
+    resource: ProvenanceResource
+    effective_source: ProvenanceSource
+    effective_source_detail: str | None
+    effective_id: str | None
+    resolved_id: str | None = None
+    resolved_name: str | None = None
+    environment_variable: str | None = None
+    environment_id: str | None = None
+    repository_root: str | None = None
+    repository_config_path: str | None = None
+    repository_id: str | None = None
+    global_config_path: str | None = None
+    global_id: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+
+def read_raw_yaml_mapping(path: Path) -> tuple[dict[str, Any], str | None]:
+    """Read a YAML mapping for diagnostics without raising user-facing errors."""
+    if not path.exists():
+        return {}, None
+
+    try:
+        raw = yaml_utils.read_yaml(str(path))
+    except (OSError, yaml.YAMLError) as exc:
+        logger.debug("Could not read config file %s", path, exc_info=True)
+        return {}, f"Could not read config file {path} ({type(exc).__name__}): {exc}"
+
+    if raw is None:
+        return {}, None
+    if not isinstance(raw, dict):
+        return {}, f"Config file exists but is not a mapping: {path}"
+    return raw, None
+
+
+def stringify_config_id(value: Any) -> str | None:
+    """Return a non-empty string for an active config ID without validating it."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def find_repository_root_for_diagnostics() -> tuple[Path | None, str | None]:
+    """Find the active repository root without constructing a ZenML client."""
+    try:
+        return Client.find_repository(enable_warnings=False), None
+    except OSError as exc:
+        return None, f"Could not inspect repository root: {type(exc).__name__}: {exc}"
+
+
+def repo_local_config_path(repository_root: Path | str) -> Path:
+    """Return the `.kitaru/config.yaml` path for a given repository root."""
+    return Path(repository_root) / KITARU_REPOSITORY_DIRECTORY_NAME / CONFIG_FILE_NAME
+
+
+def _build_selection_provenance(
+    *,
+    resource: ProvenanceResource,
+    environment_variable: str,
+    environment_id: str | None,
+    repository_root: Path | None,
+    repository_config_path: Path | None,
+    repository_id: str | None,
+    global_config_path: Path,
+    global_id: str | None,
+    notes: list[str],
+) -> ActiveConfigSelectionProvenance:
+    """Apply ZenML's active context precedence to raw diagnostic candidates."""
+    effective_source: ProvenanceSource
+    effective_source_detail: str | None
+    effective_id: str | None
+
+    if environment_id is not None:
+        effective_source = "environment"
+        effective_source_detail = environment_variable
+        effective_id = environment_id
+    elif repository_id is not None:
+        effective_source = "repo-local config"
+        effective_source_detail = (
+            str(repository_config_path) if repository_config_path else None
+        )
+        effective_id = repository_id
+    elif global_id is not None:
+        effective_source = "global config"
+        effective_source_detail = str(global_config_path)
+        effective_id = global_id
+    else:
+        effective_source = "unset"
+        effective_source_detail = None
+        effective_id = None
+
+    return ActiveConfigSelectionProvenance(
+        resource=resource,
+        effective_source=effective_source,
+        effective_source_detail=effective_source_detail,
+        effective_id=effective_id,
+        environment_variable=environment_variable,
+        environment_id=environment_id,
+        repository_root=str(repository_root) if repository_root else None,
+        repository_config_path=(
+            str(repository_config_path) if repository_config_path else None
+        ),
+        repository_id=repository_id,
+        global_config_path=str(global_config_path),
+        global_id=global_id,
+        notes=list(notes),
+    )
+
+
+def collect_active_context_provenance(
+    gc: GlobalConfiguration,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> tuple[ActiveConfigSelectionProvenance, ActiveConfigSelectionProvenance]:
+    """Collect raw active stack/project IDs before Client can sanitize them."""
+    env = os.environ if environ is None else environ
+    notes: list[str] = []
+
+    repository_root, repo_note = find_repository_root_for_diagnostics()
+    if repo_note:
+        notes.append(repo_note)
+
+    repository_config_path: Path | None = None
+    if repository_root is not None:
+        repository_config_path = repo_local_config_path(repository_root)
+
+    global_config_path = Path(gc.config_directory) / CONFIG_FILE_NAME
+    repo_config: dict[str, Any] = {}
+    global_config: dict[str, Any] = {}
+
+    if repository_config_path is not None:
+        repo_config, repo_yaml_note = read_raw_yaml_mapping(repository_config_path)
+        if repo_yaml_note:
+            notes.append(repo_yaml_note)
+
+    global_config, global_yaml_note = read_raw_yaml_mapping(global_config_path)
+    if global_yaml_note:
+        notes.append(global_yaml_note)
+
+    stack_notes = list(notes)
+    if env.get(KITARU_STACK_ENV):
+        stack_notes.append(
+            f"{KITARU_STACK_ENV} is an execution default and does not set "
+            "ZenML's active stack."
+        )
+
+    kitaru_project_id = stringify_config_id(env.get(KITARU_PROJECT_ENV))
+    zenml_project_id = stringify_config_id(env.get(ENV_ZENML_ACTIVE_PROJECT_ID))
+    project_environment_id = kitaru_project_id or zenml_project_id
+    project_environment_variable = ENV_ZENML_ACTIVE_PROJECT_ID
+    project_notes = list(notes)
+    if kitaru_project_id is not None:
+        project_environment_variable = (
+            f"{KITARU_PROJECT_ENV} -> {ENV_ZENML_ACTIVE_PROJECT_ID}"
+        )
+        if zenml_project_id is not None and zenml_project_id != kitaru_project_id:
+            project_notes.append(
+                f"Both {KITARU_PROJECT_ENV} and {ENV_ZENML_ACTIVE_PROJECT_ID} "
+                f"are set with different values; {KITARU_PROJECT_ENV} takes "
+                "precedence via Kitaru's init-hook translation."
+            )
+
+    active_stack_provenance = _build_selection_provenance(
+        resource="active_stack",
+        environment_variable=ENV_ZENML_ACTIVE_STACK_ID,
+        environment_id=stringify_config_id(env.get(ENV_ZENML_ACTIVE_STACK_ID)),
+        repository_root=repository_root,
+        repository_config_path=repository_config_path,
+        repository_id=stringify_config_id(repo_config.get("active_stack_id")),
+        global_config_path=global_config_path,
+        global_id=stringify_config_id(global_config.get("active_stack_id")),
+        notes=stack_notes,
+    )
+    active_project_provenance = _build_selection_provenance(
+        resource="active_project",
+        environment_variable=project_environment_variable,
+        environment_id=project_environment_id,
+        repository_root=repository_root,
+        repository_config_path=repository_config_path,
+        repository_id=stringify_config_id(repo_config.get("active_project_id")),
+        global_config_path=global_config_path,
+        global_id=stringify_config_id(global_config.get("active_project_id")),
+        notes=project_notes,
+    )
+    return active_stack_provenance, active_project_provenance
+
+
+def with_resolved_selection(
+    provenance: ActiveConfigSelectionProvenance | None,
+    *,
+    resolved_id: str | None,
+    resolved_name: str | None,
+) -> ActiveConfigSelectionProvenance | None:
+    """Attach resolved Client details to a previously captured provenance row."""
+    if provenance is None:
+        return None
+    return replace(
+        provenance,
+        resolved_id=resolved_id,
+        resolved_name=resolved_name,
+    )
+
+
+def selection_resolved_via_fallback(
+    provenance: ActiveConfigSelectionProvenance | None,
+) -> bool:
+    """Return whether raw configured ID differs from the resolved resource ID."""
+    if provenance is None:
+        return False
+    if provenance.effective_id is None or provenance.resolved_id is None:
+        return False
+    return provenance.effective_id != provenance.resolved_id
+
+
+def active_context_fallback_warning(
+    *,
+    active_stack: ActiveConfigSelectionProvenance | None,
+    active_project: ActiveConfigSelectionProvenance | None,
+) -> str | None:
+    """Render a clear warning for active stack/project fallback diagnostics."""
+    lines: list[str] = []
+    for label, selection in (
+        ("active stack", active_stack),
+        ("active project", active_project),
+    ):
+        if not selection_resolved_via_fallback(selection) or selection is None:
+            continue
+        source = selection.effective_source
+        if selection.effective_source_detail:
+            source = f"{source} ({selection.effective_source_detail})"
+        resolved = selection.resolved_id or "unknown"
+        if selection.resolved_name:
+            resolved = f"{selection.resolved_name} ({resolved})"
+        lines.append(
+            f"Configured {label} from {source} points to ID "
+            f"{selection.effective_id!r}, but Kitaru loaded {resolved}."
+        )
+
+    if not lines:
+        return None
+
+    return "\n".join(
+        [
+            "Kitaru detected that the saved active context changed while loading.",
+            *lines,
+            (
+                "This usually means the saved stack or project no longer exists, "
+                "or your current credentials cannot access it."
+            ),
+            (
+                "Choose the intended stack/project explicitly before running "
+                "workflows to avoid accidentally using a fallback context."
+            ),
+        ]
+    )

--- a/src/kitaru/_config/_core.py
+++ b/src/kitaru/_config/_core.py
@@ -7,12 +7,13 @@ import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 from uuid import UUID
 
 from pydantic import (
     BaseModel,
     ConfigDict,
+    Field,
     ValidationError,
     field_validator,
     model_validator,
@@ -34,6 +35,15 @@ FROZEN_EXECUTION_SPEC_METADATA_KEY = "kitaru_execution_spec"
 
 if TYPE_CHECKING:
     from kitaru._config._models import ModelRegistryConfig
+
+ExecutionStackSource = Literal[
+    "zenml_active_stack",
+    "project_config",
+    "environment",
+    "runtime",
+    "decorator",
+    "invocation",
+]
 
 
 class ImageSettings(BaseModel):
@@ -178,6 +188,7 @@ class ResolvedExecutionConfig(BaseModel):
     """Fully resolved execution settings for a flow run."""
 
     stack: str | None = None
+    stack_source: ExecutionStackSource | None = Field(default=None, exclude=True)
     image: ImageSettings | None = None
     cache: bool | None = None
     retries: int

--- a/src/kitaru/_config/_env.py
+++ b/src/kitaru/_config/_env.py
@@ -12,6 +12,7 @@ from typing import Any, TypeVar
 from zenml.constants import ENV_ZENML_ACTIVE_PROJECT_ID
 
 from kitaru._config._core import (
+    ExecutionStackSource,
     KitaruConfig,
     ResolvedConnectionConfig,
     ResolvedExecutionConfig,
@@ -200,6 +201,8 @@ def _read_global_execution_config_impl(
 def _merge_execution_layer(
     resolved: ResolvedExecutionConfig,
     layer: KitaruConfig,
+    *,
+    stack_source: ExecutionStackSource | None = None,
 ) -> ResolvedExecutionConfig:
     """Apply one execution config layer onto an already-resolved result."""
     merged_image = resolved.image
@@ -210,6 +213,9 @@ def _merge_execution_layer(
 
     return ResolvedExecutionConfig(
         stack=layer.stack if layer.stack is not None else resolved.stack,
+        stack_source=(
+            stack_source if layer.stack is not None else resolved.stack_source
+        ),
         image=merged_image,
         cache=layer.cache if layer.cache is not None else resolved.cache,
         retries=layer.retries if layer.retries is not None else resolved.retries,
@@ -298,23 +304,28 @@ def resolve_execution_config_impl(
     read_runtime_execution_config: Callable[[], KitaruConfig],
 ) -> ResolvedExecutionConfig:
     """Resolve execution configuration according to Phase 10 precedence."""
-    return _apply_layers(
-        ResolvedExecutionConfig(
-            stack=None,
-            image=None,
-            cache=None,
-            retries=0,
-        ),
-        (
-            read_global_execution_config(),
-            read_project_config(start_dir),
-            read_execution_env_config(),
-            read_runtime_execution_config(),
-            decorator_overrides or KitaruConfig(),
-            invocation_overrides or KitaruConfig(),
-        ),
-        _merge_execution_layer,
+    resolved = ResolvedExecutionConfig(
+        stack=None,
+        stack_source=None,
+        image=None,
+        cache=None,
+        retries=0,
     )
+    layers: tuple[tuple[ExecutionStackSource, KitaruConfig], ...] = (
+        ("zenml_active_stack", read_global_execution_config()),
+        ("project_config", read_project_config(start_dir)),
+        ("environment", read_execution_env_config()),
+        ("runtime", read_runtime_execution_config()),
+        ("decorator", decorator_overrides or KitaruConfig()),
+        ("invocation", invocation_overrides or KitaruConfig()),
+    )
+    for source, layer in layers:
+        resolved = _merge_execution_layer(
+            resolved,
+            layer,
+            stack_source=source,
+        )
+    return resolved
 
 
 def resolve_connection_config_impl(

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -164,6 +164,11 @@ def _guard_implicit_active_stack_fallback(
         or raw_active_stack_provenance.effective_id is None
     ):
         return
+    if raw_active_stack_provenance.effective_source not in {
+        "repo-local config",
+        "global config",
+    }:
+        return
 
     client = (client_factory or Client)()
     active_stack_model = client.active_stack_model

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -23,7 +23,9 @@ from pydantic import ConfigDict, create_model
 from zenml.client import Client
 from zenml.config.constants import DOCKER_SETTINGS_KEY
 from zenml.config.docker_settings import DockerSettings
+from zenml.config.global_config import GlobalConfiguration
 from zenml.config.retry_config import StepRetryConfig
+from zenml.constants import DEFAULT_STACK_AND_COMPONENT_NAME
 from zenml.models import PipelineRunResponse
 from zenml.pipelines.pipeline_decorator import pipeline
 from zenml.pipelines.pipeline_definition import Pipeline
@@ -31,6 +33,12 @@ from zenml.pipelines.pipeline_definition import Pipeline
 from kitaru._client._deployments import DEFAULT_DEPLOYMENT_TAG
 from kitaru._client._mappers import _to_public_status
 from kitaru._client._models import ExecutionStatus
+from kitaru._config._active_context import (
+    ActiveConfigSelectionProvenance,
+    collect_active_context_provenance,
+    stringify_config_id,
+    with_resolved_selection,
+)
 from kitaru._interface_deployments import (
     Deployment,
     ensure_stack_is_server_runnable,
@@ -122,6 +130,80 @@ def _preflight_active_stack_implementation_hydration(
         if zenml_guidance:
             message = f"{message}\n\nZenML guidance:\n\n{zenml_guidance}"
         raise KitaruStackIntegrationDependencyError(message) from None
+
+
+def _capture_active_stack_provenance_for_guard() -> (
+    ActiveConfigSelectionProvenance | None
+):
+    """Capture raw active stack provenance before Client sanitizes it."""
+    try:
+        stack_provenance, _ = collect_active_context_provenance(GlobalConfiguration())
+    except Exception:
+        logger.debug("Could not collect active stack provenance", exc_info=True)
+        return None
+    return stack_provenance
+
+
+def _guard_implicit_active_stack_fallback(
+    *,
+    operation: str,
+    resolved_execution: ResolvedExecutionConfig,
+    raw_active_stack_provenance: ActiveConfigSelectionProvenance | None,
+    client_factory: Callable[[], Any] | None = None,
+) -> None:
+    """Fail closed when an implicit stale active stack would run on default."""
+    # Status/info diagnose any raw-vs-resolved active context mismatch. Runtime
+    # blocking is deliberately narrower: only the high-risk case where Kitaru
+    # would implicitly inherit a stale active stack that resolved to `default`.
+    if resolved_execution.stack_source != "zenml_active_stack":
+        return
+    if resolved_execution.stack != DEFAULT_STACK_AND_COMPONENT_NAME:
+        return
+    if (
+        raw_active_stack_provenance is None
+        or raw_active_stack_provenance.effective_id is None
+    ):
+        return
+
+    client = (client_factory or Client)()
+    active_stack_model = client.active_stack_model
+    resolved_name = str(getattr(active_stack_model, "name", "") or "")
+    if resolved_name != DEFAULT_STACK_AND_COMPONENT_NAME:
+        return
+
+    resolved_provenance = with_resolved_selection(
+        raw_active_stack_provenance,
+        resolved_id=stringify_config_id(getattr(active_stack_model, "id", None)),
+        resolved_name=resolved_name,
+    )
+    if (
+        resolved_provenance is None
+        or resolved_provenance.resolved_id is None
+        or resolved_provenance.effective_id == resolved_provenance.resolved_id
+    ):
+        return
+
+    source = resolved_provenance.effective_source
+    if resolved_provenance.effective_source_detail:
+        source = f"{source} ({resolved_provenance.effective_source_detail})"
+    raise KitaruUsageError(
+        "\n".join(
+            [
+                f"Kitaru refused to {operation} because the saved active "
+                "stack appears stale and resolved to fallback stack "
+                f"`{DEFAULT_STACK_AND_COMPONENT_NAME}` implicitly.",
+                f"Configured active stack from {source}: "
+                f"{resolved_provenance.effective_id}",
+                f"Resolved active stack: {DEFAULT_STACK_AND_COMPONENT_NAME} "
+                f"({resolved_provenance.resolved_id})",
+                "Choose a stack explicitly before running this workflow. "
+                "For example: pass `stack=...`, set `KITARU_STACK=...`, "
+                "configure `[tool.kitaru].stack`, or run "
+                "`kitaru stack use <stack>` once the saved active stack is "
+                "correct again.",
+            ]
+        )
+    )
 
 
 def _register_pipeline_source_alias(
@@ -949,6 +1031,7 @@ class _FlowDefinition:
         snapshot. Later invocations can override those values by passing flow
         inputs to ``invoke(...)``.
         """
+        raw_active_stack_provenance = _capture_active_stack_provenance_for_guard()
         resolved_execution = resolve_execution_config(
             decorator_overrides=self._decorator_config,
             invocation_overrides=_build_execution_overrides(
@@ -957,6 +1040,11 @@ class _FlowDefinition:
                 cache=cache,
                 retries=retries,
             ),
+        )
+        _guard_implicit_active_stack_fallback(
+            operation="deploy this flow",
+            resolved_execution=resolved_execution,
+            raw_active_stack_provenance=raw_active_stack_provenance,
         )
         transport_image, _ = _prepare_model_registry_transport(resolved_execution.image)
         configured_pipeline = self._pipeline.with_options(
@@ -1083,6 +1171,7 @@ class _FlowDefinition:
         Returns:
             A handle for the replayed execution.
         """
+        raw_active_stack_provenance = _capture_active_stack_provenance_for_guard()
         resolved_connection = resolve_connection_config(validate_for_use=True)
 
         try:
@@ -1111,6 +1200,11 @@ class _FlowDefinition:
                 cache=cache,
                 retries=retries,
             ),
+        )
+        _guard_implicit_active_stack_fallback(
+            operation="replay this flow",
+            resolved_execution=resolved_execution,
+            raw_active_stack_provenance=raw_active_stack_provenance,
         )
         transport_image, effective_model_registry = _prepare_model_registry_transport(
             resolved_execution.image
@@ -1221,9 +1315,15 @@ class _FlowDefinition:
         Returns:
             A handle for the started execution.
         """
+        raw_active_stack_provenance = _capture_active_stack_provenance_for_guard()
         resolved_execution = resolve_execution_config(
             decorator_overrides=self._decorator_config,
             invocation_overrides=invocation_overrides,
+        )
+        _guard_implicit_active_stack_fallback(
+            operation="run this flow",
+            resolved_execution=resolved_execution,
+            raw_active_stack_provenance=raw_active_stack_provenance,
         )
         resolved_connection = resolve_connection_config(validate_for_use=True)
         transport_image, effective_model_registry = _prepare_model_registry_transport(

--- a/src/kitaru/inspection.py
+++ b/src/kitaru/inspection.py
@@ -1101,9 +1101,23 @@ def serialize_stack_details(details: StackDetails) -> dict[str, Any]:
     return payload
 
 
-def serialize_runtime_snapshot(snapshot: RuntimeSnapshot) -> dict[str, Any]:
-    """Serialize runtime status details for structured output."""
-    return to_jsonable(snapshot, fallback_repr=True)
+def serialize_runtime_snapshot(
+    snapshot: RuntimeSnapshot,
+    *,
+    include_provenance_details: bool = False,
+) -> dict[str, Any]:
+    """Serialize runtime status details for structured output.
+
+    Runtime snapshots keep active stack/project provenance internally so normal
+    status/info calls can still produce safety warnings. The detailed raw
+    provenance is diagnostic material, though, so structured outputs expose it
+    only when callers opt in (``kitaru info --all`` or MCP ``all=True``).
+    """
+    payload = to_jsonable(snapshot, fallback_repr=True)
+    if not include_provenance_details:
+        payload["active_stack_provenance"] = None
+        payload["active_project_provenance"] = None
+    return payload
 
 
 def serialize_log_entry(entry: LogEntry) -> dict[str, Any]:

--- a/src/kitaru/inspection.py
+++ b/src/kitaru/inspection.py
@@ -12,19 +12,12 @@ from dataclasses import asdict, dataclass, field, is_dataclass, replace
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 from urllib.parse import urlparse
 
-import yaml
 from zenml.client import Client
 from zenml.config.global_config import GlobalConfiguration
-from zenml.constants import (
-    CONFIG_FILE_NAME,
-    ENV_ZENML_ACTIVE_PROJECT_ID,
-    ENV_ZENML_ACTIVE_STACK_ID,
-)
 from zenml.models import SecretResponse
-from zenml.utils import yaml_utils
 from zenml.utils.server_utils import connected_to_local_server, get_local_server
 
 from kitaru._client._models import (
@@ -36,11 +29,17 @@ from kitaru._client._models import (
     LogEntry,
     PendingWait,
 )
-from kitaru._env import KITARU_REPOSITORY_DIRECTORY_NAME
+from kitaru._config._active_context import (
+    ActiveConfigSelectionProvenance,
+    active_context_fallback_warning,
+    collect_active_context_provenance,
+    repo_local_config_path,
+    stringify_config_id,
+    with_resolved_selection,
+)
 from kitaru._version import resolve_installed_version
 from kitaru.config import (
     KITARU_PROJECT_ENV,
-    KITARU_STACK_ENV,
     ActiveEnvironmentVariable,
     ActiveStackLogStore,
     ModelAliasEntry,
@@ -68,35 +67,6 @@ from kitaru.memory import (
 logger = logging.getLogger(__name__)
 
 _LOCALHOST_NAMES = {"127.0.0.1", "localhost", "::1"}
-
-ProvenanceResource = Literal["active_stack", "active_project"]
-ProvenanceSource = Literal[
-    "environment",
-    "repo-local config",
-    "global config",
-    "unset",
-    "unknown",
-]
-
-
-@dataclass(frozen=True)
-class ActiveConfigSelectionProvenance:
-    """Raw and resolved provenance for an active stack/project selection."""
-
-    resource: ProvenanceResource
-    effective_source: ProvenanceSource
-    effective_source_detail: str | None
-    effective_id: str | None
-    resolved_id: str | None = None
-    resolved_name: str | None = None
-    environment_variable: str | None = None
-    environment_id: str | None = None
-    repository_root: str | None = None
-    repository_config_path: str | None = None
-    repository_id: str | None = None
-    global_config_path: str | None = None
-    global_id: str | None = None
-    notes: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -368,193 +338,6 @@ class ConfigProvenance:
     uses_repo_local: bool = False
 
 
-def _read_raw_yaml_mapping(path: Path) -> tuple[dict[str, Any], str | None]:
-    """Read a YAML mapping for diagnostics without raising user-facing errors."""
-    if not path.exists():
-        return {}, None
-
-    try:
-        raw = yaml_utils.read_yaml(str(path))
-    except (OSError, yaml.YAMLError) as exc:
-        logger.debug("Could not read config file %s", path, exc_info=True)
-        return {}, f"Could not read config file {path} ({type(exc).__name__}): {exc}"
-
-    if raw is None:
-        return {}, None
-    if not isinstance(raw, dict):
-        return {}, f"Config file exists but is not a mapping: {path}"
-    return raw, None
-
-
-def _stringify_config_id(value: Any) -> str | None:
-    """Return a non-empty string for an active config ID without validating it."""
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
-
-
-def _find_repository_root_for_diagnostics() -> tuple[Path | None, str | None]:
-    """Find the active repository root without constructing a ZenML client."""
-    try:
-        return Client.find_repository(enable_warnings=False), None
-    except OSError as exc:
-        return None, f"Could not inspect repository root: {type(exc).__name__}: {exc}"
-
-
-def _repo_local_config_path(repository_root: Path | str) -> Path:
-    """Return the `.kitaru/config.yaml` path for a given repository root."""
-    return Path(repository_root) / KITARU_REPOSITORY_DIRECTORY_NAME / CONFIG_FILE_NAME
-
-
-def _build_selection_provenance(
-    *,
-    resource: ProvenanceResource,
-    environment_variable: str,
-    environment_id: str | None,
-    repository_root: Path | None,
-    repository_config_path: Path | None,
-    repository_id: str | None,
-    global_config_path: Path,
-    global_id: str | None,
-    notes: list[str],
-) -> ActiveConfigSelectionProvenance:
-    """Apply ZenML's active context precedence to raw diagnostic candidates."""
-    effective_source: ProvenanceSource
-    effective_source_detail: str | None
-    effective_id: str | None
-
-    if environment_id is not None:
-        effective_source = "environment"
-        effective_source_detail = environment_variable
-        effective_id = environment_id
-    elif repository_id is not None:
-        effective_source = "repo-local config"
-        effective_source_detail = (
-            str(repository_config_path) if repository_config_path else None
-        )
-        effective_id = repository_id
-    elif global_id is not None:
-        effective_source = "global config"
-        effective_source_detail = str(global_config_path)
-        effective_id = global_id
-    else:
-        effective_source = "unset"
-        effective_source_detail = None
-        effective_id = None
-
-    return ActiveConfigSelectionProvenance(
-        resource=resource,
-        effective_source=effective_source,
-        effective_source_detail=effective_source_detail,
-        effective_id=effective_id,
-        environment_variable=environment_variable,
-        environment_id=environment_id,
-        repository_root=str(repository_root) if repository_root else None,
-        repository_config_path=(
-            str(repository_config_path) if repository_config_path else None
-        ),
-        repository_id=repository_id,
-        global_config_path=str(global_config_path),
-        global_id=global_id,
-        notes=list(notes),
-    )
-
-
-def _collect_active_context_provenance(
-    gc: GlobalConfiguration,
-    *,
-    environ: Mapping[str, str] | None = None,
-) -> tuple[ActiveConfigSelectionProvenance, ActiveConfigSelectionProvenance]:
-    """Collect raw active stack/project IDs before Client can sanitize them."""
-    env = os.environ if environ is None else environ
-    notes: list[str] = []
-
-    repository_root, repo_note = _find_repository_root_for_diagnostics()
-    if repo_note:
-        notes.append(repo_note)
-
-    repository_config_path: Path | None = None
-    if repository_root is not None:
-        repository_config_path = _repo_local_config_path(repository_root)
-
-    global_config_path = Path(gc.config_directory) / CONFIG_FILE_NAME
-    repo_config: dict[str, Any] = {}
-    global_config: dict[str, Any] = {}
-
-    if repository_config_path is not None:
-        repo_config, repo_yaml_note = _read_raw_yaml_mapping(repository_config_path)
-        if repo_yaml_note:
-            notes.append(repo_yaml_note)
-
-    global_config, global_yaml_note = _read_raw_yaml_mapping(global_config_path)
-    if global_yaml_note:
-        notes.append(global_yaml_note)
-
-    stack_notes = list(notes)
-    if env.get(KITARU_STACK_ENV):
-        stack_notes.append(
-            f"{KITARU_STACK_ENV} is an execution default and does not set "
-            "ZenML's active stack."
-        )
-
-    kitaru_project_id = _stringify_config_id(env.get(KITARU_PROJECT_ENV))
-    zenml_project_id = _stringify_config_id(env.get(ENV_ZENML_ACTIVE_PROJECT_ID))
-    project_environment_id = kitaru_project_id or zenml_project_id
-    project_environment_variable = ENV_ZENML_ACTIVE_PROJECT_ID
-    project_notes = list(notes)
-    if kitaru_project_id is not None:
-        project_environment_variable = (
-            f"{KITARU_PROJECT_ENV} -> {ENV_ZENML_ACTIVE_PROJECT_ID}"
-        )
-        if zenml_project_id is not None and zenml_project_id != kitaru_project_id:
-            project_notes.append(
-                f"Both {KITARU_PROJECT_ENV} and {ENV_ZENML_ACTIVE_PROJECT_ID} "
-                f"are set with different values; {KITARU_PROJECT_ENV} takes "
-                "precedence via Kitaru's init-hook translation."
-            )
-
-    active_stack_provenance = _build_selection_provenance(
-        resource="active_stack",
-        environment_variable=ENV_ZENML_ACTIVE_STACK_ID,
-        environment_id=_stringify_config_id(env.get(ENV_ZENML_ACTIVE_STACK_ID)),
-        repository_root=repository_root,
-        repository_config_path=repository_config_path,
-        repository_id=_stringify_config_id(repo_config.get("active_stack_id")),
-        global_config_path=global_config_path,
-        global_id=_stringify_config_id(global_config.get("active_stack_id")),
-        notes=stack_notes,
-    )
-    active_project_provenance = _build_selection_provenance(
-        resource="active_project",
-        environment_variable=project_environment_variable,
-        environment_id=project_environment_id,
-        repository_root=repository_root,
-        repository_config_path=repository_config_path,
-        repository_id=_stringify_config_id(repo_config.get("active_project_id")),
-        global_config_path=global_config_path,
-        global_id=_stringify_config_id(global_config.get("active_project_id")),
-        notes=project_notes,
-    )
-    return active_stack_provenance, active_project_provenance
-
-
-def _with_resolved_selection(
-    provenance: ActiveConfigSelectionProvenance | None,
-    *,
-    resolved_id: str | None,
-    resolved_name: str | None,
-) -> ActiveConfigSelectionProvenance | None:
-    """Attach resolved Client details to a previously captured provenance row."""
-    if provenance is None:
-        return None
-    return replace(
-        provenance,
-        resolved_id=resolved_id,
-        resolved_name=resolved_name,
-    )
-
-
 def _unknown_provenance_pair(
     note: str,
 ) -> tuple[ActiveConfigSelectionProvenance, ActiveConfigSelectionProvenance]:
@@ -614,7 +397,7 @@ def _collect_config_provenance(
     repo_config_str: str | None = None
     uses_repo = False
     if repository_root:
-        repo_config = _repo_local_config_path(repository_root)
+        repo_config = repo_local_config_path(repository_root)
         if repo_config.exists():
             repo_config_str = str(repo_config)
             uses_repo = True
@@ -666,7 +449,7 @@ def _collect_connection_sources() -> dict[str, str]:
     else:
         try:
             repo_root = Client.find_repository(enable_warnings=False)
-            if repo_root and _repo_local_config_path(repo_root).exists():
+            if repo_root and repo_local_config_path(repo_root).exists():
                 sources["project"] = "repo-local config (.kitaru/)"
             else:
                 sources["project"] = "global config"
@@ -751,14 +534,14 @@ def build_runtime_snapshot(
         )
         return snapshot
 
-    if include_provenance_details:
-        try:
-            (
-                active_stack_provenance,
-                active_project_provenance,
-            ) = _collect_active_context_provenance(gc)
-        except Exception as exc:
-            logger.debug("Could not collect active context provenance", exc_info=True)
+    try:
+        (
+            active_stack_provenance,
+            active_project_provenance,
+        ) = collect_active_context_provenance(gc)
+    except Exception as exc:
+        logger.debug("Could not collect active context provenance", exc_info=True)
+        if include_provenance_details:
             failure_note = (
                 f"Could not collect active context provenance "
                 f"({type(exc).__name__}): {exc}"
@@ -841,9 +624,9 @@ def build_runtime_snapshot(
         snapshot.active_user = client.active_user.name
         active_stack_model = client.active_stack_model
         snapshot.active_stack = active_stack_model.name
-        snapshot.active_stack_provenance = _with_resolved_selection(
+        snapshot.active_stack_provenance = with_resolved_selection(
             snapshot.active_stack_provenance,
-            resolved_id=_stringify_config_id(getattr(active_stack_model, "id", None)),
+            resolved_id=stringify_config_id(getattr(active_stack_model, "id", None)),
             resolved_name=active_stack_model.name,
         )
         snapshot.repository_root = str(client.root) if client.root else None
@@ -855,9 +638,9 @@ def build_runtime_snapshot(
         try:
             active_project = client.active_project
             snapshot.active_project = active_project.name
-            snapshot.active_project_provenance = _with_resolved_selection(
+            snapshot.active_project_provenance = with_resolved_selection(
                 snapshot.active_project_provenance,
-                resolved_id=_stringify_config_id(getattr(active_project, "id", None)),
+                resolved_id=stringify_config_id(getattr(active_project, "id", None)),
                 resolved_name=active_project.name,
             )
         except Exception:
@@ -907,7 +690,14 @@ def build_runtime_snapshot(
     )
     snapshot.log_store_status = log_store_status
     snapshot.log_store_warning = log_store_warning
-    snapshot.warning = combine_warnings(snapshot.warning, _legacy_runner_env_warning())
+    snapshot.warning = combine_warnings(
+        snapshot.warning,
+        active_context_fallback_warning(
+            active_stack=snapshot.active_stack_provenance,
+            active_project=snapshot.active_project_provenance,
+        ),
+        _legacy_runner_env_warning(),
+    )
     return snapshot
 
 

--- a/src/kitaru/mcp/server.py
+++ b/src/kitaru/mcp/server.py
@@ -814,7 +814,10 @@ def kitaru_info(
             include_environment_type=include_environment_type,
             include_provenance_details=include_provenance_details,
         )
-        return inspection.serialize_runtime_snapshot(snapshot)
+        return inspection.serialize_runtime_snapshot(
+            snapshot,
+            include_provenance_details=include_provenance_details,
+        )
 
     return run_with_mcp_error_boundary(_info)
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -2795,7 +2795,10 @@ class TestKitaruInfo:
             include_environment_type=False,
             include_provenance_details=False,
         )
-        mock_serialize.assert_called_once_with(snapshot)
+        mock_serialize.assert_called_once_with(
+            snapshot,
+            include_provenance_details=False,
+        )
         assert payload == {"sdk_version": "0.2.0"}
 
     @pytest.mark.parametrize(
@@ -2864,11 +2867,17 @@ class TestKitaruInfo:
             patch(
                 "kitaru.inspection.serialize_runtime_snapshot",
                 return_value={},
-            ),
+            ) as mock_serialize,
         ):
             kitaru_info(**call_kwargs)
 
         mock_build.assert_called_once_with(**expected_build_kwargs)
+        mock_serialize.assert_called_once_with(
+            snapshot,
+            include_provenance_details=expected_build_kwargs[
+                "include_provenance_details"
+            ],
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8954,6 +8954,46 @@ def test_info_all_json_includes_active_context_provenance(
     assert item["active_project_provenance"]["environment_id"] == "env-project-id"
 
 
+def test_status_json_hides_active_context_provenance_by_default(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`kitaru status -o json` should hide verbose provenance by default."""
+    snapshot = _snapshot_with_active_context_provenance()
+
+    with (
+        patch("kitaru.cli._build_runtime_snapshot", return_value=snapshot),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["status", "-o", "json"])
+
+    assert exc_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command"] == "status"
+    item = payload["item"]
+    assert item["active_stack_provenance"] is None
+    assert item["active_project_provenance"] is None
+
+
+def test_info_json_hides_active_context_provenance_by_default(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`kitaru info -o json` should hide verbose provenance unless --all."""
+    snapshot = _snapshot_with_active_context_provenance()
+
+    with (
+        patch("kitaru.cli._build_runtime_snapshot", return_value=snapshot),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["info", "-o", "json"])
+
+    assert exc_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command"] == "info"
+    item = payload["item"]
+    assert item["active_stack_provenance"] is None
+    assert item["active_project_provenance"] is None
+
+
 def test_info_all_file_export_includes_active_context_provenance(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -9035,6 +9075,8 @@ def test_info_file_export_json(
     assert export_path.exists()
     data = json.loads(export_path.read_text())
     assert data["sdk_version"] == "0.3.0"
+    assert data["active_stack_provenance"] is None
+    assert data["active_project_provenance"] is None
 
 
 def test_info_file_export_json_mode(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8839,6 +8839,61 @@ def test_status_does_not_render_active_context_provenance(
     assert "repo-stack-id" not in output
 
 
+def test_status_renders_active_context_fallback_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`kitaru status` should surface fallback warnings in normal output."""
+    snapshot = RuntimeSnapshot(
+        sdk_version="0.3.0",
+        connection="local database",
+        connection_target="sqlite:///...",
+        config_directory="/tmp/config",
+        active_stack="default",
+        warning=(
+            "Kitaru detected that the saved active context changed while loading.\n"
+            "Configured active stack from repo-local config points to ID "
+            "'stale-stack-id', but Kitaru loaded default (default-stack-id)."
+        ),
+    )
+
+    with (
+        patch("kitaru.cli._build_runtime_snapshot", return_value=snapshot),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["status"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "Warning" in output
+    assert "saved active context changed" in output
+    assert "stale-stack-id" in output
+
+
+def test_info_default_renders_active_context_fallback_warning(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Default `kitaru info` should show warnings without verbose provenance."""
+    snapshot = RuntimeSnapshot(
+        sdk_version="0.3.0",
+        connection="local database",
+        connection_target="sqlite:///...",
+        config_directory="/tmp/config",
+        active_stack="default",
+        warning="Kitaru detected that the saved active context changed.",
+    )
+
+    with (
+        patch("kitaru.cli._build_runtime_snapshot", return_value=snapshot),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["info"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "saved active context changed" in output
+    assert "Active context provenance" not in output
+
+
 def test_info_all_renders_active_context_provenance(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3786,6 +3786,7 @@ SHARED = "project"
         )
 
     assert resolved.stack == "invocation-stack"
+    assert resolved.stack_source == "invocation"
     assert resolved.cache is True
     assert resolved.retries == 6
     assert resolved.image is not None
@@ -3823,6 +3824,36 @@ def test_resolve_execution_config_default_cache_is_unset() -> None:
         resolved = resolve_execution_config()
 
     assert resolved.cache is None
+    assert resolved.stack == "global-stack"
+    assert resolved.stack_source == "zenml_active_stack"
+
+
+def test_resolve_execution_config_marks_environment_stack_as_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """KITARU_STACK is an explicit Kitaru stack choice, even for default."""
+    monkeypatch.setenv(KITARU_STACK_ENV, "default")
+
+    with patch(
+        "kitaru.config.current_stack",
+        return_value=SimpleNamespace(name="fallback-default"),
+    ):
+        resolved = resolve_execution_config()
+
+    assert resolved.stack == "default"
+    assert resolved.stack_source == "environment"
+
+
+def test_resolved_execution_stack_source_is_not_persisted() -> None:
+    """Stack source is a runtime safety hint, not part of frozen specs."""
+    resolved = ResolvedExecutionConfig(
+        stack="default",
+        stack_source="zenml_active_stack",
+        cache=None,
+        retries=0,
+    )
+
+    assert "stack_source" not in resolved.model_dump()
 
 
 def test_resolve_execution_config_supports_string_image_env(

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -442,6 +442,42 @@ def test_run_fails_closed_before_submitting_on_implicit_default_fallback() -> No
     configured_pipeline.assert_not_called()
 
 
+def test_deploy_fails_closed_before_submitting_on_implicit_default_fallback() -> None:
+    configured_pipeline = MagicMock()
+    configured_pipeline._run_args = {}
+    configured_pipeline._parameters = {}
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+    client = SimpleNamespace(
+        active_stack_model=SimpleNamespace(name="default", id="default-stack-id")
+    )
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch(
+            "kitaru.flow._capture_active_stack_provenance_for_guard",
+            return_value=_stale_default_stack_provenance(),
+        ),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(
+                stack="default",
+                stack_source="zenml_active_stack",
+            ),
+        ),
+        patch("kitaru.flow.Client", return_value=client),
+        patch("kitaru.flow._prepare_model_registry_transport") as transport_mock,
+        pytest.raises(KitaruUsageError, match="fallback stack `default` implicitly"),
+    ):
+        wrapped = flow(lambda: None)
+        wrapped.deploy()
+
+    transport_mock.assert_not_called()
+    base_pipeline.with_options.assert_not_called()
+    configured_pipeline.prepare.assert_not_called()
+
+
 def test_flow_deploy_creates_snapshot_and_forwards_raw_tags() -> None:
     source_snapshot = SimpleNamespace(id=uuid4(), name="temporary-source")
     public_deployment = object()
@@ -1439,6 +1475,10 @@ def test_replay_logs_kitaru_native_execution_url() -> None:
         patch("kitaru.flow.logger.info") as logger_info_mock,
     ):
         client_cls.return_value.get_pipeline_run.return_value = source_run
+        client_cls.return_value.active_stack_model = SimpleNamespace(
+            name="default",
+            id="default-stack-id",
+        )
         wrapped = flow(lambda topic: topic)
         wrapped.replay(str(source_run.id), from_="write")
 
@@ -1557,6 +1597,54 @@ def test_replay_validates_connection_before_loading_source_run() -> None:
 
     resolve_connection_mock.assert_called_once_with(validate_for_use=True)
     client_cls.return_value.get_pipeline_run.assert_not_called()
+
+
+def test_replay_fails_closed_before_submitting_on_implicit_default_fallback() -> None:
+    """Replay should fail closed before compile/submit on implicit fallback."""
+    source_run = _DummyRun(status=ExecutionStatus.COMPLETED)
+    base_pipeline = MagicMock()
+    configured_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch(
+            "kitaru.flow._capture_active_stack_provenance_for_guard",
+            return_value=_stale_default_stack_provenance(),
+        ),
+        patch("kitaru.flow.Client") as client_cls,
+        patch(
+            "kitaru.flow.build_replay_plan",
+            return_value=ReplayPlan(
+                original_run_id=str(source_run.id),
+                steps_to_skip=set(),
+                input_overrides={},
+                step_input_overrides={},
+            ),
+        ),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(
+                stack="default",
+                stack_source="zenml_active_stack",
+            ),
+        ),
+        patch("kitaru.flow.build_frozen_execution_spec") as build_spec_mock,
+        pytest.raises(KitaruUsageError, match="fallback stack `default` implicitly"),
+    ):
+        client_cls.return_value.get_pipeline_run.return_value = source_run
+        client_cls.return_value.active_stack_model = SimpleNamespace(
+            name="default",
+            id="default-stack-id",
+        )
+        wrapped = flow(lambda topic: topic)
+        wrapped.replay(str(source_run.id), from_="write")
+
+    build_spec_mock.assert_not_called()
+    base_pipeline.with_options.assert_not_called()
+    configured_pipeline.replay.assert_not_called()
 
 
 def test_temporary_active_stack_serializes_concurrent_bindings() -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -18,6 +18,8 @@ from zenml.models import PipelineRunResponse
 
 from kitaru import memory
 from kitaru._client._models import ExecutionStatus as KitaruExecutionStatus
+from kitaru._config._active_context import ActiveConfigSelectionProvenance
+from kitaru._config._core import ExecutionStackSource
 from kitaru.analytics import AnalyticsEvent
 from kitaru.checkpoint import checkpoint
 from kitaru.config import (
@@ -47,6 +49,7 @@ from kitaru.flow import (
     _checkpoint_count_from_run,
     _duration_metadata_from_run,
     _extract_run_pipeline_id,
+    _guard_implicit_active_stack_fallback,
     _inject_model_registry_env,
     _temporary_active_stack,
     _wrap_flow_entrypoint,
@@ -63,12 +66,14 @@ def _as_pipeline_run(run: _DummyRun) -> PipelineRunResponse:
 def _resolved_execution(
     *,
     stack: str | None = None,
+    stack_source: ExecutionStackSource | None = None,
     cache: bool | None = None,
     retries: int = 0,
     image: ImageSettings | None = None,
 ) -> ResolvedExecutionConfig:
     return ResolvedExecutionConfig(
         stack=stack,
+        stack_source=stack_source,
         image=image,
         cache=cache,
         retries=retries,
@@ -166,6 +171,17 @@ class _DummyRun:
 
     def get_hydrated_version(self) -> _DummyRun:
         return self
+
+
+def _stale_default_stack_provenance() -> ActiveConfigSelectionProvenance:
+    return ActiveConfigSelectionProvenance(
+        resource="active_stack",
+        effective_source="repo-local config",
+        effective_source_detail="/work/repo/.kitaru/config.yaml",
+        effective_id="stale-stack-id",
+        repository_config_path="/work/repo/.kitaru/config.yaml",
+        repository_id="stale-stack-id",
+    )
 
 
 def test_extract_run_pipeline_id_prefers_direct_pipeline_id() -> None:
@@ -342,6 +358,88 @@ def test_flow_decorator_creates_wrapper_with_run() -> None:
     # ZenML's compiler treats any concrete run-level enable_cache as a per-step
     # override that overwrites @checkpoint(cache=...) settings.
     assert "enable_cache" not in call_kwargs.kwargs
+
+
+def test_implicit_default_stack_fallback_guard_fails_closed() -> None:
+    client = SimpleNamespace(
+        active_stack_model=SimpleNamespace(name="default", id="default-stack-id")
+    )
+
+    with pytest.raises(KitaruUsageError) as exc_info:
+        _guard_implicit_active_stack_fallback(
+            operation="run this flow",
+            resolved_execution=_resolved_execution(
+                stack="default",
+                stack_source="zenml_active_stack",
+            ),
+            raw_active_stack_provenance=_stale_default_stack_provenance(),
+            client_factory=MagicMock(return_value=client),
+        )
+
+    message = str(exc_info.value)
+    assert "refused to run this flow" in message
+    assert "fallback stack `default` implicitly" in message
+    assert "stale-stack-id" in message
+    assert "default-stack-id" in message
+    assert "pass `stack=...`" in message
+
+
+@pytest.mark.parametrize(
+    "stack_source",
+    ["project_config", "environment", "runtime", "decorator", "invocation"],
+)
+def test_explicit_default_stack_bypasses_fallback_guard(
+    stack_source: ExecutionStackSource,
+) -> None:
+    client_factory = MagicMock()
+
+    _guard_implicit_active_stack_fallback(
+        operation="run this flow",
+        resolved_execution=_resolved_execution(
+            stack="default",
+            stack_source=stack_source,
+        ),
+        raw_active_stack_provenance=_stale_default_stack_provenance(),
+        client_factory=client_factory,
+    )
+
+    client_factory.assert_not_called()
+
+
+def test_run_fails_closed_before_submitting_on_implicit_default_fallback() -> None:
+    configured_pipeline = MagicMock(
+        return_value=_DummyRun(status=ExecutionStatus.RUNNING)
+    )
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+    client = SimpleNamespace(
+        active_stack_model=SimpleNamespace(name="default", id="default-stack-id")
+    )
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch(
+            "kitaru.flow._capture_active_stack_provenance_for_guard",
+            return_value=_stale_default_stack_provenance(),
+        ),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(
+                stack="default",
+                stack_source="zenml_active_stack",
+            ),
+        ),
+        patch("kitaru.flow.Client", return_value=client),
+        patch("kitaru.flow.resolve_connection_config") as resolve_connection_mock,
+        pytest.raises(KitaruUsageError, match="fallback stack `default` implicitly"),
+    ):
+        wrapped = flow(lambda: None)
+        wrapped.run()
+
+    resolve_connection_mock.assert_not_called()
+    base_pipeline.with_options.assert_not_called()
+    configured_pipeline.assert_not_called()
 
 
 def test_flow_deploy_creates_snapshot_and_forwards_raw_tags() -> None:

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -830,6 +830,44 @@ def test_serialize_runtime_snapshot_preserves_none_fields() -> None:
     assert payload["environment"] == []
 
 
+def test_serialize_runtime_snapshot_hides_provenance_details_by_default() -> None:
+    snapshot = RuntimeSnapshot(
+        sdk_version="0.1.0",
+        connection="local database",
+        connection_target="local",
+        config_directory="/tmp/kitaru-config",
+        active_stack_provenance=ActiveConfigSelectionProvenance(
+            resource="active_stack",
+            effective_source="repo-local config",
+            effective_source_detail="/work/repo/.kitaru/config.yaml",
+            effective_id="repo-stack-id",
+            resolved_id="resolved-stack-id",
+        ),
+        active_project_provenance=ActiveConfigSelectionProvenance(
+            resource="active_project",
+            effective_source="environment",
+            effective_source_detail="KITARU_PROJECT -> ZENML_ACTIVE_PROJECT_ID",
+            effective_id="production",
+            resolved_id="project-uuid",
+        ),
+    )
+
+    default_payload = serialize_runtime_snapshot(snapshot)
+    detailed_payload = serialize_runtime_snapshot(
+        snapshot,
+        include_provenance_details=True,
+    )
+
+    assert default_payload["active_stack_provenance"] is None
+    assert default_payload["active_project_provenance"] is None
+    assert detailed_payload["active_stack_provenance"]["effective_id"] == (
+        "repo-stack-id"
+    )
+    assert detailed_payload["active_project_provenance"]["effective_id"] == (
+        "production"
+    )
+
+
 def _write_active_config(
     directory: Path,
     *,
@@ -1545,6 +1583,44 @@ def test_build_runtime_snapshot_surfaces_provenance_collector_failure(
         in note
         for note in project_provenance.notes
     )
+
+
+def test_build_runtime_snapshot_does_not_warn_for_env_name_to_uuid_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Explicit KITARU_PROJECT names may resolve to UUIDs without fallback."""
+    _clear_active_context_env(monkeypatch)
+    monkeypatch.setenv("KITARU_PROJECT", "production")
+
+    fake_gc = _fake_global_config(tmp_path)
+    fake_client = SimpleNamespace(
+        active_user=SimpleNamespace(name="alice"),
+        active_stack_model=SimpleNamespace(name="prod", id="stack-id"),
+        active_project=SimpleNamespace(name="production", id="project-uuid"),
+        root=None,
+        zen_store=SimpleNamespace(
+            get_store_info=lambda: SimpleNamespace(
+                version="0.42.0",
+                database_type="sqlite",
+                deployment_type="local",
+            )
+        ),
+    )
+    fake_client_cls = MagicMock(return_value=fake_client)
+    fake_client_cls.find_repository.return_value = None
+
+    with ExitStack() as stack:
+        for context_manager in _patch_snapshot_dependencies(fake_gc, fake_client_cls):
+            stack.enter_context(context_manager)
+        snapshot = build_runtime_snapshot(include_provenance_details=True)
+
+    project_provenance = snapshot.active_project_provenance
+    assert isinstance(project_provenance, ActiveConfigSelectionProvenance)
+    assert project_provenance.effective_source == "environment"
+    assert project_provenance.effective_id == "production"
+    assert project_provenance.resolved_id == "project-uuid"
+    assert snapshot.warning is None
 
 
 def test_build_runtime_snapshot_preserves_raw_when_client_sanitizes_stale_id(

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -875,6 +875,7 @@ def _patch_snapshot_dependencies(
             return_value=SimpleNamespace(project=None),
         ),
         patch("kitaru.inspection.Client", fake_client_cls),
+        patch("kitaru._config._active_context.Client", fake_client_cls),
         patch(
             "kitaru.inspection.resolve_log_store",
             return_value=ResolvedLogStore(
@@ -887,7 +888,7 @@ def _patch_snapshot_dependencies(
     )
 
 
-def test_build_runtime_snapshot_keeps_provenance_off_by_default(
+def test_build_runtime_snapshot_collects_provenance_by_default(
     tmp_path: Path,
 ) -> None:
     fake_gc = _fake_global_config(tmp_path)
@@ -896,16 +897,12 @@ def test_build_runtime_snapshot_keeps_provenance_off_by_default(
     with ExitStack() as stack:
         for context_manager in _patch_snapshot_dependencies(fake_gc, fake_client_cls):
             stack.enter_context(context_manager)
-        stack.enter_context(
-            patch(
-                "kitaru.inspection._collect_active_context_provenance",
-                side_effect=AssertionError("provenance should be opt-in"),
-            )
-        )
         snapshot = build_runtime_snapshot()
 
-    assert snapshot.active_stack_provenance is None
-    assert snapshot.active_project_provenance is None
+    assert isinstance(snapshot.active_stack_provenance, ActiveConfigSelectionProvenance)
+    assert isinstance(
+        snapshot.active_project_provenance, ActiveConfigSelectionProvenance
+    )
 
 
 def test_build_runtime_snapshot_collects_active_context_source_precedence(
@@ -1026,7 +1023,7 @@ def test_build_runtime_snapshot_preserves_raw_provenance_when_client_fails(
             stack.enter_context(context_manager)
         stack.enter_context(
             patch(
-                "kitaru.inspection.KITARU_REPOSITORY_DIRECTORY_NAME",
+                "kitaru._config._active_context.KITARU_REPOSITORY_DIRECTORY_NAME",
                 ".custom-kitaru",
             )
         )
@@ -1524,7 +1521,7 @@ def test_build_runtime_snapshot_surfaces_provenance_collector_failure(
             stack.enter_context(context_manager)
         stack.enter_context(
             patch(
-                "kitaru.inspection._collect_active_context_provenance",
+                "kitaru.inspection.collect_active_context_provenance",
                 side_effect=RuntimeError("yaml exploded"),
             )
         )
@@ -1605,6 +1602,10 @@ def test_build_runtime_snapshot_preserves_raw_when_client_sanitizes_stale_id(
     assert stack_provenance.resolved_id == "different-resolved-id"
     assert stack_provenance.resolved_name == "sanitized-stack"
     assert stack_provenance.resolved_id != stack_provenance.effective_id
+    assert snapshot.warning is not None
+    assert "saved active context changed" in snapshot.warning
+    assert "stale-repo-stack-id" in snapshot.warning
+    assert "sanitized-stack (different-resolved-id)" in snapshot.warning
 
 
 def test_build_runtime_snapshot_preserves_raw_when_yaml_is_invalid(


### PR DESCRIPTION
## What changed

- Added shared active-context provenance helpers so Kitaru can compare the raw saved active stack/project IDs with the post-ZenML resolved context.
- Added normal `kitaru status` / `kitaru info` warnings when saved repo-local/global active context changes while loading.
- Added runtime-only execution stack source tracking so Kitaru can tell implicit ZenML active-stack usage apart from explicit Kitaru stack choices.
- Added a fail-closed flow guard for `run`, `deploy`, and `replay` when an implicit stale saved active stack resolves to fallback `default`.
- Kept detailed active-context provenance internal by default for JSON/file/MCP outputs; `info --all` / MCP `all=True` still include the detailed provenance diagnostics.
- Added regression tests for stack-source tracking, warning rendering, provenance serialization, false-positive environment project handling, and fail-closed flow execution.

## Why

A stale repo-local `.kitaru/config.yaml` can point at an active stack UUID from another server or older server state. ZenML sanitizes that stale ID to `default`, which is useful as a fallback but unsafe for Kitaru flow execution: a user who intended a Kubernetes/remote stack could accidentally run on `default`.

This Kitaru-side fix does not change ZenML's fallback behavior. Instead, Kitaru now detects the raw-vs-resolved mismatch and blocks the high-risk implicit fallback-to-default execution path unless the user explicitly selects a stack.

Closes zenml-io/zenml-internal#86.

## Key implementation decisions

- `stack_source` is runtime-only and excluded from serialized execution specs.
- `KITARU_STACK`, `[tool.kitaru].stack`, runtime config, decorator config, and invocation overrides all count as explicit stack choices.
- The flow guard captures raw active-stack provenance before `resolve_execution_config()`, because resolving config can instantiate ZenML `Client()` and sanitize the repo config.
- Fallback warnings and runtime blocking are limited to saved repo-local/global active context, not explicit environment overrides like `KITARU_PROJECT=production` resolving to a project UUID.
- Structured outputs hide raw active-context provenance unless the caller explicitly requests full diagnostics.
- ZenML/server-side REST list/get consistency remains out of scope for this Kitaru PR.

## Tests

- `just check`
- `uv run pytest tests/test_config.py tests/test_flow.py tests/test_inspection.py tests/test_cli.py` — 705 passed
- `uv run pytest tests/test_inspection.py tests/test_cli.py tests/test_flow.py tests/mcp/test_server.py` — 639 passed
- `just test` — 1620 passed, 8 skipped

## Reviewer Notes

Please focus on:

- `src/kitaru/_config/_active_context.py` for raw-vs-resolved provenance collection and the saved-config-only fallback warning semantics.
- `src/kitaru/_config/_env.py` / `_core.py` for `stack_source` tracking and serialization exclusion.
- `src/kitaru/flow.py` for the fail-closed ordering: raw provenance must be captured before `resolve_execution_config()`.
- `src/kitaru/inspection.py`, `src/kitaru/_cli/_status.py`, and `src/kitaru/mcp/server.py` for the default-hidden / `--all`-visible provenance serialization contract.

A useful local smoke check is:

```bash
just check
uv run pytest \
  tests/test_flow.py::test_run_fails_closed_before_submitting_on_implicit_default_fallback \
  tests/test_flow.py::test_deploy_fails_closed_before_submitting_on_implicit_default_fallback \
  tests/test_flow.py::test_replay_fails_closed_before_submitting_on_implicit_default_fallback \
  tests/test_inspection.py::test_build_runtime_snapshot_does_not_warn_for_env_name_to_uuid_resolution \
  tests/test_cli.py::test_status_json_hides_active_context_provenance_by_default
```
