### PR TITLE
Group dependabot PRs by update type and family

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,11 @@ updates:
       timezone: Europe/Amsterdam
     reviewers: [strickvl]
     labels: [dependencies]
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -40,6 +45,14 @@ updates:
       timezone: Europe/Amsterdam
     reviewers: [strickvl]
     labels: [dependencies]
+    groups:
+      fumadocs:
+        patterns:
+          - "fumadocs-*"
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -55,6 +68,11 @@ updates:
       timezone: Europe/Amsterdam
     reviewers: [strickvl]
     labels: [dependencies]
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
     cooldown:
       default-days: 7
       semver-major-days: 14


### PR DESCRIPTION
## Summary

- Adds a `minor-and-patch` group to the **uv**, **npm/docs**, and **npm/site** ecosystems. Backwards-compatible bumps now land as a single PR per ecosystem instead of N individual PRs.
- Adds a `fumadocs` family group on **npm/docs** scoped to `fumadocs-*` patterns. Family packages will always bump together regardless of semver level.
- Major bumps remain individual on purpose — they get separate review attention.

## Why

Today's dependabot run produced 9 separate PRs for what was effectively three review decisions. With this config the same run would have produced ~5 PRs:

| Group | PRs collapsed |
|---|---|
| npm/docs minor+patch | postcss, @tailwindcss/postcss, next |
| npm/docs fumadocs | fumadocs-mdx (and any other fumadocs-* deps) |
| npm/site minor+patch | tailwindcss, @tailwindcss/vite |
| npm/docs major (ungrouped) | typescript |
| uv major (ungrouped) | griffe, openai |

The `fumadocs` family group is specifically motivated by #260: the bump of `fumadocs-mdx` to 14.3.x broke because `fumadocs-core` stayed pinned at 16.6.9, and the postinstall hook couldn't resolve `fumadocs-core/dist/content/md/frontmatter.js`. Family-scoped grouping forces lockstep bumps so this class of mismatch can't reach a PR in isolation.

## Reviewer Notes

- **Group ordering matters in npm/docs.** `fumadocs` is listed before `minor-and-patch` deliberately. Dependabot evaluates groups top-to-bottom and a dep can only land in one — if `minor-and-patch` came first, a patch bump of `fumadocs-mdx` would land there instead of the family group, defeating the point.
- **Cooldown windows are unchanged** (3/7/14 days for patch/minor/major). They still apply per dep before grouping.
- **Tradeoff to be aware of:** if one dep in a grouped PR is broken, the whole group is blocked until you split it out via `@dependabot recreate` excluding the bad dep. Worth knowing; not a reason to skip grouping.
- **No way to validate this end-to-end before merge** — dependabot reads the config from `develop`, so the next batch (Tuesday's run) is what proves it works. We can also force a manual run via the Insights → Dependency graph → Dependabot tab on GitHub if we want a sooner check.

## Test plan

- [x] `just check` passes locally (lint, typecheck, typos, yaml, actions lint, links)
- [x] YAML parses cleanly via `yaml.safe_load`
- [ ] First Tuesday batch after merge confirms grouping works as designed