### PR TITLE
Ignore `griffe` major bumps in dependabot until fumapy supports v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,14 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # griffe 2.x split the package into griffe / griffecli / griffelib.
+      # Our SDK doc generator depends on fumapy (docs/node_modules/fumadocs-python)
+      # which pins griffe<2.0.0. Until fumapy upstream supports griffe 2.x,
+      # accepting a major bump here is a phantom upgrade — the lockfile would
+      # claim 2.x but every real workflow either silently downgrades or breaks.
+      - dependency-name: griffe
+        update-types: ["version-update:semver-major"]
     cooldown:
       default-days: 7
       semver-major-days: 14


### PR DESCRIPTION
## Summary

Adds an `ignore` rule for `griffe` major-version bumps to the `uv` ecosystem block in `.github/dependabot.yml`. Closes #256.

## Why

#256 (griffe 1.15.0 → 2.0.2) had all-green Python CI, which is misleading. Investigated locally and found the bump is currently a *phantom upgrade*:

- The only consumer of griffe in this repo is `scripts/generate_sdk_docs.py`, which depends on **fumapy** (installed locally from `docs/node_modules/fumadocs-python`, not PyPI).
- fumapy pins `griffe>=1.13.0,<2.0.0` in its `pyproject.toml`.
- When you `uv pip install ./docs/node_modules/fumadocs-python` against a venv that has griffe 2.x, uv silently downgrades griffe back to 1.15.0.
- If you force griffe 2.x with `--no-deps`, the namespace breaks (`ModuleNotFoundError: No module named 'griffe'`) because v2 split the package into `griffe` / `griffecli` / `griffelib` and the top-level `griffe` is now just metadata.

CI doesn't catch this because CI never installs fumapy — the SDK doc tests are gated behind `pytest.importorskip("fumapy")` and silently skip.

Without this ignore rule, dependabot will keep opening the same broken PR every Tuesday until fumapy upstream releases a griffe-2-compatible version.

## Reviewer Notes

- **Scope is intentionally narrow.** Only griffe **major** bumps are ignored. Patch and minor bumps still flow through (and get grouped into `minor-and-patch`). When fumapy publishes a griffe-2 release, we delete the ignore rule and the next Tuesday batch picks up griffe 2.x.
- **Reproducing the investigation** (in case a future reviewer wants to verify):
  ```bash
  gh pr checkout 256
  uv sync --extra local --extra llm --extra mcp        # installs griffe 2.0.2
  uv pip install ./docs/node_modules/fumadocs-python    # silently downgrades griffe to 1.15.0
  .venv/bin/python -c "import griffe; print(griffe.__version__)"
  ```
- **Why not just close #256 manually each week?** Because we'd lose context every time. The ignore rule encodes the reasoning (commit message + this PR description) so future-us doesn't relitigate it.

## Test plan

- [x] `just check` passes
- [x] YAML parses; `ignore` rule is structured correctly under the `uv` ecosystem block
- [ ] Next Tuesday's dependabot run does not produce a griffe major-bump PR