### PR TITLE
Support Pydantic AI capabilities kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Checkpoint output handles now display Kitaru guidance to call `.load()` instead of leaking raw ZenML artifact metadata when stringified in flow bodies. (#127)
+- Pydantic AI adapter run methods now accept and forward per-run `capabilities`, restoring compatibility with `pydantic-ai-slim` 1.86+. (#248)
 
 ## [0.7.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Checkpoint output handles now display Kitaru guidance to call `.load()` instead of leaking raw ZenML artifact metadata when stringified in flow bodies. (#127)
-- Pydantic AI adapter run methods now accept and forward per-run `capabilities`, restoring compatibility with `pydantic-ai-slim` 1.86+. (#248)
+- Pydantic AI adapter now supports `pydantic-ai-slim>=1.86.0,<2`: per-run `capabilities` and `spec` are forwarded to Pydantic AI and included in turn-checkpoint cache keys to avoid stale cached turns. (#248)
 
 ## [0.7.0] - 2026-04-24
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,7 @@ local = [
     "zenml[server]>=0.94.3",
 ]
 pydantic-ai = [
-    # Capped at <1.86.0 because 1.86 added `capabilities`/`spec` kwargs to Agent.run()
-    # that the KitaruAgent adapter doesn't yet pass through. See #248.
-    "pydantic-ai-slim>=1.75.0,<1.86.0",
+    "pydantic-ai-slim>=1.86.0,<2",
     "typing_extensions>=4.12",
 ]
 claude-agent-sdk = [
@@ -112,8 +110,7 @@ dev = [
     "pytest-xdist[psutil]",
     "griffe>=1.13.0,<2.0.0",
     "griffe-typingdoc>=0.2.8,<1.0.0",
-    # See note on the [pydantic-ai] extra above. Capped pending #248.
-    "pydantic-ai-slim>=1.75.0,<1.86.0",
+    "pydantic-ai-slim>=1.86.0,<2",
     "openai>=1.0.0,<2",
     "anthropic>=0.40.0,<1",
     "claude-agent-sdk>=0.1.58,<0.2",

--- a/src/kitaru/adapters/pydantic_ai/_agent.py
+++ b/src/kitaru/adapters/pydantic_ai/_agent.py
@@ -660,6 +660,8 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             deferred_tool_results=deferred_tool_results,
             instructions=instructions,
             model_settings=model_settings,
+            capabilities=capabilities,
+            spec=spec,
         )
 
         error: BaseException | None = None
@@ -735,6 +737,8 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             deferred_tool_results=deferred_tool_results,
             instructions=instructions,
             model_settings=model_settings,
+            capabilities=capabilities,
+            spec=spec,
         )
 
         error: BaseException | None = None

--- a/src/kitaru/adapters/pydantic_ai/_agent.py
+++ b/src/kitaru/adapters/pydantic_ai/_agent.py
@@ -23,6 +23,7 @@ from pydantic_ai.agent.abstract import (
     AgentModelSettings,
     EventStreamHandler,
 )
+from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models import Model
 from pydantic_ai.output import OutputDataT, OutputSpec
@@ -618,6 +619,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
+        capabilities: Sequence[AbstractCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | None = None,
     ) -> Any:
         self._validate_model_override(model)
@@ -645,6 +647,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                     toolsets=prepared_toolsets,
                     builtin_tools=builtin_tools,
                     event_stream_handler=wrapped_handler,
+                    capabilities=capabilities,
                     spec=spec,
                 )
             self._remember_messages(result)
@@ -690,6 +693,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
+        capabilities: Sequence[AbstractCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | None = None,
     ) -> Any:
         self._ensure_run_sync_safe()
@@ -718,6 +722,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                     toolsets=prepared_toolsets,
                     builtin_tools=builtin_tools,
                     event_stream_handler=wrapped_handler,
+                    capabilities=capabilities,
                     spec=spec,
                 )
             self._remember_messages(result)
@@ -764,6 +769,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
         event_stream_handler: EventStreamHandler[AgentDepsT] | None = None,
+        capabilities: Sequence[AbstractCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | None = None,
     ) -> AsyncIterator[Any]:
         self._validate_model_override(model)
@@ -788,6 +794,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 toolsets=prepared_toolsets,
                 builtin_tools=builtin_tools,
                 event_stream_handler=wrapped_handler,
+                capabilities=capabilities,
                 spec=spec,
             ) as streamed_result:
                 yield streamed_result
@@ -810,6 +817,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         infer_name: bool = True,
         toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
         builtin_tools: Sequence[AgentBuiltinTool[AgentDepsT]] | None = None,
+        capabilities: Sequence[AbstractCapability[AgentDepsT]] | None = None,
         spec: dict[str, Any] | None = None,
     ) -> AsyncIterator[AgentRun[AgentDepsT, Any]]:
         # iter() yields a run handle inside an `async with` body; auto-checkpointing it
@@ -834,6 +842,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 infer_name=infer_name,
                 toolsets=prepared_toolsets,
                 builtin_tools=builtin_tools,
+                capabilities=capabilities,
                 spec=spec,
             ) as run:
                 yield run

--- a/src/kitaru/adapters/pydantic_ai/_utils.py
+++ b/src/kitaru/adapters/pydantic_ai/_utils.py
@@ -190,6 +190,8 @@ def turn_cache_key(
     deferred_tool_results: Any,
     instructions: Any,
     model_settings: Any,
+    capabilities: Any = None,
+    spec: Any = None,
 ) -> str:
     """Stable cache key for a ``KitaruAgent`` turn checkpoint.
 
@@ -197,13 +199,16 @@ def turn_cache_key(
     cache — without an explicit key, different prompts collide on the cached
     result of the previous call.
     """
-    return checkpoint_cache_key(
-        {
-            'agent_name': agent_name,
-            'user_prompt': user_prompt,
-            'message_history': message_history,
-            'deferred_tool_results': deferred_tool_results,
-            'instructions': instructions,
-            'model_settings': model_settings,
-        }
-    )
+    payload = {
+        'agent_name': agent_name,
+        'user_prompt': user_prompt,
+        'message_history': message_history,
+        'deferred_tool_results': deferred_tool_results,
+        'instructions': instructions,
+        'model_settings': model_settings,
+    }
+    if capabilities is not None:
+        payload['capabilities'] = capabilities
+    if spec is not None:
+        payload['spec'] = spec
+    return checkpoint_cache_key(payload)

--- a/tests/test_phase17_pydantic_ai_adapter.py
+++ b/tests/test_phase17_pydantic_ai_adapter.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
+from contextlib import asynccontextmanager, nullcontext
 from typing import Any
 from uuid import uuid4
 
@@ -12,6 +14,8 @@ from zenml.client import Client
 pytest.importorskip("pydantic_ai")
 
 from pydantic_ai import Agent
+from pydantic_ai.agent.abstract import AbstractAgent
+from pydantic_ai.capabilities.hooks import Hooks
 from pydantic_ai.models.test import TestModel
 
 from kitaru import flow
@@ -64,6 +68,76 @@ def _metadata_dict_from_steps(hydrated_run: Any, key: str) -> dict[str, Any]:
 
 def _event_kinds(event_map: dict[str, list[dict[str, Any]]]) -> set[str]:
     return {event["kind"] for events in event_map.values() for event in events}
+
+
+def test_phase17_capabilities_forwarded_to_pydantic_ai_run_surfaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The adapter should mirror and forward Pydantic AI's per-run capabilities."""
+    durable_agent = _make_wrapped_agent(name_prefix="capability_agent")
+    capabilities = [Hooks()]
+    captured: dict[str, object] = {}
+    run_result = object()
+    stream_result = object()
+    iter_result = object()
+
+    async def run_async_direct(body: Any, **_: Any) -> Any:
+        return await body()
+
+    def run_sync_direct(body: Any, **_: Any) -> Any:
+        return body()
+
+    async def fake_run(self: Any, *args: Any, **kwargs: Any) -> object:
+        captured["run"] = kwargs["capabilities"]
+        return run_result
+
+    def fake_run_sync(self: Any, *args: Any, **kwargs: Any) -> object:
+        captured["run_sync"] = kwargs["capabilities"]
+        return run_result
+
+    @asynccontextmanager
+    async def fake_run_stream(self: Any, *args: Any, **kwargs: Any) -> Any:
+        captured["run_stream"] = kwargs["capabilities"]
+        yield stream_result
+
+    @asynccontextmanager
+    async def fake_iter(*args: Any, **kwargs: Any) -> Any:
+        captured["iter"] = kwargs["capabilities"]
+        yield iter_result
+
+    monkeypatch.setattr(durable_agent, "_run_async", run_async_direct)
+    monkeypatch.setattr(durable_agent, "_run_sync", run_sync_direct)
+    monkeypatch.setattr(durable_agent, "_kitaru_overrides", nullcontext)
+    monkeypatch.setattr(durable_agent, "_tracking_scope", nullcontext)
+    monkeypatch.setattr(durable_agent, "_allow_internal_iter", nullcontext)
+    monkeypatch.setattr(durable_agent, "_remember_messages", lambda _result: None)
+    monkeypatch.setattr(
+        durable_agent, "_require_explicit_checkpoint", lambda _method: None
+    )
+    monkeypatch.setattr(AbstractAgent, "run", fake_run)
+    monkeypatch.setattr(AbstractAgent, "run_sync", fake_run_sync)
+    monkeypatch.setattr(AbstractAgent, "run_stream", fake_run_stream)
+    monkeypatch.setattr(durable_agent.wrapped, "iter", fake_iter)
+
+    async def exercise_async_surfaces() -> None:
+        result = await durable_agent.run("prompt", capabilities=capabilities)
+        assert result is run_result
+        async with durable_agent.run_stream(
+            "prompt", capabilities=capabilities
+        ) as streamed_result:
+            assert streamed_result is stream_result
+        async with durable_agent.iter("prompt", capabilities=capabilities) as agent_run:
+            assert agent_run is iter_result
+
+    asyncio.run(exercise_async_surfaces())
+    assert durable_agent.run_sync("prompt", capabilities=capabilities) is run_result
+
+    assert captured == {
+        "run": capabilities,
+        "run_stream": capabilities,
+        "iter": capabilities,
+        "run_sync": capabilities,
+    }
 
 
 def test_phase17_turn_mode_tracks_events_and_artifacts(primed_zenml) -> None:

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -8,6 +8,7 @@ Full end-to-end agent runs are exercised by the example tests.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -17,9 +18,142 @@ from kitaru.adapters.pydantic_ai._utils import (
     CheckpointConfig,
     reject_isolated_runtime,
     resolve_tool_checkpoint_config,
+    turn_cache_key,
     with_default_type,
 )
 from kitaru.errors import KitaruUsageError
+
+
+def _base_turn_key_kwargs() -> dict[str, Any]:
+    return {
+        "agent_name": "agent",
+        "user_prompt": "hello",
+        "message_history": [{"role": "user", "content": "before"}],
+        "deferred_tool_results": None,
+        "instructions": "be concise",
+        "model_settings": {"temperature": 0},
+    }
+
+
+class TestTurnCacheKey:
+    def test_same_inputs_produce_same_key(self) -> None:
+        kwargs = _base_turn_key_kwargs()
+
+        assert turn_cache_key(**kwargs) == turn_cache_key(**kwargs)
+
+    def test_capabilities_separate_cache_keys(self) -> None:
+        base = _base_turn_key_kwargs()
+
+        assert turn_cache_key(**base, capabilities=["hooks"]) != turn_cache_key(
+            **base,
+            capabilities=["tools"],
+        )
+
+    def test_spec_separates_cache_keys(self) -> None:
+        base = _base_turn_key_kwargs()
+
+        assert turn_cache_key(**base, spec={"profile": "fast"}) != turn_cache_key(
+            **base,
+            spec={"profile": "accurate"},
+        )
+
+    def test_none_capabilities_and_spec_do_not_crash(self) -> None:
+        key = turn_cache_key(
+            **_base_turn_key_kwargs(),
+            capabilities=None,
+            spec=None,
+        )
+
+        assert isinstance(key, str)
+        assert key
+
+    def test_real_hooks_capability_can_be_hashed(self) -> None:
+        from pydantic_ai.capabilities.hooks import Hooks
+
+        key = turn_cache_key(
+            **_base_turn_key_kwargs(),
+            capabilities=[Hooks()],
+        )
+
+        assert isinstance(key, str)
+        assert key
+
+
+class TestTurnCacheKeyCallSites:
+    def _make_agent(self):
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+
+        return KitaruAgent(Agent(TestModel(), name="cache_key_agent"))
+
+    def test_run_sync_forwards_capabilities_and_spec_to_cache_key(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from pydantic_ai.capabilities.hooks import Hooks
+
+        agent = self._make_agent()
+        capabilities = [Hooks()]
+        spec = {"profile": "sync"}
+        captured: dict[str, Any] = {}
+        sentinel = object()
+
+        def fake_turn_cache_key(**kwargs: Any) -> str:
+            captured.update(kwargs)
+            return "cache-sync"
+
+        def fake_run_sync(_body: Any, **kwargs: Any) -> object:
+            captured["run_sync_cache_key"] = kwargs["cache_key"]
+            return sentinel
+
+        monkeypatch.setattr(
+            "kitaru.adapters.pydantic_ai._agent.turn_cache_key",
+            fake_turn_cache_key,
+        )
+        monkeypatch.setattr(agent, "_run_sync", fake_run_sync)
+
+        result = agent.run_sync("hello", capabilities=capabilities, spec=spec)
+
+        assert result is sentinel
+        assert captured["capabilities"] is capabilities
+        assert captured["spec"] is spec
+        assert captured["run_sync_cache_key"] == "cache-sync"
+
+    @pytest.mark.anyio
+    async def test_run_forwards_capabilities_and_spec_to_cache_key(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from pydantic_ai.capabilities.hooks import Hooks
+
+        agent = self._make_agent()
+        capabilities = [Hooks()]
+        spec = {"profile": "async"}
+        captured: dict[str, Any] = {}
+        sentinel = object()
+
+        def fake_turn_cache_key(**kwargs: Any) -> str:
+            captured.update(kwargs)
+            return "cache-async"
+
+        async def fake_run_async(_body: Any, **kwargs: Any) -> object:
+            captured["run_cache_key"] = kwargs["cache_key"]
+            return sentinel
+
+        monkeypatch.setattr(
+            "kitaru.adapters.pydantic_ai._agent.turn_cache_key",
+            fake_turn_cache_key,
+        )
+        monkeypatch.setattr(agent, "_run_async", fake_run_async)
+
+        result = await agent.run("hello", capabilities=capabilities, spec=spec)
+
+        assert result is sentinel
+        assert captured["capabilities"] is capabilities
+        assert captured["spec"] is spec
+        assert captured["run_cache_key"] == "cache-async"
 
 
 class TestRejectIsolatedRuntime:
@@ -382,8 +516,6 @@ async def test_capture_off_still_routes_hitl(monkeypatch: pytest.MonkeyPatch) ->
 async def test_named_hitl_tool_uses_name_as_unique_wait_base(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from typing import Any
-
     from pydantic_ai import FunctionToolset
     from pydantic_ai.models.test import TestModel
     from pydantic_ai.tools import RunContext
@@ -439,8 +571,6 @@ async def test_run_sync_refuses_inside_running_event_loop() -> None:
 async def test_approval_required_routes_through_wait(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from typing import Any
-
     from pydantic_ai import FunctionToolset
     from pydantic_ai.exceptions import ApprovalRequired
     from pydantic_ai.models.test import TestModel

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-04-26T08:00:26.481382Z"
+exclude-newer = "2026-04-27T07:48:59.034149Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1245,7 +1245,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.19.0,<1.20.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0,<2" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=1.75.0,<1.86.0" },
+    { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=1.86.0,<2" },
     { name = "rich", specifier = ">=12.0.0" },
     { name = "typing-extensions", marker = "extra == 'pydantic-ai'", specifier = ">=4.12" },
     { name = "zenml", extras = ["local"], specifier = ">=0.94.3" },
@@ -1261,7 +1261,7 @@ dev = [
     { name = "griffe-typingdoc", specifier = ">=0.2.8,<1.0.0" },
     { name = "openai", specifier = ">=1.0.0,<2" },
     { name = "pip-audit", specifier = ">=2.9.0" },
-    { name = "pydantic-ai-slim", specifier = ">=1.75.0,<1.86.0" },
+    { name = "pydantic-ai-slim", specifier = ">=1.86.0,<2" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-clarity" },
     { name = "pytest-randomly" },
@@ -1997,7 +1997,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.85.1"
+version = "1.87.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -2008,9 +2008,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/6e/018aa88e340dd6e25b0a22f49737c44de56a9c69a4282377fac225197e63/pydantic_ai_slim-1.85.1.tar.gz", hash = "sha256:7394748844cbd28519add1e8aa24b665ffd7516da3579daaaf3de9e1787250a3", size = 562638, upload-time = "2026-04-22T00:08:23.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/f9/76c7943f208b09b320dc65a000689929df6a5d3b143d56b48deade6db486/pydantic_ai_slim-1.87.0.tar.gz", hash = "sha256:25822985ca21d6f2995310da915080fc3f75763aec82e815a3388257b06d6b84", size = 573802, upload-time = "2026-04-25T01:09:21.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/cc/b91513022c89a0ba26d394fa5da5e1e9fbcbb6490a0e1161f73f7f5606e2/pydantic_ai_slim-1.85.1-py3-none-any.whl", hash = "sha256:4a22e1b532e9f8c8afa118ea2cbef2ea541e2f6d7247112fefc0a2bd6b929331", size = 718957, upload-time = "2026-04-22T00:08:15.457Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/90/810dbc478bf063677cf56babc4404f2f0c59794017a5022ac93345a26d75/pydantic_ai_slim-1.87.0-py3-none-any.whl", hash = "sha256:6a9b4f9bcac3709ef47f3b3cda70446c002eb55901038a50d6224ee6743fe31a", size = 732159, upload-time = "2026-04-25T01:09:13.025Z" },
 ]
 
 [[package]]
@@ -2112,7 +2112,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.85.1"
+version = "1.87.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2120,9 +2120,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/bf/dcdcafe71411a8a31fbce0e546186f2706a44ffd4c57afe021f00bda27f3/pydantic_graph-1.85.1.tar.gz", hash = "sha256:4cfd3feb2ce7d6f5f604034e432697567551458d3c29d755221d9288336cfdfd", size = 59244, upload-time = "2026-04-22T00:08:26.378Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/fa/b2306c6dbb06e4dfe6ce6b7c5a28b82bee536d965e1dd1800b49c386b389/pydantic_graph-1.87.0.tar.gz", hash = "sha256:0f44848f8e83908ce372491c32ef349dfaf05e29f39fade0bae9309ab4f015cd", size = 59251, upload-time = "2026-04-25T01:09:23.989Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/49/71b66c79df6ffbf3a340a33602ce44873548f589548d5fb5d8873b870f05/pydantic_graph-1.85.1-py3-none-any.whl", hash = "sha256:515bee899bbfbf00911e32db941c69f2a72bc8fff56ea03a99fa10cd0fa5c436", size = 73066, upload-time = "2026-04-22T00:08:19.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9a/e99edfa37527ee04c14db7fc4b8da3f8e9c913f91c541a4b2d08438b461e/pydantic_graph-1.87.0-py3-none-any.whl", hash = "sha256:fd39e4e852808e36163474fe2af48e88a046b5e5e00596730f33c17d2429b7d2", size = 73063, upload-time = "2026-04-25T01:09:16.493Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- Updated `KitaruAgent`'s Pydantic AI run surfaces to accept and forward per-run `capabilities`.
- Included per-run `capabilities` and `spec` in turn-checkpoint cache keys for `run()` and `run_sync()` so behavior-changing kwargs do not reuse stale cached turns.
- Relaxed the `pydantic-ai-slim` dependency from `<1.86.0` to `>=1.86.0,<2` and refreshed `uv.lock` to `1.87.0`.
- Added regression tests that prove:
  - `capabilities` is forwarded through `run`, `run_sync`, `run_stream`, and `iter`.
  - different `capabilities` / `spec` values produce different turn cache keys.
  - `run()` and `run_sync()` pass those kwargs into the cache-key builder.
- Added an `[Unreleased]` changelog entry that names the new minimum supported Pydantic AI version.

## Why

Pydantic AI 1.86+ added `capabilities`/`spec` kwargs to agent execution methods. Kitaru already mirrored `spec`, but missing `capabilities` meant callers or Pydantic AI internals could hit unexpected-kwarg failures when using newer Pydantic AI versions.

The follow-up cache-key change also makes the durable turn behavior match the run behavior: if `capabilities` or `spec` changes the effective Pydantic AI run, Kitaru now treats that as a distinct turn checkpoint input instead of potentially reusing a stale cached result.

Fixes #248.

## Key implementation decisions

- Kept runtime forwarding as a direct API-mirroring pass-through rather than introducing a helper abstraction; each wrapper method already forwards upstream kwargs explicitly.
- Centralized cache-key behavior in `turn_cache_key(...)` instead of duplicating hashing logic in `_agent.py`.
- Added `capabilities` / `spec` to cache-key payloads only when non-`None`, reducing unnecessary cache invalidation for existing calls.
- Used lightweight monkeypatch-based regression tests so the new kwarg and cache-key paths are tested without requiring extra real model calls.

## Reviewer Notes

Please focus on the adapter method signatures, forwarding points, and cache-key inputs in:

```python
await durable_agent.run("prompt", capabilities=[Hooks()], spec={"profile": "x"})
durable_agent.run_sync("prompt", capabilities=[Hooks()], spec={"profile": "x"})
```

Suggested local verification:

```bash
uv sync
uv run pytest tests/test_pydantic_ai_adapter.py tests/test_phase17_pydantic_ai_adapter.py
just check
```

I also ran the full suite locally after the follow-up commit:

```text
1660 passed, 8 skipped
```
