### PR TITLE
Ignore `@takumi-rs/image-response` major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,17 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # @takumi-rs/image-response 1.x is stricter about CSS shorthand parsing
+      # and rejects `borderBottom: "8px dashed ..."`. fumadocs-ui 16.8.4's
+      # default OG image template (used via fumadocs-ui/og/takumi) emits
+      # exactly this shorthand, so the combo of fumadocs-ui 16.8+ and
+      # takumi-rs 1.x crashes static OG image generation. Hold the takumi-rs
+      # major bump until fumadocs-ui ships an OG template that uses longhand
+      # styles (or until we replace fumadocs-ui's DefaultImage with a custom
+      # template).
+      - dependency-name: "@takumi-rs/image-response"
+        update-types: ["version-update:semver-major"]
     cooldown:
       default-days: 7
       semver-major-days: 14


### PR DESCRIPTION
## Summary

Adds an `ignore` rule for `@takumi-rs/image-response` major-version bumps in the npm `/docs` ecosystem. Closes #273.

## Why

#273 (takumi-rs 0.69.5 → 1.0.10) failed `build-deploy` with:

```
Failed to render image.
Error: InvalidArg, invalid value for borderBottom, line 1, column 4 near "dashed":
string "8px dashed rgba(241, 120, 41, 0.3)";
Unexpected token: 8px dashed rgba(241, 120, 41, 0.3),
expected a value of <length>, <border-style> or <color>
```

Investigated locally and the bug is upstream, not in our code:

- **Our usage is clean** — `docs/app/og/docs/[...slug]/route.tsx` just calls `<DefaultImage>` from `fumadocs-ui/og/takumi`. We never write `borderBottom` ourselves.
- **fumadocs-ui 16.8.4 introduced a new OG template** in `dist/og/takumi.js` that uses CSS shorthand styles:
  ```js
  border: `18px solid ${primaryColor}`,
  borderBottom: `8px dashed ${primaryColor}`,
  ```
- **takumi-rs 1.x is stricter about CSS parsing** — it accepts longhand properties (`border-bottom-width`, `border-bottom-style`, `border-bottom-color`) but rejects the shorthand. takumi-rs 0.x accepted both.

So fumadocs-ui 16.8+ and takumi-rs 1.x are mutually incompatible by default. Until fumadocs-ui ships an OG template that uses longhand styles (or we replace `DefaultImage` with a custom takumi-rs-friendly template), the major bump can't land.

## Reviewer Notes

- **Same pattern as #269** (the griffe ignore rule). Major bumps stay paused; minor and patch still flow through the `minor-and-patch` group.
- **Reproducing the failure** (in case a future reviewer wants to verify):
  ```bash
  gh pr checkout 273
  cd docs && pnpm install --frozen-lockfile && pnpm run build
  # Will fail at "Generating static pages" with the borderBottom error
  ```
- **When to remove this ignore rule:** check fumadocs-ui release notes for an OG template fix (or for a takumi-rs upgrade in fumadocs's own pinned deps that signals the combo works again).
- **Alternative path** if we want the bump sooner: write our own OG template (replacing `<DefaultImage>` in `docs/app/og/docs/[...slug]/route.tsx`) using takumi-rs-compatible longhand styles. That's a meaningful piece of work, not a one-line config change, so flagging it as a follow-up rather than bundling here.

## Test plan

- [x] `just check` passes
- [x] YAML parses; `ignore` rule is structured correctly under the npm `/docs` ecosystem block
- [ ] Next Tuesday's dependabot run does not produce a takumi-rs major-bump PR