### PR TITLE
Add CLI dependency seam

### DIFF
--- a/src/kitaru/_cli/_auth.py
+++ b/src/kitaru/_cli/_auth.py
@@ -16,6 +16,7 @@ from kitaru.config import resolve_connection_config
 from kitaru.errors import KitaruBackendError, KitaruUsageError
 
 from . import auth_api_keys_app, auth_app, auth_service_accounts_app
+from ._dependencies import cli_dependencies
 from ._helpers import (
     DEFAULT_LIST_PAGE,
     DEFAULT_LIST_SIZE,
@@ -28,7 +29,6 @@ from ._helpers import (
     _emit_snapshot,
     _emit_table,
     _exit_with_error,
-    _facade_module,
     _format_table_timestamp,
     _format_timestamp,
     _is_input_interactive,
@@ -198,7 +198,7 @@ def _api_key_table_rows(api_keys: list[AuthAPIKey]) -> list[list[str]]:
 
 def _auth_management_client() -> Any:
     """Return the public SDK client configured for server-level auth management."""
-    return _facade_module().KitaruClient.for_auth_management()
+    return cli_dependencies().auth_management_client()
 
 
 def _confirm_delete(
@@ -234,7 +234,7 @@ def _active_server_access_token() -> str:
     """Return a short-lived bearer token for the active Kitaru server."""
     resolve_connection_config(validate_for_use=True, require_project=False)
     try:
-        client = _facade_module().Client()
+        client = cli_dependencies().zenml_client()
         store = client.zen_store
     except Exception as exc:
         raise KitaruUsageError(

--- a/src/kitaru/_cli/_dependencies.py
+++ b/src/kitaru/_cli/_dependencies.py
@@ -1,0 +1,344 @@
+"""Internal dependency seam for CLI command modules.
+
+Command modules should ask this module for runtime dependencies instead of
+reaching through ``kitaru.cli``.  During the migration, this seam still honors
+legacy ``kitaru.cli.<name>`` patches so existing tests and external patch-based
+callers keep working.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import Any
+
+from zenml.client import Client
+from zenml.config.global_config import GlobalConfiguration
+from zenml.login.credentials_store import get_credentials_store
+
+from kitaru._interface_memory import (
+    compact_memory_payload,
+    compaction_log_memory_payload,
+    delete_memory_payload,
+    get_memory_payload,
+    history_memory_payload,
+    list_memory_payload,
+    purge_memory_payload,
+    purge_scope_memory_payload,
+    reindex_memory_payload,
+    scopes_memory_payload,
+    set_memory_payload,
+)
+from kitaru._interface_secrets import resolve_secret_exact as _resolve_secret_exact
+from kitaru._local_server import (
+    start_or_connect_local_server,
+    stop_registered_local_server,
+)
+from kitaru.client import KitaruClient
+from kitaru.config import (
+    _create_stack_operation,
+    _delete_stack_operation,
+    _list_stack_entries,
+    _show_stack_operation,
+    list_model_aliases,
+    login_to_server,
+    register_model_alias,
+    reset_global_log_store,
+    resolve_log_store,
+    set_global_log_store,
+)
+from kitaru.config import current_stack as get_current_stack
+from kitaru.config import list_stacks as get_available_stacks
+from kitaru.config import use_stack as set_active_stack
+from kitaru.inspection import build_runtime_snapshot as _build_runtime_snapshot
+from kitaru.inspection import (
+    connected_to_local_server_safe as _connected_to_local_server,
+)
+from kitaru.inspection import log_store_mismatch_details as _log_store_mismatch_details
+
+_MISSING = object()
+_ORIGINAL_LEGACY_ATTRS: dict[str, Any] = {
+    "time": time,
+    "Client": Client,
+    "KitaruClient": KitaruClient,
+    "GlobalConfiguration": GlobalConfiguration,
+    "get_credentials_store": get_credentials_store,
+    "start_or_connect_local_server": start_or_connect_local_server,
+    "stop_registered_local_server": stop_registered_local_server,
+    "login_to_server": login_to_server,
+    "_connected_to_local_server": _connected_to_local_server,
+    "_build_runtime_snapshot": _build_runtime_snapshot,
+    "_log_store_mismatch_details": _log_store_mismatch_details,
+    "set_global_log_store": set_global_log_store,
+    "resolve_log_store": resolve_log_store,
+    "reset_global_log_store": reset_global_log_store,
+    "get_current_stack": get_current_stack,
+    "get_available_stacks": get_available_stacks,
+    "set_active_stack": set_active_stack,
+    "_list_stack_entries": _list_stack_entries,
+    "_show_stack_operation": _show_stack_operation,
+    "_create_stack_operation": _create_stack_operation,
+    "_delete_stack_operation": _delete_stack_operation,
+    "register_model_alias": register_model_alias,
+    "list_model_aliases": list_model_aliases,
+    "_resolve_secret_exact": _resolve_secret_exact,
+    "scopes_memory_payload": scopes_memory_payload,
+    "list_memory_payload": list_memory_payload,
+    "get_memory_payload": get_memory_payload,
+    "set_memory_payload": set_memory_payload,
+    "delete_memory_payload": delete_memory_payload,
+    "purge_memory_payload": purge_memory_payload,
+    "purge_scope_memory_payload": purge_scope_memory_payload,
+    "reindex_memory_payload": reindex_memory_payload,
+    "compact_memory_payload": compact_memory_payload,
+    "compaction_log_memory_payload": compaction_log_memory_payload,
+    "history_memory_payload": history_memory_payload,
+}
+
+
+class CLIDependencies:
+    """Resolve CLI runtime dependencies with legacy facade patch support."""
+
+    def _legacy_attr(self, name: str, default: Any) -> Any:
+        """Return a patched ``kitaru.cli`` attr when one exists.
+
+        Unpatched legacy re-exports should not beat the seam-local default.
+        That keeps old ``kitaru.cli.*`` patches working while allowing future
+        tests to patch this dependency module directly.
+        """
+        module = sys.modules.get("kitaru.cli")
+        if module is None:
+            return default
+        legacy = getattr(module, name, _MISSING)
+        if legacy is _MISSING:
+            return default
+        original = _ORIGINAL_LEGACY_ATTRS.get(name, _MISSING)
+        if original is not _MISSING and legacy is original:
+            return default
+        return legacy
+
+    def zenml_client(self) -> Any:
+        """Return the active low-level ZenML client."""
+        return self._legacy_attr("Client", Client)()
+
+    def kitaru_client(self) -> Any:
+        """Return the active Kitaru SDK client."""
+        return self._legacy_attr("KitaruClient", KitaruClient)()
+
+    def auth_management_client(self) -> Any:
+        """Return the SDK client configured for auth-management commands."""
+        return self._legacy_attr("KitaruClient", KitaruClient).for_auth_management()
+
+    def global_configuration(self) -> Any:
+        """Return the active ZenML global configuration object."""
+        return self._legacy_attr("GlobalConfiguration", GlobalConfiguration)()
+
+    def get_credentials_store(self) -> Any:
+        """Return the configured credentials store."""
+        return self._legacy_attr("get_credentials_store", get_credentials_store)()
+
+    def start_or_connect_local_server(self, *args: Any, **kwargs: Any) -> Any:
+        """Start or connect to the registered local Kitaru server."""
+        return self._legacy_attr(
+            "start_or_connect_local_server",
+            start_or_connect_local_server,
+        )(*args, **kwargs)
+
+    def stop_registered_local_server(self) -> Any:
+        """Stop the registered local Kitaru server if one exists."""
+        return self._legacy_attr(
+            "stop_registered_local_server",
+            stop_registered_local_server,
+        )()
+
+    def login_to_server(self, *args: Any, **kwargs: Any) -> Any:
+        """Persist/login to a remote Kitaru server."""
+        return self._legacy_attr("login_to_server", login_to_server)(*args, **kwargs)
+
+    def connected_to_local_server(self) -> bool:
+        """Return whether the current connection points at the local server."""
+        return bool(
+            self._legacy_attr(
+                "_connected_to_local_server",
+                _connected_to_local_server,
+            )()
+        )
+
+    def get_connected_server_url(self) -> str | None:
+        """Read the currently configured remote server URL, if available."""
+        patched = self._legacy_attr("_get_connected_server_url", None)
+        if patched is not None:
+            return patched()
+        try:
+            store_configuration = self.global_configuration().store_configuration
+        except Exception:
+            return None
+        server_url = getattr(store_configuration, "url", None)
+        if not server_url:
+            return None
+        return str(server_url).rstrip("/")
+
+    def build_runtime_snapshot(self, *args: Any, **kwargs: Any) -> Any:
+        """Build the runtime diagnostics snapshot."""
+        return self._legacy_attr(
+            "_build_runtime_snapshot",
+            _build_runtime_snapshot,
+        )(*args, **kwargs)
+
+    def log_store_mismatch_details(self, *args: Any, **kwargs: Any) -> Any:
+        """Return active-stack/log-store mismatch details."""
+        return self._legacy_attr(
+            "_log_store_mismatch_details",
+            _log_store_mismatch_details,
+        )(*args, **kwargs)
+
+    def set_global_log_store(self, *args: Any, **kwargs: Any) -> Any:
+        """Persist a global log-store override."""
+        return self._legacy_attr("set_global_log_store", set_global_log_store)(
+            *args,
+            **kwargs,
+        )
+
+    def resolve_log_store(self) -> Any:
+        """Resolve effective log-store configuration."""
+        return self._legacy_attr("resolve_log_store", resolve_log_store)()
+
+    def reset_global_log_store(self) -> Any:
+        """Clear the global log-store override."""
+        return self._legacy_attr("reset_global_log_store", reset_global_log_store)()
+
+    def get_current_stack(self) -> Any:
+        """Return the active stack."""
+        return self._legacy_attr("get_current_stack", get_current_stack)()
+
+    def get_available_stacks(self) -> Any:
+        """Return all available stacks."""
+        return self._legacy_attr("get_available_stacks", get_available_stacks)()
+
+    def set_active_stack(self, *args: Any, **kwargs: Any) -> Any:
+        """Set the active stack."""
+        return self._legacy_attr("set_active_stack", set_active_stack)(
+            *args,
+            **kwargs,
+        )
+
+    def list_stack_entries(self) -> Any:
+        """Return stack list entries."""
+        return self._legacy_attr("_list_stack_entries", _list_stack_entries)()
+
+    def show_stack_operation(self, *args: Any, **kwargs: Any) -> Any:
+        """Return stack details for a stack name or ID."""
+        return self._legacy_attr("_show_stack_operation", _show_stack_operation)(
+            *args,
+            **kwargs,
+        )
+
+    def create_stack_operation(self, *args: Any, **kwargs: Any) -> Any:
+        """Create a stack from CLI inputs."""
+        return self._legacy_attr("_create_stack_operation", _create_stack_operation)(
+            *args,
+            **kwargs,
+        )
+
+    def delete_stack_operation(self, *args: Any, **kwargs: Any) -> Any:
+        """Delete a stack from CLI inputs."""
+        return self._legacy_attr("_delete_stack_operation", _delete_stack_operation)(
+            *args,
+            **kwargs,
+        )
+
+    def register_model_alias(self, *args: Any, **kwargs: Any) -> Any:
+        """Persist a model alias."""
+        return self._legacy_attr("register_model_alias", register_model_alias)(
+            *args,
+            **kwargs,
+        )
+
+    def list_model_aliases(self) -> Any:
+        """List configured model aliases."""
+        return self._legacy_attr("list_model_aliases", list_model_aliases)()
+
+    def resolve_secret_exact(self, *args: Any, **kwargs: Any) -> Any:
+        """Resolve one secret by exact name or exact ID."""
+        return self._legacy_attr("_resolve_secret_exact", _resolve_secret_exact)(
+            *args,
+            **kwargs,
+        )
+
+    def scopes_memory_payload(self, *args: Any, **kwargs: Any) -> Any:
+        return self._legacy_attr("scopes_memory_payload", scopes_memory_payload)(
+            *args,
+            **kwargs,
+        )
+
+    def list_memory_payload(self, *args: Any, **kwargs: Any) -> Any:
+        return self._legacy_attr("list_memory_payload", list_memory_payload)(
+            *args,
+            **kwargs,
+        )
+
+    def get_memory_payload(self, *args: Any, **kwargs: Any) -> Any:
+        return self._legacy_attr("get_memory_payload", get_memory_payload)(
+            *args,
+            **kwargs,
+        )
+
+    def set_memory_payload(self, *args: Any, **kwargs: Any) -> Any:
+        return self._legacy_attr("set_memory_payload", set_memory_payload)(
+            *args,
+            **kwargs,
+        )
+
+    def delete_memory_payload(self, *args: Any, **kwargs: Any) -> Any:
+        return self._legacy_attr("delete_memory_payload", delete_memory_payload)(
+            *args,
+            **kwargs,
+        )
+
+    def purge_memory_payload(self, *args: Any, **kwargs: Any) -> Any:
+        return self._legacy_attr("purge_memory_payload", purge_memory_payload)(
+            *args,
+            **kwargs,
+        )
+
+    def purge_scope_memory_payload(self, *args: Any, **kwargs: Any) -> Any:
+        return self._legacy_attr(
+            "purge_scope_memory_payload",
+            purge_scope_memory_payload,
+        )(*args, **kwargs)
+
+    def reindex_memory_payload(self, *args: Any, **kwargs: Any) -> Any:
+        return self._legacy_attr("reindex_memory_payload", reindex_memory_payload)(
+            *args,
+            **kwargs,
+        )
+
+    def compact_memory_payload(self, *args: Any, **kwargs: Any) -> Any:
+        return self._legacy_attr("compact_memory_payload", compact_memory_payload)(
+            *args,
+            **kwargs,
+        )
+
+    def compaction_log_memory_payload(self, *args: Any, **kwargs: Any) -> Any:
+        return self._legacy_attr(
+            "compaction_log_memory_payload",
+            compaction_log_memory_payload,
+        )(*args, **kwargs)
+
+    def history_memory_payload(self, *args: Any, **kwargs: Any) -> Any:
+        return self._legacy_attr("history_memory_payload", history_memory_payload)(
+            *args,
+            **kwargs,
+        )
+
+    def sleep(self, seconds: float) -> None:
+        """Sleep while preserving legacy ``kitaru.cli.time.sleep`` patches."""
+        self._legacy_attr("time", time).sleep(seconds)
+
+
+_DEPENDENCIES = CLIDependencies()
+
+
+def cli_dependencies() -> CLIDependencies:
+    """Return the process-wide CLI dependency provider."""
+    return _DEPENDENCIES

--- a/src/kitaru/_cli/_dependencies.py
+++ b/src/kitaru/_cli/_dependencies.py
@@ -1,9 +1,9 @@
 """Internal dependency seam for CLI command modules.
 
 Command modules should ask this module for runtime dependencies instead of
-reaching through ``kitaru.cli``.  During the migration, this seam still honors
-legacy ``kitaru.cli.<name>`` patches so existing tests and external patch-based
-callers keep working.
+reaching through ``kitaru.cli``. The seam preserves legacy
+``kitaru.cli.<name>`` patch points for compatibility, but new code should patch
+or inject dependencies through this module directly.
 """
 
 from __future__ import annotations
@@ -103,8 +103,8 @@ class CLIDependencies:
         """Return a patched ``kitaru.cli`` attr when one exists.
 
         Unpatched legacy re-exports should not beat the seam-local default.
-        That keeps old ``kitaru.cli.*`` patches working while allowing future
-        tests to patch this dependency module directly.
+        That keeps old ``kitaru.cli.*`` patches working without preventing
+        tests from patching this dependency module directly.
         """
         module = sys.modules.get("kitaru.cli")
         if module is None:

--- a/src/kitaru/_cli/_executions.py
+++ b/src/kitaru/_cli/_executions.py
@@ -21,6 +21,7 @@ from kitaru.inspection import (
 )
 
 from . import executions_app
+from ._dependencies import cli_dependencies
 from ._helpers import (
     DEFAULT_LIST_PAGE,
     DEFAULT_LIST_SIZE,
@@ -31,7 +32,6 @@ from ._helpers import (
     _emit_snapshot,
     _emit_table,
     _exit_with_error,
-    _facade_module,
     _format_table_timestamp,
     _format_timestamp,
     _is_input_interactive,
@@ -437,7 +437,7 @@ def _follow_execution_logs(
                     )
                 last_wait_name = wait_name
 
-        _facade_module().time.sleep(interval)
+        cli_dependencies().sleep(interval)
 
 
 @executions_app.command
@@ -452,7 +452,7 @@ def get_(
     command = "executions.get"
     output_format = _resolve_output_format(output)
     execution = run_with_cli_error_boundary(
-        lambda: _facade_module().KitaruClient().executions.get(exec_id),
+        lambda: cli_dependencies().kitaru_client().executions.get(exec_id),
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
@@ -525,7 +525,7 @@ def list____(
     )
 
     def _list_executions() -> list[Execution]:
-        client = _facade_module().KitaruClient()
+        client = cli_dependencies().kitaru_client()
         if limit is not None:
             return client.executions.list(status=status, flow=flow, limit=limit)
         return client.executions.list(
@@ -635,7 +635,7 @@ def logs_(
         )
 
     verbosity = min(verbosity, 2)
-    client = _facade_module().KitaruClient()
+    client = cli_dependencies().kitaru_client()
 
     if follow:
         try:
@@ -937,7 +937,7 @@ def input_(
                 output=output_format,
             )
 
-        client = _facade_module().KitaruClient()
+        client = cli_dependencies().kitaru_client()
         try:
             exit_code = _run_interactive_input_flow(client, exec_id)
         except KeyboardInterrupt:
@@ -962,7 +962,7 @@ def input_(
             )
 
         def _abort_wait() -> Execution:
-            client = _facade_module().KitaruClient()
+            client = cli_dependencies().kitaru_client()
             wait = _auto_detect_single_pending_wait(client, exec_id)
             return client.executions.abort_wait(exec_id, wait=wait.wait_id)
 
@@ -994,7 +994,7 @@ def input_(
 
     def _resolve_input() -> Execution:
         parsed_value = _parse_json_value(value, option_name="--value")
-        client = _facade_module().KitaruClient()
+        client = cli_dependencies().kitaru_client()
         wait = _auto_detect_single_pending_wait(client, exec_id)
         return client.executions.input(exec_id, wait=wait.wait_id, value=parsed_value)
 
@@ -1052,8 +1052,8 @@ def replay_(
         flow_inputs = _parse_json_object(args, option_name="--args")
         parsed_overrides = _parse_json_object(overrides, option_name="--overrides")
         return (
-            _facade_module()
-            .KitaruClient()
+            cli_dependencies()
+            .kitaru_client()
             .executions.replay(
                 exec_id,
                 from_=from_,
@@ -1091,7 +1091,7 @@ def retry_(
     command = "executions.retry"
     output_format = _resolve_output_format(output)
     execution = run_with_cli_error_boundary(
-        lambda: _facade_module().KitaruClient().executions.retry(exec_id),
+        lambda: cli_dependencies().kitaru_client().executions.retry(exec_id),
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
@@ -1119,7 +1119,7 @@ def resume_(
     command = "executions.resume"
     output_format = _resolve_output_format(output)
     execution = run_with_cli_error_boundary(
-        lambda: _facade_module().KitaruClient().executions.resume(exec_id),
+        lambda: cli_dependencies().kitaru_client().executions.resume(exec_id),
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
@@ -1147,7 +1147,7 @@ def cancel_(
     command = "executions.cancel"
     output_format = _resolve_output_format(output)
     execution = run_with_cli_error_boundary(
-        lambda: _facade_module().KitaruClient().executions.cancel(exec_id),
+        lambda: cli_dependencies().kitaru_client().executions.cancel(exec_id),
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,

--- a/src/kitaru/_cli/_flows.py
+++ b/src/kitaru/_cli/_flows.py
@@ -47,6 +47,7 @@ from kitaru.inspection import (
 )
 
 from . import app, flow_app, flow_deployments_app
+from ._dependencies import cli_dependencies
 from ._executions import (
     _emit_control_message,
     _emit_json_log_event,
@@ -67,7 +68,6 @@ from ._helpers import (
     _emit_snapshot,
     _emit_table,
     _exit_with_error,
-    _facade_module,
     _format_table_timestamp,
     _format_timestamp,
     _paginate_items,
@@ -610,7 +610,7 @@ def invoke(
             tag=tag,
             default_tag=DEFAULT_DEPLOYMENT_TAG,
         )
-        client = _facade_module().KitaruClient()
+        client = cli_dependencies().kitaru_client()
         handle = client.deployments.invoke(
             flow=flow,
             version=selector.version,
@@ -669,7 +669,7 @@ def list_(output: OutputFormatOption = "text") -> None:
     command = "flow.list"
     output_format = _resolve_output_format(output)
     deployments = run_with_cli_error_boundary(
-        lambda: _facade_module().KitaruClient().deployments.list(),
+        lambda: cli_dependencies().kitaru_client().deployments.list(),
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
@@ -700,7 +700,7 @@ def show(
     output_format = _resolve_output_format(output)
 
     def _show_flow() -> dict[str, Any]:
-        deployments = _facade_module().KitaruClient().deployments.list(flow=flow)
+        deployments = cli_dependencies().kitaru_client().deployments.list(flow=flow)
         if not deployments:
             raise LookupError(f"No deployments found for flow {flow!r}.")
         return serialize_flow_deployment_summary(flow, deployments)
@@ -749,7 +749,7 @@ def list__(
         output=output_format,
     )
     deployments = run_with_cli_error_boundary(
-        lambda: _facade_module().KitaruClient().deployments.list(flow=flow),
+        lambda: cli_dependencies().kitaru_client().deployments.list(flow=flow),
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
@@ -797,8 +797,8 @@ def show__(
             default_tag=DEFAULT_DEPLOYMENT_TAG,
         )
         return (
-            _facade_module()
-            .KitaruClient()
+            cli_dependencies()
+            .kitaru_client()
             .deployments.get(
                 flow=flow,
                 version=resolved_version,
@@ -844,7 +844,7 @@ def curl(
             default_tag=DEFAULT_DEPLOYMENT_TAG,
         )
         server_url = _active_kitaru_server_url()
-        client = _facade_module().KitaruClient()
+        client = cli_dependencies().kitaru_client()
         deployment = client.deployments.get(
             flow=flow,
             version=resolved_version,
@@ -938,7 +938,7 @@ def logs(
         _exit_with_error(command, "`--interval` must be > 0.", output=output_format)
 
     def _resolve_logs_target() -> tuple[Any, str]:
-        client = _facade_module().KitaruClient()
+        client = cli_dependencies().kitaru_client()
         if exec_id:
             return client, exec_id
 
@@ -1043,7 +1043,9 @@ def delete(
     output_format = _resolve_output_format(output)
 
     def _delete_deployment() -> dict[str, Any]:
-        _facade_module().KitaruClient().deployments.delete(flow=flow, version=version)
+        cli_dependencies().kitaru_client().deployments.delete(
+            flow=flow, version=version
+        )
         track(
             AnalyticsEvent.DEPLOYMENT_DELETED,
             {"command": command, "selector": "version"},
@@ -1088,8 +1090,8 @@ def tag(
 
     def _tag_deployment() -> Any:
         deployment = (
-            _facade_module()
-            .KitaruClient()
+            cli_dependencies()
+            .kitaru_client()
             .deployments.tag(
                 flow=flow,
                 version=version,
@@ -1131,8 +1133,8 @@ def untag(
 
     def _untag_deployment() -> Any:
         deployment = (
-            _facade_module()
-            .KitaruClient()
+            cli_dependencies()
+            .kitaru_client()
             .deployments.untag(
                 flow=flow,
                 version=version,

--- a/src/kitaru/_cli/_helpers.py
+++ b/src/kitaru/_cli/_helpers.py
@@ -27,7 +27,11 @@ from kitaru.cli_output import exit_with_error as _structured_exit_with_error
 
 
 def _facade_module() -> ModuleType:
-    """Return the compatibility facade module used by tests and callers."""
+    """Return the legacy compatibility facade module.
+
+    Command modules should use ``kitaru._cli._dependencies`` instead. This
+    helper stays for older private imports and compatibility-only tests.
+    """
     module = sys.modules.get("kitaru.cli")
     if module is None:
         module = importlib.import_module("kitaru.cli")

--- a/src/kitaru/_cli/_memory.py
+++ b/src/kitaru/_cli/_memory.py
@@ -11,6 +11,7 @@ from kitaru._interface_errors import run_with_cli_error_boundary
 from kitaru.cli_output import CLIOutputFormat
 
 from . import memory_app
+from ._dependencies import cli_dependencies
 from ._helpers import (
     DEFAULT_LIST_PAGE,
     DEFAULT_LIST_SIZE,
@@ -25,7 +26,6 @@ from ._helpers import (
     _emit_table,
     _emit_warning,
     _exit_with_error,
-    _facade_module,
     _format_table_timestamp,
     _paginate_items,
     _print_success,
@@ -306,10 +306,10 @@ def scopes_(
     """List all discovered memory scopes."""
     command = "memory.scopes"
     output_format = _resolve_output_format(output)
-    facade = _facade_module()
+    deps = cli_dependencies()
     scopes = run_with_cli_error_boundary(
-        lambda: facade.scopes_memory_payload(
-            facade.KitaruClient(),
+        lambda: deps.scopes_memory_payload(
+            deps.kitaru_client(),
         ),
         command=command,
         output=output_format,
@@ -358,10 +358,10 @@ def list_(
         command=command,
         output=output_format,
     )
-    facade = _facade_module()
+    deps = cli_dependencies()
     entries = run_with_cli_error_boundary(
-        lambda: facade.list_memory_payload(
-            facade.KitaruClient(),
+        lambda: deps.list_memory_payload(
+            deps.kitaru_client(),
             scope=scope,
             scope_type=scope_type,
         ),
@@ -440,10 +440,10 @@ def get_(
         command=command,
         output=output_format,
     )
-    facade = _facade_module()
+    deps = cli_dependencies()
     payload = run_with_cli_error_boundary(
-        lambda: facade.get_memory_payload(
-            facade.KitaruClient(),
+        lambda: deps.get_memory_payload(
+            deps.kitaru_client(),
             key=key,
             scope=scope,
             scope_type=scope_type,
@@ -535,10 +535,10 @@ def set_(
         command=command,
         output=output_format,
     )
-    facade = _facade_module()
+    deps = cli_dependencies()
     payload = run_with_cli_error_boundary(
-        lambda: facade.set_memory_payload(
-            facade.KitaruClient(),
+        lambda: deps.set_memory_payload(
+            deps.kitaru_client(),
             key=key,
             value=_parse_memory_cli_value(value),
             scope=scope,
@@ -593,10 +593,10 @@ def delete_(
         command=command,
         output=output_format,
     )
-    facade = _facade_module()
+    deps = cli_dependencies()
     payload = run_with_cli_error_boundary(
-        lambda: facade.delete_memory_payload(
-            facade.KitaruClient(),
+        lambda: deps.delete_memory_payload(
+            deps.kitaru_client(),
             key=key,
             scope=scope,
             scope_type=scope_type,
@@ -669,10 +669,10 @@ def purge_(
         command=command,
         output=output_format,
     )
-    facade = _facade_module()
+    deps = cli_dependencies()
     payload = run_with_cli_error_boundary(
-        lambda: facade.purge_memory_payload(
-            facade.KitaruClient(),
+        lambda: deps.purge_memory_payload(
+            deps.kitaru_client(),
             key=key,
             scope=scope,
             scope_type=scope_type,
@@ -740,10 +740,10 @@ def purge_scope_(
         command=command,
         output=output_format,
     )
-    facade = _facade_module()
+    deps = cli_dependencies()
     payload = run_with_cli_error_boundary(
-        lambda: facade.purge_scope_memory_payload(
-            facade.KitaruClient(),
+        lambda: deps.purge_scope_memory_payload(
+            deps.kitaru_client(),
             scope=scope,
             scope_type=scope_type,
             keep=keep,
@@ -792,10 +792,10 @@ def reindex_(
     """
     command = "memory.reindex"
     output_format = _resolve_output_format(output)
-    facade = _facade_module()
+    deps = cli_dependencies()
     payload = run_with_cli_error_boundary(
-        lambda: facade.reindex_memory_payload(
-            facade.KitaruClient(),
+        lambda: deps.reindex_memory_payload(
+            deps.kitaru_client(),
             apply=apply,
         ),
         command=command,
@@ -934,10 +934,10 @@ def compact_(
         output=output_format,
     )
     keys_list = list(keys) if keys else None
-    facade = _facade_module()
+    deps = cli_dependencies()
     payload = run_with_cli_error_boundary(
-        lambda: facade.compact_memory_payload(
-            facade.KitaruClient(),
+        lambda: deps.compact_memory_payload(
+            deps.kitaru_client(),
             scope=scope,
             scope_type=scope_type,
             key=key,
@@ -996,10 +996,10 @@ def compaction_log_(
         command=command,
         output=output_format,
     )
-    facade = _facade_module()
+    deps = cli_dependencies()
     entries = run_with_cli_error_boundary(
-        lambda: facade.compaction_log_memory_payload(
-            facade.KitaruClient(),
+        lambda: deps.compaction_log_memory_payload(
+            deps.kitaru_client(),
             scope=scope,
             scope_type=scope_type,
         ),
@@ -1071,10 +1071,10 @@ def history_(
         command=command,
         output=output_format,
     )
-    facade = _facade_module()
+    deps = cli_dependencies()
     entries = run_with_cli_error_boundary(
-        lambda: facade.history_memory_payload(
-            facade.KitaruClient(),
+        lambda: deps.history_memory_payload(
+            deps.kitaru_client(),
             key=key,
             scope=scope,
             scope_type=scope_type,

--- a/src/kitaru/_cli/_models.py
+++ b/src/kitaru/_cli/_models.py
@@ -12,6 +12,7 @@ from kitaru.config import ModelAliasEntry
 from kitaru.inspection import serialize_model_alias
 
 from . import model_app
+from ._dependencies import cli_dependencies
 from ._helpers import (
     DEFAULT_LIST_PAGE,
     DEFAULT_LIST_SIZE,
@@ -23,7 +24,6 @@ from ._helpers import (
     _emit_pagination_note,
     _emit_snapshot,
     _exit_with_error,
-    _facade_module,
     _paginate_items,
     _print_success,
     _resolve_output_format,
@@ -74,12 +74,12 @@ def register(
     """
     command = "model.register"
     output_format = _resolve_output_format(output)
-    facade = _facade_module()
+    deps = cli_dependencies()
 
     def _register_alias() -> ModelAliasEntry:
         if secret is not None:
-            facade._resolve_secret_exact(facade.Client(), secret)
-        return facade.register_model_alias(alias, model=model, secret=secret)
+            deps.resolve_secret_exact(deps.zenml_client(), secret)
+        return deps.register_model_alias(alias, model=model, secret=secret)
 
     alias_entry = run_with_cli_error_boundary(
         _register_alias,
@@ -125,7 +125,7 @@ def list___(
         output=output_format,
     )
     aliases = run_with_cli_error_boundary(
-        _facade_module().list_model_aliases,
+        cli_dependencies().list_model_aliases,
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,

--- a/src/kitaru/_cli/_secrets.py
+++ b/src/kitaru/_cli/_secrets.py
@@ -10,11 +10,11 @@ from zenml.models import SecretResponse
 
 from kitaru._interface_errors import run_with_cli_error_boundary
 from kitaru.cli_output import CLIOutputFormat
-from kitaru.errors import KitaruRuntimeError, KitaruUsageError
 from kitaru.inspection import serialize_secret_detail, serialize_secret_summary
-from kitaru.secrets import _SECRET_KEY_PATTERN, _get_secret_response_exact
+from kitaru.secrets import _SECRET_KEY_PATTERN
 
 from . import secrets_app
+from ._dependencies import cli_dependencies
 from ._helpers import (
     DEFAULT_LIST_PAGE,
     DEFAULT_LIST_SIZE,
@@ -26,7 +26,6 @@ from ._helpers import (
     _emit_pagination_note,
     _emit_snapshot,
     _exit_with_error,
-    _facade_module,
     _paginate_items,
     _print_success,
     _resolve_output_format,
@@ -98,14 +97,6 @@ def _parse_secret_assignments(raw_assignments: list[str]) -> dict[str, str]:
         )
 
     return parsed
-
-
-def _resolve_secret_exact(client: Any, name_or_id: str) -> SecretResponse:
-    """Fetch one secret by exact name or exact ID."""
-    try:
-        return _get_secret_response_exact(name_or_id, client=client)
-    except (KitaruRuntimeError, KitaruUsageError) as exc:
-        raise ValueError(str(exc)) from exc
 
 
 def _list_accessible_secrets(client: Any) -> list[SecretResponse]:
@@ -184,11 +175,11 @@ def set_(
     """Set a public secret by default, or create it privately with --private."""
     command = "secrets.set"
     output_format = _resolve_output_format(output)
-    facade = _facade_module()
+    deps = cli_dependencies()
 
     def _set_secret() -> tuple[SecretResponse, str, int]:
         parsed_assignments = _parse_secret_assignments(assignments)
-        client = facade.Client()
+        client = deps.zenml_client()
 
         try:
             secret = client.create_secret(
@@ -198,7 +189,7 @@ def set_(
             )
             action = "Created"
         except EntityExistsError:
-            existing_secret = facade._resolve_secret_exact(client, name)
+            existing_secret = deps.resolve_secret_exact(client, name)
             secret = client.update_secret(
                 name_id_or_prefix=existing_secret.id,
                 add_or_update_values=parsed_assignments,
@@ -250,9 +241,9 @@ def show_(
     """Show a secret with metadata and optional raw values."""
     command = "secrets.show"
     output_format = _resolve_output_format(output)
-    facade = _facade_module()
+    deps = cli_dependencies()
     secret = run_with_cli_error_boundary(
-        lambda: facade._resolve_secret_exact(facade.Client(), name_or_id),
+        lambda: deps.resolve_secret_exact(deps.zenml_client(), name_or_id),
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
@@ -289,7 +280,7 @@ def list__(
         output=output_format,
     )
     secrets = run_with_cli_error_boundary(
-        lambda: _list_accessible_secrets(_facade_module().Client()),
+        lambda: _list_accessible_secrets(cli_dependencies().zenml_client()),
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
@@ -331,11 +322,11 @@ def delete_(
     """Delete a secret by exact name or exact ID."""
     command = "secrets.delete"
     output_format = _resolve_output_format(output)
-    facade = _facade_module()
+    deps = cli_dependencies()
 
     def _delete_secret() -> SecretResponse:
-        client = facade.Client()
-        secret = facade._resolve_secret_exact(client, name_or_id)
+        client = deps.zenml_client()
+        secret = deps.resolve_secret_exact(client, name_or_id)
         client.delete_secret(name_id_or_prefix=str(secret.id))
         return secret
 

--- a/src/kitaru/_cli/_stacks.py
+++ b/src/kitaru/_cli/_stacks.py
@@ -32,6 +32,7 @@ from kitaru.inspection import (
 )
 
 from . import stack_app
+from ._dependencies import cli_dependencies
 from ._helpers import (
     DEFAULT_LIST_PAGE,
     DEFAULT_LIST_SIZE,
@@ -43,7 +44,6 @@ from ._helpers import (
     _emit_pagination_note,
     _emit_snapshot,
     _exit_with_error,
-    _facade_module,
     _paginate_items,
     _print_success,
     _resolve_output_format,
@@ -382,14 +382,14 @@ def list_(
         command=command,
         output=output_format,
     )
-    facade = _facade_module()
+    deps = cli_dependencies()
 
     def _list_stacks() -> tuple[list[StackInfo], list[Any] | None]:
         if output_format == CLIOutputFormat.JSON:
-            stack_entries = facade._list_stack_entries()
+            stack_entries = deps.list_stack_entries()
             stacks = [entry.stack for entry in stack_entries]
         else:
-            stacks = facade.get_available_stacks()
+            stacks = deps.get_available_stacks()
             stack_entries = None
         return stacks, stack_entries
 
@@ -434,7 +434,7 @@ def current(output: OutputFormatOption = "text") -> None:
     command = "stack.current"
     output_format = _resolve_output_format(output)
     stack = run_with_cli_error_boundary(
-        _facade_module().get_current_stack,
+        cli_dependencies().get_current_stack,
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
@@ -459,7 +459,7 @@ def show(
     command = "stack.show"
     output_format = _resolve_output_format(output)
     details = run_with_cli_error_boundary(
-        lambda: _facade_module()._show_stack_operation(name_or_id),
+        lambda: cli_dependencies().show_stack_operation(name_or_id),
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
@@ -488,7 +488,7 @@ def use(
     command = "stack.use"
     output_format = _resolve_output_format(output)
     selected_stack = run_with_cli_error_boundary(
-        lambda: _facade_module().set_active_stack(stack),
+        lambda: cli_dependencies().set_active_stack(stack),
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
@@ -689,7 +689,7 @@ def create(
         }
         if not request.component_overrides.is_empty():
             create_kwargs["component_overrides"] = request.component_overrides
-        return _facade_module()._create_stack_operation(request.name, **create_kwargs)
+        return cli_dependencies().create_stack_operation(request.name, **create_kwargs)
 
     result = run_with_cli_error_boundary(
         _create_stack,
@@ -741,7 +741,7 @@ def delete(
     command = "stack.delete"
     output_format = _resolve_output_format(output)
     result = run_with_cli_error_boundary(
-        lambda: _facade_module()._delete_stack_operation(
+        lambda: cli_dependencies().delete_stack_operation(
             stack,
             recursive=recursive,
             force=force,

--- a/src/kitaru/_cli/_status.py
+++ b/src/kitaru/_cli/_status.py
@@ -33,6 +33,7 @@ from kitaru.inspection import (
 from kitaru.inspection import combine_warnings as _combine_warnings
 
 from . import app, log_store_app
+from ._dependencies import cli_dependencies
 from ._helpers import (
     OutputFormatOption,
     SnapshotSection,
@@ -41,7 +42,6 @@ from ._helpers import (
     _emit_snapshot_sections,
     _emit_warning,
     _exit_with_error,
-    _facade_module,
     _print_success,
     _resolve_output_format,
 )
@@ -241,9 +241,9 @@ def _clear_persisted_store_configuration(gc: Any) -> None:
 
 def _get_connected_server_url() -> str | None:
     """Read the currently configured remote server URL, if available."""
-    facade = _facade_module()
+    deps = cli_dependencies()
     try:
-        store_configuration = facade.GlobalConfiguration().store_configuration
+        store_configuration = deps.global_configuration().store_configuration
     except Exception:
         return None
 
@@ -496,11 +496,11 @@ def _environment_rows(
 
 def _logout_current_connection() -> LogoutResult:
     """Reset the active connection and clear current stored credentials."""
-    facade = _facade_module()
-    gc = facade.GlobalConfiguration()
-    connected_server_url = facade._get_connected_server_url()
-    was_connected_to_local_server = facade._connected_to_local_server()
-    stop_result = facade.stop_registered_local_server()
+    deps = cli_dependencies()
+    gc = deps.global_configuration()
+    connected_server_url = deps.get_connected_server_url()
+    was_connected_to_local_server = deps.connected_to_local_server()
+    stop_result = deps.stop_registered_local_server()
 
     if was_connected_to_local_server:
         return LogoutResult(
@@ -540,7 +540,7 @@ def _logout_current_connection() -> LogoutResult:
         )
 
     if server_url.startswith(("http://", "https://")):
-        facade.get_credentials_store().clear_credentials(server_url)
+        deps.get_credentials_store().clear_credentials(server_url)
         return LogoutResult(
             mode="remote_server",
             target=server_url,
@@ -606,8 +606,8 @@ def _logout_result_message(result: LogoutResult) -> str:
 
 def _log_store_payload(snapshot: ResolvedLogStore) -> dict[str, Any]:
     """Serialize effective log-store state for JSON output."""
-    facade = _facade_module()
-    _, mismatch_warning = facade._log_store_mismatch_details(snapshot)
+    deps = cli_dependencies()
+    _, mismatch_warning = deps.log_store_mismatch_details(snapshot)
     return serialize_resolved_log_store(
         snapshot,
         active_store=active_stack_log_store(),
@@ -660,7 +660,7 @@ def login(
     """Connect to a remote server, or start and connect to a local server."""
     command = "login"
     output_format = _resolve_output_format(output)
-    facade = _facade_module()
+    deps = cli_dependencies()
     if server is None:
         _validate_local_login_flags(
             api_key=api_key,
@@ -673,11 +673,11 @@ def login(
         )
         _warn_for_auth_environment_overrides(output=output_format)
 
-        connected_server_url = facade._get_connected_server_url()
+        connected_server_url = deps.get_connected_server_url()
         if (
             connected_server_url
             and not connected_server_url.startswith("sqlite:")
-            and not facade._connected_to_local_server()
+            and not deps.connected_to_local_server()
             and not _is_localhost_url(connected_server_url)
         ):
             _emit_warning(
@@ -686,7 +686,7 @@ def login(
             )
 
         result = run_with_cli_error_boundary(
-            lambda: facade.start_or_connect_local_server(
+            lambda: deps.start_or_connect_local_server(
                 port=port,
                 timeout=timeout,
             ),
@@ -722,7 +722,7 @@ def login(
     _ensure_no_auth_environment_overrides(command=command, output=output_format)
 
     run_with_cli_error_boundary(
-        lambda: facade.login_to_server(
+        lambda: deps.login_to_server(
             server,
             api_key=api_key,
             refresh=refresh,
@@ -744,7 +744,7 @@ def login(
         {"mode": "remote", "project_provided": project is not None},
     )
 
-    connected_server_url = facade._get_connected_server_url() or server.rstrip("/")
+    connected_server_url = deps.get_connected_server_url() or server.rstrip("/")
     if output_format == CLIOutputFormat.JSON:
         _emit_json_item(
             command,
@@ -800,7 +800,7 @@ def set(
     command = "log-store.set"
     output_format = _resolve_output_format(output)
     snapshot = run_with_cli_error_boundary(
-        lambda: _facade_module().set_global_log_store(
+        lambda: cli_dependencies().set_global_log_store(
             backend,
             endpoint=endpoint,
             api_key=api_key,
@@ -826,16 +826,16 @@ def show__(output: OutputFormatOption = "text") -> None:
     """Show the effective global runtime log-store configuration."""
     command = "log-store.show"
     output_format = _resolve_output_format(output)
-    facade = _facade_module()
+    deps = cli_dependencies()
     snapshot = run_with_cli_error_boundary(
-        facade.resolve_log_store,
+        deps.resolve_log_store,
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
         handled_exceptions=(ValueError,),
     )
 
-    _, mismatch_warning = facade._log_store_mismatch_details(snapshot)
+    _, mismatch_warning = deps.log_store_mismatch_details(snapshot)
     if output_format == CLIOutputFormat.JSON:
         _emit_json_item(command, _log_store_payload(snapshot), output=output_format)
         return
@@ -848,7 +848,7 @@ def reset(output: OutputFormatOption = "text") -> None:
     command = "log-store.reset"
     output_format = _resolve_output_format(output)
     snapshot = run_with_cli_error_boundary(
-        _facade_module().reset_global_log_store,
+        cli_dependencies().reset_global_log_store,
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
@@ -869,7 +869,7 @@ def reset(output: OutputFormatOption = "text") -> None:
 def status(output: OutputFormatOption = "text") -> None:
     """Show the current connection state and active stack context."""
     output_format = _resolve_output_format(output)
-    snapshot = _facade_module()._build_runtime_snapshot()
+    snapshot = cli_dependencies().build_runtime_snapshot()
 
     from kitaru.analytics import AnalyticsEvent, track
 
@@ -982,7 +982,7 @@ def info(
     include_environment_type = all
     include_provenance_details = all
 
-    snapshot = _facade_module()._build_runtime_snapshot(
+    snapshot = cli_dependencies().build_runtime_snapshot(
         include_packages=include_packages,
         package_names=package_names,
         include_environment_type=include_environment_type,

--- a/src/kitaru/_interface_secrets.py
+++ b/src/kitaru/_interface_secrets.py
@@ -1,0 +1,24 @@
+"""Shared secret helpers for CLI-facing command layers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from zenml.models import SecretResponse
+
+from kitaru.errors import KitaruRuntimeError, KitaruUsageError
+from kitaru.secrets import _get_secret_response_exact
+
+
+def resolve_secret_exact(client: Any, name_or_id: str) -> SecretResponse:
+    """Fetch one secret by exact name or exact ID.
+
+    Lower-level secret lookup raises Kitaru-specific exceptions. CLI command
+    surfaces historically reported these as ``ValueError`` through the shared
+    CLI error boundary, so this helper preserves that behavior for every
+    command that needs exact secret validation.
+    """
+    try:
+        return _get_secret_response_exact(name_or_id, client=client)
+    except (KitaruRuntimeError, KitaruUsageError) as exc:
+        raise ValueError(str(exc)) from exc

--- a/src/kitaru/cli.py
+++ b/src/kitaru/cli.py
@@ -9,9 +9,9 @@ from collections.abc import Sequence
 # Legacy CLI facade exports.
 #
 # Command modules now resolve runtime dependencies through
-# ``kitaru._cli._dependencies``.  These imports remain here so existing tests
-# and external integrations that patch/import ``kitaru.cli.<name>`` continue to
-# work while the old facade is being migrated away.
+# ``kitaru._cli._dependencies``. These imports remain as compatibility patch
+# points for existing tests and external integrations that patch or import
+# ``kitaru.cli.<name>``.
 from zenml.client import Client
 from zenml.config.global_config import GlobalConfiguration
 from zenml.exceptions import EntityExistsError, ZenKeyError

--- a/src/kitaru/cli.py
+++ b/src/kitaru/cli.py
@@ -6,6 +6,12 @@ import sys
 import time
 from collections.abc import Sequence
 
+# Legacy CLI facade exports.
+#
+# Command modules now resolve runtime dependencies through
+# ``kitaru._cli._dependencies``.  These imports remain here so existing tests
+# and external integrations that patch/import ``kitaru.cli.<name>`` continue to
+# work while the old facade is being migrated away.
 from zenml.client import Client
 from zenml.config.global_config import GlobalConfiguration
 from zenml.exceptions import EntityExistsError, ZenKeyError
@@ -162,7 +168,6 @@ from kitaru._cli._secrets import (
     _SECRET_KEY_PATTERN,
     _list_accessible_secrets,
     _parse_secret_assignments,
-    _resolve_secret_exact,
     _secret_list_rows,
     _secret_show_rows,
     delete_,
@@ -233,6 +238,7 @@ from kitaru._interface_memory import (
     scopes_memory_payload,
     set_memory_payload,
 )
+from kitaru._interface_secrets import resolve_secret_exact as _resolve_secret_exact
 from kitaru._local_server import (
     LocalServerConnectionResult,
     LocalServerStopResult,
@@ -264,6 +270,7 @@ from kitaru.inspection import (
 )
 from kitaru.inspection import log_store_mismatch_details as _log_store_mismatch_details
 
+# Console entrypoint and startup/bootstrap behavior.
 app.version = _UNKNOWN_VERSION
 
 # Commands that manage their own connection lifecycle or never need a live

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,18 @@ def _execution_stub(
     )
 
 
+def test_cli_command_modules_use_dependency_seam_not_legacy_facade() -> None:
+    """Command modules should not reach through the legacy ``kitaru.cli`` facade."""
+    command_modules = sorted(Path("src/kitaru/_cli").glob("_*.py"))
+    offenders = [
+        path.name
+        for path in command_modules
+        if path.name != "_helpers.py" and "_facade_module" in path.read_text()
+    ]
+
+    assert offenders == []
+
+
 def _stack_create_result_stub(
     *,
     name: str = "dev",


### PR DESCRIPTION
## What changed

- Added `src/kitaru/_cli/_dependencies.py` as the internal dependency seam for CLI command modules.
- Updated CLI command modules to use `cli_dependencies()` instead of reaching through `_facade_module()` / `kitaru.cli` for runtime dependencies.
- Kept legacy `kitaru.cli.*` re-exports and patch compatibility in place.
- Added `src/kitaru/_interface_secrets.py` for exact secret resolution shared by CLI model/secret paths.
- Added a guard test so command modules do not reintroduce `_facade_module()` usage.

## Why it was needed

`cli.py` had become both the console entrypoint and an accidental dependency injection patchboard. A command like `executions get` would ask `_facade_module()` for `kitaru.cli`, then pull `KitaruClient` from that module. Tests patched that surface, so the entrypoint file had to keep a very wide set of dependency names alive.

This PR introduces a real seam: command modules now ask `_cli/_dependencies.py` for clients/helpers. That seam is the only place that still knows how to honor legacy `kitaru.cli.*` patches.

## Key implementation decisions

- Kept `cli.py` compatibility exports; this PR does not try to delete the old facade yet.
- Preserved legacy patch behavior by checking `sys.modules["kitaru.cli"]` for values that differ from the original re-exported objects.
- Left command behavior unchanged; this is dependency routing, not CLI UX/output redesign.
- Ran the requested simplify pass; applied conservative cleanup only.

## Reviewer Notes

Please focus on:

- `src/kitaru/_cli/_dependencies.py`: this is the new seam and compatibility bridge.
- Command modules under `src/kitaru/_cli/`: they should no longer call `_facade_module()` directly.
- `tests/test_cli.py`: includes a guard against command modules using the legacy facade again.

Useful local verification snippet:

```bash
just check
uv run pytest tests/test_cli.py tests/test_bootstrap.py tests/test_analytics.py
just test
```

## Verification

- `just check` ✅
- `uv run pytest tests/test_cli.py tests/test_bootstrap.py tests/test_analytics.py` ✅ 410 passed
- `just test` ✅ 1661 passed, 8 skipped
