### PR TITLE
Emit flow terminal telemetry for completed submissions

### DIFF
--- a/src/kitaru/_config/_stacks.py
+++ b/src/kitaru/_config/_stacks.py
@@ -1949,6 +1949,23 @@ def _infer_stack_details_type(
     return "custom"
 
 
+def classify_stack_model_deployment_type(
+    stack_model: Any,
+    *,
+    selector: str = "<resolved stack>",
+) -> _StackShowType:
+    """Classify an already-hydrated stack model without resolving it again."""
+    component_details = _stack_component_details_from_stack_model(
+        stack_model,
+        selector=selector,
+    )
+    if not component_details or all(
+        component.backend is None for component in component_details
+    ):
+        raise KitaruStateError("Stack components did not include backend metadata.")
+    return _infer_stack_details_type(component_details)
+
+
 def classify_stack_deployment_type(
     name_or_id: str | None = None,
     *,
@@ -1983,15 +2000,7 @@ def classify_stack_deployment_type(
             f"Unable to classify stack deployment type for '{selector}'."
         ) from exc
 
-    component_details = _stack_component_details_from_stack_model(
-        hydrated_stack,
-        selector=selector,
-    )
-    if not component_details or all(
-        component.backend is None for component in component_details
-    ):
-        raise KitaruStateError("Stack components did not include backend metadata.")
-    return _infer_stack_details_type(component_details)
+    return classify_stack_model_deployment_type(hydrated_stack, selector=selector)
 
 
 def _show_stack_operation(

--- a/src/kitaru/_telemetry.py
+++ b/src/kitaru/_telemetry.py
@@ -1,0 +1,64 @@
+"""Shared privacy-safe telemetry helpers for Kitaru internals."""
+
+import logging
+
+from kitaru.config import (
+    classify_stack_deployment_type,
+    classify_stack_model_deployment_type,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _deployment_metadata_from_type(deployment_type: str) -> dict[str, str]:
+    """Build the shared privacy-safe deployment metadata payload."""
+    return {
+        "kitaru_deployment_type": deployment_type,
+        "deployment_type_source": "kitaru_stack_inference",
+    }
+
+
+def _unknown_deployment_metadata() -> dict[str, str]:
+    """Build the privacy-safe fallback deployment metadata payload."""
+    return {
+        "kitaru_deployment_type": "unknown",
+        "deployment_type_source": "kitaru_stack_inference_failed",
+    }
+
+
+def deployment_metadata_for_stack(stack_name_or_id: str | None) -> dict[str, str]:
+    """Return privacy-safe deployment metadata for a stack selector.
+
+    This path may resolve the stack through the backend. Prefer
+    ``deployment_metadata_for_stack_model`` when a hydrated stack model is
+    already available.
+    """
+    try:
+        deployment_type = classify_stack_deployment_type(stack_name_or_id)
+    except Exception:
+        logger.debug(
+            "Failed to classify stack deployment type for analytics.",
+            exc_info=True,
+        )
+        return _unknown_deployment_metadata()
+
+    return _deployment_metadata_from_type(deployment_type)
+
+
+def deployment_metadata_for_stack_model(stack_model: object) -> dict[str, str]:
+    """Return privacy-safe deployment metadata from an already-resolved stack.
+
+    This avoids a second backend lookup for code paths, such as deployment
+    invoke, that already loaded the deployment's hydrated stack model for
+    validation.
+    """
+    try:
+        deployment_type = classify_stack_model_deployment_type(stack_model)
+    except Exception:
+        logger.debug(
+            "Failed to classify resolved stack model for analytics.",
+            exc_info=True,
+        )
+        return _unknown_deployment_metadata()
+
+    return _deployment_metadata_from_type(deployment_type)

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -118,6 +118,7 @@ from kitaru._source_aliases import (
     normalize_checkpoint_name as _normalize_checkpoint_name,
 )
 from kitaru._source_aliases import normalize_flow_name as _normalize_flow_name
+from kitaru._telemetry import deployment_metadata_for_stack_model
 from kitaru.analytics import AnalyticsEvent, track
 from kitaru.config import (
     active_stack_log_store,
@@ -175,6 +176,14 @@ logger = logging.getLogger(__name__)
 _WAIT_CONDITION_RESOLUTION_CONTINUE = "continue"
 _WAIT_CONDITION_RESOLUTION_ABORT = "abort"
 _REPLAY_IMPORT_LOCK = threading.RLock()
+
+
+class _DeploymentStackModel(Protocol):
+    """Hydrated stack model shape needed by deployment validation/telemetry."""
+
+    id: object
+    name: str
+    components: Mapping[Any, Any]
 
 
 class _ReplayImportDependencyError(KitaruRuntimeError):
@@ -1724,7 +1733,7 @@ class _DeploymentsAPI:
     def _resolve_deployment_stack(
         self,
         deployment: DeploymentRecord | Deployment,
-    ) -> Any:
+    ) -> _DeploymentStackModel:
         """Load the stored stack model for a deployment snapshot."""
         deployment_record = self._unwrap_deployment_record(deployment)
         snapshot = self._client_ref._get_snapshot(
@@ -1762,6 +1771,24 @@ class _DeploymentsAPI:
                 "Rebuild the deployment using a stack the Kitaru server can execute "
                 "remotely and try again."
             )
+        return cast(_DeploymentStackModel, stack)
+
+    def _resolve_server_runnable_deployment_stack(
+        self,
+        deployment: DeploymentRecord | Deployment,
+        *,
+        operation: Literal["invoke", "curl"],
+    ) -> _DeploymentStackModel:
+        """Resolve and validate the stack that will execute a deployment."""
+        deployment_record = self._unwrap_deployment_record(deployment)
+        stack = self._resolve_deployment_stack(deployment_record)
+        ensure_stack_is_server_runnable(
+            zen_store=self._client_ref._client().zen_store,
+            stack=stack,
+            operation=operation,
+            flow=deployment_record.flow,
+            version=deployment_record.version,
+        )
         return stack
 
     def _ensure_deployment_server_runnable(
@@ -1771,14 +1798,9 @@ class _DeploymentsAPI:
         operation: Literal["invoke", "curl"],
     ) -> None:
         """Fail early if a stored deployment cannot run from the server."""
-        deployment_record = self._unwrap_deployment_record(deployment)
-        stack = self._resolve_deployment_stack(deployment_record)
-        ensure_stack_is_server_runnable(
-            zen_store=self._client_ref._client().zen_store,
-            stack=stack,
+        self._resolve_server_runnable_deployment_stack(
+            deployment,
             operation=operation,
-            flow=deployment_record.flow,
-            version=deployment_record.version,
         )
 
     def get(
@@ -1821,7 +1843,11 @@ class _DeploymentsAPI:
             deployment,
             known_before_resolution=known_before,
         )
-        self._ensure_deployment_server_runnable(deployment, operation="invoke")
+        deployment_stack = self._resolve_server_runnable_deployment_stack(
+            deployment,
+            operation="invoke",
+        )
+        deployment_metadata = deployment_metadata_for_stack_model(deployment_stack)
 
         zenml_client = self._client_ref._client()
         trigger_pipeline = getattr(zenml_client, "trigger_pipeline", None)
@@ -1853,7 +1879,11 @@ class _DeploymentsAPI:
             raise KitaruBackendError(
                 "Deployment invocation did not produce a pipeline run."
             )
-        return FlowHandle(run)
+        return FlowHandle(
+            run,
+            analytics_metadata=deployment_metadata,
+            track_terminal_if_finished=True,
+        )
 
     def _enforce_create_exclusive_tags(
         self,

--- a/src/kitaru/config.py
+++ b/src/kitaru/config.py
@@ -480,6 +480,13 @@ def _list_stack_entries() -> list[_StackListEntry]:
     return _config_stacks._list_stack_entries(client_factory=Client)
 
 
+def classify_stack_model_deployment_type(
+    stack_model: object,
+) -> _config_stacks._StackShowType:
+    """Classify an already-hydrated stack into Kitaru's deployment taxonomy."""
+    return _config_stacks.classify_stack_model_deployment_type(stack_model)
+
+
 def classify_stack_deployment_type(
     name_or_id: str | None = None,
 ) -> _config_stacks._StackShowType:

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -50,6 +50,9 @@ from kitaru._source_aliases import (
     build_pipeline_source_alias,
     callable_name,
 )
+from kitaru._telemetry import (
+    deployment_metadata_for_stack as _deployment_metadata_for_stack,
+)
 from kitaru.analytics import AnalyticsEvent, track
 from kitaru.config import (
     KITARU_MODEL_REGISTRY_ENV,
@@ -61,7 +64,6 @@ from kitaru.config import (
     _read_env_model_registry,
     _read_model_registry_config,
     build_frozen_execution_spec,
-    classify_stack_deployment_type,
     image_settings_to_docker_settings,
     persist_frozen_execution_spec,
     resolve_connection_config,
@@ -692,32 +694,6 @@ def _safe_classify_run_failure(run: PipelineRunResponse) -> FailureOrigin:
         return FailureOrigin.UNKNOWN
 
 
-def _deployment_metadata_for_stack(stack_name_or_id: str | None) -> dict[str, str]:
-    """Return privacy-safe flow analytics deployment metadata.
-
-    The metadata deliberately contains only the coarse Kitaru-owned deployment
-    class and a diagnostic source. It never includes stack names, stack IDs,
-    project names, server URLs, or other user-controlled selectors.
-    """
-    try:
-        deployment_type = classify_stack_deployment_type(stack_name_or_id)
-    except Exception:
-        logger.debug(
-            "Failed to classify stack deployment type for analytics (selector=%r).",
-            stack_name_or_id,
-            exc_info=True,
-        )
-        return {
-            "kitaru_deployment_type": "unknown",
-            "deployment_type_source": "kitaru_stack_inference_failed",
-        }
-
-    return {
-        "kitaru_deployment_type": deployment_type,
-        "deployment_type_source": "kitaru_stack_inference",
-    }
-
-
 def _duration_metadata_from_run(
     run: PipelineRunResponse,
     *,
@@ -1311,6 +1287,7 @@ class _FlowDefinition:
             replayed_run,
             observed_started_at=observed_started_at,
             analytics_metadata=deployment_metadata,
+            track_terminal_if_finished=True,
         )
 
     def _submit(

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -799,6 +799,7 @@ class FlowHandle:
         *,
         observed_started_at: float | None = None,
         analytics_metadata: dict[str, Any] | None = None,
+        track_terminal_if_finished: bool = False,
     ) -> None:
         """Initialize a flow handle.
 
@@ -806,6 +807,8 @@ class FlowHandle:
             run: Initial pipeline run response.
             observed_started_at: SDK-observed start time from ``time.perf_counter``.
             analytics_metadata: Privacy-safe metadata captured at submission time.
+            track_terminal_if_finished: Emit terminal analytics immediately when
+                the initial run is already terminal.
         """
         self._run = run
         self._run_id = run.id
@@ -816,6 +819,13 @@ class FlowHandle:
             else time.perf_counter()
         )
         self._analytics_metadata = dict(analytics_metadata or {})
+
+        if track_terminal_if_finished and run.status.is_finished:
+            if not run.status.is_successful:
+                origin = _safe_classify_run_failure(run)
+                self._track_terminal_once(run, failure_origin=origin)
+            else:
+                self._track_terminal_once(run)
 
     @property
     def exec_id(self) -> str:
@@ -1371,6 +1381,7 @@ class _FlowDefinition:
             run,
             observed_started_at=observed_started_at,
             analytics_metadata=deployment_metadata,
+            track_terminal_if_finished=True,
         )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, Mock, call, patch
 from uuid import UUID, uuid4
 
 import pytest
-from zenml.enums import ArtifactSaveType
+from zenml.enums import ArtifactSaveType, StackComponentType
 from zenml.enums import ExecutionStatus as ZenMLExecutionStatus
 from zenml.exceptions import EntityExistsError
 from zenml.models import PipelineRunResponse, StepRunResponse
@@ -199,6 +199,30 @@ class _DummyRun:
 
     def get_resources(self) -> Any:
         return SimpleNamespace(active_wait_condition=self._active_wait_condition)
+
+    def get_hydrated_version(self) -> _DummyRun:
+        return self
+
+
+def _server_stack_model(
+    *,
+    name: str = "prod-stack",
+    stack_id: str = "stack-secret-id",
+    orchestrator_flavor: str = "kubernetes",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=stack_id,
+        name=name,
+        components={
+            StackComponentType.ORCHESTRATOR: [
+                SimpleNamespace(
+                    name="orchestrator",
+                    flavor=SimpleNamespace(name=orchestrator_flavor),
+                    configuration={},
+                )
+            ]
+        },
+    )
 
 
 class _DummySnapshot:
@@ -1584,6 +1608,109 @@ def test_deployment_facade_invoke_returns_flow_handle_with_parameters() -> None:
     assert invoke_kwargs["snapshot_name_or_id"] == deployment.deployment_id
     assert invoke_kwargs["project"] == "proj"
     assert invoke_kwargs["run_configuration"].parameters == {"question": "hello"}
+
+
+def test_deployments_invoke_completed_run_emits_immediate_terminal_event() -> None:
+    """Already-completed deployment invokes should emit FLOW_TERMINAL once."""
+    run = _as_pipeline_run(
+        _DummyRun(status=ZenMLExecutionStatus.COMPLETED, flow_name="research_flow")
+    )
+    stack = _server_stack_model()
+    snapshot = _DummySnapshot(
+        name="kitaru::research_flow::v1",
+        tags=[deployment_public_tag("default", exclusive=True)],
+        stack=stack,
+    )
+    refresh_client = MagicMock()
+    refresh_client.get_pipeline_run.return_value = run
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(project="proj"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch("kitaru.client.ensure_stack_is_server_runnable"),
+        patch("kitaru.flow.Client", return_value=refresh_client),
+        patch("kitaru.flow.track") as track_mock,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_snapshots.return_value = SimpleNamespace(items=[snapshot])
+        client_mock.get_snapshot.return_value = snapshot
+        client_mock.trigger_pipeline.return_value = run
+
+        client = KitaruClient()
+        client.deployments.get(flow="research_flow", version=1)
+        handle = client.deployments.invoke(
+            flow="research_flow",
+            version=1,
+            inputs={"question": "please do not track this"},
+        )
+        handle.get()
+
+    client_mock.get_stack.assert_not_called()
+    track_mock.assert_called_once()
+    assert track_mock.call_args.args[0] == AnalyticsEvent.FLOW_TERMINAL
+    terminal_metadata = track_mock.call_args.args[1]
+    assert terminal_metadata["status"] == ZenMLExecutionStatus.COMPLETED.value
+    assert terminal_metadata["kitaru_deployment_type"] == "kubernetes"
+    assert terminal_metadata["deployment_type_source"] == "kitaru_stack_inference"
+    assert "prod-stack" not in terminal_metadata.values()
+    assert "stack-secret-id" not in terminal_metadata.values()
+    assert "please do not track this" not in terminal_metadata.values()
+
+
+def test_deployments_invoke_failed_run_emits_immediate_terminal_event() -> None:
+    """Already-failed deployment invokes should emit FLOW_TERMINAL with origin."""
+    run = _as_pipeline_run(
+        _DummyRun(
+            status=ZenMLExecutionStatus.FAILED,
+            flow_name="research_flow",
+            status_reason="user error",
+            exception_traceback="Traceback\nValueError: boom",
+        )
+    )
+    stack = _server_stack_model()
+    snapshot = _DummySnapshot(
+        name="kitaru::research_flow::v1",
+        tags=[deployment_public_tag("default", exclusive=True)],
+        stack=stack,
+    )
+    metadata = {
+        "kitaru_deployment_type": "kubernetes",
+        "deployment_type_source": "kitaru_stack_inference",
+    }
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(project="proj"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch("kitaru.client.ensure_stack_is_server_runnable"),
+        patch(
+            "kitaru.client.deployment_metadata_for_stack_model",
+            return_value=metadata,
+        ) as metadata_mock,
+        patch("kitaru.flow.track") as track_mock,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_snapshots.return_value = SimpleNamespace(items=[snapshot])
+        client_mock.get_snapshot.return_value = snapshot
+        client_mock.trigger_pipeline.return_value = run
+
+        client = KitaruClient()
+        client.deployments.get(flow="research_flow", version=1)
+        handle = client.deployments.invoke(flow="research_flow", version=1)
+
+    assert handle.exec_id == str(run.id)
+    metadata_mock.assert_called_once_with(stack)
+    track_mock.assert_called_once()
+    assert track_mock.call_args.args[0] == AnalyticsEvent.FLOW_TERMINAL
+    terminal_metadata = track_mock.call_args.args[1]
+    assert terminal_metadata["status"] == ZenMLExecutionStatus.FAILED.value
+    assert terminal_metadata["failure_origin"] == FailureOrigin.USER_CODE.value
+    assert terminal_metadata["kitaru_deployment_type"] == "kubernetes"
 
 
 def test_deployments_invoke_warns_for_unknown_explicit_version() -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2096,7 +2096,7 @@ def test_submit_emits_flow_submitted_event() -> None:
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
         patch("kitaru.flow.persist_frozen_execution_spec"),
-        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
+        patch("kitaru._telemetry.classify_stack_deployment_type", return_value="local"),
         patch("kitaru.flow.track") as track_mock,
     ):
         wrapped = flow(lambda x: x)
@@ -2131,7 +2131,7 @@ def test_submit_emits_terminal_event_when_run_already_completed() -> None:
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
         patch("kitaru.flow.persist_frozen_execution_spec"),
-        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
+        patch("kitaru._telemetry.classify_stack_deployment_type", return_value="local"),
         patch("kitaru.flow.track") as track_mock,
     ):
         wrapped = flow(lambda x: x)
@@ -2170,7 +2170,7 @@ def test_submit_emits_terminal_event_with_failure_origin_when_run_already_failed
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
         patch("kitaru.flow.persist_frozen_execution_spec"),
-        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
+        patch("kitaru._telemetry.classify_stack_deployment_type", return_value="local"),
         patch("kitaru.flow.track") as track_mock,
     ):
         wrapped = flow(lambda x: x)
@@ -2207,7 +2207,7 @@ def test_submit_time_terminal_event_is_not_reemitted_by_wait_or_get() -> None:
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
         patch("kitaru.flow.persist_frozen_execution_spec"),
-        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
+        patch("kitaru._telemetry.classify_stack_deployment_type", return_value="local"),
         patch("kitaru.flow.Client", return_value=client_mock),
         patch("kitaru.flow.track") as track_mock,
     ):
@@ -2238,7 +2238,7 @@ def test_submit_defers_terminal_event_when_run_still_running() -> None:
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
         patch("kitaru.flow.persist_frozen_execution_spec"),
-        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
+        patch("kitaru._telemetry.classify_stack_deployment_type", return_value="local"),
         patch("kitaru.flow.track") as track_mock,
     ):
         wrapped = flow(lambda x: x)
@@ -2267,7 +2267,7 @@ def test_submit_classification_failure_does_not_break_flow_execution() -> None:
         patch("kitaru.flow.persist_frozen_execution_spec"),
         patch("kitaru.flow._temporary_active_stack", return_value=nullcontext()),
         patch(
-            "kitaru.flow.classify_stack_deployment_type",
+            "kitaru._telemetry.classify_stack_deployment_type",
             side_effect=RuntimeError("backend unavailable"),
         ),
         patch("kitaru.flow.track") as track_mock,
@@ -2303,7 +2303,7 @@ def test_submit_does_not_emit_when_run_is_none() -> None:
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
         patch("kitaru.flow.persist_frozen_execution_spec"),
-        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
+        patch("kitaru._telemetry.classify_stack_deployment_type", return_value="local"),
         patch("kitaru.flow.track") as track_mock,
         pytest.raises(KitaruRuntimeError, match="did not produce"),
     ):
@@ -2333,7 +2333,10 @@ def test_replay_success_emits_requested_and_replayed_events() -> None:
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
         patch("kitaru.flow.persist_frozen_execution_spec"),
-        patch("kitaru.flow.classify_stack_deployment_type", return_value="kubernetes"),
+        patch(
+            "kitaru._telemetry.classify_stack_deployment_type",
+            return_value="kubernetes",
+        ),
         patch(
             "kitaru.flow.build_replay_plan",
             return_value=ReplayPlan(
@@ -2364,6 +2367,117 @@ def test_replay_success_emits_requested_and_replayed_events() -> None:
     assert replayed_call.args[1]["deployment_type_source"] == "kitaru_stack_inference"
 
 
+def test_replay_emits_immediate_terminal_event_when_replayed_run_completed() -> None:
+    """Already-completed replayed runs should emit FLOW_TERMINAL immediately."""
+    source_run = _DummyRun(status=ExecutionStatus.COMPLETED)
+    replayed_run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[("step", "output", 42)],
+    )
+    configured_pipeline = MagicMock()
+    configured_pipeline.replay.return_value = replayed_run
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.side_effect = [source_run, replayed_run]
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch("kitaru.flow.Client", return_value=client_mock),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(),
+        ),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch(
+            "kitaru._telemetry.classify_stack_deployment_type",
+            return_value="kubernetes",
+        ),
+        patch(
+            "kitaru.flow.build_replay_plan",
+            return_value=ReplayPlan(
+                original_run_id=str(source_run.id),
+                steps_to_skip=set(),
+                input_overrides={},
+                step_input_overrides={},
+            ),
+        ),
+        patch("kitaru.flow.track") as track_mock,
+    ):
+        wrapped = flow(lambda topic: topic)
+        handle = wrapped.replay(str(source_run.id), from_="write")
+        handle.get()
+
+    events = [call_args.args[0] for call_args in track_mock.call_args_list]
+    assert events == [
+        AnalyticsEvent.REPLAY_REQUESTED,
+        AnalyticsEvent.FLOW_REPLAYED,
+        AnalyticsEvent.FLOW_TERMINAL,
+    ]
+    terminal_metadata = track_mock.call_args_list[2].args[1]
+    assert terminal_metadata["status"] == ExecutionStatus.COMPLETED.value
+    assert terminal_metadata["kitaru_deployment_type"] == "kubernetes"
+    assert terminal_metadata["deployment_type_source"] == "kitaru_stack_inference"
+
+
+def test_replay_emits_immediate_terminal_event_when_replayed_run_failed() -> None:
+    """Already-failed replayed runs should emit FLOW_TERMINAL with origin."""
+    source_run = _DummyRun(status=ExecutionStatus.COMPLETED)
+    replayed_run = _DummyRun(
+        status=ExecutionStatus.FAILED,
+        status_reason="user error",
+        traceback="Traceback\nValueError: boom",
+    )
+    configured_pipeline = MagicMock()
+    configured_pipeline.replay.return_value = replayed_run
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch("kitaru.flow.Client") as client_cls,
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(),
+        ),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch(
+            "kitaru._telemetry.classify_stack_deployment_type",
+            return_value="kubernetes",
+        ),
+        patch(
+            "kitaru.flow.build_replay_plan",
+            return_value=ReplayPlan(
+                original_run_id=str(source_run.id),
+                steps_to_skip=set(),
+                input_overrides={},
+                step_input_overrides={},
+            ),
+        ),
+        patch("kitaru.flow.track") as track_mock,
+    ):
+        client_cls.return_value.get_pipeline_run.return_value = source_run
+        wrapped = flow(lambda topic: topic)
+        wrapped.replay(str(source_run.id), from_="write")
+
+    events = [call_args.args[0] for call_args in track_mock.call_args_list]
+    assert events == [
+        AnalyticsEvent.REPLAY_REQUESTED,
+        AnalyticsEvent.FLOW_REPLAYED,
+        AnalyticsEvent.FLOW_TERMINAL,
+    ]
+    terminal_metadata = track_mock.call_args_list[2].args[1]
+    assert terminal_metadata["status"] == ExecutionStatus.FAILED.value
+    assert terminal_metadata["failure_origin"] == FailureOrigin.USER_CODE.value
+    assert terminal_metadata["kitaru_deployment_type"] == "kubernetes"
+
+
 def test_replay_failure_emits_requested_then_failed_events() -> None:
     """Failed replay should emit REPLAY_REQUESTED then REPLAY_FAILED."""
     source_run = _DummyRun(status=ExecutionStatus.COMPLETED)
@@ -2382,7 +2496,10 @@ def test_replay_failure_emits_requested_then_failed_events() -> None:
         ),
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
-        patch("kitaru.flow.classify_stack_deployment_type", return_value="kubernetes"),
+        patch(
+            "kitaru._telemetry.classify_stack_deployment_type",
+            return_value="kubernetes",
+        ),
         patch(
             "kitaru.flow.build_replay_plan",
             return_value=ReplayPlan(
@@ -2431,7 +2548,10 @@ def test_replay_none_run_emits_replay_failed_with_runtime_origin() -> None:
         ),
         patch("kitaru.flow.resolve_connection_config", return_value=object()),
         patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
-        patch("kitaru.flow.classify_stack_deployment_type", return_value="kubernetes"),
+        patch(
+            "kitaru._telemetry.classify_stack_deployment_type",
+            return_value="kubernetes",
+        ),
         patch(
             "kitaru.flow.build_replay_plan",
             return_value=ReplayPlan(
@@ -2635,6 +2755,34 @@ def test_flow_handle_wait_still_raises_when_classify_fails() -> None:
     assert "duration_seconds" not in metadata
     assert "checkpoint_count" not in metadata
     assert "checkpoint_count_source" not in metadata
+
+
+def test_flow_handle_constructor_terminal_failure_classification_falls_back() -> None:
+    """Constructor-time terminal telemetry should not raise if classification fails."""
+    failed = _DummyRun(
+        status=ExecutionStatus.FAILED,
+        status_reason="user error",
+        traceback="Traceback\nValueError: boom",
+    )
+
+    with (
+        patch(
+            "kitaru.flow._classify_run_failure",
+            side_effect=RuntimeError("unexpected shape"),
+        ),
+        patch("kitaru.flow.track") as track_mock,
+    ):
+        handle = FlowHandle(
+            _as_pipeline_run(failed),
+            track_terminal_if_finished=True,
+        )
+
+    assert handle.exec_id == str(failed.id)
+    track_mock.assert_called_once()
+    assert track_mock.call_args.args[0] == AnalyticsEvent.FLOW_TERMINAL
+    metadata = track_mock.call_args.args[1]
+    assert metadata["status"] == ExecutionStatus.FAILED.value
+    assert metadata["failure_origin"] == FailureOrigin.UNKNOWN.value
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2111,6 +2111,143 @@ def test_submit_emits_flow_submitted_event() -> None:
     )
 
 
+def test_submit_emits_terminal_event_when_run_already_completed() -> None:
+    """_submit should emit FLOW_TERMINAL immediately for already terminal runs."""
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[("step", "output", 42)],
+    )
+    configured_pipeline = MagicMock(return_value=run)
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(),
+        ),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
+        patch("kitaru.flow.track") as track_mock,
+    ):
+        wrapped = flow(lambda x: x)
+        wrapped.run(123)
+
+    assert track_mock.call_count == 2
+    submitted_call, terminal_call = track_mock.call_args_list
+    assert submitted_call.args[0] == AnalyticsEvent.FLOW_SUBMITTED
+    assert terminal_call.args[0] == AnalyticsEvent.FLOW_TERMINAL
+    terminal_metadata = terminal_call.args[1]
+    assert terminal_metadata["status"] == ExecutionStatus.COMPLETED.value
+    assert terminal_metadata["kitaru_deployment_type"] == "local"
+    assert terminal_metadata["deployment_type_source"] == "kitaru_stack_inference"
+
+
+def test_submit_emits_terminal_event_with_failure_origin_when_run_already_failed() -> (
+    None
+):
+    """_submit terminal telemetry should include failure origin for failed runs."""
+    run = _DummyRun(
+        status=ExecutionStatus.FAILED,
+        status_reason="user error",
+        traceback="Traceback\nValueError: boom",
+    )
+    configured_pipeline = MagicMock(return_value=run)
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(),
+        ),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
+        patch("kitaru.flow.track") as track_mock,
+    ):
+        wrapped = flow(lambda x: x)
+        wrapped.run(123)
+
+    assert track_mock.call_count == 2
+    submitted_call, terminal_call = track_mock.call_args_list
+    assert submitted_call.args[0] == AnalyticsEvent.FLOW_SUBMITTED
+    assert terminal_call.args[0] == AnalyticsEvent.FLOW_TERMINAL
+    terminal_metadata = terminal_call.args[1]
+    assert terminal_metadata["status"] == ExecutionStatus.FAILED.value
+    assert terminal_metadata["failure_origin"] == FailureOrigin.USER_CODE.value
+
+
+def test_submit_time_terminal_event_is_not_reemitted_by_wait_or_get() -> None:
+    """Submit-time FLOW_TERMINAL should not be duplicated by wait()/get()."""
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[("step", "output", 42)],
+    )
+    configured_pipeline = MagicMock(return_value=run)
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = run
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(),
+        ),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
+        patch("kitaru.flow.Client", return_value=client_mock),
+        patch("kitaru.flow.track") as track_mock,
+    ):
+        wrapped = flow(lambda x: x)
+        handle = wrapped.run(123)
+        handle.wait()
+        handle.get()
+
+    events = [call_args.args[0] for call_args in track_mock.call_args_list]
+    assert events.count(AnalyticsEvent.FLOW_SUBMITTED) == 1
+    assert events.count(AnalyticsEvent.FLOW_TERMINAL) == 1
+
+
+def test_submit_defers_terminal_event_when_run_still_running() -> None:
+    """_submit should only emit FLOW_SUBMITTED for non-terminal runs."""
+    run = _DummyRun(status=ExecutionStatus.RUNNING)
+    configured_pipeline = MagicMock(return_value=run)
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(),
+        ),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch("kitaru.flow.classify_stack_deployment_type", return_value="local"),
+        patch("kitaru.flow.track") as track_mock,
+    ):
+        wrapped = flow(lambda x: x)
+        wrapped.run(123)
+
+    assert track_mock.call_count == 1
+    assert track_mock.call_args.args[0] == AnalyticsEvent.FLOW_SUBMITTED
+
+
 def test_submit_classification_failure_does_not_break_flow_execution() -> None:
     """Deployment classification failures should become unknown metadata only."""
     run = _DummyRun(status=ExecutionStatus.RUNNING)


### PR DESCRIPTION
## What changed

- Emit `AnalyticsEvent.FLOW_TERMINAL` immediately when a returned `FlowHandle` already points at a finished run.
- Apply that behavior consistently across:
  - direct `flow.run(...)`
  - `flow.replay(...)`
  - `client.deployments.invoke(...)` / deployment facade invoke
- Treat deployment invoke as a thick telemetry surface:
  - invoked runs now carry the same privacy-safe deployment-type metadata into terminal telemetry
  - metadata remains low-cardinality and avoids stack names/IDs, flow names, project names, URLs, inputs, paths, prompts, and secrets
- Add shared internal telemetry helpers in `src/kitaru/_telemetry.py`.
- Add stack-model classification support so invoke can classify the already-resolved deployment stack without a second backend stack fetch.
- Add regression tests for completed/failed immediate terminal events, failure-origin classification, dedup after `wait()` / `get()`, invoke metadata privacy, and replay/invoke parity.

## Why

For local or very fast Kitaru executions, ZenML can hand Kitaru back a run that is already terminal. Before this PR, Kitaru could log the start-ish event (`FLOW_SUBMITTED` / replay/invoke path) but miss the terminal/run-ended event unless user code later called `wait()` or `get()`.

Concrete story: the flow starts, finishes almost immediately, ZenML says “here is your completed run,” and Kitaru used to walk away after logging only the beginning. Now the handle notices “this run is already done” and logs the terminal event immediately.

This matters especially for example/local usage where many runs are short-lived and users often call `.run()` / invoke / replay without explicitly waiting afterward.

## Key implementation decisions

- `FlowHandle` owns terminal telemetry emission and deduplication through `track_terminal_if_finished=True`; call sites opt into that behavior rather than duplicating terminal-event code.
- Deployment metadata logic moved into a shared internal telemetry helper so `flow.py` and `client.py` use the same privacy-safe payload shape.
- Deployment invoke classifies the already-resolved deployment stack model instead of reducing it to a string and re-fetching the same stack.
- No live Mixpanel proof script was added, because that would either need real analytics credentials or would intentionally inject test events into production analytics. Unit tests prove the SDK calls the analytics sink with expected events and metadata.

## Reviewer Notes

Please focus on:

- `src/kitaru/flow.py`: `FlowHandle.__init__`, replay handle construction, submit handle construction.
- `src/kitaru/client.py`: deployment invoke path and resolved-stack metadata propagation.
- `src/kitaru/_telemetry.py` and `src/kitaru/_config/_stacks.py`: privacy-safe metadata helper and stack-model classification.
- `tests/test_flow.py` / `tests/test_client.py`: replay + invoke parity and dedup regression tests.

Useful verification commands:

```bash
uv run pytest tests/test_flow.py -k "submit or replay or terminal"
uv run pytest tests/test_flow.py tests/test_client.py tests/test_config.py
just check
just test
```

Validation already run locally:

- focused telemetry tests: `12 passed`
- `uv run pytest tests/test_flow.py tests/test_client.py tests/test_config.py`: `445 passed`
- `just check`: passed
- `just test`: `1679 passed, 8 skipped`

Also ran the `/simplify` review pass before the follow-up commit; its main finding was to avoid an extra stack re-fetch in deployment invoke, which is addressed by stack-model classification.
