### PR TITLE
Fix `HitlConfig` JSON serialization for pydantic-ai-slim 1.86+

### DIFF
--- a/src/kitaru/adapters/pydantic_ai/_hitl.py
+++ b/src/kitaru/adapters/pydantic_ai/_hitl.py
@@ -1,19 +1,33 @@
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import Any
 
+from pydantic import ConfigDict, field_serializer
+from pydantic.dataclasses import dataclass
 from pydantic_ai import Tool
 
 _HITL_MARKER = '_kitaru_hitl_config'
 _HITL_METADATA_KEY = 'kitaru_hitl_config'
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, config=ConfigDict(arbitrary_types_allowed=True))
 class HitlConfig:
     question: str | None = None
     name: str | None = None
+    # ``schema`` carries the *runtime* class for human-input validation (e.g.
+    # ``bool``). It must remain the live class so ``kitaru.wait(schema=...)``
+    # and ``request.schema is bool`` checks downstream still work. Pydantic AI
+    # 1.86+ exposes per-tool ``metadata`` through ``AgentRunResult._state``,
+    # so the surrounding agent result is now JSON-serialized end-to-end. The
+    # serializer below converts unserializable type objects to a stable string
+    # name only on the dump path; the in-memory value is unchanged.
     schema: Any = None
     question_arg: str | None = 'question'
+
+    @field_serializer('schema')
+    def _serialize_schema(self, value: Any, _info: Any) -> Any:
+        if isinstance(value, type):
+            return f'{value.__module__}.{value.__qualname__}'
+        return value
 
 
 def _config_from_target(target: object) -> HitlConfig | None:

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -367,6 +367,66 @@ class TestResolveHitlQuestion:
         assert resolve_hitl_question(config, {"question": "ignored"}) == "static only"
 
 
+class TestHitlConfigJsonSerialization:
+    """``HitlConfig`` round-trips through Pydantic JSON dumps without leaking
+    class objects.
+
+    Regression for an end-to-end break under pydantic-ai-slim 1.86+: that
+    release surfaces per-tool ``metadata`` through
+    ``AgentRunResult._state.last_model_request_parameters``, which means
+    Kitaru's auto-checkpoint output (an ``AgentRunResult``) is fully
+    JSON-serialized by ZenML's ``DataclassMaterializer``. The walked tree
+    includes every tool's ``metadata['kitaru_hitl_config']``, and a raw class
+    object in ``HitlConfig.schema`` (e.g. ``schema=bool``) crashes the dump
+    with ``PydanticSerializationError: Unable to serialize unknown type:
+    <class 'type'>``.
+    """
+
+    def test_dump_python_json_mode_stringifies_class_schema(self) -> None:
+        from pydantic import TypeAdapter
+
+        from kitaru.adapters.pydantic_ai._hitl import HitlConfig
+
+        config = HitlConfig(question="Approve?", schema=bool)
+        dumped = TypeAdapter(HitlConfig).dump_python(config, mode="json")
+
+        assert dumped["schema"] == "builtins.bool"
+        assert dumped["question"] == "Approve?"
+
+    def test_runtime_schema_is_unchanged_after_dump(self) -> None:
+        from pydantic import TypeAdapter
+
+        from kitaru.adapters.pydantic_ai._hitl import HitlConfig
+
+        config = HitlConfig(schema=bool)
+        TypeAdapter(HitlConfig).dump_python(config, mode="json")
+        # Runtime field still holds the live class so downstream identity
+        # checks (e.g. ``request.schema is bool``) and ``kitaru.wait(schema=...)``
+        # validation continue to work.
+        assert config.schema is bool
+
+    def test_nested_in_tool_metadata_dict_serializes(self) -> None:
+        """Mirror the failing path: HitlConfig nested inside a ``dict[str, Any]``."""
+        from pydantic import TypeAdapter
+
+        from kitaru.adapters.pydantic_ai._hitl import HitlConfig
+
+        config = HitlConfig(schema=bool)
+        metadata = {"kitaru_hitl_config": config, "other": "ok"}
+        dumped = TypeAdapter(dict).dump_python(metadata, mode="json")
+
+        assert dumped["kitaru_hitl_config"]["schema"] == "builtins.bool"
+        assert dumped["other"] == "ok"
+
+    def test_none_schema_passes_through(self) -> None:
+        from pydantic import TypeAdapter
+
+        from kitaru.adapters.pydantic_ai._hitl import HitlConfig
+
+        dumped = TypeAdapter(HitlConfig).dump_python(HitlConfig(), mode="json")
+        assert dumped["schema"] is None
+
+
 class TestUseGranular:
     def _make_agent(self, *, granular: bool):
         from pydantic_ai import Agent


### PR DESCRIPTION
## Summary

`pydantic-ai-slim` 1.86 (which `develop` now requires after #270) changed how per-tool `metadata` is plumbed through the result tree: it's reachable at `result._state.last_model_request_parameters.function_tools[*].metadata`. That means the `AgentRunResult` is fully JSON-serialized end-to-end when Kitaru's auto-checkpoint stores it through ZenML's `DataclassMaterializer` (`TypeAdapter.dump_python(..., mode="json")`).

That walk hits `HitlConfig.schema = bool` — a raw class object — and crashes with `PydanticSerializationError: Unable to serialize unknown type: <class 'type'>`. **Any user with `@hitl_tool(schema=bool)` (the documented HITL pattern) plus `KitaruAgent` auto-checkpointing would have hit this on the first run.** It surfaced when the smoke test for `examples/integrations/pydantic_ai_agent/pydantic_ai_adapter.py` started failing on develop.

## What changed

- `src/kitaru/adapters/pydantic_ai/_hitl.py` — convert `HitlConfig` from a stdlib `@dataclass(frozen=True)` to a `pydantic.dataclasses.dataclass` and add `@field_serializer("schema")` that converts class objects to `"<module>.<qualname>"` strings when serialized.
- `tests/test_pydantic_ai_adapter.py` — add four regression tests under `TestHitlConfigJsonSerialization` that exercise `TypeAdapter.dump_python(mode="json")` directly, including the nested `dict[str, Any]` shape that mirrors how `tool_def.metadata` is walked inside `AgentRunResult`.

## Why a Pydantic dataclass

The `schema` field has to stay the live class at runtime — downstream code does `request.schema is bool` identity checks, and `kitaru.wait(schema=schema)` uses it to validate the human-supplied input. We only need the JSON-dump path to produce something serializable. A `field_serializer` converts the value on dump while leaving the in-memory attribute untouched.

## Reviewer Notes

Two things worth scrutinising:

1. **Did anything rely on `HitlConfig` being a stdlib dataclass specifically?** Pydantic dataclasses are stdlib-compatible, but watch for callers using `dataclasses.replace(config, ...)` or `dataclasses.fields(config)`. I grepped — only `isinstance(config, HitlConfig)` and attribute access. Should be safe but worth a second look.
2. **Did I miss a place where `HitlConfig` could leak into JSON?** The fix converts class objects via `field_serializer` only on the `schema` field. If anyone adds another `Any`-typed field that can hold non-JSON-friendly values, the same crash will recur. Worth a comment in `HitlConfig` reminding contributors of the constraint — already added inline.

### Reproduce the bug (without the fix)

On a checkout of `develop` *before* this PR lands, run:

```bash
uv sync --extra local --extra llm --extra mcp --extra pydantic-ai
uv run python examples/integrations/pydantic_ai_agent/pydantic_ai_adapter.py
```

Eight demos pass, then `hitl_wiring` fails with:

```
Kitaru: Checkpoint `hitl_demo_<run_tag>` failed: Unable to serialize unknown type: <class 'type'>
1 demo(s) failed:
  - hitl_wiring: PydanticSerializationError: Unable to serialize unknown type: <class 'type'>
```

With this PR applied, all nine demos pass. The same example is exercised by `scripts/smoke-test.sh` so the pre-release smoke run now goes green.

### Verification

- `uv run pytest tests/test_pydantic_ai_adapter.py tests/test_phase17_pydantic_ai_adapter.py` → 54 passed
- `just test` → 1685 passed, 8 skipped
- `just lint` / `just typecheck` / `just format-check` / `just typos` → all green
- The four new regression tests in `TestHitlConfigJsonSerialization` fail without the fix and pass with it.

### Release context

This was found while preparing a 0.8.0 release on `develop`. Once this lands I'll re-run the smoke test on develop and trigger the release workflow. CHANGELOG already has an `[Unreleased]` `### Fixed` section that I'll add a bullet to as part of the release dispatch.

## Test plan

- [x] `just test` passes locally (1685 passed, 8 skipped)
- [x] All four new regression tests in `TestHitlConfigJsonSerialization` pass
- [x] `examples/integrations/pydantic_ai_agent/pydantic_ai_adapter.py` smoke demo (`hitl_wiring`) runs to completion locally
- [x] Existing 54 PydanticAI adapter tests still pass
- [ ] CI green