### PR TITLE
Add `/newsletter` page and signup endpoint

### DIFF
--- a/site/src/lib/formTypes.ts
+++ b/site/src/lib/formTypes.ts
@@ -1,6 +1,7 @@
 export const FORM_TYPES = {
   DEMO_REQUEST: 'demo-request',
   WAITLIST: 'waitlist',
+  NEWSLETTER: 'newsletter',
 } as const;
 
 export type FormType = typeof FORM_TYPES[keyof typeof FORM_TYPES];

--- a/site/src/pages/api/newsletter.ts
+++ b/site/src/pages/api/newsletter.ts
@@ -32,8 +32,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
       return jsonResponse({ error: 'KV not configured' }, 500);
     }
 
-    // Duplicate detection: a hit on the same email returns alreadySubscribed
-    // without re-firing the Segment event so signup counts stay clean.
+    // Skip Segment re-fire on duplicate so signup counts stay clean.
     const existing = await kv.get(email);
     if (existing) {
       return jsonResponse({ ok: true, alreadySubscribed: true });

--- a/site/src/pages/api/newsletter.ts
+++ b/site/src/pages/api/newsletter.ts
@@ -1,0 +1,82 @@
+import type { APIRoute } from 'astro';
+import { FORM_TYPES } from '../../lib/formTypes';
+import { segmentCall } from '../../lib/segment';
+
+export const prerender = false;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const POST: APIRoute = async ({ request, locals }) => {
+  try {
+    const data = await request.json();
+    const email = String(data.email ?? '').trim().toLowerCase();
+
+    if (!email || !EMAIL_RE.test(email)) {
+      return jsonResponse({ error: 'Invalid email' }, 400);
+    }
+
+    const runtime = (locals as { runtime?: { env?: Record<string, unknown>; ctx?: { waitUntil?: (p: Promise<unknown>) => void } } }).runtime;
+    const env = runtime?.env;
+    const kv = env?.NEWSLETTER_KV as
+      | { get: (k: string) => Promise<string | null>; put: (k: string, v: string) => Promise<void> }
+      | undefined;
+
+    if (!kv) {
+      return jsonResponse({ error: 'KV not configured' }, 500);
+    }
+
+    // Duplicate detection: a hit on the same email returns alreadySubscribed
+    // without re-firing the Segment event so signup counts stay clean.
+    const existing = await kv.get(email);
+    if (existing) {
+      return jsonResponse({ ok: true, alreadySubscribed: true });
+    }
+
+    await kv.put(email, JSON.stringify({
+      email,
+      timestamp: new Date().toISOString(),
+      source: 'newsletter',
+      formType: FORM_TYPES.NEWSLETTER,
+    }));
+
+    const referer = request.headers.get('referer') ?? '';
+    const userAgent = request.headers.get('user-agent') ?? '';
+    const segmentContext = { page: { url: referer }, userAgent };
+
+    const identifyCall = segmentCall('identify', {
+      userId: email,
+      traits: { email },
+      context: segmentContext,
+    });
+    const trackCall = segmentCall('track', {
+      userId: email,
+      event: 'Newsletter Signup',
+      properties: {
+        email,
+        source: 'newsletter',
+        formType: FORM_TYPES.NEWSLETTER,
+      },
+      context: segmentContext,
+    });
+
+    const analyticsCalls = Promise.all([identifyCall, trackCall]).catch((analyticsError) => {
+      console.error('[segment] newsletter analytics failed', analyticsError);
+    });
+    if (runtime?.ctx?.waitUntil) {
+      runtime.ctx.waitUntil(analyticsCalls);
+    } else {
+      await analyticsCalls;
+    }
+
+    return jsonResponse({ ok: true, alreadySubscribed: false });
+  } catch {
+    return jsonResponse({ error: 'Server error' }, 500);
+  }
+};

--- a/site/src/pages/newsletter.astro
+++ b/site/src/pages/newsletter.astro
@@ -20,7 +20,7 @@ import Footer from '../components/Footer.astro';
           Updates from the team building <span class="accent-shimmer">durable agents</span>.
         </h1>
         <p class="nl-subtitle">
-          One email field. We&rsquo;ll send the occasional release note, tutorial, and writing on durable execution. No spam.
+          We&rsquo;ll send the occasional release note, tutorial, and writing on durable execution. No spam.
         </p>
 
         <form id="newsletterForm" class="nl-form" novalidate>

--- a/site/src/pages/newsletter.astro
+++ b/site/src/pages/newsletter.astro
@@ -24,7 +24,7 @@ import Footer from '../components/Footer.astro';
         </p>
 
         <form id="newsletterForm" class="nl-form" novalidate>
-          <label for="nl-email" class="visually-hidden">Email</label>
+          <label for="nl-email" class="sr-only">Email</label>
           <div class="nl-field-row">
             <input
               type="email"
@@ -39,7 +39,7 @@ import Footer from '../components/Footer.astro';
           <p class="nl-error" id="newsletterError" aria-live="polite"></p>
         </form>
 
-        <div id="newsletterSuccess" class="nl-success" hidden>
+        <div id="newsletterSuccess" class="nl-success" role="status" aria-live="polite" hidden>
           <h2 id="newsletterSuccessHeadline">You&rsquo;re on the list.</h2>
           <p id="newsletterSuccessBody">We&rsquo;ll be in touch.</p>
         </div>
@@ -154,18 +154,6 @@ import Footer from '../components/Footer.astro';
     margin: 0;
   }
 
-  .visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    white-space: nowrap;
-    border: 0;
-  }
-
   @keyframes nl-fade-up {
     from { opacity: 0; transform: translateY(10px); }
     to { opacity: 1; transform: translateY(0); }
@@ -231,10 +219,9 @@ import Footer from '../components/Footer.astro';
       form.hidden = true;
       if (successEl) successEl.hidden = false;
 
-      const win = window as Window & { analytics?: { track?: (event: string, props?: Record<string, unknown>) => void }; plausible?: (event: string, opts?: { props?: Record<string, string> }) => void };
       const eventName = result.alreadySubscribed ? 'Newsletter Already Subscribed' : 'Newsletter Signup Confirmed';
-      win.analytics?.track?.(eventName, { source: 'newsletter' });
-      win.plausible?.(eventName, { props: { source: 'newsletter' } });
+      window.analytics?.track?.(eventName, { source: 'newsletter' });
+      window.plausible?.(eventName, { props: { source: 'newsletter' } });
     } catch {
       if (errorEl) errorEl.textContent = 'Network error. Please try again.';
       submitBtn.disabled = false;

--- a/site/src/pages/newsletter.astro
+++ b/site/src/pages/newsletter.astro
@@ -1,0 +1,244 @@
+---
+import Base from '../layouts/Base.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<Base
+  title="Newsletter | Kitaru"
+  description="Get occasional updates from the Kitaru team — release notes, tutorials, and writing on durable execution for AI agents."
+>
+  <Nav />
+  <main id="main-content">
+    <section class="nl-hero">
+      <div class="nl-card" data-reveal>
+        <span class="pill-badge">
+          <span class="pulse-dot"></span>
+          Kitaru newsletter
+        </span>
+        <h1 class="nl-headline">
+          Updates from the team building <span class="accent-shimmer">durable agents</span>.
+        </h1>
+        <p class="nl-subtitle">
+          One email field. We&rsquo;ll send the occasional release note, tutorial, and writing on durable execution. No spam.
+        </p>
+
+        <form id="newsletterForm" class="nl-form" novalidate>
+          <label for="nl-email" class="visually-hidden">Email</label>
+          <div class="nl-field-row">
+            <input
+              type="email"
+              id="nl-email"
+              name="email"
+              required
+              autocomplete="email"
+              placeholder="you@company.com"
+            />
+            <button type="submit" class="btn-accent nl-submit">Sign me up</button>
+          </div>
+          <p class="nl-error" id="newsletterError" aria-live="polite"></p>
+        </form>
+
+        <div id="newsletterSuccess" class="nl-success" hidden>
+          <h2 id="newsletterSuccessHeadline">You&rsquo;re on the list.</h2>
+          <p id="newsletterSuccessBody">We&rsquo;ll be in touch.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+  <Footer />
+</Base>
+
+<style>
+  .nl-hero {
+    min-height: 70vh;
+    padding: 140px clamp(24px, 5vw, 80px) 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .nl-card {
+    max-width: 560px;
+    width: 100%;
+    text-align: center;
+  }
+
+  .nl-headline {
+    font-size: clamp(2rem, 4.5vw, 3rem);
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: -0.03em;
+    margin: 24px 0 16px;
+    color: var(--color-primary);
+  }
+
+  .nl-subtitle {
+    font-size: 1.05rem;
+    line-height: 1.6;
+    color: var(--color-secondary);
+    margin: 0 auto 32px;
+    max-width: 480px;
+  }
+
+  .nl-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .nl-field-row {
+    display: flex;
+    gap: 10px;
+    align-items: stretch;
+  }
+
+  .nl-field-row input {
+    flex: 1;
+    padding: 14px 16px;
+    font-size: 0.95rem;
+    font-family: var(--font-ui);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    background: var(--color-surface);
+    color: var(--color-primary);
+    transition: border-color 0.2s, box-shadow 0.2s;
+  }
+
+  .nl-field-row input::placeholder {
+    color: var(--color-muted);
+  }
+
+  .nl-field-row input:focus {
+    border-color: var(--color-accent-darker);
+    box-shadow: 0 0 0 3px oklch(0.60 0.17 45 / 0.1);
+    outline: none;
+  }
+
+  .nl-submit {
+    flex-shrink: 0;
+  }
+
+  .nl-submit:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .nl-error {
+    font-size: 0.85rem;
+    color: var(--color-error);
+    margin: 0;
+    min-height: 1.2em;
+    text-align: left;
+  }
+
+  .nl-success {
+    margin-top: 8px;
+    padding: 32px 24px;
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    background: var(--color-surface);
+    animation: nl-fade-up 0.45s ease both;
+  }
+
+  .nl-success h2 {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--color-primary);
+    margin: 0 0 8px;
+  }
+
+  .nl-success p {
+    font-size: 0.95rem;
+    color: var(--color-secondary);
+    margin: 0;
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @keyframes nl-fade-up {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (max-width: 540px) {
+    .nl-hero { padding: 120px 20px 60px; }
+    .nl-field-row {
+      flex-direction: column;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .nl-success {
+      animation: none;
+    }
+  }
+</style>
+
+<script>
+  const form = document.getElementById('newsletterForm') as HTMLFormElement | null;
+  const errorEl = document.getElementById('newsletterError');
+  const successEl = document.getElementById('newsletterSuccess');
+  const headlineEl = document.getElementById('newsletterSuccessHeadline');
+  const bodyEl = document.getElementById('newsletterSuccessBody');
+
+  form?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    if (errorEl) errorEl.textContent = '';
+
+    const emailInput = form.querySelector('#nl-email') as HTMLInputElement;
+    const email = emailInput.value.trim();
+
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      if (errorEl) errorEl.textContent = 'Please enter a valid email address.';
+      return;
+    }
+
+    const submitBtn = form.querySelector('button[type="submit"]') as HTMLButtonElement;
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Submitting…';
+
+    try {
+      const resp = await fetch('/api/newsletter', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      const result = await resp.json() as { ok?: boolean; alreadySubscribed?: boolean; error?: string };
+
+      if (!resp.ok || !result.ok) {
+        if (errorEl) errorEl.textContent = result.error || 'Something went wrong. Please try again.';
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Sign me up';
+        return;
+      }
+
+      if (result.alreadySubscribed && headlineEl && bodyEl) {
+        headlineEl.textContent = 'You’re already on the list.';
+        bodyEl.textContent = 'No need to sign up again — we’ll be in touch.';
+      }
+
+      form.hidden = true;
+      if (successEl) successEl.hidden = false;
+
+      const win = window as Window & { analytics?: { track?: (event: string, props?: Record<string, unknown>) => void }; plausible?: (event: string, opts?: { props?: Record<string, string> }) => void };
+      const eventName = result.alreadySubscribed ? 'Newsletter Already Subscribed' : 'Newsletter Signup Confirmed';
+      win.analytics?.track?.(eventName, { source: 'newsletter' });
+      win.plausible?.(eventName, { props: { source: 'newsletter' } });
+    } catch {
+      if (errorEl) errorEl.textContent = 'Network error. Please try again.';
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Sign me up';
+    }
+  });
+</script>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,3 +14,11 @@ id = "7a952406df5543418f0cb8c4552ee65f"
 [[kv_namespaces]]
 binding = "GET_STARTED_KV"
 id = "a6a7c01a20c841b092649453ef2e0365"
+
+# Run `npx wrangler kv namespace create NEWSLETTER_KV` to mint a real id and
+# replace the placeholder below before deploying. The Worker tolerates the
+# binding being absent (the API route returns 500 with a clear error), so a
+# missing id only breaks production submits, not the build.
+[[kv_namespaces]]
+binding = "NEWSLETTER_KV"
+id = "REPLACE_WITH_REAL_NEWSLETTER_KV_ID"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,10 +15,6 @@ id = "7a952406df5543418f0cb8c4552ee65f"
 binding = "GET_STARTED_KV"
 id = "a6a7c01a20c841b092649453ef2e0365"
 
-# Run `npx wrangler kv namespace create NEWSLETTER_KV` to mint a real id and
-# replace the placeholder below before deploying. The Worker tolerates the
-# binding being absent (the API route returns 500 with a clear error), so a
-# missing id only breaks production submits, not the build.
 [[kv_namespaces]]
 binding = "NEWSLETTER_KV"
-id = "REPLACE_WITH_REAL_NEWSLETTER_KV_ID"
+id = "d2717e825cc84afd973fe5d3e11dc3f4"


### PR DESCRIPTION
## Summary

Adds a bare-bones newsletter signup at `kitaru.ai/newsletter` so we can route people from talks (e.g. an upcoming AI Tinkerers CTA, future webinars) into a tutorial-series list. Mirrors the shape of the existing book-a-demo flow: dedicated KV namespace, dedicated Segment event, dedicated form-type constant.

## What's in the box

- `site/src/pages/newsletter.astro` — single-card hero, single email field, two distinct success states (fresh vs. already-subscribed). Reuses existing visual primitives (`pill-badge`, `pulse-dot`, `accent-shimmer`, `btn-accent`, `.sr-only`).
- `site/src/pages/api/newsletter.ts` — POST endpoint. Validates email, reads `NEWSLETTER_KV` to detect duplicates, writes the record, fires `identify` + `Newsletter Signup` to Segment via `ctx.waitUntil`. Duplicates short-circuit before re-firing Segment so signup counts stay clean.
- `site/src/lib/formTypes.ts` — adds `NEWSLETTER: 'newsletter'` to `FORM_TYPES`.
- `wrangler.toml` — registers the new `NEWSLETTER_KV` binding (real id provisioned).

## Why a new endpoint instead of reusing `/api/waitlist`

`/api/waitlist` is dormant (no UI currently posts to it). I considered reusing it with a `source: 'newsletter'` discriminator, but the demo and waitlist precedent on this codebase is "every public form ⇒ its own route + KV + Segment event". That's the right shape because Slack/ESP routing rules downstream subscribe by event name, and the moment newsletter grows a second stage (confirmation email, ESP enrollment, double opt-in) the shared route would have to grow conditionals to handle both forms.

## Behaviour decisions (made with the requester)

- **Duplicate handling:** detect at the API and return `{ok:true, alreadySubscribed:true}`. Page swaps copy to "You're already on the list." rather than rejecting with an error.
- **Success copy:** intentionally vague ("You're on the list. We'll be in touch.") so we can pivot what the newsletter actually is without breaking the page.
- **Bot protection:** none yet. If signup spam appears, lift the Turnstile pattern from `api/get-started.ts` lines 60-70.

## Reviewer Notes

Three areas worth a closer look:

1. **`api/newsletter.ts` duplicate-detection** — `kv.get` then `kv.put` is technically TOCTOU, but Cloudflare KV has no conditional-put and the worst case is "two requests racing the same email both write the same record" which is harmless. Confirm you're happy with that or want a different approach.
2. **Segment event names** — the API fires `Newsletter Signup`; the client also fires Plausible/Segment events `Newsletter Signup Confirmed` and `Newsletter Already Subscribed`. The split is intentional (server-side captures the conversion, client-side captures the UI state) but worth a sanity check.
3. **`source: 'newsletter'` redundancy with `formType: FORM_TYPES.NEWSLETTER`** — a reviewer flagged this as stringly-typed duplication. I left it as-is because the convention on the other two routes is `source = entry point` and `formType = canonical funnel`, which lets a future second entry point (footer signup, etc.) attribute correctly. Push back if you disagree.

A simplify-pass spawned three parallel review agents (reuse / quality / efficiency) — five small findings landed in a follow-up commit (`1e6ffc3`): drop dead `Window &` cast, replace local `.visually-hidden` with global `.sr-only`, add `role="status" aria-live="polite"` for screen readers, trim a comment, and drop the now-stale wrangler placeholder comment.

### Repro

Local:

```bash
git fetch origin feature/newsletter-page
git switch feature/newsletter-page
pnpm install --filter ./site...
cd site && pnpm exec astro dev --port 4321
# open http://localhost:4321/newsletter
# POST http://localhost:4321/api/newsletter -d '{"email":"you@example.com"}'
# Re-POST the same email to see the alreadySubscribed branch.
```

After deploy, the page lives at `https://kitaru.ai/newsletter` and submits hit `https://kitaru.ai/api/newsletter` against the new `NEWSLETTER_KV` namespace.