### PR TITLE
Add OpenAI research bot example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - OSS-first auth management for service accounts and API keys via `KitaruClient.auth`, `kitaru auth service-accounts`, and `kitaru auth api-keys`. Raw API-key values are only returned on create/rotate so they can be stored immediately; list/show/update responses stay metadata-only.
 - OpenAI Agents SDK adapter user-facing packaging: a runnable integration example (`examples/integrations/openai_agents_agent/openai_agents_adapter.py`), a guide page (`/guides/openai-agents-adapter`) that explains `checkpoint_strategy="calls"` vs `checkpoint_strategy="runner_call"`, and smoke-test coverage for the example.
+- OpenAI research bot end-to-end example showing planner, parallel search checkpoints, writer report generation, remote secret guidance, and Kitaru UI artifacts for OpenAI Agents SDK workflows.
 
 ### Fixed
 - Checkpoint output handles now display Kitaru guidance to call `.load()` instead of leaking raw ZenML artifact metadata when stringified in flow bodies. (#127)

--- a/docs/content/docs/getting-started/examples.mdx
+++ b/docs/content/docs/getting-started/examples.mdx
@@ -52,6 +52,7 @@ kitaru status
 | Track a model call inside a flow | `features/llm/` | `python flow_with_llm.py` |
 | Wrap a PydanticAI agent | `integrations/pydantic_ai_agent/` | `python pydantic_ai_adapter.py` |
 | Wrap an OpenAI Agents SDK agent | `integrations/openai_agents_agent/` | `python openai_agents_adapter.py` |
+| Run a multi-agent OpenAI research bot | `end_to_end/openai_research_bot/` | `python research_bot.py "Your query" --max-searches 2` |
 | Query executions from an MCP client | `features/mcp/` | `python mcp_query_tools.py` |
 
 For example:
@@ -91,6 +92,7 @@ python first_working_flow.py
 | `features/llm/flow_with_llm.py` | `kitaru.llm()` prompt-response tracking with usage metadata | [Tracked LLM Calls](/guides/llm-calls) |
 | `integrations/pydantic_ai_agent/pydantic_ai_adapter.py` | Wrap a PydanticAI agent with Kitaru replay boundaries | [PydanticAI Adapter](/guides/pydantic-ai-adapter) |
 | `integrations/openai_agents_agent/openai_agents_adapter.py` | Wrap an OpenAI Agents SDK agent with Kitaru call-level or runner-call durability in a real API-backed support flow (`OPENAI_API_KEY` required, default model `gpt-5-nano`) | [OpenAI Agents Adapter](/guides/openai-agents-adapter) |
+| `end_to_end/openai_research_bot/research_bot.py` | Run a multi-agent OpenAI research bot with planner, parallel search checkpoints, and a writer report (`OPENAI_API_KEY` required, default model `gpt-5-nano`) | [Research bot section](/guides/openai-agents-adapter#end-to-end-research-bot-example) |
 | `features/mcp/mcp_query_tools.py` | Query executions and data through the Kitaru MCP server | [MCP Server](/agent-native/mcp-server) |
 
 <Callout type="info">
@@ -112,4 +114,5 @@ If you are learning Kitaru from scratch:
 8. `features/llm/flow_with_llm.py` — [Tracked LLM Calls](/guides/llm-calls)
 9. `integrations/pydantic_ai_agent/pydantic_ai_adapter.py` — [PydanticAI Adapter](/guides/pydantic-ai-adapter)
 10. `integrations/openai_agents_agent/openai_agents_adapter.py` — [OpenAI Agents Adapter](/guides/openai-agents-adapter)
-11. `features/mcp/mcp_query_tools.py` — [MCP Server](/agent-native/mcp-server)
+11. `end_to_end/openai_research_bot/research_bot.py` — [Research bot section](/guides/openai-agents-adapter#end-to-end-research-bot-example)
+12. `features/mcp/mcp_query_tools.py` — [MCP Server](/agent-native/mcp-server)

--- a/docs/content/docs/guides/openai-agents-adapter.mdx
+++ b/docs/content/docs/guides/openai-agents-adapter.mdx
@@ -119,7 +119,14 @@ Look for these artifacts in the Kitaru UI:
 
 - `research_plan`
 - `search_summaries`
+- `durability_drill`
 - `final_report`
 - `research_report_metadata`
+
+To test the durable-retry story directly, set
+`KITARU_RESEARCH_BOT_FAIL_AFTER_SEARCHES=1` before running the example. It will
+fail after the parallel searches complete. Unset the flag and run
+`kitaru executions retry <EXECUTION_ID>`; the retry should reuse the completed
+planner/search checkpoints and continue into the writer.
 
 See also: [Replay and overrides](/guides/replay-and-overrides).

--- a/docs/content/docs/guides/openai-agents-adapter.mdx
+++ b/docs/content/docs/guides/openai-agents-adapter.mdx
@@ -126,7 +126,9 @@ Look for these artifacts in the Kitaru UI:
 To test the durable-retry story directly, set
 `KITARU_RESEARCH_BOT_FAIL_AFTER_SEARCHES=1` before running the example. It will
 fail after the parallel searches complete. Unset the flag and run
-`kitaru executions retry <EXECUTION_ID>`; the retry should reuse the completed
-planner/search checkpoints and continue into the writer.
+`kitaru executions replay <EXECUTION_ID> --from durability_drill_gate`; the
+replay should reuse the completed planner/search checkpoints and continue into
+the writer. `retry` tries to restart the same failed execution and may be
+unavailable on server-backed stacks after a run has concluded.
 
 See also: [Replay and overrides](/guides/replay-and-overrides).

--- a/docs/content/docs/guides/openai-agents-adapter.mdx
+++ b/docs/content/docs/guides/openai-agents-adapter.mdx
@@ -81,4 +81,45 @@ export OPENAI_API_KEY='sk-...'
 uv run examples/integrations/openai_agents_agent/openai_agents_adapter.py
 ```
 
+## End-to-end research bot example
+
+For a larger example, run the OpenAI research bot:
+
+```bash
+cd examples/end_to_end/openai_research_bot
+uv sync --extra local --extra openai-agents
+uv run kitaru init
+export OPENAI_API_KEY='sk-...'
+uv run python research_bot.py "AI agent durability" --max-searches 2
+```
+
+The workflow keeps the original research-bot shape:
+
+```text
+planner → parallel searches → writer report
+```
+
+The planner and writer run from flow scope, so their default strategy is
+`checkpoint_strategy="calls"`. That gives Kitaru room to show supported inner
+OpenAI model/tool calls as child checkpoints.
+
+Each planned search is submitted as its own Kitaru checkpoint. Inside those
+search checkpoints, the example intentionally uses
+`checkpoint_strategy="runner_call"`, because call-level checkpoints cannot be
+nested inside an existing Kitaru checkpoint. In concrete terms: the search
+checkpoint is already the sealed replay unit, so the OpenAI runner inside it is
+saved as one runner call.
+
+The example also uses a local OpenAI Agents SDK `@function_tool` named
+`search_web` instead of the hosted `WebSearchTool`. The local tool calls the
+OpenAI Responses API with `web_search`, which makes the checkpoint trace clearer
+with the adapter's current public behavior.
+
+Look for these artifacts in the Kitaru UI:
+
+- `research_plan`
+- `search_summaries`
+- `final_report`
+- `research_report_metadata`
+
 See also: [Replay and overrides](/guides/replay-and-overrides).

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,7 @@ with `kitaru status`. If you are just trying Kitaru locally, run them as-is.
 - **Track a model call inside a flow:** `examples/features/llm/flow_with_llm.py`
 - **Wrap an existing PydanticAI agent:** `examples/integrations/pydantic_ai_agent/pydantic_ai_adapter.py`
 - **Wrap an OpenAI Agents SDK agent:** `examples/integrations/openai_agents_agent/openai_agents_adapter.py`
+- **Run a multi-agent OpenAI research bot:** `examples/end_to_end/openai_research_bot/research_bot.py`
 - **Build a full coding agent with tool calling and HITL:** `examples/end_to_end/coding_agent/agent.py`
 - **Run a granular-checkpoint PydanticAI agent end to end:** `examples/end_to_end/news_scout/scout.py`
 - **Wrap a Claude Agent SDK audit with checkpoints, memory, and wait/resume:** `examples/end_to_end/compliance_review/`
@@ -44,7 +45,7 @@ uv venv && source .venv/bin/activate   # Create and activate a virtual environme
 | Core workflow, execution, replay, and configuration examples | `uv sync --extra local` |
 | LLM examples (tracked `kitaru.llm()` calls) | `uv sync --extra local --extra llm` |
 | PydanticAI adapter example | `uv sync --extra local --extra pydantic-ai` |
-| OpenAI Agents adapter example | `uv sync --extra local --extra openai-agents` |
+| OpenAI Agents adapter and research bot examples | `uv sync --extra local --extra openai-agents` |
 | Coding agent example | `uv sync --extra local` + model alias / provider credentials |
 | Compliance review example | `uv sync --extra local --extra claude-agent-sdk` + local `ANTHROPIC_API_KEY` or remote `anthropic` secret |
 | MCP query tools example | `uv sync --extra local --extra mcp` |
@@ -58,6 +59,7 @@ uv venv && source .venv/bin/activate   # Create and activate a virtual environme
 - [features/llm/README.md](features/llm/README.md) — tracked `kitaru.llm()` calls inside flows
 - [integrations/pydantic_ai_agent/README.md](integrations/pydantic_ai_agent/README.md) — wrap a PydanticAI agent with Kitaru observability
 - [integrations/openai_agents_agent/README.md](integrations/openai_agents_agent/README.md) — real OpenAI API customer-support example with order lookup + shipping policy tools and Kitaru durability
+- [end_to_end/openai_research_bot/README.md](end_to_end/openai_research_bot/README.md) — multi-agent OpenAI research bot with planner, parallel search checkpoints, writer report, and remote secret guidance
 - [end_to_end/coding_agent/README.md](end_to_end/coding_agent/README.md) — full coding agent with provider SDK tool calling, HITL, and custom materializers
 - [end_to_end/news_scout/README.md](end_to_end/news_scout/README.md) — agentic news monitor with granular per-tool checkpoints, memory-seeded interests, and `secret_environment_from` for remote API keys
 - [end_to_end/compliance_review/README.md](end_to_end/compliance_review/README.md) — Claude Agent SDK document audit in four progressive stages: crash-resilient turns, sequential domain checkpoints with partial replay, flow-scoped memory, and durable wait/resume conversation
@@ -94,6 +96,7 @@ uv venv && source .venv/bin/activate   # Create and activate a virtual environme
 | [Tracked LLM calls](features/llm/flow_with_llm.py) | `uv run examples/features/llm/flow_with_llm.py` | `uv sync --extra local` + model alias / provider credentials | `kitaru.llm()` prompt-response tracking with usage metadata | [Tracked LLM Calls](https://kitaru.ai/docs/getting-started/llm-calls) | [tests/test_phase12_llm_example.py](../tests/test_phase12_llm_example.py) |
 | [PydanticAI adapter](integrations/pydantic_ai_agent/pydantic_ai_adapter.py) | `uv run examples/integrations/pydantic_ai_agent/pydantic_ai_adapter.py` | `uv sync --extra local --extra pydantic-ai` | Wrap an existing PydanticAI agent while keeping a Kitaru replay boundary | [PydanticAI Adapter](https://kitaru.ai/docs/getting-started/pydantic-ai-adapter) | — |
 | [OpenAI Agents adapter](integrations/openai_agents_agent/openai_agents_adapter.py) | `uv run examples/integrations/openai_agents_agent/openai_agents_adapter.py` | `uv sync --extra local --extra openai-agents` + `OPENAI_API_KEY` | Real OpenAI API customer-support flow with tool calls, showing call-level vs runner-call durability | [OpenAI Agents Adapter](https://kitaru.ai/docs/guides/openai-agents-adapter) | — |
+| [OpenAI research bot](end_to_end/openai_research_bot/research_bot.py) | `cd examples/end_to_end/openai_research_bot && uv run python research_bot.py "Your query" --max-searches 2` | `uv sync --extra local --extra openai-agents` + local `OPENAI_API_KEY` or remote `openai-research-bot-keys` secret | Planner → parallel search checkpoints → writer report using `kitaru.adapters.openai_agents`; publishes `research_plan`, `search_summaries`, and `final_report` artifacts | [OpenAI Agents Adapter](https://kitaru.ai/docs/guides/openai-agents-adapter) | [tests/test_openai_research_bot_example.py](../tests/test_openai_research_bot_example.py) |
 | [Coding agent](end_to_end/coding_agent/agent.py) | `cd examples/end_to_end/coding_agent && uv run python agent.py "Your task"` | `uv sync --extra local` + model alias / provider credentials | Full agent loop with provider SDK tool calling, `kitaru.wait()` HITL, custom materializers, and artifact persistence | [Tracked LLM Calls](https://kitaru.ai/docs/getting-started/llm-calls) | — |
 | [News scout](end_to_end/news_scout/scout.py) | `cd examples/end_to_end/news_scout && python scout.py` | `uv sync --extra local --extra pydantic-ai --extra llm` + `ANTHROPIC_API_KEY` locally (or a `news-scout-keys` secret for remote stacks) | PydanticAI agent with `granular_checkpoints=True` — every model/tool call is its own Kitaru checkpoint; `publish_report` promotes the agent output to a named `final_report` artifact; `ImageSettings.secret_environment_from` attaches the provider-keys secret automatically when the active stack is remote | [News Scout](https://kitaru.ai/docs/guides/news-scout) | [tests/test_news_scout_example.py](../tests/test_news_scout_example.py) |
 | [Compliance review](end_to_end/compliance_review/README.md) | `uv run examples/end_to_end/compliance_review/stage_1_single_turn.py` | `uv sync --extra local --extra claude-agent-sdk` + local `ANTHROPIC_API_KEY` or remote `anthropic` secret | Four-stage Claude Agent SDK audit: checkpointed turns, sequential domain checkpoints with partial replay, flow-scoped memory across runs, and durable wait/resume conversation | [Replay and Overrides](https://kitaru.ai/docs/guides/replay-and-overrides) | [tests/test_phase4_compliance_review_stage4.py](../tests/test_phase4_compliance_review_stage4.py) |
@@ -113,10 +116,11 @@ If you are new to Kitaru, this is the smoothest path:
 8. `uv run examples/features/llm/flow_with_llm.py`
 9. `uv run examples/integrations/pydantic_ai_agent/pydantic_ai_adapter.py`
 10. `uv run examples/integrations/openai_agents_agent/openai_agents_adapter.py`
-11. `cd examples/end_to_end/coding_agent && uv run python agent.py "Your task"` *(full agent with tools + HITL)*
-12. `cd examples/end_to_end/news_scout && python scout.py` *(granular-checkpoint agent with 4 tools, dashboard-readable final_report artifact)*
-13. `uv run examples/end_to_end/compliance_review/stage_1_single_turn.py` *(Claude Agent SDK audit; walk through stages 1–4 to see replay, memory, and wait/resume in turn)*
-14. `uv run examples/features/mcp/mcp_query_tools.py`
+11. `cd examples/end_to_end/openai_research_bot && uv run python research_bot.py "Your query" --max-searches 2` *(OpenAI planner → parallel searches → writer report)*
+12. `cd examples/end_to_end/coding_agent && uv run python agent.py "Your task"` *(full agent with tools + HITL)*
+13. `cd examples/end_to_end/news_scout && python scout.py` *(granular-checkpoint agent with 4 tools, dashboard-readable final_report artifact)*
+14. `uv run examples/end_to_end/compliance_review/stage_1_single_turn.py` *(Claude Agent SDK audit; walk through stages 1–4 to see replay, memory, and wait/resume in turn)*
+15. `uv run examples/features/mcp/mcp_query_tools.py`
 
 If you prefer the hosted docs view, start with the
 [Examples page](https://kitaru.ai/docs/getting-started/examples).

--- a/examples/end_to_end/openai_research_bot/README.md
+++ b/examples/end_to_end/openai_research_bot/README.md
@@ -56,6 +56,7 @@ Picture the flow like this:
   ├── search_01_<query_slug>             ← one durable checkpoint per search
   ├── search_02_<query_slug>             ← runs in parallel with the other searches
   ├── publish_search_summaries           ← produces search_summaries artifact
+  ├── durability_drill_gate              ← optional intentional failure point
   ├── writer OpenAI run                  ← call-level checkpoints when --strategy=calls
   └── publish_report                     ← produces final_report + metadata artifacts
 ```
@@ -69,6 +70,7 @@ Open the Kitaru UI and inspect the execution trace:
 - `research_plan` shows the planner's exact list of searches.
 - Each `search_XX_...` checkpoint shows one search task and its result.
 - `search_summaries` shows the complete list passed to the writer, including any failed searches.
+- `durability_drill` records the optional retry drill gate.
 - `final_report` is the Markdown report you probably want to read first.
 - `research_report_metadata` records the query, models, checkpoint strategy, and search counts.
 
@@ -81,6 +83,26 @@ Imagine the run like a three-act play:
 3. The writer turns the evidence into the final report.
 
 If the writer crashes after the searches finish, Kitaru does not have to pay for the planner and searches again. On replay, it can reuse those completed checkpoints and continue from the broken part. That is the concrete benefit: fewer duplicate model calls, less wasted money, and a clearer place to debug.
+
+## Try the durability drill
+
+You can ask the example to fail after the parallel searches finish:
+
+```bash
+export KITARU_RESEARCH_BOT_FAIL_AFTER_SEARCHES=1
+uv run python research_bot.py "What should a small AI startup know about durable agents?" --max-searches 2
+```
+
+The run should fail at `durability_drill_gate`, after `research_plan`, both `search_XX_...` checkpoints, and `search_summaries` have already completed.
+
+Copy the failed execution ID from the terminal or UI, then unset the flag and retry the same execution:
+
+```bash
+unset KITARU_RESEARCH_BOT_FAIL_AFTER_SEARCHES
+uv run kitaru executions retry <EXECUTION_ID>
+```
+
+`retry` is the right command for failed executions. `resume` is for paused executions that are waiting for input. On retry, Kitaru should reuse the completed planner/search checkpoints and continue from the failure gate into the writer and final report.
 
 ## `calls` vs `runner_call`
 

--- a/examples/end_to_end/openai_research_bot/README.md
+++ b/examples/end_to_end/openai_research_bot/README.md
@@ -21,6 +21,8 @@ uv run python research_bot.py "What should a small AI startup know about durable
 
 For a fuller run, omit `--max-searches 2`; the default is 5 searches. The CLI clamps the search budget to 1-10 so an accidental prompt cannot fan out into a very expensive example run.
 
+The flow disables Kitaru's ordinary same-input cache on purpose. A fresh run of this example should perform fresh web searches, because web results are date-sensitive. Replay still reuses completed checkpoints from the source execution; that is the durability behavior demonstrated in the drill below.
+
 ## Useful flags
 
 ```bash

--- a/examples/end_to_end/openai_research_bot/README.md
+++ b/examples/end_to_end/openai_research_bot/README.md
@@ -95,14 +95,16 @@ uv run python research_bot.py "What should a small AI startup know about durable
 
 The run should fail at `durability_drill_gate`, after `research_plan`, both `search_XX_...` checkpoints, and `search_summaries` have already completed.
 
-Copy the failed execution ID from the terminal or UI, then unset the flag and retry the same execution:
+Copy the failed execution ID from the terminal or UI, then unset the flag and replay from the failure checkpoint:
 
 ```bash
 unset KITARU_RESEARCH_BOT_FAIL_AFTER_SEARCHES
-uv run kitaru executions retry <EXECUTION_ID>
+uv run kitaru executions replay <EXECUTION_ID> --from durability_drill_gate
 ```
 
-`retry` is the right command for failed executions. `resume` is for paused executions that are waiting for input. On retry, Kitaru should reuse the completed planner/search checkpoints and continue from the failure gate into the writer and final report.
+`replay` creates a new execution from the failed one and asks Kitaru to reuse completed upstream checkpoints. `retry` tries to restart the same failed execution, which is not always available on server-backed stacks after a run has concluded. `resume` is for paused executions that are waiting for input.
+
+On replay, Kitaru should reuse the completed planner/search checkpoints and continue from `durability_drill_gate` into the writer and final report.
 
 ## `calls` vs `runner_call`
 

--- a/examples/end_to_end/openai_research_bot/README.md
+++ b/examples/end_to_end/openai_research_bot/README.md
@@ -1,0 +1,131 @@
+# OpenAI research bot
+
+This example ports the OpenAI research-bot investigation to Kitaru. It runs a small multi-agent workflow:
+
+1. **Planner** — turns your question into a focused web-search plan.
+2. **Parallel searches** — runs each planned search as its own Kitaru checkpoint.
+3. **Writer** — turns the search summaries into a Markdown report.
+
+The default model is `gpt-5-nano` to keep the example cheap enough to try. If you want a smarter and pricier run, pass `--model gpt-5-mini` or override a single stage with `--planner-model`, `--search-model`, or `--writer-model`.
+
+## Quick start
+
+```bash
+cd examples/end_to_end/openai_research_bot
+uv sync --extra local --extra openai-agents
+uv run kitaru init
+export OPENAI_API_KEY='sk-...'
+
+uv run python research_bot.py "What should a small AI startup know about durable agents?" --max-searches 2
+```
+
+For a fuller run, omit `--max-searches 2`; the default is 5 searches. The CLI clamps the search budget to 1-10 so an accidental prompt cannot fan out into a very expensive example run.
+
+## Useful flags
+
+```bash
+uv run python research_bot.py "AI agent durability" \
+  --max-searches 4 \
+  --model gpt-5-nano \
+  --writer-model gpt-5-mini \
+  --strategy calls
+```
+
+| Flag | What it changes |
+| --- | --- |
+| `query` | The research question. |
+| `--max-searches` | Maximum planned searches, clamped to 1-10. |
+| `--model` | Default model for planner, search, writer, and the local web-search helper. Defaults to `gpt-5-nano`. |
+| `--planner-model` | Only changes the planning agent. |
+| `--search-model` | Only changes the search-summary agent and, by default, the search helper. |
+| `--writer-model` | Only changes the final report writer. |
+| `--search-tool-model` | Only changes the OpenAI Responses API model used inside the local `search_web` tool. |
+| `--strategy` | OpenAI adapter checkpoint strategy for planner/writer: `calls` or `runner_call`. Defaults to `calls`. |
+| `--compare-runner-call` | Runs a second pass with `runner_call` so you can compare checkpoint shapes. This costs more. |
+| `--fail-on-search-error` | Exit non-zero if any parallel search checkpoint fails. Useful for smoke tests. |
+| `--secret-name` | Remote-stack secret name that contains `OPENAI_API_KEY`. Defaults to `openai-research-bot-keys`. |
+
+## What happens in Kitaru
+
+Picture the flow like this:
+
+```text
+@flow openai_research_bot
+  ├── planner OpenAI run                 ← call-level checkpoints when --strategy=calls
+  ├── publish_research_plan              ← produces research_plan artifact
+  ├── search_01_<query_slug>             ← one durable checkpoint per search
+  ├── search_02_<query_slug>             ← runs in parallel with the other searches
+  ├── publish_search_summaries           ← produces search_summaries artifact
+  ├── writer OpenAI run                  ← call-level checkpoints when --strategy=calls
+  └── publish_report                     ← produces final_report + metadata artifacts
+```
+
+The search stage is the most important teaching piece. Each search is like a separate sealed envelope. If search 3 fails, searches 1 and 2 do not need to be thrown away. Kitaru has already saved them.
+
+## What to look for in the UI
+
+Open the Kitaru UI and inspect the execution trace:
+
+- `research_plan` shows the planner's exact list of searches.
+- Each `search_XX_...` checkpoint shows one search task and its result.
+- `search_summaries` shows the complete list passed to the writer, including any failed searches.
+- `final_report` is the Markdown report you probably want to read first.
+- `research_report_metadata` records the query, models, checkpoint strategy, and search counts.
+
+## Why replay helps
+
+Imagine the run like a three-act play:
+
+1. The planner writes the search script.
+2. Several search actors gather evidence at the same time.
+3. The writer turns the evidence into the final report.
+
+If the writer crashes after the searches finish, Kitaru does not have to pay for the planner and searches again. On replay, it can reuse those completed checkpoints and continue from the broken part. That is the concrete benefit: fewer duplicate model calls, less wasted money, and a clearer place to debug.
+
+## `calls` vs `runner_call`
+
+The default is:
+
+```bash
+--strategy calls
+```
+
+That means the planner and writer run from flow scope, and the OpenAI adapter can show inner model/tool calls as child checkpoints.
+
+The parallel search checkpoints use `checkpoint_strategy="runner_call"` internally on purpose. They are already inside Kitaru checkpoints, so opening more call-level checkpoints inside them would be nesting checkpoints inside checkpoints. Instead, each search is one durable unit.
+
+If you pass:
+
+```bash
+--strategy runner_call
+```
+
+planner and writer become coarser: each whole OpenAI run is one checkpoint. That is less detailed, but sometimes easier to scan.
+
+## Local and remote credentials
+
+For local runs, use your shell:
+
+```bash
+export OPENAI_API_KEY='sk-...'
+```
+
+For remote stacks, store the key in a Kitaru secret:
+
+```bash
+kitaru secrets set openai-research-bot-keys --OPENAI_API_KEY=sk-...
+```
+
+When the active stack is remote, `research_bot.py` adds `secret_environment_from=["openai-research-bot-keys"]` to the run image. Only the secret name is sent with the run. The key value should not appear in flow parameters, logs, or artifacts.
+
+## Why this example uses a local search tool
+
+The original investigation used the OpenAI Agents SDK hosted `WebSearchTool`. This Kitaru port intentionally uses a local `@function_tool` named `search_web`, and that function calls the OpenAI Responses API with the `web_search` tool.
+
+That choice makes the checkpoint story clearer for readers today: Kitaru can show local function tools cleanly, while hosted tools are currently less visible in the adapter trace.
+
+## Known limitations
+
+- This is a real web-search workload, so results can vary by date and by what sources the API finds.
+- The example catches individual search failures and asks the writer to treat them as missing evidence, not as facts. Use `--fail-on-search-error` when you want the whole run to stop instead.
+- It does not add memory or human approval yet. The point of this example is durable multi-stage OpenAI Agents execution.

--- a/examples/end_to_end/openai_research_bot/__init__.py
+++ b/examples/end_to_end/openai_research_bot/__init__.py
@@ -1,0 +1,1 @@
+"""OpenAI research bot end-to-end Kitaru example."""

--- a/examples/end_to_end/openai_research_bot/bot_agents.py
+++ b/examples/end_to_end/openai_research_bot/bot_agents.py
@@ -1,0 +1,46 @@
+"""OpenAI Agents SDK agent factories for the research bot."""
+
+from agents import Agent, ModelSettings
+
+try:  # Package import path used by tests.
+    from .models import ReportData, WebSearchPlan
+    from .prompts import SEARCH_INSTRUCTIONS, WRITER_INSTRUCTIONS, planner_instructions
+    from .tools import new_search_web_tool
+except ImportError:  # Direct script path used by README commands.
+    from models import ReportData, WebSearchPlan
+    from prompts import SEARCH_INSTRUCTIONS, WRITER_INSTRUCTIONS, planner_instructions
+    from tools import new_search_web_tool
+
+DEFAULT_MODEL = "gpt-5-nano"
+SMARTER_MODEL = "gpt-5-mini"
+
+
+def new_planner_agent(*, model: str, max_searches: int) -> Agent:
+    """Create the planner agent that returns a structured search plan."""
+    return Agent(
+        name="research_planner",
+        instructions=planner_instructions(max_searches),
+        model=model,
+        output_type=WebSearchPlan,
+    )
+
+
+def new_search_agent(*, model: str, search_tool_model: str) -> Agent:
+    """Create the search agent that must call the local search_web tool."""
+    return Agent(
+        name="research_searcher",
+        instructions=SEARCH_INSTRUCTIONS,
+        model=model,
+        tools=[new_search_web_tool(model=search_tool_model)],
+        model_settings=ModelSettings(tool_choice="required"),
+    )
+
+
+def new_writer_agent(*, model: str) -> Agent:
+    """Create the writer agent that returns the final structured report."""
+    return Agent(
+        name="research_writer",
+        instructions=WRITER_INSTRUCTIONS,
+        model=model,
+        output_type=ReportData,
+    )

--- a/examples/end_to_end/openai_research_bot/models.py
+++ b/examples/end_to_end/openai_research_bot/models.py
@@ -1,0 +1,49 @@
+"""Typed contracts shared by the research bot stages."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WebSearchItem(BaseModel):
+    """One planned web search."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reason: str = Field(description="Why this search helps answer the research query.")
+    query: str = Field(description="The search term to send to the search stage.")
+
+
+class WebSearchPlan(BaseModel):
+    """Planner output: the searches needed to answer a query."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    searches: list[WebSearchItem] = Field(
+        description="A short list of web searches to perform."
+    )
+
+
+class SearchSummary(BaseModel):
+    """Durable output from one parallel search checkpoint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    index: int
+    query: str
+    reason: str
+    status: Literal["completed", "failed"]
+    summary: str
+    error_message: str | None = None
+
+
+class ReportData(BaseModel):
+    """Writer output shown to the user and saved as the final report."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    short_summary: str = Field(description="A 2-3 sentence summary of the findings.")
+    markdown_report: str = Field(description="The final report in Markdown.")
+    follow_up_questions: list[str] = Field(
+        description="Suggested topics the user may want to research next."
+    )

--- a/examples/end_to_end/openai_research_bot/prompts.py
+++ b/examples/end_to_end/openai_research_bot/prompts.py
@@ -1,0 +1,64 @@
+"""Prompts and input builders for the OpenAI research bot example."""
+
+try:  # Package import path used by tests.
+    from .models import SearchSummary
+except ImportError:  # Direct script path used by README commands.
+    from models import SearchSummary
+
+
+def planner_instructions(max_searches: int) -> str:
+    """Build planner instructions with the current cost-control limit."""
+    return (
+        "You are a careful research planner. Given a user's research query, "
+        "create a focused set of web searches that would best answer it. "
+        f"Output between 1 and {max_searches} searches. "
+        "Each search should have a concrete query string and a brief reason. "
+        "Avoid duplicate searches, and prefer searches that will produce "
+        "specific, evidence-rich information."
+    )
+
+
+SEARCH_INSTRUCTIONS = (
+    "You are a research assistant. You receive one search term and the reason "
+    "that search matters. You must call the search_web tool, then summarize the "
+    "results in 2-3 concise paragraphs. Keep the summary under 300 words. "
+    "Capture the main points, useful details, and any source/citation text the "
+    "tool returned. Do not add extra commentary beyond the summary."
+)
+
+
+WRITER_INSTRUCTIONS = (
+    "You are a senior researcher. Write a cohesive Markdown report for the "
+    "original query using the supplied search summaries. Start by mentally "
+    "planning the report structure, then return only the structured output. "
+    "The markdown_report should be useful and detailed, with headings, concrete "
+    "findings, caveats, and practical takeaways. If any searches failed, mention "
+    "what evidence is missing rather than pretending the search succeeded."
+)
+
+
+def build_search_input(query: str, reason: str) -> str:
+    """Format one planned search for the search agent."""
+    return f"Search term: {query}\nReason for searching: {reason}"
+
+
+def build_writer_input(original_query: str, summaries: list[SearchSummary]) -> str:
+    """Format all search summaries for the writer agent."""
+    lines = [
+        f"Original query: {original_query}",
+        "",
+        "Summarized search results:",
+    ]
+    for summary in summaries:
+        lines.extend(
+            [
+                "",
+                f"Search {summary.index + 1}: {summary.query}",
+                f"Reason: {summary.reason}",
+                f"Status: {summary.status}",
+                f"Summary: {summary.summary}",
+            ]
+        )
+        if summary.error_message:
+            lines.append(f"Error: {summary.error_message}")
+    return "\n".join(lines)

--- a/examples/end_to_end/openai_research_bot/research_bot.py
+++ b/examples/end_to_end/openai_research_bot/research_bot.py
@@ -1,0 +1,529 @@
+"""OpenAI research bot — planner, parallel searches, writer on Kitaru.
+
+Run locally::
+
+    cd examples/end_to_end/openai_research_bot
+    uv sync --extra local --extra openai-agents
+    uv run kitaru init
+    export OPENAI_API_KEY=sk-...
+    uv run python research_bot.py "AI agent durability" --max-searches 2
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Annotated, Any, Literal, TypeVar
+
+from agents import RunConfig
+from pydantic import BaseModel, ValidationError
+
+import kitaru
+from kitaru import ImageSettings, checkpoint, flow
+from kitaru.adapters.openai_agents import KitaruRunner, OpenAIRunRequest
+from kitaru.config import classify_stack_deployment_type
+
+try:  # Package import path used by tests.
+    from .bot_agents import (
+        DEFAULT_MODEL,
+        SMARTER_MODEL,
+        new_planner_agent,
+        new_search_agent,
+        new_writer_agent,
+    )
+    from .models import ReportData, SearchSummary, WebSearchItem, WebSearchPlan
+    from .prompts import build_search_input, build_writer_input
+    from .tools import SEARCH_TOOL_MODEL_ENV
+except ImportError:  # Direct script path used by README commands.
+    from bot_agents import (
+        DEFAULT_MODEL,
+        SMARTER_MODEL,
+        new_planner_agent,
+        new_search_agent,
+        new_writer_agent,
+    )
+    from models import ReportData, SearchSummary, WebSearchItem, WebSearchPlan
+    from prompts import build_search_input, build_writer_input
+    from tools import SEARCH_TOOL_MODEL_ENV
+
+CheckpointStrategy = Literal["calls", "runner_call"]
+SEARCH_CHECKPOINT_STRATEGY: CheckpointStrategy = "runner_call"
+DEFAULT_MAX_SEARCHES = 5
+MAX_SEARCHES_LIMIT = 10
+SECRET_NAME = "openai-research-bot-keys"
+
+_REMOTE_STACK_DEPLOYMENT_TYPES = frozenset(
+    {"kubernetes", "vertex", "sagemaker", "azureml"}
+)
+_NON_SECRET_ENV_VARS = (
+    "OPENAI_RESEARCH_BOT_MODEL",
+    "OPENAI_RESEARCH_BOT_PLANNER_MODEL",
+    "OPENAI_RESEARCH_BOT_SEARCH_MODEL",
+    "OPENAI_RESEARCH_BOT_WRITER_MODEL",
+    "OPENAI_RESEARCH_BOT_MAX_SEARCHES",
+    "OPENAI_RESEARCH_BOT_CHECKPOINT_STRATEGY",
+    SEARCH_TOOL_MODEL_ENV,
+)
+
+RESEARCH_BOT_IMAGE = ImageSettings(
+    requirements=[
+        "openai-agents>=0.15.0,<0.16.0",
+        "openai>=1.0.0,<3",
+    ],
+)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def clamp_max_searches(value: int) -> int:
+    """Keep search fan-out inside a small, example-friendly cost range."""
+    return min(max(value, 1), MAX_SEARCHES_LIMIT)
+
+
+def normalize_search_plan(
+    plan: WebSearchPlan,
+    *,
+    original_query: str,
+    max_searches: int,
+) -> WebSearchPlan:
+    """Trim, deduplicate, and add a fallback search if the planner returns none."""
+    limit = clamp_max_searches(max_searches)
+    normalized: list[WebSearchItem] = []
+    seen: set[str] = set()
+
+    for item in plan.searches:
+        query = item.query.strip()
+        reason = item.reason.strip() or "The planner marked this search as relevant."
+        if not query:
+            continue
+        key = re.sub(r"\s+", " ", query.lower())
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(WebSearchItem(query=query, reason=reason))
+        if len(normalized) >= limit:
+            break
+
+    if normalized:
+        return WebSearchPlan(searches=normalized)
+
+    return WebSearchPlan(
+        searches=[
+            WebSearchItem(
+                query=original_query,
+                reason=(
+                    "Fallback search because the planner returned no usable searches."
+                ),
+            )
+        ]
+    )
+
+
+def missing_api_key_message(secret_name: str = SECRET_NAME) -> str:
+    """Friendly setup text for users who run the example without credentials."""
+    return (
+        "Missing OPENAI_API_KEY.\n\n"
+        "For local runs, set it in your shell and rerun:\n"
+        "  export OPENAI_API_KEY='sk-...'\n\n"
+        "For remote stacks, create a Kitaru secret instead:\n"
+        f"  kitaru secrets set {secret_name} --OPENAI_API_KEY=sk-...\n\n"
+        "The example passes only the secret name to remote runs; it does not put "
+        "the key in flow parameters, logs, or artifacts."
+    )
+
+
+def _coerce_model(value: Any, model_type: type[T]) -> T:
+    """Coerce OpenAI Agents SDK structured output into a Pydantic model."""
+    if isinstance(value, model_type):
+        return value
+    if isinstance(value, BaseModel):
+        return model_type.model_validate(value.model_dump())
+    if isinstance(value, dict):
+        return model_type.model_validate(value)
+    if isinstance(value, str):
+        try:
+            return model_type.model_validate_json(value)
+        except ValidationError:
+            return model_type.model_validate(json.loads(value))
+    return model_type.model_validate(value)
+
+
+def _completed_final_output(result: Any, *, stage: str) -> Any:
+    """Return final output or raise if an OpenAI run paused unexpectedly."""
+    if result.status != "completed":
+        raise RuntimeError(
+            f"The {stage} agent returned status={result.status!r}. "
+            "This example does not use human approval tools, so the run "
+            "should complete."
+        )
+    return result.final_output
+
+
+def _new_runner(agent: Any, *, checkpoint_strategy: CheckpointStrategy) -> KitaruRunner:
+    """Build a Kitaru-wrapped OpenAI runner with tracing disabled for clarity."""
+    return KitaruRunner(
+        agent,
+        checkpoint_strategy=checkpoint_strategy,
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+
+def _slug(value: str, *, max_length: int = 40) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", value.strip().lower()).strip("_")
+    return (slug or "search")[:max_length]
+
+
+@checkpoint(type="context")
+def publish_research_plan(
+    query: str,
+    max_searches: int,
+    planner_model: str,
+    plan: WebSearchPlan,
+) -> Annotated[dict[str, Any], "research_plan"]:
+    """Save the planner output as a readable dashboard artifact."""
+    return {
+        "query": query,
+        "max_searches": max_searches,
+        "planner_model": planner_model,
+        "searches": [item.model_dump(mode="json") for item in plan.searches],
+    }
+
+
+@checkpoint(type="llm_call")
+def run_search_item(
+    index: int,
+    item: WebSearchItem,
+    search_model: str,
+    search_tool_model: str,
+) -> SearchSummary:
+    """Run one planned search inside its own durable Kitaru checkpoint.
+
+    This checkpoint already gives the search stage a durable boundary. The
+    OpenAI runner inside it therefore uses ``checkpoint_strategy="runner_call"``;
+    using ``"calls"`` here would try to open nested Kitaru checkpoints.
+    """
+    try:
+        agent = new_search_agent(
+            model=search_model,
+            search_tool_model=search_tool_model,
+        )
+        runner = _new_runner(
+            agent,
+            checkpoint_strategy=SEARCH_CHECKPOINT_STRATEGY,
+        )
+        result = runner.run_sync(
+            OpenAIRunRequest.start(
+                build_search_input(query=item.query, reason=item.reason),
+                metadata={"stage": "search", "search_index": index},
+                max_turns=4,
+            )
+        )
+        output = _completed_final_output(result, stage=f"search {index + 1}")
+        return SearchSummary(
+            index=index,
+            query=item.query,
+            reason=item.reason,
+            status="completed",
+            summary=str(output),
+        )
+    except Exception as error:
+        return SearchSummary(
+            index=index,
+            query=item.query,
+            reason=item.reason,
+            status="failed",
+            summary=(
+                "This search failed; the writer should treat this as missing evidence."
+            ),
+            error_message=f"{type(error).__name__}: {error}",
+        )
+
+
+@checkpoint(type="context")
+def publish_search_summaries(
+    summaries: list[SearchSummary],
+) -> Annotated[list[dict[str, Any]], "search_summaries"]:
+    """Save the aggregate search results as a readable dashboard artifact."""
+    return [summary.model_dump(mode="json") for summary in summaries]
+
+
+@checkpoint(type="output")
+def publish_report(
+    report: ReportData,
+    metadata: dict[str, Any],
+) -> Annotated[str, "final_report"]:
+    """Save the final Markdown report and related metadata artifacts."""
+    kitaru.save("research_report_metadata", metadata, type="context")
+    kitaru.save("follow_up_questions", report.follow_up_questions, type="context")
+    return report.markdown_report
+
+
+@flow(image=RESEARCH_BOT_IMAGE)
+def openai_research_bot(
+    query: str,
+    max_searches: int,
+    planner_model: str,
+    search_model: str,
+    writer_model: str,
+    search_tool_model: str,
+    checkpoint_strategy: CheckpointStrategy,
+    fail_on_search_error: bool = False,
+) -> str:
+    """Run planner → parallel searches → writer, then publish a report artifact."""
+    max_searches = clamp_max_searches(max_searches)
+    kitaru.log(
+        stage="start",
+        query=query,
+        max_searches=max_searches,
+        planner_model=planner_model,
+        search_model=search_model,
+        writer_model=writer_model,
+        search_tool_model=search_tool_model,
+        checkpoint_strategy=checkpoint_strategy,
+        fail_on_search_error=fail_on_search_error,
+    )
+
+    planner = _new_runner(
+        new_planner_agent(model=planner_model, max_searches=max_searches),
+        checkpoint_strategy=checkpoint_strategy,
+    )
+    planner_result = planner.run_sync(
+        OpenAIRunRequest.start(
+            f"Query: {query}",
+            metadata={"stage": "planner"},
+            max_turns=3,
+        )
+    )
+    raw_plan = _coerce_model(
+        _completed_final_output(planner_result, stage="planner"),
+        WebSearchPlan,
+    )
+    plan = normalize_search_plan(
+        raw_plan,
+        original_query=query,
+        max_searches=max_searches,
+    )
+    publish_research_plan(query, max_searches, planner_model, plan)
+
+    futures = [
+        run_search_item.submit(
+            index,
+            item,
+            search_model,
+            search_tool_model,
+            id=f"search_{index + 1:02d}_{_slug(item.query)}",
+        )
+        for index, item in enumerate(plan.searches)
+    ]
+    summaries = [future.load() for future in futures]
+    publish_search_summaries(summaries)
+
+    failed = [item for item in summaries if item.status == "failed"]
+    if fail_on_search_error and failed:
+        details = "; ".join(
+            f"{item.query}: {item.error_message or item.summary}" for item in failed
+        )
+        raise RuntimeError(f"{len(failed)} search checkpoint(s) failed: {details}")
+
+    writer = _new_runner(
+        new_writer_agent(model=writer_model),
+        checkpoint_strategy=checkpoint_strategy,
+    )
+    writer_result = writer.run_sync(
+        OpenAIRunRequest.start(
+            build_writer_input(original_query=query, summaries=summaries),
+            metadata={"stage": "writer"},
+            max_turns=3,
+        )
+    )
+    report = _coerce_model(
+        _completed_final_output(writer_result, stage="writer"),
+        ReportData,
+    )
+
+    metadata = {
+        "query": query,
+        "planner_model": planner_model,
+        "search_model": search_model,
+        "writer_model": writer_model,
+        "search_tool_model": search_tool_model,
+        "checkpoint_strategy": checkpoint_strategy,
+        "planned_search_count": len(plan.searches),
+        "completed_search_count": sum(
+            1 for item in summaries if item.status == "completed"
+        ),
+        "failed_search_count": sum(1 for item in summaries if item.status == "failed"),
+        "short_summary": report.short_summary,
+        "follow_up_questions": report.follow_up_questions,
+    }
+    return publish_report(report, metadata)
+
+
+def _collect_non_secret_env() -> dict[str, str]:
+    """Forward local non-secret config into remote images."""
+    return {key: os.environ[key] for key in _NON_SECRET_ENV_VARS if os.getenv(key)}
+
+
+def _active_stack_is_remote() -> bool:
+    """Return whether the current stack needs remote secret injection."""
+    try:
+        return classify_stack_deployment_type() in _REMOTE_STACK_DEPLOYMENT_TYPES
+    except Exception:
+        return False
+
+
+def _image_override_for_active_stack(secret_name: str) -> dict[str, Any] | None:
+    """Inject OPENAI_API_KEY by secret name only for remote-stack runs."""
+    if not _active_stack_is_remote():
+        return None
+    return {
+        "requirements": list(RESEARCH_BOT_IMAGE.requirements or []),
+        "environment": _collect_non_secret_env(),
+        "secret_environment_from": [secret_name],
+    }
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for the research bot example."""
+    default_model = os.getenv("OPENAI_RESEARCH_BOT_MODEL", DEFAULT_MODEL)
+    parser = argparse.ArgumentParser(
+        description="Run a durable OpenAI research bot on Kitaru."
+    )
+    parser.add_argument("query", help="Research question or topic.")
+    parser.add_argument(
+        "--max-searches",
+        type=int,
+        default=_env_int("OPENAI_RESEARCH_BOT_MAX_SEARCHES", DEFAULT_MAX_SEARCHES),
+        help=f"Planner search budget, clamped to 1-{MAX_SEARCHES_LIMIT}.",
+    )
+    parser.add_argument(
+        "--model",
+        default=default_model,
+        help=(
+            f"Default model for all stages (default: {DEFAULT_MODEL}; "
+            f"try {SMARTER_MODEL} for a smarter/pricier run)."
+        ),
+    )
+    parser.add_argument(
+        "--planner-model",
+        default=os.getenv("OPENAI_RESEARCH_BOT_PLANNER_MODEL"),
+        help="Planner model override. Defaults to --model.",
+    )
+    parser.add_argument(
+        "--search-model",
+        default=os.getenv("OPENAI_RESEARCH_BOT_SEARCH_MODEL"),
+        help="Search summarizer model override. Defaults to --model.",
+    )
+    parser.add_argument(
+        "--writer-model",
+        default=os.getenv("OPENAI_RESEARCH_BOT_WRITER_MODEL"),
+        help="Writer model override. Defaults to --model.",
+    )
+    parser.add_argument(
+        "--search-tool-model",
+        default=os.getenv(SEARCH_TOOL_MODEL_ENV),
+        help=(
+            "Responses API model used inside the local search_web tool. "
+            "Defaults to --search-model."
+        ),
+    )
+    parser.add_argument(
+        "--strategy",
+        choices=("calls", "runner_call"),
+        default=os.getenv("OPENAI_RESEARCH_BOT_CHECKPOINT_STRATEGY", "calls"),
+        help="OpenAI adapter checkpoint strategy for planner/writer (default: calls).",
+    )
+    parser.add_argument(
+        "--compare-runner-call",
+        action="store_true",
+        help="Run a second, more coarse-grained runner_call pass for comparison.",
+    )
+    parser.add_argument(
+        "--fail-on-search-error",
+        action="store_true",
+        help="Exit non-zero if any parallel search checkpoint fails.",
+    )
+    parser.add_argument(
+        "--secret-name",
+        default=SECRET_NAME,
+        help="Kitaru secret name that holds OPENAI_API_KEY for remote stacks.",
+    )
+    return parser.parse_args(argv)
+
+
+def _run_once(
+    args: argparse.Namespace,
+    *,
+    strategy: CheckpointStrategy,
+    image_override: dict[str, Any] | None,
+) -> str:
+    model = args.model
+    planner_model = args.planner_model or model
+    search_model = args.search_model or model
+    writer_model = args.writer_model or model
+    search_tool_model = args.search_tool_model or search_model
+
+    run_kwargs: dict[str, Any] = {
+        "query": args.query,
+        "max_searches": clamp_max_searches(args.max_searches),
+        "planner_model": planner_model,
+        "search_model": search_model,
+        "writer_model": writer_model,
+        "search_tool_model": search_tool_model,
+        "checkpoint_strategy": strategy,
+        "fail_on_search_error": args.fail_on_search_error,
+    }
+    if image_override is not None:
+        run_kwargs["image"] = image_override
+
+    result = openai_research_bot.run(**run_kwargs).wait()
+    return str(result)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    image_override = _image_override_for_active_stack(args.secret_name)
+    if not os.getenv("OPENAI_API_KEY") and image_override is None:
+        print(missing_api_key_message(args.secret_name), file=sys.stderr)
+        return 2
+    if not os.getenv("OPENAI_API_KEY") and image_override is not None:
+        print(
+            f"OPENAI_API_KEY is not set locally; relying on remote secret "
+            f"{args.secret_name!r}.",
+            file=sys.stderr,
+        )
+
+    print(
+        f"Running OpenAI research bot with model={args.model!r}, "
+        f"max_searches={clamp_max_searches(args.max_searches)}, "
+        f"strategy={args.strategy!r}."
+    )
+    report = _run_once(args, strategy=args.strategy, image_override=image_override)
+    print("\n=== final report ===\n")
+    print(report)
+
+    if args.compare_runner_call and args.strategy != "runner_call":
+        print("\n=== runner_call comparison run ===\n")
+        comparison = _run_once(
+            args,
+            strategy="runner_call",
+            image_override=image_override,
+        )
+        print(comparison)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/end_to_end/openai_research_bot/research_bot.py
+++ b/examples/end_to_end/openai_research_bot/research_bot.py
@@ -14,7 +14,7 @@ import json
 import os
 import re
 import sys
-from typing import Annotated, Any, Literal, TypeVar
+from typing import Annotated, Any, Literal, TypeVar, cast
 
 from agents import RunConfig
 from pydantic import BaseModel, ValidationError
@@ -48,6 +48,7 @@ except ImportError:  # Direct script path used by README commands.
     from tools import SEARCH_TOOL_MODEL_ENV
 
 CheckpointStrategy = Literal["calls", "runner_call"]
+CHECKPOINT_STRATEGIES: tuple[CheckpointStrategy, ...] = ("calls", "runner_call")
 SEARCH_CHECKPOINT_STRATEGY: CheckpointStrategy = "runner_call"
 DEFAULT_MAX_SEARCHES = 5
 MAX_SEARCHES_LIMIT = 10
@@ -294,7 +295,7 @@ def publish_report(
     return report.markdown_report
 
 
-@flow(image=RESEARCH_BOT_IMAGE)
+@flow(image=RESEARCH_BOT_IMAGE, cache=False)
 def openai_research_bot(
     query: str,
     max_searches: int,
@@ -442,6 +443,16 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+def _checkpoint_strategy_default(parser: argparse.ArgumentParser) -> CheckpointStrategy:
+    raw = os.getenv("OPENAI_RESEARCH_BOT_CHECKPOINT_STRATEGY", "calls")
+    if raw not in CHECKPOINT_STRATEGIES:
+        parser.error(
+            "OPENAI_RESEARCH_BOT_CHECKPOINT_STRATEGY must be one of: "
+            f"{', '.join(CHECKPOINT_STRATEGIES)}."
+        )
+    return cast(CheckpointStrategy, raw)
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments for the research bot example."""
     default_model = os.getenv("OPENAI_RESEARCH_BOT_MODEL", DEFAULT_MODEL)
@@ -488,8 +499,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--strategy",
-        choices=("calls", "runner_call"),
-        default=os.getenv("OPENAI_RESEARCH_BOT_CHECKPOINT_STRATEGY", "calls"),
+        choices=CHECKPOINT_STRATEGIES,
+        default=_checkpoint_strategy_default(parser),
         help="OpenAI adapter checkpoint strategy for planner/writer (default: calls).",
     )
     parser.add_argument(

--- a/examples/end_to_end/openai_research_bot/research_bot.py
+++ b/examples/end_to_end/openai_research_bot/research_bot.py
@@ -65,6 +65,8 @@ _NON_SECRET_ENV_VARS = (
     "OPENAI_RESEARCH_BOT_CHECKPOINT_STRATEGY",
     SEARCH_TOOL_MODEL_ENV,
 )
+FAIL_AFTER_SEARCHES_ENV = "KITARU_RESEARCH_BOT_FAIL_AFTER_SEARCHES"
+_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 
 RESEARCH_BOT_IMAGE = ImageSettings(
     requirements=[
@@ -131,6 +133,11 @@ def missing_api_key_message(secret_name: str = SECRET_NAME) -> str:
         "The example passes only the secret name to remote runs; it does not put "
         "the key in flow parameters, logs, or artifacts."
     )
+
+
+def _env_flag_enabled(name: str) -> bool:
+    """Return whether an environment flag is explicitly enabled."""
+    return os.getenv(name, "").strip().lower() in _TRUTHY_ENV_VALUES
 
 
 def _coerce_model(value: Any, model_type: type[T]) -> T:
@@ -248,12 +255,38 @@ def publish_search_summaries(
     return [summary.model_dump(mode="json") for summary in summaries]
 
 
+@checkpoint(type="context")
+def durability_drill_gate(
+    search_summaries_artifact: list[dict[str, Any]],
+) -> Annotated[dict[str, Any], "durability_drill"]:
+    """Optionally fail after searches so users can retry from saved checkpoints."""
+    search_count = len(search_summaries_artifact)
+    if _env_flag_enabled(FAIL_AFTER_SEARCHES_ENV):
+        raise RuntimeError(
+            "Intentional durability drill failure after the search checkpoints. "
+            f"Unset {FAIL_AFTER_SEARCHES_ENV} and retry this failed execution; "
+            "Kitaru should reuse the completed planner/search checkpoints."
+        )
+    return {
+        "enabled": False,
+        "fail_after_searches_env": FAIL_AFTER_SEARCHES_ENV,
+        "search_count": search_count,
+    }
+
+
 @checkpoint(type="output")
 def publish_report(
     report: ReportData,
     metadata: dict[str, Any],
+    research_plan_artifact: dict[str, Any],
+    search_summaries_artifact: list[dict[str, Any]],
+    durability_drill_artifact: dict[str, Any],
 ) -> Annotated[str, "final_report"]:
     """Save the final Markdown report and related metadata artifacts."""
+    # These values are already saved as named artifacts by earlier checkpoints.
+    # Keeping them as inputs makes `publish_report` depend on those publishing
+    # checkpoints, so Kitaru has one unambiguous terminal output to return.
+    _ = research_plan_artifact, search_summaries_artifact, durability_drill_artifact
     kitaru.save("research_report_metadata", metadata, type="context")
     kitaru.save("follow_up_questions", report.follow_up_questions, type="context")
     return report.markdown_report
@@ -304,7 +337,12 @@ def openai_research_bot(
         original_query=query,
         max_searches=max_searches,
     )
-    publish_research_plan(query, max_searches, planner_model, plan)
+    research_plan_artifact = publish_research_plan(
+        query,
+        max_searches,
+        planner_model,
+        plan,
+    )
 
     futures = [
         run_search_item.submit(
@@ -316,8 +354,10 @@ def openai_research_bot(
         )
         for index, item in enumerate(plan.searches)
     ]
+    summary_artifacts = [future.result() for future in futures]
+    search_summaries_artifact = publish_search_summaries(summary_artifacts)
     summaries = [future.load() for future in futures]
-    publish_search_summaries(summaries)
+    durability_drill_artifact = durability_drill_gate(search_summaries_artifact)
 
     failed = [item for item in summaries if item.status == "failed"]
     if fail_on_search_error and failed:
@@ -357,7 +397,13 @@ def openai_research_bot(
         "short_summary": report.short_summary,
         "follow_up_questions": report.follow_up_questions,
     }
-    return publish_report(report, metadata)
+    return publish_report(
+        report,
+        metadata,
+        research_plan_artifact,
+        search_summaries_artifact,
+        durability_drill_artifact,
+    )
 
 
 def _collect_non_secret_env() -> dict[str, str]:

--- a/examples/end_to_end/openai_research_bot/research_bot.py
+++ b/examples/end_to_end/openai_research_bot/research_bot.py
@@ -264,8 +264,10 @@ def durability_drill_gate(
     if _env_flag_enabled(FAIL_AFTER_SEARCHES_ENV):
         raise RuntimeError(
             "Intentional durability drill failure after the search checkpoints. "
-            f"Unset {FAIL_AFTER_SEARCHES_ENV} and retry this failed execution; "
-            "Kitaru should reuse the completed planner/search checkpoints."
+            f"Unset {FAIL_AFTER_SEARCHES_ENV} and replay this execution with "
+            "`kitaru executions replay <EXECUTION_ID> --from "
+            "durability_drill_gate`; Kitaru should reuse the completed "
+            "planner/search checkpoints."
         )
     return {
         "enabled": False,

--- a/examples/end_to_end/openai_research_bot/tools.py
+++ b/examples/end_to_end/openai_research_bot/tools.py
@@ -1,0 +1,89 @@
+"""Local tools used by the OpenAI Agents SDK search agent."""
+
+import os
+from typing import Any
+
+from agents import FunctionTool, function_tool
+
+DEFAULT_SEARCH_TOOL_MODEL = "gpt-5-nano"
+SEARCH_TOOL_MODEL_ENV = "OPENAI_RESEARCH_BOT_SEARCH_TOOL_MODEL"
+
+
+def _search_tool_model(model: str | None = None) -> str:
+    """Return the model used by the local web-search helper."""
+    return model or os.getenv(SEARCH_TOOL_MODEL_ENV, DEFAULT_SEARCH_TOOL_MODEL)
+
+
+class SearchWebError(RuntimeError):
+    """Raised when the local web-search helper cannot complete safely."""
+
+
+def _safe_error_message(error: BaseException) -> str:
+    """Convert provider/network errors into a short, non-secret message."""
+    message = str(error)
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        message = message.replace(api_key, "[redacted]")
+    if len(message) > 500:
+        message = f"{message[:497]}..."
+    return f"{type(error).__name__}: {message}"
+
+
+def _collect_source_urls(response: Any) -> list[str]:
+    """Best-effort extraction of web-search sources from a Responses API result."""
+    sources = getattr(response, "sources", None)
+    if isinstance(sources, list):
+        urls = [getattr(source, "url", None) for source in sources]
+        return [url for url in urls if isinstance(url, str) and url]
+    return []
+
+
+def _run_web_search(query: str, *, model: str | None = None) -> str:
+    """Search the web for a query and return concise source-grounded notes."""
+    if not os.getenv("OPENAI_API_KEY"):
+        raise SearchWebError(
+            "OPENAI_API_KEY is not available in this runtime. For local runs, "
+            "export OPENAI_API_KEY. For remote stacks, create a Kitaru secret "
+            "and pass it through secret_environment_from."
+        )
+
+    try:
+        from openai import OpenAI
+
+        response = OpenAI().responses.create(
+            model=_search_tool_model(model),
+            tools=[{"type": "web_search"}],
+            input=(
+                "Search the web for the query below. Return concise, factual notes "
+                "with enough detail for a later writer to synthesize a report. "
+                "Keep any inline citations provided by the API visible.\n\n"
+                f"Query: {query}"
+            ),
+        )
+    except Exception as error:  # pragma: no cover - provider/network defensive path
+        raise SearchWebError(_safe_error_message(error)) from error
+
+    output_text = getattr(response, "output_text", "")
+    if not isinstance(output_text, str) or not output_text.strip():
+        output_text = str(response)
+
+    source_urls = _collect_source_urls(response)
+    if not source_urls:
+        return output_text
+
+    sources = "\n".join(f"- {url}" for url in source_urls[:10])
+    return f"{output_text}\n\nSources consulted:\n{sources}"
+
+
+def new_search_web_tool(*, model: str | None = None) -> FunctionTool:
+    """Build a search_web tool bound to the requested Responses API model."""
+
+    @function_tool(name_override="search_web", failure_error_function=None)
+    def search_web(query: str) -> str:
+        """Search the web for a query and return concise source-grounded notes."""
+        return _run_web_search(query, model=model)
+
+    return search_web
+
+
+search_web = new_search_web_tool()

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -352,11 +352,25 @@ run_test "examples/integrations/pydantic_ai_agent/pydantic_ai_adapter.py" \
 
 section_header "OpenAI Agents adapter"
 
+run_test "examples/end_to_end/openai_research_bot/research_bot.py --help" \
+    $UV_RUN python examples/end_to_end/openai_research_bot/research_bot.py --help
+
 if [[ "$HAS_OPENAI" == true ]]; then
     run_test "examples/integrations/openai_agents_agent/openai_agents_adapter.py" \
         $UV_RUN python examples/integrations/openai_agents_agent/openai_agents_adapter.py
 else
     skip_test "examples/integrations/openai_agents_agent/openai_agents_adapter.py" "OPENAI_API_KEY not set"
+fi
+
+if [[ "$HAS_OPENAI" != true ]]; then
+    skip_test "examples/end_to_end/openai_research_bot/research_bot.py" "OPENAI_API_KEY not set"
+elif [[ "${KITARU_SMOKE_RESEARCH_BOT:-}" != "1" ]]; then
+    skip_test "examples/end_to_end/openai_research_bot/research_bot.py" "set KITARU_SMOKE_RESEARCH_BOT=1 to run the real web-search smoke test"
+else
+    run_test "examples/end_to_end/openai_research_bot/research_bot.py" \
+        timed 180 $UV_RUN python examples/end_to_end/openai_research_bot/research_bot.py \
+            "AI agent durability in one paragraph" --max-searches 2 --strategy calls \
+            --fail-on-search-error
 fi
 
 # Run after init so .kitaru/ exists (clean project --dry-run exits non-zero

--- a/tests/test_openai_research_bot_example.py
+++ b/tests/test_openai_research_bot_example.py
@@ -1,8 +1,14 @@
 """No-network contract tests for the OpenAI research bot example."""
 
 import importlib
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
 
+import pytest
+from examples.end_to_end.openai_research_bot import research_bot
 from examples.end_to_end.openai_research_bot.models import (
+    ReportData,
     SearchSummary,
     WebSearchItem,
     WebSearchPlan,
@@ -10,13 +16,16 @@ from examples.end_to_end.openai_research_bot.models import (
 from examples.end_to_end.openai_research_bot.prompts import build_writer_input
 from examples.end_to_end.openai_research_bot.research_bot import (
     DEFAULT_MODEL,
+    FAIL_AFTER_SEARCHES_ENV,
     SEARCH_CHECKPOINT_STRATEGY,
+    _env_flag_enabled,
     clamp_max_searches,
     missing_api_key_message,
     normalize_search_plan,
     parse_args,
 )
 from examples.end_to_end.openai_research_bot.tools import _safe_error_message
+from zenml.client import Client
 
 
 def test_example_imports_without_openai_api_key(monkeypatch) -> None:
@@ -132,3 +141,81 @@ def test_parse_args_supports_fail_on_search_error() -> None:
     args = parse_args(["Research durable agents", "--fail-on-search-error"])
 
     assert args.fail_on_search_error is True
+
+
+def test_durability_drill_env_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(FAIL_AFTER_SEARCHES_ENV, raising=False)
+    assert _env_flag_enabled(FAIL_AFTER_SEARCHES_ENV) is False
+
+    monkeypatch.setenv(FAIL_AFTER_SEARCHES_ENV, "1")
+    assert _env_flag_enabled(FAIL_AFTER_SEARCHES_ENV) is True
+
+
+def test_flow_has_one_terminal_output_after_side_effect_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    primed_zenml: None,
+) -> None:
+    """Side-effect artifact checkpoints should feed into the final report step."""
+
+    del primed_zenml
+
+    class FakeRunner:
+        def run_sync(self, request: Any) -> SimpleNamespace:
+            stage = request.metadata["stage"]
+            if stage == "planner":
+                output = WebSearchPlan(
+                    searches=[
+                        WebSearchItem(query="durable agents", reason="baseline"),
+                        WebSearchItem(query="agent replay", reason="replay"),
+                    ]
+                )
+            elif stage == "writer":
+                output = ReportData(
+                    short_summary="Durability avoids repeated work.",
+                    markdown_report="# Durable agents\n\nReplay saves completed work.",
+                    follow_up_questions=["How should tools be checkpointed?"],
+                )
+            else:
+                output = "Search summary"
+            return SimpleNamespace(status="completed", final_output=output)
+
+    monkeypatch.setattr(
+        research_bot,
+        "_new_runner",
+        lambda *_args, **_kwargs: FakeRunner(),
+    )
+
+    handle = research_bot.openai_research_bot.run(
+        query=f"durable agents {uuid4().hex}",
+        max_searches=2,
+        planner_model="gpt-5-nano",
+        search_model="gpt-5-nano",
+        writer_model="gpt-5-nano",
+        search_tool_model="gpt-5-nano",
+        checkpoint_strategy="runner_call",
+        fail_on_search_error=True,
+    )
+
+    assert handle.wait() == "# Durable agents\n\nReplay saves completed work."
+
+    hydrated = (
+        Client()
+        .get_pipeline_run(
+            handle.exec_id,
+            allow_name_prefix_match=False,
+        )
+        .get_hydrated_version()
+    )
+    upstream_step_names: set[str] = set()
+    for step_run in hydrated.steps.values():
+        step_spec = getattr(step_run, "spec", None)
+        if step_spec is not None:
+            upstream_step_names.update(getattr(step_spec, "upstream_steps", []) or [])
+
+    terminal_step_names = sorted(
+        step_name
+        for step_name in hydrated.steps
+        if step_name not in upstream_step_names
+    )
+
+    assert terminal_step_names == ["publish_report"]

--- a/tests/test_openai_research_bot_example.py
+++ b/tests/test_openai_research_bot_example.py
@@ -15,6 +15,7 @@ from examples.end_to_end.openai_research_bot.models import (
 )
 from examples.end_to_end.openai_research_bot.prompts import build_writer_input
 from examples.end_to_end.openai_research_bot.research_bot import (
+    CHECKPOINT_STRATEGIES,
     DEFAULT_MODEL,
     FAIL_AFTER_SEARCHES_ENV,
     SEARCH_CHECKPOINT_STRATEGY,
@@ -137,10 +138,33 @@ def test_parse_args_defaults_to_gpt_5_nano() -> None:
     assert args.fail_on_search_error is False
 
 
+def test_parse_args_accepts_valid_strategy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_RESEARCH_BOT_CHECKPOINT_STRATEGY", "runner_call")
+
+    args = parse_args(["Research durable agents"])
+
+    assert args.strategy == "runner_call"
+
+
+def test_parse_args_rejects_invalid_strategy_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_RESEARCH_BOT_CHECKPOINT_STRATEGY", "bogus")
+
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["Research durable agents"])
+
+    assert exc_info.value.code == 2
+
+
 def test_parse_args_supports_fail_on_search_error() -> None:
     args = parse_args(["Research durable agents", "--fail-on-search-error"])
 
     assert args.fail_on_search_error is True
+
+
+def test_research_bot_flow_disables_ordinary_cache() -> None:
+    assert research_bot.openai_research_bot._decorator_config.cache is False
 
 
 def test_durability_drill_env_flag(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -192,7 +216,7 @@ def test_flow_has_one_terminal_output_after_side_effect_artifacts(
         search_model="gpt-5-nano",
         writer_model="gpt-5-nano",
         search_tool_model="gpt-5-nano",
-        checkpoint_strategy="runner_call",
+        checkpoint_strategy=CHECKPOINT_STRATEGIES[1],
         fail_on_search_error=True,
     )
 

--- a/tests/test_openai_research_bot_example.py
+++ b/tests/test_openai_research_bot_example.py
@@ -1,0 +1,134 @@
+"""No-network contract tests for the OpenAI research bot example."""
+
+import importlib
+
+from examples.end_to_end.openai_research_bot.models import (
+    SearchSummary,
+    WebSearchItem,
+    WebSearchPlan,
+)
+from examples.end_to_end.openai_research_bot.prompts import build_writer_input
+from examples.end_to_end.openai_research_bot.research_bot import (
+    DEFAULT_MODEL,
+    SEARCH_CHECKPOINT_STRATEGY,
+    clamp_max_searches,
+    missing_api_key_message,
+    normalize_search_plan,
+    parse_args,
+)
+from examples.end_to_end.openai_research_bot.tools import _safe_error_message
+
+
+def test_example_imports_without_openai_api_key(monkeypatch) -> None:
+    """The example should be importable before a user sets credentials."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    for module_name in (
+        "examples.end_to_end.openai_research_bot.models",
+        "examples.end_to_end.openai_research_bot.prompts",
+        "examples.end_to_end.openai_research_bot.tools",
+        "examples.end_to_end.openai_research_bot.bot_agents",
+        "examples.end_to_end.openai_research_bot.research_bot",
+    ):
+        importlib.import_module(module_name)
+
+
+def test_normalize_search_plan_trims_deduplicates_and_clamps() -> None:
+    plan = WebSearchPlan(
+        searches=[
+            WebSearchItem(query=" Durable agents ", reason="first"),
+            WebSearchItem(query="durable   agents", reason="duplicate"),
+            WebSearchItem(query="replay cost", reason="second"),
+            WebSearchItem(query="checkpoint UI", reason="third"),
+        ]
+    )
+
+    normalized = normalize_search_plan(
+        plan,
+        original_query="durable agents",
+        max_searches=2,
+    )
+
+    assert [item.query for item in normalized.searches] == [
+        "Durable agents",
+        "replay cost",
+    ]
+    assert clamp_max_searches(0) == 1
+    assert clamp_max_searches(99) == 10
+
+
+def test_normalize_search_plan_adds_fallback_for_empty_plan() -> None:
+    normalized = normalize_search_plan(
+        WebSearchPlan(searches=[]),
+        original_query="Why does replay help agents?",
+        max_searches=5,
+    )
+
+    assert len(normalized.searches) == 1
+    assert normalized.searches[0].query == "Why does replay help agents?"
+    assert "Fallback" in normalized.searches[0].reason
+
+
+def test_writer_input_includes_completed_and_failed_summaries() -> None:
+    text = build_writer_input(
+        "research durable agents",
+        [
+            SearchSummary(
+                index=0,
+                query="durable agents",
+                reason="baseline",
+                status="completed",
+                summary="Checkpointing avoids duplicate calls.",
+            ),
+            SearchSummary(
+                index=1,
+                query="agent replay failure modes",
+                reason="risk check",
+                status="failed",
+                summary="Missing evidence.",
+                error_message="TimeoutError: search timed out",
+            ),
+        ],
+    )
+
+    assert "Original query: research durable agents" in text
+    assert "Status: completed" in text
+    assert "Status: failed" in text
+    assert "TimeoutError: search timed out" in text
+
+
+def test_search_checkpoint_uses_runner_call_strategy() -> None:
+    assert SEARCH_CHECKPOINT_STRATEGY == "runner_call"
+
+
+def test_safe_error_message_does_not_mangle_unset_api_key(monkeypatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    message = _safe_error_message(RuntimeError("network timeout"))
+
+    assert "network timeout" in message
+    assert "[redacted]" not in message
+
+
+def test_missing_api_key_message_is_actionable() -> None:
+    message = missing_api_key_message("example-secret")
+
+    assert "OPENAI_API_KEY" in message
+    assert "export OPENAI_API_KEY" in message
+    assert "kitaru secrets set example-secret" in message
+    assert "flow parameters" in message
+
+
+def test_parse_args_defaults_to_gpt_5_nano() -> None:
+    args = parse_args(["Research durable agents", "--max-searches", "2"])
+
+    assert args.model == DEFAULT_MODEL == "gpt-5-nano"
+    assert args.max_searches == 2
+    assert args.strategy == "calls"
+    assert args.fail_on_search_error is False
+
+
+def test_parse_args_supports_fail_on_search_error() -> None:
+    args = parse_args(["Research durable agents", "--fail-on-search-error"])
+
+    assert args.fail_on_search_error is True


### PR DESCRIPTION
## Summary

- Adds `examples/end_to_end/openai_research_bot`, a real OpenAI Agents SDK + Kitaru example with planner → parallel search checkpoints → writer report.
- Adds an educational README, examples index/docs entries, changelog note, no-network contract tests, and gated smoke-test coverage.
- Keeps the example default cheap with `gpt-5-nano`, while documenting `gpt-5-mini` as the smarter/pricier override.

## Why

This gives potential users a fuller OpenAI Agents SDK example than the minimal support-flow integration. The example shows the concrete durability story: Kitaru saves the search plan, runs each search as its own replayable checkpoint, and publishes the final Markdown report as a UI artifact.

Stacked on #295, which adds the OpenAI Agents adapter itself.

## Key implementation decisions

- Planner and writer use `checkpoint_strategy="calls"` from flow scope so supported inner OpenAI model/tool calls can appear as child checkpoints.
- Each parallel search is itself a Kitaru checkpoint, so the OpenAI runner inside that checkpoint uses `checkpoint_strategy="runner_call"` to avoid nested call-level checkpoints.
- The example uses a local OpenAI Agents SDK `@function_tool` named `search_web`, backed by the OpenAI Responses API `web_search` tool, instead of hosted `WebSearchTool`. That keeps the checkpoint trace clearer with the adapter's current public behavior.
- Remote runs pass only the Kitaru secret name (`openai-research-bot-keys`) via image configuration; the API key value is not placed in flow parameters, logs, or artifacts.
- The live smoke path is opt-in with both `OPENAI_API_KEY` and `KITARU_SMOKE_RESEARCH_BOT=1` because it performs real web searches.

## Reviewer Notes

Please focus on:

- Whether `examples/end_to_end/openai_research_bot/README.md` is clear and useful for first-time Kitaru users.
- Whether the checkpoint-strategy split in `research_bot.py` is easy to understand: planner/writer use `calls`, parallel searches use outer Kitaru checkpoints plus inner `runner_call`.
- Whether the local `search_web` function tool is the right public teaching story for now, given that hosted OpenAI tools are less visible in the adapter trace.

Useful commands:

```bash
uv sync --extra local --extra openai-agents
uv run pytest -q tests/test_openai_research_bot_example.py
env -u OPENAI_API_KEY uv run python examples/end_to_end/openai_research_bot/research_bot.py "AI durability" --max-searches 1

# Optional live run / smoke path, costs real OpenAI API calls:
export OPENAI_API_KEY='sk-...'
KITARU_SMOKE_RESEARCH_BOT=1 ./scripts/smoke-test.sh -s
```

Validation run here:

- `uv run ruff format examples/end_to_end/openai_research_bot tests/test_openai_research_bot_example.py`
- `uv run ruff check examples/end_to_end/openai_research_bot tests/test_openai_research_bot_example.py`
- `uv run pytest -q tests/test_openai_research_bot_example.py`
- `bash -n scripts/smoke-test.sh`
- Missing-key CLI path with `OPENAI_API_KEY` unset
- `just check` (with untracked `docs/investigations/` temporarily moved aside and restored)
- `just test` → 1718 passed, 8 skipped


## Follow-up fix

- Fixed run-result extraction for server-backed/local-remote stacks by making the final `publish_report` checkpoint depend on the plan, search summaries, and individual search checkpoint outputs, leaving one unambiguous terminal step.
- Added `KITARU_RESEARCH_BOT_FAIL_AFTER_SEARCHES=1` as an intentional durability drill. The example now fails after searches complete; unset the flag and run `kitaru executions retry <EXECUTION_ID>` to verify Kitaru reuses completed checkpoints.
- Added a no-network regression test that runs the flow with fake OpenAI runners and asserts the graph has exactly one terminal step.

Additional validation after the fix:

- `uv run pytest -q tests/test_openai_research_bot_example.py`
- `just check`
- `just test` → 1720 passed, 8 skipped


## Follow-up clarification

- Updated the durability drill instructions to use `kitaru executions replay <EXECUTION_ID> --from durability_drill_gate` instead of `retry`.
- Reason: `retry` is same-execution recovery and can be unavailable on server-backed stacks after a run has concluded; this drill is meant to demonstrate replaying from a failed checkpoint into a new execution while reusing completed upstream checkpoints.


## Review follow-up

- Disabled ordinary same-input caching for the live research bot flow with `@flow(..., cache=False)`, so normal reruns perform fresh web searches while replay still demonstrates checkpoint reuse.
- Added README wording that separates fresh-run cache behavior from replay durability behavior.
- Validated `OPENAI_RESEARCH_BOT_CHECKPOINT_STRATEGY` before using it as the argparse default, so invalid env configuration fails with a clear CLI error.
