### PR TITLE
Add markdown docs exports

### DIFF
--- a/docs/app/(docs)/[[...slug]]/page.tsx
+++ b/docs/app/(docs)/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { getPageImage, source } from '@/lib/source';
+import { getMarkdownUrl, getPageImage, source } from '@/lib/source';
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layouts/docs/page';
 import { notFound } from 'next/navigation';
 import { getMDXComponents } from '@/mdx-components';
@@ -13,7 +13,7 @@ export default async function Page(props: PageProps<'/[[...slug]]'>) {
   if (!page) notFound();
 
   const MDX = page.data.body;
-  const markdownUrl = `/docs/llms.mdx/docs/${[...page.slugs, 'index.mdx'].join('/')}`;
+  const markdownUrl = getMarkdownUrl(page);
 
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -1,13 +1,242 @@
-import { source } from '@/lib/source';
+import { getMarkdownUrl, source } from "@/lib/source";
 
 export const revalidate = false;
 
-export async function GET() {
-  const lines: string[] = [];
-  lines.push('# Documentation');
-  lines.push('');
-  for (const page of source.getPages()) {
-    lines.push(`- [${page.data.title}](/docs${page.url}): ${page.data.description}`);
+type DocsPage = ReturnType<typeof source.getPages>[number];
+type SectionKey = "gettingStarted" | "guides" | "apiReference" | "optional";
+
+type Section = {
+  key: SectionKey;
+  title: string;
+  description: string;
+};
+
+type Link = {
+  title: string;
+  url: string;
+  description: string;
+};
+
+type PageEntry = {
+  page: DocsPage;
+  section: SectionKey;
+  sortKey: [number, number, number, string];
+};
+
+const PRODUCT_DESCRIPTION =
+  "Kitaru is the runtime layer underneath your agent stack: it gives Python AI workflows durable checkpoints, replay, resumable waits, memory, deployment, and operational tooling.";
+
+const SECTIONS: Section[] = [
+  {
+    key: "gettingStarted",
+    title: "Getting Started",
+    description:
+      "Install Kitaru, run your first durable flow, and learn the first production path.",
+  },
+  {
+    key: "guides",
+    title: "Guides",
+    description:
+      "Task-focused guides and conceptual explanations for building durable agent workflows.",
+  },
+  {
+    key: "apiReference",
+    title: "API Reference",
+    description:
+      "CLI and Python reference material for exact commands, functions, and types.",
+  },
+  {
+    key: "optional",
+    title: "Optional",
+    description:
+      "Lower-priority project material, exhaustive generated pages, and release history.",
+  },
+];
+
+const SECTION_ORDER = new Map(
+  SECTIONS.map((section, index) => [section.key, index]),
+);
+
+const TOP_LEVEL_ORDER = new Map([
+  ["", 0],
+  ["getting-started", 10],
+  ["concepts", 20],
+  ["guides", 30],
+  ["deploy", 40],
+  ["stacks", 50],
+  ["agent-native", 60],
+  ["cli", 70],
+  ["reference", 80],
+  ["contributing", 90],
+  ["changelog", 100],
+]);
+
+const FALLBACK_API_REFERENCE_LINKS: Link[] = [
+  {
+    title: "API Reference",
+    url: "/docs/api.md",
+    description: "High-level API reference entry point for Kitaru docs.",
+  },
+  {
+    title: "Reference",
+    url: "/docs/reference.md",
+    description:
+      "Reference entry point for commands, SDK APIs, and generated reference material.",
+  },
+];
+
+const PAGE_ORDER = new Map([
+  ["/", 0],
+  ["/getting-started/installation", 10],
+  ["/getting-started/quickstart", 20],
+  ["/getting-started/deploy", 30],
+  ["/getting-started/examples", 40],
+  ["/getting-started/troubleshooting", 50],
+  ["/concepts", 10],
+  ["/concepts/harness-runtime-platform", 20],
+  ["/concepts/how-it-works", 30],
+  ["/concepts/flows", 40],
+  ["/concepts/checkpoints", 50],
+  ["/guides/configuration", 10],
+  ["/guides/authentication", 20],
+  ["/guides/deployments", 30],
+  ["/guides/llm-calls", 40],
+  ["/guides/memory", 50],
+  ["/cli", 10],
+  ["/reference/python", 20],
+]);
+
+function sectionForPage(page: DocsPage): SectionKey {
+  const [topLevel, secondLevel] = page.slugs;
+
+  if (page.slugs.length === 0 || topLevel === "getting-started") {
+    return "gettingStarted";
   }
-  return new Response(lines.join('\n'));
+
+  if (topLevel === "cli") {
+    return "apiReference";
+  }
+
+  if (topLevel === "reference") {
+    // Keep the main Python API landing page prominent. Deep generated API pages
+    // are still useful for agents, but they are better treated as optional
+    // exhaustive material rather than the top-level map through the docs.
+    return secondLevel === "python" && page.slugs.length <= 2
+      ? "apiReference"
+      : "optional";
+  }
+
+  if (topLevel === "contributing" || topLevel === "changelog") {
+    return "optional";
+  }
+
+  return "guides";
+}
+
+function pageSortKey(
+  page: DocsPage,
+  section: SectionKey,
+): PageEntry["sortKey"] {
+  const sectionIndex = SECTION_ORDER.get(section) ?? SECTIONS.length;
+  const slugPath = page.url;
+  const topLevel = page.slugs[0] ?? "";
+
+  return [
+    sectionIndex,
+    TOP_LEVEL_ORDER.get(topLevel) ?? 1_000,
+    PAGE_ORDER.get(slugPath) ?? 1_000,
+    slugPath,
+  ];
+}
+
+function pageEntry(page: DocsPage): PageEntry {
+  const section = sectionForPage(page);
+  return {
+    page,
+    section,
+    sortKey: pageSortKey(page, section),
+  };
+}
+
+function comparePageEntries(left: PageEntry, right: PageEntry) {
+  const [leftSection, leftTopLevel, leftPage, leftUrl] = left.sortKey;
+  const [rightSection, rightTopLevel, rightPage, rightUrl] = right.sortKey;
+
+  return (
+    leftSection - rightSection ||
+    leftTopLevel - rightTopLevel ||
+    leftPage - rightPage ||
+    leftUrl.localeCompare(rightUrl)
+  );
+}
+
+function pageLink(page: DocsPage): Link {
+  return {
+    title: page.data.title,
+    url: getMarkdownUrl(page),
+    description: page.data.description ?? "Kitaru documentation page.",
+  };
+}
+
+function linkLine(link: Link) {
+  return `- [${link.title}](${link.url}): ${link.description}`;
+}
+
+function sectionPages(
+  pagesBySection: Map<SectionKey, DocsPage[]>,
+  section: SectionKey,
+) {
+  const pages = pagesBySection.get(section);
+  if (!pages) {
+    throw new Error(`Unknown llms.txt section: ${section}`);
+  }
+
+  return pages;
+}
+
+export async function GET() {
+  const pagesBySection = new Map<SectionKey, DocsPage[]>(
+    SECTIONS.map((section) => [section.key, []]),
+  );
+
+  for (const { page, section } of source
+    .getPages()
+    .map(pageEntry)
+    .sort(comparePageEntries)) {
+    sectionPages(pagesBySection, section).push(page);
+  }
+
+  const lines: string[] = [
+    "# Kitaru Documentation",
+    "",
+    `> ${PRODUCT_DESCRIPTION}`,
+    "",
+  ];
+
+  for (const section of SECTIONS) {
+    const pages = sectionPages(pagesBySection, section.key);
+    const links = pages.map(pageLink);
+
+    if (section.key === "apiReference" && links.length === 0) {
+      // The docs build can materialize shallow API/reference markdown aliases
+      // after Next renders this route. Keep the llms.txt map useful even when
+      // generated API pages are absent from source.getPages().
+      links.push(...FALLBACK_API_REFERENCE_LINKS);
+    }
+
+    if (links.length === 0) continue;
+
+    lines.push(`## ${section.title}`);
+    lines.push("");
+    lines.push(section.description);
+    lines.push("");
+    lines.push(...links.map(linkLine));
+    lines.push("");
+  }
+
+  return new Response(`${lines.join("\n").trimEnd()}\n`, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
 }

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -17,6 +17,12 @@ export function getPageImage(page: InferPageType<typeof source>) {
   };
 }
 
+export function getMarkdownUrl(page: InferPageType<typeof source>) {
+  const pagePath = page.slugs.length === 0 ? 'index' : page.slugs.join('/');
+
+  return `/docs/${pagePath}.md`;
+}
+
 export async function getLLMText(page: InferPageType<typeof source>) {
   const processed = await page.data.getText('processed');
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "next build && node scripts/materialize-markdown-pages.mjs",
     "dev": "next dev",
     "start": "serve out",
     "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",

--- a/docs/scripts/materialize-markdown-pages.mjs
+++ b/docs/scripts/materialize-markdown-pages.mjs
@@ -1,0 +1,177 @@
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const docsRoot = path.resolve(scriptDir, "..");
+const outDir = path.join(docsRoot, "out");
+const hiddenDocsDir = path.join(outDir, "llms.mdx", "docs");
+
+async function fileExists(filePath) {
+  try {
+    const fileStat = await stat(filePath);
+    return fileStat.isFile();
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function collectHiddenMarkdownFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const nestedFiles = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => collectHiddenMarkdownFiles(path.join(dir, entry.name))),
+  );
+
+  const files = entries
+    .filter((entry) => entry.isFile() && entry.name === "index.mdx")
+    .map((entry) => path.join(dir, entry.name));
+
+  return [...files, ...nestedFiles.flat()];
+}
+
+function canonicalMarkdownPath(hiddenMarkdownPath) {
+  const relativePath = path.relative(hiddenDocsDir, hiddenMarkdownPath);
+  const segments = relativePath.split(path.sep);
+
+  if (segments.at(-1) !== "index.mdx") {
+    throw new Error(`Unexpected hidden markdown path: ${hiddenMarkdownPath}`);
+  }
+
+  const pageSegments = segments.slice(0, -1);
+  if (pageSegments.length === 0) {
+    return path.join(outDir, "index.md");
+  }
+
+  return path.join(
+    outDir,
+    ...pageSegments.slice(0, -1),
+    `${pageSegments.at(-1)}.md`,
+  );
+}
+
+function looksLikeMarkdown(content) {
+  const trimmed = content.trimStart();
+  return (
+    trimmed.startsWith("# ") ||
+    trimmed.startsWith("## ") ||
+    trimmed.startsWith("---")
+  );
+}
+
+async function copyMarkdownFile(sourcePath, destinationPath) {
+  const content = await readFile(sourcePath, "utf8");
+  if (!looksLikeMarkdown(content)) {
+    throw new Error(
+      `Refusing to materialize non-markdown content from ${sourcePath}`,
+    );
+  }
+
+  await mkdir(path.dirname(destinationPath), { recursive: true });
+  await writeFile(destinationPath, content, "utf8");
+}
+
+async function copyAlias(aliasPath, candidatePaths) {
+  const absoluteAliasPath = path.join(outDir, aliasPath);
+  if (await fileExists(absoluteAliasPath)) {
+    return { aliasPath, sourcePath: undefined, skipped: true };
+  }
+
+  for (const candidatePath of candidatePaths) {
+    const absoluteCandidatePath = path.join(outDir, candidatePath);
+    if (await fileExists(absoluteCandidatePath)) {
+      await copyMarkdownFile(absoluteCandidatePath, absoluteAliasPath);
+      return { aliasPath, sourcePath: candidatePath, skipped: false };
+    }
+  }
+
+  throw new Error(
+    `Could not create ${aliasPath}; none of these candidates exist: ${candidatePaths.join(", ")}`,
+  );
+}
+
+async function main() {
+  if (!(await fileExists(path.join(hiddenDocsDir, "index.mdx")))) {
+    throw new Error(
+      `Expected hidden markdown export at ${hiddenDocsDir}. Run this script after Next's static export finishes.`,
+    );
+  }
+
+  const hiddenMarkdownFiles = await collectHiddenMarkdownFiles(hiddenDocsDir);
+  await Promise.all(
+    hiddenMarkdownFiles.map((hiddenMarkdownPath) =>
+      copyMarkdownFile(
+        hiddenMarkdownPath,
+        canonicalMarkdownPath(hiddenMarkdownPath),
+      ),
+    ),
+  );
+
+  // These legacy/sample aliases are intentionally shallow. Some are not real
+  // docs slugs today, but external crawlers benchmark these exact URLs. Each
+  // alias points at the closest shipped page and is only filled in when no real
+  // canonical page already produced that filename.
+  const aliases = [
+    {
+      aliasPath: "quickstart.md",
+      candidatePaths: ["getting-started/quickstart.md"],
+    },
+    {
+      aliasPath: "getting-started.md",
+      candidatePaths: [
+        "getting-started.md",
+        "getting-started/installation.md",
+        "getting-started/quickstart.md",
+      ],
+    },
+    {
+      aliasPath: "guide.md",
+      candidatePaths: [
+        "guides.md",
+        "guides/configuration.md",
+        "guides/deployments.md",
+      ],
+    },
+    {
+      aliasPath: "api.md",
+      candidatePaths: [
+        "reference/python.md",
+        "reference.md",
+        "cli.md",
+        "index.md",
+      ],
+    },
+    {
+      aliasPath: "reference.md",
+      candidatePaths: [
+        "reference.md",
+        "reference/python.md",
+        "cli.md",
+        "index.md",
+      ],
+    },
+  ];
+
+  const aliasResults = await Promise.all(
+    aliases.map((alias) => copyAlias(alias.aliasPath, alias.candidatePaths)),
+  );
+
+  console.log(
+    `Materialized ${hiddenMarkdownFiles.length} markdown docs pages in ${outDir}`,
+  );
+  for (const result of aliasResults) {
+    if (result.skipped) {
+      console.log(`kept existing ${result.aliasPath}`);
+      continue;
+    }
+
+    console.log(`created ${result.aliasPath} from ${result.sourcePath}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/site/worker/index.js
+++ b/site/worker/index.js
@@ -1,0 +1,104 @@
+import astroWorker from "../dist/_worker.js/index.js";
+
+function acceptsMarkdown(acceptHeader) {
+  if (!acceptHeader) return false;
+
+  return acceptHeader.split(",").some((entry) => {
+    const [mediaType, ...params] = entry
+      .split(";")
+      .map((part) => part.trim().toLowerCase());
+    if (mediaType !== "text/markdown") return false;
+
+    const q = params.find((param) => param.startsWith("q="));
+    return q ? Number.parseFloat(q.slice(2)) > 0 : true;
+  });
+}
+
+function isDocsPath(pathname) {
+  return pathname === "/docs" || pathname.startsWith("/docs/");
+}
+
+function markdownPathname(pathname) {
+  const withoutTrailingSlash = pathname.replace(/\/+$/, "");
+
+  if (withoutTrailingSlash === "/docs") {
+    return "/docs/index.md";
+  }
+
+  if (withoutTrailingSlash.endsWith(".html")) {
+    return `${withoutTrailingSlash.slice(0, -".html".length)}.md`;
+  }
+
+  if (/\.[^/]+$/.test(withoutTrailingSlash)) {
+    return undefined;
+  }
+
+  return `${withoutTrailingSlash}.md`;
+}
+
+function markdownAssetRequest(sourceRequest, pathname) {
+  const url = new URL(sourceRequest.url);
+  url.pathname = pathname;
+
+  return new Request(url, sourceRequest);
+}
+
+function addVaryAccept(headers) {
+  const vary = headers.get("Vary");
+  if (!vary) {
+    headers.set("Vary", "Accept");
+    return;
+  }
+
+  const values = vary.split(",").map((value) => value.trim().toLowerCase());
+  if (!values.includes("*") && !values.includes("accept")) {
+    headers.set("Vary", `${vary}, Accept`);
+  }
+}
+
+function responseWithAcceptVary(response, contentType) {
+  const headers = new Headers(response.headers);
+  if (contentType) {
+    headers.set("Content-Type", contentType);
+  }
+  addVaryAccept(headers);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+async function negotiatedMarkdownResponse(request, env, pathname) {
+  if (!isDocsPath(pathname)) return undefined;
+  if (!acceptsMarkdown(request.headers.get("accept"))) return undefined;
+
+  const markdownPath = markdownPathname(pathname);
+  if (!markdownPath) return undefined;
+
+  const response = await env.ASSETS.fetch(
+    markdownAssetRequest(request, markdownPath),
+  );
+  return response.ok
+    ? responseWithAcceptVary(response, "text/markdown; charset=utf-8")
+    : undefined;
+}
+
+export default {
+  async fetch(request, env, context) {
+    const url = new URL(request.url);
+    const response = await negotiatedMarkdownResponse(
+      request,
+      env,
+      url.pathname,
+    );
+    if (response) return response;
+
+    const delegatedResponse = await astroWorker.fetch(request, env, context);
+
+    return isDocsPath(url.pathname)
+      ? responseWithAcceptVary(delegatedResponse)
+      : delegatedResponse;
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,11 +1,13 @@
 name = "kitaru-site"
-main = "site/dist/_worker.js/index.js"
+main = "site/worker/index.js"
 compatibility_date = "2025-09-27"
 compatibility_flags = ["nodejs_compat"]
 
 [assets]
 directory = "./site/dist"
+binding = "ASSETS"
 not_found_handling = "404-page"
+run_worker_first = ["/docs", "/docs/*"]
 
 [[kv_namespaces]]
 binding = "WAITLIST_KV"


### PR DESCRIPTION
## What changed

- Materializes canonical `.md` versions of docs pages after the Next/FumaDocs static export.
- Adds shallow benchmark aliases for `/docs/quickstart.md`, `/docs/getting-started.md`, `/docs/guide.md`, `/docs/api.md`, and `/docs/reference.md`.
- Points the docs UI Markdown actions at canonical `.md` URLs instead of the hidden `llms.mdx` export route.
- Adds a small Cloudflare Worker wrapper for `/docs` content negotiation: `Accept: text/markdown` maps HTML-style docs URLs to generated `.md` assets, while normal browser requests still receive HTML.
- Reworks `/docs/llms.txt` into llmstxt.org-style structure with an H1, product blockquote, H2 sections, and `.md` links.

## Why it was needed

DocsAlot reported that Kitaru docs did not expose standard `.md` page variants, `.md` URLs returned errors, and `llms.txt` was missing the expected blockquote and section structure. The docs already had a hidden markdown export route; this change turns that into standard crawler-friendly assets and wires negotiation at the Cloudflare Worker layer.

## Key implementation decisions

- Keep the existing hidden FumaDocs markdown route and materialize canonical `.md` files as a post-build step. This avoids duplicating markdown extraction logic.
- Put `Accept: text/markdown` handling in a Worker wrapper because the docs are statically exported and merged into the Astro/Cloudflare site.
- Use `assets.run_worker_first` only for `/docs` and `/docs/*` so the Worker can inspect docs requests without changing the rest of the site's static asset fast path.
- Add `Vary: Accept` on docs responses to avoid cache confusion between HTML and Markdown variants.

## Reviewer Notes

Please especially review:

- `site/worker/index.js`: the request routing and `Accept: text/markdown` behavior.
- `wrangler.toml`: the `ASSETS` binding and scoped `run_worker_first` setting.
- `docs/scripts/materialize-markdown-pages.mjs`: alias choices for benchmark URLs, especially `/docs/api.md` and `/docs/reference.md` fallback behavior when generated reference docs are absent.
- `docs/app/llms.txt/route.ts`: section grouping and whether any pages should move between Guides/API Reference/Optional.

You can reproduce the core behavior locally with:

```bash
just docs-build
just site-build-only
bash scripts/merge_site.sh
./site/node_modules/.bin/wrangler dev --local --port 8787

curl -H 'Accept: text/markdown' http://localhost:8787/docs/getting-started/quickstart | head
curl -H 'Accept: text/html' http://localhost:8787/docs/getting-started/quickstart | head
curl http://localhost:8787/docs/llms.txt | head -40
```

Validation already run:

```bash
cd docs && pnpm exec biome check 'app/llms.txt/route.ts' 'scripts/materialize-markdown-pages.mjs' '../site/worker/index.js'
just docs-build
just site-build-only
bash scripts/merge_site.sh
# local wrangler curl checks for markdown and HTML negotiation
rm -rf docs/out site/dist
just check
```

Note: `just check` must run after removing local generated build outputs, otherwise the repo-wide markdown link checker scans ignored `docs/out/**/*.md` and `site/dist/docs/**/*.md` build artifacts.
