### PR TITLE
Update agent guidance docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Kitaru is a **mixed Python + web repo** that produces three things: a Python SDK
 src/kitaru/           # Python SDK package (src layout)
   cli.py              # CLI facade / console entrypoint (cyclopts)
   _cli/               # Internal command modules + shared CLI helpers
-  adapters/           # Framework adapters (includes PydanticAI)
+  adapters/           # Framework adapters (includes PydanticAI and OpenAI Agents)
   mcp/                # MCP server tools (optional `kitaru[mcp]` extra)
 tests/                # pytest tests
 tests/mcp/            # MCP-specific tests (runs in `[mcp]` CI path)
@@ -20,8 +20,7 @@ docs/                 # FumaDocs Next.js app — documentation at kitaru.ai/docs
 site/                 # Astro landing page + runtime shell at kitaru.ai/
   src/pages/api/      # Server-side API routes (e.g. /api/waitlist with KV)
 scripts/              # Doc generation, site merge, and smoke test scripts
-docker/               # Dockerfiles (Dockerfile = production server, Dockerfile.dev = dev/testing stack)
-spec/                 # SDK design specifications (planning material, not shipped code)
+docker/               # Dockerfiles (production server, server-dev, and dev flow images)
 design/               # Design docs, meeting notes (gitignored, never commit)
 wrangler.toml         # Unified Cloudflare Worker deployment config
 ```
@@ -52,7 +51,7 @@ Use `uv` for Python dependency management and `just` as the command stack.
 
 | Command | What it does | When to run |
 |---|---|---|
-| **`just check`** | All checks: format, lint, typecheck, typos, yaml, links | After every chunk of work, before commit/push |
+| **`just check`** | All checks: format, lint, typecheck, typos, yaml, actions lint, links | After every chunk of work, before commit/push |
 | **`just fix`** | Auto-fixes formatting, lint issues, yaml | When `just check` reports fixable issues — resolves most linting problems automatically |
 | **`just test`** | Full pytest suite | After code changes, before commit/push |
 
@@ -65,6 +64,9 @@ Use `uv` for Python dependency management and `just` as the command stack.
 - `just typos`: typo check only
 - `just format-check`: check formatting without modifying
 - `just yaml-check`: check YAML formatting
+- `just actions-lint`: lint GitHub Actions workflows (requires `actionlint`: `brew install actionlint`)
+- `just zizmor`: audit GitHub Actions workflow security with `zizmor`
+- `just audit`: audit Python dependencies with `pip-audit` and the documented ignore list
 - `just links`: check markdown links offline (requires `lychee`: `brew install lychee`)
 - `just links-external`: check links including external URLs (slow)
 - `just build`: build wheel and sdist locally
@@ -149,19 +151,20 @@ When adding a new CLI command, MCP tool, or SDK feature:
 
 ### Python CI (`ci.yml`)
 
-Runs on push/PR to `develop`. Jobs: lint + format check + yaml check, typos, type check, link check, base tests (Python 3.11 + 3.12 + 3.13), and additional test lanes with `kitaru[mcp]` installed (3.11 + 3.12).
+Runs on push/PR to `develop`. Jobs: lint + format check + yaml check, typos, type check, dependency audit, link check, Docker server smoke test, wheel-packaging check, base tests (Python 3.11 + 3.12 + 3.13), and additional test lanes with `kitaru[mcp]` installed (3.11 + 3.12).
 
 ### Site CI (`site.yml`)
 
-Runs on push to `main` (production deploy) and PRs touching `docs/`, `site/`, `scripts/`, `src/kitaru/`, `CHANGELOG.md`, or `wrangler.toml`. Generates docs content, builds both apps, merges output, and deploys:
+Runs on manual dispatch, push to `main` (production deploy), and PRs touching `site/**`, `docs/**`, `scripts/generate_*.py`, `scripts/merge_site.sh`, `CHANGELOG.md`, or `wrangler.toml`. Generates docs content, builds both apps, merges output, and deploys:
 - **Production:** deploys unified Worker to `kitaru.ai` on `main` push
 - **PR previews:** deploys a preview Worker for same-repo PRs; cleans up on PR close
 
 ### Other workflows
 
 - `release.yml`: release automation (version bump, PyPI publish, Docker image publish, GitHub Release)
-- `spellcheck.yml`: separate typo/spell checking on `develop` PRs/pushes
-- `image-optimiser.yml`: PR-only image compression for docs assets
+- `spellcheck.yml`: separate typo/spell checking on `develop` pushes and non-draft PRs
+- `image-optimiser.yml`: PR-only compression for changed JPG/JPEG/PNG/WebP files in same-repo non-draft PRs, with `site/public/dashboard.png` ignored
+- `zizmor.yml`: GitHub Actions security analysis for workflow/dependabot changes, plus weekly and manual runs
 
 ## Branching and Release Strategy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Kitaru is ZenML's **durable execution layer for AI agents**. It provides primiti
 src/kitaru/           # Python SDK package (src layout)
   cli.py              # CLI facade / console entrypoint (cyclopts)
   _cli/               # Internal command modules + shared CLI helpers
-  adapters/           # Framework adapters (includes PydanticAI)
+  adapters/           # Framework adapters (includes PydanticAI and OpenAI Agents)
   mcp/                # MCP server tools (optional `kitaru[mcp]` extra)
 tests/                # pytest tests
 tests/mcp/            # MCP-specific unit tests (runs in `[mcp]` CI path)
@@ -121,7 +121,7 @@ Copy `.env.example` to `.env` and fill in R2 credentials. The site build does NO
 3. Run the smoke test: `./scripts/smoke-test.sh` (or `./scripts/smoke-test.sh -s` to skip reinstall). This exercises CLI, SDK flows, MCP tools, and LLM integration against a local server. Set `OPENAI_API_KEY` to include LLM tests. Use `-k` to keep the server running and inspect the dashboard afterward.
 4. Go to Actions > Release > Run workflow (or push a `vX.Y.Z` tag).
 5. Enter the version (e.g. `0.2.0`); optionally enable dry-run.
-6. The workflow bumps version, runs CI, publishes to PyPI, builds and pushes the Docker image (`zenmldocker/kitaru:<version>` + `latest`), builds and pushes the Helm chart to ECR, creates `release/X.Y.Z`, updates `main`, tags, and creates a GitHub Release with auto-generated notes.
+6. The workflow bumps version, runs CI, publishes to PyPI, builds and pushes the Docker image (`zenmldocker/kitaru:<version>` + `latest`), builds and pushes the Helm chart to Amazon ECR Public as an OCI chart, creates `release/X.Y.Z`, updates `main`, tags, and creates a GitHub Release with auto-generated notes.
 7. After the workflow completes, edit the GitHub Release notes (`gh release edit vX.Y.Z --notes ...`) to replace the auto-generated PR list with a structured changelog: a **Highlights** section for the most notable changes, then **Added/Changed/Fixed/Infrastructure** categories mirroring the changelog.
 
 ## Development commands
@@ -144,10 +144,10 @@ This project uses [just](https://github.com/casey/just) as a command stack. Run 
 # Setup
 uv sync                              # Install dependencies
 uv sync --extra local                # Include local ZenML runtime components
-kitaru init                          # Required in a fresh git worktree — see note below
+uv run kitaru init                   # Required in a fresh git worktree — see note below
 
 # Common Python workflows
-just check                            # Run all checks (format, lint, typecheck, typos, yaml, actions, links)
+just check                            # Run all checks (format, lint, typecheck, typos, yaml, actions lint, links)
 just test                             # Run all tests
 just test tests/test_foo.py           # Run a single test file
 just test tests/test_foo.py::test_bar # Run a single test
@@ -168,6 +168,8 @@ just typos                            # Typo check only
 just format-check                     # Check formatting without modifying
 just yaml-check                       # Check YAML formatting
 just actions-lint                     # Lint GitHub Actions workflows (requires actionlint)
+just zizmor                           # Audit GitHub Actions workflow security
+just audit                            # Audit Python dependencies with pip-audit
 just links                            # Check markdown links offline (requires lychee)
 just build                            # Build wheel + sdist locally
 
@@ -195,11 +197,12 @@ just site-build && npx wrangler deploy   # Build + deploy
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | Push/PR to `develop` | Python checks: lint, format, yaml, typos, links, typecheck, and tests across base installs (3.11 + 3.12 + 3.13) plus additional `kitaru[mcp]` test lanes |
-| `site.yml` | Push to `main`; PRs touching docs/site/scripts | Build + deploy unified site; PR preview Workers |
-| `release.yml` | Workflow dispatch or `v*` tag | Version bump, PyPI publish, Docker image publish, GitHub Release |
-| `spellcheck.yml` | Push/PR to `develop` | Separate typo/spell checking |
-| `image-optimiser.yml` | PRs only | Image compression for docs assets |
+| `ci.yml` | Push/PR to `develop` | Python checks: lint, format, yaml, typos, typecheck, dependency audit, links, Docker server smoke, wheel packaging, and tests across base installs (3.11 + 3.12 + 3.13) plus additional `kitaru[mcp]` test lanes |
+| `site.yml` | Manual dispatch; push to `main`; selected docs/site/script PR paths | Build + deploy unified site; PR preview Workers for same-repo PRs; preview cleanup on PR close |
+| `release.yml` | Workflow dispatch or `v*` tag | Version/changelog/lock handling for dispatch releases, PyPI publish, Docker image publish, Helm OCI chart publish, release branch/main update, GitHub Release |
+| `spellcheck.yml` | Manual/reusable runs, push to `develop`, non-draft PRs | Separate typo/spell checking |
+| `image-optimiser.yml` | PRs changing JPG/JPEG/PNG/WebP files | Image compression for same-repo non-draft PRs, with `site/public/dashboard.png` ignored |
+| `zizmor.yml` | Workflow/dependabot changes, weekly schedule, manual runs | GitHub Actions security analysis |
 
 When working with Python, invoke the relevant /astral:<skill> for uv, ty, and ruff to ensure best practices are followed.
 
@@ -240,9 +243,9 @@ When working with Python, invoke the relevant /astral:<skill> for uv, ty, and ru
 
 ### Framework adapters
 
-The first framework adapter is implemented: `kitaru.adapters.pydantic_ai.KitaruAgent(agent, ...)`.
+Implemented framework adapters include `kitaru.adapters.pydantic_ai.KitaruAgent(agent, ...)` and the OpenAI Agents adapter under `kitaru.adapters.openai_agents`. The OpenAI Agents adapter is behind the `openai-agents` optional extra (`uv sync --extra openai-agents` or `kitaru[openai-agents]`) and exposes `KitaruRunner` for durable OpenAI Agents runs.
 
-It keeps the enclosing checkpoint as the replay boundary while tracking PydanticAI model requests and tool calls as child events/artifacts under that checkpoint. At flow scope, `run()` / `run_sync()` automatically open a synthetic checkpoint per turn so tracking still works without an explicit outer checkpoint; outside any flow they auto-open a local flow (remote stacks require an explicit `@kitaru.flow`). Capture is controlled via a `CapturePolicy` (`tool_capture="full"|"metadata"|None` plus per-tool overrides). HITL is auto-bridged: PydanticAI's native `requires_approval=True`, `ApprovalRequired`, and `CallDeferred` all route through `kitaru.wait(...)` with no decorator. For explicit HITL markers, use `kitaru.adapters.pydantic_ai.hitl_tool(...)`. Per-turn checkpoint behavior (runtime, retries, type) is configurable via `KitaruAgent(..., turn_checkpoint_config={"runtime": "inline"})`; adapter-managed checkpoints do not yet support `runtime="isolated"`.
+The PydanticAI adapter keeps the enclosing checkpoint as the replay boundary while tracking PydanticAI model requests and tool calls as child events/artifacts under that checkpoint. At flow scope, `run()` / `run_sync()` automatically open a synthetic checkpoint per turn so tracking still works without an explicit outer checkpoint; outside any flow they auto-open a local flow (remote stacks require an explicit `@kitaru.flow`). Capture is controlled via a `CapturePolicy` (`tool_capture="full"|"metadata"|None` plus per-tool overrides). HITL is auto-bridged: PydanticAI's native `requires_approval=True`, `ApprovalRequired`, and `CallDeferred` all route through `kitaru.wait(...)` with no decorator. For explicit HITL markers, use `kitaru.adapters.pydantic_ai.hitl_tool(...)`. Per-turn checkpoint behavior (runtime, retries, type) is configurable via `KitaruAgent(..., turn_checkpoint_config={"runtime": "inline"})`; adapter-managed checkpoints do not yet support `runtime="isolated"`.
 
 ### Observability (current MVP + planned)
 


### PR DESCRIPTION
## What changed

- Updated root `AGENTS.md` and `CLAUDE.md` to match the current repo layout, Justfile command surface, CI workflow jobs, site workflow triggers, adapter set, and release wording.
- Removed the stale root `spec/` entry from `AGENTS.md`.
- Added current references for OpenAI Agents, `actions-lint`, `zizmor`, dependency audit, Docker smoke, wheel packaging, and Helm OCI chart publishing.

## Why

These root guidance docs are the operating manual for future agents and contributors. A few claims had drifted from the current source-of-truth files (`Justfile`, `pyproject.toml`, `.github/workflows/*.yml`, release workflow, adapter tree), so this keeps the guidance accurate without rewriting the docs wholesale.

## Key implementation decisions

- Kept the change docs-only and limited to `AGENTS.md` and `CLAUDE.md`.
- Verified facts from a fresh worktree based on `origin/develop` before editing.
- Left the `docker/CLAUDE.md` reference intact because that file exists in the fresh worktree.

## Reviewer Notes

Please focus review on whether the updated guidance matches the current command/workflow surface:

```bash
just check
```

Validation run locally:

- `just typos` ✅
- `just links` ✅
- `just check` ✅
