### PR TITLE
Make `.wait()` ambiguity discoverable + recommend `runner_call` for OpenAI Agents adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- OpenAI Agents SDK adapter (`kitaru.adapters.openai_agents`) — wrap an `Agent`/`Runner` with `KitaruAgent` to make OpenAI Agents SDK runs durable, replayable, and observable under a Kitaru flow. Supports two tracking strategies via `checkpoint_strategy="calls"` (per-tool/per-model checkpoints) or `checkpoint_strategy="runner_call"` (one checkpoint per `Runner.run`), plus a guide page at `/guides/openai-agents-adapter` that walks through the trade-offs. (#295)
+- OpenAI Agents SDK adapter (`kitaru.adapters.openai_agents`) — wrap an `Agent`/`Runner` with `KitaruRunner` to make OpenAI Agents SDK runs durable, replayable, and observable under a Kitaru flow. Supports two tracking strategies via `checkpoint_strategy="runner_call"` (one checkpoint per `Runner.run`, recommended when you want a clean `.wait()` return value) or `checkpoint_strategy="calls"` (per-tool/per-model checkpoints for finer replay units, with per-checkpoint artifacts visible in the Kitaru UI / `KitaruClient`). The guide at `/guides/openai-agents-adapter` walks through the trade-offs. (#295)
 - OpenAI Agents integration example (`examples/integrations/openai_agents_agent/`) and an end-to-end `openai_research_bot` example (planner + parallel search checkpoints + writer report generation, with remote secret guidance and Kitaru UI artifacts). Both are exercised by the smoke test. (#295)
 - Markdown exports for every docs page at `kitaru.ai/docs/<slug>.md`, plus a substantially expanded `/llms.txt` index — making the docs friendlier for LLMs and agents that consume them programmatically. (#303)
+
+### Changed
+- `flow.run(...).wait()` now raises a new dedicated `KitaruAmbiguousFlowResultError` (subclass of `KitaruRuntimeError`) when the flow has multiple terminal checkpoints with no single sink (common with the OpenAI Agents adapter's `checkpoint_strategy="calls"`). The error names the terminal checkpoints, points at the execution's artifacts in the Kitaru UI, and suggests `KitaruClient` retrieval and the `runner_call` strategy as alternatives. Catching this specific subclass lets callers handle the ambiguity case without accidentally swallowing real execution failures.
 
 ## [0.8.0] - 2026-05-04
 

--- a/docs/content/docs/guides/openai-agents-adapter.mdx
+++ b/docs/content/docs/guides/openai-agents-adapter.mdx
@@ -11,8 +11,12 @@ from agents import Agent
 from kitaru.adapters.openai_agents import KitaruRunner
 
 agent = Agent(name="researcher", model=your_model)
-runner = KitaruRunner(agent)
+runner = KitaruRunner(agent, checkpoint_strategy="runner_call")
 ```
+
+The runtime default is `checkpoint_strategy="calls"` (per-call checkpoints —
+see below); pass `"runner_call"` whenever you want a single terminal
+checkpoint so `flow.run(...).wait()` returns the run result directly.
 
 You run the agent through `runner.run(...)` or `runner.run_sync(...)` with an
 `OpenAIRunRequest`.
@@ -37,7 +41,7 @@ kitaru status
 from kitaru import flow
 from kitaru.adapters.openai_agents import KitaruRunner, OpenAIRunRequest
 
-runner = KitaruRunner(agent, checkpoint_strategy="calls")
+runner = KitaruRunner(agent, checkpoint_strategy="runner_call")
 
 @flow
 def research(prompt: str) -> str:
@@ -49,18 +53,32 @@ def research(prompt: str) -> str:
 
 You choose how Kitaru places checkpoints with `checkpoint_strategy=`.
 
+### `checkpoint_strategy="runner_call"` (recommended for `.wait()`)
+
+Kitaru places one checkpoint around the outer `Runner.run(...)` call. That
+single checkpoint becomes the flow's terminal artifact, so
+`flow.run(...).wait()` returns the run result cleanly.
+
+Use this when you want one coarse replay boundary for the whole agent run, or
+whenever you want a clean Python value back from `.wait()`.
+
 ### `checkpoint_strategy="calls"` (default)
 
-Kitaru catches supported model/tool calls individually.
+Kitaru catches supported model/tool calls individually as separate peer
+checkpoints under the flow.
 
 Use this when you want finer replay units (for example: if call 6 fails, calls
 1–5 can come from cache).
 
-### `checkpoint_strategy="runner_call"`
-
-Kitaru places one checkpoint around the outer `Runner.run(...)` call.
-
-Use this when you want one coarse replay boundary for the whole agent run.
+Because the per-call checkpoints are siblings under the flow with no single
+sink, `flow.run(...).wait()` cannot pick one as "the" return value and raises
+`KitaruAmbiguousFlowResultError`. The per-checkpoint artifacts are still
+fully visible in the Kitaru UI and retrievable via `KitaruClient` — the
+error message points at them. If you need a clean `.wait()` return value,
+switch to `checkpoint_strategy="runner_call"`. Wrapping the `runner.run_sync()`
+call in your own `@checkpoint` is **not** a workaround here — the adapter
+guards against it and will raise, because per-call checkpoints cannot be
+nested inside another Kitaru checkpoint.
 
 ## Important guardrail
 

--- a/examples/end_to_end/openai_research_bot/research_bot.py
+++ b/examples/end_to_end/openai_research_bot/research_bot.py
@@ -23,6 +23,7 @@ import kitaru
 from kitaru import ImageSettings, checkpoint, flow
 from kitaru.adapters.openai_agents import KitaruRunner, OpenAIRunRequest
 from kitaru.config import classify_stack_deployment_type
+from kitaru.errors import KitaruAmbiguousFlowResultError
 
 try:  # Package import path used by tests.
     from .bot_agents import (
@@ -546,8 +547,24 @@ def _run_once(
     if image_override is not None:
         run_kwargs["image"] = image_override
 
-    result = openai_research_bot.run(**run_kwargs).wait()
-    return str(result)
+    handle = openai_research_bot.run(**run_kwargs)
+    try:
+        return str(handle.wait())
+    except KitaruAmbiguousFlowResultError as error:
+        # `--strategy calls` produces per-call peer checkpoints with no single
+        # sink, so `.wait()` cannot pick a single return value. The artifacts
+        # ARE persisted under the execution and visible in the Kitaru UI; the
+        # error message names them and points users at `KitaruClient`. Surface
+        # that here as a friendly summary instead of a stack trace, since
+        # this is the documented characteristic of the `calls` strategy
+        # rather than a real failure.
+        return (
+            f"(strategy={strategy!r}: per-checkpoint artifacts only; "
+            f"`.wait()` raised because there is no single terminal sink. "
+            f"View artifacts at the Kitaru UI URL above, or via "
+            f"`KitaruClient().executions.get('{handle.exec_id}')`.)\n\n"
+            f"Full error message:\n{error}"
+        )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/examples/integrations/openai_agents_agent/README.md
+++ b/examples/integrations/openai_agents_agent/README.md
@@ -33,31 +33,32 @@ If `OPENAI_API_KEY` is missing, the script exits early with a friendly message.
 
 ## What to look for in Kitaru UI
 
-In `checkpoint_strategy="calls"` mode (default in this example), you should see
-multiple checkpoints for one request, typically in a pattern like:
-
-- model decides to call tool
-- `lookup_order(...)`
-- model decides to call tool
-- `shipping_policy(...)`
-- model writes final customer answer
-
-That gives you a clear model/tool/model/tool/model durability story.
+By default this example uses `checkpoint_strategy="runner_call"` — Kitaru
+places one checkpoint around the whole `Runner.run(...)` call, so the
+adapter's `OpenAIRunResult` becomes the flow's terminal artifact and
+`flow.run(...).wait()` returns it cleanly.
 
 ## `calls` vs `runner_call` (plain-language version)
 
-- `calls`: Kitaru places smaller checkpoints around each supported model/tool
-  call.
 - `runner_call`: Kitaru places one bigger checkpoint around the entire
-  `Runner.run(...)` call.
+  `Runner.run(...)` call. Single terminal artifact, clean `.wait()` return.
+- `calls`: Kitaru places smaller checkpoints around each supported model/tool
+  call. Finer replay units, but each call becomes a peer checkpoint with no
+  single sink — `.wait()` raises `KitaruAmbiguousFlowResultError` because
+  there is no "the" return value. The per-checkpoint artifacts are still
+  visible in the Kitaru UI.
 
-This example focuses on `calls` so the UI clearly shows each step.
-
-If you want a side-by-side comparison, run with:
+To see both side-by-side (the default `runner_call` run, then the `calls`
+run with the expected ambiguity error printed), use:
 
 ```bash
-OPENAI_AGENTS_COMPARE_RUNNER_CALL=1 uv run python openai_agents_adapter.py
+OPENAI_AGENTS_COMPARE_CALLS=1 uv run python openai_agents_adapter.py
 ```
+
+In that mode you'll see the `runner_call` model output first, then a
+`=== calls strategy output ===` section showing the new actionable error
+that names the terminal checkpoints, gives the execution ID, and points at
+the Kitaru UI / `KitaruClient` for per-checkpoint artifact retrieval.
 
 ## Why this example uses the real API
 

--- a/examples/integrations/openai_agents_agent/openai_agents_adapter.py
+++ b/examples/integrations/openai_agents_agent/openai_agents_adapter.py
@@ -26,6 +26,7 @@ from kitaru.adapters.openai_agents import (
     OpenAIRunRequest,
     OpenAIRunResult,
 )
+from kitaru.errors import KitaruAmbiguousFlowResultError
 
 ORDERS: dict[str, dict[str, str]] = {
     "ORD-1007": {
@@ -174,18 +175,30 @@ def main() -> None:
     model_label = os.getenv("OPENAI_AGENTS_MODEL", "gpt-5-nano")
     print(f"Using model: {model_label}")
 
-    calls_output = _run_once("calls")
-    print("\n=== calls strategy output ===")
-    print(calls_output)
+    runner_call_output = _run_once("runner_call")
+    print("\n=== runner_call strategy output ===")
+    print(runner_call_output)
 
-    if os.getenv("OPENAI_AGENTS_COMPARE_RUNNER_CALL", "").lower() in {
+    if os.getenv("OPENAI_AGENTS_COMPARE_CALLS", "").lower() in {
         "1",
         "true",
         "yes",
     }:
-        runner_call_output = _run_once("runner_call")
-        print("\n=== runner_call strategy output ===")
-        print(runner_call_output)
+        # `calls` strategy creates per-tool/per-model peer checkpoints with no
+        # single sink, so `.wait()` raises `KitaruAmbiguousFlowResultError`
+        # when it can't pick a single terminal artifact. The raised message
+        # points at the per-checkpoint artifacts in the Kitaru UI /
+        # `KitaruClient`, which is the right surface for `calls` flows.
+        # Real execution failures (model error, tool failure, etc.) will not
+        # match this specific subclass and will propagate normally.
+        try:
+            calls_output = _run_once("calls")
+        except KitaruAmbiguousFlowResultError as error:
+            print("\n=== calls strategy output ===")
+            print(f"(per-checkpoint artifacts only; .wait() raised: {error})")
+        else:
+            print("\n=== calls strategy output ===")
+            print(calls_output)
 
 
 if __name__ == "__main__":

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -369,7 +369,7 @@ elif [[ "${KITARU_SMOKE_RESEARCH_BOT:-}" != "1" ]]; then
 else
     run_test "examples/end_to_end/openai_research_bot/research_bot.py" \
         timed 180 $UV_RUN python examples/end_to_end/openai_research_bot/research_bot.py \
-            "AI agent durability in one paragraph" --max-searches 2 --strategy calls \
+            "AI agent durability in one paragraph" --max-searches 2 --strategy runner_call \
             --fail-on-search-error
 fi
 

--- a/src/kitaru/__init__.py
+++ b/src/kitaru/__init__.py
@@ -80,6 +80,7 @@ from kitaru.config import (
 )
 from kitaru.errors import (
     FailureOrigin,
+    KitaruAmbiguousFlowResultError,
     KitaruBackendError,
     KitaruContextError,
     KitaruDivergenceError,
@@ -115,6 +116,7 @@ __all__ = [
     "FailureOrigin",
     "FlowHandle",
     "ImageSettings",
+    "KitaruAmbiguousFlowResultError",
     "KitaruBackendError",
     "KitaruClient",
     "KitaruConfig",

--- a/src/kitaru/errors.py
+++ b/src/kitaru/errors.py
@@ -37,6 +37,16 @@ class KitaruRuntimeError(KitaruError, RuntimeError):
     """Raised for runtime/serialization/materialization failures."""
 
 
+class KitaruAmbiguousFlowResultError(KitaruRuntimeError):
+    """Raised when ``flow.run(...).wait()`` cannot pick a single return value.
+
+    Common in agent-style flows where each model/tool call produces its own
+    checkpoint with no DAG sink. The per-checkpoint artifacts are still
+    persisted and visible in the Kitaru UI / via ``KitaruClient`` — the
+    exception message points at them.
+    """
+
+
 if TYPE_CHECKING:
     from kitaru._client._models import ExecutionStatus
 
@@ -274,6 +284,7 @@ def format_recovery_hint(exec_id: str, *, status: str) -> str | None:
 
 __all__ = [
     "FailureOrigin",
+    "KitaruAmbiguousFlowResultError",
     "KitaruBackendError",
     "KitaruContextError",
     "KitaruDeploymentInputValuesError",

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -71,6 +71,7 @@ from kitaru.config import (
 )
 from kitaru.errors import (
     FailureOrigin,
+    KitaruAmbiguousFlowResultError,
     KitaruBackendError,
     KitaruDeploymentInputValuesError,
     KitaruRuntimeError,
@@ -582,6 +583,34 @@ def _extract_values_from_output_specs(run: PipelineRunResponse) -> list[Any]:
     return values
 
 
+def _ambiguous_terminal_message(execution_id: str, *, reason: str) -> str:
+    """Build a discoverable message when terminal-step extraction can't pick.
+
+    Common in agent-style flows where each model/tool call produces its own
+    checkpoint with no DAG sink — there is no single artifact that represents
+    "the" flow result, but the per-checkpoint artifacts are still visible in
+    the Kitaru UI and retrievable via ``KitaruClient``.
+    """
+    lines = [
+        f"This flow's return value cannot be extracted automatically because {reason}.",
+        "",
+        "This typically happens when a flow uses an agent adapter that "
+        "creates per-call checkpoints (e.g. `checkpoint_strategy='calls'`) "
+        "without a single sink. The per-checkpoint artifacts ARE persisted "
+        "and visible:",
+        f"  - View artifacts in the Kitaru UI for execution {execution_id}",
+        f"  - Retrieve via the client: "
+        f"`KitaruClient().executions.get('{execution_id}')` and inspect "
+        "checkpoint outputs",
+        "",
+        "To get a clean `.wait()` return value, either return a single "
+        "checkpoint's output from your flow, or use a coarser strategy "
+        "(e.g. `checkpoint_strategy='runner_call'` for the OpenAI Agents "
+        "adapter).",
+    ]
+    return "\n".join(lines)
+
+
 def _extract_values_from_terminal_steps(run: PipelineRunResponse) -> list[Any]:
     """Extract return values from terminal step outputs as a fallback.
 
@@ -605,23 +634,37 @@ def _extract_values_from_terminal_steps(run: PipelineRunResponse) -> list[Any]:
     )
     if not terminal_step_names:
         return []
+    execution_id = str(hydrated_run.id)
     if len(terminal_step_names) > 1:
-        raise KitaruRuntimeError(
-            "Execution output metadata is missing and fallback extraction is "
-            "ambiguous because multiple terminal steps were found."
+        raise KitaruAmbiguousFlowResultError(
+            _ambiguous_terminal_message(
+                execution_id,
+                reason=(
+                    f"multiple terminal checkpoints were found "
+                    f"({len(terminal_step_names)}): "
+                    f"{', '.join(terminal_step_names)}"
+                ),
+            )
         )
 
     terminal_step_name = terminal_step_names[0]
     terminal_step = step_runs[terminal_step_name]
     if not terminal_step.regular_outputs:
         raise KitaruRuntimeError(
-            f"Execution {hydrated_run.id} has no regular outputs on terminal "
+            f"Execution {execution_id} has no regular outputs on terminal "
             f"step '{terminal_step_name}'."
         )
     if len(terminal_step.regular_outputs) > 1:
-        raise KitaruRuntimeError(
-            "Execution output metadata is missing and fallback extraction is "
-            "ambiguous because the terminal step has multiple outputs."
+        output_names = ", ".join(sorted(terminal_step.regular_outputs))
+        raise KitaruAmbiguousFlowResultError(
+            _ambiguous_terminal_message(
+                execution_id,
+                reason=(
+                    f"terminal checkpoint '{terminal_step_name}' has "
+                    f"{len(terminal_step.regular_outputs)} outputs: "
+                    f"{output_names}"
+                ),
+            )
         )
 
     output_name = next(iter(terminal_step.regular_outputs))

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -31,6 +31,7 @@ from kitaru.config import (
 )
 from kitaru.errors import (
     FailureOrigin,
+    KitaruAmbiguousFlowResultError,
     KitaruBackendError,
     KitaruExecutionError,
     KitaruRuntimeError,
@@ -1921,9 +1922,47 @@ def test_flow_handle_get_raises_on_ambiguous_terminal_fallback() -> None:
     handle = FlowHandle(_as_pipeline_run(completed))
     with (
         patch("kitaru.flow.Client", return_value=client_mock),
-        pytest.raises(KitaruRuntimeError, match="fallback extraction is ambiguous"),
+        pytest.raises(KitaruAmbiguousFlowResultError) as exc_info,
     ):
         handle.get()
+
+    message = str(exc_info.value)
+    assert "final_a" in message and "final_b" in message
+    assert "KitaruClient" in message
+
+
+def test_flow_handle_get_ambiguous_terminal_outputs_message_lists_outputs() -> None:
+    completed = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            ("final", "output_a", "a"),
+            ("final", "output_b", "b"),
+        ],
+    )
+    completed.snapshot.pipeline_spec.outputs = []
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = completed
+
+    handle = FlowHandle(_as_pipeline_run(completed))
+    with (
+        patch("kitaru.flow.Client", return_value=client_mock),
+        pytest.raises(KitaruAmbiguousFlowResultError) as exc_info,
+    ):
+        handle.get()
+
+    message = str(exc_info.value)
+    assert "'final'" in message
+    assert "output_a" in message and "output_b" in message
+
+
+def test_flow_ambiguous_flow_result_error_subclasses_runtime_error() -> None:
+    """Callers using `except KitaruRuntimeError` continue to catch ambiguity,
+    but more specific code can target `KitaruAmbiguousFlowResultError` to
+    avoid swallowing real execution failures.
+    """
+    assert issubclass(KitaruAmbiguousFlowResultError, KitaruRuntimeError)
+    assert not issubclass(KitaruExecutionError, KitaruAmbiguousFlowResultError)
 
 
 def test_flow_handle_get_raises_when_step_metadata_is_missing() -> None:

--- a/tests/test_kitaru.py
+++ b/tests/test_kitaru.py
@@ -79,6 +79,7 @@ class TestPublicExports:
             "FailureOrigin",
             "FlowHandle",
             "ImageSettings",
+            "KitaruAmbiguousFlowResultError",
             "KitaruBackendError",
             "KitaruClient",
             "KitaruConfig",


### PR DESCRIPTION
## Summary

While running pre-release smoke tests for v0.9.0, the OpenAI Agents adapter integration example crashed on `.wait()` with a `KitaruRuntimeError` whose message said:

> Execution output metadata is missing and fallback extraction is ambiguous because multiple terminal steps were found.

…and gave the user no way to know that the per-call artifacts were still in the Kitaru UI, or how to retrieve them, or what alternative to try. The headline new feature of v0.9.0 was failing on its own documented "Minimal flow" example.

This PR keeps the loud raise (silencing it would hide the real per-checkpoint artifacts from users — a quiet observability regression) and makes the raise *actionable*. It also flips the documented adapter default from `calls` → `runner_call`, since that's the strategy that produces a clean single-sink terminal artifact and lets `.wait()` return a value cleanly. Several follow-on consistency fixes also land here: a stale README, a CHANGELOG typo, a doc workaround that contradicted an adapter guardrail, the gated research-bot smoke test (which had the same ambiguity bug pre-existing), and the research-bot CLI surfacing the new error humanely instead of as a stack trace.

## What changed

### Core (`src/kitaru/`)
- **New `KitaruAmbiguousFlowResultError`** (subclass of `KitaruRuntimeError`) raised by `_extract_values_from_terminal_steps` in `src/kitaru/flow.py`. Callers can now target the ambiguity case specifically — the old `except KitaruRuntimeError` would also catch `KitaruExecutionError` (real run failures) and silently swallow them. Re-exported from `kitaru.errors` and the package root.
- **New error message** names the colliding terminal checkpoints (or the multiple outputs of a single terminal, by name), gives the execution ID, points at the Kitaru UI + `KitaruClient().executions.get('<id>')`, and suggests `checkpoint_strategy="runner_call"` as the alternative.

### OpenAI Agents adapter docs + examples
- **`docs/content/docs/guides/openai-agents-adapter.mdx`**: leads with `runner_call` as the documented default; first install snippet uses `runner_call` explicitly. Drops a workaround sentence that contradicted the adapter's `_require_calls_scope()` guardrail (wrapping a `calls` runner in your own `@checkpoint` raises — the docs now say so).
- **`examples/integrations/openai_agents_agent/openai_agents_adapter.py`**: defaults to `runner_call`. `calls` becomes an opt-in comparison (`OPENAI_AGENTS_COMPARE_CALLS=1`, renamed from `OPENAI_AGENTS_COMPARE_RUNNER_CALL`), with an explicit `try/except KitaruAmbiguousFlowResultError` that *demonstrates* what `calls` strategy does to `.wait()` instead of hiding it.
- **`examples/integrations/openai_agents_agent/README.md`** updated to match the new default and the renamed env var (catch from Codex review).
- **`examples/end_to_end/openai_research_bot/research_bot.py`**: the CLI's `_run_once` now catches `KitaruAmbiguousFlowResultError` and prints a friendly summary (execution URL, `KitaruClient` pointer, the full error text) instead of letting the user see a stack trace when they pick `--strategy calls`. The research bot's `publish_report` checkpoint already threads the side-effect artifacts to be a single sink under `runner_call`, but the adapter's per-call peer checkpoints under `calls` cannot be threaded — so this CLI ambiguity was a pre-existing bug that the new error message exposed.

### Smoke test
- **`scripts/smoke-test.sh`**: gated `KITARU_SMOKE_RESEARCH_BOT=1` entry switched from `--strategy calls` to `--strategy runner_call`. Validates the documented happy path on release rehearsals.

### CHANGELOG
- Fixed pre-existing `KitaruAgent` → `KitaruRunner` typo in the v0.9.0 OpenAI Agents adapter bullet.
- Added "Changed" section noting the new dedicated error class and the recommendation flip.

## Reviewer Notes

The most important pieces to look at:

- **`src/kitaru/errors.py`** — the new exception class. Subclassing `KitaruRuntimeError` keeps existing `except KitaruRuntimeError` callers compatible while letting newer code be more specific.
- **`src/kitaru/flow.py`** — the new `_ambiguous_terminal_message(execution_id, *, reason)` helper and the two raise sites. The single-terminal-multiple-outputs branch now lists the output names too (was previously a count only).
- **`examples/integrations/openai_agents_agent/openai_agents_adapter.py`** — the `try/except KitaruAmbiguousFlowResultError` block is intentionally visible in the example body. The comment explains *why* (per-call peers, no single sink), which is the educational point. Examples stay as primary teaching surface, not behind helpers.
- **`examples/end_to_end/openai_research_bot/research_bot.py`** — same pattern at the CLI's `_run_once`, with the friendly summary text giving users the URL + `KitaruClient` next-step.
- **`docs/content/docs/guides/openai-agents-adapter.mdx`** — note the "Important guardrail" interaction: the section now warns explicitly that wrapping the `calls` runner in your own `@checkpoint` is **not** a workaround.

### How to reproduce

**Locally (the original failure on `develop` before this PR):** with `OPENAI_API_KEY` set:

```bash
uv sync --extra local --extra llm --extra mcp --extra openai-agents
uv run kitaru init
uv run examples/integrations/openai_agents_agent/openai_agents_adapter.py
```

You'll see the run complete server-side, then `.wait()` raise the unhelpful "fallback extraction is ambiguous" message.

**With this PR:** the same command runs `runner_call` strategy by default and prints the model output cleanly. To exercise the (now opt-in) `calls` path and see the new actionable error message:

```bash
OPENAI_AGENTS_COMPARE_CALLS=1 uv run examples/integrations/openai_agents_agent/openai_agents_adapter.py
```

You'll see the `runner_call` output, then a `=== calls strategy output ===` section showing the new message that lists the terminal checkpoints, gives the execution ID, and suggests `KitaruClient` + `runner_call`.

**Research bot CLI (graceful ambiguity handling):**

```bash
uv run python examples/end_to_end/openai_research_bot/research_bot.py \
  "AI agent durability in one paragraph" --max-searches 2 --strategy calls --fail-on-search-error
```

Exits 0 with a friendly summary pointing at the execution URL, instead of a stack trace.

**Gated smoke test (pre-release rehearsal of the recommended path):**

```bash
KITARU_SMOKE_RESEARCH_BOT=1 ./scripts/smoke-test.sh -s
```

Now exercises `--strategy runner_call` and exits with `Failed: 0`.

**On a remote stack (k8s):** the same examples work against a remote stack — `runner_call` is what users will want by default there too, since they typically `.wait()` and consume the return value.

### Test plan

- [x] `just lint` — clean
- [x] `just typecheck` — clean
- [x] `just format-check` — clean
- [x] `just test` — 1731 passed, 8 skipped (added 3 new tests: error message contents, output name listing, error class hierarchy)
- [x] Manual reproduction of integration example shows the new error message text
- [x] Research bot CLI surfaces friendly summary instead of stack trace
- [x] Confirm gated smoke test passes end-to-end with `KITARU_SMOKE_RESEARCH_BOT=1` (recommended pre-merge sanity check)