### PR TITLE
Fix PydanticAI tool event ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- PydanticAI adapter parallel tool-call events now keep assistant-emitted order in event logs, summaries, and fan-in metadata, even when tools start or finish out of order. (#306)
 - PydanticAI adapter checkpoint configs now accept `cache`, and granular model checkpoint cache keys ignore PydanticAI-generated per-run message metadata so identical logical prompts can cache across runs. (#279)
 
 ## [0.9.0] - 2026-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- OpenAI Agents adapter parallel tool-call events now keep assistant-emitted order in event logs and summaries, even when tools start or finish out of order. (#306)
 - PydanticAI adapter parallel tool-call events now keep assistant-emitted order in event logs, summaries, and fan-in metadata, even when tools start or finish out of order. (#306)
 - PydanticAI adapter checkpoint configs now accept `cache`, and granular model checkpoint cache keys ignore PydanticAI-generated per-run message metadata so identical logical prompts can cache across runs. (#279)
 

--- a/src/kitaru/adapters/openai_agents/_model.py
+++ b/src/kitaru/adapters/openai_agents/_model.py
@@ -1,10 +1,11 @@
 """Model/provider checkpoint wrappers for OpenAI Agents SDK calls."""
 
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from typing import Any
 
 from agents.models.interface import Model, ModelProvider
+from agents.tool import FunctionTool
 
 import kitaru
 
@@ -82,7 +83,7 @@ class KitaruOpenAIModel(Model):
                     prompt=prompt,
                 )
 
-            return await run_async_in_checkpoint(
+            response = await run_async_in_checkpoint(
                 config=with_default_type(self._checkpoint_config, "llm_call"),
                 step_name=safe_step_name(f"{self._agent_name}_openai_model_call"),
                 body=_in_checkpoint,
@@ -101,7 +102,9 @@ class KitaruOpenAIModel(Model):
                     }
                 ),
             )
-        return await self._tracked_get_response(
+            self._reserve_tool_call_order(response, tools)
+            return response
+        response = await self._tracked_get_response(
             system_instructions,
             input,
             model_settings,
@@ -113,6 +116,8 @@ class KitaruOpenAIModel(Model):
             conversation_id=conversation_id,
             prompt=prompt,
         )
+        self._reserve_tool_call_order(response, tools)
+        return response
 
     async def _tracked_get_response(
         self,
@@ -220,6 +225,12 @@ class KitaruOpenAIModel(Model):
             metadata=metadata,
         )
         return response
+
+    def _reserve_tool_call_order(self, response: Any, tools: list[Any]) -> None:
+        tracker = get_current_tracker()
+        if tracker is None or not self._capture.emit_child_events:
+            return
+        tracker.reserve_tool_call_order(_trackable_tool_call_ids(response, tools))
 
     def _model_cache_identity(self) -> dict[str, Any]:
         wrapped_type = type(self._wrapped)
@@ -334,3 +345,41 @@ def _tool_cache_identity(tool: Any) -> dict[str, Any]:
         "description": getattr(tool, "description", None),
         "tool_namespace": getattr(tool, "_tool_namespace", None),
     }
+
+
+def _trackable_tool_call_ids(response: Any, tools: list[Any]) -> list[str]:
+    """Return local function-tool call IDs in assistant-emitted order."""
+    function_tool_names = {
+        tool.name
+        for tool in tools
+        if isinstance(tool, FunctionTool) and isinstance(tool.name, str)
+    }
+    if not function_tool_names:
+        return []
+
+    tool_call_ids: list[str] = []
+    for item in getattr(response, "output", []) or []:
+        tool_name = _tool_name_from_response_item(item)
+        tool_call_id = _tool_call_id_from_response_item(item)
+        if tool_name in function_tool_names and tool_call_id is not None:
+            tool_call_ids.append(tool_call_id)
+    return tool_call_ids
+
+
+def _tool_name_from_response_item(item: Any) -> str | None:
+    value = _response_item_value(item, "name")
+    return value if isinstance(value, str) and value else None
+
+
+def _tool_call_id_from_response_item(item: Any) -> str | None:
+    for key in ("call_id", "tool_call_id"):
+        value = _response_item_value(item, key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _response_item_value(item: Any, key: str) -> Any:
+    if isinstance(item, Mapping):
+        return item.get(key)
+    return getattr(item, key, None)

--- a/src/kitaru/adapters/openai_agents/_tools.py
+++ b/src/kitaru/adapters/openai_agents/_tools.py
@@ -149,7 +149,7 @@ async def _tracked_tool_call(
         return await callback(context, input_json)
 
     assert tracker is not None
-    event_id, event_context = tracker.start_tool_event()
+    event_id, event_context = tracker.start_tool_event(tool_call_id=tool_call_id)
     artifacts: dict[str, str] = {}
     parsed_args = _parse_json(input_json)
     if capture.save_input:

--- a/src/kitaru/adapters/openai_agents/_tracking.py
+++ b/src/kitaru/adapters/openai_agents/_tracking.py
@@ -1,9 +1,10 @@
 """Lightweight event tracking for OpenAI Agents SDK runs."""
 
 import re
+import threading
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -41,6 +42,13 @@ class EventContext:
     sequence_index: int
 
 
+@dataclass(frozen=True)
+class _ReservedToolEvent:
+    tool_call_id: str
+    event_id: str
+    sequence_index: int
+
+
 @dataclass
 class EventTracker:
     """Tracks model/tool events for one OpenAI runner call."""
@@ -55,9 +63,23 @@ class EventTracker:
     _tool_call_count: int = 0
     _tool_checkpoint_sequence: int = 0
     _started_at: float = field(default_factory=time.perf_counter)
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False
+    )
+    _reserved_tool_events_by_call_id: dict[str, list[_ReservedToolEvent]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _active_tool_event_ids: set[str] = field(
+        default_factory=set, init=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         self.agent_name = normalize_agent_name(self.agent_name)
+
+    @property
+    def events(self) -> Sequence[OpenAIAdapterEvent]:
+        with self._lock:
+            return tuple(self._ordered_events())
 
     @property
     def event_log_artifact_name(self) -> str:
@@ -72,20 +94,77 @@ class EventTracker:
         event_id = f"{self.agent_name}_{self.run_label}_{event_kind}_{self._counter}"
         return event_id, self._counter
 
+    def _ordered_events(self) -> list[OpenAIAdapterEvent]:
+        return sorted(self._events, key=lambda event: event.sequence_index)
+
+    def _clear_reserved_tool_events_unlocked(self) -> None:
+        self._reserved_tool_events_by_call_id.clear()
+
     def start_llm_event(self) -> tuple[str, EventContext]:
-        event_id, sequence_index = self._next_event_id("llm_call")
-        self._model_call_count += 1
-        return event_id, EventContext(sequence_index=sequence_index)
+        with self._lock:
+            if not self._active_tool_event_ids:
+                self._clear_reserved_tool_events_unlocked()
+            event_id, sequence_index = self._next_event_id("llm_call")
+            self._model_call_count += 1
+            return event_id, EventContext(sequence_index=sequence_index)
+
+    def reserve_tool_call_order(
+        self,
+        tool_call_ids: Sequence[str],
+    ) -> None:
+        """Reserve event slots for assistant-emitted local tool calls.
+
+        The model response is the only point where Kitaru sees the assistant's
+        intended tool-call order before the SDK may start local tools in
+        parallel. Reservations are numbered parking spaces: they become real
+        events only if a matching tool callback actually starts.
+        """
+        with self._lock:
+            for tool_call_id in tool_call_ids:
+                if not tool_call_id:
+                    continue
+                event_id, sequence_index = self._next_event_id("tool_call")
+                reserved = _ReservedToolEvent(
+                    tool_call_id=tool_call_id,
+                    event_id=event_id,
+                    sequence_index=sequence_index,
+                )
+                self._reserved_tool_events_by_call_id.setdefault(
+                    tool_call_id, []
+                ).append(reserved)
 
     def next_tool_checkpoint_sequence(self) -> int:
         """Return a per-run deterministic fallback tool call sequence."""
-        self._tool_checkpoint_sequence += 1
-        return self._tool_checkpoint_sequence
+        with self._lock:
+            self._tool_checkpoint_sequence += 1
+            return self._tool_checkpoint_sequence
 
-    def start_tool_event(self) -> tuple[str, EventContext]:
-        event_id, sequence_index = self._next_event_id("tool_call")
-        self._tool_call_count += 1
-        return event_id, EventContext(sequence_index=sequence_index)
+    def start_tool_event(
+        self,
+        *,
+        tool_call_id: str | None = None,
+    ) -> tuple[str, EventContext]:
+        with self._lock:
+            reservation: _ReservedToolEvent | None = None
+            reservations = (
+                self._reserved_tool_events_by_call_id.get(tool_call_id)
+                if tool_call_id
+                else None
+            )
+            if tool_call_id and reservations:
+                reservation = reservations.pop(0)
+                if not reservations:
+                    del self._reserved_tool_events_by_call_id[tool_call_id]
+
+            if reservation is None:
+                event_id, sequence_index = self._next_event_id("tool_call")
+            else:
+                event_id = reservation.event_id
+                sequence_index = reservation.sequence_index
+
+            self._tool_call_count += 1
+            self._active_tool_event_ids.add(event_id)
+            return event_id, EventContext(sequence_index=sequence_index)
 
     def record_event(
         self,
@@ -99,34 +178,41 @@ class EventTracker:
         metadata: dict[str, object] | None = None,
         error: BaseException | None = None,
     ) -> None:
-        self._events.append(
-            OpenAIAdapterEvent(
-                event_id=event_id,
-                kind=kind,
-                status=status,
-                sequence_index=context.sequence_index,
-                run_label=self.run_label,
-                agent_name=self.agent_name,
-                duration_ms=duration_ms,
-                metadata=metadata or {},
-                artifacts=artifacts or {},
-                error=error_from_exception(error) if error is not None else None,
+        with self._lock:
+            if kind == "tool_call":
+                self._active_tool_event_ids.discard(event_id)
+            self._events.append(
+                OpenAIAdapterEvent(
+                    event_id=event_id,
+                    kind=kind,
+                    status=status,
+                    sequence_index=context.sequence_index,
+                    run_label=self.run_label,
+                    agent_name=self.agent_name,
+                    duration_ms=duration_ms,
+                    metadata=metadata or {},
+                    artifacts=artifacts or {},
+                    error=error_from_exception(error) if error is not None else None,
+                )
             )
-        )
 
     def set_run_error(self, error: BaseException) -> None:
-        self._status = "failed"
-        self._error = error
+        with self._lock:
+            self._status = "failed"
+            self._error = error
 
-    def build_run_summary(self) -> dict[str, object]:
+    def _build_run_summary_unlocked(
+        self,
+        ordered_events: list[OpenAIAdapterEvent],
+    ) -> dict[str, object]:
         return {
             "agent_name": self.agent_name,
             "run_label": self.run_label,
             "status": self._status,
             "model_call_count": self._model_call_count,
             "tool_call_count": self._tool_call_count,
-            "total_events": self._counter,
-            "event_ids_in_order": [event.event_id for event in self._events],
+            "total_events": len(ordered_events),
+            "event_ids_in_order": [event.event_id for event in ordered_events],
             "duration_ms": round((time.perf_counter() - self._started_at) * 1000, 3),
             "error": (
                 error_from_exception(self._error).model_dump(mode="json")
@@ -135,17 +221,22 @@ class EventTracker:
             ),
         }
 
+    def build_run_summary(self) -> dict[str, object]:
+        with self._lock:
+            return self._build_run_summary_unlocked(self._ordered_events())
+
     def persist(self) -> None:
         if not (is_inside_flow() or is_inside_checkpoint()):
             return
-        events_dump = dump_openai_events(self._events)
-        summary_dump = self.build_run_summary()
+        run_label = self.run_label
+        with self._lock:
+            ordered_events = self._ordered_events()
+            events_dump = dump_openai_events(ordered_events)
+            summary_dump = self._build_run_summary_unlocked(ordered_events)
         kitaru.log(
             **{
-                OPENAI_AGENTS_EVENTS_METADATA_KEY: {self.run_label: events_dump},
-                OPENAI_AGENTS_RUN_SUMMARIES_METADATA_KEY: {
-                    self.run_label: summary_dump
-                },
+                OPENAI_AGENTS_EVENTS_METADATA_KEY: {run_label: events_dump},
+                OPENAI_AGENTS_RUN_SUMMARIES_METADATA_KEY: {run_label: summary_dump},
             }
         )
 

--- a/src/kitaru/adapters/pydantic_ai/_model.py
+++ b/src/kitaru/adapters/pydantic_ai/_model.py
@@ -33,7 +33,7 @@ from ._kitaru_internal import is_inside_checkpoint, is_inside_flow
 from ._logging import logger
 from ._otel import attach_model_correlation
 from ._policy import CapturePolicy
-from ._tracking import get_current_tracker
+from ._tracking import EventTracker, ModelEventContext, get_current_tracker
 from ._utils import (
     CheckpointConfig,
     checkpoint_cache_key,
@@ -89,6 +89,28 @@ def _serialize_model_response(response: ModelResponse) -> dict[str, Any]:
     return cast(
         dict[str, Any], _MODEL_RESPONSE_ADAPTER.dump_python(response, mode="json")
     )
+
+
+def _trackable_tool_call_ids(
+    response: ModelResponse,
+    model_request_parameters: ModelRequestParameters,
+    capture: CapturePolicy,
+) -> list[str]:
+    """Return executable response tool-call ids that will produce Kitaru events."""
+    function_tool_names = {
+        tool.name for tool in model_request_parameters.function_tools
+    }
+    tool_call_ids: list[str] = []
+    for tool_call in response.tool_calls:
+        tool_call_id = tool_call.tool_call_id
+        if (
+            tool_call.tool_name in function_tool_names
+            and isinstance(tool_call_id, str)
+            and tool_call_id
+            and capture.capture_mode_for_tool(tool_call.tool_name) is not None
+        ):
+            tool_call_ids.append(tool_call_id)
+    return tool_call_ids
 
 
 def _serialize_stream_event(event: Any) -> dict[str, Any]:
@@ -167,6 +189,25 @@ class KitaruModel(WrapperModel):
 
     def _should_track(self) -> bool:
         return self._capture.emit_child_events and is_inside_checkpoint()
+
+    def _reserve_tool_call_order(
+        self,
+        *,
+        tracker: EventTracker,
+        event_id: str,
+        event_context: ModelEventContext,
+        response: ModelResponse,
+        model_request_parameters: ModelRequestParameters,
+    ) -> None:
+        tracker.reserve_tool_call_order(
+            parent_model_event_id=event_id,
+            turn_index=event_context.turn_index,
+            tool_call_ids=_trackable_tool_call_ids(
+                response,
+                model_request_parameters,
+                self._capture,
+            ),
+        )
 
     async def request(
         self,
@@ -261,6 +302,13 @@ class KitaruModel(WrapperModel):
             model_name=response.model_name,
             usage=response.usage,
         )
+        self._reserve_tool_call_order(
+            tracker=tracker,
+            event_id=event_id,
+            event_context=event_context,
+            response=response,
+            model_request_parameters=model_request_parameters,
+        )
         return response
 
     @asynccontextmanager
@@ -353,4 +401,14 @@ class KitaruModel(WrapperModel):
             model_name=response.model_name,
             usage=response.usage,
             stream_event_count=stream_event_count,
+        )
+        # Pydantic AI only builds the CallToolsNode after this stream context
+        # closes and the final ModelResponse is returned, so this reservation is
+        # still made before any corresponding KitaruToolset calls can start.
+        self._reserve_tool_call_order(
+            tracker=tracker,
+            event_id=event_id,
+            event_context=event_context,
+            response=response,
+            model_request_parameters=model_request_parameters,
         )

--- a/src/kitaru/adapters/pydantic_ai/_toolset.py
+++ b/src/kitaru/adapters/pydantic_ai/_toolset.py
@@ -12,7 +12,12 @@ from pydantic_core import to_jsonable_python
 
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred
 from pydantic_ai.tools import AgentDepsT, RunContext
-from pydantic_ai.toolsets import AbstractToolset, FunctionToolset, ToolsetTool, WrapperToolset
+from pydantic_ai.toolsets import (
+    AbstractToolset,
+    FunctionToolset,
+    ToolsetTool,
+    WrapperToolset,
+)
 
 from kitaru.errors import KitaruContextError, KitaruUsageError
 from kitaru.wait import _WAIT_INSIDE_CHECKPOINT_ERROR
@@ -35,7 +40,6 @@ from ._utils import (
 )
 
 
-
 class _ToolApprovalDenied(Exception):
     """Raised when a human denies a HITL approval request."""
 
@@ -44,23 +48,26 @@ def _json_safe(value: Any) -> Any:
     try:
         return to_jsonable_python(value, serialize_unknown=True)
     except ValueError:  # circular reference
-        logger.warning('Failed to JSON-serialize adapter payload; falling back to repr.', exc_info=True)
+        logger.warning(
+            "Failed to JSON-serialize adapter payload; falling back to repr.",
+            exc_info=True,
+        )
         return {
-            'repr': repr(value),
-            'python_type': value.__class__.__name__,
-            'serialization_error': 'json_safe_failed',
+            "repr": repr(value),
+            "python_type": value.__class__.__name__,
+            "serialization_error": "json_safe_failed",
         }
 
 
 def _raise_checkpoint_wait_not_supported(tool_name: str, kind: DeferredKind) -> None:
     raise KitaruUsageError(
-        f'PydanticAI tool {tool_name!r} requested {kind!r} human input while '
-        'running inside a checkpoint. Kitaru waits must be created at flow '
-        'scope, not from checkpoint scope. Use `@hitl_tool` for pure wait '
-        'tools, disable checkpointing for this tool with '
+        f"PydanticAI tool {tool_name!r} requested {kind!r} human input while "
+        "running inside a checkpoint. Kitaru waits must be created at flow "
+        "scope, not from checkpoint scope. Use `@hitl_tool` for pure wait "
+        "tools, disable checkpointing for this tool with "
         '`tool_checkpoint_config_by_name={"tool_name": False}` while running '
-        'the agent in granular mode, or move the wait before/after the agent '
-        'call in flow code.'
+        "the agent in granular mode, or move the wait before/after the agent "
+        "call in flow code."
     )
 
 
@@ -78,20 +85,21 @@ class _DeferredRequest:
 class KitaruToolset(WrapperToolset[AgentDepsT]):
     """Wraps any toolset so Kitaru tracks tool calls and routes HITL waits through the flow."""
 
-    toolset_kind: ToolsetKind = 'generic'
+    toolset_kind: ToolsetKind = "generic"
     capture: CapturePolicy = field(default_factory=CapturePolicy)
     # Granular-mode: when set, each ``call_tool`` opens its own @kitaru.checkpoint.
     # Per-name overrides can replace or disable (`False`) per-tool.
     tool_checkpoint_config: CheckpointConfig | None = None
     tool_checkpoint_config_by_name: ToolCheckpointOverrides | None = None
-    _default_checkpoint_type: str = field(default='tool_call', init=False)
+    _default_checkpoint_type: str = field(default="tool_call", init=False)
 
     @property
     def id(self) -> str | None:
         return self.wrapped.id
 
     def visit_and_replace(
-        self, visitor: Callable[[AbstractToolset[AgentDepsT]], AbstractToolset[AgentDepsT]]
+        self,
+        visitor: Callable[[AbstractToolset[AgentDepsT]], AbstractToolset[AgentDepsT]],
     ) -> AbstractToolset[AgentDepsT]:
         return self
 
@@ -101,7 +109,9 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             return self
         return replace(self, wrapped=new_wrapped)
 
-    async def for_run_step(self, ctx: RunContext[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
+    async def for_run_step(
+        self, ctx: RunContext[AgentDepsT]
+    ) -> AbstractToolset[AgentDepsT]:
         new_wrapped = await self.wrapped.for_run_step(ctx)
         if new_wrapped is self.wrapped:
             return self
@@ -116,7 +126,9 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
     ) -> Any:
         hitl_config = hitl_config_from_tool_metadata(tool.tool_def.metadata)
         if hitl_config is not None:
-            return await self._call_tool_tracked(name, tool_args, ctx, tool, hitl_config)
+            return await self._call_tool_tracked(
+                name, tool_args, ctx, tool, hitl_config
+            )
 
         checkpoint_config = resolve_tool_checkpoint_config(
             name,
@@ -128,19 +140,24 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             and is_inside_flow()
             and not is_inside_checkpoint()
         ):
+
             async def _in_checkpoint() -> Any:
-                return await self._call_tool_tracked(name, tool_args, ctx, tool, hitl_config)
+                return await self._call_tool_tracked(
+                    name, tool_args, ctx, tool, hitl_config
+                )
 
             return await run_async_in_checkpoint(
-                config=with_default_type(checkpoint_config, self._default_checkpoint_type),
-                step_name=f'{name}_tool',
+                config=with_default_type(
+                    checkpoint_config, self._default_checkpoint_type
+                ),
+                step_name=f"{name}_tool",
                 body=_in_checkpoint,
                 cache_key=checkpoint_cache_key(
                     {
-                        'tool_name': name,
-                        'tool_args': tool_args,
-                        'tool_call_id': ctx.tool_call_id,
-                        'retry': ctx.retry,
+                        "tool_name": name,
+                        "tool_args": tool_args,
+                        "tool_call_id": ctx.tool_call_id,
+                        "retry": ctx.retry,
                     }
                 ),
             )
@@ -174,13 +191,13 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
         if self.capture.correlate_otel_spans:
             attach_tool_correlation(event_id, event_context)
 
-        safe_args = _json_safe(tool_args) if capture_mode == 'full' else None
+        safe_args = _json_safe(tool_args) if capture_mode == "full" else None
 
         artifacts: dict[str, str] = {}
-        if capture_mode == 'full' and is_inside_checkpoint():
-            args_key = tracker.artifact_name(event_id, 'args')
-            kitaru.save(args_key, safe_args, type='input')
-            artifacts['args'] = args_key
+        if capture_mode == "full" and is_inside_checkpoint():
+            args_key = tracker.artifact_name(event_id, "args")
+            kitaru.save(args_key, safe_args, type="input")
+            artifacts["args"] = args_key
 
         started_at = time.perf_counter()
         try:
@@ -198,7 +215,7 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             tracker.record_tool_event(
                 event_id,
                 event_context,
-                status='failed',
+                status="failed",
                 name=name,
                 toolset_kind=self.toolset_kind,
                 capture_mode=capture_mode,
@@ -210,15 +227,15 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             raise
 
         duration_ms = _elapsed_ms(started_at)
-        if capture_mode == 'full' and is_inside_checkpoint():
-            result_key = tracker.artifact_name(event_id, 'result')
-            kitaru.save(result_key, _json_safe(result), type='output')
-            artifacts['result'] = result_key
+        if capture_mode == "full" and is_inside_checkpoint():
+            result_key = tracker.artifact_name(event_id, "result")
+            kitaru.save(result_key, _json_safe(result), type="output")
+            artifacts["result"] = result_key
 
         tracker.record_tool_event(
             event_id,
             event_context,
-            status='completed',
+            status="completed",
             name=name,
             toolset_kind=self.toolset_kind,
             capture_mode=capture_mode,
@@ -241,13 +258,13 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
         capture_mode: str | None,
     ) -> Any:
         def _call_suffix() -> str:
-            return _wait_call_suffix(getattr(ctx, 'tool_call_id', None))
+            return _wait_call_suffix(getattr(ctx, "tool_call_id", None))
 
         if hitl_config is not None:
             call_suffix = _call_suffix()
             request = _DeferredRequest(
-                kind='hitl',
-                wait_name=f'{hitl_config.name or name}_{call_suffix}',
+                kind="hitl",
+                wait_name=f"{hitl_config.name or name}_{call_suffix}",
                 schema=hitl_config.schema,
                 question=resolve_hitl_question(hitl_config, tool_args),
                 exception_metadata=None,
@@ -268,29 +285,29 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             return await super().call_tool(name, tool_args, ctx, tool)
         except KitaruContextError as error:
             if is_inside_checkpoint() and str(error) == _WAIT_INSIDE_CHECKPOINT_ERROR:
-                _raise_checkpoint_wait_not_supported(name, 'hitl')
+                _raise_checkpoint_wait_not_supported(name, "hitl")
             raise
         except ApprovalRequired as error:
             if is_inside_checkpoint():
-                _raise_checkpoint_wait_not_supported(name, 'approval_required')
+                _raise_checkpoint_wait_not_supported(name, "approval_required")
             call_suffix = _call_suffix()
             request = _DeferredRequest(
-                kind='approval_required',
-                wait_name=f'approve_{name}_{call_suffix}',
+                kind="approval_required",
+                wait_name=f"approve_{name}_{call_suffix}",
                 schema=bool,
-                question=f'Approve tool call: {name}?',
+                question=f"Approve tool call: {name}?",
                 exception_metadata=error.metadata,
                 run_after_wait=True,
             )
         except CallDeferred as error:
             if is_inside_checkpoint():
-                _raise_checkpoint_wait_not_supported(name, 'call_deferred')
+                _raise_checkpoint_wait_not_supported(name, "call_deferred")
             call_suffix = _call_suffix()
             request = _DeferredRequest(
-                kind='call_deferred',
-                wait_name=f'defer_{name}_{call_suffix}',
+                kind="call_deferred",
+                wait_name=f"defer_{name}_{call_suffix}",
                 schema=self._schema_for_deferred_tool(name, ctx),
-                question=f'Provide result for deferred tool: {name}',
+                question=f"Provide result for deferred tool: {name}",
                 exception_metadata=error.metadata,
                 run_after_wait=False,
             )
@@ -319,7 +336,7 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
     ) -> Any:
         if is_inside_checkpoint():
             _raise_checkpoint_wait_not_supported(name, request.kind)
-        if capture_mode == 'full' and safe_args is None:
+        if capture_mode == "full" and safe_args is None:
             safe_args = _json_safe(tool_args)
         wait_metadata = self._wait_metadata(
             name=name,
@@ -336,8 +353,8 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
         )
         approved = bool(wait_value) if request.schema is bool else None
         deferred_metadata = (
-            {'exception_metadata': _json_safe(request.exception_metadata)}
-            if capture_mode == 'full' and request.exception_metadata
+            {"exception_metadata": _json_safe(request.exception_metadata)}
+            if capture_mode == "full" and request.exception_metadata
             else None
         )
         if tracker is not None:
@@ -349,23 +366,27 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
                 approved=approved,
             )
         if approved is False:
-            raise _ToolApprovalDenied(f'Tool {name!r} was not approved.')
+            raise _ToolApprovalDenied(f"Tool {name!r} was not approved.")
         if not request.run_after_wait:
             return wait_value
-        approved_ctx = replace(ctx, tool_call_approved=True, tool_call_metadata=request.exception_metadata)
+        approved_ctx = replace(
+            ctx, tool_call_approved=True, tool_call_metadata=request.exception_metadata
+        )
         return await super().call_tool(name, tool_args, approved_ctx, tool)
 
     def _schema_for_deferred_tool(self, name: str, ctx: RunContext[AgentDepsT]) -> Any:
         if isinstance(self.wrapped, FunctionToolset):
-            for candidate_name in (getattr(ctx, 'tool_name', None), name):
+            for candidate_name in (getattr(ctx, "tool_name", None), name):
                 if candidate_name and candidate_name in self.wrapped.tools:
                     function = self.wrapped.tools[candidate_name].function
-                    annotation = get_type_hints(function).get('return', inspect.Signature.empty)
+                    annotation = get_type_hints(function).get(
+                        "return", inspect.Signature.empty
+                    )
                     if annotation not in {inspect.Signature.empty, Any}:
                         return annotation
         raise KitaruUsageError(
-            f'Cannot infer a wait schema for deferred tool {name!r}. '
-            'Add an explicit return annotation or use `@hitl_tool(schema=...)`.'
+            f"Cannot infer a wait schema for deferred tool {name!r}. "
+            "Add an explicit return annotation or use `@hitl_tool(schema=...)`."
         )
 
     def _wait_metadata(
@@ -379,13 +400,13 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
     ) -> dict[str, Any]:
         metadata: dict[str, Any] = {
             ADAPTER_METADATA_KEY: ADAPTER_ID,
-            'tool_name': name,
-            'tool_call_id': ctx.tool_call_id,
+            "tool_name": name,
+            "tool_call_id": ctx.tool_call_id,
         }
-        if capture_mode == 'full':
-            metadata['tool_args'] = safe_args
+        if capture_mode == "full":
+            metadata["tool_args"] = safe_args
             if exception_metadata:
-                metadata['exception_metadata'] = _json_safe(exception_metadata)
+                metadata["exception_metadata"] = _json_safe(exception_metadata)
         return metadata
 
     def _invoke_wait(
@@ -404,7 +425,7 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
         )
 
 
-_NON_WORD_PATTERN = re.compile(r'\W+')
+_NON_WORD_PATTERN = re.compile(r"\W+")
 
 
 def _wait_call_suffix(tool_call_id: str | None) -> str:
@@ -417,13 +438,13 @@ def _wait_call_suffix(tool_call_id: str | None) -> str:
     would drift across resume/replay.
     """
     if isinstance(tool_call_id, str) and tool_call_id:
-        sanitized = _NON_WORD_PATTERN.sub('_', tool_call_id).strip('_')
+        sanitized = _NON_WORD_PATTERN.sub("_", tool_call_id).strip("_")
         if sanitized:
             return sanitized
     raise KitaruUsageError(
-        'PydanticAI did not provide a stable `tool_call_id` for this '
-        'HITL/deferred tool call. Kitaru cannot create a replay-safe wait '
-        'name without it. Upgrade PydanticAI or avoid durable HITL for this tool.'
+        "PydanticAI did not provide a stable `tool_call_id` for this "
+        "HITL/deferred tool call. Kitaru cannot create a replay-safe wait "
+        "name without it. Upgrade PydanticAI or avoid durable HITL for this tool."
     )
 
 
@@ -443,8 +464,8 @@ def kitaruify_toolset(
         return toolset
 
     common = {
-        'capture': capture,
-        'tool_checkpoint_config_by_name': tool_checkpoint_config_by_name,
+        "capture": capture,
+        "tool_checkpoint_config_by_name": tool_checkpoint_config_by_name,
     }
 
     if isinstance(toolset, FunctionToolset):
@@ -468,7 +489,7 @@ def kitaruify_toolset(
 
     return KitaruToolset(
         toolset,
-        toolset_kind='generic',
+        toolset_kind="generic",
         tool_checkpoint_config=tool_checkpoint_config,
         **common,
     )

--- a/src/kitaru/adapters/pydantic_ai/_toolset.py
+++ b/src/kitaru/adapters/pydantic_ai/_toolset.py
@@ -168,7 +168,9 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
                 capture_mode=capture_mode,
             )
 
-        event_id, event_context = tracker.start_tool_event()
+        event_id, event_context = tracker.start_tool_event(
+            tool_call_id=ctx.tool_call_id,
+        )
         if self.capture.correlate_otel_spans:
             attach_tool_correlation(event_id, event_context)
 

--- a/src/kitaru/adapters/pydantic_ai/_tracking.py
+++ b/src/kitaru/adapters/pydantic_ai/_tracking.py
@@ -189,6 +189,15 @@ class ToolEventContext:
     fan_out_from: str | None
 
 
+@dataclass(frozen=True)
+class _ReservedToolEvent:
+    tool_call_id: str
+    event_id: str
+    sequence_index: int
+    turn_index: int
+    fan_out_from: str | None
+
+
 @dataclass
 class EventTracker:
     agent_name: str
@@ -209,6 +218,15 @@ class EventTracker:
     _event_stream_handler_call_count: int = 0
     _event_stream_handler_duration_ms: float = 0.0
     _started_at: float = field(default_factory=time.perf_counter)
+    _lock: threading.RLock = field(
+        default_factory=threading.RLock, init=False, repr=False
+    )
+    _reserved_tool_events_by_call_id: dict[str, list[_ReservedToolEvent]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _event_sequence_by_id: dict[str, int] = field(
+        default_factory=dict, init=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         self.agent_name = normalize_agent_name(self.agent_name)
@@ -223,7 +241,8 @@ class EventTracker:
 
     @property
     def events(self) -> Sequence[AgentEvent]:
-        return tuple(self._events)
+        with self._lock:
+            return tuple(self._ordered_events())
 
     @property
     def event_log_artifact_name(self) -> str:
@@ -243,23 +262,63 @@ class EventTracker:
     def _next_event_id(self, event_kind: str) -> tuple[str, int]:
         self._counter += 1
         event_id = f'{self.agent_name}_{self.run_label}_{event_kind}_{self._counter}'
+        self._event_sequence_by_id[event_id] = self._counter
         return event_id, self._counter
 
+    def _ordered_events(self) -> list[AgentEvent]:
+        return sorted(self._events, key=lambda event: event.sequence_index)
+
+    def _event_sequence_index(self, event_id: str) -> int:
+        return self._event_sequence_by_id.get(event_id, self._counter + 1)
+
+    def _clear_reserved_tool_events_unlocked(self) -> None:
+        for reservations in self._reserved_tool_events_by_call_id.values():
+            for reservation in reservations:
+                self._event_sequence_by_id.pop(reservation.event_id, None)
+        self._reserved_tool_events_by_call_id.clear()
+
     def set_run_error(self, error: BaseException) -> None:
-        self._status = 'failed'
-        self._error = error_from_exception(error)
+        with self._lock:
+            self._status = 'failed'
+            self._error = error_from_exception(error)
 
     def start_model_event(self) -> tuple[str, ModelEventContext]:
-        event_id, sequence_index = self._next_event_id('llm_call')
-        self._model_call_count += 1
-        self._turn_index += 1
-        fan_in_from = list(self._pending_tool_event_ids)
-        self._pending_tool_event_ids.clear()
-        return event_id, ModelEventContext(
-            sequence_index=sequence_index,
-            turn_index=self._turn_index,
-            fan_in_from=fan_in_from,
-        )
+        with self._lock:
+            fan_in_from = sorted(
+                self._pending_tool_event_ids,
+                key=self._event_sequence_index,
+            )
+            self._pending_tool_event_ids.clear()
+            self._clear_reserved_tool_events_unlocked()
+            event_id, sequence_index = self._next_event_id('llm_call')
+            self._model_call_count += 1
+            self._turn_index += 1
+            return event_id, ModelEventContext(
+                sequence_index=sequence_index,
+                turn_index=self._turn_index,
+                fan_in_from=fan_in_from,
+            )
+
+    def reserve_tool_call_order(
+        self,
+        *,
+        parent_model_event_id: str,
+        turn_index: int,
+        tool_call_ids: Sequence[str],
+    ) -> None:
+        with self._lock:
+            for tool_call_id in tool_call_ids:
+                event_id, sequence_index = self._next_event_id('tool_call')
+                reserved = _ReservedToolEvent(
+                    tool_call_id=tool_call_id,
+                    event_id=event_id,
+                    sequence_index=sequence_index,
+                    turn_index=turn_index,
+                    fan_out_from=parent_model_event_id,
+                )
+                self._reserved_tool_events_by_call_id.setdefault(
+                    tool_call_id, []
+                ).append(reserved)
 
     def record_model_event(
         self,
@@ -274,36 +333,59 @@ class EventTracker:
         stream_event_count: int | None = None,
         error: BaseException | None = None,
     ) -> None:
-        if status == 'completed':
-            self._current_model_event_id = event_id
-        elif self._current_model_event_id == event_id:
-            self._current_model_event_id = None
+        with self._lock:
+            if status == 'completed':
+                self._current_model_event_id = event_id
+            elif self._current_model_event_id == event_id:
+                self._current_model_event_id = None
 
-        self._events.append(
-            ModelEvent(
-                event_id=event_id,
-                status=status,
-                sequence_index=event_context.sequence_index,
-                turn_index=event_context.turn_index,
-                parent_event_ids=event_context.fan_in_from,
-                fan_in_from=event_context.fan_in_from,
-                duration_ms=duration_ms,
-                artifacts=artifacts,
-                model_name=model_name,
-                usage=usage,
-                stream_event_count=stream_event_count,
-                error=error_from_exception(error) if error is not None else None,
+            self._events.append(
+                ModelEvent(
+                    event_id=event_id,
+                    status=status,
+                    sequence_index=event_context.sequence_index,
+                    turn_index=event_context.turn_index,
+                    parent_event_ids=event_context.fan_in_from,
+                    fan_in_from=event_context.fan_in_from,
+                    duration_ms=duration_ms,
+                    artifacts=artifacts,
+                    model_name=model_name,
+                    usage=usage,
+                    stream_event_count=stream_event_count,
+                    error=error_from_exception(error) if error is not None else None,
+                )
             )
-        )
 
-    def start_tool_event(self) -> tuple[str, ToolEventContext]:
-        event_id, sequence_index = self._next_event_id('tool_call')
-        self._tool_call_count += 1
-        return event_id, ToolEventContext(
-            sequence_index=sequence_index,
-            turn_index=self._turn_index,
-            fan_out_from=self._current_model_event_id,
-        )
+    def start_tool_event(
+        self,
+        *,
+        tool_call_id: str | None = None,
+    ) -> tuple[str, ToolEventContext]:
+        with self._lock:
+            reservation: _ReservedToolEvent | None = None
+            if isinstance(tool_call_id, str) and tool_call_id:
+                reservations = self._reserved_tool_events_by_call_id.get(tool_call_id)
+                if reservations:
+                    reservation = reservations.pop(0)
+                    if not reservations:
+                        self._reserved_tool_events_by_call_id.pop(tool_call_id, None)
+
+            if reservation is None:
+                event_id, sequence_index = self._next_event_id('tool_call')
+                turn_index = self._turn_index
+                fan_out_from = self._current_model_event_id
+            else:
+                event_id = reservation.event_id
+                sequence_index = reservation.sequence_index
+                turn_index = reservation.turn_index
+                fan_out_from = reservation.fan_out_from
+
+            self._tool_call_count += 1
+            return event_id, ToolEventContext(
+                sequence_index=sequence_index,
+                turn_index=turn_index,
+                fan_out_from=fan_out_from,
+            )
 
     def record_tool_event(
         self,
@@ -319,29 +401,30 @@ class EventTracker:
         artifacts: dict[str, str],
         error: BaseException | None = None,
     ) -> None:
-        if status == 'completed':
-            self._pending_tool_event_ids.append(event_id)
-        elif event_id in self._pending_tool_event_ids:
-            self._pending_tool_event_ids.remove(event_id)
+        with self._lock:
+            if status == 'completed':
+                self._pending_tool_event_ids.append(event_id)
+            elif event_id in self._pending_tool_event_ids:
+                self._pending_tool_event_ids.remove(event_id)
 
-        parent_event_ids = [event_context.fan_out_from] if event_context.fan_out_from is not None else []
-        self._events.append(
-            ToolEvent(
-                event_id=event_id,
-                status=status,
-                sequence_index=event_context.sequence_index,
-                turn_index=event_context.turn_index,
-                parent_event_ids=parent_event_ids,
-                tool_name=name,
-                toolset_kind=toolset_kind,
-                hitl=hitl,
-                capture_mode=capture_mode,
-                fan_out_from=event_context.fan_out_from,
-                duration_ms=duration_ms,
-                artifacts=artifacts,
-                error=error_from_exception(error) if error is not None else None,
+            parent_event_ids = [event_context.fan_out_from] if event_context.fan_out_from is not None else []
+            self._events.append(
+                ToolEvent(
+                    event_id=event_id,
+                    status=status,
+                    sequence_index=event_context.sequence_index,
+                    turn_index=event_context.turn_index,
+                    parent_event_ids=parent_event_ids,
+                    tool_name=name,
+                    toolset_kind=toolset_kind,
+                    hitl=hitl,
+                    capture_mode=capture_mode,
+                    fan_out_from=event_context.fan_out_from,
+                    duration_ms=duration_ms,
+                    artifacts=artifacts,
+                    error=error_from_exception(error) if error is not None else None,
+                )
             )
-        )
 
     def record_deferred_event(
         self,
@@ -352,42 +435,48 @@ class EventTracker:
         metadata: dict[str, object] | None,
         approved: bool | None = None,
     ) -> None:
-        event_id, sequence_index = self._next_event_id('deferred')
-        parent_event_ids = [self._current_model_event_id] if self._current_model_event_id else []
-        self._events.append(
-            DeferredEvent(
-                event_id=event_id,
-                status='completed',
-                sequence_index=sequence_index,
-                turn_index=self._turn_index,
-                parent_event_ids=parent_event_ids,
-                tool_name=tool_name,
-                deferred_kind=deferred_kind,
-                wait_name=wait_name,
-                metadata=metadata,
-                approved=approved,
+        with self._lock:
+            event_id, sequence_index = self._next_event_id('deferred')
+            parent_event_ids = [self._current_model_event_id] if self._current_model_event_id else []
+            self._events.append(
+                DeferredEvent(
+                    event_id=event_id,
+                    status='completed',
+                    sequence_index=sequence_index,
+                    turn_index=self._turn_index,
+                    parent_event_ids=parent_event_ids,
+                    tool_name=tool_name,
+                    deferred_kind=deferred_kind,
+                    wait_name=wait_name,
+                    metadata=metadata,
+                    approved=approved,
+                )
             )
-        )
 
     def record_stream_event(self, *, duration_ms: float, error: BaseException | None) -> None:
-        self._event_stream_handler_call_count += 1
-        self._event_stream_handler_duration_ms = round(self._event_stream_handler_duration_ms + duration_ms, 3)
-        event_id, sequence_index = self._next_event_id('event_stream')
-        self._events.append(
-            StreamEvent(
-                event_id=event_id,
-                status='failed' if error is not None else 'completed',
-                sequence_index=sequence_index,
-                turn_index=self._turn_index,
-                parent_event_ids=[],
-                index=self._event_stream_handler_call_count,
-                duration_ms=duration_ms,
-                error=error_from_exception(error) if error is not None else None,
+        with self._lock:
+            self._event_stream_handler_call_count += 1
+            self._event_stream_handler_duration_ms = round(
+                self._event_stream_handler_duration_ms + duration_ms, 3
             )
-        )
+            event_id, sequence_index = self._next_event_id('event_stream')
+            self._events.append(
+                StreamEvent(
+                    event_id=event_id,
+                    status='failed' if error is not None else 'completed',
+                    sequence_index=sequence_index,
+                    turn_index=self._turn_index,
+                    parent_event_ids=[],
+                    index=self._event_stream_handler_call_count,
+                    duration_ms=duration_ms,
+                    error=error_from_exception(error) if error is not None else None,
+                )
+            )
 
-    def build_run_summary(self) -> RunSummary:
-        ordered_events = sorted(self._events, key=lambda event: event.sequence_index)
+    def _build_run_summary_unlocked(
+        self,
+        ordered_events: list[AgentEvent],
+    ) -> RunSummary:
         event_stream_handler = None
         if self._event_stream_handler_call_count:
             event_stream_handler = EventStreamHandlerSummary(
@@ -400,7 +489,7 @@ class EventTracker:
             status=self._status,
             model_call_count=self._model_call_count,
             tool_call_count=self._tool_call_count,
-            total_events=self._counter,
+            total_events=len(ordered_events),
             turn_count=self._turn_index,
             event_ids_in_order=[event.event_id for event in ordered_events],
             duration_ms=round((time.perf_counter() - self._started_at) * 1000, 3),
@@ -411,20 +500,33 @@ class EventTracker:
             error=self._error,
         )
 
+    def build_run_summary(self) -> RunSummary:
+        with self._lock:
+            return self._build_run_summary_unlocked(self._ordered_events())
+
     def persist(self) -> None:
-        events_dump = dump_agent_events(self._events)
-        summary_dump = self.build_run_summary().model_dump(mode='json')
+        with self._lock:
+            ordered_events = self._ordered_events()
+            events_dump = dump_agent_events(ordered_events)
+            summary_dump = self._build_run_summary_unlocked(ordered_events).model_dump(
+                mode='json'
+            )
+            event_log_artifact_name = self.event_log_artifact_name
+            run_summary_artifact_name = self.run_summary_artifact_name
+            run_label = self.run_label
+            agent_name = self.agent_name
+
         if is_inside_checkpoint():
-            kitaru.save(self.event_log_artifact_name, events_dump, type='context')
-            kitaru.save(self.run_summary_artifact_name, summary_dump, type='context')
+            kitaru.save(event_log_artifact_name, events_dump, type='context')
+            kitaru.save(run_summary_artifact_name, summary_dump, type='context')
         else:
             logger.debug(
                 'Persisting PydanticAI tracker outside a checkpoint; emitting flow-level metadata only.',
-                extra={'agent_name': self.agent_name, 'run_label': self.run_label},
+                extra={'agent_name': agent_name, 'run_label': run_label},
             )
         kitaru.log(
-            pydantic_ai_events={self.run_label: events_dump},
-            pydantic_ai_run_summaries={self.run_label: summary_dump},
+            pydantic_ai_events={run_label: events_dump},
+            pydantic_ai_run_summaries={run_label: summary_dump},
         )
 
 

--- a/src/kitaru/adapters/pydantic_ai/_tracking.py
+++ b/src/kitaru/adapters/pydantic_ai/_tracking.py
@@ -37,10 +37,14 @@ from ._kitaru_internal import (
 )
 from ._policy import CaptureMode
 
-_NON_WORD_PATTERN = re.compile(r'\W+')
-_EVENT_ID_DISPLAY_PATTERN = re.compile(r'_(llm_call|tool_call|event_stream|deferred)_(\d+)$')
+_NON_WORD_PATTERN = re.compile(r"\W+")
+_EVENT_ID_DISPLAY_PATTERN = re.compile(
+    r"_(llm_call|tool_call|event_stream|deferred)_(\d+)$"
+)
 
-ArtifactKind = Literal['args', 'result', 'prompt', 'response', 'stream_transcript', 'context']
+ArtifactKind = Literal[
+    "args", "result", "prompt", "response", "stream_transcript", "context"
+]
 
 
 CheckpointKey = tuple[str | None, str | None, str | None, int]
@@ -61,29 +65,31 @@ class _ArtifactNamespaceState:
 _ARTIFACT_NAMESPACE_LOCK = threading.Lock()
 _ARTIFACT_NAMESPACE_COUNTS: dict[CheckpointKey, int] = {}
 _ARTIFACT_NAMESPACE_FINALIZERS: dict[CheckpointKey, weakref.finalize] = {}
-_CONTEXT_ARTIFACT_NAMESPACE_STATE: ContextVar[_ArtifactNamespaceState | None] = ContextVar(
-    'kitaru_pydantic_ai_context_artifact_namespace_state',
-    default=None,
+_CONTEXT_ARTIFACT_NAMESPACE_STATE: ContextVar[_ArtifactNamespaceState | None] = (
+    ContextVar(
+        "kitaru_pydantic_ai_context_artifact_namespace_state",
+        default=None,
+    )
 )
 
 
 def normalize_agent_name(agent_name: str | None) -> str:
-    normalized = _NON_WORD_PATTERN.sub('_', (agent_name or '').strip()).strip('_')
-    return normalized or 'agent'
+    normalized = _NON_WORD_PATTERN.sub("_", (agent_name or "").strip()).strip("_")
+    return normalized or "agent"
 
 
 def _with_namespace(name: str, namespace: str | None) -> str:
     if namespace is None:
         return name
-    return f'{namespace}_{name}'
+    return f"{namespace}_{name}"
 
 
 def _event_artifact_base_name(event_id: str, kind: ArtifactKind) -> str:
     match = _EVENT_ID_DISPLAY_PATTERN.search(event_id)
     if match is None:
-        return f'{event_id}_{kind}'
+        return f"{event_id}_{kind}"
     event_kind, sequence_index = match.groups()
-    return f'{event_kind}_{sequence_index}_{kind}'
+    return f"{event_kind}_{sequence_index}_{kind}"
 
 
 def artifact_name(event_id: str, kind: ArtifactKind) -> str:
@@ -111,7 +117,9 @@ def _reset_artifact_namespace_state(checkpoint: _CheckpointLike | None = None) -
         keys = (
             [checkpoint_key]
             if checkpoint_key is not None
-            else list(set(_ARTIFACT_NAMESPACE_COUNTS) | set(_ARTIFACT_NAMESPACE_FINALIZERS))
+            else list(
+                set(_ARTIFACT_NAMESPACE_COUNTS) | set(_ARTIFACT_NAMESPACE_FINALIZERS)
+            )
         )
         for key in keys:
             if key is None:
@@ -137,8 +145,10 @@ def _reset_artifact_namespace_state_for_key(
             finalizer.detach()
 
 
-def _tracker_artifact_namespace(agent_name: str, run_label: str, tracker_count: int) -> str:
-    return f'{agent_name}_{run_label}_tracker_{tracker_count}'
+def _tracker_artifact_namespace(
+    agent_name: str, run_label: str, tracker_count: int
+) -> str:
+    return f"{agent_name}_{run_label}_tracker_{tracker_count}"
 
 
 def _context_artifact_namespace(
@@ -168,7 +178,9 @@ def _allocate_artifact_namespace(agent_name: str, run_label: str) -> str | None:
                     checkpoint_key,
                 )
             except TypeError:
-                return _context_artifact_namespace(agent_name, run_label, checkpoint_key)
+                return _context_artifact_namespace(
+                    agent_name, run_label, checkpoint_key
+                )
         tracker_count = _ARTIFACT_NAMESPACE_COUNTS.get(checkpoint_key, 0) + 1
         _ARTIFACT_NAMESPACE_COUNTS[checkpoint_key] = tracker_count
 
@@ -211,7 +223,7 @@ class EventTracker:
     _current_model_event_id: str | None = None
     _pending_tool_event_ids: list[str] = field(default_factory=list)
     _events: list[AgentEvent] = field(default_factory=list)
-    _status: EventStatus = 'completed'
+    _status: EventStatus = "completed"
     _error: EventError | None = None
     _model_call_count: int = 0
     _tool_call_count: int = 0
@@ -232,7 +244,9 @@ class EventTracker:
         self.agent_name = normalize_agent_name(self.agent_name)
         checkpoint = get_current_checkpoint()
         self.checkpoint_name = get_current_checkpoint_name()
-        self.checkpoint_id = checkpoint.checkpoint_id if checkpoint is not None else None
+        self.checkpoint_id = (
+            checkpoint.checkpoint_id if checkpoint is not None else None
+        )
         self.exec_id = get_current_execution_id()
         self.artifact_namespace = _allocate_artifact_namespace(
             self.agent_name,
@@ -246,11 +260,11 @@ class EventTracker:
 
     @property
     def event_log_artifact_name(self) -> str:
-        return _with_namespace('event_log', self.artifact_namespace)
+        return _with_namespace("event_log", self.artifact_namespace)
 
     @property
     def run_summary_artifact_name(self) -> str:
-        return _with_namespace('run_summary', self.artifact_namespace)
+        return _with_namespace("run_summary", self.artifact_namespace)
 
     def artifact_name(self, event_id: str, kind: ArtifactKind) -> str:
         return _namespaced_artifact_name(
@@ -261,7 +275,7 @@ class EventTracker:
 
     def _next_event_id(self, event_kind: str) -> tuple[str, int]:
         self._counter += 1
-        event_id = f'{self.agent_name}_{self.run_label}_{event_kind}_{self._counter}'
+        event_id = f"{self.agent_name}_{self.run_label}_{event_kind}_{self._counter}"
         self._event_sequence_by_id[event_id] = self._counter
         return event_id, self._counter
 
@@ -279,7 +293,7 @@ class EventTracker:
 
     def set_run_error(self, error: BaseException) -> None:
         with self._lock:
-            self._status = 'failed'
+            self._status = "failed"
             self._error = error_from_exception(error)
 
     def start_model_event(self) -> tuple[str, ModelEventContext]:
@@ -290,7 +304,7 @@ class EventTracker:
             )
             self._pending_tool_event_ids.clear()
             self._clear_reserved_tool_events_unlocked()
-            event_id, sequence_index = self._next_event_id('llm_call')
+            event_id, sequence_index = self._next_event_id("llm_call")
             self._model_call_count += 1
             self._turn_index += 1
             return event_id, ModelEventContext(
@@ -308,7 +322,7 @@ class EventTracker:
     ) -> None:
         with self._lock:
             for tool_call_id in tool_call_ids:
-                event_id, sequence_index = self._next_event_id('tool_call')
+                event_id, sequence_index = self._next_event_id("tool_call")
                 reserved = _ReservedToolEvent(
                     tool_call_id=tool_call_id,
                     event_id=event_id,
@@ -334,7 +348,7 @@ class EventTracker:
         error: BaseException | None = None,
     ) -> None:
         with self._lock:
-            if status == 'completed':
+            if status == "completed":
                 self._current_model_event_id = event_id
             elif self._current_model_event_id == event_id:
                 self._current_model_event_id = None
@@ -371,7 +385,7 @@ class EventTracker:
                         self._reserved_tool_events_by_call_id.pop(tool_call_id, None)
 
             if reservation is None:
-                event_id, sequence_index = self._next_event_id('tool_call')
+                event_id, sequence_index = self._next_event_id("tool_call")
                 turn_index = self._turn_index
                 fan_out_from = self._current_model_event_id
             else:
@@ -402,12 +416,16 @@ class EventTracker:
         error: BaseException | None = None,
     ) -> None:
         with self._lock:
-            if status == 'completed':
+            if status == "completed":
                 self._pending_tool_event_ids.append(event_id)
             elif event_id in self._pending_tool_event_ids:
                 self._pending_tool_event_ids.remove(event_id)
 
-            parent_event_ids = [event_context.fan_out_from] if event_context.fan_out_from is not None else []
+            parent_event_ids = (
+                [event_context.fan_out_from]
+                if event_context.fan_out_from is not None
+                else []
+            )
             self._events.append(
                 ToolEvent(
                     event_id=event_id,
@@ -436,12 +454,14 @@ class EventTracker:
         approved: bool | None = None,
     ) -> None:
         with self._lock:
-            event_id, sequence_index = self._next_event_id('deferred')
-            parent_event_ids = [self._current_model_event_id] if self._current_model_event_id else []
+            event_id, sequence_index = self._next_event_id("deferred")
+            parent_event_ids = (
+                [self._current_model_event_id] if self._current_model_event_id else []
+            )
             self._events.append(
                 DeferredEvent(
                     event_id=event_id,
-                    status='completed',
+                    status="completed",
                     sequence_index=sequence_index,
                     turn_index=self._turn_index,
                     parent_event_ids=parent_event_ids,
@@ -453,17 +473,19 @@ class EventTracker:
                 )
             )
 
-    def record_stream_event(self, *, duration_ms: float, error: BaseException | None) -> None:
+    def record_stream_event(
+        self, *, duration_ms: float, error: BaseException | None
+    ) -> None:
         with self._lock:
             self._event_stream_handler_call_count += 1
             self._event_stream_handler_duration_ms = round(
                 self._event_stream_handler_duration_ms + duration_ms, 3
             )
-            event_id, sequence_index = self._next_event_id('event_stream')
+            event_id, sequence_index = self._next_event_id("event_stream")
             self._events.append(
                 StreamEvent(
                     event_id=event_id,
-                    status='failed' if error is not None else 'completed',
+                    status="failed" if error is not None else "completed",
                     sequence_index=sequence_index,
                     turn_index=self._turn_index,
                     parent_event_ids=[],
@@ -509,7 +531,7 @@ class EventTracker:
             ordered_events = self._ordered_events()
             events_dump = dump_agent_events(ordered_events)
             summary_dump = self._build_run_summary_unlocked(ordered_events).model_dump(
-                mode='json'
+                mode="json"
             )
             event_log_artifact_name = self.event_log_artifact_name
             run_summary_artifact_name = self.run_summary_artifact_name
@@ -517,12 +539,12 @@ class EventTracker:
             agent_name = self.agent_name
 
         if is_inside_checkpoint():
-            kitaru.save(event_log_artifact_name, events_dump, type='context')
-            kitaru.save(run_summary_artifact_name, summary_dump, type='context')
+            kitaru.save(event_log_artifact_name, events_dump, type="context")
+            kitaru.save(run_summary_artifact_name, summary_dump, type="context")
         else:
             logger.debug(
-                'Persisting PydanticAI tracker outside a checkpoint; emitting flow-level metadata only.',
-                extra={'agent_name': agent_name, 'run_label': run_label},
+                "Persisting PydanticAI tracker outside a checkpoint; emitting flow-level metadata only.",
+                extra={"agent_name": agent_name, "run_label": run_label},
             )
         kitaru.log(
             pydantic_ai_events={run_label: events_dump},
@@ -531,14 +553,14 @@ class EventTracker:
 
 
 _CURRENT_TRACKER: ContextVar[EventTracker | None] = ContextVar(
-    'kitaru_pydantic_ai_event_tracker',
+    "kitaru_pydantic_ai_event_tracker",
     default=None,
 )
 
 
 @contextmanager
 def tracker_scope(agent_name: str | None) -> Iterator[EventTracker]:
-    tracker = EventTracker(agent_name=agent_name or 'agent')
+    tracker = EventTracker(agent_name=agent_name or "agent")
     token = _CURRENT_TRACKER.set(tracker)
     try:
         yield tracker
@@ -551,9 +573,12 @@ def tracker_scope(agent_name: str | None) -> Iterator[EventTracker]:
                 tracker.persist()
             except Exception:
                 logger.warning(
-                    'Failed to persist PydanticAI tracker state.',
+                    "Failed to persist PydanticAI tracker state.",
                     exc_info=True,
-                    extra={'agent_name': tracker.agent_name, 'run_label': tracker.run_label},
+                    extra={
+                        "agent_name": tracker.agent_name,
+                        "run_label": tracker.run_label,
+                    },
                 )
         finally:
             _CURRENT_TRACKER.reset(token)

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -1,5 +1,6 @@
 """Focused tests for OpenAI Agents SDK call-level checkpointing."""
 
+from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
 
@@ -126,6 +127,386 @@ def _wait_for_hydrated_run(exec_id: str) -> Any:
 
 def _step_names(hydrated_run: Any) -> set[str]:
     return set(hydrated_run.steps)
+
+
+class TestOpenAIEventTrackerToolCallOrdering:
+    def _record_completed_model(self, tracker: Any) -> tuple[str, Any]:
+        event_id, event_context = tracker.start_llm_event()
+        tracker.record_event(
+            event_id,
+            event_context,
+            kind="llm_call",
+            status="completed",
+            duration_ms=1.0,
+            artifacts={},
+            metadata={"response_id": "resp_ordering"},
+        )
+        return event_id, event_context
+
+    def _record_completed_tool(
+        self,
+        tracker: Any,
+        event_id: str,
+        event_context: Any,
+        *,
+        name: str,
+    ) -> None:
+        tracker.record_event(
+            event_id,
+            event_context,
+            kind="tool_call",
+            status="completed",
+            duration_ms=1.0,
+            artifacts={},
+            metadata={"tool_name": name},
+        )
+
+    def test_reserved_tool_ids_follow_model_order_when_start_order_reverses(
+        self,
+    ) -> None:
+        from kitaru.adapters.openai_agents._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        _model_id, model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(["call_alpha", "call_beta"])
+
+        beta_id, beta_context = tracker.start_tool_event(tool_call_id="call_beta")
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+
+        assert alpha_id != beta_id
+        assert model_context.sequence_index < alpha_context.sequence_index
+        assert alpha_context.sequence_index < beta_context.sequence_index
+
+    def test_reverse_completion_order_sorts_events_persisted_log_and_summary(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kitaru.adapters.openai_agents import _tracking
+
+        tracker = _tracking.EventTracker(agent_name="ordering_agent", run_label="test")
+        model_id, _model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(["call_alpha", "call_beta"])
+        beta_id, beta_context = tracker.start_tool_event(tool_call_id="call_beta")
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+        self._record_completed_tool(tracker, beta_id, beta_context, name="beta")
+        self._record_completed_tool(tracker, alpha_id, alpha_context, name="alpha")
+
+        assert [event.event_id for event in tracker.events] == [
+            model_id,
+            alpha_id,
+            beta_id,
+        ]
+
+        logged: dict[str, Any] = {}
+        monkeypatch.setattr(_tracking, "is_inside_flow", lambda: True)
+        monkeypatch.setattr(
+            _tracking.kitaru,
+            "log",
+            lambda **kwargs: logged.update(kwargs),
+        )
+
+        tracker.persist()
+
+        events_dump = logged["openai_agents_events"][tracker.run_label]
+        summary_dump = logged["openai_agents_run_summaries"][tracker.run_label]
+        assert [event["event_id"] for event in events_dump] == [
+            model_id,
+            alpha_id,
+            beta_id,
+        ]
+        assert summary_dump["event_ids_in_order"] == [model_id, alpha_id, beta_id]
+        assert summary_dump["total_events"] == 3
+
+    def test_missing_or_unreserved_tool_call_id_keeps_counter_fallback(self) -> None:
+        from kitaru.adapters.openai_agents._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        _model_id, model_context = self._record_completed_model(tracker)
+
+        event_id, event_context = tracker.start_tool_event(tool_call_id=None)
+
+        assert event_id.startswith(
+            f"{tracker.agent_name}_{tracker.run_label}_tool_call_"
+        )
+        assert event_context.sequence_index > model_context.sequence_index
+
+    def test_abandoned_reserved_tool_slot_does_not_count_or_leak(self) -> None:
+        from kitaru.adapters.openai_agents._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        model_id, _model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(["call_alpha", "call_beta"])
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+        self._record_completed_tool(
+            tracker,
+            alpha_id,
+            alpha_context,
+            name="alpha",
+        )
+
+        summary = tracker.build_run_summary()
+
+        assert summary["total_events"] == 2
+        assert summary["event_ids_in_order"] == [model_id, alpha_id]
+
+        next_model_id, next_model_context = tracker.start_llm_event()
+        fallback_id, fallback_context = tracker.start_tool_event(
+            tool_call_id="call_beta"
+        )
+        assert fallback_id != next_model_id
+        assert fallback_context.sequence_index > next_model_context.sequence_index
+
+    def test_nested_llm_start_does_not_clear_sibling_tool_reservation(self) -> None:
+        from kitaru.adapters.openai_agents._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        _model_id, _model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(["call_alpha", "call_beta"])
+
+        beta_id, beta_context = tracker.start_tool_event(tool_call_id="call_beta")
+        nested_model_id, nested_context = tracker.start_llm_event()
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+
+        assert alpha_id != beta_id
+        assert nested_model_id not in {alpha_id, beta_id}
+        assert alpha_context.sequence_index < beta_context.sequence_index
+        assert beta_context.sequence_index < nested_context.sequence_index
+
+
+class TestOpenAIModelToolCallReservations:
+    def test_trackable_tool_call_ids_follow_model_response_order(self) -> None:
+        from kitaru.adapters.openai_agents._model import _trackable_tool_call_ids
+
+        @function_tool
+        def alpha() -> str:
+            return "alpha"
+
+        @function_tool
+        def beta() -> str:
+            return "beta"
+
+        response = SimpleNamespace(
+            output=[
+                ResponseFunctionToolCall(
+                    arguments="{}",
+                    call_id="call_alpha",
+                    id="fc_alpha",
+                    name="alpha",
+                    status="completed",
+                    type="function_call",
+                ),
+                {"name": "hosted_lookup", "call_id": "call_hosted"},
+                ResponseFunctionToolCall(
+                    arguments="{}",
+                    call_id="call_beta",
+                    id="fc_beta",
+                    name="beta",
+                    status="completed",
+                    type="function_call",
+                ),
+            ]
+        )
+
+        assert _trackable_tool_call_ids(response, [alpha, beta]) == [
+            "call_alpha",
+            "call_beta",
+        ]
+
+    @pytest.mark.anyio
+    async def test_get_response_reserves_tool_order_when_checkpoint_is_cached(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import kitaru.adapters.openai_agents._model as openai_model
+        from kitaru.adapters.openai_agents._model import KitaruOpenAIModel
+        from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+        @function_tool
+        def alpha() -> str:
+            return "alpha"
+
+        @function_tool
+        def beta() -> str:
+            return "beta"
+
+        cached_response = SimpleNamespace(
+            output=[
+                ResponseFunctionToolCall(
+                    arguments="{}",
+                    call_id="call_alpha",
+                    id="fc_alpha",
+                    name="alpha",
+                    status="completed",
+                    type="function_call",
+                ),
+                ResponseFunctionToolCall(
+                    arguments="{}",
+                    call_id="call_beta",
+                    id="fc_beta",
+                    name="beta",
+                    status="completed",
+                    type="function_call",
+                ),
+            ],
+            usage=None,
+            response_id="resp_cached",
+        )
+        seen_tool_call_ids: list[list[str]] = []
+
+        class FakeTracker:
+            def reserve_tool_call_order(self, tool_call_ids: list[str]) -> None:
+                seen_tool_call_ids.append(tool_call_ids)
+
+        async def fake_run_async_in_checkpoint(**_kwargs: Any) -> Any:
+            return cached_response
+
+        monkeypatch.setattr(openai_model, "is_inside_flow", lambda: True)
+        monkeypatch.setattr(openai_model, "is_inside_checkpoint", lambda: False)
+        monkeypatch.setattr(openai_model, "get_current_tracker", lambda: FakeTracker())
+        monkeypatch.setattr(
+            openai_model,
+            "run_async_in_checkpoint",
+            fake_run_async_in_checkpoint,
+        )
+        model = KitaruOpenAIModel(
+            SimpleNamespace(),
+            capture=OpenAICapturePolicy(),
+            agent_name="cached_agent",
+            checkpoint_config={},
+        )
+
+        response = await model.get_response(
+            None,
+            "prompt",
+            None,
+            [alpha, beta],
+            None,
+            [],
+            None,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+
+        assert response is cached_response
+        assert seen_tool_call_ids == [["call_alpha", "call_beta"]]
+
+
+@pytest.mark.anyio
+async def test_openai_tool_call_passes_tool_call_id_to_event_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kitaru.adapters.openai_agents._tools as openai_tools
+    from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+    seen_tool_call_ids: list[str | None] = []
+
+    @function_tool
+    def publish() -> str:
+        return "unused"
+
+    class FakeTracker:
+        def start_tool_event(
+            self,
+            *,
+            tool_call_id: str | None = None,
+        ) -> tuple[str, SimpleNamespace]:
+            seen_tool_call_ids.append(tool_call_id)
+            return "event-1", SimpleNamespace(sequence_index=1)
+
+        def record_event(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    async def callback(_context: Any, _input_json: str) -> str:
+        return "published"
+
+    monkeypatch.setattr(openai_tools, "get_current_tracker", lambda: FakeTracker())
+    monkeypatch.setattr(openai_tools, "is_inside_checkpoint", lambda: True)
+
+    result = await openai_tools._tracked_tool_call(
+        callback,
+        SimpleNamespace(),
+        "{}",
+        tool=publish,
+        capture=OpenAICapturePolicy(save_input=False, save_final_output=False),
+        tool_call_id="call_publish",
+    )
+
+    assert result == "published"
+    assert seen_tool_call_ids == ["call_publish"]
+
+
+@pytest.mark.anyio
+async def test_openai_tracked_tool_execution_remains_concurrent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import anyio
+
+    import kitaru.adapters.openai_agents._tools as openai_tools
+    from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+    started: list[str] = []
+    both_started = anyio.Event()
+
+    async def _mark_started(name: str) -> None:
+        started.append(name)
+        if len(started) == 2:
+            both_started.set()
+        await both_started.wait()
+
+    @function_tool
+    def alpha() -> str:
+        return "unused"
+
+    @function_tool
+    def beta() -> str:
+        return "unused"
+
+    class FakeTracker:
+        def __init__(self) -> None:
+            self._counter = 0
+
+        def start_tool_event(
+            self,
+            *,
+            tool_call_id: str | None = None,
+        ) -> tuple[str, SimpleNamespace]:
+            del tool_call_id
+            self._counter += 1
+            return f"event-{self._counter}", SimpleNamespace(
+                sequence_index=self._counter,
+            )
+
+        def record_event(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    fake_tracker = FakeTracker()
+    monkeypatch.setattr(openai_tools, "get_current_tracker", lambda: fake_tracker)
+    monkeypatch.setattr(openai_tools, "is_inside_checkpoint", lambda: True)
+    capture = OpenAICapturePolicy(save_input=False, save_final_output=False)
+    results: dict[str, str] = {}
+
+    async def _run_tool(name: str, tool: Any, tool_call_id: str) -> None:
+        async def callback(_context: Any, _input_json: str) -> str:
+            await _mark_started(name)
+            return name
+
+        results[name] = await openai_tools._tracked_tool_call(
+            callback,
+            SimpleNamespace(),
+            "{}",
+            tool=tool,
+            capture=capture,
+            tool_call_id=tool_call_id,
+        )
+
+    with anyio.fail_after(1):
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(_run_tool, "alpha", alpha, "call_alpha")
+            task_group.start_soon(_run_tool, "beta", beta, "call_beta")
+
+    assert set(started) == {"alpha", "beta"}
+    assert results == {"alpha": "alpha", "beta": "beta"}
 
 
 def test_calls_strategy_model_call_runs_inside_checkpoint(primed_zenml) -> None:

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -326,6 +326,225 @@ class TestWaitCallSuffix:
         assert _wait_call_suffix("call_a") != _wait_call_suffix("call_b")
 
 
+class TestModelToolCallReservations:
+    def test_trackable_tool_call_ids_follow_model_response_order(self) -> None:
+        from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
+        from pydantic_ai.models import ModelRequestParameters
+        from pydantic_ai.tools import ToolDefinition
+
+        from kitaru.adapters.pydantic_ai._model import _trackable_tool_call_ids
+        from kitaru.adapters.pydantic_ai._policy import CapturePolicy
+
+        response = ModelResponse(
+            parts=[
+                TextPart(content="I will call tools."),
+                ToolCallPart(
+                    tool_name="alpha",
+                    args={},
+                    tool_call_id="call_alpha_1",
+                ),
+                ToolCallPart(
+                    tool_name="output_tool",
+                    args={},
+                    tool_call_id="call_output",
+                ),
+                ToolCallPart(
+                    tool_name="skip",
+                    args={},
+                    tool_call_id="call_skip",
+                ),
+                ToolCallPart(
+                    tool_name="alpha",
+                    args={},
+                    tool_call_id="call_alpha_2",
+                ),
+                ToolCallPart(tool_name="beta", args={}, tool_call_id=""),
+            ]
+        )
+
+        assert _trackable_tool_call_ids(
+            response,
+            ModelRequestParameters(
+                function_tools=[
+                    ToolDefinition(name="alpha"),
+                    ToolDefinition(name="skip"),
+                ],
+                output_tools=[ToolDefinition(name="output_tool")],
+            ),
+            CapturePolicy(
+                tool_capture="metadata",
+                tool_capture_overrides={"skip": None},
+            ),
+        ) == ["call_alpha_1", "call_alpha_2"]
+
+
+class TestEventTrackerToolCallOrdering:
+    def _record_completed_model(self, tracker: Any) -> tuple[str, Any]:
+        event_id, event_context = tracker.start_model_event()
+        tracker.record_model_event(
+            event_id,
+            event_context,
+            status="completed",
+            duration_ms=1.0,
+            artifacts={},
+            model_name="test-model",
+        )
+        return event_id, event_context
+
+    def _record_completed_tool(
+        self,
+        tracker: Any,
+        event_id: str,
+        event_context: Any,
+        *,
+        name: str,
+    ) -> None:
+        tracker.record_tool_event(
+            event_id,
+            event_context,
+            status="completed",
+            name=name,
+            toolset_kind="function",
+            capture_mode="metadata",
+            duration_ms=1.0,
+            hitl=False,
+            artifacts={},
+        )
+
+    def test_reserved_tool_ids_follow_model_order_when_start_order_reverses(
+        self,
+    ) -> None:
+        from kitaru.adapters.pydantic_ai._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        model_id, model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(
+            parent_model_event_id=model_id,
+            turn_index=model_context.turn_index,
+            tool_call_ids=["call_alpha", "call_beta"],
+        )
+
+        beta_id, beta_context = tracker.start_tool_event(tool_call_id="call_beta")
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+
+        assert alpha_context.sequence_index < beta_context.sequence_index
+        assert alpha_id.endswith("_tool_call_2")
+        assert beta_id.endswith("_tool_call_3")
+        assert alpha_context.fan_out_from == model_id
+        assert beta_context.fan_out_from == model_id
+
+    def test_reverse_completion_order_still_sorts_events_and_fan_in(self) -> None:
+        from kitaru.adapters.pydantic_ai._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        model_id, model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(
+            parent_model_event_id=model_id,
+            turn_index=model_context.turn_index,
+            tool_call_ids=["call_alpha", "call_beta"],
+        )
+        beta_id, beta_context = tracker.start_tool_event(tool_call_id="call_beta")
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+
+        self._record_completed_tool(
+            tracker, beta_id, beta_context, name="beta"
+        )
+        self._record_completed_tool(
+            tracker, alpha_id, alpha_context, name="alpha"
+        )
+
+        assert [event.event_id for event in tracker.events] == [
+            model_id,
+            alpha_id,
+            beta_id,
+        ]
+        next_model_id, next_model_context = tracker.start_model_event()
+        assert next_model_context.fan_in_from == [alpha_id, beta_id]
+        assert next_model_id.endswith("_llm_call_4")
+
+    def test_persisted_events_and_summary_use_reserved_sequence_order(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kitaru.adapters.pydantic_ai import _tracking
+
+        tracker = _tracking.EventTracker(agent_name="ordering_agent", run_label="test")
+        model_id, model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(
+            parent_model_event_id=model_id,
+            turn_index=model_context.turn_index,
+            tool_call_ids=["call_alpha", "call_beta"],
+        )
+        beta_id, beta_context = tracker.start_tool_event(tool_call_id="call_beta")
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+        self._record_completed_tool(
+            tracker, beta_id, beta_context, name="beta"
+        )
+        self._record_completed_tool(
+            tracker, alpha_id, alpha_context, name="alpha"
+        )
+        logged: dict[str, Any] = {}
+        monkeypatch.setattr(
+            _tracking.kitaru,
+            "log",
+            lambda **kwargs: logged.update(kwargs),
+        )
+
+        tracker.persist()
+
+        events_dump = logged["pydantic_ai_events"][tracker.run_label]
+        summary_dump = logged["pydantic_ai_run_summaries"][tracker.run_label]
+        assert [event["event_id"] for event in events_dump] == [
+            model_id,
+            alpha_id,
+            beta_id,
+        ]
+        assert summary_dump["event_ids_in_order"] == [model_id, alpha_id, beta_id]
+        assert summary_dump["total_events"] == 3
+
+    def test_missing_or_unreserved_tool_call_id_keeps_counter_fallback(self) -> None:
+        from kitaru.adapters.pydantic_ai._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        model_id, _model_context = self._record_completed_model(tracker)
+
+        event_id, event_context = tracker.start_tool_event(tool_call_id=None)
+
+        assert event_id.endswith("_tool_call_2")
+        assert event_context.sequence_index == 2
+        assert event_context.fan_out_from == model_id
+
+    def test_abandoned_reserved_tool_slot_does_not_count_as_recorded_event(
+        self,
+    ) -> None:
+        from kitaru.adapters.pydantic_ai._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        model_id, model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(
+            parent_model_event_id=model_id,
+            turn_index=model_context.turn_index,
+            tool_call_ids=["call_alpha", "call_beta"],
+        )
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+        self._record_completed_tool(
+            tracker,
+            alpha_id,
+            alpha_context,
+            name="alpha",
+        )
+
+        summary = tracker.build_run_summary()
+
+        assert summary.total_events == 2
+        assert summary.event_ids_in_order == [model_id, alpha_id]
+
+        abandoned_beta_id = f"{tracker.agent_name}_{tracker.run_label}_tool_call_3"
+        _next_model_id, next_model_context = tracker.start_model_event()
+        assert next_model_context.fan_in_from == [alpha_id]
+        assert abandoned_beta_id not in tracker._event_sequence_by_id
+
+
 class TestModelMessageCacheSerialization:
     def _messages(self, *, run_id: str, second: int) -> list[Any]:
         from pydantic_ai.messages import (
@@ -1457,6 +1676,143 @@ async def test_wait_metadata_omits_payload_when_capture_not_full(
 
 
 @pytest.mark.anyio
+async def test_toolset_passes_tool_call_id_to_event_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pydantic_ai import FunctionToolset
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._toolset import kitaruify_toolset
+
+    seen_tool_call_ids: list[str | None] = []
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    @toolset.tool_plain
+    def publish() -> str:
+        return "published"
+
+    class FakeTracker:
+        def start_tool_event(
+            self,
+            *,
+            tool_call_id: str | None = None,
+        ) -> tuple[str, SimpleNamespace]:
+            seen_tool_call_ids.append(tool_call_id)
+            return "event-1", SimpleNamespace(
+                sequence_index=1,
+                turn_index=1,
+                fan_out_from=None,
+            )
+
+        def record_tool_event(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    wrapped = kitaruify_toolset(
+        toolset,
+        capture=CapturePolicy(tool_capture="metadata", correlate_otel_spans=False),
+        tool_checkpoint_config_by_name={"publish": False},
+    )
+    ctx = _with_tool_call_id(
+        RunContext(deps=None, model=TestModel(), usage=RunUsage()),
+        "call_publish",
+    )
+    tool = (await wrapped.get_tools(ctx))["publish"]
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._toolset.get_current_tracker",
+        lambda: FakeTracker(),
+    )
+
+    assert await wrapped.call_tool("publish", {}, ctx, tool) == "published"
+
+    assert seen_tool_call_ids == ["call_publish"]
+
+
+@pytest.mark.anyio
+async def test_tracked_tool_execution_remains_concurrent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import anyio
+    from pydantic_ai import FunctionToolset
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._toolset import kitaruify_toolset
+
+    started: list[str] = []
+    both_started = anyio.Event()
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    async def _mark_started(name: str) -> None:
+        started.append(name)
+        if len(started) == 2:
+            both_started.set()
+        await both_started.wait()
+
+    @toolset.tool_plain
+    async def alpha() -> str:
+        await _mark_started("alpha")
+        return "alpha"
+
+    @toolset.tool_plain
+    async def beta() -> str:
+        await _mark_started("beta")
+        return "beta"
+
+    class FakeTracker:
+        def __init__(self) -> None:
+            self._counter = 0
+
+        def start_tool_event(
+            self,
+            *,
+            tool_call_id: str | None = None,
+        ) -> tuple[str, SimpleNamespace]:
+            del tool_call_id
+            self._counter += 1
+            return f"event-{self._counter}", SimpleNamespace(
+                sequence_index=self._counter,
+                turn_index=1,
+                fan_out_from=None,
+            )
+
+        def record_tool_event(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    fake_tracker = FakeTracker()
+    wrapped = kitaruify_toolset(
+        toolset,
+        capture=CapturePolicy(tool_capture="metadata", correlate_otel_spans=False),
+        tool_checkpoint_config_by_name={"alpha": False, "beta": False},
+    )
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._toolset.get_current_tracker",
+        lambda: fake_tracker,
+    )
+    results: dict[str, str] = {}
+
+    async def _run_tool(name: str, tool_call_id: str) -> None:
+        ctx = _with_tool_call_id(
+            RunContext(deps=None, model=TestModel(), usage=RunUsage()),
+            tool_call_id,
+        )
+        tool = (await wrapped.get_tools(ctx))[name]
+        results[name] = await wrapped.call_tool(name, {}, ctx, tool)
+
+    with anyio.fail_after(1):
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(_run_tool, "alpha", "call_alpha")
+            task_group.start_soon(_run_tool, "beta", "call_beta")
+
+    assert set(started) == {"alpha", "beta"}
+    assert results == {"alpha": "alpha", "beta": "beta"}
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize("tool_capture", [None, "metadata"])
 async def test_deferred_event_metadata_omits_payload_when_capture_not_full(
     monkeypatch: pytest.MonkeyPatch,
@@ -1475,7 +1831,12 @@ async def test_deferred_event_metadata_omits_payload_when_capture_not_full(
     recorded_deferred_events: list[dict[str, Any]] = []
 
     class FakeTracker:
-        def start_tool_event(self) -> tuple[str, dict[str, Any]]:
+        def start_tool_event(
+            self,
+            *,
+            tool_call_id: str | None = None,
+        ) -> tuple[str, dict[str, Any]]:
+            del tool_call_id
             return "event-1", {}
 
         def record_tool_event(self, *_args: Any, **_kwargs: Any) -> None:

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -446,12 +446,8 @@ class TestEventTrackerToolCallOrdering:
         beta_id, beta_context = tracker.start_tool_event(tool_call_id="call_beta")
         alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
 
-        self._record_completed_tool(
-            tracker, beta_id, beta_context, name="beta"
-        )
-        self._record_completed_tool(
-            tracker, alpha_id, alpha_context, name="alpha"
-        )
+        self._record_completed_tool(tracker, beta_id, beta_context, name="beta")
+        self._record_completed_tool(tracker, alpha_id, alpha_context, name="alpha")
 
         assert [event.event_id for event in tracker.events] == [
             model_id,
@@ -477,12 +473,8 @@ class TestEventTrackerToolCallOrdering:
         )
         beta_id, beta_context = tracker.start_tool_event(tool_call_id="call_beta")
         alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
-        self._record_completed_tool(
-            tracker, beta_id, beta_context, name="beta"
-        )
-        self._record_completed_tool(
-            tracker, alpha_id, alpha_context, name="alpha"
-        )
+        self._record_completed_tool(tracker, beta_id, beta_context, name="beta")
+        self._record_completed_tool(tracker, alpha_id, alpha_context, name="alpha")
         logged: dict[str, Any] = {}
         monkeypatch.setattr(
             _tracking.kitaru,


### PR DESCRIPTION
## What changed

- Reserved PydanticAI tool event sequence slots from the assistant-emitted `tool_call_id` order.
- Passed `ctx.tool_call_id` from the PydanticAI tool wrapper into the event tracker.
- Sorted fan-in metadata, event logs, and run summaries by logical sequence rather than physical async completion order.
- Preserved fallback behavior for missing/unreserved tool IDs and kept parallel tool execution concurrent.
- Added regression tests for reverse start order, reverse completion order, persisted event ordering, abandoned reservations, and concurrency.
- Added an Unreleased changelog entry.

Closes #306.

## Why it was needed

Parallel PydanticAI tool calls could start or finish in a different order from the assistant response. Kitaru was assigning event IDs and `sequence_index` values when tool wrappers reached the tracker, and building next-model `fan_in_from` from completion order. That made event logs, summaries, and OTel sequence attributes drift across logically identical runs.

The fix separates the two clocks: tools still run concurrently, but durable metadata follows the assistant's stable tool-call order.

## Key implementation decisions

- Used `ModelResponse.tool_calls` plus executable function-tool definitions as the source of logical tool order.
- Stored reservations as FIFO queues per `tool_call_id` so duplicate IDs do not corrupt state.
- Counted `RunSummary.total_events` from recorded events, not reserved-but-unused slots.
- Avoided a recording turnstile; sequence reservation plus sorted output sinks is simpler and avoids serializing tool execution.

## Reviewer Notes

Please focus review on:

- `src/kitaru/adapters/pydantic_ai/_tracking.py` reservation and ordering behavior.
- `src/kitaru/adapters/pydantic_ai/_model.py` filtering of tool calls to executable function tools.
- Regression tests in `tests/test_pydantic_ai_adapter.py`, especially the reverse-order and concurrency cases.

Useful checks:

```bash
UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/test_pydantic_ai_adapter.py -q
UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/test_phase17_pydantic_ai_adapter.py -q
UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check src/kitaru/adapters/pydantic_ai/_tracking.py src/kitaru/adapters/pydantic_ai/_model.py src/kitaru/adapters/pydantic_ai/_toolset.py tests/test_pydantic_ai_adapter.py
```
