### PR TITLE
Fix `/api/*` routing in Cloudflare Workers Static Assets

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,7 +7,7 @@ compatibility_flags = ["nodejs_compat"]
 directory = "./site/dist"
 binding = "ASSETS"
 not_found_handling = "404-page"
-run_worker_first = ["/docs", "/docs/*"]
+run_worker_first = ["/docs", "/docs/*", "/api/*", "/_server-islands/*", "/_image"]
 
 [[kv_namespaces]]
 binding = "WAITLIST_KV"


### PR DESCRIPTION
## Summary

The site's API routes (`/api/get-started`, `/api/waitlist`, `/api/newsletter`) have been silently broken in production. Every POST to `/api/*` returned `405 Method Not Allowed` with an empty body; every GET returned the cached 404 page. The forms on `/book-a-demo` and the new `/newsletter` page both surface as "Network error. Please try again." in the browser because the page script's `await resp.json()` throws on the empty 405 body and trips the catch branch.

This means the book-a-demo name/email pre-capture step (and any `Book a Demo Signup` Segment events that flow from it) has been silently failing for an unknown duration. Worth checking the Segment dashboard for whether `Book a Demo Signup` events have arrived recently — if not, demo leads have been dropped.

## Root cause

`wrangler.toml`'s `[assets]` block uses **Cloudflare Workers Static Assets** routing, in which the asset layer runs *before* the Worker for any path that isn't listed in `run_worker_first`. That field was previously:

```toml
run_worker_first = ["/docs", "/docs/*"]
```

— scoped to the custom Worker's markdown content-negotiation surface (`site/worker/index.js`). API routes were never added.

As a result, every `POST /api/*` hit Cloudflare's static-asset layer first. Static assets only support GET/HEAD, so POSTs returned `405 Method Not Allowed` with an empty body, and the Astro Worker never saw the request.

The Astro-emitted `_routes.json` (`include: ["/api/*", ...]`) belongs to the older Cloudflare Pages routing system; under Workers Static Assets it is ignored, and `run_worker_first` is the equivalent mechanism.

## Fix

Extend `run_worker_first` to cover `/api/*` plus the Astro internals already enumerated in the auto-generated `_routes.json`:

```diff
-run_worker_first = ["/docs", "/docs/*"]
+run_worker_first = ["/docs", "/docs/*", "/api/*", "/_server-islands/*", "/_image"]
```

`/_server-islands/*` and `/_image` aren't actively used today (no server islands, no `<Image />` runtime optimization on any current page), but matching `_routes.json` makes the intent clear and avoids the next surprise.

## Validation

- Production probe before fix: every `POST /api/*` (including made-up paths like `/api/madeup-route`) returns identical empty-body 405. Identical responses for non-existent paths confirm the Worker is never invoked.
- `pnpm run build` succeeds.
- `npx wrangler deploy --dry-run` accepts the new config and lists all four bindings (3× KV, 1× ASSETS).

## Reviewer Notes

This is a one-line config change. Two things worth a closer look:

1. **Whether to also delete the stale `_routes.json` Astro emits.** It's harmless (Workers Static Assets ignores it), but it's misleading for anyone reading the build output trying to understand routing. Out of scope for this PR — would require Astro Cloudflare adapter config — but worth filing as a follow-up.

2. **Why `/_server-islands/*` and `/_image` are included even though no current page uses them.** Justified above; happy to drop them if you prefer the strict version. The diff would simply omit those two globs.

### Repro / verification after deploy

After this is merged and the site workflow is dispatched:

```bash
# Should return 400 "Email is required" / "Invalid email" instead of 405
curl -s -X POST https://kitaru.ai/api/newsletter \
  -H "Content-Type: application/json" \
  -d '{"email":""}' -w "\nHTTP %{http_code}\n"

# Should return {"ok":true,"alreadySubscribed":false} (or true if already in KV)
curl -s -X POST https://kitaru.ai/api/newsletter \
  -H "Content-Type: application/json" \
  -d '{"email":"alex+postfix@zenml.io"}' -w "\nHTTP %{http_code}\n"

# Same probe pattern for the demo route
curl -s -X POST https://kitaru.ai/api/get-started \
  -H "Content-Type: application/json" \
  -d '{}' -w "\nHTTP %{http_code}\n"
```

### Deployment note

This change only takes effect after the site Worker is redeployed. The `site.yml` workflow auto-deploys on `push` to `main` and on `workflow_dispatch` from any branch. After merge to `develop`, dispatch the workflow manually (Actions → Site → Run workflow → from `develop`) to push the fix live.