### PR TITLE
Fix OpenAI Agents tool event ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- OpenAI Agents adapter parallel tool-call events now keep assistant-emitted order in event logs and summaries, even when tools start or finish out of order. (#306)
 - PydanticAI adapter parallel tool-call events now keep assistant-emitted order in event logs, summaries, and fan-in metadata, even when tools start or finish out of order. (#306)
 - PydanticAI adapter checkpoint configs now accept `cache`, and granular model checkpoint cache keys ignore PydanticAI-generated per-run message metadata so identical logical prompts can cache across runs. (#279)
 

--- a/src/kitaru/adapters/openai_agents/_model.py
+++ b/src/kitaru/adapters/openai_agents/_model.py
@@ -1,10 +1,11 @@
 """Model/provider checkpoint wrappers for OpenAI Agents SDK calls."""
 
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from typing import Any
 
 from agents.models.interface import Model, ModelProvider
+from agents.tool import FunctionTool
 
 import kitaru
 
@@ -82,7 +83,7 @@ class KitaruOpenAIModel(Model):
                     prompt=prompt,
                 )
 
-            return await run_async_in_checkpoint(
+            response = await run_async_in_checkpoint(
                 config=with_default_type(self._checkpoint_config, "llm_call"),
                 step_name=safe_step_name(f"{self._agent_name}_openai_model_call"),
                 body=_in_checkpoint,
@@ -101,7 +102,9 @@ class KitaruOpenAIModel(Model):
                     }
                 ),
             )
-        return await self._tracked_get_response(
+            self._reserve_tool_call_order(response, tools)
+            return response
+        response = await self._tracked_get_response(
             system_instructions,
             input,
             model_settings,
@@ -113,6 +116,8 @@ class KitaruOpenAIModel(Model):
             conversation_id=conversation_id,
             prompt=prompt,
         )
+        self._reserve_tool_call_order(response, tools)
+        return response
 
     async def _tracked_get_response(
         self,
@@ -220,6 +225,12 @@ class KitaruOpenAIModel(Model):
             metadata=metadata,
         )
         return response
+
+    def _reserve_tool_call_order(self, response: Any, tools: list[Any]) -> None:
+        tracker = get_current_tracker()
+        if tracker is None or not self._capture.emit_child_events:
+            return
+        tracker.reserve_tool_call_order(_trackable_tool_call_ids(response, tools))
 
     def _model_cache_identity(self) -> dict[str, Any]:
         wrapped_type = type(self._wrapped)
@@ -334,3 +345,41 @@ def _tool_cache_identity(tool: Any) -> dict[str, Any]:
         "description": getattr(tool, "description", None),
         "tool_namespace": getattr(tool, "_tool_namespace", None),
     }
+
+
+def _trackable_tool_call_ids(response: Any, tools: list[Any]) -> list[str]:
+    """Return local function-tool call IDs in assistant-emitted order."""
+    function_tool_names = {
+        tool.name
+        for tool in tools
+        if isinstance(tool, FunctionTool) and isinstance(tool.name, str)
+    }
+    if not function_tool_names:
+        return []
+
+    tool_call_ids: list[str] = []
+    for item in getattr(response, "output", []) or []:
+        tool_name = _tool_name_from_response_item(item)
+        tool_call_id = _tool_call_id_from_response_item(item)
+        if tool_name in function_tool_names and tool_call_id is not None:
+            tool_call_ids.append(tool_call_id)
+    return tool_call_ids
+
+
+def _tool_name_from_response_item(item: Any) -> str | None:
+    value = _response_item_value(item, "name")
+    return value if isinstance(value, str) and value else None
+
+
+def _tool_call_id_from_response_item(item: Any) -> str | None:
+    for key in ("call_id", "tool_call_id"):
+        value = _response_item_value(item, key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _response_item_value(item: Any, key: str) -> Any:
+    if isinstance(item, Mapping):
+        return item.get(key)
+    return getattr(item, key, None)

--- a/src/kitaru/adapters/openai_agents/_tools.py
+++ b/src/kitaru/adapters/openai_agents/_tools.py
@@ -149,7 +149,7 @@ async def _tracked_tool_call(
         return await callback(context, input_json)
 
     assert tracker is not None
-    event_id, event_context = tracker.start_tool_event()
+    event_id, event_context = tracker.start_tool_event(tool_call_id=tool_call_id)
     artifacts: dict[str, str] = {}
     parsed_args = _parse_json(input_json)
     if capture.save_input:

--- a/src/kitaru/adapters/openai_agents/_tracking.py
+++ b/src/kitaru/adapters/openai_agents/_tracking.py
@@ -1,9 +1,10 @@
 """Lightweight event tracking for OpenAI Agents SDK runs."""
 
 import re
+import threading
 import time
 import uuid
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -41,6 +42,13 @@ class EventContext:
     sequence_index: int
 
 
+@dataclass(frozen=True)
+class _ReservedToolEvent:
+    tool_call_id: str
+    event_id: str
+    sequence_index: int
+
+
 @dataclass
 class EventTracker:
     """Tracks model/tool events for one OpenAI runner call."""
@@ -55,9 +63,23 @@ class EventTracker:
     _tool_call_count: int = 0
     _tool_checkpoint_sequence: int = 0
     _started_at: float = field(default_factory=time.perf_counter)
+    _lock: threading.Lock = field(
+        default_factory=threading.Lock, init=False, repr=False
+    )
+    _reserved_tool_events_by_call_id: dict[str, list[_ReservedToolEvent]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _active_tool_event_ids: set[str] = field(
+        default_factory=set, init=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         self.agent_name = normalize_agent_name(self.agent_name)
+
+    @property
+    def events(self) -> Sequence[OpenAIAdapterEvent]:
+        with self._lock:
+            return tuple(self._ordered_events())
 
     @property
     def event_log_artifact_name(self) -> str:
@@ -72,20 +94,77 @@ class EventTracker:
         event_id = f"{self.agent_name}_{self.run_label}_{event_kind}_{self._counter}"
         return event_id, self._counter
 
+    def _ordered_events(self) -> list[OpenAIAdapterEvent]:
+        return sorted(self._events, key=lambda event: event.sequence_index)
+
+    def _clear_reserved_tool_events_unlocked(self) -> None:
+        self._reserved_tool_events_by_call_id.clear()
+
     def start_llm_event(self) -> tuple[str, EventContext]:
-        event_id, sequence_index = self._next_event_id("llm_call")
-        self._model_call_count += 1
-        return event_id, EventContext(sequence_index=sequence_index)
+        with self._lock:
+            if not self._active_tool_event_ids:
+                self._clear_reserved_tool_events_unlocked()
+            event_id, sequence_index = self._next_event_id("llm_call")
+            self._model_call_count += 1
+            return event_id, EventContext(sequence_index=sequence_index)
+
+    def reserve_tool_call_order(
+        self,
+        tool_call_ids: Sequence[str],
+    ) -> None:
+        """Reserve event slots for assistant-emitted local tool calls.
+
+        The model response is the only point where Kitaru sees the assistant's
+        intended tool-call order before the SDK may start local tools in
+        parallel. Reservations are numbered parking spaces: they become real
+        events only if a matching tool callback actually starts.
+        """
+        with self._lock:
+            for tool_call_id in tool_call_ids:
+                if not tool_call_id:
+                    continue
+                event_id, sequence_index = self._next_event_id("tool_call")
+                reserved = _ReservedToolEvent(
+                    tool_call_id=tool_call_id,
+                    event_id=event_id,
+                    sequence_index=sequence_index,
+                )
+                self._reserved_tool_events_by_call_id.setdefault(
+                    tool_call_id, []
+                ).append(reserved)
 
     def next_tool_checkpoint_sequence(self) -> int:
         """Return a per-run deterministic fallback tool call sequence."""
-        self._tool_checkpoint_sequence += 1
-        return self._tool_checkpoint_sequence
+        with self._lock:
+            self._tool_checkpoint_sequence += 1
+            return self._tool_checkpoint_sequence
 
-    def start_tool_event(self) -> tuple[str, EventContext]:
-        event_id, sequence_index = self._next_event_id("tool_call")
-        self._tool_call_count += 1
-        return event_id, EventContext(sequence_index=sequence_index)
+    def start_tool_event(
+        self,
+        *,
+        tool_call_id: str | None = None,
+    ) -> tuple[str, EventContext]:
+        with self._lock:
+            reservation: _ReservedToolEvent | None = None
+            reservations = (
+                self._reserved_tool_events_by_call_id.get(tool_call_id)
+                if tool_call_id
+                else None
+            )
+            if tool_call_id and reservations:
+                reservation = reservations.pop(0)
+                if not reservations:
+                    del self._reserved_tool_events_by_call_id[tool_call_id]
+
+            if reservation is None:
+                event_id, sequence_index = self._next_event_id("tool_call")
+            else:
+                event_id = reservation.event_id
+                sequence_index = reservation.sequence_index
+
+            self._tool_call_count += 1
+            self._active_tool_event_ids.add(event_id)
+            return event_id, EventContext(sequence_index=sequence_index)
 
     def record_event(
         self,
@@ -99,34 +178,41 @@ class EventTracker:
         metadata: dict[str, object] | None = None,
         error: BaseException | None = None,
     ) -> None:
-        self._events.append(
-            OpenAIAdapterEvent(
-                event_id=event_id,
-                kind=kind,
-                status=status,
-                sequence_index=context.sequence_index,
-                run_label=self.run_label,
-                agent_name=self.agent_name,
-                duration_ms=duration_ms,
-                metadata=metadata or {},
-                artifacts=artifacts or {},
-                error=error_from_exception(error) if error is not None else None,
+        with self._lock:
+            if kind == "tool_call":
+                self._active_tool_event_ids.discard(event_id)
+            self._events.append(
+                OpenAIAdapterEvent(
+                    event_id=event_id,
+                    kind=kind,
+                    status=status,
+                    sequence_index=context.sequence_index,
+                    run_label=self.run_label,
+                    agent_name=self.agent_name,
+                    duration_ms=duration_ms,
+                    metadata=metadata or {},
+                    artifacts=artifacts or {},
+                    error=error_from_exception(error) if error is not None else None,
+                )
             )
-        )
 
     def set_run_error(self, error: BaseException) -> None:
-        self._status = "failed"
-        self._error = error
+        with self._lock:
+            self._status = "failed"
+            self._error = error
 
-    def build_run_summary(self) -> dict[str, object]:
+    def _build_run_summary_unlocked(
+        self,
+        ordered_events: list[OpenAIAdapterEvent],
+    ) -> dict[str, object]:
         return {
             "agent_name": self.agent_name,
             "run_label": self.run_label,
             "status": self._status,
             "model_call_count": self._model_call_count,
             "tool_call_count": self._tool_call_count,
-            "total_events": self._counter,
-            "event_ids_in_order": [event.event_id for event in self._events],
+            "total_events": len(ordered_events),
+            "event_ids_in_order": [event.event_id for event in ordered_events],
             "duration_ms": round((time.perf_counter() - self._started_at) * 1000, 3),
             "error": (
                 error_from_exception(self._error).model_dump(mode="json")
@@ -135,17 +221,22 @@ class EventTracker:
             ),
         }
 
+    def build_run_summary(self) -> dict[str, object]:
+        with self._lock:
+            return self._build_run_summary_unlocked(self._ordered_events())
+
     def persist(self) -> None:
         if not (is_inside_flow() or is_inside_checkpoint()):
             return
-        events_dump = dump_openai_events(self._events)
-        summary_dump = self.build_run_summary()
+        run_label = self.run_label
+        with self._lock:
+            ordered_events = self._ordered_events()
+            events_dump = dump_openai_events(ordered_events)
+            summary_dump = self._build_run_summary_unlocked(ordered_events)
         kitaru.log(
             **{
-                OPENAI_AGENTS_EVENTS_METADATA_KEY: {self.run_label: events_dump},
-                OPENAI_AGENTS_RUN_SUMMARIES_METADATA_KEY: {
-                    self.run_label: summary_dump
-                },
+                OPENAI_AGENTS_EVENTS_METADATA_KEY: {run_label: events_dump},
+                OPENAI_AGENTS_RUN_SUMMARIES_METADATA_KEY: {run_label: summary_dump},
             }
         )
 

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -1,5 +1,6 @@
 """Focused tests for OpenAI Agents SDK call-level checkpointing."""
 
+from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
 
@@ -126,6 +127,386 @@ def _wait_for_hydrated_run(exec_id: str) -> Any:
 
 def _step_names(hydrated_run: Any) -> set[str]:
     return set(hydrated_run.steps)
+
+
+class TestOpenAIEventTrackerToolCallOrdering:
+    def _record_completed_model(self, tracker: Any) -> tuple[str, Any]:
+        event_id, event_context = tracker.start_llm_event()
+        tracker.record_event(
+            event_id,
+            event_context,
+            kind="llm_call",
+            status="completed",
+            duration_ms=1.0,
+            artifacts={},
+            metadata={"response_id": "resp_ordering"},
+        )
+        return event_id, event_context
+
+    def _record_completed_tool(
+        self,
+        tracker: Any,
+        event_id: str,
+        event_context: Any,
+        *,
+        name: str,
+    ) -> None:
+        tracker.record_event(
+            event_id,
+            event_context,
+            kind="tool_call",
+            status="completed",
+            duration_ms=1.0,
+            artifacts={},
+            metadata={"tool_name": name},
+        )
+
+    def test_reserved_tool_ids_follow_model_order_when_start_order_reverses(
+        self,
+    ) -> None:
+        from kitaru.adapters.openai_agents._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        _model_id, model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(["call_alpha", "call_beta"])
+
+        beta_id, beta_context = tracker.start_tool_event(tool_call_id="call_beta")
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+
+        assert alpha_id != beta_id
+        assert model_context.sequence_index < alpha_context.sequence_index
+        assert alpha_context.sequence_index < beta_context.sequence_index
+
+    def test_reverse_completion_order_sorts_events_persisted_log_and_summary(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kitaru.adapters.openai_agents import _tracking
+
+        tracker = _tracking.EventTracker(agent_name="ordering_agent", run_label="test")
+        model_id, _model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(["call_alpha", "call_beta"])
+        beta_id, beta_context = tracker.start_tool_event(tool_call_id="call_beta")
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+        self._record_completed_tool(tracker, beta_id, beta_context, name="beta")
+        self._record_completed_tool(tracker, alpha_id, alpha_context, name="alpha")
+
+        assert [event.event_id for event in tracker.events] == [
+            model_id,
+            alpha_id,
+            beta_id,
+        ]
+
+        logged: dict[str, Any] = {}
+        monkeypatch.setattr(_tracking, "is_inside_flow", lambda: True)
+        monkeypatch.setattr(
+            _tracking.kitaru,
+            "log",
+            lambda **kwargs: logged.update(kwargs),
+        )
+
+        tracker.persist()
+
+        events_dump = logged["openai_agents_events"][tracker.run_label]
+        summary_dump = logged["openai_agents_run_summaries"][tracker.run_label]
+        assert [event["event_id"] for event in events_dump] == [
+            model_id,
+            alpha_id,
+            beta_id,
+        ]
+        assert summary_dump["event_ids_in_order"] == [model_id, alpha_id, beta_id]
+        assert summary_dump["total_events"] == 3
+
+    def test_missing_or_unreserved_tool_call_id_keeps_counter_fallback(self) -> None:
+        from kitaru.adapters.openai_agents._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        _model_id, model_context = self._record_completed_model(tracker)
+
+        event_id, event_context = tracker.start_tool_event(tool_call_id=None)
+
+        assert event_id.startswith(
+            f"{tracker.agent_name}_{tracker.run_label}_tool_call_"
+        )
+        assert event_context.sequence_index > model_context.sequence_index
+
+    def test_abandoned_reserved_tool_slot_does_not_count_or_leak(self) -> None:
+        from kitaru.adapters.openai_agents._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        model_id, _model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(["call_alpha", "call_beta"])
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+        self._record_completed_tool(
+            tracker,
+            alpha_id,
+            alpha_context,
+            name="alpha",
+        )
+
+        summary = tracker.build_run_summary()
+
+        assert summary["total_events"] == 2
+        assert summary["event_ids_in_order"] == [model_id, alpha_id]
+
+        next_model_id, next_model_context = tracker.start_llm_event()
+        fallback_id, fallback_context = tracker.start_tool_event(
+            tool_call_id="call_beta"
+        )
+        assert fallback_id != next_model_id
+        assert fallback_context.sequence_index > next_model_context.sequence_index
+
+    def test_nested_llm_start_does_not_clear_sibling_tool_reservation(self) -> None:
+        from kitaru.adapters.openai_agents._tracking import EventTracker
+
+        tracker = EventTracker(agent_name="ordering_agent", run_label="test")
+        _model_id, _model_context = self._record_completed_model(tracker)
+        tracker.reserve_tool_call_order(["call_alpha", "call_beta"])
+
+        beta_id, beta_context = tracker.start_tool_event(tool_call_id="call_beta")
+        nested_model_id, nested_context = tracker.start_llm_event()
+        alpha_id, alpha_context = tracker.start_tool_event(tool_call_id="call_alpha")
+
+        assert alpha_id != beta_id
+        assert nested_model_id not in {alpha_id, beta_id}
+        assert alpha_context.sequence_index < beta_context.sequence_index
+        assert beta_context.sequence_index < nested_context.sequence_index
+
+
+class TestOpenAIModelToolCallReservations:
+    def test_trackable_tool_call_ids_follow_model_response_order(self) -> None:
+        from kitaru.adapters.openai_agents._model import _trackable_tool_call_ids
+
+        @function_tool
+        def alpha() -> str:
+            return "alpha"
+
+        @function_tool
+        def beta() -> str:
+            return "beta"
+
+        response = SimpleNamespace(
+            output=[
+                ResponseFunctionToolCall(
+                    arguments="{}",
+                    call_id="call_alpha",
+                    id="fc_alpha",
+                    name="alpha",
+                    status="completed",
+                    type="function_call",
+                ),
+                {"name": "hosted_lookup", "call_id": "call_hosted"},
+                ResponseFunctionToolCall(
+                    arguments="{}",
+                    call_id="call_beta",
+                    id="fc_beta",
+                    name="beta",
+                    status="completed",
+                    type="function_call",
+                ),
+            ]
+        )
+
+        assert _trackable_tool_call_ids(response, [alpha, beta]) == [
+            "call_alpha",
+            "call_beta",
+        ]
+
+    @pytest.mark.anyio
+    async def test_get_response_reserves_tool_order_when_checkpoint_is_cached(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import kitaru.adapters.openai_agents._model as openai_model
+        from kitaru.adapters.openai_agents._model import KitaruOpenAIModel
+        from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+        @function_tool
+        def alpha() -> str:
+            return "alpha"
+
+        @function_tool
+        def beta() -> str:
+            return "beta"
+
+        cached_response = SimpleNamespace(
+            output=[
+                ResponseFunctionToolCall(
+                    arguments="{}",
+                    call_id="call_alpha",
+                    id="fc_alpha",
+                    name="alpha",
+                    status="completed",
+                    type="function_call",
+                ),
+                ResponseFunctionToolCall(
+                    arguments="{}",
+                    call_id="call_beta",
+                    id="fc_beta",
+                    name="beta",
+                    status="completed",
+                    type="function_call",
+                ),
+            ],
+            usage=None,
+            response_id="resp_cached",
+        )
+        seen_tool_call_ids: list[list[str]] = []
+
+        class FakeTracker:
+            def reserve_tool_call_order(self, tool_call_ids: list[str]) -> None:
+                seen_tool_call_ids.append(tool_call_ids)
+
+        async def fake_run_async_in_checkpoint(**_kwargs: Any) -> Any:
+            return cached_response
+
+        monkeypatch.setattr(openai_model, "is_inside_flow", lambda: True)
+        monkeypatch.setattr(openai_model, "is_inside_checkpoint", lambda: False)
+        monkeypatch.setattr(openai_model, "get_current_tracker", lambda: FakeTracker())
+        monkeypatch.setattr(
+            openai_model,
+            "run_async_in_checkpoint",
+            fake_run_async_in_checkpoint,
+        )
+        model = KitaruOpenAIModel(
+            SimpleNamespace(),
+            capture=OpenAICapturePolicy(),
+            agent_name="cached_agent",
+            checkpoint_config={},
+        )
+
+        response = await model.get_response(
+            None,
+            "prompt",
+            None,
+            [alpha, beta],
+            None,
+            [],
+            None,
+            previous_response_id=None,
+            conversation_id=None,
+            prompt=None,
+        )
+
+        assert response is cached_response
+        assert seen_tool_call_ids == [["call_alpha", "call_beta"]]
+
+
+@pytest.mark.anyio
+async def test_openai_tool_call_passes_tool_call_id_to_event_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kitaru.adapters.openai_agents._tools as openai_tools
+    from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+    seen_tool_call_ids: list[str | None] = []
+
+    @function_tool
+    def publish() -> str:
+        return "unused"
+
+    class FakeTracker:
+        def start_tool_event(
+            self,
+            *,
+            tool_call_id: str | None = None,
+        ) -> tuple[str, SimpleNamespace]:
+            seen_tool_call_ids.append(tool_call_id)
+            return "event-1", SimpleNamespace(sequence_index=1)
+
+        def record_event(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    async def callback(_context: Any, _input_json: str) -> str:
+        return "published"
+
+    monkeypatch.setattr(openai_tools, "get_current_tracker", lambda: FakeTracker())
+    monkeypatch.setattr(openai_tools, "is_inside_checkpoint", lambda: True)
+
+    result = await openai_tools._tracked_tool_call(
+        callback,
+        SimpleNamespace(),
+        "{}",
+        tool=publish,
+        capture=OpenAICapturePolicy(save_input=False, save_final_output=False),
+        tool_call_id="call_publish",
+    )
+
+    assert result == "published"
+    assert seen_tool_call_ids == ["call_publish"]
+
+
+@pytest.mark.anyio
+async def test_openai_tracked_tool_execution_remains_concurrent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import anyio
+
+    import kitaru.adapters.openai_agents._tools as openai_tools
+    from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+    started: list[str] = []
+    both_started = anyio.Event()
+
+    async def _mark_started(name: str) -> None:
+        started.append(name)
+        if len(started) == 2:
+            both_started.set()
+        await both_started.wait()
+
+    @function_tool
+    def alpha() -> str:
+        return "unused"
+
+    @function_tool
+    def beta() -> str:
+        return "unused"
+
+    class FakeTracker:
+        def __init__(self) -> None:
+            self._counter = 0
+
+        def start_tool_event(
+            self,
+            *,
+            tool_call_id: str | None = None,
+        ) -> tuple[str, SimpleNamespace]:
+            del tool_call_id
+            self._counter += 1
+            return f"event-{self._counter}", SimpleNamespace(
+                sequence_index=self._counter,
+            )
+
+        def record_event(self, *_args: Any, **_kwargs: Any) -> None:
+            return None
+
+    fake_tracker = FakeTracker()
+    monkeypatch.setattr(openai_tools, "get_current_tracker", lambda: fake_tracker)
+    monkeypatch.setattr(openai_tools, "is_inside_checkpoint", lambda: True)
+    capture = OpenAICapturePolicy(save_input=False, save_final_output=False)
+    results: dict[str, str] = {}
+
+    async def _run_tool(name: str, tool: Any, tool_call_id: str) -> None:
+        async def callback(_context: Any, _input_json: str) -> str:
+            await _mark_started(name)
+            return name
+
+        results[name] = await openai_tools._tracked_tool_call(
+            callback,
+            SimpleNamespace(),
+            "{}",
+            tool=tool,
+            capture=capture,
+            tool_call_id=tool_call_id,
+        )
+
+    with anyio.fail_after(1):
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(_run_tool, "alpha", alpha, "call_alpha")
+            task_group.start_soon(_run_tool, "beta", beta, "call_beta")
+
+    assert set(started) == {"alpha", "beta"}
+    assert results == {"alpha": "alpha", "beta": "beta"}
 
 
 def test_calls_strategy_model_call_runs_inside_checkpoint(primed_zenml) -> None:


### PR DESCRIPTION
## What changed

- Reserved OpenAI Agents adapter tool event sequence slots from assistant-emitted function-call order.
- Passed the existing extracted OpenAI `tool_call_id` / `call_id` into the event tracker when tool callbacks run.
- Sorted OpenAI adapter event logs and run summaries by deterministic `sequence_index` instead of physical callback timing.
- Preserved fallback behavior for missing/unreserved IDs and kept tool execution concurrent.
- Added regression tests for reverse start/completion ordering, cached model responses, abandoned reservations, fallback behavior, and concurrency preservation.
- Added an Unreleased changelog entry.

Refs #306. This is the OpenAI Agents adapter follow-up stacked on the PydanticAI fix in #309.

## Why it was needed

Issue #306's ordering problem applies to both adapter implementations. The PydanticAI PR fixes the Pydantic path; this PR applies the same durable-metadata invariant to the OpenAI Agents adapter.

The runtime story is the same: the assistant can ask for `alpha` then `beta`, while the SDK may start or finish the callbacks in the opposite order. Tool execution should stay parallel, but Kitaru's event metadata should follow the assistant's stable call order.

## Key implementation decisions

- Reservation happens after `get_response()` returns so it works for both live and cached model checkpoint responses.
- Reservations are only durable metadata slots; they do not serialize tool callbacks.
- Missing or unreserved IDs fall back to the previous counter behavior.
- Stale reservations are handled so nested LLM calls do not clear sibling tool reservations prematurely.

## Reviewer Notes

This PR is intentionally based on `fix/issue-306-pydantic-ai-event-order` / #309. Please review only the OpenAI adapter delta here.

Focus areas:

- `src/kitaru/adapters/openai_agents/_tracking.py` reservation and ordering behavior.
- `src/kitaru/adapters/openai_agents/_model.py` extraction of local function-tool call IDs from `ModelResponse.output`.
- `tests/test_openai_agents_calls_strategy.py` regression tests for reverse order, cached responses, and concurrency.

Useful checks:

```bash
just test -n 0 tests/test_openai_agents_calls_strategy.py tests/test_openai_agents_runner_call_strategy.py tests/test_openai_agents_adapter_foundation.py tests/test_openai_agents_import_guard.py
uv run ruff check src/kitaru/adapters/openai_agents/_tracking.py src/kitaru/adapters/openai_agents/_model.py src/kitaru/adapters/openai_agents/_tools.py tests/test_openai_agents_calls_strategy.py
uv run ruff format --check src/kitaru/adapters/openai_agents/_tracking.py src/kitaru/adapters/openai_agents/_model.py src/kitaru/adapters/openai_agents/_tools.py tests/test_openai_agents_calls_strategy.py
```
