### PR TITLE
Fix PydanticAI MCP lifecycle hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed PydanticAI MCP tool calls hanging after a successful request when an explicitly lifecycle-managed MCP server was already open. Kitaru now keeps those MCP calls on the active event loop instead of routing them through the granular checkpoint worker-thread bridge; auto-connected MCP servers still use granular MCP checkpoints by default.
+- Added a compatibility shim for the `pydantic_ai.mcp` import path used by current PydanticAI releases when Kitaru is installed with the MCP SDK version still compatible with ZenML server dependencies.
+
 ### Security
 - Bumped transitive dependencies flagged by `pip-audit`: `gitpython` 3.1.47 → 3.1.49 (CVE-2026-44244), `mako` 1.3.11 → 1.3.12 (CVE-2026-44307), and `python-multipart` 0.0.26 → 0.0.27 (CVE-2026-42561). Lockfile-only change; no API surface affected.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- Fixed PydanticAI MCP tool calls hanging after a successful request when an explicitly lifecycle-managed MCP server was already open. Kitaru now keeps those MCP calls on the active event loop instead of routing them through the granular checkpoint worker-thread bridge; auto-connected MCP servers still use granular MCP checkpoints by default.
+- Fixed PydanticAI MCP tool calls hanging after a successful request when an explicitly lifecycle-managed MCP server was already open. Kitaru now keeps already-running MCP calls on the active event loop inside explicit flows, and fails fast when auto-flow would otherwise move a pre-opened MCP server across event loops; auto-connected MCP servers still use granular MCP checkpoints by default.
 - Added a compatibility shim for the `pydantic_ai.mcp` import path used by current PydanticAI releases when Kitaru is installed with the MCP SDK version still compatible with ZenML server dependencies.
 
 ### Security

--- a/src/kitaru/adapters/pydantic_ai/README.md
+++ b/src/kitaru/adapters/pydantic_ai/README.md
@@ -158,7 +158,12 @@ This also affects where event details land. Flow-scope explicit HITL calls are s
 
 MCP servers attached to the agent are wrapped automatically. Their tool calls appear as `ToolEvent`s with `toolset_kind='mcp'` alongside native tools. In the default granular mode, each top-level MCP call gets its own adapter checkpoint when Kitaru can safely own the MCP call lifecycle. `MCPServer.cache_tools=True` is honored to skip redundant `tools/list` round-trips on replay.
 
-If the PydanticAI MCP server is already running because you entered it with `async with server:` or `async with agent:`, Kitaru keeps the MCP call on the current event loop instead of moving it into the worker-thread checkpoint bridge. That avoids the concrete failure mode where the MCP request reaches the server successfully, but the client waits or tears down from the wrong event loop afterwards. In this pre-opened case the call is still tracked as adapter event metadata, but it is not persisted as its own per-call `mcp_call` checkpoint, so checkpoint-scoped args/result artifacts are not saved for that call. If you need per-call MCP checkpointing, let PydanticAI auto-connect the MCP server so the connection opens inside the checkpoint worker loop.
+If the PydanticAI MCP server is already running because you entered it with `async with server:` or `async with agent:`, behavior depends on where the agent run happens:
+
+- **Inside an explicit `@kitaru.flow`:** Kitaru keeps the MCP call on the current event loop instead of moving it into the worker-thread checkpoint bridge. That avoids the concrete failure mode where the MCP request reaches the server successfully, but the client waits or tears down from the wrong event loop afterwards. In this pre-opened case the call is still tracked as adapter event metadata, but it is not persisted as its own per-call `mcp_call` checkpoint, so checkpoint-scoped args/result artifacts are not saved for that call.
+- **Outside an explicit `@kitaru.flow`:** `KitaruAgent.run(...)` would normally auto-open a flow by moving the async agent body to a worker thread/event loop. If the MCP server is already open on your caller loop, Kitaru fails fast with `KitaruUsageError` instead of risking a hang. Wrap the call in an explicit flow while the MCP lifecycle is open, or do not pre-open the MCP server and let PydanticAI/Kitaru auto-connect it.
+
+If you need per-call MCP checkpointing, let PydanticAI auto-connect the MCP server so the connection opens inside the checkpoint worker loop.
 
 ```python
 from kitaru.adapters.pydantic_ai import KitaruAgent

--- a/src/kitaru/adapters/pydantic_ai/README.md
+++ b/src/kitaru/adapters/pydantic_ai/README.md
@@ -156,12 +156,14 @@ This also affects where event details land. Flow-scope explicit HITL calls are s
 
 ### 4. MCP servers
 
-MCP servers attached to the agent are wrapped automatically. Their tool calls appear as `ToolEvent`s with `toolset_kind='mcp'` alongside native tools; in the default granular mode, each top-level MCP call gets its own adapter checkpoint. `MCPServer.cache_tools=True` is honored to skip redundant `tools/list` round-trips on replay.
+MCP servers attached to the agent are wrapped automatically. Their tool calls appear as `ToolEvent`s with `toolset_kind='mcp'` alongside native tools. In the default granular mode, each top-level MCP call gets its own adapter checkpoint when Kitaru can safely own the MCP call lifecycle. `MCPServer.cache_tools=True` is honored to skip redundant `tools/list` round-trips on replay.
+
+If the PydanticAI MCP server is already running because you entered it with `async with server:` or `async with agent:`, Kitaru keeps the MCP call on the current event loop instead of moving it into the worker-thread checkpoint bridge. That avoids the concrete failure mode where the MCP request reaches the server successfully, but the client waits or tears down from the wrong event loop afterwards. In this pre-opened case the call is still tracked as adapter event metadata, but it is not persisted as its own per-call `mcp_call` checkpoint, so checkpoint-scoped args/result artifacts are not saved for that call. If you need per-call MCP checkpointing, let PydanticAI auto-connect the MCP server so the connection opens inside the checkpoint worker loop.
 
 ```python
+from kitaru.adapters.pydantic_ai import KitaruAgent
 from pydantic_ai import Agent
 from pydantic_ai.mcp import MCPServerStdio
-from kitaru.adapters.pydantic_ai import KitaruAgent
 
 server = MCPServerStdio('npx', args=['-y', '@modelcontextprotocol/server-filesystem', '/tmp'], cache_tools=True)
 agent = Agent('openai:gpt-4o', name='researcher', toolsets=[server])

--- a/src/kitaru/adapters/pydantic_ai/__init__.py
+++ b/src/kitaru/adapters/pydantic_ai/__init__.py
@@ -7,6 +7,8 @@ from typing import Any, Literal, TypedDict
 
 from kitaru.errors import KitaruFeatureNotAvailableError
 
+from ._mcp_compat import ensure_pydantic_ai_mcp_import_compat
+
 try:
     import pydantic_ai  # noqa: F401
 except ImportError as exc:  # pragma: no cover - import-time guard only
@@ -24,6 +26,8 @@ from ._policy import CaptureMode, CapturePolicy
 from ._toolset import KitaruToolset, kitaruify_toolset
 from ._utils import CheckpointConfig, CheckpointRuntime
 from ._wait_for_input import wait_for_input
+
+ensure_pydantic_ai_mcp_import_compat()
 
 LegacyCaptureMode = Literal['full', 'metadata_only', 'off']
 

--- a/src/kitaru/adapters/pydantic_ai/_agent.py
+++ b/src/kitaru/adapters/pydantic_ai/_agent.py
@@ -35,6 +35,7 @@ from pydantic_ai.toolsets import AbstractToolset
 
 from ._kitaru_internal import is_inside_checkpoint, is_inside_flow
 from ._logging import logger
+from ._mcp_server import has_running_mcp_toolset
 from ._model import KitaruModel
 from ._policy import CapturePolicy
 from ._toolset import kitaruify_toolset
@@ -710,6 +711,32 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             'Use `await agent.run(...)` instead.'
         )
 
+    def _ensure_auto_flow_mcp_lifecycle_safe(
+        self,
+        *,
+        call_toolsets: Sequence[AbstractToolset[AgentDepsT]] | None,
+    ) -> None:
+        if is_inside_flow():
+            return
+
+        if not call_toolsets:
+            effective_toolsets = self._toolsets
+        else:
+            effective_toolsets = (*self._toolsets, *call_toolsets)
+        if not has_running_mcp_toolset(effective_toolsets):
+            return
+
+        raise KitaruUsageError(
+            'KitaruAgent cannot auto-open a flow around an already-running '
+            'PydanticAI MCP server. Auto-flow runs async agent bodies in a '
+            'worker thread/event loop so it can wait for the flow without '
+            'blocking your caller loop. Your MCP server is already open on the '
+            'caller loop, so moving the agent run can hang after a successful '
+            'MCP request. Wrap this call in an explicit `@kitaru.flow` while '
+            'the MCP server lifecycle is open, or do not pre-open the MCP server '
+            'and let PydanticAI/Kitaru auto-connect it.'
+        )
+
     async def _run_async(
         self,
         body: Callable[[], Awaitable[Any]],
@@ -718,6 +745,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         cache_key: str | None = None,
         checkpoint_inputs: Mapping[str, Any] | None = None,
         checkpoint_config: CheckpointConfig | None = None,
+        auto_flow_toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
     ) -> Any:
         if is_inside_flow():
             if is_inside_checkpoint() or self._use_granular(force_turn_checkpoint):
@@ -729,6 +757,8 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 checkpoint_config=checkpoint_config,
             )
 
+        self._ensure_auto_flow_mcp_lifecycle_safe(call_toolsets=auto_flow_toolsets)
+
         # Outside any flow: auto-open one. FlowHandle.wait() is sync-blocking,
         # so we dispatch the flow to a worker thread (no running loop there,
         # so asyncio.run is safe for the agent coroutine).
@@ -739,6 +769,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 cache_key=cache_key,
                 checkpoint_inputs=checkpoint_inputs,
                 checkpoint_config=checkpoint_config,
+                auto_flow_toolsets=auto_flow_toolsets,
             )
 
         loop = asyncio.get_running_loop()
@@ -755,6 +786,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         cache_key: str | None = None,
         checkpoint_inputs: Mapping[str, Any] | None = None,
         checkpoint_config: CheckpointConfig | None = None,
+        auto_flow_toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
     ) -> Any:
         if is_inside_flow():
             if is_inside_checkpoint() or self._use_granular(force_turn_checkpoint):
@@ -765,6 +797,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 checkpoint_inputs=checkpoint_inputs,
                 checkpoint_config=checkpoint_config,
             )
+        self._ensure_auto_flow_mcp_lifecycle_safe(call_toolsets=auto_flow_toolsets)
         return self._invoke_in_auto_flow(
             lambda: self._run_sync(
                 body,
@@ -772,6 +805,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 cache_key=cache_key,
                 checkpoint_inputs=checkpoint_inputs,
                 checkpoint_config=checkpoint_config,
+                auto_flow_toolsets=auto_flow_toolsets,
             )
         )
 
@@ -866,6 +900,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 cache_key=turn_call_config.cache_key,
                 checkpoint_inputs=turn_call_config.checkpoint_inputs,
                 checkpoint_config=turn_call_config.checkpoint_config,
+                auto_flow_toolsets=prepared_toolsets,
             )
             self._remember_messages(result)
             return result
@@ -959,6 +994,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 cache_key=turn_call_config.cache_key,
                 checkpoint_inputs=turn_call_config.checkpoint_inputs,
                 checkpoint_config=turn_call_config.checkpoint_config,
+                auto_flow_toolsets=prepared_toolsets,
             )
             self._remember_messages(result)
             return result

--- a/src/kitaru/adapters/pydantic_ai/_mcp_compat.py
+++ b/src/kitaru/adapters/pydantic_ai/_mcp_compat.py
@@ -1,0 +1,23 @@
+"""Compatibility helpers for PydanticAI MCP optional dependencies."""
+
+from __future__ import annotations
+
+
+def ensure_pydantic_ai_mcp_import_compat() -> None:
+    """Install import aliases needed by supported PydanticAI/MCP combinations.
+
+    PydanticAI 1.86+ imports ``streamable_http_client`` from the MCP SDK. The
+    MCP version currently compatible with Kitaru's ZenML server dependency still
+    exposes the same helper as ``streamablehttp_client``. Adding the alias lets
+    ``pydantic_ai.mcp`` import without forcing an unsatisfiable MCP upgrade.
+    """
+    try:
+        from mcp.client import streamable_http
+    except ImportError:
+        return
+
+    if hasattr(streamable_http, "streamable_http_client"):
+        return
+    legacy_client = getattr(streamable_http, "streamablehttp_client", None)
+    if legacy_client is not None:
+        streamable_http.__dict__["streamable_http_client"] = legacy_client

--- a/src/kitaru/adapters/pydantic_ai/_mcp_server.py
+++ b/src/kitaru/adapters/pydantic_ai/_mcp_server.py
@@ -89,13 +89,9 @@ class KitaruMCPServer(KitaruToolset[AgentDepsT]):
         if self._warned_running_mcp_checkpoint_bypass:
             return
         self._warned_running_mcp_checkpoint_bypass = True
-        logger.warning(
-            "Kitaru detected an already-running PydanticAI MCP server while "
-            "calling tool %r. The MCP tool call will stay on the current event "
-            "loop instead of opening a granular MCP checkpoint, which avoids "
-            "moving loop-bound MCP lifecycle resources across threads. The call "
-            "is still tracked as an adapter tool event, but it is not persisted "
-            "as its own per-call checkpoint.",
+        logger.info(
+            "Kitaru recorded MCP tool %r without a separate MCP-call checkpoint "
+            "because its PydanticAI MCP server is already running.",
             tool_name,
         )
 

--- a/src/kitaru/adapters/pydantic_ai/_mcp_server.py
+++ b/src/kitaru/adapters/pydantic_ai/_mcp_server.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from pydantic_ai.tools import AgentDepsT, RunContext
-from pydantic_ai.toolsets import ToolsetTool
+from pydantic_ai.toolsets import AbstractToolset, ToolsetTool
 
 from ._events import ToolsetKind
 from ._logging import logger
@@ -98,6 +98,15 @@ class KitaruMCPServer(KitaruToolset[AgentDepsT]):
             "as its own per-call checkpoint.",
             tool_name,
         )
+
+
+def has_running_mcp_toolset(toolsets: Sequence[AbstractToolset[Any]]) -> bool:
+    """Return whether any prepared Kitaru MCP wrapper is already open."""
+    return any(
+        isinstance(toolset, KitaruMCPServer)
+        and _mcp_server_is_running(toolset.wrapped)
+        for toolset in toolsets
+    )
 
 
 def kitaruify_mcp_server(

--- a/src/kitaru/adapters/pydantic_ai/_mcp_server.py
+++ b/src/kitaru/adapters/pydantic_ai/_mcp_server.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
-from pydantic_ai.tools import AgentDepsT
+from pydantic_ai.tools import AgentDepsT, RunContext
+from pydantic_ai.toolsets import ToolsetTool
 
 from ._events import ToolsetKind
+from ._logging import logger
 from ._policy import CapturePolicy
 from ._utils import CheckpointConfig, ToolCheckpointOverrides
 from ._toolset import KitaruToolset
@@ -16,12 +19,44 @@ if TYPE_CHECKING:
     from pydantic_ai.mcp import MCPServer
 
 
+_MISSING = object()
+
+
+def _mcp_server_is_running(server: object) -> bool:
+    """Return whether a PydanticAI MCP server is already lifecycle-open."""
+    try:
+        is_running = getattr(server, "is_running", _MISSING)
+    except Exception:
+        return False
+
+    if is_running is not _MISSING:
+        try:
+            if callable(is_running):
+                return bool(cast(Callable[[], object], is_running)())
+            return bool(is_running)
+        except Exception:
+            return False
+
+    try:
+        running_count = getattr(server, "_running_count", None)
+        if running_count is not None:
+            return bool(running_count)
+        return getattr(server, "_client", None) is not None
+    except Exception:
+        return False
+
+
 @dataclass
 class KitaruMCPServer(KitaruToolset[AgentDepsT]):
     """Tracked toolset wrapper for an ``MCPServer``; instantiate via :func:`kitaruify_toolset`."""
 
-    toolset_kind: ToolsetKind = field(default='mcp', init=False)
-    _default_checkpoint_type: str = field(default='mcp_call', init=False)
+    toolset_kind: ToolsetKind = field(default="mcp", init=False)
+    _default_checkpoint_type: str = field(default="mcp_call", init=False)
+    _warned_running_mcp_checkpoint_bypass: bool = field(
+        default=False,
+        init=False,
+        repr=False,
+    )
 
     @property
     def _server(self) -> MCPServer:
@@ -29,6 +64,40 @@ class KitaruMCPServer(KitaruToolset[AgentDepsT]):
 
         assert isinstance(self.wrapped, MCPServer)
         return self.wrapped
+
+    def _should_use_tool_checkpoint(
+        self,
+        *,
+        name: str,
+        ctx: RunContext[AgentDepsT],
+        tool: ToolsetTool[AgentDepsT],
+        checkpoint_config: CheckpointConfig | None,
+    ) -> bool:
+        if not super()._should_use_tool_checkpoint(
+            name=name,
+            ctx=ctx,
+            tool=tool,
+            checkpoint_config=checkpoint_config,
+        ):
+            return False
+        if _mcp_server_is_running(self.wrapped):
+            self._warn_running_mcp_checkpoint_bypass_once(name)
+            return False
+        return True
+
+    def _warn_running_mcp_checkpoint_bypass_once(self, tool_name: str) -> None:
+        if self._warned_running_mcp_checkpoint_bypass:
+            return
+        self._warned_running_mcp_checkpoint_bypass = True
+        logger.warning(
+            "Kitaru detected an already-running PydanticAI MCP server while "
+            "calling tool %r. The MCP tool call will stay on the current event "
+            "loop instead of opening a granular MCP checkpoint, which avoids "
+            "moving loop-bound MCP lifecycle resources across threads. The call "
+            "is still tracked as an adapter tool event, but it is not persisted "
+            "as its own per-call checkpoint.",
+            tool_name,
+        )
 
 
 def kitaruify_mcp_server(

--- a/src/kitaru/adapters/pydantic_ai/_toolset.py
+++ b/src/kitaru/adapters/pydantic_ai/_toolset.py
@@ -117,6 +117,22 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             return self
         return replace(self, wrapped=new_wrapped)
 
+    def _should_use_tool_checkpoint(
+        self,
+        *,
+        name: str,
+        ctx: RunContext[AgentDepsT],
+        tool: ToolsetTool[AgentDepsT],
+        checkpoint_config: CheckpointConfig | None,
+    ) -> bool:
+        """Return whether this tool call should open an adapter checkpoint."""
+        del name, ctx, tool
+        return (
+            checkpoint_config is not None
+            and is_inside_flow()
+            and not is_inside_checkpoint()
+        )
+
     async def call_tool(
         self,
         name: str,
@@ -135,11 +151,13 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             default=self.tool_checkpoint_config,
             by_name=self.tool_checkpoint_config_by_name,
         )
-        if (
-            checkpoint_config is not None
-            and is_inside_flow()
-            and not is_inside_checkpoint()
+        if self._should_use_tool_checkpoint(
+            name=name,
+            ctx=ctx,
+            tool=tool,
+            checkpoint_config=checkpoint_config,
         ):
+            assert checkpoint_config is not None
 
             async def _in_checkpoint() -> Any:
                 return await self._call_tool_tracked(
@@ -476,6 +494,9 @@ def kitaruify_toolset(
         )
 
     try:
+        from ._mcp_compat import ensure_pydantic_ai_mcp_import_compat
+
+        ensure_pydantic_ai_mcp_import_compat()
         from pydantic_ai.mcp import MCPServer
     except ImportError:  # pragma: no cover
         MCPServer = None

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -1650,6 +1650,136 @@ async def test_non_hitl_tool_still_uses_granular_tool_checkpoint(
 
 
 @pytest.mark.anyio
+async def test_running_mcp_server_bypasses_granular_checkpoint_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pydantic_ai import FunctionToolset
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._mcp_server import KitaruMCPServer
+    from kitaru.runtime import _flow_scope
+
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    @toolset.tool_plain
+    def echo(text: str) -> str:
+        return f"echo:{text}"
+
+    wrapped = KitaruMCPServer(
+        toolset,
+        capture=CapturePolicy(correlate_otel_spans=False),
+        tool_checkpoint_config={},
+    )
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+    tool = (await wrapped.get_tools(ctx))["echo"]
+
+    async def fail_checkpoint(**_kwargs: Any) -> Any:
+        raise AssertionError("pre-opened MCP calls must stay on the current loop")
+
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._mcp_server._mcp_server_is_running",
+        lambda _server: True,
+    )
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._toolset.run_async_in_checkpoint",
+        fail_checkpoint,
+    )
+
+    with _flow_scope(name="demo_flow"):
+        result = await wrapped.call_tool("echo", {"text": "preopened"}, ctx, tool)
+
+    assert result == "echo:preopened"
+
+
+@pytest.mark.anyio
+async def test_closed_mcp_server_still_uses_granular_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pydantic_ai import FunctionToolset
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._mcp_server import KitaruMCPServer
+    from kitaru.runtime import _flow_scope
+
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    @toolset.tool_plain
+    def echo(text: str) -> str:
+        return f"echo:{text}"
+
+    wrapped = KitaruMCPServer(
+        toolset,
+        capture=CapturePolicy(correlate_otel_spans=False),
+        tool_checkpoint_config={},
+    )
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+    tool = (await wrapped.get_tools(ctx))["echo"]
+    checkpoint_steps = _install_checkpoint_step_recorder(monkeypatch)
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._mcp_server._mcp_server_is_running",
+        lambda _server: False,
+    )
+
+    with _flow_scope(name="demo_flow"):
+        result = await wrapped.call_tool("echo", {"text": "auto"}, ctx, tool)
+
+    assert result == "echo:auto"
+    assert checkpoint_steps == ["echo_tool"]
+
+
+def test_mcp_server_running_detection() -> None:
+    from kitaru.adapters.pydantic_ai._mcp_server import _mcp_server_is_running
+
+    class RunningProperty:
+        is_running = True
+
+    class StoppedProperty:
+        is_running = False
+
+    class RunningMethod:
+        def is_running(self) -> bool:
+            return True
+
+    class ClientOnly:
+        _client = object()
+
+    class RunningCount:
+        _running_count = 1
+        _client = object()
+
+    class StoppedCount:
+        _running_count = 0
+        _client = object()
+
+    class ExitStackOnly:
+        _exit_stack = object()
+
+    class NoClient:
+        _client = None
+
+    class RaisingRunning:
+        @property
+        def is_running(self) -> bool:
+            raise RuntimeError("boom")
+
+    assert _mcp_server_is_running(RunningProperty()) is True
+    assert _mcp_server_is_running(StoppedProperty()) is False
+    assert _mcp_server_is_running(RunningMethod()) is True
+    assert _mcp_server_is_running(ClientOnly()) is True
+    assert _mcp_server_is_running(RunningCount()) is True
+    assert _mcp_server_is_running(StoppedCount()) is False
+    assert _mcp_server_is_running(ExitStackOnly()) is False
+    assert _mcp_server_is_running(NoClient()) is False
+    assert _mcp_server_is_running(RaisingRunning()) is False
+
+
+@pytest.mark.anyio
 async def test_named_hitl_tool_uses_name_as_unique_wait_base(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -1695,6 +1695,46 @@ async def test_running_mcp_server_bypasses_granular_checkpoint_bridge(
 
 
 @pytest.mark.anyio
+async def test_auto_flow_rejects_preopened_mcp_server_before_worker_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pydantic_ai import Agent, FunctionToolset
+    from pydantic_ai.models.test import TestModel
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy, KitaruAgent
+    from kitaru.adapters.pydantic_ai._mcp_server import KitaruMCPServer
+
+    toolset: FunctionToolset[None] = FunctionToolset()
+    running_mcp = KitaruMCPServer(
+        toolset,
+        capture=CapturePolicy(correlate_otel_spans=False),
+    )
+    agent = KitaruAgent(Agent(TestModel(), name="auto_flow_mcp_guard"))
+    agent._toolsets = [running_mcp]
+    auto_flow_called = False
+
+    def fail_auto_flow(_body: Any) -> Any:
+        nonlocal auto_flow_called
+        auto_flow_called = True
+        raise AssertionError("auto-flow should fail before the worker-thread bridge")
+
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._mcp_server._mcp_server_is_running",
+        lambda _server: True,
+    )
+    monkeypatch.setattr(agent, "_invoke_in_auto_flow", fail_auto_flow)
+
+    with pytest.raises(KitaruUsageError) as exc_info:
+        await agent.run("hello")
+
+    message = str(exc_info.value)
+    assert "already-running PydanticAI MCP server" in message
+    assert "`@kitaru.flow`" in message
+    assert "auto-connect" in message
+    assert auto_flow_called is False
+
+
+@pytest.mark.anyio
 async def test_closed_mcp_server_still_uses_granular_checkpoint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_pydantic_ai_mcp_adapter.py
+++ b/tests/test_pydantic_ai_mcp_adapter.py
@@ -20,6 +20,8 @@ def anyio_backend() -> str:
 
 def _import_mcp_stdio() -> Any:
     pytest.importorskip("pydantic_ai")
+    pytest.importorskip("mcp")
+    pytest.importorskip("mcp.server.fastmcp")
     import kitaru.adapters.pydantic_ai  # noqa: F401
 
     try:
@@ -30,10 +32,9 @@ def _import_mcp_stdio() -> Any:
 
 
 def test_pydantic_ai_mcp_import_smoke() -> None:
+    MCPServerStdio = _import_mcp_stdio()
     kitaru_adapter = importlib.import_module("kitaru.adapters.pydantic_ai")
     pydantic_ai = importlib.import_module("pydantic_ai")
-
-    MCPServerStdio = _import_mcp_stdio()
     assert "Agent" in pydantic_ai.__dict__
     assert "KitaruAgent" in kitaru_adapter.__dict__
     assert MCPServerStdio is not None
@@ -118,6 +119,37 @@ async def test_preopened_mcp_server_call_stays_on_current_loop(
             )
 
     assert result == "echo:preopened"
+
+
+@pytest.mark.anyio
+async def test_preopened_mcp_server_outside_flow_fails_fast(
+    tmp_path: Path,
+) -> None:
+    from pydantic_ai import Agent
+    from pydantic_ai.models.test import TestModel
+
+    from kitaru.adapters.pydantic_ai import KitaruAgent
+    from kitaru.errors import KitaruUsageError
+
+    MCPServerStdio = _import_mcp_stdio()
+    server = MCPServerStdio(
+        sys.executable,
+        args=[str(_write_echo_server(tmp_path))],
+        read_timeout=2,
+        timeout=5,
+        cache_tools=True,
+    )
+    durable_agent = KitaruAgent(
+        Agent(TestModel(), name="preopened_mcp_agent", toolsets=[server])
+    )
+
+    async with server:
+        with pytest.raises(KitaruUsageError) as exc_info:
+            await durable_agent.run("hello")
+
+    message = str(exc_info.value)
+    assert "already-running PydanticAI MCP server" in message
+    assert "`@kitaru.flow`" in message
 
 
 @pytest.mark.anyio

--- a/tests/test_pydantic_ai_mcp_adapter.py
+++ b/tests/test_pydantic_ai_mcp_adapter.py
@@ -1,0 +1,173 @@
+"""PydanticAI MCP lifecycle regression tests for the Kitaru adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _import_mcp_stdio() -> Any:
+    pytest.importorskip("pydantic_ai")
+    import kitaru.adapters.pydantic_ai  # noqa: F401
+
+    try:
+        from pydantic_ai.mcp import MCPServerStdio
+    except ImportError as exc:  # pragma: no cover - failure message is the test value
+        pytest.fail(f"pydantic_ai.mcp import failed: {exc}")
+    return MCPServerStdio
+
+
+def test_pydantic_ai_mcp_import_smoke() -> None:
+    kitaru_adapter = importlib.import_module("kitaru.adapters.pydantic_ai")
+    pydantic_ai = importlib.import_module("pydantic_ai")
+
+    MCPServerStdio = _import_mcp_stdio()
+    assert "Agent" in pydantic_ai.__dict__
+    assert "KitaruAgent" in kitaru_adapter.__dict__
+    assert MCPServerStdio is not None
+    try:
+        import mcp.server.fastmcp  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - failure message is the test value
+        pytest.fail(f"mcp.server.fastmcp import failed: {exc}")
+
+
+def _write_echo_server(tmp_path: Path) -> Path:
+    server_path = tmp_path / "echo_mcp_server.py"
+    server_path.write_text(
+        dedent(
+            """
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("kitaru-test-mcp")
+
+            @mcp.tool()
+            def echo(text: str) -> str:
+                return f"echo:{text}"
+
+            if __name__ == "__main__":
+                mcp.run()
+            """
+        ).strip()
+        + "\n"
+    )
+    return server_path
+
+
+def _run_context() -> Any:
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+
+    return RunContext(deps=None, model=TestModel(), usage=RunUsage())
+
+
+@pytest.mark.anyio
+async def test_preopened_mcp_server_call_stays_on_current_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import anyio
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._toolset import kitaruify_toolset
+    from kitaru.runtime import _flow_scope
+
+    MCPServerStdio = _import_mcp_stdio()
+    server = MCPServerStdio(
+        sys.executable,
+        args=[str(_write_echo_server(tmp_path))],
+        read_timeout=2,
+        timeout=5,
+        cache_tools=True,
+    )
+    wrapped = kitaruify_toolset(
+        server,
+        capture=CapturePolicy(correlate_otel_spans=False),
+        mcp_checkpoint_config={},
+    )
+
+    async def fail_checkpoint(**_kwargs: Any) -> Any:
+        raise AssertionError("pre-opened MCP calls must not cross the thread bridge")
+
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._toolset.run_async_in_checkpoint",
+        fail_checkpoint,
+    )
+
+    async with server:
+        ctx = _run_context()
+        tool = (await wrapped.get_tools(ctx))["echo"]
+        with anyio.fail_after(5), _flow_scope(name="preopened_mcp_flow"):
+            result = await wrapped.call_tool(
+                "echo",
+                {"text": "preopened"},
+                ctx,
+                tool,
+            )
+
+    assert result == "echo:preopened"
+
+
+@pytest.mark.anyio
+async def test_auto_connect_mcp_server_still_uses_granular_checkpoint_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import anyio
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._toolset import kitaruify_toolset
+    from kitaru.runtime import _flow_scope
+
+    MCPServerStdio = _import_mcp_stdio()
+    server = MCPServerStdio(
+        sys.executable,
+        args=[str(_write_echo_server(tmp_path))],
+        read_timeout=2,
+        timeout=5,
+        cache_tools=True,
+    )
+    wrapped = kitaruify_toolset(
+        server,
+        capture=CapturePolicy(correlate_otel_spans=False),
+        mcp_checkpoint_config={},
+    )
+    checkpoint_called = False
+
+    async def bridge_checkpoint(
+        *,
+        body: Callable[[], Awaitable[Any]],
+        **_kwargs: Any,
+    ) -> Any:
+        nonlocal checkpoint_called
+        checkpoint_called = True
+
+        async def run_body() -> Any:
+            return await body()
+
+        return await asyncio.to_thread(lambda: asyncio.run(run_body()))
+
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._toolset.run_async_in_checkpoint",
+        bridge_checkpoint,
+    )
+
+    ctx = _run_context()
+    tool = (await wrapped.get_tools(ctx))["echo"]
+    with anyio.fail_after(5), _flow_scope(name="auto_connect_mcp_flow"):
+        result = await wrapped.call_tool("echo", {"text": "auto"}, ctx, tool)
+
+    assert result == "echo:auto"
+    assert checkpoint_called is True


### PR DESCRIPTION
## What changed

- Fixed PydanticAI MCP tool calls for explicitly lifecycle-managed MCP servers (`async with server:` / `async with agent:`) so they stay on the active event loop instead of crossing Kitaru's worker-thread checkpoint bridge.
- Preserved granular MCP checkpointing for auto-connected MCP servers where Kitaru can safely own the MCP lifecycle inside the checkpoint worker loop.
- Added a follow-up guard from review: if an already-running MCP server would be carried through `KitaruAgent.run(...)` auto-flow outside an explicit Kitaru flow, Kitaru now fails fast with a clear `KitaruUsageError` instead of risking a post-request hang.
- Added a small compatibility shim for the current `pydantic_ai.mcp` import mismatch with the solvable MCP dependency set.
- Added regression coverage for:
  - running/pre-opened MCP server bypass behavior,
  - closed/auto-connected MCP server checkpoint behavior,
  - pre-opened MCP outside explicit flow failing before auto-flow crosses the worker-thread bridge,
  - real FastMCP stdio + PydanticAI `MCPServerStdio` calls under timeout guards,
  - PydanticAI MCP import smoke,
  - MCP tests skipping cleanly when optional `mcp` is absent.
- Updated the PydanticAI adapter README and changelog.

## Why it was needed

Michael reported that a FastMCP-backed PydanticAI MCPServer request reached the server successfully, but the Kitaru/PydanticAI execution then got stuck afterwards.

The concrete failure mode is: the MCP server is opened on event loop A, then Kitaru's granular MCP checkpoint bridge moves the actual tool call into a worker thread with event loop B. The server sees the request, but client response/teardown waits across the wrong lifecycle boundary.

A review follow-up found a second bridge: outside an explicit Kitaru flow, `KitaruAgent.run(...)` auto-flow can move the whole async agent body into a worker event loop. This PR now rejects the unsafe combination early when the MCP server is already running.

## Key implementation decisions

- Added a small `_should_use_tool_checkpoint(...)` hook to `KitaruToolset` instead of duplicating `call_tool(...)` in the MCP wrapper.
- Overrode that hook in `KitaruMCPServer` to bypass granular checkpointing only when the wrapped MCP server is already running/open.
- Added an agent-level auto-flow guard rather than adding a second auto-flow execution mode. Users with pre-opened MCP servers should either use an explicit `@kitaru.flow` or let PydanticAI/Kitaru auto-connect the MCP server.
- Kept auto-connected MCP calls checkpointed by default.
- Used a compatibility shim rather than broadening MCP dependencies, because the clean `pydantic-ai-slim[mcp]` / newer `mcp` path currently conflicts with ZenML server's `PyJWT` pin.

## Validation

```bash
uv run pytest tests/test_pydantic_ai_adapter.py -k "mcp or auto_flow" -n 0
uv run pytest tests/test_pydantic_ai_mcp_adapter.py -n 0
uv run pytest tests/test_pydantic_ai_import_guard.py tests/test_mcp_import_guard.py -n 0
uv run pytest tests/test_pydantic_ai_adapter.py tests/test_pydantic_ai_mcp_adapter.py tests/test_pydantic_ai_import_guard.py tests/test_mcp_import_guard.py
just test 2>&1 | grep -E "FAILED|ERROR|passed|failed|warnings" | tail -30
```

Results:

- Targeted MCP/auto-flow tests: `4 passed`
- MCP integration tests: `4 passed`
- Import guard tests: `4 passed`
- Broader PydanticAI/import suite: `117 passed, 1 warning`
- Full test suite: `1806 passed, 8 skipped, 86 warnings`
- `just check`: passed format, lint, typecheck, typos, yaml, and actionlint; failed at links due to an existing local `lychee.toml` parse issue (`include_fragments = true`) unrelated to this PR.

## Reviewer Notes

Please focus on:

1. `src/kitaru/adapters/pydantic_ai/_agent.py` — whether the auto-flow fail-fast guard is the right behavior for pre-opened MCP servers outside explicit flows.
2. `src/kitaru/adapters/pydantic_ai/_mcp_server.py` — whether the running/open MCP server detection is defensive enough across PydanticAI versions.
3. `src/kitaru/adapters/pydantic_ai/_toolset.py` — whether the new checkpoint-decision hook keeps generic tool behavior unchanged.
4. `tests/test_pydantic_ai_mcp_adapter.py` — whether the FastMCP regression tests reproduce the important lifecycle shapes without being too brittle.
5. `src/kitaru/adapters/pydantic_ai/_mcp_compat.py` — whether the temporary shim is acceptable until the dependency conflict is resolved.

Useful local checks:

```bash
uv run pytest tests/test_pydantic_ai_mcp_adapter.py::test_preopened_mcp_server_call_stays_on_current_loop \
  tests/test_pydantic_ai_mcp_adapter.py::test_auto_connect_mcp_server_still_uses_granular_checkpoint_bridge \
  tests/test_pydantic_ai_mcp_adapter.py::test_preopened_mcp_server_outside_flow_fails_fast -q
```
