### PR TITLE
Fix `lychee.toml` for lychee 0.24+ schema change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,15 +62,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2
+      # Pinned to a post-v2.8.0 master commit because the v2.8.0 release
+      # ships an installer that can't extract lychee >= 0.24.0 tarballs
+      # (subfolder layout) and defaults to lychee v0.23.0, which doesn't
+      # understand the new `include_fragments` enum in lychee.toml. The
+      # pinned SHA freezes behavior; revisit when a tagged release lands.
+      - uses: lycheeverse/lychee-action@b40e218fdac9481d3c13098d4e1ee56f3b589356  # master @ 2026-05-03
         with:
           args: --root-dir . --verbose --no-progress './**/*.md'
           fail: true
           jobSummary: true
-          # Pin lychee >= 0.24.0 so the action matches the version brew
-          # installs locally; required for the new `include_fragments` enum
-          # syntax in lychee.toml.
-          lycheeVersion: v0.24.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   docker-smoke:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
           args: --root-dir . --verbose --no-progress './**/*.md'
           fail: true
           jobSummary: true
+          # Pin lychee >= 0.24.0 so the action matches the version brew
+          # installs locally; required for the new `include_fragments` enum
+          # syntax in lychee.toml.
+          lycheeVersion: v0.24.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   docker-smoke:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -72,14 +72,14 @@ jobs:
 
       # --- Check internal links in built output ---
       - name: Check internal links
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2
+        # Keep this SHA in sync with .github/workflows/ci.yml — see the
+        # comment there for why we pin a post-v2.8.0 master commit.
+        uses: lycheeverse/lychee-action@b40e218fdac9481d3c13098d4e1ee56f3b589356  # master @ 2026-05-03
         with:
           args: --offline --root-dir site/dist --no-progress --verbose --index-files
             index.html 'site/dist/**/*.html'
           fail: true
           jobSummary: true
-          # Keep this in sync with .github/workflows/ci.yml.
-          lycheeVersion: v0.24.2
 
       # --- Deploy unified Worker (production) ---
       - name: Deploy production

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -78,6 +78,8 @@ jobs:
             index.html 'site/dist/**/*.html'
           fail: true
           jobSummary: true
+          # Keep this in sync with .github/workflows/ci.yml.
+          lycheeVersion: v0.24.2
 
       # --- Deploy unified Worker (production) ---
       - name: Deploy production

--- a/lychee.toml
+++ b/lychee.toml
@@ -39,5 +39,7 @@ exclude_path = [
 
 #############################  Checking  ############################
 
-# Also check URL fragments/anchors (e.g. #section-name)
-include_fragments = true
+# Check URL fragments/anchors (e.g. #section-name).
+# Lychee 0.24.0 changed this from a boolean to an enum: none | anchor-only |
+# text-only | full. "anchor-only" preserves the pre-0.24.0 behavior.
+include_fragments = "anchor-only"


### PR DESCRIPTION
## Summary

`just check` (and `just links`) currently fail to even parse `lychee.toml` on any locally-installed lychee `>= 0.24.0`:

```
[ERROR] Error while loading config: Cannot load configuration file: lychee.toml

Caused by:
    0: Failed to parse configuration file
    1: TOML parse error at line 43, column 21
          |
       43 | include_fragments = true
          |                     ^^^^
       wanted string or table
```

[Lychee 0.24.0](https://github.com/lycheeverse/lychee/releases/tag/lychee-v0.24.0) (2026-04-24) split fragment checking into anchor vs. text fragments via [#2138](https://github.com/lycheeverse/lychee/pull/2138). Two coupled changes happened upstream that this PR has to reconcile:

1. The `include_fragments` config option became an enum: `none | anchor-only | text-only | full`.
2. The lychee release tarballs got reorganized: the binary is now nested under `lychee-x86_64-unknown-linux-gnu/lychee` instead of being flat at the top level.

So this PR is three small things that have to land together:

| File | Change | Why |
|---|---|---|
| `lychee.toml` | `include_fragments = true` → `"anchor-only"` | New enum schema; `"anchor-only"` matches the old boolean's behavior. |
| `.github/workflows/ci.yml` | Bump `lychee-action` SHA from `8646ba30…` (`v2`/`v2.8.0`) to `b40e218f…` (master @ 2026-05-03) | Released action defaults to lychee v0.23.0 *and* its installer can't unpack the new tarball layout. Master fixes both. SHA-pinned, so behavior is still frozen. |
| `.github/workflows/site.yml` | Same SHA bump, kept in sync | `site/dist/` link check doesn't load `lychee.toml`, but pin in lockstep so the two workflows stay aligned. |

Followed the iteration honestly through the commit history if you want to see the dead ends — first commit fixes the config but leaves CI on v0.23.0 (red), second commit pins `lycheeVersion: v0.24.2` (still red because the v2.8.0 installer can't unpack v0.24.x), third commit bumps the action SHA to a master commit that handles both.

## Why CI on develop has been green up to now

CI was on lychee **v0.23.0** the whole time — the `v2.8.0` action defaults to it. `include_fragments = true` is valid in v0.23.0, so nothing complained. The schema break only surfaces locally when someone upgrades brew's lychee to >= 0.24.0.

## Notes on pinning to an unreleased commit

`b40e218f` is on `master`, not on a tagged release. lychee-action hasn't cut a v2.9.0 yet (latest tag is v2.8.0 from 2026-02-25). Because we pin by SHA, the pin freezes behavior just like the old one did — there's no "auto-update" risk. When a tagged release lands that includes the same fix, we can swap the pin back to a tagged ref (with a `# v2.9.x` comment).

## Reviewer Notes

Three small files changed:

- `lychee.toml` — config value flipped from boolean to enum string, with an inline comment about the schema change.
- `.github/workflows/ci.yml` — SHA bumped, multi-line comment explains why.
- `.github/workflows/site.yml` — same SHA, points at the ci.yml comment.

To reproduce the original failure on `develop`:

```bash
git fetch origin develop
git checkout origin/develop -- lychee.toml
brew install lychee  # or upgrade if you already have it; needs >= 0.24.0
just links           # explodes with the TOML parse error above
```

To verify the fix locally:

```bash
git checkout fix/lychee-include-fragments-schema -- lychee.toml
just links           # passes; "🔍 145 Total ✅ 70 OK 🚫 0 Errors 👻 75 Excluded"
just check           # all checks green
```

CI verification is just "the `links` job goes green on this PR" — the workflow change can't really be tested any other way short of running it.

No behavior change for users — this is dev/CI tooling only, so no `CHANGELOG.md` entry.

## Test plan

- [x] `just links` passes locally on lychee 0.24.2
- [x] `just check` passes end-to-end locally
- [x] `just yaml-check`, `just actions-lint`, `just zizmor` all green on the workflow edits
- [ ] CI `links` job green on this PR