### PR TITLE
Fix adapter artifact semantics and readable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - Added `kitaru.current_execution_id()` as the public way to read the active Kitaru execution ID inside a running flow or checkpoint.
 
+### Fixed
+- PydanticAI granular checkpoints now store model messages and tool arguments as structural checkpoint inputs and use the returned checkpoint output as the canonical response/result artifact, avoiding duplicate manual artifacts in new runs.
+
 ## [0.11.0] - 2026-05-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - PydanticAI granular checkpoints now store model messages and tool arguments as structural checkpoint inputs and use the returned checkpoint output as the canonical response/result artifact, avoiding duplicate manual artifacts in new runs.
+- OpenAI Agents `checkpoint_strategy="calls"` now stores model inputs and function-tool arguments as structural checkpoint inputs, and adapter-generated artifact names now put the human-readable role first across PydanticAI, OpenAI Agents, and Claude Agent SDK captures.
 
 ## [0.11.0] - 2026-05-12
 

--- a/examples/features/replay/replay_with_overrides.py
+++ b/examples/features/replay/replay_with_overrides.py
@@ -78,7 +78,10 @@ def run_workflow(topic: str = "kitaru") -> tuple[str, str, str, str]:
 
     # Load the replayed output from the publish checkpoint.
     publish_cp = next(cp for cp in execution.checkpoints if cp.name == "publish")
-    replay_output = str(publish_cp.artifacts[0].load())
+    publish_output = next(
+        artifact for artifact in publish_cp.artifacts if artifact.direction == "output"
+    )
+    replay_output = str(publish_output.load())
     print(f"Replay output:  {replay_output}")
 
     return source_handle.exec_id, replayed.exec_id, original_result, replay_output

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -265,6 +265,19 @@ def _map_artifact_ref(
     )
 
 
+def _adapter_structural_input_kind(
+    *,
+    checkpoint_type: str | None,
+    input_name: str,
+) -> str | None:
+    """Return public kind for adapter structural inputs, if exposable."""
+    if checkpoint_type == "llm_call" and input_name == "input":
+        return "prompt"
+    if checkpoint_type == "tool_call" and input_name == "tool_args":
+        return "input"
+    return None
+
+
 def _map_checkpoint_call(
     *,
     step: StepRunResponse,
@@ -278,17 +291,18 @@ def _map_checkpoint_call(
     artifacts: list[ArtifactRef] = []
 
     for input_name, input_artifacts in step.inputs.items():
+        input_kind = _adapter_structural_input_kind(
+            checkpoint_type=checkpoint_type,
+            input_name=input_name,
+        )
+        if input_kind is None:
+            continue
         for artifact in input_artifacts:
             artifact_id = str(artifact.id)
             if artifact_id in seen_artifact_ids:
                 continue
             seen_artifact_ids.add(artifact_id)
             input_type = getattr(getattr(artifact, "input_type", None), "value", None)
-            input_kind = (
-                "prompt"
-                if checkpoint_type == "llm_call" and input_name == "messages"
-                else "input"
-            )
             artifacts.append(
                 _map_artifact_ref(
                     artifact=artifact,
@@ -614,6 +628,7 @@ __all__ = [
     "_CHECKPOINT_SOURCE_ALIAS_PREFIX",
     "_PIPELINE_SOURCE_ALIAS_PREFIX",
     "_WAIT_CONDITION_STATUS_PENDING",
+    "_adapter_structural_input_kind",
     "_checkpoint_lineage_key",
     "_coerce_status_filter",
     "_first_pending_wait",

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import ValidationError
 from zenml.models import PipelineRunResponse, StepRunResponse
@@ -241,20 +241,27 @@ def _map_artifact_ref(
     artifact: ArtifactVersionResponse,
     client: KitaruClient,
     producing_call: str | None,
+    name: str | None = None,
+    direction: Literal["input", "output"] = "output",
+    input_type: str | None = None,
+    fallback_kind: str | None = None,
 ) -> ArtifactRef:
     """Map a ZenML artifact response into a Kitaru artifact reference."""
     metadata = _to_plain_dict(artifact.run_metadata)
     raw_kind = metadata.get("kitaru_artifact_type")
-    kind = raw_kind if isinstance(raw_kind, str) else None
+    kind = raw_kind if isinstance(raw_kind, str) else fallback_kind
+    artifact_name = name or artifact.name
 
     return ArtifactRef(
         artifact_id=str(artifact.id),
-        name=artifact.name,
+        name=artifact_name,
         kind=kind,
         save_type=artifact.save_type.value,
         producing_call=producing_call,
         metadata=metadata,
         _client=client,
+        direction=direction,
+        input_type=input_type,
     )
 
 
@@ -266,20 +273,52 @@ def _map_checkpoint_call(
 ) -> CheckpointCall:
     """Map a ZenML step run into a Kitaru checkpoint call."""
     producing_call = _normalize_checkpoint_name(step.name)
+    checkpoint_type = step.type.value if step.type else None
     seen_artifact_ids: set[str] = set()
     artifacts: list[ArtifactRef] = []
 
-    for output_artifacts in step.outputs.values():
+    for input_name, input_artifacts in step.inputs.items():
+        for artifact in input_artifacts:
+            artifact_id = str(artifact.id)
+            if artifact_id in seen_artifact_ids:
+                continue
+            seen_artifact_ids.add(artifact_id)
+            input_type = getattr(getattr(artifact, "input_type", None), "value", None)
+            input_kind = (
+                "prompt"
+                if checkpoint_type == "llm_call" and input_name == "messages"
+                else "input"
+            )
+            artifacts.append(
+                _map_artifact_ref(
+                    artifact=artifact,
+                    client=client,
+                    producing_call=None,
+                    name=input_name,
+                    direction="input",
+                    input_type=input_type,
+                    fallback_kind=input_kind,
+                )
+            )
+
+    for output_name, output_artifacts in step.outputs.items():
         for artifact in output_artifacts:
             artifact_id = str(artifact.id)
             if artifact_id in seen_artifact_ids:
                 continue
             seen_artifact_ids.add(artifact_id)
+            output_kind = None
+            if output_name == "output":
+                if checkpoint_type == "llm_call":
+                    output_kind = "response"
+                elif checkpoint_type == "tool_call":
+                    output_kind = "output"
             artifacts.append(
                 _map_artifact_ref(
                     artifact=artifact,
                     client=client,
                     producing_call=producing_call,
+                    fallback_kind=output_kind,
                 )
             )
 
@@ -294,8 +333,6 @@ def _map_checkpoint_call(
     original_call_id: str | None = None
     if step.original_step_run_id is not None:
         original_call_id = str(step.original_step_run_id)
-
-    checkpoint_type = step.type.value if step.type else None
 
     return CheckpointCall(
         call_id=str(step.id),

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -558,13 +558,18 @@ def _map_execution(
                 )
             )
 
-        seen_artifact_ids: set[str] = set()
+        artifact_indexes_by_id: dict[str, int] = {}
         for checkpoint in checkpoints:
             for artifact in checkpoint.artifacts:
-                if artifact.artifact_id in seen_artifact_ids:
+                existing_index = artifact_indexes_by_id.get(artifact.artifact_id)
+                if existing_index is None:
+                    artifact_indexes_by_id[artifact.artifact_id] = len(artifacts)
+                    artifacts.append(artifact)
                     continue
-                seen_artifact_ids.add(artifact.artifact_id)
-                artifacts.append(artifact)
+
+                existing = artifacts[existing_index]
+                if existing.direction == "input" and artifact.direction == "output":
+                    artifacts[existing_index] = artifact
 
     metadata = _to_plain_dict(run.run_metadata)
 

--- a/src/kitaru/_client/_models.py
+++ b/src/kitaru/_client/_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from kitaru.config import FrozenExecutionSpec
 from kitaru.errors import FailureOrigin
@@ -159,6 +159,8 @@ class ArtifactRef:
     producing_call: str | None
     metadata: dict[str, Any]
     _client: KitaruClient = field(repr=False, compare=False)
+    direction: Literal["input", "output"] = "output"
+    input_type: str | None = None
 
     def load(self) -> Any:
         """Load and materialize this artifact value."""

--- a/src/kitaru/_inspection_serialization.py
+++ b/src/kitaru/_inspection_serialization.py
@@ -114,7 +114,7 @@ def serialize_pending_wait(wait: PendingWait | None) -> dict[str, Any] | None:
 
 def serialize_artifact_ref(artifact: ArtifactRef) -> dict[str, Any]:
     """Serialize artifact metadata."""
-    return {
+    payload = {
         "artifact_id": artifact.artifact_id,
         "name": artifact.name,
         "kind": artifact.kind,
@@ -122,6 +122,11 @@ def serialize_artifact_ref(artifact: ArtifactRef) -> dict[str, Any]:
         "producing_call": artifact.producing_call,
         "metadata": to_jsonable(artifact.metadata, fallback_repr=True),
     }
+    if artifact.direction == "input":
+        payload["direction"] = "input"
+    if artifact.input_type is not None:
+        payload["input_type"] = artifact.input_type
+    return payload
 
 
 def serialize_artifact_value(value: Any) -> dict[str, Any]:

--- a/src/kitaru/adapters/claude_agent_sdk/_tracking.py
+++ b/src/kitaru/adapters/claude_agent_sdk/_tracking.py
@@ -46,7 +46,7 @@ def normalize_runner_name(runner_name: str | None) -> str:
 
 
 def artifact_name(runner_name: str, run_label: str, kind: ArtifactKind) -> str:
-    return f"{normalize_runner_name(runner_name)}_{run_label}_{kind}"
+    return f"{kind}__{normalize_runner_name(runner_name)}_{run_label}"
 
 
 @dataclass(frozen=True)

--- a/src/kitaru/adapters/openai_agents/_events.py
+++ b/src/kitaru/adapters/openai_agents/_events.py
@@ -35,6 +35,8 @@ class OpenAIRunEvent(BaseModel):
     sequence_index: int
     run_label: str
     agent_name: str
+    checkpoint_id: str | None = None
+    checkpoint_name: str | None = None
     duration_ms: float | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
     artifacts: dict[str, str] = Field(default_factory=dict)

--- a/src/kitaru/adapters/openai_agents/_kitaru_internal.py
+++ b/src/kitaru/adapters/openai_agents/_kitaru_internal.py
@@ -5,6 +5,9 @@ try:
         _get_current_checkpoint as get_current_checkpoint,
     )
     from kitaru.runtime import (
+        _get_current_checkpoint_id as get_current_checkpoint_id,
+    )
+    from kitaru.runtime import (
         _get_current_checkpoint_name as get_current_checkpoint_name,
     )
     from kitaru.runtime import (
@@ -20,13 +23,15 @@ except ImportError as error:  # pragma: no cover - unsupported old Kitaru only
     raise ImportError(
         "Unsupported Kitaru version for `kitaru.adapters.openai_agents`: "
         "install a Kitaru release that exposes the runtime helpers "
-        "(`_get_current_checkpoint`, `_get_current_checkpoint_name`, "
-        "`_get_current_execution_id`, `_is_inside_checkpoint`, "
+        "(`_get_current_checkpoint`, `_get_current_checkpoint_id`, "
+        "`_get_current_checkpoint_name`, `_get_current_execution_id`, "
+        "`_is_inside_checkpoint`, "
         "`_is_inside_flow`)."
     ) from error
 
 __all__ = [
     "get_current_checkpoint",
+    "get_current_checkpoint_id",
     "get_current_checkpoint_name",
     "get_current_execution_id",
     "is_inside_checkpoint",

--- a/src/kitaru/adapters/openai_agents/_model.py
+++ b/src/kitaru/adapters/openai_agents/_model.py
@@ -16,12 +16,33 @@ from ._tracking import artifact_name, get_current_tracker
 from ._usage import normalize_usage
 from ._utils import (
     CheckpointConfig,
+    adapter_checkpoint_artifact_refs,
     checkpoint_cache_key,
     elapsed_ms,
+    get_adapter_checkpoint_artifact_refs,
     run_async_in_checkpoint,
     safe_step_name,
     with_default_type,
 )
+
+
+def _model_input_envelope(
+    *,
+    system_instructions: str | None,
+    input: Any,
+    model_settings: Any,
+    previous_response_id: str | None,
+    conversation_id: str | None,
+    prompt: Any,
+) -> dict[str, Any]:
+    return {
+        "system_instructions": system_instructions,
+        "input": to_json_safe(input),
+        "model_settings": to_json_safe(model_settings),
+        "previous_response_id": previous_response_id,
+        "conversation_id": conversation_id,
+        "prompt": to_json_safe(prompt),
+    }
 
 
 class KitaruOpenAIModel(Model):
@@ -68,20 +89,44 @@ class KitaruOpenAIModel(Model):
             and is_inside_flow()
             and not is_inside_checkpoint()
         ):
-
-            async def _in_checkpoint() -> Any:
-                return await self._tracked_get_response(
-                    system_instructions,
-                    input,
-                    model_settings,
-                    tools,
-                    output_schema,
-                    handoffs,
-                    tracing,
+            input_envelope = (
+                _model_input_envelope(
+                    system_instructions=system_instructions,
+                    input=input,
+                    model_settings=model_settings,
                     previous_response_id=previous_response_id,
                     conversation_id=conversation_id,
                     prompt=prompt,
                 )
+                if self._capture.save_input
+                else None
+            )
+            checkpoint_inputs = (
+                {"input": input_envelope} if input_envelope is not None else None
+            )
+            input_artifacts = {"input": "input"} if self._capture.save_input else {}
+            output_artifacts = (
+                {"response": "output"} if self._capture.save_final_output else {}
+            )
+
+            async def _in_checkpoint() -> Any:
+                with adapter_checkpoint_artifact_refs(
+                    input_artifacts=input_artifacts,
+                    output_artifacts=output_artifacts,
+                ):
+                    return await self._tracked_get_response(
+                        system_instructions,
+                        input,
+                        model_settings,
+                        tools,
+                        output_schema,
+                        handoffs,
+                        tracing,
+                        previous_response_id=previous_response_id,
+                        conversation_id=conversation_id,
+                        prompt=prompt,
+                        input_envelope=input_envelope,
+                    )
 
             response = await run_async_in_checkpoint(
                 config=with_default_type(self._checkpoint_config, "llm_call"),
@@ -101,6 +146,7 @@ class KitaruOpenAIModel(Model):
                         "prompt": to_cache_identity(prompt),
                     }
                 ),
+                checkpoint_inputs=checkpoint_inputs,
             )
             self._reserve_tool_call_order(response, tools)
             return response
@@ -132,6 +178,7 @@ class KitaruOpenAIModel(Model):
         previous_response_id: str | None,
         conversation_id: str | None,
         prompt: Any,
+        input_envelope: Mapping[str, Any] | None = None,
     ) -> Any:
         tracker = get_current_tracker()
         should_track = (
@@ -156,21 +203,22 @@ class KitaruOpenAIModel(Model):
         assert tracker is not None
         event_id, event_context = tracker.start_llm_event()
         artifacts: dict[str, str] = {}
+        adapter_refs = get_adapter_checkpoint_artifact_refs()
         if self._capture.save_input:
-            input_key = artifact_name(event_id, "input")
-            kitaru.save(
-                input_key,
-                {
-                    "system_instructions": system_instructions,
-                    "input": to_json_safe(input),
-                    "model_settings": to_json_safe(model_settings),
-                    "previous_response_id": previous_response_id,
-                    "conversation_id": conversation_id,
-                    "prompt": to_json_safe(prompt),
-                },
-                type="input",
-            )
-            artifacts["input"] = input_key
+            if adapter_refs is not None and "input" in adapter_refs.input_artifacts:
+                artifacts["input"] = adapter_refs.input_artifacts["input"]
+            else:
+                input_envelope = input_envelope or _model_input_envelope(
+                    system_instructions=system_instructions,
+                    input=input,
+                    model_settings=model_settings,
+                    previous_response_id=previous_response_id,
+                    conversation_id=conversation_id,
+                    prompt=prompt,
+                )
+                input_key = artifact_name(event_id, "input")
+                kitaru.save(input_key, input_envelope, type="input")
+                artifacts["input"] = input_key
 
         started_at = time.perf_counter()
         try:
@@ -207,9 +255,12 @@ class KitaruOpenAIModel(Model):
         if self._capture.save_response_items:
             metadata["response_item_count"] = len(getattr(response, "output", []) or [])
         if self._capture.save_final_output:
-            response_key = artifact_name(event_id, "response")
-            kitaru.save(response_key, to_json_safe(response), type="response")
-            artifacts["response"] = response_key
+            if adapter_refs is not None and "response" in adapter_refs.output_artifacts:
+                artifacts["response"] = adapter_refs.output_artifacts["response"]
+            else:
+                response_key = artifact_name(event_id, "response")
+                kitaru.save(response_key, to_json_safe(response), type="response")
+                artifacts["response"] = response_key
         if self._capture.save_usage:
             usage_key = artifact_name(event_id, "usage")
             kitaru.save(usage_key, usage.model_dump(mode="json"), type="context")

--- a/src/kitaru/adapters/openai_agents/_tools.py
+++ b/src/kitaru/adapters/openai_agents/_tools.py
@@ -16,8 +16,10 @@ from ._tracking import artifact_name, get_current_tracker
 from ._utils import (
     CheckpointConfig,
     ToolCheckpointOverrides,
+    adapter_checkpoint_artifact_refs,
     checkpoint_cache_key,
     elapsed_ms,
+    get_adapter_checkpoint_artifact_refs,
     resolve_tool_checkpoint_config,
     run_async_in_checkpoint,
     safe_step_name,
@@ -93,16 +95,35 @@ def _wrap_function_tool(
             and is_inside_flow()
             and not is_inside_checkpoint()
         ):
+            input_envelope = (
+                _tool_input_envelope(
+                    tool=tool,
+                    tool_call_id=tool_call_id,
+                    input_json=input_json,
+                )
+                if capture.save_input
+                else None
+            )
+            checkpoint_inputs = (
+                {"tool_args": input_envelope} if input_envelope is not None else None
+            )
+            input_artifacts = {"input": "tool_args"} if capture.save_input else {}
+            output_artifacts = {"result": "output"} if capture.save_final_output else {}
 
             async def _in_checkpoint() -> Any:
-                return await _tracked_tool_call(
-                    original_callback,
-                    context,
-                    input_json,
-                    tool=tool,
-                    capture=capture,
-                    tool_call_id=tool_call_id,
-                )
+                with adapter_checkpoint_artifact_refs(
+                    input_artifacts=input_artifacts,
+                    output_artifacts=output_artifacts,
+                ):
+                    return await _tracked_tool_call(
+                        original_callback,
+                        context,
+                        input_json,
+                        tool=tool,
+                        capture=capture,
+                        tool_call_id=tool_call_id,
+                        input_envelope=input_envelope,
+                    )
 
             return await run_async_in_checkpoint(
                 config=with_default_type(checkpoint_config, "tool_call"),
@@ -117,6 +138,7 @@ def _wrap_function_tool(
                         "input_json": input_json,
                     }
                 ),
+                checkpoint_inputs=checkpoint_inputs,
             )
         return await _tracked_tool_call(
             original_callback,
@@ -140,6 +162,7 @@ async def _tracked_tool_call(
     tool: FunctionTool,
     capture: OpenAICapturePolicy,
     tool_call_id: str | None,
+    input_envelope: dict[str, Any] | None = None,
 ) -> Any:
     tracker = get_current_tracker()
     should_track = (
@@ -151,20 +174,19 @@ async def _tracked_tool_call(
     assert tracker is not None
     event_id, event_context = tracker.start_tool_event(tool_call_id=tool_call_id)
     artifacts: dict[str, str] = {}
-    parsed_args = _parse_json(input_json)
+    adapter_refs = get_adapter_checkpoint_artifact_refs()
     if capture.save_input:
-        args_key = artifact_name(event_id, "input")
-        kitaru.save(
-            args_key,
-            {
-                "tool_name": tool.name,
-                "tool_call_id": tool_call_id,
-                "raw_args": input_json,
-                "parsed_args": parsed_args,
-            },
-            type="input",
-        )
-        artifacts["input"] = args_key
+        if adapter_refs is not None and "input" in adapter_refs.input_artifacts:
+            artifacts["input"] = adapter_refs.input_artifacts["input"]
+        else:
+            input_envelope = input_envelope or _tool_input_envelope(
+                tool=tool,
+                tool_call_id=tool_call_id,
+                input_json=input_json,
+            )
+            args_key = artifact_name(event_id, "input")
+            kitaru.save(args_key, input_envelope, type="input")
+            artifacts["input"] = args_key
 
     started_at = time.perf_counter()
     try:
@@ -183,9 +205,12 @@ async def _tracked_tool_call(
         raise
 
     if capture.save_final_output:
-        result_key = artifact_name(event_id, "result")
-        kitaru.save(result_key, to_json_safe(result), type="output")
-        artifacts["result"] = result_key
+        if adapter_refs is not None and "result" in adapter_refs.output_artifacts:
+            artifacts["result"] = adapter_refs.output_artifacts["result"]
+        else:
+            result_key = artifact_name(event_id, "result")
+            kitaru.save(result_key, to_json_safe(result), type="output")
+            artifacts["result"] = result_key
 
     tracker.record_event(
         event_id,
@@ -202,6 +227,20 @@ async def _tracked_tool_call(
         },
     )
     return result
+
+
+def _tool_input_envelope(
+    *,
+    tool: FunctionTool,
+    tool_call_id: str | None,
+    input_json: str,
+) -> dict[str, Any]:
+    return {
+        "tool_name": tool.name,
+        "tool_call_id": tool_call_id,
+        "raw_args": input_json,
+        "parsed_args": _parse_json(input_json),
+    }
 
 
 def _tool_checkpoint_sequence() -> int | None:

--- a/src/kitaru/adapters/openai_agents/_tracking.py
+++ b/src/kitaru/adapters/openai_agents/_tracking.py
@@ -25,6 +25,7 @@ from ._events import (
 from ._kitaru_internal import is_inside_checkpoint, is_inside_flow
 
 _NON_WORD_PATTERN = re.compile(r"\W+")
+_EVENT_ID_DISPLAY_PATTERN = re.compile(r"^(.+)_(llm_call|tool_call)_(\d+)$")
 ArtifactKind = Literal["input", "result", "response", "usage", "error"]
 
 
@@ -34,7 +35,11 @@ def normalize_agent_name(agent_name: str | None) -> str:
 
 
 def artifact_name(event_id: str, kind: ArtifactKind) -> str:
-    return f"{event_id}_{kind}"
+    match = _EVENT_ID_DISPLAY_PATTERN.match(event_id)
+    if match is None:
+        return f"{event_id}_{kind}"
+    namespace, event_kind, sequence_index = match.groups()
+    return f"{event_kind}_{sequence_index}_{kind}__{namespace}"
 
 
 @dataclass(frozen=True)
@@ -83,11 +88,11 @@ class EventTracker:
 
     @property
     def event_log_artifact_name(self) -> str:
-        return f"{self.agent_name}_{self.run_label}_event_log"
+        return f"event_log__{self.agent_name}_{self.run_label}"
 
     @property
     def run_summary_artifact_name(self) -> str:
-        return f"{self.agent_name}_{self.run_label}_run_summary"
+        return f"run_summary__{self.agent_name}_{self.run_label}"
 
     def _next_event_id(self, event_kind: str) -> tuple[str, int]:
         self._counter += 1

--- a/src/kitaru/adapters/openai_agents/_tracking.py
+++ b/src/kitaru/adapters/openai_agents/_tracking.py
@@ -22,7 +22,12 @@ from ._events import (
     dump_openai_events,
     error_from_exception,
 )
-from ._kitaru_internal import is_inside_checkpoint, is_inside_flow
+from ._kitaru_internal import (
+    get_current_checkpoint_id,
+    get_current_checkpoint_name,
+    is_inside_checkpoint,
+    is_inside_flow,
+)
 
 _NON_WORD_PATTERN = re.compile(r"\W+")
 _EVENT_ID_DISPLAY_PATTERN = re.compile(r"^(.+)_(llm_call|tool_call)_(\d+)$")
@@ -45,6 +50,23 @@ def artifact_name(event_id: str, kind: ArtifactKind) -> str:
 @dataclass(frozen=True)
 class EventContext:
     sequence_index: int
+    checkpoint_id: str | None = None
+    checkpoint_name: str | None = None
+
+
+def _current_checkpoint_identity() -> tuple[str | None, str | None]:
+    """Return active checkpoint identity without letting observability fail calls."""
+    try:
+        if not is_inside_checkpoint():
+            return None, None
+        checkpoint_id = get_current_checkpoint_id()
+        checkpoint_name = get_current_checkpoint_name()
+        return (
+            str(checkpoint_id) if checkpoint_id is not None else None,
+            str(checkpoint_name) if checkpoint_name is not None else None,
+        )
+    except Exception:
+        return None, None
 
 
 @dataclass(frozen=True)
@@ -110,8 +132,13 @@ class EventTracker:
             if not self._active_tool_event_ids:
                 self._clear_reserved_tool_events_unlocked()
             event_id, sequence_index = self._next_event_id("llm_call")
+            checkpoint_id, checkpoint_name = _current_checkpoint_identity()
             self._model_call_count += 1
-            return event_id, EventContext(sequence_index=sequence_index)
+            return event_id, EventContext(
+                sequence_index=sequence_index,
+                checkpoint_id=checkpoint_id,
+                checkpoint_name=checkpoint_name,
+            )
 
     def reserve_tool_call_order(
         self,
@@ -167,9 +194,14 @@ class EventTracker:
                 event_id = reservation.event_id
                 sequence_index = reservation.sequence_index
 
+            checkpoint_id, checkpoint_name = _current_checkpoint_identity()
             self._tool_call_count += 1
             self._active_tool_event_ids.add(event_id)
-            return event_id, EventContext(sequence_index=sequence_index)
+            return event_id, EventContext(
+                sequence_index=sequence_index,
+                checkpoint_id=checkpoint_id,
+                checkpoint_name=checkpoint_name,
+            )
 
     def record_event(
         self,
@@ -182,6 +214,8 @@ class EventTracker:
         artifacts: dict[str, str] | None = None,
         metadata: dict[str, object] | None = None,
         error: BaseException | None = None,
+        checkpoint_id: str | None = None,
+        checkpoint_name: str | None = None,
     ) -> None:
         with self._lock:
             if kind == "tool_call":
@@ -194,6 +228,10 @@ class EventTracker:
                     sequence_index=context.sequence_index,
                     run_label=self.run_label,
                     agent_name=self.agent_name,
+                    checkpoint_id=checkpoint_id
+                    or getattr(context, "checkpoint_id", None),
+                    checkpoint_name=checkpoint_name
+                    or getattr(context, "checkpoint_name", None),
                     duration_ms=duration_ms,
                     metadata=metadata or {},
                     artifacts=artifacts or {},

--- a/src/kitaru/adapters/openai_agents/_utils.py
+++ b/src/kitaru/adapters/openai_agents/_utils.py
@@ -11,7 +11,10 @@ import json
 import re
 import sys
 import time
-from collections.abc import Callable, Coroutine, Mapping
+from collections.abc import Callable, Coroutine, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 from pydantic_core import to_jsonable_python
@@ -35,6 +38,19 @@ class CheckpointConfig(TypedDict, total=False):
 
 ToolCheckpointOverride = CheckpointConfig | Literal[False]
 ToolCheckpointOverrides = Mapping[str, ToolCheckpointOverride]
+
+
+@dataclass(frozen=True)
+class AdapterCheckpointArtifactRefs:
+    """Display references for artifacts owned by a synthetic checkpoint."""
+
+    input_artifacts: Mapping[str, str]
+    output_artifacts: Mapping[str, str]
+
+
+_ADAPTER_CHECKPOINT_ARTIFACT_REFS: ContextVar[AdapterCheckpointArtifactRefs | None] = (
+    ContextVar("kitaru_openai_agents_adapter_checkpoint_artifact_refs", default=None)
+)
 
 _ALLOWED_CHECKPOINT_CONFIG_KEYS = frozenset({"runtime", "retries", "type"})
 _VALID_CHECKPOINT_STRATEGIES = frozenset({"calls", "runner_call"})
@@ -146,6 +162,29 @@ def with_default_type(config: CheckpointConfig, default_type: str) -> Checkpoint
     return {**config, "type": default_type}
 
 
+@contextmanager
+def adapter_checkpoint_artifact_refs(
+    *,
+    input_artifacts: Mapping[str, str] | None = None,
+    output_artifacts: Mapping[str, str] | None = None,
+) -> Iterator[AdapterCheckpointArtifactRefs]:
+    """Expose structural/canonical artifact slot names inside a checkpoint."""
+    refs = AdapterCheckpointArtifactRefs(
+        input_artifacts=input_artifacts or {},
+        output_artifacts=output_artifacts or {},
+    )
+    token = _ADAPTER_CHECKPOINT_ARTIFACT_REFS.set(refs)
+    try:
+        yield refs
+    finally:
+        _ADAPTER_CHECKPOINT_ARTIFACT_REFS.reset(token)
+
+
+def get_adapter_checkpoint_artifact_refs() -> AdapterCheckpointArtifactRefs | None:
+    """Return granular checkpoint artifact slot references, if any."""
+    return _ADAPTER_CHECKPOINT_ARTIFACT_REFS.get()
+
+
 def resolve_tool_checkpoint_config(
     tool_name: str,
     *,
@@ -192,18 +231,47 @@ def safe_step_name(value: str) -> str:
 
 
 def _build_checkpoint_step(
-    *, config: CheckpointConfig, step_name: str, body: Callable[[], Any]
+    *,
+    config: CheckpointConfig,
+    step_name: str,
+    body: Callable[[], Any],
+    checkpoint_inputs: Mapping[str, Any] | None = None,
 ) -> Callable[..., Any]:
     reject_isolated_runtime(config)
 
-    def _call(_cache_key: str | None = None) -> Any:
-        return body()
+    input_names = frozenset(checkpoint_inputs or {})
+    if input_names == frozenset():
 
-    _call.__name__ = safe_step_name(step_name)
-    checkpoint_def = kitaru.checkpoint(**config)(_call)
+        def _call_without_inputs(_cache_key: str | None = None) -> Any:
+            return body()
+
+        call = _call_without_inputs
+    elif input_names == {"input"}:
+
+        def _call_with_input(input: Any, _cache_key: str | None = None) -> Any:
+            return body()
+
+        call = _call_with_input
+    elif input_names == {"tool_args"}:
+
+        def _call_with_tool_args(
+            tool_args: Any,
+            _cache_key: str | None = None,
+        ) -> Any:
+            return body()
+
+        call = _call_with_tool_args
+    else:
+        unsupported = ", ".join(sorted(input_names))
+        raise KitaruUsageError(
+            f"Unsupported synthetic checkpoint inputs: {unsupported}."
+        )
+
+    call.__name__ = safe_step_name(step_name)
+    checkpoint_def = kitaru.checkpoint(**config)(call)
     step_obj = getattr(checkpoint_def, "_step", None)
     if step_obj is not None:
-        alias = build_checkpoint_source_alias(_call.__name__)
+        alias = build_checkpoint_source_alias(call.__name__)
         for module_name in {__name__, f"src.{__name__}"}:
             module = sys.modules.get(module_name)
             if module is not None:
@@ -217,14 +285,18 @@ def run_sync_in_checkpoint(
     step_name: str,
     body: Callable[[], Any],
     cache_key: str | None = None,
+    checkpoint_inputs: Mapping[str, Any] | None = None,
 ) -> Any:
     """Run a sync body inside a synthetic ``@kitaru.checkpoint``."""
     checkpoint_def = _build_checkpoint_step(
         config=config,
         step_name=step_name,
         body=body,
+        checkpoint_inputs=checkpoint_inputs,
     )
-    return materialize_step_output(checkpoint_def(cache_key))
+    return materialize_step_output(
+        checkpoint_def(**(checkpoint_inputs or {}), _cache_key=cache_key)
+    )
 
 
 async def run_async_in_checkpoint(
@@ -233,6 +305,7 @@ async def run_async_in_checkpoint(
     step_name: str,
     body: Callable[[], Coroutine[Any, Any, Any]],
     cache_key: str | None = None,
+    checkpoint_inputs: Mapping[str, Any] | None = None,
 ) -> Any:
     """Run an async body inside a synthetic ``@kitaru.checkpoint``.
 
@@ -244,6 +317,11 @@ async def run_async_in_checkpoint(
         config=config,
         step_name=step_name,
         body=lambda: asyncio.run(body()),
+        checkpoint_inputs=checkpoint_inputs,
     )
-    step_output = await asyncio.to_thread(checkpoint_def, cache_key)
+    step_output = await asyncio.to_thread(
+        checkpoint_def,
+        **(checkpoint_inputs or {}),
+        _cache_key=cache_key,
+    )
     return materialize_step_output(step_output)

--- a/src/kitaru/adapters/pydantic_ai/README.md
+++ b/src/kitaru/adapters/pydantic_ai/README.md
@@ -281,9 +281,9 @@ With `persist_message_history=True` the adapter remembers `result.all_messages()
 ## Requirements and constraints
 
 - **Concrete model at construction time.** The wrapped agent must have a bound `Model` — late model binding and per-run `model=` overrides are not supported. If you need a different model, wrap a different agent.
-- **Stable agent name.** A `name` is required; the adapter uses it for artifact keys and auto-created flow/checkpoint names. Changing it orphans existing executions.
+- **Stable agent name.** A `name` is required; the adapter uses it for artifact keys and auto-created flow/checkpoint names. `KitaruAgent(name=...)` wins over the wrapped Pydantic AI `Agent(name=...)`; if the wrapper name is omitted, the wrapped agent name is used. Changing this stable name orphans existing executions.
 - **No nested checkpoints.** Kitaru's MVP forbids opening a checkpoint inside another. Granular mode therefore cannot coexist with an enclosing turn checkpoint — the adapter runs the agent body inline at flow scope when `granular_checkpoints=True`.
-- **Auto-flow is local-only.** When called outside any flow, `KitaruAgent` auto-opens one using an in-process registry. Remote stacks (Kubernetes, Vertex, SageMaker, AzureML) cannot see that registry — wrap the call in an explicit `@kitaru.flow` for those. Serializing an arbitrary agent closure isn't worth the machinery when a one-line decorator does the job.
+- **Auto-flow is local-only.** When called outside any flow, `KitaruAgent` auto-opens a flow named `{stable_agent_name}_flow` using an in-process registry. If you call the agent inside your own explicit `@kitaru.flow`, that outer flow keeps its own name. Remote stacks (Kubernetes, Vertex, SageMaker, AzureML) cannot see the auto-flow registry — wrap the call in an explicit `@kitaru.flow` for those. Serializing an arbitrary agent closure isn't worth the machinery when a one-line decorator does the job.
 
 ## Advanced composition
 

--- a/src/kitaru/adapters/pydantic_ai/_agent.py
+++ b/src/kitaru/adapters/pydantic_ai/_agent.py
@@ -7,12 +7,21 @@ import time
 import uuid
 import warnings
 from dataclasses import dataclass
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Iterator, Mapping, Sequence
+from collections.abc import (
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from typing import Any
 
 import kitaru
+from kitaru._source_aliases import build_pipeline_registration_name
 from kitaru.analytics import AnalyticsEvent, track
 from kitaru.errors import KitaruRuntimeError, KitaruUsageError
 from kitaru.flow import _is_multiple_terminal_steps_output_error
@@ -51,10 +60,12 @@ from ._utils import (
     validate_tool_checkpoint_overrides,
 )
 
-_TRACKING_ACTIVE: ContextVar[bool] = ContextVar('kitaru_tracking_active', default=False)
-_INTERNAL_ITER_ALLOWED: ContextVar[bool] = ContextVar('kitaru_internal_iter_allowed', default=False)
+_TRACKING_ACTIVE: ContextVar[bool] = ContextVar("kitaru_tracking_active", default=False)
+_INTERNAL_ITER_ALLOWED: ContextVar[bool] = ContextVar(
+    "kitaru_internal_iter_allowed", default=False
+)
 _INTERNAL_RUN_SYNC_DELEGATION: ContextVar[bool] = ContextVar(
-    'kitaru_internal_run_sync_delegation', default=False
+    "kitaru_internal_run_sync_delegation", default=False
 )
 
 
@@ -65,19 +76,23 @@ class _TurnCheckpointCallConfig:
     checkpoint_config: CheckpointConfig
     force_turn_checkpoint: bool
 
+
 # Auto-flow bodies keyed by uuid. The @kitaru.flow entrypoint must be module-
 # level for ZenML dynamic-pipeline source resolution, so it can't close over
 # its body — the registry bridges the gap. In-process only; remote stacks
 # require an explicit @kitaru.flow.
-_AUTO_FLOW_BODIES: dict[str, '_AutoFlowSlot'] = {}
+_AUTO_FLOW_BODIES: dict[str, "_AutoFlowSlot"] = {}
+# Intentionally unbounded: agent names should be stable/low-cardinality, and
+# evicting generated flows can break ZenML/Kitaru source resolution.
+_AUTO_FLOW_DEFINITIONS: dict[str, Any] = {}
 _AUTO_FLOW_LOCK = threading.Lock()
 
-if f'src.{__name__}' not in sys.modules:
-    sys.modules[f'src.{__name__}'] = sys.modules[__name__]
+if f"src.{__name__}" not in sys.modules:
+    sys.modules[f"src.{__name__}"] = sys.modules[__name__]
 
 
 class _AutoFlowSlot:
-    __slots__ = ('body', 'error', 'has_result', 'result')
+    __slots__ = ("body", "error", "has_result", "result")
 
     def __init__(self, body: Callable[[], Any]) -> None:
         self.body = body
@@ -91,9 +106,9 @@ def _load_auto_flow_body(serialized_body_path: str) -> Callable[[], Any]:
         import cloudpickle
     except ImportError as error:  # pragma: no cover - depends on env packaging
         raise KitaruUsageError(
-            'Auto-flow requires `cloudpickle` in the local runtime environment.'
+            "Auto-flow requires `cloudpickle` in the local runtime environment."
         ) from error
-    with open(serialized_body_path, 'rb') as stream:
+    with open(serialized_body_path, "rb") as stream:
         return cloudpickle.load(stream)
 
 
@@ -106,15 +121,15 @@ def _try_serialize_auto_flow_body(body: Callable[[], Any]) -> str | None:
     path: str | None = None
     try:
         with tempfile.NamedTemporaryFile(
-            delete=False, suffix='.kitaru-autoflow'
+            delete=False, suffix=".kitaru-autoflow"
         ) as stream:
             path = stream.name
             cloudpickle.dump(body, stream)
         return path
     except Exception:
         logger.debug(
-            'Auto-flow body could not be cloudpickled; remote stacks will need '
-            'an explicit `@kitaru.flow` wrapper.',
+            "Auto-flow body could not be cloudpickled; remote stacks will need "
+            "an explicit `@kitaru.flow` wrapper.",
             exc_info=True,
         )
         if path is not None:
@@ -125,17 +140,16 @@ def _try_serialize_auto_flow_body(body: Callable[[], Any]) -> str | None:
         return None
 
 
-@kitaru.flow
-def _kitaru_pydantic_ai_auto_flow(run_id: str, serialized_body_path: str | None = None) -> Any:
+def _run_auto_flow_body(run_id: str, serialized_body_path: str | None = None) -> Any:
     with _AUTO_FLOW_LOCK:
         slot = _AUTO_FLOW_BODIES.get(run_id)
     if slot is None and serialized_body_path is not None:
         slot = _AutoFlowSlot(_load_auto_flow_body(serialized_body_path))
     if slot is None:
         raise KitaruUsageError(
-            f'Kitaru auto-flow body {run_id!r} not found in registry. Auto-flow '
-            'is local-only; wrap your agent call in an explicit `@kitaru.flow` '
-            'for remote stacks.'
+            f"Kitaru auto-flow body {run_id!r} not found in registry. Auto-flow "
+            "is local-only; wrap your agent call in an explicit `@kitaru.flow` "
+            "for remote stacks."
         )
     try:
         slot.result = slot.body()
@@ -146,20 +160,68 @@ def _kitaru_pydantic_ai_auto_flow(run_id: str, serialized_body_path: str | None 
         raise
 
 
+# Keep the original importable auto-flow for runs recorded before per-agent
+# auto-flow names existed.
+@kitaru.flow
+def _kitaru_pydantic_ai_auto_flow(
+    run_id: str, serialized_body_path: str | None = None
+) -> Any:
+    return _run_auto_flow_body(run_id, serialized_body_path)
+
+
+def _auto_flow_name_for_agent(agent_name: str) -> str:
+    return build_pipeline_registration_name(f"{agent_name}_flow")
+
+
+def _install_auto_flow_source_entrypoint(
+    flow_name: str,
+    entrypoint: Callable[[str, str | None], Any],
+) -> None:
+    # ZenML reloads dynamic pipelines by importing module attributes; install
+    # generated entrypoints before decoration so Kitaru can source-alias them.
+    setattr(sys.modules[__name__], flow_name, entrypoint)
+
+
+def _make_auto_flow_entrypoint(flow_name: str) -> Callable[[str, str | None], Any]:
+    def _auto_flow_entrypoint(
+        run_id: str, serialized_body_path: str | None = None
+    ) -> Any:
+        return _run_auto_flow_body(run_id, serialized_body_path)
+
+    _auto_flow_entrypoint.__name__ = flow_name
+    _auto_flow_entrypoint.__qualname__ = flow_name
+    _auto_flow_entrypoint.__module__ = __name__
+    return _auto_flow_entrypoint
+
+
+def _auto_flow_for_agent(agent_name: str) -> Any:
+    flow_name = _auto_flow_name_for_agent(agent_name)
+    with _AUTO_FLOW_LOCK:
+        flow_definition = _AUTO_FLOW_DEFINITIONS.get(flow_name)
+        if flow_definition is not None:
+            return flow_definition
+
+        entrypoint = _make_auto_flow_entrypoint(flow_name)
+        _install_auto_flow_source_entrypoint(flow_name, entrypoint)
+        flow_definition = kitaru.flow(entrypoint)
+        _AUTO_FLOW_DEFINITIONS[flow_name] = flow_definition
+        return flow_definition
+
+
 def _is_wrapped_handler(handler: Any) -> bool:
-    if getattr(handler, '_kitaru_wrapped', False):
+    if getattr(handler, "_kitaru_wrapped", False):
         return True
-    inner = getattr(handler, 'func', None) or getattr(handler, '__func__', None)
-    return bool(inner is not None and getattr(inner, '_kitaru_wrapped', False))
+    inner = getattr(handler, "func", None) or getattr(handler, "__func__", None)
+    return bool(inner is not None and getattr(inner, "_kitaru_wrapped", False))
 
 
 _STREAMING_HOOK_ATTRS = (
-    'on_event',
-    'on_run_event_stream',
-    'event',
-    'run_event_stream',
+    "on_event",
+    "on_run_event_stream",
+    "event",
+    "run_event_stream",
 )
-_STREAMING_HOOK_REGISTRY_KEYS = ('_on_event', 'wrap_run_event_stream')
+_STREAMING_HOOK_REGISTRY_KEYS = ("_on_event", "wrap_run_event_stream")
 
 
 def _capabilities_imply_streaming_hooks(
@@ -169,10 +231,10 @@ def _capabilities_imply_streaming_hooks(
         return False
 
     for capability in capabilities:
-        if getattr(capability, 'has_wrap_run_event_stream', False):
+        if getattr(capability, "has_wrap_run_event_stream", False):
             return True
 
-        registry = getattr(capability, '_registry', None)
+        registry = getattr(capability, "_registry", None)
         if isinstance(registry, Mapping) and any(
             registry.get(key) for key in _STREAMING_HOOK_REGISTRY_KEYS
         ):
@@ -194,22 +256,22 @@ def _upstream_run_kwargs(
     """Return PydanticAI run kwargs only when callers explicitly set them."""
     kwargs: dict[str, Any] = {}
     if conversation_id is not None:
-        kwargs['conversation_id'] = conversation_id
+        kwargs["conversation_id"] = conversation_id
     if output_retries is not None:
-        kwargs['output_retries'] = output_retries
+        kwargs["output_retries"] = output_retries
     return kwargs
 
 
 def _track_run_completed(method: str, error: BaseException | None) -> None:
     if error is None:
-        status = 'completed'
+        status = "completed"
     elif isinstance(error, asyncio.CancelledError):
-        status = 'cancelled'
+        status = "cancelled"
     else:
-        status = 'failed'
-    payload: dict[str, Any] = {'method': method, 'status': status}
+        status = "failed"
+    payload: dict[str, Any] = {"method": method, "status": status}
     if error is not None:
-        payload['error_type'] = type(error).__name__
+        payload["error_type"] = type(error).__name__
     track(AnalyticsEvent.PYDANTIC_AI_RUN_COMPLETED, payload)
 
 
@@ -271,19 +333,21 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
 
         if not isinstance(wrapped.model, Model):
             raise UserError(
-                'KitaruAgent requires the wrapped agent to define a concrete model at construction time; '
-                'pass `model=` to the Agent constructor.'
+                "KitaruAgent requires the wrapped agent to define a concrete model at construction time; "
+                "pass `model=` to the Agent constructor."
             )
 
         self._name = name or wrapped.name
         if self._name is None:
             raise UserError(
-                'KitaruAgent requires a stable `name`; pass `name=` to KitaruAgent or set the wrapped agent name.'
+                "KitaruAgent requires a stable `name`; pass `name=` to KitaruAgent or set the wrapped agent name."
             )
         self._capture = capture or CapturePolicy()
         self._event_stream_handler = event_stream_handler
         self._turn_checkpoint_config: CheckpointConfig = (
-            validate_checkpoint_config(turn_checkpoint_config, context='turn_checkpoint_config')
+            validate_checkpoint_config(
+                turn_checkpoint_config, context="turn_checkpoint_config"
+            )
             or {}
         )
         self._granular_checkpoints = granular_checkpoints
@@ -300,33 +364,33 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         )
         if has_granular_configs and not granular_checkpoints:
             raise KitaruUsageError(
-                'Per-call checkpoint configs require `granular_checkpoints=True`.'
+                "Per-call checkpoint configs require `granular_checkpoints=True`."
             )
         if granular_checkpoints:
             self._model_checkpoint_config = (
                 validate_checkpoint_config(
                     model_checkpoint_config or {},
-                    context='model_checkpoint_config',
+                    context="model_checkpoint_config",
                 )
                 or {}
             )
             self._tool_checkpoint_config = (
                 validate_checkpoint_config(
                     tool_checkpoint_config or {},
-                    context='tool_checkpoint_config',
+                    context="tool_checkpoint_config",
                 )
                 or {}
             )
             self._tool_checkpoint_config_by_name: ToolCheckpointOverrides | None = (
                 validate_tool_checkpoint_overrides(
                     tool_checkpoint_config_by_name,
-                    context='tool_checkpoint_config_by_name',
+                    context="tool_checkpoint_config_by_name",
                 )
             )
             self._mcp_checkpoint_config = (
                 validate_checkpoint_config(
                     mcp_checkpoint_config or {},
-                    context='mcp_checkpoint_config',
+                    context="mcp_checkpoint_config",
                 )
                 or {}
             )
@@ -348,9 +412,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         track(
             AnalyticsEvent.PYDANTIC_AI_WRAPPED,
             {
-                'toolset_count': len(self._toolsets),
-                'granular_checkpoints': granular_checkpoints,
-                'persist_message_history': persist_message_history,
+                "toolset_count": len(self._toolsets),
+                "granular_checkpoints": granular_checkpoints,
+                "persist_message_history": persist_message_history,
             },
         )
 
@@ -360,7 +424,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
 
     @name.setter
     def name(self, value: str | None) -> None:
-        raise UserError('The agent name cannot be changed after creation. Create a new KitaruAgent instead.')
+        raise UserError(
+            "The agent name cannot be changed after creation. Create a new KitaruAgent instead."
+        )
 
     @property
     def model(self) -> Model:
@@ -383,7 +449,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         with super().override(model=self._model, toolsets=self._toolsets, tools=[]):
             yield
 
-    def _prepare_toolsets(self, toolsets: Sequence[AbstractToolset[AgentDepsT]]) -> list[AbstractToolset[AgentDepsT]]:
+    def _prepare_toolsets(
+        self, toolsets: Sequence[AbstractToolset[AgentDepsT]]
+    ) -> list[AbstractToolset[AgentDepsT]]:
         def _visit(value: AbstractToolset[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
             return kitaruify_toolset(
                 value,
@@ -424,12 +492,14 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         _tracked_handler._kitaru_wrapped = True  # ty: ignore[unresolved-attribute]
         return _tracked_handler
 
-    def _validate_model_override(self, model: models.Model | models.KnownModelName | str | None) -> None:
+    def _validate_model_override(
+        self, model: models.Model | models.KnownModelName | str | None
+    ) -> None:
         if model is None:
             return
         raise UserError(
-            'KitaruAgent does not support per-run `model=` overrides; create a new KitaruAgent '
-            'wrapping a different agent instead.'
+            "KitaruAgent does not support per-run `model=` overrides; create a new KitaruAgent "
+            "wrapping a different agent instead."
         )
 
     @contextmanager
@@ -447,17 +517,17 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
     ) -> Iterator[None]:
         unsupported: list[str] = []
         if _utils.is_set(name):
-            unsupported.append('`name=`')
+            unsupported.append("`name=`")
         if _utils.is_set(model):
-            unsupported.append('`model=`')
+            unsupported.append("`model=`")
         if _utils.is_set(toolsets):
-            unsupported.append('`toolsets=`')
+            unsupported.append("`toolsets=`")
         if _utils.is_set(tools):
-            unsupported.append('`tools=`')
+            unsupported.append("`tools=`")
         if unsupported:
-            overrides = ', '.join(unsupported)
+            overrides = ", ".join(unsupported)
             raise UserError(
-                f'KitaruAgent does not support contextual {overrides} overrides; create a new KitaruAgent instead.'
+                f"KitaruAgent does not support contextual {overrides} overrides; create a new KitaruAgent instead."
             )
 
         with super().override(
@@ -504,9 +574,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
     ) -> dict[str, Any]:
         inputs: dict[str, Any] = {}
         if user_prompt is not None:
-            inputs['user_prompt'] = checkpoint_input_value(user_prompt)
+            inputs["user_prompt"] = checkpoint_input_value(user_prompt)
         if message_history is not None:
-            inputs['message_history'] = checkpoint_input_value(list(message_history))
+            inputs["message_history"] = checkpoint_input_value(list(message_history))
         return inputs
 
     def _turn_checkpoint_config_for_call(
@@ -516,7 +586,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
     ) -> CheckpointConfig:
         if not disable_cache:
             return self._turn_checkpoint_config
-        return {**self._turn_checkpoint_config, 'cache': False}
+        return {**self._turn_checkpoint_config, "cache": False}
 
     def _prepare_turn_checkpoint_call_config(
         self,
@@ -540,8 +610,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         capabilities: Sequence[AbstractCapability[AgentDepsT]] | None,
         spec: dict[str, Any] | None,
     ) -> _TurnCheckpointCallConfig:
-        force_turn_checkpoint = event_stream_handler is not None or _capabilities_imply_streaming_hooks(
-            capabilities
+        force_turn_checkpoint = (
+            event_stream_handler is not None
+            or _capabilities_imply_streaming_hooks(capabilities)
         )
         return _TurnCheckpointCallConfig(
             cache_key=turn_cache_key(
@@ -585,7 +656,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
     ) -> Any:
         return await run_async_in_checkpoint(
             config=checkpoint_config or self._turn_checkpoint_config,
-            step_name=self._name or 'agent',
+            step_name=self._name or "agent",
             body=body,
             cache_key=cache_key,
             checkpoint_inputs=checkpoint_inputs,
@@ -601,7 +672,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
     ) -> Any:
         return run_sync_in_checkpoint(
             config=checkpoint_config or self._turn_checkpoint_config,
-            step_name=self._name or 'agent',
+            step_name=self._name or "agent",
             body=body,
             cache_key=cache_key,
             checkpoint_inputs=checkpoint_inputs,
@@ -616,7 +687,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             _AUTO_FLOW_BODIES[run_id] = slot
         try:
             serialized_body_path = _try_serialize_auto_flow_body(body)
-            handle = _kitaru_pydantic_ai_auto_flow.run(run_id, serialized_body_path)
+            handle = _auto_flow_for_agent(self._name).run(run_id, serialized_body_path)
             try:
                 flow_result = handle.wait()
             except KitaruRuntimeError as error:
@@ -654,11 +725,11 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
     def _remember_messages(self, result: Any) -> None:
         if not self._persist_message_history:
             return
-        all_messages = getattr(result, 'all_messages', None)
+        all_messages = getattr(result, "all_messages", None)
         if not callable(all_messages):
             raise KitaruRuntimeError(
-                'KitaruAgent could not refresh persisted message history because '
-                'the run result does not expose all_messages().'
+                "KitaruAgent could not refresh persisted message history because "
+                "the run result does not expose all_messages()."
             )
         with self._message_history_lock:
             self._last_messages = list(all_messages())
@@ -673,13 +744,13 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             return
         self._warned_checkpoint_history_limit = True
         message = (
-            '`persist_message_history=True` is only in-memory. This agent call '
-            'is running inside an existing `@kitaru.checkpoint`; if that '
-            'checkpoint is served from cache during replay/resume, the adapter '
-            'will not execute and cannot restore `_last_messages`. For '
-            'resume-safe conversations, call the agent at flow scope in '
-            'granular mode, or pass `message_history=` explicitly from your '
-            'own durable storage.'
+            "`persist_message_history=True` is only in-memory. This agent call "
+            "is running inside an existing `@kitaru.checkpoint`; if that "
+            "checkpoint is served from cache during replay/resume, the adapter "
+            "will not execute and cannot restore `_last_messages`. For "
+            "resume-safe conversations, call the agent at flow scope in "
+            "granular mode, or pass `message_history=` explicitly from your "
+            "own durable storage."
         )
         warnings.warn(message, UserWarning, stacklevel=3)
 
@@ -696,10 +767,13 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         dropped_configs = [
             name
             for name, config in (
-                ('model_checkpoint_config', self._model_checkpoint_config),
-                ('tool_checkpoint_config', self._tool_checkpoint_config),
-                ('tool_checkpoint_config_by_name', self._tool_checkpoint_config_by_name),
-                ('mcp_checkpoint_config', self._mcp_checkpoint_config),
+                ("model_checkpoint_config", self._model_checkpoint_config),
+                ("tool_checkpoint_config", self._tool_checkpoint_config),
+                (
+                    "tool_checkpoint_config_by_name",
+                    self._tool_checkpoint_config_by_name,
+                ),
+                ("mcp_checkpoint_config", self._mcp_checkpoint_config),
             )
             if config
         ]
@@ -707,13 +781,13 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             return
         self._warned_streaming_fallback = True
         logger.warning(
-            'Falling back to turn checkpointing for a streamed PydanticAI run; '
-            'granular checkpoint configs are ignored for this call.',
-            extra={'dropped_configs': dropped_configs, 'agent_name': self._name},
+            "Falling back to turn checkpointing for a streamed PydanticAI run; "
+            "granular checkpoint configs are ignored for this call.",
+            extra={"dropped_configs": dropped_configs, "agent_name": self._name},
         )
         if is_inside_flow() and not is_inside_checkpoint():
             kitaru.log(
-                adapter='pydantic_ai',
+                adapter="pydantic_ai",
                 streaming_fallback=True,
                 dropped_checkpoint_configs=dropped_configs,
             )
@@ -725,8 +799,8 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         except RuntimeError:
             return
         raise KitaruUsageError(
-            '`KitaruAgent.run_sync()` cannot be called from a running event loop. '
-            'Use `await agent.run(...)` instead.'
+            "`KitaruAgent.run_sync()` cannot be called from a running event loop. "
+            "Use `await agent.run(...)` instead."
         )
 
     def _ensure_auto_flow_mcp_lifecycle_safe(
@@ -745,14 +819,14 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             return
 
         raise KitaruUsageError(
-            'KitaruAgent cannot auto-open a flow around an already-running '
-            'PydanticAI MCP server. Auto-flow runs async agent bodies in a '
-            'worker thread/event loop so it can wait for the flow without '
-            'blocking your caller loop. Your MCP server is already open on the '
-            'caller loop, so moving the agent run can hang after a successful '
-            'MCP request. Wrap this call in an explicit `@kitaru.flow` while '
-            'the MCP server lifecycle is open, or do not pre-open the MCP server '
-            'and let PydanticAI/Kitaru auto-connect it.'
+            "KitaruAgent cannot auto-open a flow around an already-running "
+            "PydanticAI MCP server. Auto-flow runs async agent bodies in a "
+            "worker thread/event loop so it can wait for the flow without "
+            "blocking your caller loop. Your MCP server is already open on the "
+            "caller loop, so moving the agent run can hang after a successful "
+            "MCP request. Wrap this call in an explicit `@kitaru.flow` while "
+            "the MCP server lifecycle is open, or do not pre-open the MCP server "
+            "and let PydanticAI/Kitaru auto-connect it."
         )
 
     async def _run_async(
@@ -833,10 +907,10 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         if is_inside_checkpoint():
             return
         raise UserError(
-            f'`agent.{method_name}()` requires an explicit `@kitaru.checkpoint`. '
-            'Kitaru cannot auto-open one around a streaming context manager; '
-            'wrap the surrounding block in `@kitaru.flow` + `@kitaru.checkpoint`, '
-            'or use `agent.run()` with an `event_stream_handler` instead.'
+            f"`agent.{method_name}()` requires an explicit `@kitaru.checkpoint`. "
+            "Kitaru cannot auto-open one around a streaming context manager; "
+            "wrap the surrounding block in `@kitaru.flow` + `@kitaru.checkpoint`, "
+            "or use `agent.run()` with an `event_stream_handler` instead."
         )
 
     async def run(
@@ -864,7 +938,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
     ) -> Any:
         self._validate_model_override(model)
         self._warn_if_persist_history_inside_checkpoint()
-        prepared_toolsets = self._prepare_toolsets(toolsets) if toolsets is not None else None
+        prepared_toolsets = (
+            self._prepare_toolsets(toolsets) if toolsets is not None else None
+        )
         wrapped_handler = self._prepare_event_stream_handler(event_stream_handler)
         effective_history = self._effective_message_history(message_history)
         upstream_run_kwargs = _upstream_run_kwargs(
@@ -942,7 +1018,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             error = exc
             raise
         finally:
-            _track_run_completed('run', error)
+            _track_run_completed("run", error)
 
     def run_sync(
         self,
@@ -970,7 +1046,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         self._ensure_run_sync_safe()
         self._validate_model_override(model)
         self._warn_if_persist_history_inside_checkpoint()
-        prepared_toolsets = self._prepare_toolsets(toolsets) if toolsets is not None else None
+        prepared_toolsets = (
+            self._prepare_toolsets(toolsets) if toolsets is not None else None
+        )
         wrapped_handler = self._prepare_event_stream_handler(event_stream_handler)
         effective_history = self._effective_message_history(message_history)
         upstream_run_kwargs = _upstream_run_kwargs(
@@ -1052,7 +1130,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             error = exc
             raise
         finally:
-            _track_run_completed('run_sync', error)
+            _track_run_completed("run_sync", error)
 
     @asynccontextmanager
     async def run_stream(
@@ -1079,8 +1157,10 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         spec: dict[str, Any] | None = None,
     ) -> AsyncIterator[Any]:
         self._validate_model_override(model)
-        self._require_explicit_checkpoint('run_stream')
-        prepared_toolsets = self._prepare_toolsets(toolsets) if toolsets is not None else None
+        self._require_explicit_checkpoint("run_stream")
+        prepared_toolsets = (
+            self._prepare_toolsets(toolsets) if toolsets is not None else None
+        )
         wrapped_handler = self._prepare_event_stream_handler(event_stream_handler)
         upstream_run_kwargs = _upstream_run_kwargs(
             conversation_id=conversation_id,
@@ -1143,8 +1223,10 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         # would require a checkpoint primitive that itself is a context manager, which
         # kitaru.checkpoint isn't. Wrap iter() in an explicit @kitaru.checkpoint instead.
         self._validate_model_override(model)
-        self._require_explicit_checkpoint('iter')
-        prepared_toolsets = self._prepare_toolsets(toolsets) if toolsets is not None else None
+        self._require_explicit_checkpoint("iter")
+        prepared_toolsets = (
+            self._prepare_toolsets(toolsets) if toolsets is not None else None
+        )
         upstream_run_kwargs = _upstream_run_kwargs(
             conversation_id=conversation_id,
             output_retries=output_retries,

--- a/src/kitaru/adapters/pydantic_ai/_constants.py
+++ b/src/kitaru/adapters/pydantic_ai/_constants.py
@@ -1,4 +1,13 @@
 """Shared constants for the PydanticAI adapter."""
 
-ADAPTER_ID = 'pydantic_ai'
-ADAPTER_METADATA_KEY = 'adapter'
+ADAPTER_ID = "pydantic_ai"
+ADAPTER_METADATA_KEY = "adapter"
+
+ARTIFACT_ROLE_ARGS = "args"
+ARTIFACT_ROLE_PROMPT = "prompt"
+ARTIFACT_ROLE_RESPONSE = "response"
+ARTIFACT_ROLE_RESULT = "result"
+ARTIFACT_ROLE_STREAM_TRANSCRIPT = "stream_transcript"
+ARTIFACT_SLOT_MESSAGES = "messages"
+ARTIFACT_SLOT_OUTPUT = "output"
+ARTIFACT_SLOT_TOOL_ARGS = "tool_args"

--- a/src/kitaru/adapters/pydantic_ai/_events.py
+++ b/src/kitaru/adapters/pydantic_ai/_events.py
@@ -6,30 +6,32 @@ from pydantic_ai.usage import RequestUsage
 
 from ._policy import CaptureMode
 
-EventStatus = Literal['completed', 'failed']
-ToolsetKind = Literal['function', 'mcp', 'generic']
-DeferredKind = Literal['hitl', 'approval_required', 'call_deferred']
+EventStatus = Literal["completed", "failed"]
+ToolsetKind = Literal["function", "mcp", "generic"]
+DeferredKind = Literal["hitl", "approval_required", "call_deferred"]
 
 
 class EventError(BaseModel):
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
     exception_type: str
     message: str
 
 
 class _BaseEvent(BaseModel):
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
     event_id: str
     status: EventStatus
     sequence_index: int
     turn_index: int
     parent_event_ids: list[str] = Field(default_factory=list)
+    checkpoint_name: str | None = None
+    checkpoint_id: str | None = None
 
 
 class ModelEvent(_BaseEvent):
-    kind: Literal['llm_call'] = 'llm_call'
+    kind: Literal["llm_call"] = "llm_call"
     fan_in_from: list[str] = Field(default_factory=list)
     duration_ms: float | None = None
     artifacts: dict[str, str] = Field(default_factory=dict)
@@ -40,7 +42,7 @@ class ModelEvent(_BaseEvent):
 
 
 class ToolEvent(_BaseEvent):
-    kind: Literal['tool_call'] = 'tool_call'
+    kind: Literal["tool_call"] = "tool_call"
     tool_name: str
     toolset_kind: ToolsetKind
     hitl: bool = False
@@ -52,7 +54,7 @@ class ToolEvent(_BaseEvent):
 
 
 class DeferredEvent(_BaseEvent):
-    kind: Literal['deferred'] = 'deferred'
+    kind: Literal["deferred"] = "deferred"
     tool_name: str
     deferred_kind: DeferredKind
     wait_name: str
@@ -61,25 +63,27 @@ class DeferredEvent(_BaseEvent):
 
 
 class StreamEvent(_BaseEvent):
-    kind: Literal['event_stream'] = 'event_stream'
+    kind: Literal["event_stream"] = "event_stream"
     index: int
     duration_ms: float
     error: EventError | None = None
 
 
-AgentEvent = Annotated[ModelEvent | ToolEvent | DeferredEvent | StreamEvent, Field(discriminator='kind')]
+AgentEvent = Annotated[
+    ModelEvent | ToolEvent | DeferredEvent | StreamEvent, Field(discriminator="kind")
+]
 AgentEventsTypeAdapter = TypeAdapter(list[AgentEvent])
 
 
 class EventStreamHandlerSummary(BaseModel):
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
     call_count: int
     duration_ms: float
 
 
 class RunSummary(BaseModel):
-    model_config = ConfigDict(extra='forbid')
+    model_config = ConfigDict(extra="forbid")
 
     agent_name: str
     run_label: str
@@ -102,4 +106,6 @@ def error_from_exception(error: BaseException) -> EventError:
 
 
 def dump_agent_events(events: list[AgentEvent]) -> list[dict[str, Any]]:
-    return cast(list[dict[str, Any]], AgentEventsTypeAdapter.dump_python(events, mode='json'))
+    return cast(
+        list[dict[str, Any]], AgentEventsTypeAdapter.dump_python(events, mode="json")
+    )

--- a/src/kitaru/adapters/pydantic_ai/_model.py
+++ b/src/kitaru/adapters/pydantic_ai/_model.py
@@ -30,6 +30,13 @@ from pydantic_ai.models.wrapper import WrapperModel
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import RequestUsage
 
+from ._constants import (
+    ARTIFACT_ROLE_PROMPT,
+    ARTIFACT_ROLE_RESPONSE,
+    ARTIFACT_ROLE_STREAM_TRANSCRIPT,
+    ARTIFACT_SLOT_MESSAGES,
+    ARTIFACT_SLOT_OUTPUT,
+)
 from ._kitaru_internal import is_inside_checkpoint, is_inside_flow
 from ._logging import logger
 from ._otel import attach_model_correlation
@@ -37,7 +44,10 @@ from ._policy import CapturePolicy
 from ._tracking import EventTracker, ModelEventContext, get_current_tracker
 from ._utils import (
     CheckpointConfig,
+    adapter_checkpoint_artifact_refs,
     checkpoint_cache_key,
+    checkpoint_input_value,
+    get_adapter_checkpoint_artifact_refs,
     run_async_in_checkpoint,
     with_default_type,
 )
@@ -129,12 +139,18 @@ def _strip_message_envelope_for_cache(message: dict[str, Any]) -> dict[str, Any]
     return stable_message
 
 
+def _messages_for_cache(
+    serialized_messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return serialized messages with volatile envelope fields removed."""
+    return [
+        _strip_message_envelope_for_cache(message) for message in serialized_messages
+    ]
+
+
 def _serialize_messages_for_cache(messages: list[ModelMessage]) -> list[dict[str, Any]]:
     """Serialize messages for cache keys while preserving user payload content."""
-    return [
-        _strip_message_envelope_for_cache(message)
-        for message in _serialize_messages(messages)
-    ]
+    return _messages_for_cache(_serialize_messages(messages))
 
 
 def _serialize_model_response(response: ModelResponse) -> dict[str, Any]:
@@ -267,6 +283,7 @@ class KitaruModel(WrapperModel):
         response: ModelResponse,
         model_request_parameters: ModelRequestParameters,
         duration_ms: float,
+        checkpoint_name: str,
     ) -> None:
         tracker = get_current_tracker()
         if tracker is None or not self._capture.emit_child_events:
@@ -275,14 +292,20 @@ class KitaruModel(WrapperModel):
         event_id, event_context = tracker.start_model_event()
         if self._capture.correlate_otel_spans:
             attach_model_correlation(event_id, event_context)
+        artifacts: dict[str, str] = {}
+        if self._capture.save_prompts:
+            artifacts[ARTIFACT_ROLE_PROMPT] = ARTIFACT_SLOT_MESSAGES
+        if self._capture.save_responses:
+            artifacts[ARTIFACT_ROLE_RESPONSE] = ARTIFACT_SLOT_OUTPUT
         tracker.record_model_event(
             event_id,
             event_context,
             status="completed",
             duration_ms=duration_ms,
-            artifacts={},
+            artifacts=artifacts,
             model_name=response.model_name,
             usage=response.usage,
+            checkpoint_name=checkpoint_name,
         )
         self._reserve_tool_call_order(
             tracker=tracker,
@@ -305,38 +328,59 @@ class KitaruModel(WrapperModel):
         ):
             body_executed = False
 
+            serialized_messages = _serialize_messages(messages)
+            input_artifacts: dict[str, str] = {}
+            output_artifacts: dict[str, str] = {}
+            checkpoint_inputs: dict[str, Any] = {}
+            if self._capture.save_prompts:
+                input_artifacts[ARTIFACT_ROLE_PROMPT] = ARTIFACT_SLOT_MESSAGES
+                checkpoint_inputs[ARTIFACT_SLOT_MESSAGES] = checkpoint_input_value(
+                    serialized_messages
+                )
+            if self._capture.save_responses:
+                output_artifacts[ARTIFACT_ROLE_RESPONSE] = ARTIFACT_SLOT_OUTPUT
+
             # `_in_checkpoint` closes over live `messages` / `self`; safe only for
             # inline runtime. `run_async_in_checkpoint` rejects `runtime='isolated'`
             # to stop these references from hitting a pickling boundary.
             async def _in_checkpoint() -> ModelResponse:
                 nonlocal body_executed
                 body_executed = True
-                return await self._tracked_request(
-                    messages, model_settings, model_request_parameters
-                )
+                with adapter_checkpoint_artifact_refs(
+                    input_artifacts=input_artifacts,
+                    output_artifacts=output_artifacts,
+                ):
+                    return await self._tracked_request(
+                        messages, model_settings, model_request_parameters
+                    )
 
             cache_key = None
             if self._checkpoint_config.get("cache") is not False:
                 cache_key = checkpoint_cache_key(
                     {
-                        "messages": _serialize_messages_for_cache(messages),
+                        ARTIFACT_SLOT_MESSAGES: _messages_for_cache(
+                            serialized_messages
+                        ),
                         "explicit_run_conversation_id": _EXPLICIT_RUN_CONVERSATION_ID.get(),
                         "model_settings": model_settings,
                         "model_request_parameters": model_request_parameters,
                     }
                 )
             started_at = time.perf_counter()
+            checkpoint_name = f"{self._agent_name}_model_request"
             response = await run_async_in_checkpoint(
                 config=with_default_type(self._checkpoint_config, "llm_call"),
-                step_name=f"{self._agent_name}_model_request",
+                step_name=checkpoint_name,
                 body=_in_checkpoint,
                 cache_key=cache_key,
+                checkpoint_inputs=checkpoint_inputs,
             )
             if not body_executed:
                 self._record_cached_model_checkpoint_event(
                     response=response,
                     model_request_parameters=model_request_parameters,
                     duration_ms=round((time.perf_counter() - started_at) * 1000, 3),
+                    checkpoint_name=checkpoint_name,
                 )
             return response
         return await self._tracked_request(
@@ -360,10 +404,23 @@ class KitaruModel(WrapperModel):
             attach_model_correlation(event_id, event_context)
 
         artifacts: dict[str, str] = {}
+        adapter_refs = get_adapter_checkpoint_artifact_refs()
         if self._capture.save_prompts:
-            prompt_key = tracker.artifact_name(event_id, "prompt")
-            kitaru.save(prompt_key, _serialize_messages(messages), type="prompt")
-            artifacts["prompt"] = prompt_key
+            if (
+                adapter_refs is not None
+                and ARTIFACT_ROLE_PROMPT in adapter_refs.input_artifacts
+            ):
+                artifacts[ARTIFACT_ROLE_PROMPT] = adapter_refs.input_artifacts[
+                    ARTIFACT_ROLE_PROMPT
+                ]
+            else:
+                prompt_key = tracker.artifact_name(event_id, ARTIFACT_ROLE_PROMPT)
+                kitaru.save(
+                    prompt_key,
+                    _serialize_messages(messages),
+                    type=ARTIFACT_ROLE_PROMPT,
+                )
+                artifacts[ARTIFACT_ROLE_PROMPT] = prompt_key
 
         started_at = time.perf_counter()
         try:
@@ -383,11 +440,21 @@ class KitaruModel(WrapperModel):
 
         duration_ms = round((time.perf_counter() - started_at) * 1000, 3)
         if self._capture.save_responses:
-            response_key = tracker.artifact_name(event_id, "response")
-            kitaru.save(
-                response_key, _serialize_model_response(response), type="response"
-            )
-            artifacts["response"] = response_key
+            if (
+                adapter_refs is not None
+                and ARTIFACT_ROLE_RESPONSE in adapter_refs.output_artifacts
+            ):
+                artifacts[ARTIFACT_ROLE_RESPONSE] = adapter_refs.output_artifacts[
+                    ARTIFACT_ROLE_RESPONSE
+                ]
+            else:
+                response_key = tracker.artifact_name(event_id, ARTIFACT_ROLE_RESPONSE)
+                kitaru.save(
+                    response_key,
+                    _serialize_model_response(response),
+                    type=ARTIFACT_ROLE_RESPONSE,
+                )
+                artifacts[ARTIFACT_ROLE_RESPONSE] = response_key
 
         tracker.record_model_event(
             event_id,
@@ -429,9 +496,13 @@ class KitaruModel(WrapperModel):
 
         artifacts: dict[str, str] = {}
         if self._capture.save_prompts:
-            prompt_key = tracker.artifact_name(event_id, "prompt")
-            kitaru.save(prompt_key, _serialize_messages(messages), type="prompt")
-            artifacts["prompt"] = prompt_key
+            prompt_key = tracker.artifact_name(event_id, ARTIFACT_ROLE_PROMPT)
+            kitaru.save(
+                prompt_key,
+                _serialize_messages(messages),
+                type=ARTIFACT_ROLE_PROMPT,
+            )
+            artifacts[ARTIFACT_ROLE_PROMPT] = prompt_key
 
         save_transcripts = self._capture.save_stream_transcripts
         save_responses = self._capture.save_responses
@@ -471,11 +542,17 @@ class KitaruModel(WrapperModel):
         if save_responses or save_transcripts:
             serialized_response = _serialize_model_response(response)
         if save_responses:
-            response_key = tracker.artifact_name(event_id, "response")
-            kitaru.save(response_key, serialized_response, type="response")
-            artifacts["response"] = response_key
+            response_key = tracker.artifact_name(event_id, ARTIFACT_ROLE_RESPONSE)
+            kitaru.save(
+                response_key,
+                serialized_response,
+                type=ARTIFACT_ROLE_RESPONSE,
+            )
+            artifacts[ARTIFACT_ROLE_RESPONSE] = response_key
         if save_transcripts:
-            transcript_key = tracker.artifact_name(event_id, "stream_transcript")
+            transcript_key = tracker.artifact_name(
+                event_id, ARTIFACT_ROLE_STREAM_TRANSCRIPT
+            )
             kitaru.save(
                 transcript_key,
                 {
@@ -486,7 +563,7 @@ class KitaruModel(WrapperModel):
                 },
                 type="context",
             )
-            artifacts["stream_transcript"] = transcript_key
+            artifacts[ARTIFACT_ROLE_STREAM_TRANSCRIPT] = transcript_key
 
         tracker.record_model_event(
             event_id,

--- a/src/kitaru/adapters/pydantic_ai/_toolset.py
+++ b/src/kitaru/adapters/pydantic_ai/_toolset.py
@@ -22,7 +22,14 @@ from pydantic_ai.toolsets import (
 from kitaru.errors import KitaruContextError, KitaruUsageError
 from kitaru.wait import _WAIT_INSIDE_CHECKPOINT_ERROR
 
-from ._constants import ADAPTER_ID, ADAPTER_METADATA_KEY
+from ._constants import (
+    ADAPTER_ID,
+    ADAPTER_METADATA_KEY,
+    ARTIFACT_ROLE_ARGS,
+    ARTIFACT_ROLE_RESULT,
+    ARTIFACT_SLOT_OUTPUT,
+    ARTIFACT_SLOT_TOOL_ARGS,
+)
 from ._events import DeferredKind, ToolsetKind
 from ._hitl import HitlConfig, hitl_config_from_tool_metadata, resolve_hitl_question
 from ._kitaru_internal import is_inside_checkpoint, is_inside_flow
@@ -33,7 +40,10 @@ from ._tracking import EventTracker, get_current_tracker
 from ._utils import (
     CheckpointConfig,
     ToolCheckpointOverrides,
+    adapter_checkpoint_artifact_refs,
     checkpoint_cache_key,
+    checkpoint_input_value,
+    get_adapter_checkpoint_artifact_refs,
     resolve_tool_checkpoint_config,
     run_async_in_checkpoint,
     with_default_type,
@@ -158,11 +168,31 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             checkpoint_config=checkpoint_config,
         ):
             assert checkpoint_config is not None
+            capture_mode = self.capture.capture_mode_for_tool(name)
+            input_artifacts: dict[str, str] = {}
+            output_artifacts: dict[str, str] = {}
+            checkpoint_inputs: dict[str, Any] = {}
+            safe_args = _json_safe(tool_args) if capture_mode == "full" else None
+            if capture_mode == "full":
+                input_artifacts[ARTIFACT_ROLE_ARGS] = ARTIFACT_SLOT_TOOL_ARGS
+                output_artifacts[ARTIFACT_ROLE_RESULT] = ARTIFACT_SLOT_OUTPUT
+                checkpoint_inputs[ARTIFACT_SLOT_TOOL_ARGS] = checkpoint_input_value(
+                    safe_args
+                )
 
             async def _in_checkpoint() -> Any:
-                return await self._call_tool_tracked(
-                    name, tool_args, ctx, tool, hitl_config
-                )
+                with adapter_checkpoint_artifact_refs(
+                    input_artifacts=input_artifacts,
+                    output_artifacts=output_artifacts,
+                ):
+                    return await self._call_tool_tracked(
+                        name,
+                        tool_args,
+                        ctx,
+                        tool,
+                        hitl_config,
+                        safe_args=safe_args,
+                    )
 
             return await run_async_in_checkpoint(
                 config=with_default_type(
@@ -173,11 +203,14 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
                 cache_key=checkpoint_cache_key(
                     {
                         "tool_name": name,
-                        "tool_args": tool_args,
+                        ARTIFACT_SLOT_TOOL_ARGS: safe_args
+                        if capture_mode == "full"
+                        else tool_args,
                         "tool_call_id": ctx.tool_call_id,
                         "retry": ctx.retry,
                     }
                 ),
+                checkpoint_inputs=checkpoint_inputs,
             )
         return await self._call_tool_tracked(name, tool_args, ctx, tool, hitl_config)
 
@@ -188,6 +221,8 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
         hitl_config: HitlConfig | None,
+        *,
+        safe_args: Any | None = None,
     ) -> Any:
         capture_mode = self.capture.capture_mode_for_tool(name)
         tracker = get_current_tracker()
@@ -209,13 +244,25 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
         if self.capture.correlate_otel_spans:
             attach_tool_correlation(event_id, event_context)
 
-        safe_args = _json_safe(tool_args) if capture_mode == "full" else None
+        if capture_mode != "full":
+            safe_args = None
+        elif safe_args is None:
+            safe_args = _json_safe(tool_args)
 
         artifacts: dict[str, str] = {}
+        adapter_refs = get_adapter_checkpoint_artifact_refs()
         if capture_mode == "full" and is_inside_checkpoint():
-            args_key = tracker.artifact_name(event_id, "args")
-            kitaru.save(args_key, safe_args, type="input")
-            artifacts["args"] = args_key
+            if (
+                adapter_refs is not None
+                and ARTIFACT_ROLE_ARGS in adapter_refs.input_artifacts
+            ):
+                artifacts[ARTIFACT_ROLE_ARGS] = adapter_refs.input_artifacts[
+                    ARTIFACT_ROLE_ARGS
+                ]
+            else:
+                args_key = tracker.artifact_name(event_id, ARTIFACT_ROLE_ARGS)
+                kitaru.save(args_key, safe_args, type="input")
+                artifacts[ARTIFACT_ROLE_ARGS] = args_key
 
         started_at = time.perf_counter()
         try:
@@ -246,9 +293,17 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
 
         duration_ms = _elapsed_ms(started_at)
         if capture_mode == "full" and is_inside_checkpoint():
-            result_key = tracker.artifact_name(event_id, "result")
-            kitaru.save(result_key, _json_safe(result), type="output")
-            artifacts["result"] = result_key
+            if (
+                adapter_refs is not None
+                and ARTIFACT_ROLE_RESULT in adapter_refs.output_artifacts
+            ):
+                artifacts[ARTIFACT_ROLE_RESULT] = adapter_refs.output_artifacts[
+                    ARTIFACT_ROLE_RESULT
+                ]
+            else:
+                result_key = tracker.artifact_name(event_id, ARTIFACT_ROLE_RESULT)
+                kitaru.save(result_key, _json_safe(result), type="output")
+                artifacts[ARTIFACT_ROLE_RESULT] = result_key
 
         tracker.record_tool_event(
             event_id,

--- a/src/kitaru/adapters/pydantic_ai/_tracking.py
+++ b/src/kitaru/adapters/pydantic_ai/_tracking.py
@@ -285,6 +285,13 @@ class EventTracker:
     def _event_sequence_index(self, event_id: str) -> int:
         return self._event_sequence_by_id.get(event_id, self._counter + 1)
 
+    def _current_checkpoint_refs(self) -> tuple[str | None, str | None]:
+        checkpoint = get_current_checkpoint()
+        return (
+            get_current_checkpoint_name(),
+            checkpoint.checkpoint_id if checkpoint is not None else None,
+        )
+
     def _clear_reserved_tool_events_unlocked(self) -> None:
         for reservations in self._reserved_tool_events_by_call_id.values():
             for reservation in reservations:
@@ -346,6 +353,8 @@ class EventTracker:
         usage: RequestUsage | None = None,
         stream_event_count: int | None = None,
         error: BaseException | None = None,
+        checkpoint_name: str | None = None,
+        checkpoint_id: str | None = None,
     ) -> None:
         with self._lock:
             if status == "completed":
@@ -353,6 +362,9 @@ class EventTracker:
             elif self._current_model_event_id == event_id:
                 self._current_model_event_id = None
 
+            current_checkpoint_name, current_checkpoint_id = (
+                self._current_checkpoint_refs()
+            )
             self._events.append(
                 ModelEvent(
                     event_id=event_id,
@@ -360,6 +372,8 @@ class EventTracker:
                     sequence_index=event_context.sequence_index,
                     turn_index=event_context.turn_index,
                     parent_event_ids=event_context.fan_in_from,
+                    checkpoint_name=checkpoint_name or current_checkpoint_name,
+                    checkpoint_id=checkpoint_id or current_checkpoint_id,
                     fan_in_from=event_context.fan_in_from,
                     duration_ms=duration_ms,
                     artifacts=artifacts,
@@ -426,6 +440,7 @@ class EventTracker:
                 if event_context.fan_out_from is not None
                 else []
             )
+            checkpoint_name, checkpoint_id = self._current_checkpoint_refs()
             self._events.append(
                 ToolEvent(
                     event_id=event_id,
@@ -433,6 +448,8 @@ class EventTracker:
                     sequence_index=event_context.sequence_index,
                     turn_index=event_context.turn_index,
                     parent_event_ids=parent_event_ids,
+                    checkpoint_name=checkpoint_name,
+                    checkpoint_id=checkpoint_id,
                     tool_name=name,
                     toolset_kind=toolset_kind,
                     hitl=hitl,
@@ -458,6 +475,7 @@ class EventTracker:
             parent_event_ids = (
                 [self._current_model_event_id] if self._current_model_event_id else []
             )
+            checkpoint_name, checkpoint_id = self._current_checkpoint_refs()
             self._events.append(
                 DeferredEvent(
                     event_id=event_id,
@@ -465,6 +483,8 @@ class EventTracker:
                     sequence_index=sequence_index,
                     turn_index=self._turn_index,
                     parent_event_ids=parent_event_ids,
+                    checkpoint_name=checkpoint_name,
+                    checkpoint_id=checkpoint_id,
                     tool_name=tool_name,
                     deferred_kind=deferred_kind,
                     wait_name=wait_name,
@@ -482,6 +502,7 @@ class EventTracker:
                 self._event_stream_handler_duration_ms + duration_ms, 3
             )
             event_id, sequence_index = self._next_event_id("event_stream")
+            checkpoint_name, checkpoint_id = self._current_checkpoint_refs()
             self._events.append(
                 StreamEvent(
                     event_id=event_id,
@@ -489,6 +510,8 @@ class EventTracker:
                     sequence_index=sequence_index,
                     turn_index=self._turn_index,
                     parent_event_ids=[],
+                    checkpoint_name=checkpoint_name,
+                    checkpoint_id=checkpoint_id,
                     index=self._event_stream_handler_call_count,
                     duration_ms=duration_ms,
                     error=error_from_exception(error) if error is not None else None,

--- a/src/kitaru/adapters/pydantic_ai/_tracking.py
+++ b/src/kitaru/adapters/pydantic_ai/_tracking.py
@@ -81,7 +81,7 @@ def normalize_agent_name(agent_name: str | None) -> str:
 def _with_namespace(name: str, namespace: str | None) -> str:
     if namespace is None:
         return name
-    return f"{namespace}_{name}"
+    return f"{name}__{namespace}"
 
 
 def _event_artifact_base_name(event_id: str, kind: ArtifactKind) -> str:

--- a/src/kitaru/adapters/pydantic_ai/_utils.py
+++ b/src/kitaru/adapters/pydantic_ai/_utils.py
@@ -8,7 +8,10 @@ import asyncio
 import hashlib
 import json
 import sys
-from collections.abc import Coroutine, Mapping
+from collections.abc import Coroutine, Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import Any, Callable, Literal, TypedDict, cast
 
 import kitaru
@@ -32,6 +35,25 @@ ToolCheckpointOverride = CheckpointConfig | Literal[False]
 ToolCheckpointOverrides = Mapping[str, ToolCheckpointOverride]
 _ALLOWED_CHECKPOINT_CONFIG_KEYS = frozenset({"cache", "runtime", "retries", "type"})
 
+
+@dataclass(frozen=True)
+class AdapterCheckpointArtifactRefs:
+    """Display references for artifacts owned by a synthetic checkpoint.
+
+    In granular adapter checkpoints, some event payloads now live in structural
+    step slots rather than manual artifacts. These mappings let the event log
+    say "prompt -> messages" or "result -> output" without creating duplicate
+    manual artifacts inside the step.
+    """
+
+    input_artifacts: Mapping[str, str]
+    output_artifacts: Mapping[str, str]
+
+
+_ADAPTER_CHECKPOINT_ARTIFACT_REFS: ContextVar[AdapterCheckpointArtifactRefs | None] = (
+    ContextVar("kitaru_adapter_checkpoint_artifact_refs", default=None)
+)
+
 if f"src.{__name__}" not in sys.modules:
     sys.modules[f"src.{__name__}"] = sys.modules[__name__]
 
@@ -41,6 +63,29 @@ def with_default_type(config: CheckpointConfig, default_type: str) -> Checkpoint
     if "type" in config:
         return config
     return {**config, "type": default_type}
+
+
+@contextmanager
+def adapter_checkpoint_artifact_refs(
+    *,
+    input_artifacts: Mapping[str, str] | None = None,
+    output_artifacts: Mapping[str, str] | None = None,
+) -> Iterator[AdapterCheckpointArtifactRefs]:
+    """Expose structural/canonical artifact slot names inside a checkpoint."""
+    refs = AdapterCheckpointArtifactRefs(
+        input_artifacts=input_artifacts or {},
+        output_artifacts=output_artifacts or {},
+    )
+    token = _ADAPTER_CHECKPOINT_ARTIFACT_REFS.set(refs)
+    try:
+        yield refs
+    finally:
+        _ADAPTER_CHECKPOINT_ARTIFACT_REFS.reset(token)
+
+
+def get_adapter_checkpoint_artifact_refs() -> AdapterCheckpointArtifactRefs | None:
+    """Return granular checkpoint artifact slot references, if any."""
+    return _ADAPTER_CHECKPOINT_ARTIFACT_REFS.get()
 
 
 def resolve_tool_checkpoint_config(
@@ -187,6 +232,24 @@ def _build_checkpoint_step(
             return body()
 
         turn = _turn_with_prompt_and_history
+    elif input_names == {"tool_args"}:
+
+        def _turn_with_tool_args(
+            tool_args: Any,
+            _cache_key: str | None = None,
+        ) -> Any:
+            return body()
+
+        turn = _turn_with_tool_args
+    elif input_names == {"messages"}:
+
+        def _turn_with_messages(
+            messages: Any,
+            _cache_key: str | None = None,
+        ) -> Any:
+            return body()
+
+        turn = _turn_with_messages
     else:
         unsupported = ", ".join(sorted(input_names))
         raise KitaruUsageError(

--- a/tests/test_claude_agent_sdk_invocation_strategy.py
+++ b/tests/test_claude_agent_sdk_invocation_strategy.py
@@ -130,6 +130,18 @@ def _raise_runtime_error(message: str) -> None:
     raise RuntimeError(message)
 
 
+def test_claude_artifact_names_use_role_first_suffix_namespace() -> None:
+    from kitaru.adapters.claude_agent_sdk._tracking import EventTracker, artifact_name
+
+    assert (
+        artifact_name("Claude Reviewer", "abc123", "messages")
+        == "messages__Claude_Reviewer_abc123"
+    )
+    tracker = EventTracker(runner_name="Claude Reviewer", run_label="abc123")
+    assert tracker.event_log_artifact_name == "event_log__Claude_Reviewer_abc123"
+    assert tracker.run_summary_artifact_name == "run_summary__Claude_Reviewer_abc123"
+
+
 def test_nested_checkpoint_rejected_before_sdk_call_by_default(
     claude_adapter: types.ModuleType,
     fake_sdk: types.ModuleType,
@@ -261,12 +273,12 @@ def test_runner_invocation_extracts_result_and_artifact_names(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _patch_inline_scope(monkeypatch)
-    saved: list[str] = []
+    saved: list[tuple[str, str]] = []
     logs: list[dict[str, object]] = []
     _patch_direct_execution_persistence(
         monkeypatch,
-        save_artifact=lambda name, value, *, type: saved.append(name),
-        save_event=lambda name, value, *, type: saved.append(name),
+        save_artifact=lambda name, value, *, type: saved.append((name, type)),
+        save_event=lambda name, value, *, type: saved.append((name, type)),
         log_event=lambda **kwargs: logs.append(kwargs),
     )
 
@@ -296,9 +308,16 @@ def test_runner_invocation_extracts_result_and_artifact_names(
     assert result.messages_artifact_name is not None
     assert result.options_manifest_artifact_name is not None
     assert result.output_artifact_name is not None
-    assert result.messages_artifact_name in saved
-    assert result.options_manifest_artifact_name in saved
-    assert result.event_log_artifact_name in saved
+    assert (result.messages_artifact_name, "context") in saved
+    assert (result.options_manifest_artifact_name, "context") in saved
+    if result.transcript_artifact_name is not None:
+        assert (result.transcript_artifact_name, "context") in saved
+    assert (result.usage_artifact_name, "context") in saved
+    assert (result.output_artifact_name, "response") in saved
+    assert (result.event_log_artifact_name, "context") in saved
+    assert (result.run_summary_artifact_name, "context") in saved
+    assert result.messages_artifact_name.startswith("messages__")
+    assert result.output_artifact_name.startswith("output__")
     assert logs
 
 
@@ -309,7 +328,7 @@ def test_artifact_capture_failure_is_non_fatal_by_default(
     _patch_inline_scope(monkeypatch)
 
     def fake_save(name: str, value: object, *, type: str) -> None:
-        if name.endswith("messages"):
+        if name.startswith("messages__"):
             raise RuntimeError("simulated capture failure")
 
     _patch_direct_execution_persistence(monkeypatch, save_artifact=fake_save)
@@ -455,7 +474,7 @@ def test_event_persistence_failure_is_non_fatal_by_default(
     _patch_inline_scope(monkeypatch)
 
     def fake_event_save(name: str, value: object, *, type: str) -> None:
-        if name.endswith("event_log"):
+        if name.startswith("event_log__"):
             raise RuntimeError("event log save failed")
 
     def fail_log_event(**kwargs: object) -> None:
@@ -517,7 +536,7 @@ def test_options_factory_receives_request_and_redacts_manifest(
     manifests: list[dict[str, object]] = []
 
     def fake_save(name: str, value: object, *, type: str) -> None:
-        if name.endswith("options_manifest") and isinstance(value, dict):
+        if name.startswith("options_manifest__") and isinstance(value, dict):
             manifests.append(cast(dict[str, object], value))
 
     _patch_direct_execution_persistence(monkeypatch, save_artifact=fake_save)
@@ -622,8 +641,8 @@ def test_emit_events_false_suppresses_event_artifacts_and_log(
 
     assert result.event_log_artifact_name is None
     assert result.run_summary_artifact_name is None
-    assert not any(name.endswith("event_log") for name in saved)
-    assert not any(name.endswith("run_summary") for name in saved)
+    assert not any(name.startswith("event_log__") for name in saved)
+    assert not any(name.startswith("run_summary__") for name in saved)
     assert logs == []
 
 
@@ -709,7 +728,7 @@ def test_transcript_file_is_captured_when_available(
     transcript_file.write_text('{"type":"result"}\n', encoding="utf-8")
 
     def fake_save(name: str, value: object, *, type: str) -> None:
-        if name.endswith("transcript"):
+        if name.startswith("transcript__"):
             captured["value"] = value
 
     _patch_direct_execution_persistence(monkeypatch, save_artifact=fake_save)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1960,6 +1960,44 @@ def test_get_maps_execution_details() -> None:
     assert artifact_ref.kind == "context"
 
 
+def test_get_does_not_expose_ordinary_checkpoint_inputs_as_artifacts() -> None:
+    input_artifact = _DummyArtifact(
+        name="content_flow::research::output",
+        save_type=ArtifactSaveType.STEP_OUTPUT,
+        value="notes about kitaru",
+        metadata={"kitaru_artifact_type": "context"},
+    )
+    step = _DummyStep(
+        name="write_draft",
+        status=ZenMLExecutionStatus.COMPLETED,
+        inputs={"research_notes": [input_artifact]},
+        outputs={},
+        step_type=SimpleNamespace(value="checkpoint"),
+    )
+    run = _DummyRun(
+        status=ZenMLExecutionStatus.COMPLETED,
+        flow_name="content_flow",
+        steps={step.name: step},
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
+
+        client = KitaruClient()
+        execution = client.executions.get(str(run.id))
+
+    assert len(execution.checkpoints) == 1
+    assert execution.checkpoints[0].artifacts == []
+    assert execution.artifacts == []
+
+
 def test_get_prefers_output_artifact_ref_when_input_seen_first() -> None:
     artifact = _DummyArtifact(
         name="content_flow::research::output",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1960,6 +1960,50 @@ def test_get_maps_execution_details() -> None:
     assert artifact_ref.kind == "context"
 
 
+def test_get_prefers_output_artifact_ref_when_input_seen_first() -> None:
+    artifact = _DummyArtifact(
+        name="content_flow::research::output",
+        save_type=ArtifactSaveType.STEP_OUTPUT,
+        value="notes about kitaru",
+        metadata={"kitaru_artifact_type": "context"},
+    )
+    consumer_step = _DummyStep(
+        name="write_draft",
+        status=ZenMLExecutionStatus.COMPLETED,
+        inputs={"research_notes": [artifact]},
+        outputs={},
+    )
+    producer_step = _DummyStep(
+        name="research",
+        status=ZenMLExecutionStatus.COMPLETED,
+        outputs={"output": [artifact]},
+    )
+    run = _DummyRun(
+        status=ZenMLExecutionStatus.COMPLETED,
+        flow_name="content_flow",
+        steps={consumer_step.name: consumer_step, producer_step.name: producer_step},
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
+
+        client = KitaruClient()
+        execution = client.executions.get(str(run.id))
+
+    assert len(execution.artifacts) == 1
+    artifact_ref = execution.artifacts[0]
+    assert artifact_ref.name == "content_flow::research::output"
+    assert artifact_ref.direction == "output"
+    assert artifact_ref.producing_call == "research"
+
+
 def test_get_surfaces_checkpoint_attempt_history() -> None:
     attempt_one = _DummyStep(
         name="research",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -134,6 +134,7 @@ class _DummyStep:
         name: str,
         status: Any,
         outputs: dict[str, list[_DummyArtifact]],
+        inputs: dict[str, list[_DummyArtifact]] | None = None,
         step_id: UUID | None = None,
         original_step_run_id: UUID | None = None,
         run_metadata: dict[str, Any] | None = None,
@@ -149,6 +150,7 @@ class _DummyStep:
         self.run_metadata = run_metadata or {}
         self.original_step_run_id = original_step_run_id
         self.parent_step_ids: list[UUID] = []
+        self.inputs = inputs or {}
         self.outputs = outputs
         self.spec = spec
         self.type = step_type

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -340,7 +340,7 @@ def test_checkpoint_mapping_includes_structural_input_artifacts() -> None:
         original_step_run_id=None,
         parent_step_ids=[],
         type=SimpleNamespace(value="llm_call"),
-        inputs={"messages": [input_artifact]},
+        inputs={"input": [input_artifact]},
         outputs={"output": [output_artifact]},
     )
 
@@ -353,7 +353,7 @@ def test_checkpoint_mapping_includes_structural_input_artifacts() -> None:
     assert [
         (artifact.name, artifact.direction) for artifact in checkpoint.artifacts
     ] == [
-        ("messages", "input"),
+        ("input", "input"),
         ("output", "output"),
     ]
     input_ref = checkpoint.artifacts[0]
@@ -363,7 +363,53 @@ def test_checkpoint_mapping_includes_structural_input_artifacts() -> None:
     assert checkpoint.artifacts[1].kind == "response"
 
 
-def test_checkpoint_mapping_does_not_label_generic_messages_input_as_prompt() -> None:
+def test_checkpoint_mapping_includes_tool_call_structural_input_artifacts() -> None:
+    input_artifact = SimpleNamespace(
+        id="input-artifact-id",
+        name="raw-zenml-tool-args-artifact-name",
+        run_metadata={},
+        save_type=SimpleNamespace(value="step_output"),
+        input_type=SimpleNamespace(value="step_output"),
+    )
+    output_artifact = SimpleNamespace(
+        id="output-artifact-id",
+        name="output",
+        run_metadata={},
+        save_type=SimpleNamespace(value="step_output"),
+    )
+    step = SimpleNamespace(
+        id="step-id",
+        name="agent_tool_call",
+        status="completed",
+        start_time=None,
+        end_time=None,
+        run_metadata={},
+        original_step_run_id=None,
+        parent_step_ids=[],
+        type=SimpleNamespace(value="tool_call"),
+        inputs={"tool_args": [input_artifact]},
+        outputs={"output": [output_artifact]},
+    )
+
+    checkpoint = _map_checkpoint_call(
+        step=cast(Any, step),
+        client=cast(Any, SimpleNamespace()),
+        attempts_by_lineage={},
+    )
+
+    assert [
+        (artifact.name, artifact.direction) for artifact in checkpoint.artifacts
+    ] == [
+        ("tool_args", "input"),
+        ("output", "output"),
+    ]
+    assert checkpoint.artifacts[0].kind == "input"
+    assert checkpoint.artifacts[0].producing_call is None
+    assert checkpoint.artifacts[0].input_type == "step_output"
+    assert checkpoint.artifacts[1].kind == "output"
+
+
+def test_checkpoint_mapping_does_not_expose_generic_input_artifacts() -> None:
     input_artifact = SimpleNamespace(
         id="input-artifact-id",
         name="raw-zenml-input-artifact-name",
@@ -391,8 +437,7 @@ def test_checkpoint_mapping_does_not_label_generic_messages_input_as_prompt() ->
         attempts_by_lineage={},
     )
 
-    assert checkpoint.artifacts[0].name == "messages"
-    assert checkpoint.artifacts[0].kind == "input"
+    assert checkpoint.artifacts == []
 
 
 def test_serialize_artifact_value_json_contract() -> None:

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 
 import pytest
 
+from kitaru._client._mappers import _map_checkpoint_call
 from kitaru.client import (
     ArtifactRef,
     CheckpointAttempt,
@@ -288,6 +289,110 @@ def test_serialize_artifact_ref_contract() -> None:
         "producing_call": "research",
         "metadata": {"source": "notes"},
     }
+
+
+def test_serialize_input_artifact_ref_includes_direction_fields() -> None:
+    artifact = ArtifactRef(
+        artifact_id="artifact-input-1",
+        name="messages",
+        kind="prompt",
+        save_type="step_output",
+        producing_call=None,
+        metadata={},
+        direction="input",
+        input_type="step_output",
+        _client=cast(Any, SimpleNamespace()),
+    )
+
+    assert serialize_artifact_ref(artifact) == {
+        "artifact_id": "artifact-input-1",
+        "name": "messages",
+        "kind": "prompt",
+        "save_type": "step_output",
+        "producing_call": None,
+        "metadata": {},
+        "direction": "input",
+        "input_type": "step_output",
+    }
+
+
+def test_checkpoint_mapping_includes_structural_input_artifacts() -> None:
+    input_artifact = SimpleNamespace(
+        id="input-artifact-id",
+        name="raw-zenml-input-artifact-name",
+        run_metadata={},
+        save_type=SimpleNamespace(value="step_output"),
+        input_type=SimpleNamespace(value="step_output"),
+    )
+    output_artifact = SimpleNamespace(
+        id="output-artifact-id",
+        name="output",
+        run_metadata={"kitaru_artifact_type": "response"},
+        save_type=SimpleNamespace(value="step_output"),
+    )
+    step = SimpleNamespace(
+        id="step-id",
+        name="agent_model_request",
+        status="completed",
+        start_time=None,
+        end_time=None,
+        run_metadata={},
+        original_step_run_id=None,
+        parent_step_ids=[],
+        type=SimpleNamespace(value="llm_call"),
+        inputs={"messages": [input_artifact]},
+        outputs={"output": [output_artifact]},
+    )
+
+    checkpoint = _map_checkpoint_call(
+        step=cast(Any, step),
+        client=cast(Any, SimpleNamespace()),
+        attempts_by_lineage={},
+    )
+
+    assert [
+        (artifact.name, artifact.direction) for artifact in checkpoint.artifacts
+    ] == [
+        ("messages", "input"),
+        ("output", "output"),
+    ]
+    input_ref = checkpoint.artifacts[0]
+    assert input_ref.kind == "prompt"
+    assert input_ref.producing_call is None
+    assert input_ref.input_type == "step_output"
+    assert checkpoint.artifacts[1].kind == "response"
+
+
+def test_checkpoint_mapping_does_not_label_generic_messages_input_as_prompt() -> None:
+    input_artifact = SimpleNamespace(
+        id="input-artifact-id",
+        name="raw-zenml-input-artifact-name",
+        run_metadata={},
+        save_type=SimpleNamespace(value="step_output"),
+        input_type=SimpleNamespace(value="step_output"),
+    )
+    step = SimpleNamespace(
+        id="step-id",
+        name="ordinary_checkpoint",
+        status="completed",
+        start_time=None,
+        end_time=None,
+        run_metadata={},
+        original_step_run_id=None,
+        parent_step_ids=[],
+        type=SimpleNamespace(value="checkpoint"),
+        inputs={"messages": [input_artifact]},
+        outputs={},
+    )
+
+    checkpoint = _map_checkpoint_call(
+        step=cast(Any, step),
+        client=cast(Any, SimpleNamespace()),
+        attempts_by_lineage={},
+    )
+
+    assert checkpoint.artifacts[0].name == "messages"
+    assert checkpoint.artifacts[0].kind == "input"
 
 
 def test_serialize_artifact_value_json_contract() -> None:

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -1,7 +1,8 @@
 """Focused tests for OpenAI Agents SDK call-level checkpointing."""
 
+import re
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from uuid import uuid4
 
 import pytest
@@ -127,6 +128,58 @@ def _wait_for_hydrated_run(exec_id: str) -> Any:
 
 def _step_names(hydrated_run: Any) -> set[str]:
     return set(hydrated_run.steps)
+
+
+def _input_names_by_step(hydrated_run: Any) -> list[set[str]]:
+    return [set(step.inputs) for step in hydrated_run.steps.values()]
+
+
+def _artifact_names(hydrated_run: Any) -> list[str]:
+    names: list[str] = []
+    for step in hydrated_run.steps.values():
+        for artifacts in step.outputs.values():
+            names.extend(artifact.name for artifact in artifacts)
+    return names
+
+
+def _events(event_map: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    return [event for events in event_map.values() for event in events]
+
+
+def _expected_model_input_envelope(
+    *,
+    system_instructions: str | None = None,
+    input_value: Any = None,
+    model_settings: Any = None,
+    previous_response_id: str | None = None,
+    conversation_id: str | None = None,
+    prompt: Any = None,
+) -> dict[str, Any]:
+    return {
+        "system_instructions": system_instructions,
+        "input": input_value,
+        "model_settings": model_settings,
+        "previous_response_id": previous_response_id,
+        "conversation_id": conversation_id,
+        "prompt": prompt,
+    }
+
+
+def test_openai_artifact_names_use_role_first_suffix_namespace() -> None:
+    from kitaru.adapters.openai_agents._tracking import EventTracker, artifact_name
+
+    assert (
+        artifact_name("agent_ab12cd34_llm_call_1", "input")
+        == "llm_call_1_input__agent_ab12cd34"
+    )
+    assert (
+        artifact_name("agent_ab12cd34_tool_call_2", "result")
+        == "tool_call_2_result__agent_ab12cd34"
+    )
+
+    tracker = EventTracker(agent_name="Agent Name", run_label="ab12cd34")
+    assert tracker.event_log_artifact_name == "event_log__Agent_Name_ab12cd34"
+    assert tracker.run_summary_artifact_name == "run_summary__Agent_Name_ab12cd34"
 
 
 class TestOpenAIEventTrackerToolCallOrdering:
@@ -352,12 +405,14 @@ class TestOpenAIModelToolCallReservations:
             response_id="resp_cached",
         )
         seen_tool_call_ids: list[list[str]] = []
+        seen_checkpoint_inputs: list[dict[str, Any] | None] = []
 
         class FakeTracker:
             def reserve_tool_call_order(self, tool_call_ids: list[str]) -> None:
                 seen_tool_call_ids.append(tool_call_ids)
 
-        async def fake_run_async_in_checkpoint(**_kwargs: Any) -> Any:
+        async def fake_run_async_in_checkpoint(**kwargs: Any) -> Any:
+            seen_checkpoint_inputs.append(kwargs.get("checkpoint_inputs"))
             return cached_response
 
         monkeypatch.setattr(openai_model, "is_inside_flow", lambda: True)
@@ -390,6 +445,184 @@ class TestOpenAIModelToolCallReservations:
 
         assert response is cached_response
         assert seen_tool_call_ids == [["call_alpha", "call_beta"]]
+        assert seen_checkpoint_inputs == [
+            {"input": _expected_model_input_envelope(input_value="prompt")}
+        ]
+
+
+@pytest.mark.anyio
+async def test_openai_model_checkpoint_uses_structural_input_and_output_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kitaru.adapters.openai_agents._model as openai_model
+    from kitaru.adapters.openai_agents._model import KitaruOpenAIModel
+    from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+    inside_checkpoint = False
+    seen_checkpoint_inputs: list[dict[str, Any] | None] = []
+    recorded_artifacts: list[dict[str, str]] = []
+    saved: list[tuple[str, str]] = []
+
+    async def fake_wrapped_get_response(*_args: Any, **_kwargs: Any) -> Any:
+        return SimpleNamespace(output=[], usage=None, response_id="resp_structural")
+
+    class FakeTracker:
+        def start_llm_event(self) -> tuple[str, SimpleNamespace]:
+            return "agent_ab12cd34_llm_call_1", SimpleNamespace(sequence_index=1)
+
+        def record_event(self, *_args: Any, **kwargs: Any) -> None:
+            recorded_artifacts.append(kwargs["artifacts"])
+
+        def reserve_tool_call_order(self, _tool_call_ids: list[str]) -> None:
+            return None
+
+    async def fake_run_async_in_checkpoint(**kwargs: Any) -> Any:
+        nonlocal inside_checkpoint
+        seen_checkpoint_inputs.append(kwargs.get("checkpoint_inputs"))
+        inside_checkpoint = True
+        try:
+            return await kwargs["body"]()
+        finally:
+            inside_checkpoint = False
+
+    monkeypatch.setattr(openai_model, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(openai_model, "is_inside_checkpoint", lambda: inside_checkpoint)
+    monkeypatch.setattr(openai_model, "get_current_tracker", lambda: FakeTracker())
+    monkeypatch.setattr(
+        openai_model, "run_async_in_checkpoint", fake_run_async_in_checkpoint
+    )
+    monkeypatch.setattr(
+        openai_model.kitaru,
+        "save",
+        lambda name, _value, *, type: saved.append((name, type)),
+    )
+
+    model = KitaruOpenAIModel(
+        SimpleNamespace(get_response=fake_wrapped_get_response),
+        capture=OpenAICapturePolicy(save_usage=False),
+        agent_name="structural_agent",
+        checkpoint_config={},
+    )
+
+    response = await model.get_response(
+        "system",
+        [{"role": "user", "content": "hello"}],
+        {"temperature": 0},
+        [],
+        None,
+        [],
+        None,
+        previous_response_id="previous",
+        conversation_id="conversation",
+        prompt={"id": "prompt"},
+    )
+
+    assert response.response_id == "resp_structural"
+    assert seen_checkpoint_inputs == [
+        {
+            "input": _expected_model_input_envelope(
+                system_instructions="system",
+                input_value=[{"role": "user", "content": "hello"}],
+                model_settings={"temperature": 0},
+                previous_response_id="previous",
+                conversation_id="conversation",
+                prompt={"id": "prompt"},
+            )
+        }
+    ]
+    assert recorded_artifacts == [{"input": "input", "response": "output"}]
+    assert saved == []
+
+
+@pytest.mark.anyio
+async def test_openai_tool_checkpoint_uses_structural_tool_args_and_output_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kitaru.adapters.openai_agents._tools as openai_tools
+    from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+    inside_checkpoint = False
+    seen_checkpoint_inputs: list[dict[str, Any] | None] = []
+    recorded_artifacts: list[dict[str, str]] = []
+    saved: list[tuple[str, str]] = []
+
+    from agents.tool import FunctionTool
+
+    async def invoke_double_value(_context: Any, input_json: str) -> str:
+        assert input_json == '{"value": 4}'
+        return "doubled=8"
+
+    double_value = FunctionTool(
+        name="double_value",
+        description="Double a value.",
+        params_json_schema={
+            "type": "object",
+            "properties": {"value": {"type": "integer"}},
+            "required": ["value"],
+            "additionalProperties": False,
+        },
+        on_invoke_tool=invoke_double_value,
+    )
+
+    class FakeTracker:
+        def start_tool_event(
+            self,
+            *,
+            tool_call_id: str | None = None,
+        ) -> tuple[str, SimpleNamespace]:
+            assert tool_call_id == "call_structural_tool"
+            return "agent_ab12cd34_tool_call_2", SimpleNamespace(sequence_index=2)
+
+        def record_event(self, *_args: Any, **kwargs: Any) -> None:
+            recorded_artifacts.append(kwargs["artifacts"])
+
+    async def fake_run_async_in_checkpoint(**kwargs: Any) -> Any:
+        nonlocal inside_checkpoint
+        seen_checkpoint_inputs.append(kwargs.get("checkpoint_inputs"))
+        inside_checkpoint = True
+        try:
+            return await kwargs["body"]()
+        finally:
+            inside_checkpoint = False
+
+    monkeypatch.setattr(openai_tools, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(openai_tools, "is_inside_checkpoint", lambda: inside_checkpoint)
+    monkeypatch.setattr(openai_tools, "get_current_tracker", lambda: FakeTracker())
+    monkeypatch.setattr(
+        openai_tools, "run_async_in_checkpoint", fake_run_async_in_checkpoint
+    )
+    monkeypatch.setattr(
+        openai_tools.kitaru,
+        "save",
+        lambda name, _value, *, type: saved.append((name, type)),
+    )
+
+    wrapped = openai_tools._wrap_function_tool(
+        double_value,
+        capture=OpenAICapturePolicy(),
+        agent_name="structural_agent",
+        tool_checkpoint_config={},
+        tool_checkpoint_config_by_name=None,
+    )
+
+    result = await wrapped.on_invoke_tool(
+        cast(Any, SimpleNamespace(tool_call_id="call_structural_tool")),
+        '{"value": 4}',
+    )
+
+    assert result == "doubled=8"
+    assert seen_checkpoint_inputs == [
+        {
+            "tool_args": {
+                "tool_name": "double_value",
+                "tool_call_id": "call_structural_tool",
+                "raw_args": '{"value": 4}',
+                "parsed_args": {"value": 4},
+            }
+        }
+    ]
+    assert recorded_artifacts == [{"input": "tool_args", "result": "output"}]
+    assert saved == []
 
 
 @pytest.mark.anyio
@@ -577,11 +810,34 @@ def test_calls_strategy_function_tool_runs_inside_checkpoint_and_caches(
         return str(runner.run_sync(OpenAIRunRequest.start(prompt)).final_output)
 
     first = tool_flow.run("please use the tool", "first")
-    _wait_for_hydrated_run(first.exec_id)
+    first_hydrated = _wait_for_hydrated_run(first.exec_id)
     assert side_effects == [4]
     assert model.call_count == 2
-    first_hydrated = _wait_for_hydrated_run(first.exec_id)
     assert any("double_value_tool_call" in name for name in _step_names(first_hydrated))
+    inputs_by_step = _input_names_by_step(first_hydrated)
+    assert any("input" in inputs for inputs in inputs_by_step)
+    assert any("tool_args" in inputs for inputs in inputs_by_step)
+    event_map = first_hydrated.run_metadata["openai_agents_events"]
+    events = _events(event_map)
+    assert any(
+        event["kind"] == "llm_call"
+        and event["artifacts"].get("input") == "input"
+        and event["artifacts"].get("response") == "output"
+        for event in events
+    )
+    assert any(
+        event["kind"] == "tool_call"
+        and event["artifacts"].get("input") == "tool_args"
+        and event["artifacts"].get("result") == "output"
+        for event in events
+    )
+    artifact_names = _artifact_names(first_hydrated)
+    assert not any(
+        re.fullmatch(r"llm_call_\d+_input__.*", name) for name in artifact_names
+    )
+    assert not any(
+        re.fullmatch(r"tool_call_\d+_input__.*", name) for name in artifact_names
+    )
 
     second = tool_flow.run("please use the tool", "second")
     _wait_for_hydrated_run(second.exec_id)

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -182,6 +182,61 @@ def test_openai_artifact_names_use_role_first_suffix_namespace() -> None:
     assert tracker.run_summary_artifact_name == "run_summary__Agent_Name_ab12cd34"
 
 
+def test_openai_event_tracker_records_checkpoint_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kitaru.adapters.openai_agents import _tracking
+
+    checkpoint_ids = iter(["checkpoint-model", "checkpoint-tool"])
+    checkpoint_names = iter(
+        [
+            "agent_openai_model_call",
+            "agent_double_value_tool_call",
+        ]
+    )
+    monkeypatch.setattr(_tracking, "is_inside_checkpoint", lambda: True)
+    monkeypatch.setattr(
+        _tracking,
+        "get_current_checkpoint_id",
+        lambda: next(checkpoint_ids),
+    )
+    monkeypatch.setattr(
+        _tracking,
+        "get_current_checkpoint_name",
+        lambda: next(checkpoint_names),
+    )
+
+    tracker = _tracking.EventTracker(agent_name="Agent Name", run_label="ab12cd34")
+    model_id, model_context = tracker.start_llm_event()
+    tool_id, tool_context = tracker.start_tool_event(tool_call_id="call_1")
+    tracker.record_event(
+        model_id,
+        model_context,
+        kind="llm_call",
+        status="completed",
+        duration_ms=1.0,
+        artifacts={"response": "output"},
+    )
+    tracker.record_event(
+        tool_id,
+        tool_context,
+        kind="tool_call",
+        status="completed",
+        duration_ms=1.0,
+        artifacts={"result": "output"},
+    )
+
+    events = list(tracker.events)
+    assert [event.checkpoint_id for event in events] == [
+        "checkpoint-model",
+        "checkpoint-tool",
+    ]
+    assert [event.checkpoint_name for event in events] == [
+        "agent_openai_model_call",
+        "agent_double_value_tool_call",
+    ]
+
+
 class TestOpenAIEventTrackerToolCallOrdering:
     def _record_completed_model(self, tracker: Any) -> tuple[str, Any]:
         event_id, event_context = tracker.start_llm_event()
@@ -830,6 +885,18 @@ def test_calls_strategy_function_tool_runs_inside_checkpoint_and_caches(
         and event["artifacts"].get("input") == "tool_args"
         and event["artifacts"].get("result") == "output"
         for event in events
+    )
+    output_events = [
+        event
+        for event in events
+        if event["artifacts"].get("response") == "output"
+        or event["artifacts"].get("result") == "output"
+    ]
+    assert len(output_events) >= 2
+    assert all(event.get("checkpoint_id") for event in output_events)
+    assert all(event.get("checkpoint_name") for event in output_events)
+    assert len({event["checkpoint_id"] for event in output_events}) == len(
+        output_events
     )
     artifact_names = _artifact_names(first_hydrated)
     assert not any(

--- a/tests/test_phase17_pydantic_ai_adapter.py
+++ b/tests/test_phase17_pydantic_ai_adapter.py
@@ -98,12 +98,13 @@ def _event_kinds(event_map: dict[str, list[dict[str, Any]]]) -> set[str]:
 
 
 def _assert_event_artifacts_use_display_names(
-    event_map: dict[str, list[dict[str, Any]]], artifact_names: list[str]
+    event_map: dict[str, list[dict[str, Any]]], allowed_refs: list[str] | set[str]
 ) -> None:
+    allowed = set(allowed_refs)
     for event in _events(event_map):
         event_id = event["event_id"]
         for artifact_name in event.get("artifacts", {}).values():
-            assert artifact_name in artifact_names
+            assert artifact_name in allowed
             assert not artifact_name.startswith(f"{event_id}_")
 
 
@@ -358,19 +359,24 @@ def test_phase17_default_granular_mode_tracks_at_flow_scope(primed_zenml) -> Non
     assert summary["tool_call_count"] >= 1
     assert {"llm_call", "tool_call"} <= _event_kinds(event_map)
     artifact_names = _artifact_names(hydrated_run)
-    run_label = summary["run_label"]
     assert len(hydrated_run.steps) >= 2
-    assert "llm_call_1_prompt" not in artifact_names
-    assert "llm_call_1_response" not in artifact_names
-    assert any(
-        re.fullmatch(rf"[a-zA-Z0-9_]+_{run_label}_tracker_1_llm_call_1_prompt", name)
-        for name in artifact_names
+    assert _has_step_input(hydrated_run, "messages")
+    assert _has_step_input(hydrated_run, "tool_args")
+    assert not any(name.endswith("_llm_call_1_prompt") for name in artifact_names)
+    assert not any(name.endswith("_llm_call_1_response") for name in artifact_names)
+    assert not any(
+        re.fullmatch(r".*_tool_call_\d+_args", name) for name in artifact_names
     )
-    assert any(
-        re.fullmatch(rf"[a-zA-Z0-9_]+_{run_label}_tracker_1_llm_call_1_response", name)
-        for name in artifact_names
+    assert not any(
+        re.fullmatch(r".*_tool_call_\d+_result", name) for name in artifact_names
     )
-    _assert_event_artifacts_use_display_names(event_map, artifact_names)
+    allowed_event_refs = set(artifact_names) | {"messages", "tool_args", "output"}
+    _assert_event_artifacts_use_display_names(event_map, allowed_event_refs)
+    assert all(
+        event.get("checkpoint_name")
+        for event in _events(event_map)
+        if "output" in event.get("artifacts", {}).values()
+    )
     assert "event_log" not in artifact_names
     assert "run_summary" not in artifact_names
     assert not any(name.endswith("_event_log") for name in artifact_names)
@@ -449,25 +455,22 @@ def test_phase17_multiple_tracker_scopes_at_flow_scope_get_unique_namespaces(
     run_labels = {summary["run_label"] for summary in summaries}
     assert len(run_labels) == 2
 
-    model_artifact_names = [
+    model_artifact_refs = [
         stored_name
         for event in _events(event_map)
         if event["kind"] == "llm_call"
         for stored_name in event.get("artifacts", {}).values()
     ]
-    assert model_artifact_names
-    assert len(model_artifact_names) == len(set(model_artifact_names))
-    assert all(stored_name in artifact_names for stored_name in model_artifact_names)
-    assert all(
-        any(run_label in stored_name for stored_name in model_artifact_names)
-        for run_label in run_labels
-    )
-    assert all("_tracker_1_" in stored_name for stored_name in model_artifact_names)
-    assert "llm_call_1_prompt" not in artifact_names
-    assert "llm_call_1_response" not in artifact_names
+    assert model_artifact_refs
+    assert {"messages", "output"} <= set(model_artifact_refs)
+    assert _has_step_input(hydrated_run, "messages")
+    assert _has_step_input(hydrated_run, "tool_args")
+    assert not any(name.endswith("_llm_call_1_prompt") for name in artifact_names)
+    assert not any(name.endswith("_llm_call_1_response") for name in artifact_names)
     assert not any(name.endswith("_event_log") for name in artifact_names)
     assert not any(name.endswith("_run_summary") for name in artifact_names)
-    _assert_event_artifacts_use_display_names(event_map, artifact_names)
+    allowed_event_refs = set(artifact_names) | {"messages", "tool_args", "output"}
+    _assert_event_artifacts_use_display_names(event_map, allowed_event_refs)
 
 
 def test_phase17_multiple_tracker_scopes_in_checkpoint_get_namespaces(

--- a/tests/test_phase17_pydantic_ai_adapter.py
+++ b/tests/test_phase17_pydantic_ai_adapter.py
@@ -124,7 +124,7 @@ def test_phase17_event_artifact_names_use_short_display_shape() -> None:
             "stream_transcript",
             namespace="agent_ab12cd34_tracker_2",
         )
-        == "agent_ab12cd34_tracker_2_llm_call_1_stream_transcript"
+        == "llm_call_1_stream_transcript__agent_ab12cd34_tracker_2"
     )
 
 
@@ -258,24 +258,24 @@ def test_phase17_turn_mode_tracks_events_and_artifacts(primed_zenml) -> None:
     artifact_names = _artifact_names(hydrated_run)
     run_label = summary["run_label"]
     assert any(
-        re.fullmatch(rf"[a-zA-Z0-9_]+_{run_label}_tracker_1_event_log", name)
+        re.fullmatch(rf"event_log__[a-zA-Z0-9_]+_{run_label}_tracker_1", name)
         for name in artifact_names
     )
     assert any(
-        re.fullmatch(rf"[a-zA-Z0-9_]+_{run_label}_tracker_1_run_summary", name)
+        re.fullmatch(rf"run_summary__[a-zA-Z0-9_]+_{run_label}_tracker_1", name)
         for name in artifact_names
     )
     assert any(
-        re.fullmatch(rf"[a-zA-Z0-9_]+_{run_label}_tracker_1_llm_call_1_prompt", name)
+        re.fullmatch(rf"llm_call_1_prompt__[a-zA-Z0-9_]+_{run_label}_tracker_1", name)
         for name in artifact_names
     )
     assert any(
-        re.fullmatch(rf"[a-zA-Z0-9_]+_{run_label}_tracker_1_llm_call_1_response", name)
+        re.fullmatch(rf"llm_call_1_response__[a-zA-Z0-9_]+_{run_label}_tracker_1", name)
         for name in artifact_names
     )
-    assert any(re.fullmatch(r".*_tool_call_\d+_args", name) for name in artifact_names)
+    assert any(re.fullmatch(r"tool_call_\d+_args__.*", name) for name in artifact_names)
     assert any(
-        re.fullmatch(r".*_tool_call_\d+_result", name) for name in artifact_names
+        re.fullmatch(r"tool_call_\d+_result__.*", name) for name in artifact_names
     )
     _assert_event_artifacts_use_display_names(event_map, artifact_names)
 
@@ -307,8 +307,8 @@ def test_phase17_turn_mode_tracks_effective_history_input_for_continuations(
         for inputs in inputs_by_step
     )
     artifact_names = _artifact_names(hydrated_run)
-    assert any(name.endswith("_llm_call_1_prompt") for name in artifact_names)
-    assert any(name.endswith("_llm_call_1_response") for name in artifact_names)
+    assert any(name.startswith("llm_call_1_prompt__") for name in artifact_names)
+    assert any(name.startswith("llm_call_1_response__") for name in artifact_names)
 
 
 def test_phase17_turn_mode_omits_absent_prompt_and_history_inputs(
@@ -333,8 +333,8 @@ def test_phase17_turn_mode_omits_absent_prompt_and_history_inputs(
     assert not _has_step_input(hydrated_run, "user_prompt")
     assert not _has_step_input(hydrated_run, "message_history")
     artifact_names = _artifact_names(hydrated_run)
-    assert any(name.endswith("_llm_call_1_prompt") for name in artifact_names)
-    assert any(name.endswith("_llm_call_1_response") for name in artifact_names)
+    assert any(name.startswith("llm_call_1_prompt__") for name in artifact_names)
+    assert any(name.startswith("llm_call_1_response__") for name in artifact_names)
 
 
 def test_phase17_default_granular_mode_tracks_at_flow_scope(primed_zenml) -> None:
@@ -362,13 +362,13 @@ def test_phase17_default_granular_mode_tracks_at_flow_scope(primed_zenml) -> Non
     assert len(hydrated_run.steps) >= 2
     assert _has_step_input(hydrated_run, "messages")
     assert _has_step_input(hydrated_run, "tool_args")
-    assert not any(name.endswith("_llm_call_1_prompt") for name in artifact_names)
-    assert not any(name.endswith("_llm_call_1_response") for name in artifact_names)
+    assert not any(name.startswith("llm_call_1_prompt__") for name in artifact_names)
+    assert not any(name.startswith("llm_call_1_response__") for name in artifact_names)
     assert not any(
-        re.fullmatch(r".*_tool_call_\d+_args", name) for name in artifact_names
+        re.fullmatch(r"tool_call_\d+_args__.*", name) for name in artifact_names
     )
     assert not any(
-        re.fullmatch(r".*_tool_call_\d+_result", name) for name in artifact_names
+        re.fullmatch(r"tool_call_\d+_result__.*", name) for name in artifact_names
     )
     allowed_event_refs = set(artifact_names) | {"messages", "tool_args", "output"}
     _assert_event_artifacts_use_display_names(event_map, allowed_event_refs)
@@ -379,8 +379,8 @@ def test_phase17_default_granular_mode_tracks_at_flow_scope(primed_zenml) -> Non
     )
     assert "event_log" not in artifact_names
     assert "run_summary" not in artifact_names
-    assert not any(name.endswith("_event_log") for name in artifact_names)
-    assert not any(name.endswith("_run_summary") for name in artifact_names)
+    assert not any(name.startswith("event_log__") for name in artifact_names)
+    assert not any(name.startswith("run_summary__") for name in artifact_names)
 
 
 _AUTO_FLOW_AGENT: KitaruAgent[Any, str] | None = None
@@ -465,10 +465,10 @@ def test_phase17_multiple_tracker_scopes_at_flow_scope_get_unique_namespaces(
     assert {"messages", "output"} <= set(model_artifact_refs)
     assert _has_step_input(hydrated_run, "messages")
     assert _has_step_input(hydrated_run, "tool_args")
-    assert not any(name.endswith("_llm_call_1_prompt") for name in artifact_names)
-    assert not any(name.endswith("_llm_call_1_response") for name in artifact_names)
-    assert not any(name.endswith("_event_log") for name in artifact_names)
-    assert not any(name.endswith("_run_summary") for name in artifact_names)
+    assert not any(name.startswith("llm_call_1_prompt__") for name in artifact_names)
+    assert not any(name.startswith("llm_call_1_response__") for name in artifact_names)
+    assert not any(name.startswith("event_log__") for name in artifact_names)
+    assert not any(name.startswith("run_summary__") for name in artifact_names)
     allowed_event_refs = set(artifact_names) | {"messages", "tool_args", "output"}
     _assert_event_artifacts_use_display_names(event_map, allowed_event_refs)
 
@@ -508,22 +508,22 @@ def test_phase17_multiple_tracker_scopes_in_checkpoint_get_namespaces(
     assert len(run_labels) == 2
     for tracker_index in (1, 2):
         assert any(
-            re.fullmatch(rf"[a-zA-Z0-9_]+_tracker_{tracker_index}_event_log", name)
+            re.fullmatch(rf"event_log__[a-zA-Z0-9_]+_tracker_{tracker_index}", name)
             for name in artifact_names
         )
         assert any(
-            re.fullmatch(rf"[a-zA-Z0-9_]+_tracker_{tracker_index}_run_summary", name)
+            re.fullmatch(rf"run_summary__[a-zA-Z0-9_]+_tracker_{tracker_index}", name)
             for name in artifact_names
         )
         assert any(
             re.fullmatch(
-                rf"[a-zA-Z0-9_]+_tracker_{tracker_index}_llm_call_1_prompt", name
+                rf"llm_call_1_prompt__[a-zA-Z0-9_]+_tracker_{tracker_index}", name
             )
             for name in artifact_names
         )
         assert any(
             re.fullmatch(
-                rf"[a-zA-Z0-9_]+_tracker_{tracker_index}_llm_call_1_response", name
+                rf"llm_call_1_response__[a-zA-Z0-9_]+_tracker_{tracker_index}", name
             )
             for name in artifact_names
         )
@@ -537,13 +537,15 @@ def test_phase17_multiple_tracker_scopes_in_checkpoint_get_namespaces(
         for stored_name in event.get("artifacts", {}).values()
     ]
     assert any(
-        re.fullmatch(r"[a-zA-Z0-9_]+_tracker_2_llm_call_1_prompt", name)
+        re.fullmatch(r"llm_call_1_prompt__[a-zA-Z0-9_]+_tracker_2", name)
         for name in event_artifact_names
     )
 
-    event_log_names = [name for name in artifact_names if name.endswith("event_log")]
+    event_log_names = [
+        name for name in artifact_names if name.startswith("event_log__")
+    ]
     run_summary_names = [
-        name for name in artifact_names if name.endswith("run_summary")
+        name for name in artifact_names if name.startswith("run_summary__")
     ]
     assert len(event_log_names) == 2
     assert len(run_summary_names) == 2

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -175,6 +175,191 @@ class TestTurnCacheKeyCallSites:
         assert captured["run_cache_key"] == "cache-async"
 
 
+class TestPydanticAIAutoFlowNaming:
+    def _install_inline_model_checkpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fake_checkpoint(*, body: Any, **_kwargs: Any) -> Any:
+            return await body()
+
+        monkeypatch.setattr(
+            "kitaru.adapters.pydantic_ai._model.run_async_in_checkpoint",
+            fake_checkpoint,
+        )
+
+    def _install_fake_auto_flow(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> list[str]:
+        from kitaru.adapters.pydantic_ai import _agent as agent_module
+        from kitaru.runtime import _flow_scope
+
+        flow_names: list[str] = []
+
+        class FakeHandle:
+            def __init__(self, result: Any) -> None:
+                self._result = result
+
+            def wait(self) -> Any:
+                return self._result
+
+        class FakeAutoFlow:
+            def __init__(self, agent_name: str) -> None:
+                self.flow_name = agent_module._auto_flow_name_for_agent(agent_name)
+
+            def run(
+                self,
+                run_id: str,
+                serialized_body_path: str | None = None,
+            ) -> FakeHandle:
+                flow_names.append(self.flow_name)
+                with _flow_scope(name=self.flow_name):
+                    result = agent_module._run_auto_flow_body(
+                        run_id,
+                        serialized_body_path,
+                    )
+                return FakeHandle(result)
+
+        def fake_auto_flow_for_agent(agent_name: str) -> FakeAutoFlow:
+            return FakeAutoFlow(agent_name)
+
+        monkeypatch.setattr(
+            agent_module,
+            "_auto_flow_for_agent",
+            fake_auto_flow_for_agent,
+        )
+        monkeypatch.setattr(
+            agent_module,
+            "_try_serialize_auto_flow_body",
+            lambda _body: None,
+        )
+        return flow_names
+
+    def test_auto_flow_name_helper_uses_flow_name_normalization(self) -> None:
+        from kitaru.adapters.pydantic_ai._agent import _auto_flow_name_for_agent
+
+        assert _auto_flow_name_for_agent("research_agent") == "research_agent_flow"
+        assert _auto_flow_name_for_agent("research agent") == "research_agent_flow"
+        assert _auto_flow_name_for_agent("123") == "flow_123_flow"
+
+    def test_direct_run_sync_uses_wrapped_agent_name_when_wrapper_name_absent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+
+        self._install_inline_model_checkpoint(monkeypatch)
+        flow_names = self._install_fake_auto_flow(monkeypatch)
+
+        agent = KitaruAgent(Agent(TestModel(), name="wrapped_agent"))
+        agent.run_sync("hello")
+
+        assert flow_names == ["wrapped_agent_flow"]
+
+    def test_direct_run_sync_wrapper_name_wins_over_wrapped_agent_name(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+
+        self._install_inline_model_checkpoint(monkeypatch)
+        flow_names = self._install_fake_auto_flow(monkeypatch)
+
+        agent = KitaruAgent(
+            Agent(TestModel(), name="wrapped_agent"),
+            name="wrapper_agent",
+        )
+        agent.run_sync("hello")
+
+        assert flow_names == ["wrapper_agent_flow"]
+
+    def test_direct_run_sync_accepts_equal_wrapper_and_wrapped_names(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+
+        self._install_inline_model_checkpoint(monkeypatch)
+        flow_names = self._install_fake_auto_flow(monkeypatch)
+
+        agent = KitaruAgent(
+            Agent(TestModel(), name="shared_agent"),
+            name="shared_agent",
+        )
+        agent.run_sync("hello")
+
+        assert flow_names == ["shared_agent_flow"]
+
+    def test_direct_run_sync_uses_wrapper_name_when_wrapped_agent_is_unnamed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+
+        self._install_inline_model_checkpoint(monkeypatch)
+        flow_names = self._install_fake_auto_flow(monkeypatch)
+
+        agent = KitaruAgent(Agent(TestModel()), name="wrapper_only")
+        agent.run_sync("hello")
+
+        assert flow_names == ["wrapper_only_flow"]
+
+    def test_unnamed_wrapper_and_wrapped_agent_still_raise(self) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.exceptions import UserError
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+
+        with pytest.raises(UserError, match="requires a stable `name`"):
+            KitaruAgent(Agent(TestModel()))
+
+    def test_inside_explicit_flow_does_not_open_auto_flow(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+        from kitaru.adapters.pydantic_ai import _agent as agent_module
+        from kitaru.runtime import _flow_scope
+
+        def fail_auto_flow(_agent_name: str) -> Any:
+            raise AssertionError("explicit flow should not use auto-flow")
+
+        self._install_inline_model_checkpoint(monkeypatch)
+        monkeypatch.setattr(agent_module, "_auto_flow_for_agent", fail_auto_flow)
+        agent = KitaruAgent(Agent(TestModel(), name="explicit_agent"))
+
+        with _flow_scope(name="explicit_flow"):
+            agent.run_sync("hello")
+
+    def test_real_auto_flow_factory_caches_and_registers_source_alias(self) -> None:
+        from kitaru._source_aliases import build_pipeline_source_alias
+        from kitaru.adapters.pydantic_ai import _agent as agent_module
+
+        flow_name = agent_module._auto_flow_name_for_agent("source alias agent")
+        source_alias = build_pipeline_source_alias(flow_name)
+
+        first = agent_module._auto_flow_for_agent("source alias agent")
+        second = agent_module._auto_flow_for_agent("source alias agent")
+
+        assert first is second
+        assert getattr(agent_module, flow_name).__name__ == flow_name
+        assert getattr(agent_module, source_alias) is first._pipeline
+
+
 class TestStreamingHookCapabilities:
     def test_detects_configured_streaming_hooks(self) -> None:
         from pydantic_ai.capabilities.hooks import Hooks

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -540,6 +540,119 @@ class TestCachedGranularModelCheckpoints:
         assert alpha_id.endswith("_tool_call_2")
         assert beta_id.endswith("_tool_call_3")
 
+    @pytest.mark.anyio
+    async def test_granular_model_checkpoint_uses_structural_messages_and_output_refs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from pydantic_ai.messages import ModelResponse, TextPart
+        from pydantic_ai.models.function import FunctionModel
+
+        from kitaru.adapters.pydantic_ai._model import KitaruModel
+        from kitaru.adapters.pydantic_ai._policy import CapturePolicy
+        from kitaru.adapters.pydantic_ai._tracking import EventTracker
+        from kitaru.runtime import _checkpoint_scope, _flow_scope
+
+        response = ModelResponse(parts=[TextPart(content="fixed answer")])
+        tracker = EventTracker(agent_name="structural_agent", run_label="structural")
+        captured_checkpoint_inputs: dict[str, Any] = {}
+
+        def model_function(_messages: list[Any], _info: Any) -> Any:
+            return response
+
+        async def fake_checkpoint(**kwargs: Any) -> Any:
+            captured_checkpoint_inputs.update(kwargs.get("checkpoint_inputs") or {})
+            with _checkpoint_scope(
+                name=kwargs["step_name"],
+                checkpoint_type=kwargs["config"].get("type", "llm_call"),
+            ):
+                return await kwargs["body"]()
+
+        monkeypatch.setattr(
+            "kitaru.adapters.pydantic_ai._model.run_async_in_checkpoint",
+            fake_checkpoint,
+        )
+        monkeypatch.setattr(
+            "kitaru.adapters.pydantic_ai._model.get_current_tracker",
+            lambda: tracker,
+        )
+
+        def fail_model_manual_save(*args: Any, **kwargs: Any) -> None:
+            pytest.fail(
+                "granular model checkpoint should not manually save "
+                f"{args!r} {kwargs!r}"
+            )
+
+        monkeypatch.setattr(
+            "kitaru.adapters.pydantic_ai._model.kitaru.save",
+            fail_model_manual_save,
+        )
+        model = KitaruModel(
+            FunctionModel(model_function),
+            capture=CapturePolicy(correlate_otel_spans=False),
+            agent_name="structural_agent",
+            checkpoint_config={"cache": True},
+        )
+
+        with _flow_scope(name="structural_flow"):
+            actual = await model.request([], None, self._model_request_parameters())
+
+        assert actual is response
+        assert captured_checkpoint_inputs == {"messages": []}
+        model_events = [event for event in tracker.events if event.kind == "llm_call"]
+        assert len(model_events) == 1
+        model_event = cast(Any, model_events[0])
+        assert model_event.artifacts == {
+            "prompt": "messages",
+            "response": "output",
+        }
+
+    @pytest.mark.anyio
+    async def test_cached_granular_model_event_uses_canonical_refs_when_captured(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai._model import KitaruModel
+        from kitaru.adapters.pydantic_ai._policy import CapturePolicy
+        from kitaru.adapters.pydantic_ai._tracking import EventTracker
+        from kitaru.runtime import _flow_scope
+
+        cached_response = self._tool_call_response()
+        tracker = EventTracker(agent_name="cached_refs", run_label="cached_refs")
+
+        async def fake_checkpoint(**_kwargs: Any) -> Any:
+            return cached_response
+
+        monkeypatch.setattr(
+            "kitaru.adapters.pydantic_ai._model.run_async_in_checkpoint",
+            fake_checkpoint,
+        )
+        monkeypatch.setattr(
+            "kitaru.adapters.pydantic_ai._model.get_current_tracker",
+            lambda: tracker,
+        )
+        model = KitaruModel(
+            TestModel(),
+            capture=CapturePolicy(correlate_otel_spans=False),
+            agent_name="cached_refs",
+            checkpoint_config={"cache": True},
+        )
+
+        with _flow_scope(name="cached_refs_flow"):
+            response = await model.request([], None, self._model_request_parameters())
+
+        assert response is cached_response
+        model_events = [event for event in tracker.events if event.kind == "llm_call"]
+        assert len(model_events) == 1
+        model_event = cast(Any, model_events[0])
+        assert model_event.artifacts == {
+            "prompt": "messages",
+            "response": "output",
+        }
+        assert model_event.checkpoint_name == "cached_refs_model_request"
+
 
 class TestEventTrackerToolCallOrdering:
     def _record_completed_model(self, tracker: Any) -> tuple[str, Any]:
@@ -1788,6 +1901,70 @@ async def test_non_hitl_tool_still_uses_granular_tool_checkpoint(
 
     assert result == "ordinary result"
     assert checkpoint_steps == ["ordinary_tool_tool"]
+
+
+@pytest.mark.anyio
+async def test_granular_tool_checkpoint_uses_structural_args_and_output_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pydantic_ai import FunctionToolset
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._toolset import kitaruify_toolset
+    from kitaru.adapters.pydantic_ai._tracking import EventTracker
+    from kitaru.runtime import _checkpoint_scope, _flow_scope
+
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    @toolset.tool_plain
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    tracker = EventTracker(agent_name="tool_agent", run_label="tool")
+    captured_checkpoint_inputs: dict[str, Any] = {}
+
+    async def fake_checkpoint(**kwargs: Any) -> Any:
+        captured_checkpoint_inputs.update(kwargs.get("checkpoint_inputs") or {})
+        with _checkpoint_scope(
+            name=kwargs["step_name"],
+            checkpoint_type=kwargs["config"].get("type", "tool_call"),
+        ):
+            return await kwargs["body"]()
+
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._toolset.run_async_in_checkpoint",
+        fake_checkpoint,
+    )
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._toolset.get_current_tracker",
+        lambda: tracker,
+    )
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._toolset.kitaru.save",
+        lambda *args, **kwargs: pytest.fail(
+            f"granular tool checkpoint should not manually save {args!r} {kwargs!r}"
+        ),
+    )
+    wrapped = kitaruify_toolset(
+        toolset,
+        capture=CapturePolicy(correlate_otel_spans=False),
+        tool_checkpoint_config={},
+    )
+    ctx = _with_tool_call_id(RunContext(deps=None, model=TestModel(), usage=RunUsage()))
+    tool = (await wrapped.get_tools(ctx))["add"]
+
+    with _flow_scope(name="demo_flow"):
+        result = await wrapped.call_tool("add", {"a": 2, "b": 3}, ctx, tool)
+
+    assert result == 5
+    assert captured_checkpoint_inputs == {"tool_args": {"a": 2, "b": 3}}
+    tool_events = [event for event in tracker.events if event.kind == "tool_call"]
+    assert len(tool_events) == 1
+    tool_event = cast(Any, tool_events[0])
+    assert tool_event.artifacts == {"args": "tool_args", "result": "output"}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## What changed

- Stores granular PydanticAI model messages and tool arguments as structural checkpoint inputs (`messages`, `tool_args`) instead of manual output-side artifacts with only semantic metadata.
- Extends the same structural-input pattern to OpenAI Agents `checkpoint_strategy="calls"`:
  - model request envelopes are checkpoint input `input`
  - function-tool argument envelopes are checkpoint input `tool_args`
  - checkpoint `output` is the canonical response/result ref
- Adds checkpoint identity (`checkpoint_id`, `checkpoint_name`) to OpenAI child events so structural refs like `output` are tied to the checkpoint that owns them.
- Keeps OpenAI `runner_call` mode and Claude Agent SDK invocation semantics unchanged.
- Changes adapter-generated artifact names to put the human-readable role first and the uniqueness namespace last, e.g. `llm_call_1_prompt__agent_run_tracker_1` and `messages__Claude_Reviewer_ab12cd34`.
- Preserves Claude captured artifact types (`context` for messages/transcript/options/usage, `response` for output) while improving raw artifact names.
- Names direct PydanticAI auto-flows from the stable adapter name: `KitaruAgent(name=...)` wins over the wrapped Pydantic AI `Agent(name=...)`, otherwise the wrapped agent name is used. Direct calls now create `{stable_agent_name}_flow` instead of `_kitaru_pydantic_ai_auto_flow`; explicit `@kitaru.flow(name=...)` wrappers keep their explicit flow names.
- Narrows client execution mapping so ordinary checkpoint inputs are not exposed as default loadable `CheckpointCall.artifacts`; only known adapter structural inputs are surfaced with `direction="input"`.
- Updates replay/example code to load the publish checkpoint output artifact explicitly now that checkpoint artifacts can include both inputs and outputs.
- Adds/updates regression coverage for PydanticAI, OpenAI Agents, Claude Agent SDK, inspection/test doubles, replay example behavior, PydanticAI auto-flow naming, OpenAI event checkpoint identity, and client input-artifact exposure.

## Why

`kitaru.save(..., type="input")` only stores Kitaru semantic metadata; it does not create a structural checkpoint input edge. If an adapter manually saves an input-like value inside a checkpoint, ZenML still treats that artifact as produced by the checkpoint. The UI/client therefore sees it on the output side.

PydanticAI granular checkpoints already needed this fix for prompts/tool args. OpenAI Agents `calls` mode had the same shape, so this PR now fixes both granular adapter paths. Claude is different: it currently wraps one coarse SDK invocation, so its captured artifacts are mostly invocation observations/results rather than clean model/tool-call input sockets. For Claude, this PR only changes naming.

The naming changes address two related UI readability issues without changing UI code. First, uniqueness prefixes appeared first, so truncated artifact pills all looked identical. New adapter artifacts keep uniqueness, but start with the useful role/event label. Second, direct PydanticAI calls previously appeared under the generic `_kitaru_pydantic_ai_auto_flow`; they now use the stable agent name so the flow itself is recognizable.

The final review pass also tightened two correctness boundaries: OpenAI event artifact refs now include checkpoint context, and default client inspection no longer turns every ordinary checkpoint input into a public loadable artifact ref.

## Key implementation decisions

- Kept UI changes out of scope.
- Kept PydanticAI turn-mode and streaming manual-artifact behavior unchanged.
- Kept OpenAI `runner_call` unchanged because it is intentionally coarse-grained.
- Did not structurally convert Claude invocation captures; that should be a separate design decision if we later want request-level inputs there.
- Kept naming helpers adapter-local for now; a shared adapter checkpoint/naming utility could be a later cleanup, but was not necessary for this fix.
- OpenAI usage remains a manual context artifact/metadata, not a structural input or canonical output.
- Kept PydanticAI auto-flow execution local-only. The per-agent auto-flow definitions are cached and installed as module attributes before decoration so Kitaru/ZenML source aliasing can still resolve them.
- Kept `CheckpointCall.artifacts` backward-compatible for ordinary checkpoints by exposing outputs by default, while surfacing only adapter structural inputs (`llm_call.input`, `tool_call.tool_args`) as input refs.

## Reviewer Notes

Please focus on four areas:

1. **Structural artifact semantics**
   - `src/kitaru/adapters/openai_agents/_utils.py`
   - `src/kitaru/adapters/openai_agents/_model.py`
   - `src/kitaru/adapters/openai_agents/_tools.py`
   - `src/kitaru/adapters/pydantic_ai/_model.py`
   - `src/kitaru/adapters/pydantic_ai/_toolset.py`
   - `src/kitaru/_client/_mappers.py`

2. **Role-first artifact naming**
   - `src/kitaru/adapters/pydantic_ai/_tracking.py`
   - `src/kitaru/adapters/openai_agents/_tracking.py`
   - `src/kitaru/adapters/claude_agent_sdk/_tracking.py`

3. **PydanticAI auto-flow naming**
   - `src/kitaru/adapters/pydantic_ai/_agent.py`
   - `tests/test_pydantic_ai_adapter.py::TestPydanticAIAutoFlowNaming`
   - `src/kitaru/adapters/pydantic_ai/README.md`

4. **Review must-fix regressions**
   - OpenAI event checkpoint identity: `src/kitaru/adapters/openai_agents/_events.py`, `_tracking.py`, `_kitaru_internal.py`
   - Client input exposure boundary: `src/kitaru/_client/_mappers.py`
   - Regression tests: `tests/test_openai_agents_calls_strategy.py`, `tests/test_client.py`, `tests/test_inspection.py`

Suggested local checks:

```bash
uv run pytest tests/test_pydantic_ai_adapter.py::TestPydanticAIAutoFlowNaming
uv run pytest tests/test_openai_agents_calls_strategy.py tests/test_client.py tests/test_inspection.py
just check
just test
```

To manually reproduce the latest PydanticAI naming fix, create/run a direct `KitaruAgent.run_sync(...)` outside an explicit `@kitaru.flow` with either `Agent(..., name="my_agent")` or `KitaruAgent(..., name="my_agent")`; the flow should appear as `my_agent_flow`. If both names differ, the `KitaruAgent(name=...)` value should win.

Refs #338
