### PR TITLE
Update Claude Code skills docs

### DIFF
--- a/docs/content/docs/agent-native/claude-code-skill.mdx
+++ b/docs/content/docs/agent-native/claude-code-skill.mdx
@@ -1,18 +1,31 @@
 ---
 title: Claude Code Skills
-description: Install Kitaru's Claude Code skills for scoping and authoring durable agent workflows
+description: Install Kitaru's Claude Code skills for quickstart, scoping, and authoring durable agent workflows
 ---
 
-Kitaru provides two Claude Code skills that teach Claude how to design and build
-durable agent workflows.
+Kitaru provides three Claude Code skills that teach Claude how to discover,
+design, and build durable agent workflows.
 
 ## Available skills
+
+### Quickstart skill
+
+The **kitaru-quickstart** skill gives you an interactive tour of Kitaru. It
+scaffolds a small demo flow and walks through the core ideas: crash recovery
+with replay, human-in-the-loop pauses with `wait()`, artifact capture, and
+optional MCP integration.
+
+**Use it when:**
+- You want to try Kitaru and see what it does before designing a real workflow
+- You want a five-minute tour of crash recovery, replay, waits, and artifacts
+- You want Claude Code to set up a small local demo for your own workflow shape
 
 ### Scoping skill
 
 The **kitaru-scoping** skill helps you decide whether your agent workflow
 benefits from durable execution, then designs the flow architecture —
-checkpoint boundaries, wait points, artifact strategy, and MVP scope.
+checkpoint boundaries, wait points, replay anchors, artifact strategy, operator
+surface, and MVP scope.
 
 It runs a structured interview and produces a `flow_architecture.md`
 specification that feeds directly into the authoring skill.
@@ -25,21 +38,27 @@ specification that feeds directly into the authoring skill.
 ### Authoring skill
 
 The **kitaru-authoring** skill teaches Claude how to write valid Kitaru flows,
-checkpoints, waits, and adapter usage patterns.
+checkpoints, waits, logging, artifacts, `KitaruClient` usage, replay/resume/retry
+flows, deployments, secrets, CLI/MCP operations, and adapter usage patterns.
 
 **What it covers:**
 - `@flow` and `@checkpoint` roles
 - `kitaru.wait()` flow-level guardrails
 - `kitaru.log()`, `kitaru.save()`, `kitaru.load()`, `kitaru.llm()`
 - `.submit()` / `.result()` checkpoint concurrency
-- PydanticAI adapter guidance (`kitaru.adapters.pydantic_ai.KitaruAgent(...)`)
-- Common mistakes (nested flows, non-serializable checkpoint outputs, etc.)
+- PydanticAI adapter guidance with `kitaru.adapters.pydantic_ai.KitaruAgent(...)`
+- OpenAI Agents adapter guidance with `KitaruRunner`
+- LangGraph adapter guidance with `KitaruGraphRunner`
+- Claude Agent SDK adapter guidance with `KitaruClaudeRunner`
+- Common mistakes such as nested flows, non-serializable checkpoint outputs, and unsafe side effects
 
 ## Recommended workflow
 
-1. **Scope first** — use `/kitaru-scoping` (or let Claude trigger it automatically)
-   to validate fit and define your flow architecture
-2. **Author second** — use `/kitaru-authoring` to build the flows defined in
+1. **Quickstart first** — use `/kitaru-quickstart` to see what Kitaru does and
+   build intuition for crash recovery, replay, waits, and artifacts
+2. **Scope second** — use `/kitaru-scoping` to validate fit and define your flow
+   architecture before writing code
+3. **Author third** — use `/kitaru-authoring` to build the flows defined in
    your `flow_architecture.md`
 
 ## Install from the marketplace
@@ -53,33 +72,49 @@ and install with two commands:
 ```
 
 Once installed, Claude Code will automatically use the skills based on context.
-You can also invoke them explicitly with `/kitaru-scoping` or `/kitaru-authoring`.
+You can also invoke them explicitly with `/kitaru-quickstart`,
+`/kitaru-scoping`, or `/kitaru-authoring`.
 
 ## Manual installation
 
-If you prefer to copy the skill files directly:
+If you prefer to copy the skill directories directly:
 
 ```bash
-mkdir -p .claude/skills/kitaru-scoping .claude/skills/kitaru-authoring
-
-curl -fsSL https://raw.githubusercontent.com/zenml-io/kitaru-skills/main/skills/kitaru-scoping/SKILL.md \
-  -o .claude/skills/kitaru-scoping/SKILL.md
-
-curl -fsSL https://raw.githubusercontent.com/zenml-io/kitaru-skills/main/skills/kitaru-authoring/SKILL.md \
-  -o .claude/skills/kitaru-authoring/SKILL.md
+tmpdir=$(mktemp -d)
+git clone --depth 1 https://github.com/zenml-io/kitaru-skills.git "$tmpdir/kitaru-skills"
+mkdir -p .claude/skills
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-quickstart" .claude/skills/
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-scoping" .claude/skills/
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-authoring" .claude/skills/
+rm -rf "$tmpdir"
 ```
 
+Copying the full `kitaru-quickstart` directory is important because that skill
+includes reference files used during the guided demo.
+
 ## Good prompts to pair with the skills
+
+**Quickstart:**
+- "I want to try Kitaru — show me what it does."
+- "Give me a five-minute tour of Kitaru's crash recovery."
+- "Set up a Kitaru demo for my data pipeline workflow."
+- "Walk me through Kitaru with MCP integration."
 
 **Scoping:**
 - "I want to build a research agent — is Kitaru right for this?"
 - "Help me figure out where to put checkpoints in my coding agent workflow."
+- "Should repo conventions be stored as explicit artifacts or outside the flow?"
 - "I have a complex agent with 10 steps — help me scope it down."
 
 **Authoring:**
 - "Refactor this script into one `@flow` with explicit checkpoints."
 - "Add a flow-level `kitaru.wait()` approval gate before publish."
-- "Wrap this PydanticAI call in a `@checkpoint` and preserve replay safety."
+- "Add explicit artifact saving to this flow."
+- "How do I inspect executions, waits, logs, and artifacts from the CLI or MCP?"
+- "Convert this PydanticAI agent to `KitaruAgent` and preserve replay safety."
+- "Use `KitaruRunner` for this OpenAI Agents workflow and choose the checkpoint strategy."
+- "Help me add Kitaru durability around a LangGraph graph."
+- "Make this Claude Agent SDK invocation durable without promising granular tool replay."
 
 ## Related pages
 


### PR DESCRIPTION
## What changed

- Updated the public Claude Code skills docs page from a two-skill description to the current three-skill plugin shape.
- Added the quickstart skill, updated the recommended workflow, and refreshed manual install commands to copy all three skill directories.
- Updated authoring coverage and example prompts to mention current adapter families beyond PydanticAI.

## Why it was needed

The public docs lagged behind the `zenml-io/kitaru-skills` plugin. A user following the docs would only see scoping and authoring, missing the quickstart skill and its reference files.

## Key implementation decisions

- Kept the page concise and install-focused rather than duplicating the full skill README.
- Manual install now clones the plugin repo and copies full directories, which is important for `kitaru-quickstart` because it has bundled references.
- No native memory guidance was added.

## Reviewer Notes

The important behavior is documentation consistency: the public Kitaru docs should now tell the same story as the plugin README — quickstart first, then scoping, then authoring.

Please check the manual installation snippet carefully. The old curl-based approach copied only individual SKILL.md files; the new approach copies full skill directories so quickstart references are available.

### Reproduction

1. Open `/agent-native/claude-code-skill` in the docs preview.
2. Confirm the page lists quickstart, scoping, and authoring.
3. Confirm the manual install snippet copies all three directories.
4. Confirm example prompts include quickstart and non-PydanticAI adapter prompts.

Local checks run:

```text
git diff --check -- docs/content/docs/agent-native/claude-code-skill.mdx
forbidden native-memory term search on edited page
```
