### PR TITLE
Remove stale memory docs references

### DIFF
--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -24,7 +24,7 @@ type PageEntry = {
 };
 
 const PRODUCT_DESCRIPTION =
-  "Kitaru is the runtime layer underneath your agent stack: it gives Python AI workflows durable checkpoints, replay, resumable waits, memory, deployment, and operational tooling.";
+  "Kitaru is the runtime layer underneath your agent stack: it gives Python AI workflows durable checkpoints, replay, resumable waits, tracked LLM calls, artifact lineage, deployment, and operational tooling.";
 
 const SECTIONS: Section[] = [
   {
@@ -101,7 +101,9 @@ const PAGE_ORDER = new Map([
   ["/guides/authentication", 20],
   ["/guides/deployments", 30],
   ["/guides/llm-calls", 40],
-  ["/guides/memory", 50],
+  ["/guides/artifacts", 50],
+  ["/guides/wait-and-resume", 60],
+  ["/guides/execution-management", 70],
   ["/cli", 10],
   ["/reference/python", 20],
 ]);

--- a/docs/content/docs/agent-native/claude-code-skill.mdx
+++ b/docs/content/docs/agent-native/claude-code-skill.mdx
@@ -1,18 +1,31 @@
 ---
-title: Claude Code Skills
-description: Install Kitaru's Claude Code skills for scoping and authoring durable agent workflows
+title: Agent Skills
+description: Install Kitaru's agent skills for quickstart, scoping, and authoring durable agent workflows
 ---
 
-Kitaru provides two Claude Code skills that teach Claude how to design and build
-durable agent workflows.
+Kitaru provides three agent skills that teach coding agents how to discover,
+design, and build durable workflows with Kitaru.
 
 ## Available skills
+
+### Quickstart skill
+
+The **kitaru-quickstart** skill gives you an interactive tour of Kitaru. It
+scaffolds a small demo flow and walks through the core ideas: crash recovery
+with replay, human-in-the-loop pauses with `wait()`, artifact capture, and
+optional MCP integration.
+
+**Use it when:**
+- You want to try Kitaru and see what it does before designing a real workflow
+- You want a five-minute tour of crash recovery, replay, waits, and artifacts
+- You want an agent to set up a small local demo for your own workflow shape
 
 ### Scoping skill
 
 The **kitaru-scoping** skill helps you decide whether your agent workflow
 benefits from durable execution, then designs the flow architecture —
-checkpoint boundaries, wait points, artifact strategy, and MVP scope.
+checkpoint boundaries, wait points, replay anchors, artifact strategy, operator
+surface, and MVP scope.
 
 It runs a structured interview and produces a `flow_architecture.md`
 specification that feeds directly into the authoring skill.
@@ -24,22 +37,28 @@ specification that feeds directly into the authoring skill.
 
 ### Authoring skill
 
-The **kitaru-authoring** skill teaches Claude how to write valid Kitaru flows,
-checkpoints, waits, and adapter usage patterns.
+The **kitaru-authoring** skill teaches coding agents how to write valid Kitaru flows,
+checkpoints, waits, logging, artifacts, `KitaruClient` usage, replay/resume/retry
+flows, deployments, secrets, CLI/MCP operations, and adapter usage patterns.
 
 **What it covers:**
 - `@flow` and `@checkpoint` roles
 - `kitaru.wait()` flow-level guardrails
 - `kitaru.log()`, `kitaru.save()`, `kitaru.load()`, `kitaru.llm()`
 - `.submit()` / `.result()` checkpoint concurrency
-- PydanticAI adapter guidance (`kitaru.adapters.pydantic_ai.KitaruAgent(...)`)
-- Common mistakes (nested flows, non-serializable checkpoint outputs, etc.)
+- PydanticAI adapter guidance with `kitaru.adapters.pydantic_ai.KitaruAgent(...)`
+- OpenAI Agents adapter guidance with `KitaruRunner`
+- LangGraph adapter guidance with `KitaruGraphRunner`
+- Claude Agent SDK adapter guidance with `KitaruClaudeRunner`
+- Common mistakes such as nested flows, non-serializable checkpoint outputs, and unsafe side effects
 
 ## Recommended workflow
 
-1. **Scope first** — use `/kitaru-scoping` (or let Claude trigger it automatically)
-   to validate fit and define your flow architecture
-2. **Author second** — use `/kitaru-authoring` to build the flows defined in
+1. **Quickstart first** — use `/kitaru-quickstart` to see what Kitaru does and
+   build intuition for crash recovery, replay, waits, and artifacts
+2. **Scope second** — use `/kitaru-scoping` to validate fit and define your flow
+   architecture before writing code
+3. **Author third** — use `/kitaru-authoring` to build the flows defined in
    your `flow_architecture.md`
 
 ## Install from the marketplace
@@ -52,34 +71,53 @@ and install with two commands:
 /plugin install kitaru@kitaru
 ```
 
+These are Markdown skill directories, so the same files can also be reused by
+other agent hosts that support local skill folders.
+
 Once installed, Claude Code will automatically use the skills based on context.
-You can also invoke them explicitly with `/kitaru-scoping` or `/kitaru-authoring`.
+You can also invoke them explicitly with `/kitaru-quickstart`,
+`/kitaru-scoping`, or `/kitaru-authoring`.
 
 ## Manual installation
 
-If you prefer to copy the skill files directly:
+If you prefer to copy the skill directories directly:
 
 ```bash
-mkdir -p .claude/skills/kitaru-scoping .claude/skills/kitaru-authoring
-
-curl -fsSL https://raw.githubusercontent.com/zenml-io/kitaru-skills/main/skills/kitaru-scoping/SKILL.md \
-  -o .claude/skills/kitaru-scoping/SKILL.md
-
-curl -fsSL https://raw.githubusercontent.com/zenml-io/kitaru-skills/main/skills/kitaru-authoring/SKILL.md \
-  -o .claude/skills/kitaru-authoring/SKILL.md
+tmpdir=$(mktemp -d)
+git clone --depth 1 https://github.com/zenml-io/kitaru-skills.git "$tmpdir/kitaru-skills"
+mkdir -p .claude/skills
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-quickstart" .claude/skills/
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-scoping" .claude/skills/
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-authoring" .claude/skills/
+rm -rf "$tmpdir"
 ```
 
+Copying the full `kitaru-quickstart` directory is important because that skill
+includes reference files used during the guided demo.
+
 ## Good prompts to pair with the skills
+
+**Quickstart:**
+- "I want to try Kitaru — show me what it does."
+- "Give me a five-minute tour of Kitaru's crash recovery."
+- "Set up a Kitaru demo for my data pipeline workflow."
+- "Walk me through Kitaru with MCP integration."
 
 **Scoping:**
 - "I want to build a research agent — is Kitaru right for this?"
 - "Help me figure out where to put checkpoints in my coding agent workflow."
+- "Should repo conventions be stored as explicit artifacts or outside the flow?"
 - "I have a complex agent with 10 steps — help me scope it down."
 
 **Authoring:**
 - "Refactor this script into one `@flow` with explicit checkpoints."
 - "Add a flow-level `kitaru.wait()` approval gate before publish."
-- "Wrap this PydanticAI call in a `@checkpoint` and preserve replay safety."
+- "Add explicit artifact saving to this flow."
+- "How do I inspect executions, waits, logs, and artifacts from the CLI or MCP?"
+- "Convert this PydanticAI agent to `KitaruAgent` and preserve replay safety."
+- "Use `KitaruRunner` for this OpenAI Agents workflow and choose the checkpoint strategy."
+- "Help me add Kitaru durability around a LangGraph graph."
+- "Make this Claude Agent SDK invocation durable without promising granular tool replay."
 
 ## Related pages
 

--- a/docs/content/docs/guides/claude-agent-sdk-adapter.mdx
+++ b/docs/content/docs/guides/claude-agent-sdk-adapter.mdx
@@ -540,7 +540,7 @@ For a richer workflow, see the compliance-review example:
 uv run examples/end_to_end/compliance_review/stage_1_single_turn.py
 ```
 
-That example shows staged audit checkpoints, memory, and wait/resume around
+That example shows staged audit checkpoints, artifact persistence, and wait/resume around
 Claude turns. It uses the same high-level boundary: one Claude SDK invocation is
 one Kitaru checkpoint. It also has a custom transcript materializer for its
 multi-turn remote-stack story. That extra materializer is example-specific; the

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -132,8 +132,8 @@ durable.
     href="/agent-native/mcp-server/"
   />
   <Card
-    title="Claude Code Skills"
-    description="Install the Kitaru scoping and authoring skills"
+    title="Agent Skills"
+    description="Install the Kitaru quickstart, scoping, and authoring skills"
     href="/agent-native/claude-code-skill/"
   />
   <Card

--- a/site/src/components/compare/graphics/inngest/AgentPrimitives.astro
+++ b/site/src/components/compare/graphics/inngest/AgentPrimitives.astro
@@ -49,7 +49,7 @@
   <div class="panel panel--kitaru">
     <div class="panel-head">
       <span class="panel-label panel-label--accent">Kitaru · Python agent primitives</span>
-      <span class="panel-sub">The glue every Python agent team writes, shipped in the box</span>
+      <span class="panel-sub">LLM calls, waits, and artifacts shipped in the box</span>
     </div>
 
     <div class="wrap">
@@ -67,8 +67,8 @@
         <span class="pval">human or external input, compute released</span>
       </div>
       <div class="prim">
-        <span class="mono pkey">kitaru.memory</span>
-        <span class="pval">typed scopes, versioned across runs</span>
+        <span class="mono pkey">kitaru.save() / kitaru.load()</span>
+        <span class="pval">named artifacts across executions</span>
       </div>
       <div class="prim">
         <span class="mono pkey">@checkpoint</span>

--- a/site/src/components/compare/graphics/inngest/RuntimeUnderHarness.astro
+++ b/site/src/components/compare/graphics/inngest/RuntimeUnderHarness.astro
@@ -49,7 +49,7 @@
       </div>
       <div class="layer layer--accent">
         <span class="layer-key">Runtime</span>
-        <span class="layer-val">Kitaru: <code>@flow</code>, <code>@checkpoint</code>, <code>llm()</code>, <code>wait()</code>, <code>memory</code></span>
+        <span class="layer-val">Kitaru: <code>@flow</code>, <code>@checkpoint</code>, <code>llm()</code>, <code>wait()</code>, <code>save/load</code></span>
       </div>
       <div class="layer">
         <span class="layer-key">Model</span>

--- a/site/src/content/comparisons/kitaru-vs-inngest.mdx
+++ b/site/src/content/comparisons/kitaru-vs-inngest.mdx
@@ -2,8 +2,8 @@
 competitor: "Inngest"
 competitorLogo: "https://assets.kitaru.ai/compare/aab08903/inngest-mark.png"
 title: "Kitaru vs Inngest: The runtime layer underneath your Python agents"
-description: "Inngest is a broad event-driven workflow platform spanning TypeScript, Python, and Go. Kitaru is the self-hosted Python runtime that slots underneath the agent harness you already picked, with LLM, wait, memory, and artifact lineage in the box."
-cardSubtitle: "The self-hosted Python runtime layer underneath your existing agent harness, with primitives for `llm()`, `wait()`, memory, and artifact lineage."
+description: "Inngest is a broad event-driven workflow platform spanning TypeScript, Python, and Go. Kitaru is the self-hosted Python runtime that slots underneath the agent harness you already picked, with LLM calls, waits, and artifact lineage in the box."
+cardSubtitle: "The self-hosted Python runtime layer underneath your existing agent harness, with primitives for `llm()`, `wait()`, and artifact save/load."
 ctaHeading: "Durable execution, shaped for Python agents"
 order: 70
 ogImage: "https://assets.kitaru.ai/compare/b4ea27b1/inngest-og.avif"
@@ -22,13 +22,13 @@ import ArtifactLineage from '../../components/compare/graphics/inngest/ArtifactL
 
 Inngest makes the pitch: "make any code durable across an event-driven app," and they genuinely do that. One platform takes your TypeScript, Python, or Go function, wraps it in retries and step memoization, and gives you the flow-control surface (concurrency, throttling, rate limiting, debounce, batching, prioritization) that most workflow engines leave you to wire up yourself. Add managed Inngest Cloud with SOC 2 Type II, enterprise SAML, HIPAA BAA available, and isolated branch environments for non-production branches, plus a single-binary self-host path, and you can see why a lot of app teams on Vercel or Lambda picked it. So if your durability problem is shaped like an event-driven app, Inngest is the pragmatic answer.
 
-Kitaru is narrower on purpose. We built it for Python agents, because that's the workload most teams we talk to are trying to ship right now. Today, it's increasingly obvious that every company running agents in production needs the same capabilities: a durable `llm()` call, wait/resume, typed versioned memory, artifact lineage across runs, human/agent approval gates, and a runtime that understands the cloud underneath it. Those don't come in the box with a general-purpose event-and-function platform. So we put them there, underneath whatever harness your team already picked rather than asking you to re-shape the app around a new platform.
+Kitaru is narrower on purpose. We built it for Python agents, because that's the workload most teams we talk to are trying to ship right now. Today, it's increasingly obvious that every company running agents in production needs the same capabilities: a durable `llm()` call, wait/resume, artifact lineage across runs, human/agent approval gates, and a runtime that understands the cloud underneath it. Those don't come in the box with a general-purpose event-and-function platform. So we put them there, underneath whatever harness your team already picked rather than asking you to re-shape the app around a new platform.
 
 <WhenToUseEach
   kitaru={{
     title: "Use Kitaru if you are",
     items: [
-      "Running Python agents and want `kitaru.llm()`, `kitaru.wait()`, `kitaru.memory`, and artifact lineage as primitives, not glue code your platform team maintains forever",
+      "Running Python agents and want `kitaru.llm()`, `kitaru.wait()`, and `kitaru.save()` / `kitaru.load()` as primitives, not glue code your platform team maintains forever",
       "Deploying across Kubernetes, AWS, GCP, or Azure (Vertex AI, SageMaker, AzureML) and want an opinionated stack abstraction where one config switches every flow's backend",
       "Keeping the agent harness, auth, entitlements, and observability stack you already picked, and adding only the runtime layer underneath them",
       "Designing around dynamic agent loops: tool calls, conditional branches, human/agent approval gates, hours-long waits, replay from a specific checkpoint",
@@ -52,7 +52,7 @@ Kitaru is narrower on purpose. We built it for Python agents, because that's the
 <FeatureWithGraphic title="Runtime under your harness vs platform across your stack">
   <RuntimeUnderHarness slot="graphic" />
 
-  Defaults tell you what a tool is actually for. Inngest's defaults are workflows, background jobs, agents, durable endpoints, cron, and queue replacement: a packaged platform across your stack. Kitaru's defaults are `@flow` and `@checkpoint` on ordinary Python, with `kitaru.llm()`, `kitaru.wait()`, and `kitaru.memory` shipped underneath whatever harness your team already picked. Different opinion about the workload, same commitment to durability.
+  Defaults tell you what a tool is actually for. Inngest's defaults are workflows, background jobs, agents, durable endpoints, cron, and queue replacement: a packaged platform across your stack. Kitaru's defaults are `@flow` and `@checkpoint` on ordinary Python, with `kitaru.llm()`, `kitaru.wait()`, and `kitaru.save()` / `kitaru.load()` shipped underneath whatever harness your team already picked. Different opinion about the workload, same commitment to durability.
 
   <Fragment slot="bullets">
     - **Layered model:** We think about the agent stack as four layers (model, harness, runtime, platform). Kitaru owns one of them, the runtime, and stays out of the other three. Inngest is broader on purpose: it packages an event-driven platform that also acts as the runtime underneath it. It's the wrong shape if you've already chosen your harness, your auth, your observability stack, and your data path, and only need durability under them.
@@ -63,7 +63,7 @@ Kitaru is narrower on purpose. We built it for Python agents, because that's the
 <FeatureWithGraphic title="Python-agent primitives vs polyglot durable functions">
   <AgentPrimitives slot="graphic" />
 
-  The shape of the SDK tells you who the team was watching when they set the defaults. Inngest's surface is `step.run`, `step.sleep`, `step.wait_for_event`, `step.send_event`, `step.invoke`. Kitaru's surface is `kitaru.llm()`, `kitaru.wait()`, `kitaru.memory`, and `kitaru.save()` / `kitaru.load()`, the primitives every Python agent team writes on top of a general-purpose workflow engine.
+  The shape of the SDK tells you who the team was watching when they set the defaults. Inngest's surface is `step.run`, `step.sleep`, `step.wait_for_event`, `step.send_event`, `step.invoke`. Kitaru's surface is `kitaru.llm()`, `kitaru.wait()`, and `kitaru.save()` / `kitaru.load()` for persisted artifacts: the primitives every Python agent team writes on top of a general-purpose workflow engine.
 
   <Fragment slot="bullets">
     - **Languages:** Inngest ships SDKs for TypeScript, Python, and Go (with a Kotlin/Java repo). Kitaru is Python 3.11+ only. If you're running TypeScript-and-Python-and-Go services that need one durability primitive across all of it, Inngest is the right tool.
@@ -103,7 +103,7 @@ Kitaru is narrower on purpose. We built it for Python agents, because that's the
     { feature: "Durable execution and replay", kitaru: true, competitor: true },
     { feature: "Human/agent-in-the-loop waiting with compute released", kitaru: true, competitor: true },
     { feature: "Self-hostable (Kitaru: Apache 2.0; Inngest server: SSPL with delayed Apache; SDKs Apache 2.0)", kitaru: true, competitor: true },
-    { feature: "Python-agent-shaped primitives (`kitaru.llm()`, `kitaru.wait()`, `kitaru.memory`)", kitaru: true, competitor: false },
+    { feature: "Python-agent-shaped primitives (`kitaru.llm()`, `kitaru.wait()`, `kitaru.save()` / `kitaru.load()`)", kitaru: true, competitor: false },
     { feature: "Built-in LLM primitive with alias-resolved secrets and per-call token/latency logging", kitaru: true, competitor: false },
     { feature: "Typed, versioned artifact lineage per checkpoint with cross-run diff", kitaru: true, competitor: false },
     { feature: "Opinionated stack abstraction for Kubernetes, AWS, GCP, Azure", kitaru: true, competitor: false },
@@ -124,10 +124,10 @@ Kitaru is narrower on purpose. We built it for Python agents, because that's the
 | Durable step | `await ctx.step.run("name", fn)` memoizes the return value in the engine | `@checkpoint` persists a typed, versioned artifact in your own bucket |
 | Determinism / replay safety | Side effects that need replay protection should live inside `step.run`, so the engine can memoize the result | `@flow` and `@checkpoint` stay plain Python, but replay-safe external side effects still need durable boundaries or idempotency |
 | Pause and resume | `await ctx.step.wait_for_event("name", event="...")` plus an external send to resolve it | `kitaru.wait(name="...", schema=...)` releases compute, resumes from any input source |
-| Cross-run state | Roll your own (Redis, Postgres, KV) | `kitaru.memory`: typed, scoped, versioned KV in the box |
+| Cross-run mutable state / memory | Built from your own Redis, Postgres, or KV | Out of scope for Kitaru today; bring your own database/KV and pass values into flows explicitly |
+| Artifacts | Step return values memoized in the durable engine | Immutable, replayable execution outputs in your bucket; queryable across runs via `kitaru.load(exec_id, name)`, but not a KV replacement |
 | LLM call | Your code inside `step.run`; provider key, prompt and token logging are glue you write | `kitaru.llm()` resolves the model alias, injects the provider key, logs prompt/tokens/latency per call |
 | Invocation | `await inngest_client.send(inngest.Event(name="review.start", data={...}))` to send an event | `flow.run(...)` for source/local execution; saved deployments via `kitaru invoke FLOW ...`, `KitaruClient().deployments.invoke(flow="...", inputs={...})`, or `flow.invoke(...)` |
-| Artifacts | Step return values memoized in the durable engine | Typed artifact in your bucket, queryable across runs via `kitaru.load(exec_id, name)` |
 <CodeCompare
   kitaruLabel="Kitaru"
   competitorLabel="Inngest (Python SDK)"
@@ -197,7 +197,7 @@ async def review_flow(ctx: inngest.Context) -> str:
 />
 
 <ComparisonCta headline={frontmatter.ctaHeading}>
-If your durability problem is shaped like an event-driven app (workflows triggered by events, cron jobs, durable endpoints, queue replacement), Inngest is the right tool, and I'd tell any team that. For Python agent work specifically (LLM calls, memory, artifacts, human/agent approval gates, a stack abstraction over your own cloud), the glue you'd write on top of a general-purpose event-and-function platform is the stuff we ship in the box.
+If your durability problem is shaped like an event-driven app (workflows triggered by events, cron jobs, durable endpoints, queue replacement), Inngest is the right tool, and I'd tell any team that. For Python agent work specifically (LLM calls, artifacts, human/agent approval gates, a stack abstraction over your own cloud), the glue you'd write on top of a general-purpose event-and-function platform is the stuff we ship in the box.
 
 We've spent five years building the MLOps-ready version of this problem space at ZenML. JetBrains runs their AI globally on it; Adeo runs across all their brands and geographies on it. Kitaru is that team two years into the agent version. Bet on us for agent infrastructure and you're betting on the group that's been doing this the whole time.
 </ComparisonCta>


### PR DESCRIPTION
## What changed

- Removed stale user-facing claims that Kitaru ships native `kitaru.memory` / typed memory from the Inngest comparison page and graphics.
- Reframed Kitaru's current primitives around `kitaru.llm()`, `kitaru.wait()`, and artifact save/load.
- Updated `llms.txt` source metadata so retired `/guides/memory` is no longer promoted.
- Reworded the Claude Agent SDK guide's compliance-review example blurb to say artifact persistence instead of memory.

## Why

The native Kitaru memory surface was removed in v0.11.0, but a few current docs/site surfaces still described it as a shipped primitive. That could send users looking for APIs and CLI commands that no longer exist.

## Key implementation decisions

- Kept historical changelog entries and retired-URL redirect plumbing intact.
- Did not change legitimate non-native-memory mentions such as LangGraph `InMemorySaver`, process memory, competitor memory systems, or explicit “memory is out of scope for Kitaru today” comparison wording.
- Kept the change to copy/docs only; no runtime/API behavior changed.

## Reviewer Notes

The story to check is simple: before this PR, the Inngest comparison still told users that Kitaru had `kitaru.memory`. After this PR, that page says the honest current thing: Kitaru gives durable LLM calls, waits, checkpoints, and immutable artifacts, while mutable cross-run state/memory remains something users bring themselves via Postgres, Redis, KV, etc.

The highest-risk area is the distinction between artifacts and memory. `kitaru.save()` / `kitaru.load()` are useful for replayable persisted outputs, but they are not a mutable shared KV store. Please especially review the “How the two surfaces map” table in `site/src/content/comparisons/kitaru-vs-inngest.mdx` and make sure that distinction is clear.

### Reproduction

1. Open `site/src/content/comparisons/kitaru-vs-inngest.mdx`.
2. Search for `kitaru.memory` and `typed versioned memory`; there should be no matches.
3. In the surface map table, confirm:
   - cross-run mutable state/memory is described as out of scope for Kitaru today;
   - artifacts are described as immutable, replayable execution outputs, not a KV replacement.
4. Open the two Inngest graphics under `site/src/components/compare/graphics/inngest/` and confirm the visual primitive list now uses `kitaru.save()` / `kitaru.load()` instead of `kitaru.memory`.

Local checks run:

- `git diff --check`
- targeted grep for removed native memory API terms outside changelog/redirect files
- `just check`
- `/simplify` review pass with reuse, quality, and efficiency agents
