### PR TITLE
Fix smaller safety findings + bugs

### DIFF
--- a/src/kitaru/_cleanup.py
+++ b/src/kitaru/_cleanup.py
@@ -713,14 +713,11 @@ def execute_cleanup_plan(
             server_result = stop_registered_local_server_for_cleanup(timeout=10)
             server_stopped = server_result.stopped
             force_killed_pid = server_result.force_killed_pid
-            if force_killed_pid is not None:
+            if not server_result.stopped:
                 warnings.append(
-                    "Local server did not shut down gracefully. "
-                    f"Force-killed process {force_killed_pid}."
-                )
-            elif not server_result.stopped:
-                warnings.append(
-                    "Could not stop the local server. The database backup "
+                    "Could not stop the local server. Kitaru did not kill "
+                    "the stored PID because PID-only evidence can be stale "
+                    "and may refer to another process. The database backup "
                     "may be incomplete if the server is still writing."
                 )
 

--- a/src/kitaru/_cleanup.py
+++ b/src/kitaru/_cleanup.py
@@ -65,6 +65,7 @@ class CleanupPlan:
     model_registry_alias_count: int | None = None
     local_server_status: str | None = None
     local_server_would_stop: bool = False
+    local_server_inspection_failed: bool = False
     custom_config_path_warning: str | None = None
     active_environment_overrides: tuple[ActiveEnvironmentVariable, ...] = ()
     can_reinitialize_project: bool = False
@@ -87,6 +88,7 @@ class CleanupResult:
     preview_entries: tuple[CleanupPreviewEntry, ...] = ()
     total_bytes: int = 0
     local_server_status: str | None = None
+    local_server_inspection_failed: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -417,27 +419,40 @@ def _compute_backup_path(config_root: Path) -> str | None:
     return str(backup_dir / f"backup-{timestamp}.db")
 
 
-def _describe_local_server_for_cleanup() -> tuple[str | None, bool]:
-    """Return local server status description and whether it would be stopped."""
+def _describe_local_server_for_cleanup() -> tuple[str | None, bool, bool]:
+    """Return local server status, stop intent, and inspection-failure state."""
     try:
         from zenml.utils.server_utils import get_local_server
     except ImportError:
-        return None, False
+        return None, False, False
 
     try:
         local_server = get_local_server()
-    except Exception:
-        return None, False
+    except Exception as exc:
+        logger.warning("Could not inspect registered local server", exc_info=True)
+        return f"unknown (inspection failed: {exc})", True, True
 
     if local_server is None:
-        return "not running", False
+        return "not running", False, False
 
     from kitaru._local_server import _existing_local_server_url
 
     url = _existing_local_server_url(local_server)
     if url:
-        return f"running at {url}", True
-    return "registered but not running", True
+        return f"running at {url}", True, False
+    return "registered but not running", True, False
+
+
+def _local_server_inspection_warning(
+    status: str | None, *, inspection_failed: bool
+) -> str | None:
+    """Build the warning shown when local-server inspection failed."""
+    if not inspection_failed:
+        return None
+    return (
+        "Could not inspect the registered local server. Cleanup will attempt "
+        f"safe daemon shutdown before deleting global state. Status: {status}"
+    )
 
 
 def build_cleanup_plan(
@@ -452,6 +467,7 @@ def build_cleanup_plan(
     custom_config_warning: str | None = None
     local_server_status: str | None = None
     local_server_would_stop = False
+    local_server_inspection_failed = False
     can_reinit = False
     preview_entries: list[CleanupPreviewEntry] = []
     total_bytes = 0
@@ -482,9 +498,11 @@ def build_cleanup_plan(
 
         alias_count = _read_alias_count()
         backup_path = _compute_backup_path(config_root)
-        local_server_status, local_server_would_stop = (
-            _describe_local_server_for_cleanup()
-        )
+        (
+            local_server_status,
+            local_server_would_stop,
+            local_server_inspection_failed,
+        ) = _describe_local_server_for_cleanup()
 
         global_entries = _build_global_preview(
             config_root,
@@ -521,6 +539,7 @@ def build_cleanup_plan(
         model_registry_alias_count=alias_count,
         local_server_status=local_server_status,
         local_server_would_stop=local_server_would_stop,
+        local_server_inspection_failed=local_server_inspection_failed,
         custom_config_path_warning=custom_config_warning,
         active_environment_overrides=tuple(env_overrides),
         can_reinitialize_project=can_reinit,
@@ -529,17 +548,24 @@ def build_cleanup_plan(
 
 def build_cleanup_preview_result(plan: CleanupPlan) -> CleanupResult:
     """Build a dry-run CleanupResult from a resolved plan."""
-    warnings: tuple[str, ...] = ()
+    warnings: list[str] = []
     if plan.custom_config_path_warning:
-        warnings = (plan.custom_config_path_warning,)
+        warnings.append(plan.custom_config_path_warning)
+    inspection_warning = _local_server_inspection_warning(
+        plan.local_server_status,
+        inspection_failed=plan.local_server_inspection_failed,
+    )
+    if inspection_warning:
+        warnings.append(inspection_warning)
     return CleanupResult(
         scope=plan.scope,
         dry_run=True,
         preview_entries=plan.preview_entries,
         total_bytes=plan.total_bytes,
         local_server_status=plan.local_server_status,
+        local_server_inspection_failed=plan.local_server_inspection_failed,
         active_environment_overrides=plan.active_environment_overrides,
-        warnings=warnings,
+        warnings=tuple(warnings),
     )
 
 
@@ -668,6 +694,12 @@ def execute_cleanup_plan(
 
     if plan.custom_config_path_warning:
         warnings.append(plan.custom_config_path_warning)
+    inspection_warning = _local_server_inspection_warning(
+        plan.local_server_status,
+        inspection_failed=plan.local_server_inspection_failed,
+    )
+    if inspection_warning:
+        warnings.append(inspection_warning)
 
     # Enforce --force for model registry protection
     if scope in (CleanScope.GLOBAL, CleanScope.ALL):
@@ -793,6 +825,7 @@ def execute_cleanup_plan(
         preview_entries=plan.preview_entries,
         total_bytes=plan.total_bytes,
         local_server_status=plan.local_server_status,
+        local_server_inspection_failed=plan.local_server_inspection_failed,
     )
 
 

--- a/src/kitaru/_cli/_secrets.py
+++ b/src/kitaru/_cli/_secrets.py
@@ -32,6 +32,8 @@ from ._helpers import (
     _validate_pagination,
 )
 
+_SECRETS_BACKEND_SCAN_SIZE = 50
+
 
 def _parse_secret_assignments(raw_assignments: list[str]) -> dict[str, str]:
     """Parse `--KEY=value` style assignment tokens into a dictionary."""
@@ -100,12 +102,15 @@ def _parse_secret_assignments(raw_assignments: list[str]) -> dict[str, str]:
 
 
 def _list_accessible_secrets(client: Any) -> list[SecretResponse]:
-    """List all accessible secrets across all pages."""
-    first_page = client.list_secrets(page=1)
+    """List all accessible secrets across all backend pages."""
+    first_page = client.list_secrets(page=1, size=_SECRETS_BACKEND_SCAN_SIZE)
     secrets = list(first_page.items)
 
     for page_number in range(2, first_page.total_pages + 1):
-        page = client.list_secrets(page=page_number, size=first_page.max_size)
+        page = client.list_secrets(
+            page=page_number,
+            size=_SECRETS_BACKEND_SCAN_SIZE,
+        )
         secrets.extend(page.items)
 
     return secrets

--- a/src/kitaru/_cli/_status.py
+++ b/src/kitaru/_cli/_status.py
@@ -239,6 +239,22 @@ def _clear_persisted_store_configuration(gc: Any) -> None:
     gc._write_config()
 
 
+def _reset_to_local_store(gc: Any) -> bool:
+    """Reset persisted connection state to the local default store.
+
+    Returns whether the normal local fallback store was available. If the
+    local ZenML store backend cannot be imported, clear persisted store fields
+    directly so logout still removes stale remote/local-server connection
+    state.
+    """
+    try:
+        gc.set_default_store()
+    except ImportError:
+        _clear_persisted_store_configuration(gc)
+        return False
+    return True
+
+
 def _get_connected_server_url() -> str | None:
     """Read the currently configured remote server URL, if available."""
     deps = cli_dependencies()
@@ -503,8 +519,10 @@ def _logout_current_connection() -> LogoutResult:
     stop_result = deps.stop_registered_local_server()
 
     if was_connected_to_local_server:
+        local_fallback_available = _reset_to_local_store(gc)
         return LogoutResult(
             mode="local_server",
+            local_fallback_available=local_fallback_available,
             local_server_stopped=stop_result.stopped,
             local_server_url=stop_result.url,
         )
@@ -524,12 +542,7 @@ def _logout_current_connection() -> LogoutResult:
             local_server_url=stop_result.url,
         )
 
-    local_fallback_available = True
-    try:
-        gc.set_default_store()
-    except ImportError:
-        local_fallback_available = False
-        _clear_persisted_store_configuration(gc)
+    local_fallback_available = _reset_to_local_store(gc)
 
     if _is_localhost_url(server_url or connected_server_url):
         return LogoutResult(

--- a/src/kitaru/_cli/_status.py
+++ b/src/kitaru/_cli/_status.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Annotated, Any
 from urllib.parse import urlparse
@@ -12,6 +13,7 @@ from urllib.parse import urlparse
 from cyclopts import Parameter
 
 from kitaru._interface_errors import run_with_cli_error_boundary
+from kitaru._local_server import LocalServerStopResult
 from kitaru.cli_output import CLIOutputFormat
 from kitaru.config import (
     KITARU_AUTH_TOKEN_ENV,
@@ -45,6 +47,8 @@ from ._helpers import (
     _print_success,
     _resolve_output_format,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -510,64 +514,81 @@ def _environment_rows(
     return [(entry.name, entry.value) for entry in environment]
 
 
+def _stop_registered_local_server_best_effort(deps: Any) -> LocalServerStopResult:
+    """Stop the registered local daemon without blocking logout state reset."""
+    try:
+        return deps.stop_registered_local_server()
+    except Exception:
+        logger.warning(
+            "Could not stop registered local server during logout", exc_info=True
+        )
+        return LocalServerStopResult(stopped=False, url=None)
+
+
+def _finalize_logout_result(result: LogoutResult, deps: Any) -> LogoutResult:
+    """Attach best-effort local-server stop details to a logout result."""
+    stop_result = _stop_registered_local_server_best_effort(deps)
+    return replace(
+        result,
+        local_server_stopped=stop_result.stopped,
+        local_server_url=stop_result.url or result.local_server_url,
+    )
+
+
 def _logout_current_connection() -> LogoutResult:
     """Reset the active connection and clear current stored credentials."""
     deps = cli_dependencies()
     gc = deps.global_configuration()
     connected_server_url = deps.get_connected_server_url()
     was_connected_to_local_server = deps.connected_to_local_server()
-    stop_result = deps.stop_registered_local_server()
 
     if was_connected_to_local_server:
         local_fallback_available = _reset_to_local_store(gc)
-        return LogoutResult(
-            mode="local_server",
-            local_fallback_available=local_fallback_available,
-            local_server_stopped=stop_result.stopped,
-            local_server_url=stop_result.url,
+        return _finalize_logout_result(
+            LogoutResult(
+                mode="local_server",
+                local_fallback_available=local_fallback_available,
+            ),
+            deps,
         )
 
     try:
         if gc.uses_local_store:
-            return LogoutResult(
-                mode="local_store",
-                local_server_stopped=stop_result.stopped,
-                local_server_url=stop_result.url,
-            )
+            return _finalize_logout_result(LogoutResult(mode="local_store"), deps)
         server_url = gc.store_configuration.url.rstrip("/")
     except ImportError:
-        return LogoutResult(
-            mode="unavailable",
-            local_server_stopped=stop_result.stopped,
-            local_server_url=stop_result.url,
-        )
+        return _finalize_logout_result(LogoutResult(mode="unavailable"), deps)
 
     local_fallback_available = _reset_to_local_store(gc)
 
     if _is_localhost_url(server_url or connected_server_url):
-        return LogoutResult(
-            mode="local_server",
-            local_fallback_available=local_fallback_available,
-            local_server_stopped=stop_result.stopped,
-            local_server_url=stop_result.url or server_url,
+        return _finalize_logout_result(
+            LogoutResult(
+                mode="local_server",
+                local_fallback_available=local_fallback_available,
+                local_server_url=server_url,
+            ),
+            deps,
         )
 
     if server_url.startswith(("http://", "https://")):
         deps.get_credentials_store().clear_credentials(server_url)
-        return LogoutResult(
-            mode="remote_server",
-            target=server_url,
-            local_fallback_available=local_fallback_available,
-            local_server_stopped=stop_result.stopped,
-            local_server_url=stop_result.url,
+        return _finalize_logout_result(
+            LogoutResult(
+                mode="remote_server",
+                target=server_url,
+                local_fallback_available=local_fallback_available,
+            ),
+            deps,
         )
 
-    return LogoutResult(
-        mode="remote_store",
-        target=server_url,
-        local_fallback_available=local_fallback_available,
-        local_server_stopped=stop_result.stopped,
-        local_server_url=stop_result.url,
+    return _finalize_logout_result(
+        LogoutResult(
+            mode="remote_store",
+            target=server_url,
+            local_fallback_available=local_fallback_available,
+        ),
+        deps,
     )
 
 

--- a/src/kitaru/_env.py
+++ b/src/kitaru/_env.py
@@ -7,6 +7,11 @@ re-exports everything so existing ``from kitaru._env import ...``
 imports continue to work.
 """
 
+import os
+from collections.abc import Mapping
+from contextlib import contextmanager
+from typing import Any
+
 from kitaru_init_hook import (
     KITARU_ANALYTICS_OPT_IN_ENV,
     KITARU_AUTH_TOKEN_ENV,
@@ -29,6 +34,25 @@ from kitaru_init_hook import (
     apply_env_translations,
 )
 
+
+@contextmanager
+def _temporary_env(additions: Mapping[str, str]) -> Any:
+    """Temporarily add or override environment variables."""
+    previous_values: dict[str, str | None] = {}
+    for key, value in additions.items():
+        previous_values[key] = os.environ.get(key)
+        os.environ[key] = value
+
+    try:
+        yield
+    finally:
+        for key, previous in previous_values.items():
+            if previous is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = previous
+
+
 __all__ = [
     "KITARU_ANALYTICS_OPT_IN_ENV",
     "KITARU_AUTH_TOKEN_ENV",
@@ -48,5 +72,6 @@ __all__ = [
     "ZENML_STORE_URL_ENV",
     "_normalized_kitaru_env",
     "_reset_applied",
+    "_temporary_env",
     "apply_env_translations",
 ]

--- a/src/kitaru/_local_server.py
+++ b/src/kitaru/_local_server.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlparse
 
+from kitaru._env import ZENML_DEFAULT_ANALYTICS_SOURCE_ENV, _temporary_env
 from kitaru.errors import KitaruBackendError, KitaruUsageError
 
 logger = logging.getLogger(__name__)
@@ -184,24 +184,23 @@ def _deploy_and_connect(
         provider_type=provider_type,
         port=port,
     )
+    env_overlay = {ZENML_DEFAULT_ANALYTICS_SOURCE_ENV: "kitaru-api"}
+    if ui_dir := _resolve_bundled_ui_dir():
+        env_overlay["ZENML_SERVER_DASHBOARD_FILES_PATH"] = str(ui_dir)
+        logger.info("Kitaru UI directory: %s", ui_dir)
+    else:
+        logger.debug(
+            "No bundled Kitaru UI found (expected at %s); "
+            "server will use default ZenML dashboard",
+            Path(__file__).parent / "_ui" / "dist",
+        )
+
     try:
-        if ui_dir := _resolve_bundled_ui_dir():
-            os.environ["ZENML_SERVER_DASHBOARD_FILES_PATH"] = str(ui_dir)
-            logger.info("Kitaru UI directory: %s", ui_dir)
-        else:
-            logger.debug(
-                "No bundled Kitaru UI found (expected at %s); "
-                "server will use default ZenML dashboard",
-                Path(__file__).parent / "_ui" / "dist",
-            )
-        os.environ["ZENML_DEFAULT_ANALYTICS_SOURCE"] = "kitaru-api"
-        deployed_server = deployer.deploy_server(config, timeout=timeout)
-        deployer.connect_to_server()
+        with _temporary_env(env_overlay):
+            deployed_server = deployer.deploy_server(config, timeout=timeout)
+            deployer.connect_to_server()
     except Exception as exc:
         raise _local_server_start_error(action=action, exc=exc) from exc
-    finally:
-        os.environ.pop("ZENML_SERVER_DASHBOARD_FILES_PATH", None)
-        os.environ["ZENML_DEFAULT_ANALYTICS_SOURCE"] = "kitaru-python"
 
     deployed_url = (
         _existing_local_server_url(deployed_server)
@@ -300,59 +299,15 @@ class LocalServerCleanupResult:
     force_killed_pid: int | None = None
 
 
-def _force_kill_server_process(local_server: Any) -> int | None:
-    """Attempt to force-kill the local server daemon process.
-
-    Returns the killed PID, or None if the PID could not be resolved
-    or the kill failed.
-    """
-    import signal
-
-    pid: int | None = None
-
-    status = getattr(local_server, "status", None)
-    if status is not None:
-        pid = getattr(status, "pid", None)
-
-    if pid is None:
-        config = getattr(local_server, "config", None)
-        if config is not None:
-            pid = getattr(config, "pid", None)
-
-    if pid is None or not isinstance(pid, int) or pid <= 0:
-        return None
-
-    # Verify the process still exists before sending SIGKILL.
-    # Note: this cannot confirm it's the *same* server process (the PID
-    # may have been recycled), but it avoids killing a non-existent PID.
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        logger.debug("Server PID %d no longer exists", pid)
-        return None
-    except OSError:
-        pass  # EPERM means the process exists but we may not own it
-
-    try:
-        os.kill(pid, signal.SIGKILL)
-        return pid
-    except ProcessLookupError:
-        # Process already exited — don't claim we killed it
-        return None
-    except OSError:
-        logger.warning("Could not force-kill server process %d", pid, exc_info=True)
-        return None
-
-
 def stop_registered_local_server_for_cleanup(
     *,
     timeout: int = 10,
 ) -> LocalServerCleanupResult:
-    """Stop the registered local server for cleanup, with force-kill fallback.
+    """Stop the registered local server for cleanup.
 
     Unlike ``stop_registered_local_server``, this function:
     - uses a timeout on graceful shutdown
-    - force-kills the daemon if graceful stop fails
+    - never force-kills a PID-only daemon record
     - never raises; always returns a result
     """
     try:
@@ -360,24 +315,26 @@ def stop_registered_local_server_for_cleanup(
     except ImportError:
         return LocalServerCleanupResult(stopped=False, url=None)
 
-    local_server = get_local_server()
-    if local_server is None:
-        return LocalServerCleanupResult(stopped=False, url=None)
+    try:
+        local_server = get_local_server()
+        if local_server is None:
+            return LocalServerCleanupResult(stopped=False, url=None)
 
-    url = _existing_local_server_url(local_server)
+        url = _existing_local_server_url(local_server)
+    except Exception:
+        logger.warning("Could not inspect registered local server", exc_info=True)
+        return LocalServerCleanupResult(stopped=False, url=None)
 
     try:
         local_server_deployer_cls().remove_server(timeout=timeout)
         return LocalServerCleanupResult(stopped=True, url=url)
     except Exception:
-        logger.warning("Graceful local server shutdown failed; attempting force-kill")
-
-    killed_pid = _force_kill_server_process(local_server)
-    return LocalServerCleanupResult(
-        stopped=killed_pid is not None,
-        url=url,
-        force_killed_pid=killed_pid,
-    )
+        logger.warning(
+            "Graceful local server shutdown failed; not killing the stored PID "
+            "because PID-only evidence can be stale",
+            exc_info=True,
+        )
+        return LocalServerCleanupResult(stopped=False, url=url)
 
 
 def stop_registered_local_server() -> LocalServerStopResult:

--- a/src/kitaru/llm.py
+++ b/src/kitaru/llm.py
@@ -10,12 +10,12 @@ import os
 import re
 import time
 from collections.abc import Mapping, Sequence
-from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
+from kitaru._env import _temporary_env
 from kitaru._safe_save import _safe_save
 from kitaru.artifacts import save
 from kitaru.checkpoint import checkpoint
@@ -258,24 +258,6 @@ def _normalize_messages(
 # ---------------------------------------------------------------------------
 # Provider SDK helpers (lazy imports)
 # ---------------------------------------------------------------------------
-
-
-@contextmanager
-def _temporary_env(additions: Mapping[str, str]) -> Any:
-    """Temporarily add/override environment variables for one call."""
-    previous_values: dict[str, str | None] = {}
-    for key, value in additions.items():
-        previous_values[key] = os.environ.get(key)
-        os.environ[key] = value
-
-    try:
-        yield
-    finally:
-        for key, previous in previous_values.items():
-            if previous is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = previous
 
 
 def _call_openai(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -60,6 +60,21 @@ def test_ui_package_scaffold_exists() -> None:
     assert ui_init.is_file(), f"Missing tracked file: {ui_init}"
 
 
+def test_typed_classifier_matches_pep_561_marker_and_wheel_package() -> None:
+    """The typed classifier should have a marker inside the packaged SDK."""
+    repo_root = Path(__file__).resolve().parents[1]
+    pyproject = tomllib.loads(_PYPROJECT_PATH.read_text())
+
+    classifiers = pyproject["project"].get("classifiers", [])
+    marker = repo_root / "src" / "kitaru" / "py.typed"
+    wheel_target = pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]
+    packages = wheel_target.get("packages", [])
+
+    assert "Typing :: Typed" in classifiers
+    assert marker.is_file(), f"Missing PEP 561 marker: {marker}"
+    assert "src/kitaru" in packages
+
+
 def test_cli_entrypoint_populates_version_before_dispatch() -> None:
     """The package CLI entrypoint should set the version before running the app."""
     import kitaru.cli as cli_module

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import importlib.metadata
+import subprocess
 import tomllib
+import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -73,6 +75,23 @@ def test_typed_classifier_matches_pep_561_marker_and_wheel_package() -> None:
     assert "Typing :: Typed" in classifiers
     assert marker.is_file(), f"Missing PEP 561 marker: {marker}"
     assert "src/kitaru" in packages
+
+
+def test_built_wheel_contains_pep_561_marker(tmp_path: Path) -> None:
+    """The built wheel should ship the PEP 561 marker file."""
+    repo_root = Path(__file__).resolve().parents[1]
+
+    subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(tmp_path)],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    wheel_path = next(tmp_path.glob("*.whl"))
+
+    with zipfile.ZipFile(wheel_path) as wheel:
+        assert "kitaru/py.typed" in wheel.namelist()
 
 
 def test_cli_entrypoint_populates_version_before_dispatch() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3646,6 +3646,39 @@ def test_logout_resets_remote_connection() -> None:
     )
 
 
+def test_logout_resets_remote_connection_when_daemon_stop_fails() -> None:
+    """Remote logout should reset persisted state even if daemon stop fails."""
+    fake_gc = Mock()
+    fake_gc.uses_local_store = False
+    fake_gc.store_configuration = SimpleNamespace(url="https://example.com/")
+    fake_credentials_store = Mock()
+
+    with (
+        patch("kitaru.cli.GlobalConfiguration", return_value=fake_gc),
+        patch("kitaru.cli._connected_to_local_server", return_value=False),
+        patch(
+            "kitaru.cli._get_connected_server_url", return_value="https://example.com"
+        ),
+        patch(
+            "kitaru.cli.stop_registered_local_server",
+            side_effect=RuntimeError("daemon stop failed"),
+        ),
+        patch(
+            "kitaru.cli.get_credentials_store",
+            return_value=fake_credentials_store,
+        ),
+    ):
+        result = _logout_current_connection()
+
+    fake_gc.set_default_store.assert_called_once_with()
+    fake_credentials_store.clear_credentials.assert_called_once_with(
+        "https://example.com"
+    )
+    assert result.mode == "remote_server"
+    assert result.local_server_stopped is False
+    assert str(result) == "Logged out from Kitaru server: https://example.com"
+
+
 def test_logout_returns_local_server_mode_for_local_connection() -> None:
     """Local logout should report local-server mode and stop the daemon."""
     fake_gc = Mock()
@@ -7327,7 +7360,7 @@ class TestCleanGlobal:
             ),
             patch(
                 "kitaru._cleanup._describe_local_server_for_cleanup",
-                return_value=("not running", False),
+                return_value=("not running", False, False),
             ),
             pytest.raises(SystemExit) as exc_info,
         ):
@@ -7359,7 +7392,7 @@ class TestCleanGlobal:
             ),
             patch(
                 "kitaru._cleanup._describe_local_server_for_cleanup",
-                return_value=("not running", False),
+                return_value=("not running", False, False),
             ),
             pytest.raises(SystemExit) as exc_info,
         ):
@@ -7394,7 +7427,7 @@ class TestCleanGlobal:
             ),
             patch(
                 "kitaru._cleanup._describe_local_server_for_cleanup",
-                return_value=("not running", False),
+                return_value=("not running", False, False),
             ),
             pytest.raises(SystemExit) as exc_info,
         ):
@@ -7402,6 +7435,44 @@ class TestCleanGlobal:
         assert exc_info.value.code == 0
         output = capsys.readouterr().out
         assert "Backup" in output or "backup" in output
+
+    def test_dry_run_surfaces_local_server_inspection_failure(
+        self, capsys: pytest.CaptureFixture[str], tmp_path: Path
+    ) -> None:
+        """Dry-run should warn when local-server state cannot be inspected."""
+        config_root = tmp_path / "config"
+        config_root.mkdir()
+        (config_root / "kitaru.yaml").write_text("version: 1\n")
+
+        with (
+            patch(
+                "kitaru._cleanup._resolve_repo_root",
+                return_value=None,
+            ),
+            patch(
+                "kitaru._cleanup._resolve_config_root",
+                return_value=config_root,
+            ),
+            patch(
+                "kitaru._cleanup._read_alias_count",
+                return_value=0,
+            ),
+            patch(
+                "zenml.utils.server_utils.get_local_server",
+                side_effect=RuntimeError("registry unreadable"),
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            app(["clean", "global", "--dry-run", "-o", "json"])
+
+        assert exc_info.value.code == 0
+        payload = json.loads(capsys.readouterr().out)
+        item = payload["item"]
+        assert "inspection failed: registry unreadable" in item["local_server_status"]
+        assert any(
+            "Could not inspect the registered local server" in warning
+            for warning in item["warnings"]
+        )
 
 
 class TestCleanAll:
@@ -7430,7 +7501,7 @@ class TestCleanAll:
             ),
             patch(
                 "kitaru._cleanup._describe_local_server_for_cleanup",
-                return_value=("not running", False),
+                return_value=("not running", False, False),
             ),
             pytest.raises(SystemExit) as exc_info,
         ):
@@ -7544,6 +7615,69 @@ class TestExecuteCleanupPlan:
             and "PID-only evidence can be stale" in warning
             for warning in result.warnings
         )
+
+    def test_global_cleanup_inspection_failure_warning_uses_explicit_state(
+        self, tmp_path: Path
+    ) -> None:
+        """Inspection-failure warnings should not depend on status text."""
+        from kitaru._cleanup import (
+            CleanScope,
+            CleanupPlan,
+            execute_cleanup_plan,
+        )
+        from kitaru._local_server import LocalServerCleanupResult
+
+        config_root = tmp_path / "config"
+        config_root.mkdir()
+
+        plan = CleanupPlan(
+            scope=CleanScope.GLOBAL,
+            global_config_root=str(config_root),
+            model_registry_alias_count=0,
+            local_server_status="local server state could not be read",
+            local_server_would_stop=True,
+            local_server_inspection_failed=True,
+        )
+
+        with (
+            patch("kitaru._cleanup._reset_global_config"),
+            patch(
+                "kitaru._local_server.stop_registered_local_server_for_cleanup",
+                return_value=LocalServerCleanupResult(
+                    stopped=True,
+                    url=None,
+                    force_killed_pid=None,
+                ),
+            ) as mock_stop,
+        ):
+            result = execute_cleanup_plan(plan, yes=True, force=False)
+
+        mock_stop.assert_called_once_with(timeout=10)
+        assert result.local_server_inspection_failed is True
+        assert any(
+            "Could not inspect the registered local server" in warning
+            and "local server state could not be read" in warning
+            for warning in result.warnings
+        )
+
+    def test_preview_warning_does_not_parse_unknown_status_prefix(self) -> None:
+        """Display text alone should not create an inspection-failure warning."""
+        from kitaru._cleanup import (
+            CleanScope,
+            CleanupPlan,
+            build_cleanup_preview_result,
+        )
+
+        plan = CleanupPlan(
+            scope=CleanScope.GLOBAL,
+            local_server_status="unknown (inspection failed: display text only)",
+            local_server_inspection_failed=False,
+        )
+
+        result = build_cleanup_preview_result(plan)
+
+        assert result.local_server_inspection_failed is False
+        assert result.warnings == ()
 
     def test_reinit_failure_produces_warning(self, tmp_path: Path) -> None:
         """Failed re-initialization should add a warning."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3667,7 +3667,45 @@ def test_logout_returns_local_server_mode_for_local_connection() -> None:
     ):
         result = _logout_current_connection()
 
+    fake_gc.set_default_store.assert_called_once_with()
     assert result.mode == "local_server"
+    assert result.local_fallback_available is True
+    assert result.local_server_stopped is True
+    assert str(result) == "Logged out from the local Kitaru server."
+
+
+def test_logout_local_server_branch_clears_store_on_missing_fallback() -> None:
+    """Local-server logout should clear persisted state if local fallback is absent."""
+    fake_gc = Mock()
+    fake_gc.set_default_store.side_effect = ImportError("sqlalchemy missing")
+
+    with (
+        patch("kitaru.cli.GlobalConfiguration", return_value=fake_gc),
+        patch("kitaru.cli._connected_to_local_server", return_value=True),
+        patch(
+            "kitaru.cli._get_connected_server_url",
+            return_value="http://127.0.0.1:8383",
+        ),
+        patch(
+            "kitaru.cli.stop_registered_local_server",
+            return_value=SimpleNamespace(
+                stopped=True,
+                url="http://127.0.0.1:8383",
+            ),
+        ),
+    ):
+        result = _logout_current_connection()
+
+    fake_gc.set_default_store.assert_called_once_with()
+    assert fake_gc.store is None
+    assert fake_gc._zen_store is None
+    assert fake_gc.active_stack_id is None
+    assert fake_gc.active_project_id is None
+    assert fake_gc._active_stack is None
+    assert fake_gc._active_project is None
+    fake_gc._write_config.assert_called_once_with()
+    assert result.mode == "local_server"
+    assert result.local_fallback_available is False
     assert result.local_server_stopped is True
     assert str(result) == "Logged out from the local Kitaru server."
 
@@ -4451,12 +4489,13 @@ def test_secrets_list_renders_all_pages_sorted(
         app(["secrets", "list"])
 
     assert exc_info.value.code == 0
-    fake_client.list_secrets.assert_has_calls(
-        [
-            call(page=1),
-            call(page=2, size=1),
-        ]
-    )
+    calls = fake_client.list_secrets.call_args_list
+    assert len(calls) == 2
+    backend_scan_size = calls[0].kwargs["size"]
+    assert calls == [
+        call(page=1, size=backend_scan_size),
+        call(page=2, size=backend_scan_size),
+    ]
     output = capsys.readouterr().out
     assert "Kitaru secrets" in output
     assert "alpha: secret-a (private)" in output
@@ -4464,6 +4503,45 @@ def test_secrets_list_renders_all_pages_sorted(
     assert output.index("alpha: secret-a (private)") < output.index(
         "zeta: secret-z (public)"
     )
+
+
+def test_secrets_list_uses_stable_backend_page_size(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Backend scan pagination should not switch sizes after the first page."""
+    secret_z = SimpleNamespace(name="zeta", id="secret-z", private=False)
+    secret_a = SimpleNamespace(name="alpha", id="secret-a", private=True)
+    observed_sizes: list[int] = []
+
+    def list_secrets(*, page: int, size: int | None = None) -> SimpleNamespace:
+        if size is None:
+            raise AssertionError("backend scan calls must pass an explicit size")
+        observed_sizes.append(size)
+        if page == 1:
+            return SimpleNamespace(
+                items=[secret_z],
+                total_pages=2,
+                max_size=size + 100,
+            )
+        if page == 2 and size == observed_sizes[0]:
+            return SimpleNamespace(items=[secret_a], total_pages=2, max_size=size + 100)
+        return SimpleNamespace(items=[], total_pages=2, max_size=size + 100)
+
+    fake_client = Mock()
+    fake_client.list_secrets.side_effect = list_secrets
+
+    with (
+        patch("kitaru.cli.Client", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["secrets", "list"])
+
+    assert exc_info.value.code == 0
+    assert len(observed_sizes) == 2
+    assert observed_sizes[0] == observed_sizes[1]
+    output = capsys.readouterr().out
+    assert "alpha: secret-a (private)" in output
+    assert "zeta: secret-z (public)" in output
 
 
 def test_secrets_list_paginates_after_sorting(
@@ -7423,6 +7501,50 @@ class TestExecuteCleanupPlan:
         assert not config_root.exists()
         assert str(config_root) in result.deleted_paths
 
+    def test_global_cleanup_warns_when_local_server_cannot_stop_safely(
+        self, tmp_path: Path
+    ) -> None:
+        """Cleanup should warn and continue instead of killing a stored PID."""
+        from kitaru._cleanup import (
+            CleanScope,
+            CleanupPlan,
+            execute_cleanup_plan,
+        )
+        from kitaru._local_server import LocalServerCleanupResult
+
+        config_root = tmp_path / "config"
+        config_root.mkdir()
+
+        plan = CleanupPlan(
+            scope=CleanScope.GLOBAL,
+            global_config_root=str(config_root),
+            model_registry_alias_count=0,
+            local_server_would_stop=True,
+        )
+
+        with (
+            patch("kitaru._cleanup._reset_global_config"),
+            patch(
+                "kitaru._local_server.stop_registered_local_server_for_cleanup",
+                return_value=LocalServerCleanupResult(
+                    stopped=False,
+                    url="http://localhost:8383",
+                    force_killed_pid=None,
+                ),
+            ),
+        ):
+            result = execute_cleanup_plan(plan, yes=True, force=False)
+
+        assert not result.aborted
+        assert result.local_server_stopped is False
+        assert result.local_server_force_killed_pid is None
+        assert str(config_root) in result.deleted_paths
+        assert any(
+            "did not kill the stored PID" in warning
+            and "PID-only evidence can be stale" in warning
+            for warning in result.warnings
+        )
+
     def test_reinit_failure_produces_warning(self, tmp_path: Path) -> None:
         """Failed re-initialization should add a warning."""
         from kitaru._cleanup import (
@@ -7601,117 +7723,6 @@ class TestExecuteCleanupPlan:
             execute_cleanup_plan(plan, yes=True, force=True)
 
 
-class TestForceKillServerProcess:
-    """Tests for _force_kill_server_process."""
-
-    def test_kill_succeeds_returns_pid(self) -> None:
-        """Successful kill returns the PID."""
-        from kitaru._local_server import _force_kill_server_process
-
-        server = SimpleNamespace(
-            status=SimpleNamespace(pid=12345),
-            config=None,
-        )
-
-        with patch("os.kill") as mock_kill:
-            result = _force_kill_server_process(server)
-
-        assert result == 12345
-        # Signal 0 probe + SIGKILL
-        assert mock_kill.call_count == 2
-
-    def test_pid_from_config_fallback(self) -> None:
-        """PID should be resolved from config when status.pid is missing."""
-        from kitaru._local_server import _force_kill_server_process
-
-        server = SimpleNamespace(
-            status=SimpleNamespace(pid=None),
-            config=SimpleNamespace(pid=99999),
-        )
-
-        with patch("os.kill") as mock_kill:
-            result = _force_kill_server_process(server)
-
-        assert result == 99999
-        assert mock_kill.call_count == 2
-
-    def test_no_pid_returns_none(self) -> None:
-        """When no PID is available, should return None without killing."""
-        from kitaru._local_server import _force_kill_server_process
-
-        server = SimpleNamespace(status=None, config=None)
-
-        with patch("os.kill") as mock_kill:
-            result = _force_kill_server_process(server)
-
-        assert result is None
-        mock_kill.assert_not_called()
-
-    def test_pid_zero_returns_none(self) -> None:
-        """PID <= 0 should be rejected to prevent os.kill(0, SIGKILL)."""
-        from kitaru._local_server import _force_kill_server_process
-
-        server = SimpleNamespace(
-            status=SimpleNamespace(pid=0),
-            config=None,
-        )
-
-        with patch("os.kill") as mock_kill:
-            result = _force_kill_server_process(server)
-
-        assert result is None
-        mock_kill.assert_not_called()
-
-    def test_negative_pid_returns_none(self) -> None:
-        """Negative PIDs should be rejected."""
-        from kitaru._local_server import _force_kill_server_process
-
-        server = SimpleNamespace(
-            status=SimpleNamespace(pid=-1),
-            config=None,
-        )
-
-        with patch("os.kill") as mock_kill:
-            result = _force_kill_server_process(server)
-
-        assert result is None
-        mock_kill.assert_not_called()
-
-    def test_process_already_exited_returns_none(self) -> None:
-        """ProcessLookupError on probe means process is gone."""
-        from kitaru._local_server import _force_kill_server_process
-
-        server = SimpleNamespace(
-            status=SimpleNamespace(pid=12345),
-            config=None,
-        )
-
-        with patch("os.kill", side_effect=ProcessLookupError):
-            result = _force_kill_server_process(server)
-
-        assert result is None
-
-    def test_permission_error_returns_none(self) -> None:
-        """OSError (e.g. EPERM) on kill returns None."""
-        import signal
-
-        from kitaru._local_server import _force_kill_server_process
-
-        server = SimpleNamespace(
-            status=SimpleNamespace(pid=12345),
-            config=None,
-        )
-
-        def selective_kill(pid: int, sig: int) -> None:
-            if sig == signal.SIGKILL:
-                raise PermissionError("Operation not permitted")
-
-        with patch("os.kill", side_effect=selective_kill):
-            result = _force_kill_server_process(server)
-
-        assert result is None
-
-
 class TestStopRegisteredLocalServerForCleanup:
     """Tests for stop_registered_local_server_for_cleanup."""
 
@@ -7733,9 +7744,10 @@ class TestStopRegisteredLocalServerForCleanup:
 
         assert result.stopped is True
         assert result.force_killed_pid is None
+        mock_deployer.return_value.remove_server.assert_called_once_with(timeout=5)
 
-    def test_graceful_fails_force_kill_succeeds(self) -> None:
-        """When graceful fails but force-kill works, stopped=True with PID."""
+    def test_graceful_fails_does_not_kill_stored_pid(self) -> None:
+        """When graceful shutdown fails, cleanup does not kill by PID only."""
         from kitaru._local_server import stop_registered_local_server_for_cleanup
 
         mock_deployer_cls = MagicMock()
@@ -7750,32 +7762,15 @@ class TestStopRegisteredLocalServerForCleanup:
                 "kitaru._local_server._load_local_server_runtime",
                 return_value=(mock_deployer_cls, None, None, lambda: mock_server),
             ),
-            patch("os.kill"),
-        ):
-            result = stop_registered_local_server_for_cleanup(timeout=5)
-
-        assert result.stopped is True
-        assert result.force_killed_pid == 42
-
-    def test_graceful_fails_force_kill_fails_stopped_false(self) -> None:
-        """When both graceful and force-kill fail, stopped=False."""
-        from kitaru._local_server import stop_registered_local_server_for_cleanup
-
-        mock_deployer_cls = MagicMock()
-        mock_deployer_cls.return_value.remove_server.side_effect = RuntimeError("fail")
-        mock_server = SimpleNamespace(
-            status=SimpleNamespace(url="http://localhost:8383", pid=None),
-            config=None,
-        )
-
-        with patch(
-            "kitaru._local_server._load_local_server_runtime",
-            return_value=(mock_deployer_cls, None, None, lambda: mock_server),
+            patch("os.kill") as mock_kill,
         ):
             result = stop_registered_local_server_for_cleanup(timeout=5)
 
         assert result.stopped is False
+        assert result.url == "http://localhost:8383"
         assert result.force_killed_pid is None
+        mock_deployer_cls.return_value.remove_server.assert_called_once_with(timeout=5)
+        mock_kill.assert_not_called()
 
     def test_import_error_returns_not_stopped(self) -> None:
         """ImportError from loading runtime should return stopped=False."""
@@ -7802,6 +7797,28 @@ class TestStopRegisteredLocalServerForCleanup:
             result = stop_registered_local_server_for_cleanup(timeout=5)
 
         assert result.stopped is False
+
+    def test_inspection_error_returns_not_stopped(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Failures while inspecting the registered server should not raise."""
+        from kitaru._local_server import stop_registered_local_server_for_cleanup
+
+        def raise_inspection_error() -> None:
+            raise RuntimeError("corrupt daemon registration")
+
+        mock_deployer = MagicMock()
+
+        with patch(
+            "kitaru._local_server._load_local_server_runtime",
+            return_value=(mock_deployer, None, None, raise_inspection_error),
+        ):
+            result = stop_registered_local_server_for_cleanup(timeout=5)
+
+        assert result.stopped is False
+        assert result.url is None
+        assert "Could not inspect registered local server" in caplog.text
+        mock_deployer.return_value.remove_server.assert_not_called()
 
 
 class TestPathSafety:

--- a/tests/test_local_server.py
+++ b/tests/test_local_server.py
@@ -162,12 +162,60 @@ class TestDeployAndConnect:
         assert captured_env["analytics"] == "kitaru-api"
 
         assert os.environ.get("ZENML_SERVER_DASHBOARD_FILES_PATH") is None
-        assert os.environ.get("ZENML_DEFAULT_ANALYTICS_SOURCE") == "kitaru-python"
+        assert os.environ.get("ZENML_DEFAULT_ANALYTICS_SOURCE") is None
 
         assert result == LocalServerConnectionResult(
             url="http://127.0.0.1:9090", action="started"
         )
         deployer.connect_to_server.assert_called_once()
+
+    def test_restores_preexisting_env_vars_after_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ZENML_SERVER_DASHBOARD_FILES_PATH", "/caller/ui")
+        monkeypatch.setenv("ZENML_DEFAULT_ANALYTICS_SOURCE", "caller-source")
+
+        captured_env: dict[str, str | None] = {}
+        fake_ui_dir = Path("/fake/ui/dist")
+
+        def capture_env_during_deploy(_config: Any, **_kw: Any) -> SimpleNamespace:
+            captured_env["deploy_dashboard"] = os.environ.get(
+                "ZENML_SERVER_DASHBOARD_FILES_PATH"
+            )
+            captured_env["deploy_analytics"] = os.environ.get(
+                "ZENML_DEFAULT_ANALYTICS_SOURCE"
+            )
+            return SimpleNamespace(status=SimpleNamespace(url="http://127.0.0.1:9090"))
+
+        def capture_env_during_connect() -> None:
+            captured_env["connect_dashboard"] = os.environ.get(
+                "ZENML_SERVER_DASHBOARD_FILES_PATH"
+            )
+            captured_env["connect_analytics"] = os.environ.get(
+                "ZENML_DEFAULT_ANALYTICS_SOURCE"
+            )
+
+        deployer = MagicMock()
+        deployer.deploy_server.side_effect = capture_env_during_deploy
+        deployer.connect_to_server.side_effect = capture_env_during_connect
+
+        with patch.object(ls_mod, "_resolve_bundled_ui_dir", return_value=fake_ui_dir):
+            _deploy_and_connect(
+                deployer=deployer,
+                deployment_config_cls=_FakeDeploymentConfig,
+                provider_type=_FAKE_PROVIDER,
+                port=9090,
+                timeout=30,
+                action="started",
+            )
+
+        assert captured_env["deploy_dashboard"] == str(fake_ui_dir)
+        assert captured_env["deploy_analytics"] == "kitaru-api"
+        assert captured_env["connect_dashboard"] == str(fake_ui_dir)
+        assert captured_env["connect_analytics"] == "kitaru-api"
+
+        assert os.environ.get("ZENML_SERVER_DASHBOARD_FILES_PATH") == "/caller/ui"
+        assert os.environ.get("ZENML_DEFAULT_ANALYTICS_SOURCE") == "caller-source"
 
     def test_cleans_up_env_on_deploy_failure(
         self, monkeypatch: pytest.MonkeyPatch
@@ -194,7 +242,35 @@ class TestDeployAndConnect:
             )
 
         assert os.environ.get("ZENML_SERVER_DASHBOARD_FILES_PATH") is None
-        assert os.environ.get("ZENML_DEFAULT_ANALYTICS_SOURCE") == "kitaru-python"
+        assert os.environ.get("ZENML_DEFAULT_ANALYTICS_SOURCE") is None
+
+    def test_restores_preexisting_env_vars_on_deploy_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ZENML_SERVER_DASHBOARD_FILES_PATH", "/caller/ui")
+        monkeypatch.setenv("ZENML_DEFAULT_ANALYTICS_SOURCE", "caller-source")
+
+        deployer = MagicMock()
+        deployer.deploy_server.side_effect = RuntimeError("connection refused")
+
+        with (
+            patch.object(
+                ls_mod, "_resolve_bundled_ui_dir", return_value=Path("/fake/ui/dist")
+            ),
+            pytest.raises(KitaruBackendError, match="failed to start"),
+        ):
+            _deploy_and_connect(
+                deployer=deployer,
+                deployment_config_cls=_FakeDeploymentConfig,
+                provider_type=_FAKE_PROVIDER,
+                port=8383,
+                timeout=30,
+                action="started",
+            )
+
+        assert os.environ.get("ZENML_SERVER_DASHBOARD_FILES_PATH") == "/caller/ui"
+        assert os.environ.get("ZENML_DEFAULT_ANALYTICS_SOURCE") == "caller-source"
+        deployer.connect_to_server.assert_not_called()
 
     def test_cleans_up_env_on_connect_failure(
         self, monkeypatch: pytest.MonkeyPatch
@@ -224,7 +300,37 @@ class TestDeployAndConnect:
             )
 
         assert os.environ.get("ZENML_SERVER_DASHBOARD_FILES_PATH") is None
-        assert os.environ.get("ZENML_DEFAULT_ANALYTICS_SOURCE") == "kitaru-python"
+        assert os.environ.get("ZENML_DEFAULT_ANALYTICS_SOURCE") is None
+
+    def test_restores_preexisting_env_vars_on_connect_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ZENML_SERVER_DASHBOARD_FILES_PATH", "/caller/ui")
+        monkeypatch.setenv("ZENML_DEFAULT_ANALYTICS_SOURCE", "caller-source")
+
+        deployer = MagicMock()
+        deployer.deploy_server.return_value = SimpleNamespace(
+            status=SimpleNamespace(url="http://127.0.0.1:8383")
+        )
+        deployer.connect_to_server.side_effect = RuntimeError("refused")
+
+        with (
+            patch.object(
+                ls_mod, "_resolve_bundled_ui_dir", return_value=Path("/fake/ui/dist")
+            ),
+            pytest.raises(KitaruBackendError, match="failed to start"),
+        ):
+            _deploy_and_connect(
+                deployer=deployer,
+                deployment_config_cls=_FakeDeploymentConfig,
+                provider_type=_FAKE_PROVIDER,
+                port=8383,
+                timeout=30,
+                action="started",
+            )
+
+        assert os.environ.get("ZENML_SERVER_DASHBOARD_FILES_PATH") == "/caller/ui"
+        assert os.environ.get("ZENML_DEFAULT_ANALYTICS_SOURCE") == "caller-source"
 
     def test_restart_action_produces_restart_error_message(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- Make local-server cleanup stop relying on PID-only force-kill fallback, and surface local-server inspection failures instead of pretending no daemon exists.
- Restore temporary local-server environment variables exactly after startup attempts.
- Prioritize logout disconnection/reset before best-effort daemon shutdown.
- Use a stable backend page size when gathering secrets.
- Ship and verify PEP 561 typing support with `kitaru/py.typed` in the built wheel.

## Reviewer Notes

This PR fixes the higher-value Clawpatch findings from the safety/correctness triage, plus the follow-up review issues from this branch.

The most important behavior change is in local-server cleanup. Previously, if graceful local-server shutdown failed during `kitaru clean global/all`, Kitaru looked at the stored daemon PID and sent `SIGKILL`. The dangerous story is: the original daemon exits, the OS reuses that PID for another process, and cleanup kills the wrong thing. This PR removes that PID-only kill path. Cleanup now warns and continues, preserving the existing “backup may be incomplete” behavior rather than risking an unrelated process.

The follow-up cleanup change handles the “we cannot even inspect the daemon registration” case. Instead of silently treating an inspection failure as “no local server,” cleanup now reports an `unknown (inspection failed: ...)` status, carries an explicit inspection-failed state internally, adds a user-visible warning, and still attempts the existing safe daemon-stop path when cleanup executes. In concrete terms: if the registry drawer is jammed, Kitaru says “I cannot tell what is in here, so I will be careful,” rather than “the drawer must be empty.”

Logout now puts disconnection first. The persisted store reset / credential clearing happens before daemon shutdown, and daemon shutdown is best-effort. So if stopping the local daemon throws, the user is still logged out from Kitaru’s point of view instead of being left pointed at a broken or stopped server.

The second local-server thread is environment restoration. `kitaru login` temporarily points ZenML at the bundled Kitaru UI and switches the analytics source while deploying the local daemon. Those overrides now use a shared `_temporary_env` helper and restore the caller’s process environment exactly on success or failure.

The remaining fixes are smaller contract repairs: `kitaru secrets list` uses one stable backend page size while still sorting before CLI pagination, and the package now includes `src/kitaru/py.typed`; the tests also build a real wheel and assert `kitaru/py.typed` is present in the artifact users install.

### Reproduction

1. For cleanup safety, run the focused cleanup tests:
   ```bash
   uv run pytest tests/test_cli.py::TestStopRegisteredLocalServerForCleanup tests/test_cli.py::TestExecuteCleanupPlan tests/mcp/test_server.py::TestKitaruCleanPreview
   ```
   The key cases show graceful shutdown still works, failed shutdown does not call `os.kill`, inspection failures return `stopped=False` instead of escaping, and dry-run/execute results warn when local-server inspection failed.

2. For logout ordering, run:
   ```bash
   uv run pytest tests/test_cli.py::test_logout_resets_remote_connection_when_daemon_stop_fails tests/test_cli.py::test_logout_returns_local_server_mode_when_stop_fails_after_reset
   ```
   These prove the persisted reset/credential-clearing side of logout happens even when daemon shutdown fails.

3. For environment restoration, run:
   ```bash
   uv run pytest tests/test_local_server.py::TestDeployAndConnect
   ```
   The deployer sees the temporary Kitaru/ZENML env values during deploy/connect, and caller-provided env values are restored afterward.

4. For package typing, run:
   ```bash
   uv run pytest tests/test_bootstrap.py::test_built_wheel_contains_pep_561_marker
   ```
   This builds a wheel into a temp directory and checks that `kitaru/py.typed` is included in the wheel.

Local checks run:
- `/simplify` — run; one cleanup-state simplification applied, no remaining must-fix simplification findings.
- Oracle review of the final four-file follow-up diff — no must-fix correctness issues found.
- `uv run pytest tests/test_cli.py::test_logout_resets_remote_connection_when_daemon_stop_fails tests/test_cli.py::test_logout_returns_local_server_mode_when_stop_fails_after_reset tests/test_cli.py::TestCleanGlobal::test_dry_run_surfaces_local_server_inspection_failure tests/test_cli.py::TestExecuteCleanupPlan::test_global_cleanup_inspection_failure_warning_uses_explicit_state tests/test_cli.py::TestExecuteCleanupPlan::test_preview_warning_does_not_parse_unknown_status_prefix tests/test_cli.py::TestExecuteCleanupPlan::test_global_cleanup_executes_local_server_shutdown_when_inspection_failed tests/test_bootstrap.py::test_built_wheel_contains_pep_561_marker` — 11 passed
- `just check` — passed
- `just test` — 1743 passed, 8 skipped
