### PR TITLE
Bump ZenML to 0.94.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
   docker-smoke:
     runs-on: ubuntu-latest
     env:
-      ZENML_SERVER_TAG: 0.94.3
+      ZENML_SERVER_TAG: 0.94.4
       KITARU_UI_TAG: latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -447,7 +447,7 @@ jobs:
           target: server
           push: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
           build-args: |
-            ZENML_SERVER_TAG=0.94.3
+            ZENML_SERVER_TAG=0.94.4
             KITARU_UI_TAG=${{ env.KITARU_UI_TAG }}
             ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') && format('KITARU_VERSION={0}', env.VERSION) || '' }}
           tags: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 - Bumped the minimum ZenML dependency, server image, and Helm subchart versions to `0.94.4` so Kitaru tracks the latest upstream ZenML release.
 
+### Fixed
+- Fixed Kitaru flow return compatibility with ZenML `0.94.4` dynamic-pipeline output validation by persisting plain flow returns as internal artifacts while preserving user-facing Python return values and avoiding marker-shaped user dictionaries being mistaken for hidden tuple metadata.
+
 ## [0.12.0] - 2026-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Bumped the minimum ZenML dependency, server image, and Helm subchart versions to `0.94.4` so Kitaru tracks the latest upstream ZenML release.
+
 ## [0.12.0] - 2026-05-17
 
 ### Added

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,6 @@
 # Pinned ZenML server image version — bump here when upgrading.
-# Must match the ARG ZENML_SERVER_TAG default in docker/Dockerfile and
-# docker/Dockerfile.server-dev (those two are enforced by contract tests;
-# this Justfile value and the CI/release workflow values are not).
+# Must match pyproject.toml, uv.lock, the server Dockerfiles, CI/release
+# workflow pins, and helm/Chart.yaml; contract tests enforce alignment.
 ZENML_SERVER_TAG := "0.94.4"
 DOCKER_REPO := "zenmldocker/kitaru"
 DOCKER_TAG := "latest"

--- a/Justfile
+++ b/Justfile
@@ -2,7 +2,7 @@
 # Must match the ARG ZENML_SERVER_TAG default in docker/Dockerfile and
 # docker/Dockerfile.server-dev (those two are enforced by contract tests;
 # this Justfile value and the CI/release workflow values are not).
-ZENML_SERVER_TAG := "0.94.3"
+ZENML_SERVER_TAG := "0.94.4"
 DOCKER_REPO := "zenmldocker/kitaru"
 DOCKER_TAG := "latest"
 UI_TAG := "latest"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 # Published to: zenmldocker/kitaru
 
-ARG ZENML_SERVER_TAG=0.94.3
+ARG ZENML_SERVER_TAG=0.94.4
 
 FROM zenmldocker/zenml-server:${ZENML_SERVER_TAG} AS server
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -19,10 +19,10 @@ COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /uvx /bin/
 ENV UV_SYSTEM_PYTHON=1
 
 # Install kitaru from local source. Its pyproject.toml pulls
-# zenml[local]>=0.94.3 from PyPI automatically.
+# zenml[local]>=0.94.4 from PyPI automatically.
 COPY . /tmp/kitaru
 RUN cd /tmp/kitaru && uv pip install . && rm -rf /tmp/kitaru
 
 # Layer on cloud extras for remote artifact stores and connectors.
 RUN uv pip install \
-    "zenml[s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure]>=0.94.3"
+    "zenml[s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure]>=0.94.4"

--- a/docker/Dockerfile.server-dev
+++ b/docker/Dockerfile.server-dev
@@ -13,7 +13,7 @@
 #   4. Run:
 #        docker run -p 8080:8080 kitaru-server-dev
 
-ARG ZENML_SERVER_TAG=0.94.3
+ARG ZENML_SERVER_TAG=0.94.4
 
 FROM zenmldocker/zenml-server:${ZENML_SERVER_TAG} AS server
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://kitaru.ai/kitaru-logo.svg
 
 dependencies:
   - name: zenml
-    version: "0.94.3"
+    version: "0.94.4"
     repository: "oci://public.ecr.aws/zenml"
     alias: kitaru

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "cyclopts>=3.0",
     "pydantic>=2.0",
     "rich>=12.0.0",
-    "zenml[local]>=0.94.3",
+    "zenml[local]>=0.94.4",
 ]
 
 [project.optional-dependencies]
@@ -57,7 +57,7 @@ llm = [
     "kitaru[anthropic]",
 ]
 local = [
-    "zenml[server]>=0.94.3",
+    "zenml[server]>=0.94.4",
 ]
 pydantic-ai = [
     "pydantic-ai-slim>=1.89.0,<1.93.0",
@@ -118,7 +118,7 @@ dev = [
     "ruff>=0.11",
     "ty>=0.0.1a7",
     "yamlfix",
-    "zenml[server]>=0.94.3",
+    "zenml[server]>=0.94.4",
     "pytest>=8.0",
     "pytest-randomly",
     "pytest-clarity",

--- a/src/kitaru/errors.py
+++ b/src/kitaru/errors.py
@@ -160,6 +160,9 @@ _RUNTIME_HINTS: Final[tuple[str, ...]] = (
     "hydrate",
     "reconstruct",
     "materializer",
+    "kitaruruntimeerror",
+    "could not persist the flow return value",
+    "artifact save failed",
 )
 _BACKEND_HINTS: Final[tuple[str, ...]] = (
     "backend communication",

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -14,6 +14,7 @@ import time
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 from datetime import datetime
 from functools import update_wrapper, wraps
 from typing import Any, cast, overload
@@ -244,6 +245,8 @@ def _register_pipeline_source_alias(
 _FLOW_RESULT_ARTIFACT_NAME = "kitaru_flow_result"
 _FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME = "kitaru_flow_result_tuple_metadata"
 _FLOW_RESULT_TUPLE_METADATA_MARKER = "kitaru_flow_result_tuple_v1"
+_FLOW_RESULT_ROLE_METADATA_KEY = "kitaru_flow_result_role"
+_FLOW_RESULT_TUPLE_METADATA_ROLE = "tuple_metadata"
 _FLOW_RESULT_COERCION_ENABLED: ContextVar[bool] = ContextVar(
     "kitaru_flow_result_coercion_enabled",
     default=True,
@@ -271,20 +274,31 @@ def _is_zenml_pipeline_output_artifact(value: Any) -> bool:
     return isinstance(value, ArtifactVersionResponse | OutputArtifact)
 
 
-def _save_flow_result_artifact(value: Any, *, name: str) -> ArtifactVersionResponse:
+def _save_flow_result_artifact(
+    value: Any,
+    *,
+    name: str,
+    user_metadata: Mapping[str, Any] | None = None,
+) -> ArtifactVersionResponse:
     """Persist one plain flow result value as a ZenML artifact."""
+    metadata: dict[str, Any] = {"kitaru_artifact_type": "output"}
+    if user_metadata is not None:
+        metadata.update(user_metadata)
+
     try:
         return save_artifact(
             data=value,
             name=name,
             artifact_type=ArtifactType.DATA,
-            user_metadata={"kitaru_artifact_type": "output"},
+            user_metadata=metadata,
         )
     except Exception as exc:
         raise KitaruRuntimeError(
             "Kitaru could not persist the flow return value as a ZenML "
             "artifact. The user flow returned successfully, but the backend "
-            f"artifact save failed: {exc}"
+            "artifact save failed after user code returned. If ZenML retries "
+            "this flow body, non-idempotent side effects in the flow may run "
+            f"again: {exc}"
         ) from exc
 
 
@@ -342,6 +356,9 @@ def _coerce_flow_return_for_zenml(value: Any) -> Any:
         metadata = _save_flow_result_artifact(
             _flow_result_tuple_metadata(len(value)),
             name=_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
+            user_metadata={
+                _FLOW_RESULT_ROLE_METADATA_KEY: _FLOW_RESULT_TUPLE_METADATA_ROLE,
+            },
         )
         return (*coerced_items, metadata)
 
@@ -665,8 +682,20 @@ def _emit_kitaru_execution_url(
     logger.info("Execution URL: %s", url)
 
 
-def _extract_values_from_output_specs(run: PipelineRunResponse) -> list[Any]:
-    """Extract return values using explicit pipeline output specs."""
+@dataclass(frozen=True)
+class _FlowResultOutput:
+    """Loaded flow-output value plus the artifact identity it came from."""
+
+    step_name: str
+    output_name: str
+    artifact: Any
+    value: Any
+
+
+def _extract_outputs_from_output_specs(
+    run: PipelineRunResponse,
+) -> list[_FlowResultOutput]:
+    """Extract return outputs using explicit pipeline output specs."""
     hydrated_run = run.get_hydrated_version()
 
     snapshot = hydrated_run.snapshot
@@ -676,7 +705,7 @@ def _extract_values_from_output_specs(run: PipelineRunResponse) -> list[Any]:
         return []
 
     step_runs = hydrated_run.steps
-    values: list[Any] = []
+    outputs: list[_FlowResultOutput] = []
     for output_spec in output_specs:
         step_run = step_runs.get(output_spec.step_name)
         if step_run is None:
@@ -692,9 +721,16 @@ def _extract_values_from_output_specs(run: PipelineRunResponse) -> list[Any]:
                 f"'{output_spec.output_name}' on step '{output_spec.step_name}'."
             )
 
-        values.append(artifact.load())
+        outputs.append(
+            _FlowResultOutput(
+                step_name=output_spec.step_name,
+                output_name=output_spec.output_name,
+                artifact=artifact,
+                value=artifact.load(),
+            )
+        )
 
-    return values
+    return outputs
 
 
 class _MultipleTerminalStepsOutputError(KitaruAmbiguousFlowResultError):
@@ -740,8 +776,10 @@ def _ambiguous_terminal_message(execution_id: str, *, reason: str) -> str:
     return "\n".join(lines)
 
 
-def _extract_values_from_terminal_steps(run: PipelineRunResponse) -> list[Any]:
-    """Extract return values from terminal step outputs as a fallback.
+def _extract_outputs_from_terminal_steps(
+    run: PipelineRunResponse,
+) -> list[_FlowResultOutput]:
+    """Extract return outputs from terminal step outputs as a fallback.
 
     This fallback is intentionally conservative to avoid returning values in an
     incorrect order when ZenML pipeline-level output specs are unavailable.
@@ -798,7 +836,73 @@ def _extract_values_from_terminal_steps(run: PipelineRunResponse) -> list[Any]:
 
     output_name = next(iter(terminal_step.regular_outputs))
     artifact = terminal_step.regular_outputs[output_name]
-    return [artifact.load()]
+    return [
+        _FlowResultOutput(
+            step_name=terminal_step_name,
+            output_name=output_name,
+            artifact=artifact,
+            value=artifact.load(),
+        )
+    ]
+
+
+def _safe_artifact_name(artifact: Any) -> str | None:
+    """Best-effort artifact name lookup that tolerates lazy/test doubles."""
+    try:
+        name = getattr(artifact, "name", None)
+    except Exception:
+        return None
+    if name is None:
+        return None
+    return str(name)
+
+
+def _metadata_value(value: Any) -> Any:
+    """Unwrap ZenML metadata wrappers when present."""
+    if hasattr(value, "value"):
+        try:
+            return value.value
+        except Exception:
+            return value
+    return value
+
+
+def _artifact_metadata_value(artifact: Any, key: str) -> Any:
+    """Return one metadata value from a ZenML artifact if available."""
+    for attr_name in ("run_metadata", "user_metadata", "metadata"):
+        try:
+            metadata = getattr(artifact, attr_name, None)
+        except Exception:
+            continue
+        if isinstance(metadata, Mapping) and key in metadata:
+            return _metadata_value(metadata[key])
+    return None
+
+
+def _tuple_metadata_length_from_output(output: _FlowResultOutput) -> int | None:
+    """Return tuple length only for Kitaru's reserved metadata artifact."""
+    if (
+        _safe_artifact_name(output.artifact)
+        != _FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME
+    ):
+        return None
+
+    role = _artifact_metadata_value(output.artifact, _FLOW_RESULT_ROLE_METADATA_KEY)
+    # New Kitaru runs stamp an explicit role. We still accept missing metadata
+    # because some ZenML artifact views do not hydrate user metadata reliably;
+    # the reserved artifact name plus marker payload is the compatibility path.
+    if role not in (None, _FLOW_RESULT_TUPLE_METADATA_ROLE):
+        raise KitaruRuntimeError(
+            "Execution flow result tuple metadata artifact has an unexpected "
+            f"role: {role!r}."
+        )
+
+    if not _is_flow_result_tuple_metadata(output.value):
+        raise KitaruRuntimeError(
+            "Execution flow result tuple metadata artifact did not contain "
+            "valid Kitaru tuple metadata."
+        )
+    return cast(int, output.value["length"])
 
 
 def _extract_flow_result(run: PipelineRunResponse) -> Any:
@@ -813,24 +917,35 @@ def _extract_flow_result(run: PipelineRunResponse) -> Any:
     Returns:
         The flow result (`None`, a single value, or a tuple of values).
     """
-    values = _extract_values_from_output_specs(run)
-    if not values:
-        values = _extract_values_from_terminal_steps(run)
+    outputs = _extract_outputs_from_output_specs(run)
+    if not outputs:
+        outputs = _extract_outputs_from_terminal_steps(run)
 
-    if not values:
+    if not outputs:
         return None
 
-    maybe_tuple_metadata = values[-1]
-    if len(values) > 1 and _is_flow_result_tuple_metadata(maybe_tuple_metadata):
-        tuple_values = values[:-1]
-        expected_length = maybe_tuple_metadata["length"]
-        if len(tuple_values) != expected_length:
+    metadata_outputs: list[tuple[_FlowResultOutput, int]] = []
+    for output in outputs:
+        length = _tuple_metadata_length_from_output(output)
+        if length is not None:
+            metadata_outputs.append((output, length))
+
+    if len(metadata_outputs) > 1:
+        raise KitaruRuntimeError(
+            "Execution flow result contained multiple Kitaru tuple metadata artifacts."
+        )
+
+    if metadata_outputs:
+        metadata_output, expected_length = metadata_outputs[0]
+        tuple_outputs = [output for output in outputs if output is not metadata_output]
+        if len(tuple_outputs) != expected_length:
             raise KitaruRuntimeError(
                 "Execution flow result tuple metadata did not match the "
                 "loaded output count."
             )
-        return tuple(tuple_values)
+        return tuple(output.value for output in tuple_outputs)
 
+    values = [output.value for output in outputs]
     if len(values) == 1:
         return values[0]
     return tuple(values)
@@ -1162,7 +1277,9 @@ class _FlowDefinition:
             stack: Optional stack override.
             image: Optional image override.
             cache: Optional cache override.
-            retries: Optional retry override.
+            retries: Optional retry override. Retries rerun the whole flow body;
+                if an internal result-artifact save fails after user code
+                returns, ZenML may replay any side effects in the flow.
             **kwargs: Flow input kwargs.
 
         Returns:
@@ -1341,7 +1458,10 @@ class _FlowDefinition:
             stack: Optional stack override for the replay run.
             image: Optional image override for the replay run.
             cache: Optional cache override for the replay run.
-            retries: Optional retry override for the replay run.
+            retries: Optional retry override for the replay run. Retries rerun
+                the whole flow body; if an internal result-artifact save fails
+                after user code returns, ZenML may replay any side effects in
+                the flow.
             **flow_inputs: Optional flow input overrides.
 
         Returns:
@@ -1590,7 +1710,9 @@ def flow(
         cache: Optional cache override (when omitted, lower-precedence config
             sources apply and eventually default to ``True``).
         retries: Optional retry override (when omitted, lower-precedence config
-            sources apply and eventually default to ``0``).
+            sources apply and eventually default to ``0``). Retries rerun the
+            whole flow body, including any side effects that happened before a
+            post-return internal result-artifact save failure.
 
     Returns:
         The wrapped flow object or a decorator that returns it.

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -20,13 +20,17 @@ from urllib.parse import quote
 from uuid import uuid4
 
 from pydantic import ConfigDict, create_model
+from zenml.artifacts.utils import save_artifact
 from zenml.client import Client
 from zenml.config.constants import DOCKER_SETTINGS_KEY
 from zenml.config.docker_settings import DockerSettings
 from zenml.config.global_config import GlobalConfiguration
 from zenml.config.retry_config import StepRetryConfig
 from zenml.constants import DEFAULT_STACK_AND_COMPONENT_NAME
+from zenml.enums import ArtifactType
+from zenml.execution.pipeline.dynamic.outputs import OutputArtifact
 from zenml.models import PipelineRunResponse
+from zenml.models.v2.core.artifact_version import ArtifactVersionResponse
 from zenml.pipelines.pipeline_decorator import pipeline
 from zenml.pipelines.pipeline_definition import Pipeline
 
@@ -236,6 +240,39 @@ def _register_pipeline_source_alias(
     setattr(module, alias, pipeline_obj)
 
 
+_FLOW_RESULT_ARTIFACT_NAME = "kitaru_flow_result"
+
+
+def _is_zenml_pipeline_output_artifact(value: Any) -> bool:
+    """Return whether ``value`` is already valid as a ZenML pipeline output."""
+    return isinstance(value, ArtifactVersionResponse | OutputArtifact)
+
+
+def _coerce_flow_return_for_zenml(value: Any) -> Any:
+    """Convert a user flow return value into a ZenML 0.94.4-compatible output.
+
+    ZenML 0.94.4 validates dynamic pipeline return values and only accepts
+    artifact references (or tuples of artifact references). Kitaru flows expose
+    normal Python return values, so plain values need to be persisted manually
+    before they are handed back to ZenML's pipeline finalizer.
+    """
+    if value is None:
+        return None
+    if _is_zenml_pipeline_output_artifact(value):
+        return value
+    if isinstance(value, tuple) and all(
+        _is_zenml_pipeline_output_artifact(item) for item in value
+    ):
+        return value
+
+    return save_artifact(
+        data=value,
+        name=_FLOW_RESULT_ARTIFACT_NAME,
+        artifact_type=ArtifactType.DATA,
+        user_metadata={"kitaru_artifact_type": "output"},
+    )
+
+
 def _wrap_flow_entrypoint(func: Callable[..., Any]) -> Callable[..., Any]:
     """Wrap a flow entrypoint with Kitaru flow runtime scope."""
 
@@ -244,7 +281,8 @@ def _wrap_flow_entrypoint(func: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(func)
     def _wrapped(*args: Any, **kwargs: Any) -> Any:
         with _flow_scope(name=flow_name):
-            return func(*args, **kwargs)
+            result = func(*args, **kwargs)
+            return _coerce_flow_return_for_zenml(result)
 
     return _wrapped
 

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -270,7 +270,9 @@ def _coerce_flow_return_for_zenml(value: Any) -> Any:
         return None
     if _is_zenml_pipeline_output_artifact(value):
         return value
-    if isinstance(value, tuple):
+    if isinstance(value, tuple) and any(
+        _is_zenml_pipeline_output_artifact(item) for item in value
+    ):
         return tuple(
             item
             if _is_zenml_pipeline_output_artifact(item)

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -888,10 +888,9 @@ def _tuple_metadata_length_from_output(output: _FlowResultOutput) -> int | None:
         return None
 
     role = _artifact_metadata_value(output.artifact, _FLOW_RESULT_ROLE_METADATA_KEY)
-    # New Kitaru runs stamp an explicit role. We still accept missing metadata
-    # because some ZenML artifact views do not hydrate user metadata reliably;
-    # the reserved artifact name plus marker payload is the compatibility path.
-    if role not in (None, _FLOW_RESULT_TUPLE_METADATA_ROLE):
+    if role is None:
+        return None
+    if role != _FLOW_RESULT_TUPLE_METADATA_ROLE:
         raise KitaruRuntimeError(
             "Execution flow result tuple metadata artifact has an unexpected "
             f"role: {role!r}."

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -248,6 +248,16 @@ def _is_zenml_pipeline_output_artifact(value: Any) -> bool:
     return isinstance(value, ArtifactVersionResponse | OutputArtifact)
 
 
+def _save_flow_result_artifact(value: Any, *, name: str) -> ArtifactVersionResponse:
+    """Persist one plain flow result value as a ZenML artifact."""
+    return save_artifact(
+        data=value,
+        name=name,
+        artifact_type=ArtifactType.DATA,
+        user_metadata={"kitaru_artifact_type": "output"},
+    )
+
+
 def _coerce_flow_return_for_zenml(value: Any) -> Any:
     """Convert a user flow return value into a ZenML 0.94.4-compatible output.
 
@@ -260,17 +270,18 @@ def _coerce_flow_return_for_zenml(value: Any) -> Any:
         return None
     if _is_zenml_pipeline_output_artifact(value):
         return value
-    if isinstance(value, tuple) and all(
-        _is_zenml_pipeline_output_artifact(item) for item in value
-    ):
-        return value
+    if isinstance(value, tuple):
+        return tuple(
+            item
+            if _is_zenml_pipeline_output_artifact(item)
+            else _save_flow_result_artifact(
+                item,
+                name=f"{_FLOW_RESULT_ARTIFACT_NAME}_{index}",
+            )
+            for index, item in enumerate(value)
+        )
 
-    return save_artifact(
-        data=value,
-        name=_FLOW_RESULT_ARTIFACT_NAME,
-        artifact_type=ArtifactType.DATA,
-        user_metadata={"kitaru_artifact_type": "output"},
-    )
+    return _save_flow_result_artifact(value, name=_FLOW_RESULT_ARTIFACT_NAME)
 
 
 def _wrap_flow_entrypoint(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -13,6 +13,7 @@ import threading
 import time
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import datetime
 from functools import update_wrapper, wraps
 from typing import Any, cast, overload
@@ -241,6 +242,28 @@ def _register_pipeline_source_alias(
 
 
 _FLOW_RESULT_ARTIFACT_NAME = "kitaru_flow_result"
+_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME = "kitaru_flow_result_tuple_metadata"
+_FLOW_RESULT_TUPLE_METADATA_MARKER = "kitaru_flow_result_tuple_v1"
+_FLOW_RESULT_COERCION_ENABLED: ContextVar[bool] = ContextVar(
+    "kitaru_flow_result_coercion_enabled",
+    default=True,
+)
+
+
+@contextmanager
+def _suspend_flow_return_coercion() -> Iterator[None]:
+    """Temporarily skip return-value artifact persistence.
+
+    Deployment snapshot preparation may execute the dynamic pipeline function with
+    representative inputs. That phase is only compiling a saved snapshot, not
+    producing a real user-invoked execution, so it must not create durable flow
+    result artifacts.
+    """
+    token = _FLOW_RESULT_COERCION_ENABLED.set(False)
+    try:
+        yield
+    finally:
+        _FLOW_RESULT_COERCION_ENABLED.reset(token)
 
 
 def _is_zenml_pipeline_output_artifact(value: Any) -> bool:
@@ -250,11 +273,37 @@ def _is_zenml_pipeline_output_artifact(value: Any) -> bool:
 
 def _save_flow_result_artifact(value: Any, *, name: str) -> ArtifactVersionResponse:
     """Persist one plain flow result value as a ZenML artifact."""
-    return save_artifact(
-        data=value,
-        name=name,
-        artifact_type=ArtifactType.DATA,
-        user_metadata={"kitaru_artifact_type": "output"},
+    try:
+        return save_artifact(
+            data=value,
+            name=name,
+            artifact_type=ArtifactType.DATA,
+            user_metadata={"kitaru_artifact_type": "output"},
+        )
+    except Exception as exc:
+        raise KitaruRuntimeError(
+            "Kitaru could not persist the flow return value as a ZenML "
+            "artifact. The user flow returned successfully, but the backend "
+            f"artifact save failed: {exc}"
+        ) from exc
+
+
+def _flow_result_tuple_metadata(length: int) -> dict[str, Any]:
+    """Return hidden metadata that marks expanded pipeline outputs as a tuple."""
+    return {
+        "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+        "version": 1,
+        "length": length,
+    }
+
+
+def _is_flow_result_tuple_metadata(value: Any) -> bool:
+    """Return whether a loaded output value is Kitaru tuple metadata."""
+    return (
+        isinstance(value, Mapping)
+        and value.get("kitaru_artifact_type") == _FLOW_RESULT_TUPLE_METADATA_MARKER
+        and value.get("version") == 1
+        and isinstance(value.get("length"), int)
     )
 
 
@@ -273,7 +322,15 @@ def _coerce_flow_return_for_zenml(value: Any) -> Any:
     if isinstance(value, tuple) and any(
         _is_zenml_pipeline_output_artifact(item) for item in value
     ):
-        return tuple(
+        if type(value) is not tuple:
+            raise KitaruUsageError(
+                "Kitaru cannot preserve tuple subclass return values that "
+                "contain checkpoint output handles. Return a plain tuple, or "
+                "wrap the structured value in a final @checkpoint so ZenML "
+                "materializes it as one artifact."
+            )
+
+        coerced_items = tuple(
             item
             if _is_zenml_pipeline_output_artifact(item)
             else _save_flow_result_artifact(
@@ -282,6 +339,11 @@ def _coerce_flow_return_for_zenml(value: Any) -> Any:
             )
             for index, item in enumerate(value)
         )
+        metadata = _save_flow_result_artifact(
+            _flow_result_tuple_metadata(len(value)),
+            name=_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
+        )
+        return (*coerced_items, metadata)
 
     return _save_flow_result_artifact(value, name=_FLOW_RESULT_ARTIFACT_NAME)
 
@@ -295,6 +357,8 @@ def _wrap_flow_entrypoint(func: Callable[..., Any]) -> Callable[..., Any]:
     def _wrapped(*args: Any, **kwargs: Any) -> Any:
         with _flow_scope(name=flow_name):
             result = func(*args, **kwargs)
+            if not _FLOW_RESULT_COERCION_ENABLED.get():
+                return result
             return _coerce_flow_return_for_zenml(result)
 
     return _wrapped
@@ -755,6 +819,18 @@ def _extract_flow_result(run: PipelineRunResponse) -> Any:
 
     if not values:
         return None
+
+    maybe_tuple_metadata = values[-1]
+    if len(values) > 1 and _is_flow_result_tuple_metadata(maybe_tuple_metadata):
+        tuple_values = values[:-1]
+        expected_length = maybe_tuple_metadata["length"]
+        if len(tuple_values) != expected_length:
+            raise KitaruRuntimeError(
+                "Execution flow result tuple metadata did not match the "
+                "loaded output count."
+            )
+        return tuple(tuple_values)
+
     if len(values) == 1:
         return values[0]
     return tuple(values)
@@ -1165,7 +1241,8 @@ class _FlowDefinition:
             )
             _preflight_active_stack_implementation_hydration()
             try:
-                configured_pipeline.prepare(*args, **kwargs)
+                with _suspend_flow_return_coercion():
+                    configured_pipeline.prepare(*args, **kwargs)
             except (RuntimeError, ValueError) as exc:
                 raise KitaruDeploymentInputValuesError(
                     "Unable to create this deployment because Kitaru needs concrete "

--- a/tests/test_dockerfile_contract.py
+++ b/tests/test_dockerfile_contract.py
@@ -2,23 +2,65 @@ from __future__ import annotations
 
 import re
 import tomllib
+from collections.abc import Mapping
+from functools import cache
 from pathlib import Path
+from typing import Any, cast
+
+from zenml.utils import yaml_utils
+
+_VERSION_PATTERN = r"[0-9]+(?:\.[0-9]+)+"
 
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
+@cache
+def _read_file(relative_path: str) -> str:
+    return (_repo_root() / relative_path).read_text()
+
+
 def _read_dockerfile() -> str:
-    return (_repo_root() / "docker" / "Dockerfile").read_text()
+    return _read_file("docker/Dockerfile")
 
 
 def _read_server_dev_dockerfile() -> str:
-    return (_repo_root() / "docker" / "Dockerfile.server-dev").read_text()
+    return _read_file("docker/Dockerfile.server-dev")
 
 
 def _read_pyproject() -> str:
-    return (_repo_root() / "pyproject.toml").read_text()
+    return _read_file("pyproject.toml")
+
+
+@cache
+def _read_toml(relative_path: str) -> dict[str, Any]:
+    return tomllib.loads(_read_file(relative_path))
+
+
+@cache
+def _read_yaml(relative_path: str) -> dict[str, Any]:
+    data = yaml_utils.read_yaml(str(_repo_root() / relative_path))
+    assert isinstance(data, dict), f"{relative_path} should contain a YAML mapping."
+    return data
+
+
+def _extract_zenml_minimum(requirement: str) -> str:
+    match = re.search(rf"\bzenml(?:\[[^\]]+\])?>=({_VERSION_PATTERN})", requirement)
+    assert match, f"Could not extract ZenML minimum from {requirement!r}."
+    return match.group(1)
+
+
+def _expected_zenml_version() -> str:
+    pyproject = _read_toml("pyproject.toml")
+    dependencies = pyproject["project"]["dependencies"]  # type: ignore[index]
+    zenml_requirements = [
+        requirement
+        for requirement in dependencies
+        if isinstance(requirement, str) and requirement.startswith("zenml[")
+    ]
+    assert len(zenml_requirements) == 1
+    return _extract_zenml_minimum(zenml_requirements[0])
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +192,143 @@ def test_dockerfiles_use_same_zenml_server_tag() -> None:
     )
 
 
+def _extract_just_assignment(name: str) -> str:
+    match = re.search(
+        rf"^{re.escape(name)}\s*:=\s*\"([^\"]+)\"$",
+        _read_file("Justfile"),
+        re.MULTILINE,
+    )
+    assert match, f"Justfile should assign {name}."
+    return match.group(1)
+
+
+def _find_yaml_values(data: object, name: str) -> list[str]:
+    if isinstance(data, Mapping):
+        mapping = cast(Mapping[str, object], data)
+        values: list[str] = []
+        value = mapping.get(name)
+        if isinstance(value, str):
+            values.append(value)
+        for nested_value in mapping.values():
+            values.extend(_find_yaml_values(nested_value, name))
+        return values
+    if isinstance(data, list):
+        values = []
+        for item in data:
+            values.extend(_find_yaml_values(item, name))
+        return values
+    return []
+
+
+def _extract_workflow_env_value(relative_path: str, name: str) -> str:
+    values = _find_yaml_values(_read_yaml(relative_path), name)
+    assert len(values) == 1, f"{relative_path} should set env {name} once."
+    return values[0]
+
+
+def _extract_release_build_arg(name: str) -> str:
+    match = re.search(
+        rf"^\s+{re.escape(name)}=({_VERSION_PATTERN})\s*$",
+        _read_file(".github/workflows/release.yml"),
+        re.MULTILINE,
+    )
+    assert match, f"release.yml should pass build arg {name}."
+    return match.group(1)
+
+
+def _extract_helm_dependency_version(name: str) -> str:
+    chart = _read_yaml("helm/Chart.yaml")
+    dependencies = chart.get("dependencies")
+    assert isinstance(dependencies, list), (
+        "helm/Chart.yaml should declare dependencies."
+    )
+    matches = [
+        dependency
+        for dependency in dependencies
+        if isinstance(dependency, dict) and dependency.get("name") == name
+    ]
+    assert len(matches) == 1, f"helm/Chart.yaml should declare dependency {name}."
+    version = matches[0].get("version")
+    assert isinstance(version, str), f"Helm dependency {name} should have a version."
+    return version.strip('"')
+
+
+def _lock_package(name: str) -> dict[str, Any]:
+    lock = _read_toml("uv.lock")
+    packages = lock["package"]  # type: ignore[index]
+    matches = [
+        package
+        for package in packages
+        if isinstance(package, dict) and package.get("name") == name
+    ]
+    assert len(matches) == 1, f"uv.lock should contain exactly one {name} package."
+    return matches[0]
+
+
+def _zenml_lock_specifiers(entries: object) -> list[str]:
+    assert isinstance(entries, list)
+    specifiers: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        mapping = cast(Mapping[str, object], entry)
+        specifier = mapping.get("specifier")
+        if mapping.get("name") == "zenml" and isinstance(specifier, str):
+            specifiers.append(specifier)
+    return specifiers
+
+
+def test_zenml_python_dependency_surfaces_are_aligned() -> None:
+    """Python dependency specs and the lockfile should move together."""
+    expected = _expected_zenml_version()
+    pyproject = _read_toml("pyproject.toml")
+
+    project_dependencies = pyproject["project"]["dependencies"]  # type: ignore[index]
+    local_extra = pyproject["project"]["optional-dependencies"]["local"]  # type: ignore[index]
+    dev_dependencies = pyproject["dependency-groups"]["dev"]  # type: ignore[index]
+
+    requirements = [
+        next(req for req in project_dependencies if req.startswith("zenml[local]")),
+        next(req for req in local_extra if req.startswith("zenml[server]")),
+        next(req for req in dev_dependencies if req.startswith("zenml[server]")),
+    ]
+    assert [_extract_zenml_minimum(req) for req in requirements] == [
+        expected,
+        expected,
+        expected,
+    ]
+
+    kitaru_package = _lock_package("kitaru")
+    metadata = kitaru_package["metadata"]  # type: ignore[index]
+    lock_specs = [
+        *_zenml_lock_specifiers(metadata["requires-dist"]),  # type: ignore[index]
+        *_zenml_lock_specifiers(
+            metadata["requires-dev"]["dev"]  # type: ignore[index]
+        ),
+    ]
+    assert lock_specs == [f">={expected}", f">={expected}", f">={expected}"]
+    assert _lock_package("zenml")["version"] == expected
+
+
+def test_zenml_server_version_surfaces_are_aligned() -> None:
+    """Server image, workflow, Justfile, and Helm pins should match Python."""
+    expected = _expected_zenml_version()
+    surfaces = {
+        "docker/Dockerfile": _extract_zenml_server_tag(_read_dockerfile()),
+        "docker/Dockerfile.server-dev": _extract_zenml_server_tag(
+            _read_server_dev_dockerfile()
+        ),
+        "ci.yml docker-smoke env": _extract_workflow_env_value(
+            ".github/workflows/ci.yml",
+            "ZENML_SERVER_TAG",
+        ),
+        "release.yml Docker build arg": _extract_release_build_arg("ZENML_SERVER_TAG"),
+        "Justfile": _extract_just_assignment("ZENML_SERVER_TAG"),
+        "helm/Chart.yaml": _extract_helm_dependency_version("zenml"),
+    }
+    assert surfaces == {name: expected for name in surfaces}
+
+
 def test_server_dev_dockerfile_copies_local_ui_dist() -> None:
     """The server-dev image should copy local UI dist, not download from GitHub."""
     dockerfile = _read_server_dev_dockerfile()
@@ -164,7 +343,20 @@ def test_server_dev_dockerfile_copies_local_ui_dist() -> None:
 
 def _read_dev_dockerfile() -> str:
     """Read the flow-execution image Dockerfile (not the dev *server*)."""
-    return (_repo_root() / "docker" / "Dockerfile.dev").read_text()
+    return _read_file("docker/Dockerfile.dev")
+
+
+def _extract_dockerfile_dev_zenml_minimums() -> list[str]:
+    """Extract executable ZenML lower bounds from the flow-execution image."""
+    executable_lines = "\n".join(
+        line
+        for line in _read_dev_dockerfile().splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    return re.findall(
+        rf"\bzenml(?:\[[^\]]+\])?>=({_VERSION_PATTERN})",
+        executable_lines,
+    )
 
 
 def test_dockerfile_dev_has_no_git_refs() -> None:
@@ -175,6 +367,14 @@ def test_dockerfile_dev_has_no_git_refs() -> None:
             f"Dockerfile.dev contains git ref marker '{marker}'. "
             "Use PyPI version specs instead."
         )
+
+
+def test_dockerfile_dev_zenml_minimum_matches_package_contract() -> None:
+    """Dockerfile.dev may use >=, but its floor must match pyproject."""
+    expected = _expected_zenml_version()
+    minimums = _extract_dockerfile_dev_zenml_minimums()
+    assert minimums, "Dockerfile.dev should contain at least one ZenML minimum."
+    assert minimums == [expected for _ in minimums]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1003,6 +1003,28 @@ def test_flow_return_coercion_saves_plain_values_as_pipeline_artifacts() -> None
     }
 
 
+def test_flow_return_coercion_preserves_mixed_tuple_outputs() -> None:
+    """Mixed artifact/plain tuples should remain tuple-shaped pipeline outputs."""
+    handle = OutputArtifact.model_construct(
+        id=uuid4(),
+        step_name="produce_value",
+        output_name="output",
+    )
+    saved_plain = object()
+
+    with patch("kitaru.flow.save_artifact", return_value=saved_plain) as save_mock:
+        result = _coerce_flow_return_for_zenml((handle, 1))
+
+    assert result == (handle, saved_plain)
+    save_mock.assert_called_once()
+    assert save_mock.call_args.kwargs == {
+        "data": 1,
+        "name": f"{_FLOW_RESULT_ARTIFACT_NAME}_1",
+        "artifact_type": ArtifactType.DATA,
+        "user_metadata": {"kitaru_artifact_type": "output"},
+    }
+
+
 def test_checkpoint_cache_survives_pipeline_with_options_when_execution_unset() -> None:
     """Mixed ``@checkpoint(cache=...)`` values must survive ``with_options``.
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import threading
+from collections import namedtuple
 from contextlib import nullcontext
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -1001,6 +1002,38 @@ def test_flow_return_coercion_saves_plain_values_as_pipeline_artifacts() -> None
         "artifact_type": ArtifactType.DATA,
         "user_metadata": {"kitaru_artifact_type": "output"},
     }
+
+
+def test_flow_return_coercion_preserves_plain_tuple_as_one_artifact() -> None:
+    """Plain tuples are ordinary Python return values, not pipeline fan-out."""
+    saved_tuple = object()
+
+    with patch("kitaru.flow.save_artifact", return_value=saved_tuple) as save_mock:
+        result = _coerce_flow_return_for_zenml((1,))
+
+    assert result is saved_tuple
+    save_mock.assert_called_once()
+    assert save_mock.call_args.kwargs == {
+        "data": (1,),
+        "name": _FLOW_RESULT_ARTIFACT_NAME,
+        "artifact_type": ArtifactType.DATA,
+        "user_metadata": {"kitaru_artifact_type": "output"},
+    }
+
+
+def test_flow_return_coercion_preserves_namedtuple_as_one_artifact() -> None:
+    """Tuple subclasses should keep their user-facing object semantics."""
+    Pair = namedtuple("Pair", ["left", "right"])
+    value = Pair(left=1, right=2)
+    saved_pair = object()
+
+    with patch("kitaru.flow.save_artifact", return_value=saved_pair) as save_mock:
+        result = _coerce_flow_return_for_zenml(value)
+
+    assert result is saved_pair
+    save_mock.assert_called_once()
+    assert save_mock.call_args.kwargs["data"] == value
+    assert save_mock.call_args.kwargs["name"] == _FLOW_RESULT_ARTIFACT_NAME
 
 
 def test_flow_return_coercion_preserves_mixed_tuple_outputs() -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import sys
 import threading
 from collections import namedtuple
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import nullcontext
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any, cast
@@ -47,7 +48,10 @@ from kitaru.errors import (
 )
 from kitaru.flow import (
     _FLOW_RESULT_ARTIFACT_NAME,
+    _FLOW_RESULT_ROLE_METADATA_KEY,
+    _FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
     _FLOW_RESULT_TUPLE_METADATA_MARKER,
+    _FLOW_RESULT_TUPLE_METADATA_ROLE,
     FlowHandle,
     _build_kitaru_execution_url,
     _build_pipeline_options,
@@ -59,6 +63,7 @@ from kitaru.flow import (
     _guard_implicit_active_stack_fallback,
     _inject_model_registry_env,
     _is_multiple_terminal_steps_output_error,
+    _suspend_flow_return_coercion,
     _temporary_active_stack,
     _wrap_flow_entrypoint,
     flow,
@@ -122,9 +127,26 @@ class _ClientWithMissingStackDependency:
         )
 
 
+@dataclass(frozen=True)
+class _DummyOutput:
+    step_name: str
+    output_name: str
+    value: object
+    artifact_name: str | None = None
+    run_metadata: Mapping[str, object] | None = None
+
+
 class _DummyArtifact:
-    def __init__(self, value: object) -> None:
+    def __init__(
+        self,
+        value: object,
+        *,
+        name: str = "output",
+        run_metadata: dict[str, object] | None = None,
+    ) -> None:
         self._value = value
+        self.name = name
+        self.run_metadata = run_metadata or {}
 
     def load(self) -> object:
         return self._value
@@ -135,7 +157,7 @@ class _DummyRun:
         self,
         *,
         status: ExecutionStatus,
-        outputs: list[tuple[str, str, object]] | None = None,
+        outputs: list[tuple[str, str, object] | _DummyOutput] | None = None,
         run_id: object | None = None,
         pipeline_id: object | None = None,
         pipeline: object | None = None,
@@ -161,11 +183,26 @@ class _DummyRun:
         outputs = outputs or []
         output_specs: list[SimpleNamespace] = []
         step_outputs: dict[str, dict[str, _DummyArtifact]] = {}
-        for step_name, output_name, value in outputs:
+        for output in outputs:
+            if isinstance(output, _DummyOutput):
+                step_name = output.step_name
+                output_name = output.output_name
+                value = output.value
+                artifact_name = output.artifact_name or output_name
+                run_metadata = dict(output.run_metadata or {})
+            else:
+                step_name, output_name, value = output
+                artifact_name = output_name
+                run_metadata = None
+
             output_specs.append(
                 SimpleNamespace(step_name=step_name, output_name=output_name)
             )
-            step_outputs.setdefault(step_name, {})[output_name] = _DummyArtifact(value)
+            step_outputs.setdefault(step_name, {})[output_name] = _DummyArtifact(
+                value,
+                name=artifact_name,
+                run_metadata=run_metadata,
+            )
 
         self.snapshot = SimpleNamespace(
             pipeline_spec=SimpleNamespace(outputs=output_specs),
@@ -599,6 +636,34 @@ def test_flow_deploy_prepare_does_not_persist_flow_result_artifacts() -> None:
     save_mock.assert_not_called()
     configured_pipeline._create_snapshot.assert_called_once()
     deployments_api.create.assert_called_once()
+
+
+def test_real_zenml_prepare_does_not_persist_flow_result_artifacts() -> None:
+    """Real ZenML prepare must stay a dry run for Kitaru result artifacts."""
+    calls: list[int] = []
+
+    @flow
+    def prepare_regression_flow(x):
+        calls.append(x)
+        return {"answer": x}
+
+    coerce_mock = MagicMock(side_effect=AssertionError("coercion called"))
+    save_mock = MagicMock(side_effect=AssertionError("save_artifact called"))
+
+    with (
+        patch("kitaru.flow._coerce_flow_return_for_zenml", coerce_mock),
+        patch("kitaru.flow.save_artifact", save_mock),
+        _suspend_flow_return_coercion(),
+    ):
+        prepare_regression_flow._pipeline.prepare(1)
+
+    # Real ZenML prepare currently compiles the dynamic pipeline without
+    # executing the user body. The deploy-level mock test above covers the
+    # defensive Kitaru suspension path if an entrypoint is invoked during
+    # preparation.
+    assert calls == []
+    coerce_mock.assert_not_called()
+    save_mock.assert_not_called()
 
 
 def test_flow_deploy_resolves_invocation_image_and_threads_it_to_with_options() -> None:
@@ -1047,6 +1112,10 @@ def test_flow_return_coercion_preserves_zenml_output_handles() -> None:
         "version": 1,
         "length": 1,
     }
+    assert save_mock.call_args.kwargs["user_metadata"] == {
+        "kitaru_artifact_type": "output",
+        _FLOW_RESULT_ROLE_METADATA_KEY: _FLOW_RESULT_TUPLE_METADATA_ROLE,
+    }
 
 
 def test_flow_return_coercion_saves_plain_values_as_pipeline_artifacts() -> None:
@@ -1074,7 +1143,37 @@ def test_flow_return_coercion_wraps_artifact_save_failures() -> None:
     ):
         _coerce_flow_return_for_zenml({"answer": 42})
 
+    message = str(exc_info.value)
+    assert "returned successfully" in message
+    assert "after user code returned" in message
+    assert "retries" in message
+    assert "side effects" in message
     assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+def test_post_return_artifact_save_failure_does_not_retry_inside_wrapper() -> None:
+    """Kitaru reports the retry risk but does not add its own inner retry."""
+    side_effects = {"count": 0}
+
+    def user_flow() -> dict[str, int]:
+        side_effects["count"] += 1
+        return {"answer": 42}
+
+    wrapped = _wrap_flow_entrypoint(user_flow)
+
+    with (
+        patch("kitaru.runtime.StepContext.get", return_value=None),
+        patch("kitaru.runtime.DynamicPipelineRunContext.get", return_value=None),
+        patch("kitaru.flow.save_artifact", side_effect=RuntimeError("store down")),
+        pytest.raises(KitaruRuntimeError) as exc_info,
+    ):
+        wrapped()
+
+    message = str(exc_info.value)
+    assert "after user code returned" in message
+    assert "retries" in message
+    assert "side effects" in message
+    assert side_effects["count"] == 1
 
 
 def test_flow_return_coercion_preserves_plain_tuple_as_one_artifact() -> None:
@@ -1138,6 +1237,10 @@ def test_flow_return_coercion_preserves_mixed_tuple_outputs() -> None:
         "version": 1,
         "length": 2,
     }
+    assert save_mock.call_args_list[1].kwargs["user_metadata"] == {
+        "kitaru_artifact_type": "output",
+        _FLOW_RESULT_ROLE_METADATA_KEY: _FLOW_RESULT_TUPLE_METADATA_ROLE,
+    }
 
 
 def test_flow_result_extraction_restores_singleton_tuple_outputs() -> None:
@@ -1146,13 +1249,17 @@ def test_flow_result_extraction_restores_singleton_tuple_outputs() -> None:
         status=ExecutionStatus.COMPLETED,
         outputs=[
             ("step", "output_0", "value"),
-            (
-                "step",
-                "output_1",
-                {
+            _DummyOutput(
+                step_name="step",
+                output_name="output_1",
+                value={
                     "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
                     "version": 1,
                     "length": 1,
+                },
+                artifact_name=_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
+                run_metadata={
+                    _FLOW_RESULT_ROLE_METADATA_KEY: _FLOW_RESULT_TUPLE_METADATA_ROLE
                 },
             ),
         ],
@@ -1174,6 +1281,108 @@ def test_flow_result_extraction_preserves_marker_shaped_single_output() -> None:
     )
 
     assert _extract_flow_result(_as_pipeline_run(run)) == value
+
+
+def test_flow_result_extraction_preserves_marker_shaped_last_output() -> None:
+    """Tuple metadata detection must not rely on loaded dict shape alone."""
+    marker_shaped_user_value = {
+        "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+        "version": 1,
+        "length": 1,
+    }
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            ("step", "output_0", "value"),
+            ("step", "output_1", marker_shaped_user_value),
+        ],
+    )
+
+    assert _extract_flow_result(_as_pipeline_run(run)) == (
+        "value",
+        marker_shaped_user_value,
+    )
+
+
+def test_flow_result_extraction_rejects_unexpected_tuple_metadata_role() -> None:
+    """Reserved tuple metadata artifacts must not carry another Kitaru role."""
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            ("step", "output_0", "value"),
+            _DummyOutput(
+                step_name="step",
+                output_name="output_1",
+                value={
+                    "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+                    "version": 1,
+                    "length": 1,
+                },
+                artifact_name=_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
+                run_metadata={_FLOW_RESULT_ROLE_METADATA_KEY: "not_tuple_metadata"},
+            ),
+        ],
+    )
+
+    with pytest.raises(KitaruRuntimeError, match="unexpected role"):
+        _extract_flow_result(_as_pipeline_run(run))
+
+
+def test_flow_result_extraction_rejects_malformed_tuple_metadata() -> None:
+    """Reserved tuple metadata artifacts must contain valid marker payloads."""
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            ("step", "output_0", "value"),
+            _DummyOutput(
+                step_name="step",
+                output_name="output_1",
+                value={"kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER},
+                artifact_name=_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
+                run_metadata={
+                    _FLOW_RESULT_ROLE_METADATA_KEY: _FLOW_RESULT_TUPLE_METADATA_ROLE
+                },
+            ),
+        ],
+    )
+
+    with pytest.raises(KitaruRuntimeError, match="valid Kitaru tuple metadata"):
+        _extract_flow_result(_as_pipeline_run(run))
+
+
+def test_flow_result_extraction_rejects_multiple_tuple_metadata_artifacts() -> None:
+    """Only one hidden tuple metadata artifact may describe a flow result."""
+    metadata_value = {
+        "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+        "version": 1,
+        "length": 1,
+    }
+    metadata_output = _DummyOutput(
+        step_name="step",
+        output_name="output_1",
+        value=metadata_value,
+        artifact_name=_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
+        run_metadata={_FLOW_RESULT_ROLE_METADATA_KEY: _FLOW_RESULT_TUPLE_METADATA_ROLE},
+    )
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            ("step", "output_0", "value"),
+            metadata_output,
+            _DummyOutput(
+                step_name="step",
+                output_name="output_2",
+                value=metadata_value,
+                artifact_name=_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
+                run_metadata={
+                    _FLOW_RESULT_ROLE_METADATA_KEY: _FLOW_RESULT_TUPLE_METADATA_ROLE
+                },
+            ),
+        ],
+    )
+
+    with pytest.raises(KitaruRuntimeError, match="multiple Kitaru tuple metadata"):
+        _extract_flow_result(_as_pipeline_run(run))
 
 
 def test_flow_return_coercion_rejects_mixed_tuple_subclasses() -> None:
@@ -2092,7 +2301,9 @@ def test_flow_handle_get_classifies_result_save_failure_as_runtime() -> None:
             "Traceback\n"
             "kitaru.errors.KitaruRuntimeError: Kitaru could not persist "
             "the flow return value as a ZenML artifact. The user flow returned "
-            "successfully, but the backend artifact save failed: store down"
+            "successfully, but the backend artifact save failed after user "
+            "code returned. If ZenML retries this flow body, non-idempotent "
+            "side effects in the flow may run again: store down"
         ),
     )
     client_mock = MagicMock()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import sys
 import threading
 from collections import namedtuple
+from collections.abc import Callable
 from contextlib import nullcontext
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock, call, patch
 from uuid import uuid4
 
@@ -46,12 +47,14 @@ from kitaru.errors import (
 )
 from kitaru.flow import (
     _FLOW_RESULT_ARTIFACT_NAME,
+    _FLOW_RESULT_TUPLE_METADATA_MARKER,
     FlowHandle,
     _build_kitaru_execution_url,
     _build_pipeline_options,
     _checkpoint_count_from_run,
     _coerce_flow_return_for_zenml,
     _duration_metadata_from_run,
+    _extract_flow_result,
     _extract_run_pipeline_id,
     _guard_implicit_active_stack_fallback,
     _inject_model_registry_env,
@@ -545,6 +548,59 @@ def test_flow_deploy_creates_snapshot_and_forwards_raw_tags() -> None:
     )
 
 
+def test_flow_deploy_prepare_does_not_persist_flow_result_artifacts() -> None:
+    """Deployment snapshot preparation is a dry run, not a flow execution."""
+    source_snapshot = SimpleNamespace(id=uuid4(), name="temporary-source")
+    configured_pipeline = MagicMock()
+    configured_pipeline._run_args = {}
+    configured_pipeline._parameters = {"x": 1}
+    configured_pipeline._create_snapshot.return_value = source_snapshot
+    captured: dict[str, Callable[..., Any]] = {}
+
+    def _decorate(entrypoint: Callable[..., Any]) -> object:
+        captured["entrypoint"] = entrypoint
+        return base_pipeline
+
+    def _prepare(*args: Any, **kwargs: Any) -> None:
+        captured["entrypoint"](*args, **kwargs)
+
+    configured_pipeline.prepare.side_effect = _prepare
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(side_effect=_decorate)
+    deployments_api = SimpleNamespace(create=MagicMock(return_value=object()))
+    client = SimpleNamespace(deployments=deployments_api)
+    stack_client = SimpleNamespace(
+        active_stack_model=SimpleNamespace(name="prod"),
+        zen_store=object(),
+        active_stack=object(),
+    )
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(stack="prod"),
+        ),
+        patch(
+            "kitaru.flow._prepare_model_registry_transport",
+            return_value=(None, ModelRegistryConfig()),
+        ),
+        patch("kitaru.flow._temporary_active_stack", return_value=nullcontext()),
+        patch("kitaru.flow.Client", return_value=stack_client),
+        patch("kitaru.flow.ensure_stack_is_server_runnable"),
+        patch("kitaru.flow.save_artifact") as save_mock,
+        patch("kitaru.client.KitaruClient", return_value=client),
+    ):
+        wrapped = flow(lambda x: {"answer": x})
+        wrapped.deploy(1)
+
+    configured_pipeline.prepare.assert_called_once_with(1)
+    save_mock.assert_not_called()
+    configured_pipeline._create_snapshot.assert_called_once()
+    deployments_api.create.assert_called_once()
+
+
 def test_flow_deploy_resolves_invocation_image_and_threads_it_to_with_options() -> None:
     """Deploy should pass image overrides into config resolution and Docker settings."""
     source_snapshot = SimpleNamespace(id=uuid4(), name="temporary-source")
@@ -977,14 +1033,20 @@ def test_flow_return_coercion_preserves_zenml_output_handles() -> None:
         step_name="produce_value",
         output_name="output",
     )
+    tuple_metadata = object()
 
-    with patch("kitaru.flow.save_artifact") as save_mock:
+    with patch("kitaru.flow.save_artifact", return_value=tuple_metadata) as save_mock:
         result = _coerce_flow_return_for_zenml(artifact)
         tuple_result = _coerce_flow_return_for_zenml((artifact,))
 
     assert result is artifact
-    assert tuple_result == (artifact,)
-    save_mock.assert_not_called()
+    assert tuple_result == (artifact, tuple_metadata)
+    save_mock.assert_called_once()
+    assert save_mock.call_args.kwargs["data"] == {
+        "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+        "version": 1,
+        "length": 1,
+    }
 
 
 def test_flow_return_coercion_saves_plain_values_as_pipeline_artifacts() -> None:
@@ -1002,6 +1064,17 @@ def test_flow_return_coercion_saves_plain_values_as_pipeline_artifacts() -> None
         "artifact_type": ArtifactType.DATA,
         "user_metadata": {"kitaru_artifact_type": "output"},
     }
+
+
+def test_flow_return_coercion_wraps_artifact_save_failures() -> None:
+    """Internal result-artifact failures should not look like user-code errors."""
+    with (
+        patch("kitaru.flow.save_artifact", side_effect=RuntimeError("store down")),
+        pytest.raises(KitaruRuntimeError, match="could not persist") as exc_info,
+    ):
+        _coerce_flow_return_for_zenml({"answer": 42})
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
 
 
 def test_flow_return_coercion_preserves_plain_tuple_as_one_artifact() -> None:
@@ -1044,18 +1117,76 @@ def test_flow_return_coercion_preserves_mixed_tuple_outputs() -> None:
         output_name="output",
     )
     saved_plain = object()
+    tuple_metadata = object()
 
-    with patch("kitaru.flow.save_artifact", return_value=saved_plain) as save_mock:
+    with patch(
+        "kitaru.flow.save_artifact",
+        side_effect=[saved_plain, tuple_metadata],
+    ) as save_mock:
         result = _coerce_flow_return_for_zenml((handle, 1))
 
-    assert result == (handle, saved_plain)
-    save_mock.assert_called_once()
-    assert save_mock.call_args.kwargs == {
+    assert result == (handle, saved_plain, tuple_metadata)
+    assert save_mock.call_count == 2
+    assert save_mock.call_args_list[0].kwargs == {
         "data": 1,
         "name": f"{_FLOW_RESULT_ARTIFACT_NAME}_1",
         "artifact_type": ArtifactType.DATA,
         "user_metadata": {"kitaru_artifact_type": "output"},
     }
+    assert save_mock.call_args_list[1].kwargs["data"] == {
+        "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+        "version": 1,
+        "length": 2,
+    }
+
+
+def test_flow_result_extraction_restores_singleton_tuple_outputs() -> None:
+    """Hidden tuple metadata keeps one-item artifact tuples tuple-shaped."""
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            ("step", "output_0", "value"),
+            (
+                "step",
+                "output_1",
+                {
+                    "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+                    "version": 1,
+                    "length": 1,
+                },
+            ),
+        ],
+    )
+
+    assert _extract_flow_result(_as_pipeline_run(run)) == ("value",)
+
+
+def test_flow_result_extraction_preserves_marker_shaped_single_output() -> None:
+    """A user value shaped like tuple metadata should still round-trip as data."""
+    value = {
+        "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+        "version": 1,
+        "length": 0,
+    }
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[("step", "output", value)],
+    )
+
+    assert _extract_flow_result(_as_pipeline_run(run)) == value
+
+
+def test_flow_return_coercion_rejects_mixed_tuple_subclasses() -> None:
+    """Tuple subclasses with handles would otherwise lose their field semantics."""
+    Pair = namedtuple("Pair", ["left", "right"])
+    handle = OutputArtifact.model_construct(
+        id=uuid4(),
+        step_name="produce_value",
+        output_name="output",
+    )
+
+    with pytest.raises(KitaruUsageError, match="tuple subclass"):
+        _coerce_flow_return_for_zenml(Pair(handle, 1))
 
 
 def test_checkpoint_cache_survives_pipeline_with_options_when_execution_unset() -> None:
@@ -1950,6 +2081,32 @@ def test_flow_handle_get_raises_with_failure_context() -> None:
     assert exc_info.value.status == KitaruExecutionStatus.FAILED
     assert isinstance(exc_info.value.status, KitaruExecutionStatus)
     assert exc_info.value.failure_origin == FailureOrigin.USER_CODE
+
+
+def test_flow_handle_get_classifies_result_save_failure_as_runtime() -> None:
+    """Kitaru's internal result save failures should not blame user code."""
+    failed = _DummyRun(
+        status=ExecutionStatus.FAILED,
+        status_reason="Kitaru could not persist the flow return value",
+        traceback=(
+            "Traceback\n"
+            "kitaru.errors.KitaruRuntimeError: Kitaru could not persist "
+            "the flow return value as a ZenML artifact. The user flow returned "
+            "successfully, but the backend artifact save failed: store down"
+        ),
+    )
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = failed
+
+    handle = FlowHandle(_as_pipeline_run(failed))
+    with (
+        patch("kitaru.flow.Client", return_value=client_mock),
+        pytest.raises(KitaruExecutionError, match="could not persist") as exc_info,
+    ):
+        handle.get()
+
+    assert not isinstance(exc_info.value, KitaruUserCodeError)
+    assert exc_info.value.failure_origin == FailureOrigin.RUNTIME
 
 
 def test_flow_handle_get_returns_tuple_for_multiple_outputs() -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1304,6 +1304,28 @@ def test_flow_result_extraction_preserves_marker_shaped_last_output() -> None:
     )
 
 
+def test_flow_result_extraction_preserves_reserved_name_without_metadata_role() -> None:
+    """Reserved names alone should not turn user artifacts into metadata."""
+    value = {
+        "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+        "version": 1,
+        "length": 1,
+    }
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            _DummyOutput(
+                step_name="step",
+                output_name="output",
+                value=value,
+                artifact_name=_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
+            ),
+        ],
+    )
+
+    assert _extract_flow_result(_as_pipeline_run(run)) == value
+
+
 def test_flow_result_extraction_rejects_unexpected_tuple_metadata_role() -> None:
     """Reserved tuple metadata artifacts must not carry another Kitaru role."""
     run = _DummyRun(

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2052,14 +2052,20 @@ def test_flow_runtime_scope_sets_execution_id_from_zenml_run_context() -> None:
 
     wrapped = _wrap_flow_entrypoint(_user_flow)
 
-    with patch(
-        "kitaru.runtime.DynamicPipelineRunContext.get",
-        return_value=SimpleNamespace(
-            run=SimpleNamespace(
-                id="exec-123",
-                pipeline=SimpleNamespace(id="flow-abc", name="_user_flow"),
+    with (
+        patch(
+            "kitaru.runtime.DynamicPipelineRunContext.get",
+            return_value=SimpleNamespace(
+                run=SimpleNamespace(
+                    id="exec-123",
+                    pipeline=SimpleNamespace(id="flow-abc", name="_user_flow"),
+                ),
+                pipeline=SimpleNamespace(id=None, name=None),
             ),
-            pipeline=SimpleNamespace(id=None, name=None),
+        ),
+        patch(
+            "kitaru.flow._coerce_flow_return_for_zenml",
+            side_effect=lambda value: value,
         ),
     ):
         result = wrapped()
@@ -2075,14 +2081,20 @@ def test_public_current_execution_id_reads_flow_scope_only() -> None:
 
     wrapped = _wrap_flow_entrypoint(_user_flow)
 
-    with patch(
-        "kitaru.runtime.DynamicPipelineRunContext.get",
-        return_value=SimpleNamespace(
-            run=SimpleNamespace(
-                id="exec-public-123",
-                pipeline=SimpleNamespace(id="flow-abc", name="_user_flow"),
+    with (
+        patch(
+            "kitaru.runtime.DynamicPipelineRunContext.get",
+            return_value=SimpleNamespace(
+                run=SimpleNamespace(
+                    id="exec-public-123",
+                    pipeline=SimpleNamespace(id="flow-abc", name="_user_flow"),
+                ),
+                pipeline=SimpleNamespace(id=None, name=None),
             ),
-            pipeline=SimpleNamespace(id=None, name=None),
+        ),
+        patch(
+            "kitaru.flow._coerce_flow_return_for_zenml",
+            side_effect=lambda value: value,
         ),
     ):
         result = wrapped()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -13,7 +13,8 @@ from uuid import uuid4
 
 import pytest
 from zenml.config.docker_settings import DockerSettings
-from zenml.enums import ExecutionStatus
+from zenml.enums import ArtifactType, ExecutionStatus
+from zenml.execution.pipeline.dynamic.outputs import OutputArtifact
 from zenml.models import PipelineRunResponse
 
 import kitaru
@@ -43,10 +44,12 @@ from kitaru.errors import (
     format_recovery_hint,
 )
 from kitaru.flow import (
+    _FLOW_RESULT_ARTIFACT_NAME,
     FlowHandle,
     _build_kitaru_execution_url,
     _build_pipeline_options,
     _checkpoint_count_from_run,
+    _coerce_flow_return_for_zenml,
     _duration_metadata_from_run,
     _extract_run_pipeline_id,
     _guard_implicit_active_stack_fallback,
@@ -964,6 +967,40 @@ def test_flow_run_omits_secrets_when_none_configured() -> None:
 
     call_kwargs = base_pipeline.with_options.call_args.kwargs
     assert "secrets" not in call_kwargs
+
+
+def test_flow_return_coercion_preserves_zenml_output_handles() -> None:
+    """Compilation-time checkpoint output handles must not be re-saved."""
+    artifact = OutputArtifact.model_construct(
+        id=uuid4(),
+        step_name="produce_value",
+        output_name="output",
+    )
+
+    with patch("kitaru.flow.save_artifact") as save_mock:
+        result = _coerce_flow_return_for_zenml(artifact)
+        tuple_result = _coerce_flow_return_for_zenml((artifact,))
+
+    assert result is artifact
+    assert tuple_result == (artifact,)
+    save_mock.assert_not_called()
+
+
+def test_flow_return_coercion_saves_plain_values_as_pipeline_artifacts() -> None:
+    """Plain Kitaru flow results must satisfy ZenML pipeline output validation."""
+    artifact = object()
+
+    with patch("kitaru.flow.save_artifact", return_value=artifact) as save_mock:
+        result = _coerce_flow_return_for_zenml({"answer": 42})
+
+    assert result is artifact
+    save_mock.assert_called_once()
+    assert save_mock.call_args.kwargs == {
+        "data": {"answer": 42},
+        "name": _FLOW_RESULT_ARTIFACT_NAME,
+        "artifact_type": ArtifactType.DATA,
+        "user_metadata": {"kitaru_artifact_type": "output"},
+    }
 
 
 def test_checkpoint_cache_survives_pipeline_with_options_when_execution_unset() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1297,8 +1297,8 @@ requires-dist = [
     { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=1.89.0,<1.93.0" },
     { name = "rich", specifier = ">=12.0.0" },
     { name = "typing-extensions", marker = "extra == 'pydantic-ai'", specifier = ">=4.12" },
-    { name = "zenml", extras = ["local"], specifier = ">=0.94.3" },
-    { name = "zenml", extras = ["server"], marker = "extra == 'local'", specifier = ">=0.94.3" },
+    { name = "zenml", extras = ["local"], specifier = ">=0.94.4" },
+    { name = "zenml", extras = ["server"], marker = "extra == 'local'", specifier = ">=0.94.4" },
 ]
 provides-extras = ["openai", "anthropic", "llm", "local", "pydantic-ai", "openai-agents", "langgraph", "langgraph-openai", "langgraph-anthropic", "claude-agent-sdk", "mcp"]
 
@@ -1322,7 +1322,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11" },
     { name = "ty", specifier = ">=0.0.1a7" },
     { name = "yamlfix" },
-    { name = "zenml", extras = ["server"], specifier = ">=0.94.3" },
+    { name = "zenml", extras = ["server"], specifier = ">=0.94.4" },
 ]
 
 [[package]]
@@ -3933,7 +3933,7 @@ wheels = [
 
 [[package]]
 name = "zenml"
-version = "0.94.3"
+version = "0.94.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
@@ -3952,9 +3952,9 @@ dependencies = [
     { name = "rich" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/41/8f3aa68a00bbee24916d0256973cc61a4815672d9ee348cb0f8125b208ca/zenml-0.94.3.tar.gz", hash = "sha256:213115670540df182808179d96026a4c57537ba0838e5562a8442d40290137b9", size = 7134264, upload-time = "2026-04-24T13:40:12.38Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/19/6947d4b33761475b681e59229cdc3e052b869ff673046fe64ebdae9c9f57/zenml-0.94.4.tar.gz", hash = "sha256:71e2a3b919b42235fd7746853244b3e9bf7c5b75cfdeb3ab32f7e8db15da54cb", size = 7169262, upload-time = "2026-05-12T15:01:11.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/49/97827f97078bc67ad8f4dae20baf3b7a2b1d6ca8b2bff0927046be44b074/zenml-0.94.3-py3-none-any.whl", hash = "sha256:0ad07adf44d6736119e6b72a50ee3f9314e96f5b1152b76fd2b1f6810e59d142", size = 8274402, upload-time = "2026-04-24T13:40:09.698Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e3/21a7dd71780b7581160f707e39be1ccc75ba0f5dcc72aa9b8d33ad6c8739/zenml-0.94.4-py3-none-any.whl", hash = "sha256:a660adc70205919cb41ca6344ae2a94b6c0b430257c6d8c79f8a5089a30102ef", size = 8322261, upload-time = "2026-05-12T15:01:08.748Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Bump Kitaru’s ZenML compatibility contract to the 0.94.4 release surfaces.
- Update flow-result coercion so ZenML 0.94.4 accepts Kitaru flow returns while users still get their original Python return values back from `wait()` / `get()`.
- Add regression and contract tests for mixed tuple returns, `prepare()` dry runs, post-return artifact-save failures, and ZenML version alignment across package, Docker, CI/release, Helm, and `Justfile` surfaces.
- Record the user-facing compatibility fix in the changelog.

## Reviewer Notes

The key story is in `src/kitaru/flow.py`. ZenML 0.94.4 became stricter about dynamic pipeline outputs, so a plain Kitaru flow return like `return {"ok": True}` can no longer simply fall through as arbitrary Python data. Kitaru now saves plain return values as internal result artifacts after the user function returns, then reconstructs the user-facing value when `FlowHandle.wait()` / `get()` reads the finished run.

The tricky part is tuple-shaped returns. If a flow returns mixed values, for example `(checkpoint_value, 1)`, Kitaru must keep the checkpoint artifact handle as a handle but save the plain `1` separately. The reconstruction path now uses the hidden tuple metadata artifact’s reserved artifact name plus Kitaru role metadata, instead of trusting a marker-shaped dictionary payload. That means real user data shaped like Kitaru’s marker remains user data, while Kitaru’s own hidden tuple metadata is used to rebuild the tuple.

The other important path is deploy/prepare. ZenML `prepare()` should inspect/compile the pipeline without persisting Kitaru result artifacts, so the tests now include a real ZenML `prepare()` regression check. Artifact-save failure messages also now say clearly that the user function already returned, and that ZenML retries can rerun non-idempotent side effects if the internal save fails after user code.

Reviewer focus areas:

- `src/kitaru/flow.py`: result coercion, hidden tuple metadata, extraction fallback, and the retry/error wording.
- `tests/test_flow.py`: public return semantics for plain values, tuples, tuple subclasses, marker-shaped user dictionaries, malformed tuple metadata, and real `prepare()` behavior.
- `tests/test_dockerfile_contract.py`: version alignment checks. `docker/Dockerfile.dev` is intentionally allowed to float with `zenml>=0.94.4`; it is not exact-pinned like the server images.

### Reproduction

A concrete behavior to inspect is a flow that returns a mixed tuple: one checkpoint output plus one plain Python value. Before this fix, Kitaru could accidentally pack the whole mixed tuple into one artifact, or later confuse hidden tuple metadata with user data. After this fix, `wait()` / `get()` should return the same tuple shape and values that the user returned.

Useful local checks:

```bash
uv run pytest tests/test_flow.py -k "flow_return or prepare or retry or artifact_save or tuple"
uv run pytest tests/test_dockerfile_contract.py
uv run pytest tests/test_flow.py tests/test_dockerfile_contract.py
```

Local checks run on this branch:

- `uv run ruff format src/kitaru/flow.py tests/test_flow.py tests/test_dockerfile_contract.py`
- `uv run ruff check src/kitaru/flow.py tests/test_flow.py tests/test_dockerfile_contract.py`
- `just typecheck`
- `git diff --check`
- `just yaml-check`
- `just actions-lint`
- `just links`
- Focused pytest commands above: passing (`149 passed` for `tests/test_flow.py tests/test_dockerfile_contract.py`)
- Full `just test`: reached `1759 passed, 8 skipped`, then failed only because local `uv build` could not fetch `hatchling` from PyPI due repeated TLS/connect timeouts.
- `uvx typos`: not completed locally for the same PyPI timeout reason.
