### PR TITLE
Add OpenAI Agents context passthrough

### DIFF
--- a/docs/content/docs/guides/openai-agents-adapter.mdx
+++ b/docs/content/docs/guides/openai-agents-adapter.mdx
@@ -164,6 +164,35 @@ call in your own `@checkpoint` is **not** a workaround here — the adapter
 guards against it and will raise, because per-call checkpoints cannot be
 nested inside another Kitaru checkpoint.
 
+## Structured outputs, guardrails, and nested agents
+
+OpenAI Agents SDK structured outputs work through the adapter. If your agent is
+created with `Agent(output_type=...)`, Kitaru preserves the SDK result object and
+its typed `final_output` in both supported strategies:
+
+- `checkpoint_strategy="runner_call"` records the outer runner call and returns
+  the structured result from `.wait()` cleanly.
+- `checkpoint_strategy="calls"` records supported model and tool calls
+  individually, while the SDK still produces the typed final output for your
+  Python code.
+
+For tool-input guardrails, use `checkpoint_strategy="calls"` when you need to
+see blocked tool attempts. In that strategy, Kitaru records a rejected tool
+attempt as an existing `tool_call` event with guardrail metadata before the tool
+function runs. It does not create a new event type, and it does not save a tool
+checkpoint for arguments that the guardrail rejected.
+
+`checkpoint_strategy="runner_call"` still only sees the outer `Runner.run(...)`
+boundary. That is useful for a single durable result, but it cannot show each
+individual tool guardrail decision. Choose `"calls"` when per-tool guardrail
+observability matters.
+
+One more boundary to remember: raw nested `agents.Runner.run(...)` calls remain
+outside Kitaru unless you wrap that evaluator agent with its own `KitaruRunner`.
+Raw nested agents are fine for quick ephemeral checks. If their inputs, outputs,
+or guardrail decisions need Kitaru observability, run them through
+`KitaruRunner` too.
+
 ## Important guardrail
 
 `checkpoint_strategy="calls"` must run from flow scope (not from inside another

--- a/docs/content/docs/guides/openai-agents-adapter.mdx
+++ b/docs/content/docs/guides/openai-agents-adapter.mdx
@@ -49,6 +49,90 @@ def research(prompt: str) -> str:
     return str(result.final_output)
 ```
 
+## Fresh-run context
+
+OpenAI Agents SDK tools and guardrails often use a local application context:
+for example, "which team is this user in?", "which thread is this request part
+of?", or "which plugin settings are active?" Pass that object to Kitaru the same
+way you pass it to the OpenAI SDK: as a runner-call argument, not as part of the
+serializable `OpenAIRunRequest`.
+
+```python
+from dataclasses import dataclass
+from typing import Any
+
+from agents import RunContextWrapper, function_tool
+from kitaru.adapters.openai_agents import KitaruRunner, OpenAIRunRequest
+
+@dataclass(frozen=True)
+class WorkerContext:
+    team_id: str
+    user_id: str
+    thread_id: str
+    message_id: str
+    tool_settings: dict[str, Any]
+
+@function_tool
+def lookup_customer(ctx: RunContextWrapper[WorkerContext], customer_id: str) -> str:
+    # The context stays local to your Python process. The model only sees what
+    # your tool chooses to return.
+    return f"team={ctx.context.team_id}, customer={customer_id}"
+
+runner = KitaruRunner(
+    agent,
+    context_cache_identity=lambda ctx: {
+        "team_id": ctx.team_id,
+        "user_id": ctx.user_id,
+        "thread_id": ctx.thread_id,
+        "tool_settings": ctx.tool_settings,
+    },
+)
+
+result = runner.run_sync(
+    OpenAIRunRequest.start("Look up customer 123"),
+    context=WorkerContext(
+        team_id="team_abc",
+        user_id="user_123",
+        thread_id="thread_456",
+        message_id="msg_this_run_only",
+        tool_settings={"include_private_notes": False},
+    ),
+)
+```
+
+A concrete way to think about this: the `OpenAIRunRequest` is the written travel
+plan Kitaru can save and replay. `context=` is the live badge the worker carries
+while doing the trip. Tools and guardrails can inspect the badge through
+`RunContextWrapper.context`, but Kitaru does not save that badge as a visible
+artifact or send it to the model automatically. Kitaru still uses the context
+identity internally for safe replay, without adding your raw context or projection
+to visible tool input artifacts.
+
+Context does matter for safe replay. Imagine two teams both call
+`lookup_customer(customer_id="123")`. The visible tool arguments are identical,
+but team A and team B may be allowed to see different customer records. Kitaru
+therefore includes a context identity in adapter cache keys. If your context is
+plain data, Kitaru can derive a structural identity. For production contexts,
+prefer `context_cache_identity=` so you can include stable fields such as team,
+user, thread, project, plugin, and JSON-primitive `tool_settings`, while
+excluding per-run fields such as `message_id`, `trace_id`, or a changing
+document cursor. That keeps replay safe without making every new message miss
+the cache unnecessarily.
+
+`context=` is different from `metadata=` on `OpenAIRunRequest.start(...)`:
+metadata is Kitaru run/checkpoint metadata; context is local OpenAI Agents SDK
+runtime state for your tools, guardrails, handoffs, and hooks.
+
+Fresh context is only for new `kind="start"` requests. Interrupted/resumed runs
+use the saved OpenAI `RunState`; `context_serializer=` and
+`context_deserializer=` on `KitaruRunner` remain the way to serialize and rebuild
+context that is already inside an interrupted SDK state.
+
+One more boundary to remember: if your guardrail manually calls raw
+`agents.Runner.run(...)` for a nested evaluator, that nested call is not managed
+by Kitaru automatically. Wrap the nested evaluator with its own `KitaruRunner` if
+you need Kitaru checkpoints there too.
+
 ## Checkpoint strategy choices
 
 You choose how Kitaru places checkpoints with `checkpoint_strategy=`.
@@ -153,7 +237,7 @@ runner = KitaruRunner(
 
 Checkpoint config accepts `retries`, `type`, and `runtime`. `runtime="isolated"` is rejected for adapter-managed checkpoints today because those synthetic checkpoint closures capture live OpenAI SDK objects; use inline runtime or omit `runtime`.
 
-If your agent context contains objects that are not JSON-serializable, pass `context_serializer=` and `context_deserializer=` to `KitaruRunner`. By default `strict_context=True`, so Kitaru fails loudly instead of saving a resume state that cannot be reconstructed later.
+For interrupted OpenAI runs, the SDK stores its own `RunState` so the run can resume later. If that saved `RunState` contains context objects that are not JSON-serializable, pass `context_serializer=` and `context_deserializer=` to `KitaruRunner`. These hooks are for serializing resume state after an interruption; they do not control the fresh-run `context=` object you pass when starting a new run. By default `strict_context=True`, so Kitaru fails loudly instead of saving a resume state that cannot be reconstructed later.
 
 ## Runnable example
 

--- a/docs/content/docs/guides/openai-agents-adapter.mdx
+++ b/docs/content/docs/guides/openai-agents-adapter.mdx
@@ -126,7 +126,12 @@ runtime state for your tools, guardrails, handoffs, and hooks.
 Fresh context is only for new `kind="start"` requests. Interrupted/resumed runs
 use the saved OpenAI `RunState`; `context_serializer=` and
 `context_deserializer=` on `KitaruRunner` remain the way to serialize and rebuild
-context that is already inside an interrupted SDK state.
+context that is already inside an interrupted SDK state. With
+`checkpoint_strategy="calls"`, tool checkpoint cache keys use that restored SDK
+context identity when it is available, so an approved resumed tool call for team
+A does not accidentally reuse a cached tool result from team B. Kitaru uses only
+the derived cache key for that separation; it does not save the raw context or
+your `context_cache_identity=` projection in visible tool input artifacts.
 
 One more boundary to remember: if your guardrail manually calls raw
 `agents.Runner.run(...)` for a nested evaluator, that nested call is not managed
@@ -181,6 +186,13 @@ see blocked tool attempts. In that strategy, Kitaru records a rejected tool
 attempt as an existing `tool_call` event with guardrail metadata before the tool
 function runs. It does not create a new event type, and it does not save a tool
 checkpoint for arguments that the guardrail rejected.
+
+Privacy follows the capture policy here too. If `save_input=False`, Kitaru omits
+raw tool input artifacts and also redacts guardrail rejection messages and
+unexpected guardrail exception details from persisted event metadata, because
+those strings may repeat the user/tool input the guardrail just inspected. The
+event still shows that a guardrail blocked the call, which guardrail did it, and
+whether the behavior was `reject_content`, `raise_exception`, or an exception.
 
 `checkpoint_strategy="runner_call"` still only sees the outer `Runner.run(...)`
 boundary. That is useful for a single durable result, but it cannot show each
@@ -263,6 +275,14 @@ runner = KitaruRunner(
 ```
 
 `OpenAICapturePolicy` defaults are designed for useful traces: child events, input, final output, run state, interruption payloads, usage, and OTel correlation are on; raw response items are off by default because they can be noisy.
+
+Two privacy switches are worth calling out:
+
+- `save_input=False` keeps raw model/tool inputs out of artifacts and redacts
+  tool-input guardrail messages or exception text that may contain those inputs.
+- `save_interruption_payloads=False` keeps approval interruption summaries
+  usable for resume decisions — index, kind, tool name, call ID, and message when
+  the SDK exposes them — but omits raw `arguments` and `arguments_preview`.
 
 Checkpoint config accepts `retries`, `type`, and `runtime`. `runtime="isolated"` is rejected for adapter-managed checkpoints today because those synthetic checkpoint closures capture live OpenAI SDK objects; use inline runtime or omit `runtime`.
 

--- a/examples/integrations/openai_agents_agent/README.md
+++ b/examples/integrations/openai_agents_agent/README.md
@@ -66,7 +66,7 @@ If your OpenAI Agents SDK tools or guardrails need per-run application context,
 pass it to `runner.run_sync(..., context=...)` or `await runner.run(..., context=...)`.
 This example covers the basic checkpointing flow; for a compact context example
 and cache-identity guidance, see the main
-[OpenAI Agents adapter guide](/docs/guides/openai-agents-adapter/).
+[OpenAI Agents adapter guide](https://kitaru.ai/docs/guides/openai-agents-adapter/).
 
 ## Why this example uses the real API
 

--- a/examples/integrations/openai_agents_agent/README.md
+++ b/examples/integrations/openai_agents_agent/README.md
@@ -60,6 +60,14 @@ In that mode you'll see the `runner_call` model output first, then a
 that names the terminal checkpoints, gives the execution ID, and points at
 the Kitaru UI / `KitaruClient` for per-checkpoint artifact retrieval.
 
+## Passing OpenAI Agents context
+
+If your OpenAI Agents SDK tools or guardrails need per-run application context,
+pass it to `runner.run_sync(..., context=...)` or `await runner.run(..., context=...)`.
+This example covers the basic checkpointing flow; for a compact context example
+and cache-identity guidance, see the main
+[OpenAI Agents adapter guide](/docs/guides/openai-agents-adapter/).
+
 ## Why this example uses the real API
 
 Our automated tests for the adapter use stubs to stay fast and deterministic.

--- a/src/kitaru/adapters/openai_agents/_agent.py
+++ b/src/kitaru/adapters/openai_agents/_agent.py
@@ -376,6 +376,9 @@ class KitaruRunner:
                     strict_sdk_version=self._strict_sdk_version,
                     context_serializer=self._context_serializer,
                     strict_context=self._strict_context,
+                    save_interruption_payloads=(
+                        self._capture.save_interruption_payloads
+                    ),
                 ),
                 tracker=tracker,
             )
@@ -403,6 +406,9 @@ class KitaruRunner:
                     strict_sdk_version=self._strict_sdk_version,
                     context_serializer=self._context_serializer,
                     strict_context=self._strict_context,
+                    save_interruption_payloads=(
+                        self._capture.save_interruption_payloads
+                    ),
                 ),
                 tracker=tracker,
             )
@@ -489,6 +495,9 @@ class KitaruRunner:
         )
         return stable_cache_identity(projected, opaque_objects_unique=True)
 
+    def _context_cache_key_for_context(self, context: Any | None) -> str | None:
+        return self._context_cache_key(self._context_cache_identity(context))
+
     @staticmethod
     def _context_cache_key(context_cache_identity: Any) -> str | None:
         if context_cache_identity is None:
@@ -566,6 +575,7 @@ class KitaruRunner:
                 tool_checkpoint_config_by_name=self._tool_checkpoint_config_by_name,
                 context_cache_identity=context_cache_identity,
                 context_cache_key=context_cache_key,
+                context_cache_key_factory=self._context_cache_key_for_context,
             )
             wrapped_handoffs = [
                 _prepare_agent(handoff, seen) if _is_openai_agent(handoff) else handoff

--- a/src/kitaru/adapters/openai_agents/_agent.py
+++ b/src/kitaru/adapters/openai_agents/_agent.py
@@ -1,8 +1,8 @@
 """Public runner wrapper for the OpenAI Agents SDK adapter foundation."""
 
 import asyncio
-from collections.abc import Callable, Mapping
-from dataclasses import fields, is_dataclass, replace
+from collections.abc import Callable
+from dataclasses import replace
 from typing import Any, cast
 
 from kitaru.analytics import AnalyticsEvent, track
@@ -19,6 +19,7 @@ from ._runner import (
     run_openai_agent,
     run_openai_agent_sync,
 )
+from ._serialization import stable_cache_identity
 from ._tracking import tracker_scope
 from ._types import (
     OpenAIApprovalDecision,
@@ -76,6 +77,7 @@ class KitaruRunner:
         mcp_checkpoint_config: CheckpointConfig | None = None,
         context_serializer: Callable[[Any], Any] | None = None,
         context_deserializer: Callable[[Any], Any] | None = None,
+        context_cache_identity: Callable[[Any], Any] | None = None,
         strict_context: bool = True,
         strict_sdk_version: bool = True,
         cost_calculator: Callable[[OpenAIUsageSummary], float | None] | None = None,
@@ -136,6 +138,7 @@ class KitaruRunner:
         )
         self._context_serializer = context_serializer
         self._context_deserializer = context_deserializer
+        self._context_cache_identity_projection = context_cache_identity
         self._strict_context = strict_context
         self._strict_sdk_version = strict_sdk_version
         self._cost_calculator = cost_calculator
@@ -166,17 +169,40 @@ class KitaruRunner:
     def capture(self) -> OpenAICapturePolicy:
         return self._capture
 
-    async def run(self, request: OpenAIRunRequest) -> OpenAIRunResult:
+    async def run(
+        self,
+        request: OpenAIRunRequest,
+        *,
+        context: Any | None = None,
+    ) -> OpenAIRunResult:
         """Run or resume an OpenAI agent asynchronously."""
+        self._validate_fresh_context(request, context)
+        context_cache_identity = self._context_cache_identity(context)
+        context_cache_key = self._context_cache_key(context_cache_identity)
         if self._checkpoint_strategy == "calls":
             self._require_calls_scope()
-            result = await self._run_calls_async(request)
+            result = await self._run_calls_async(
+                request,
+                context=context,
+                context_cache_identity=context_cache_identity,
+                context_cache_key=context_cache_key,
+            )
         else:
-            result = await self._run_runner_call_async(request)
+            result = await self._run_runner_call_async(
+                request,
+                context=context,
+                context_cache_identity=context_cache_identity,
+                context_cache_key=context_cache_key,
+            )
         self._track_completed("run", result)
         return result
 
-    def run_sync(self, request: OpenAIRunRequest) -> OpenAIRunResult:
+    def run_sync(
+        self,
+        request: OpenAIRunRequest,
+        *,
+        context: Any | None = None,
+    ) -> OpenAIRunResult:
         """Run or resume an OpenAI agent synchronously."""
         try:
             asyncio.get_running_loop()
@@ -187,11 +213,24 @@ class KitaruRunner:
                 "`KitaruRunner.run_sync()` cannot be called inside an already "
                 "running event loop. Use `await KitaruRunner.run(...)` instead."
             )
+        self._validate_fresh_context(request, context)
+        context_cache_identity = self._context_cache_identity(context)
+        context_cache_key = self._context_cache_key(context_cache_identity)
         if self._checkpoint_strategy == "calls":
             self._require_calls_scope()
-            result = self._run_calls_sync(request)
+            result = self._run_calls_sync(
+                request,
+                context=context,
+                context_cache_identity=context_cache_identity,
+                context_cache_key=context_cache_key,
+            )
         else:
-            result = self._run_runner_call_sync(request)
+            result = self._run_runner_call_sync(
+                request,
+                context=context,
+                context_cache_identity=context_cache_identity,
+                context_cache_key=context_cache_key,
+            )
         self._track_completed("run_sync", result)
         return result
 
@@ -202,32 +241,66 @@ class KitaruRunner:
                 "must run from a flow body, not from inside another checkpoint."
             )
 
-    async def _run_calls_async(self, request: OpenAIRunRequest) -> OpenAIRunResult:
-        prepared_agent, run_config = self._prepare_execution_objects(wrap_calls=True)
+    async def _run_calls_async(
+        self,
+        request: OpenAIRunRequest,
+        *,
+        context: Any | None,
+        context_cache_identity: Any,
+        context_cache_key: str | None,
+    ) -> OpenAIRunResult:
+        prepared_agent, run_config = self._prepare_execution_objects(
+            wrap_calls=True,
+            context_cache_identity=context_cache_identity,
+            context_cache_key=context_cache_key,
+        )
         return await self._run_sdk_async(
             request,
             agent=prepared_agent,
             run_config=run_config,
+            context=context,
         )
 
-    def _run_calls_sync(self, request: OpenAIRunRequest) -> OpenAIRunResult:
-        prepared_agent, run_config = self._prepare_execution_objects(wrap_calls=True)
+    def _run_calls_sync(
+        self,
+        request: OpenAIRunRequest,
+        *,
+        context: Any | None,
+        context_cache_identity: Any,
+        context_cache_key: str | None,
+    ) -> OpenAIRunResult:
+        prepared_agent, run_config = self._prepare_execution_objects(
+            wrap_calls=True,
+            context_cache_identity=context_cache_identity,
+            context_cache_key=context_cache_key,
+        )
         return self._run_sdk_sync(
             request,
             agent=prepared_agent,
             run_config=run_config,
+            context=context,
         )
 
     async def _run_runner_call_async(
-        self, request: OpenAIRunRequest
+        self,
+        request: OpenAIRunRequest,
+        *,
+        context: Any | None,
+        context_cache_identity: Any,
+        context_cache_key: str | None,
     ) -> OpenAIRunResult:
-        prepared_agent, run_config = self._prepare_execution_objects(wrap_calls=False)
+        prepared_agent, run_config = self._prepare_execution_objects(
+            wrap_calls=False,
+            context_cache_identity=context_cache_identity,
+            context_cache_key=context_cache_key,
+        )
 
         async def _body() -> OpenAIRunResult:
             return await self._run_sdk_async(
                 request,
                 agent=prepared_agent,
                 run_config=run_config,
+                context=context,
             )
 
         if is_inside_flow() and not is_inside_checkpoint():
@@ -239,18 +312,31 @@ class KitaruRunner:
                     request,
                     agent=prepared_agent,
                     run_config=run_config,
+                    context_cache_identity=context_cache_identity,
                 ),
             )
         return await _body()
 
-    def _run_runner_call_sync(self, request: OpenAIRunRequest) -> OpenAIRunResult:
-        prepared_agent, run_config = self._prepare_execution_objects(wrap_calls=False)
+    def _run_runner_call_sync(
+        self,
+        request: OpenAIRunRequest,
+        *,
+        context: Any | None,
+        context_cache_identity: Any,
+        context_cache_key: str | None,
+    ) -> OpenAIRunResult:
+        prepared_agent, run_config = self._prepare_execution_objects(
+            wrap_calls=False,
+            context_cache_identity=context_cache_identity,
+            context_cache_key=context_cache_key,
+        )
 
         def _body() -> OpenAIRunResult:
             return self._run_sdk_sync(
                 request,
                 agent=prepared_agent,
                 run_config=run_config,
+                context=context,
             )
 
         if is_inside_flow() and not is_inside_checkpoint():
@@ -262,6 +348,7 @@ class KitaruRunner:
                     request,
                     agent=prepared_agent,
                     run_config=run_config,
+                    context_cache_identity=context_cache_identity,
                 ),
             )
         return _body()
@@ -272,6 +359,7 @@ class KitaruRunner:
         *,
         agent: Any,
         run_config: Any,
+        context: Any | None,
     ) -> OpenAIRunResult:
         sdk_input = await self._sdk_input_async(request, agent=agent)
         with tracker_scope(self._name) as tracker:
@@ -280,6 +368,7 @@ class KitaruRunner:
                 input=sdk_input,
                 max_turns=request.max_turns or 10,
                 run_config=run_config,
+                context=context,
             )
             return self._finalize_run_result(
                 build_run_result(
@@ -297,6 +386,7 @@ class KitaruRunner:
         *,
         agent: Any,
         run_config: Any,
+        context: Any | None,
     ) -> OpenAIRunResult:
         sdk_input = self._sdk_input_sync(request, agent=agent)
         with tracker_scope(self._name) as tracker:
@@ -305,6 +395,7 @@ class KitaruRunner:
                 input=sdk_input,
                 max_turns=request.max_turns or 10,
                 run_config=run_config,
+                context=context,
             )
             return self._finalize_run_result(
                 build_run_result(
@@ -374,56 +465,35 @@ class KitaruRunner:
         *,
         agent: Any,
         run_config: Any,
+        context_cache_identity: Any,
     ) -> str:
-        return checkpoint_cache_key(
-            {
-                "adapter": "openai_agents",
-                "checkpoint_strategy": "runner_call",
-                "agents_sdk_version": agents_sdk_version(),
-                "agent": self._agent_cache_identity(agent),
-                "run_config": self._stable_cache_identity(run_config),
-                "request": request.model_dump(mode="json"),
-            }
-        )
-
-    def _stable_cache_identity(self, value: Any) -> Any:
-        if value is None or isinstance(value, str | int | float | bool):
-            return value
-        if isinstance(value, list | tuple | set | frozenset):
-            return [self._stable_cache_identity(item) for item in value]
-        if isinstance(value, Mapping):
-            return {
-                str(key): self._stable_cache_identity(nested)
-                for key, nested in sorted(value.items(), key=lambda item: str(item[0]))
-            }
-        if is_dataclass(value) and not isinstance(value, type):
-            value_type = type(value)
-            return {
-                "python_type": f"{value_type.__module__}.{value_type.__qualname__}",
-                "fields": {
-                    field.name: self._stable_cache_identity(getattr(value, field.name))
-                    for field in fields(value)
-                    if not field.name.startswith("_")
-                },
-            }
-        model_dump = getattr(value, "model_dump", None)
-        if callable(model_dump):
-            try:
-                return model_dump(mode="json")
-            except Exception as exc:
-                value_type = type(value)
-                return {
-                    "python_type": f"{value_type.__module__}.{value_type.__qualname__}",
-                    "name": getattr(value, "name", None),
-                    "model_name": getattr(value, "model_name", None),
-                    "serialization_error": type(exc).__name__,
-                }
-        value_type = type(value)
-        return {
-            "python_type": f"{value_type.__module__}.{value_type.__qualname__}",
-            "name": getattr(value, "name", None),
-            "model_name": getattr(value, "model_name", None),
+        payload = {
+            "adapter": "openai_agents",
+            "checkpoint_strategy": "runner_call",
+            "agents_sdk_version": agents_sdk_version(),
+            "agent": self._agent_cache_identity(agent),
+            "run_config": stable_cache_identity(run_config),
+            "request": request.model_dump(mode="json"),
         }
+        if context_cache_identity is not None:
+            payload["context"] = context_cache_identity
+        return checkpoint_cache_key(payload)
+
+    def _context_cache_identity(self, context: Any | None) -> Any:
+        if context is None:
+            return None
+        projected = (
+            self._context_cache_identity_projection(context)
+            if self._context_cache_identity_projection is not None
+            else context
+        )
+        return stable_cache_identity(projected, opaque_objects_unique=True)
+
+    @staticmethod
+    def _context_cache_key(context_cache_identity: Any) -> str | None:
+        if context_cache_identity is None:
+            return None
+        return checkpoint_cache_key({"context": context_cache_identity})
 
     def _agent_cache_identity(self, agent: Any) -> dict[str, Any]:
         agent_type = type(agent)
@@ -450,7 +520,13 @@ class KitaruRunner:
             "handoffs": [getattr(handoff, "name", None) for handoff in handoffs],
         }
 
-    def _prepare_execution_objects(self, *, wrap_calls: bool) -> tuple[Any, Any]:
+    def _prepare_execution_objects(
+        self,
+        *,
+        wrap_calls: bool,
+        context_cache_identity: Any,
+        context_cache_key: str | None,
+    ) -> tuple[Any, Any]:
         from agents import RunConfig
 
         run_config = self._run_config_factory() if self._run_config_factory else None
@@ -488,6 +564,8 @@ class KitaruRunner:
                 agent_name=self._name,
                 tool_checkpoint_config=self._tool_checkpoint_config,
                 tool_checkpoint_config_by_name=self._tool_checkpoint_config_by_name,
+                context_cache_identity=context_cache_identity,
+                context_cache_key=context_cache_key,
             )
             wrapped_handoffs = [
                 _prepare_agent(handoff, seen) if _is_openai_agent(handoff) else handoff
@@ -536,6 +614,17 @@ class KitaruRunner:
                 "interruption_count": len(result.interruptions),
             },
         )
+
+    @staticmethod
+    def _validate_fresh_context(
+        request: OpenAIRunRequest,
+        context: Any | None,
+    ) -> None:
+        if context is not None and request.kind == "resume":
+            raise KitaruUsageError(
+                "Fresh `context=` can only be supplied for kind='start' requests. "
+                "Resume requests rebuild SDK state from the saved RunState envelope."
+            )
 
     @staticmethod
     def _validated_resume_request_parts(

--- a/src/kitaru/adapters/openai_agents/_runner.py
+++ b/src/kitaru/adapters/openai_agents/_runner.py
@@ -31,6 +31,7 @@ async def run_openai_agent(
     input: Any,
     max_turns: int,
     run_config: Any,
+    context: Any | None = None,
 ) -> Any:
     from agents import Runner
 
@@ -39,6 +40,7 @@ async def run_openai_agent(
         input,
         max_turns=max_turns,
         run_config=run_config,
+        context=context,
     )
 
 
@@ -48,6 +50,7 @@ def run_openai_agent_sync(
     input: Any,
     max_turns: int,
     run_config: Any,
+    context: Any | None = None,
 ) -> Any:
     from agents import Runner
 
@@ -56,6 +59,7 @@ def run_openai_agent_sync(
         input,
         max_turns=max_turns,
         run_config=run_config,
+        context=context,
     )
 
 

--- a/src/kitaru/adapters/openai_agents/_runner.py
+++ b/src/kitaru/adapters/openai_agents/_runner.py
@@ -186,6 +186,7 @@ def build_run_result(
     context_serializer: Any | None = None,
     strict_context: bool = False,
     warnings: list[str] | None = None,
+    save_interruption_payloads: bool = True,
 ) -> OpenAIRunResult:
     """Convert an OpenAI SDK ``RunResult`` into Kitaru's serializable result."""
     interruptions = list(getattr(sdk_result, "interruptions", []) or [])
@@ -207,7 +208,11 @@ def build_run_result(
             status="interrupted",
             pending_state=envelope,
             interruptions=[
-                _summarize_interruption(index, interruption)
+                _summarize_interruption(
+                    index,
+                    interruption,
+                    save_payloads=save_interruption_payloads,
+                )
                 for index, interruption in enumerate(interruptions)
             ],
             last_response_id=getattr(sdk_result, "last_response_id", None),
@@ -264,7 +269,12 @@ def _usage_from_result(sdk_result: Any) -> dict[str, Any] | None:
     return normalize_usage(to_json_safe(raw_usage)).model_dump(mode="json")
 
 
-def _summarize_interruption(index: int, interruption: Any) -> OpenAIInterruptionSummary:
+def _summarize_interruption(
+    index: int,
+    interruption: Any,
+    *,
+    save_payloads: bool,
+) -> OpenAIInterruptionSummary:
     raw = to_json_safe(interruption)
     tool_name = getattr(interruption, "tool_name", None)
     call_id = getattr(interruption, "call_id", None)
@@ -272,20 +282,31 @@ def _summarize_interruption(index: int, interruption: Any) -> OpenAIInterruption
     raw_item = getattr(interruption, "raw_item", None)
     raw_arguments = getattr(raw_item, "arguments", None)
     if tool_name is None:
-        tool_name = _find_nested(raw, "tool_name") or _find_nested(raw, "name")
+        if save_payloads:
+            tool_name = _find_nested(raw, "tool_name") or _find_nested(raw, "name")
+        elif isinstance(raw, dict):
+            tool_name = raw.get("tool_name") or raw.get("name")
     if call_id is None:
-        call_id = _find_nested(raw, "call_id")
+        if save_payloads:
+            call_id = _find_nested(raw, "call_id")
+        elif isinstance(raw, dict):
+            call_id = raw.get("call_id")
     if message is None:
-        message = _find_nested(raw, "message") or _find_nested(raw, "reason")
+        if save_payloads:
+            message = _find_nested(raw, "message") or _find_nested(raw, "reason")
+        elif isinstance(raw, dict):
+            message = raw.get("message") or raw.get("reason")
     return OpenAIInterruptionSummary(
         index=index,
         kind=type(interruption).__name__,
         tool_name=tool_name if isinstance(tool_name, str) else None,
         call_id=call_id if isinstance(call_id, str) else None,
         message=message if isinstance(message, str) else None,
-        arguments=raw if isinstance(raw, dict) else None,
+        arguments=raw if save_payloads and isinstance(raw, dict) else None,
         arguments_preview=(
-            raw_arguments[:500] if isinstance(raw_arguments, str) else repr(raw)[:500]
+            (raw_arguments[:500] if isinstance(raw_arguments, str) else repr(raw)[:500])
+            if save_payloads
+            else None
         ),
     )
 

--- a/src/kitaru/adapters/openai_agents/_serialization.py
+++ b/src/kitaru/adapters/openai_agents/_serialization.py
@@ -1,6 +1,9 @@
 """JSON-safe serialization helpers for OpenAI Agents SDK adapter capture."""
 
+from collections.abc import Mapping
+from dataclasses import fields, is_dataclass
 from typing import Any
+from uuid import uuid4
 
 from pydantic_core import to_jsonable_python
 
@@ -37,3 +40,198 @@ def to_cache_identity(value: Any) -> Any:
             "python_type": f"{value_type.__module__}.{value_type.__qualname__}",
             "serialization_error": "cache_identity_serialization_failed",
         }
+
+
+def stable_cache_identity(
+    value: Any,
+    *,
+    opaque_objects_unique: bool = False,
+    max_depth: int = 12,
+    max_items: int = 512,
+) -> Any:
+    """Return a deterministic, bounded cache identity for public API values.
+
+    The happy path is plain JSON-like data, dataclasses, and Pydantic models.
+    Cycles or very large object graphs fall back to a miss-safe opaque token
+    instead of recursing forever or collapsing distinct contexts together.
+    """
+    remaining_items = [max_items]
+    seen: set[int] = set()
+    return _stable_cache_identity(
+        value,
+        opaque_objects_unique=opaque_objects_unique,
+        max_depth=max_depth,
+        remaining_items=remaining_items,
+        seen=seen,
+    )
+
+
+def _stable_cache_identity(
+    value: Any,
+    *,
+    opaque_objects_unique: bool,
+    max_depth: int,
+    remaining_items: list[int],
+    seen: set[int],
+) -> Any:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if max_depth <= 0:
+        return _opaque_cache_identity(value, reason="max_depth_exceeded")
+    if remaining_items[0] <= 0:
+        return _opaque_cache_identity(value, reason="max_items_exceeded")
+
+    value_id = id(value)
+    if value_id in seen:
+        return _opaque_cache_identity(value, reason="cycle_detected")
+
+    if isinstance(value, list | tuple):
+        if len(value) > remaining_items[0]:
+            return _opaque_cache_identity(value, reason="max_items_exceeded")
+        seen.add(value_id)
+        remaining_items[0] -= len(value)
+        try:
+            return {
+                "collection_type": type(value).__name__,
+                "items": [
+                    _stable_cache_identity(
+                        item,
+                        opaque_objects_unique=opaque_objects_unique,
+                        max_depth=max_depth - 1,
+                        remaining_items=remaining_items,
+                        seen=seen,
+                    )
+                    for item in value
+                ],
+            }
+        finally:
+            seen.remove(value_id)
+
+    if isinstance(value, set | frozenset):
+        if len(value) > remaining_items[0]:
+            return _opaque_cache_identity(value, reason="max_items_exceeded")
+        seen.add(value_id)
+        remaining_items[0] -= len(value)
+        try:
+            item_identities = [
+                _stable_cache_identity(
+                    item,
+                    opaque_objects_unique=opaque_objects_unique,
+                    max_depth=max_depth - 1,
+                    remaining_items=remaining_items,
+                    seen=seen,
+                )
+                for item in value
+            ]
+            return {
+                "collection_type": type(value).__name__,
+                "items": sorted(item_identities, key=_identity_sort_key),
+            }
+        finally:
+            seen.remove(value_id)
+
+    if isinstance(value, Mapping):
+        if len(value) > remaining_items[0]:
+            return _opaque_cache_identity(value, reason="max_items_exceeded")
+        seen.add(value_id)
+        remaining_items[0] -= len(value)
+        try:
+            if all(isinstance(key, str) for key in value):
+                return {
+                    key: _stable_cache_identity(
+                        nested,
+                        opaque_objects_unique=opaque_objects_unique,
+                        max_depth=max_depth - 1,
+                        remaining_items=remaining_items,
+                        seen=seen,
+                    )
+                    for key, nested in sorted(value.items())
+                }
+            pairs = [
+                {
+                    "key": _stable_cache_identity(
+                        key,
+                        opaque_objects_unique=opaque_objects_unique,
+                        max_depth=max_depth - 1,
+                        remaining_items=remaining_items,
+                        seen=seen,
+                    ),
+                    "value": _stable_cache_identity(
+                        nested,
+                        opaque_objects_unique=opaque_objects_unique,
+                        max_depth=max_depth - 1,
+                        remaining_items=remaining_items,
+                        seen=seen,
+                    ),
+                }
+                for key, nested in value.items()
+            ]
+            return {
+                "collection_type": "dict",
+                "items": sorted(
+                    pairs, key=lambda item: _identity_sort_key(item["key"])
+                ),
+            }
+        finally:
+            seen.remove(value_id)
+
+    if is_dataclass(value) and not isinstance(value, type):
+        seen.add(value_id)
+        value_type = type(value)
+        public_fields = [
+            field for field in fields(value) if not field.name.startswith("_")
+        ]
+        if len(public_fields) > remaining_items[0]:
+            return _opaque_cache_identity(value, reason="max_items_exceeded")
+        remaining_items[0] -= len(public_fields)
+        try:
+            return {
+                "python_type": f"{value_type.__module__}.{value_type.__qualname__}",
+                "fields": {
+                    field.name: _stable_cache_identity(
+                        getattr(value, field.name),
+                        opaque_objects_unique=opaque_objects_unique,
+                        max_depth=max_depth - 1,
+                        remaining_items=remaining_items,
+                        seen=seen,
+                    )
+                    for field in public_fields
+                },
+            }
+        finally:
+            seen.remove(value_id)
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return stable_cache_identity(
+                model_dump(mode="json"),
+                opaque_objects_unique=opaque_objects_unique,
+                max_depth=max_depth - 1,
+                max_items=remaining_items[0],
+            )
+        except Exception as exc:
+            return _opaque_cache_identity(value, reason=type(exc).__name__)
+
+    if opaque_objects_unique:
+        return _opaque_cache_identity(value, reason="opaque_object")
+
+    value_type = type(value)
+    return {
+        "python_type": f"{value_type.__module__}.{value_type.__qualname__}",
+        "name": getattr(value, "name", None),
+        "model_name": getattr(value, "model_name", None),
+    }
+
+
+def _opaque_cache_identity(value: Any, *, reason: str) -> dict[str, Any]:
+    value_type = type(value)
+    return {
+        "python_type": f"{value_type.__module__}.{value_type.__qualname__}",
+        "opaque_cache_token": uuid4().hex,
+        "serialization_error": reason,
+    }
+
+
+def _identity_sort_key(value: Any) -> str:
+    return repr(to_cache_identity(value))

--- a/src/kitaru/adapters/openai_agents/_tools.py
+++ b/src/kitaru/adapters/openai_agents/_tools.py
@@ -391,7 +391,9 @@ def _guardrail_event_error(
         return None
     if capture.save_input or behavior_type == _GUARDRAIL_BEHAVIOR_RAISE_EXCEPTION:
         return error
-    return RuntimeError(_GUARDRAIL_ERROR_REDACTED_MESSAGE)
+    redacted_error = RuntimeError(_GUARDRAIL_ERROR_REDACTED_MESSAGE)
+    redacted_error.__dict__["_kitaru_redacted_run_error"] = True
+    return redacted_error
 
 
 def _should_record_tool_input_guardrail_event(

--- a/src/kitaru/adapters/openai_agents/_tools.py
+++ b/src/kitaru/adapters/openai_agents/_tools.py
@@ -34,9 +34,14 @@ def kitaruify_openai_tool(
     agent_name: str,
     tool_checkpoint_config: CheckpointConfig | None = None,
     tool_checkpoint_config_by_name: ToolCheckpointOverrides | None = None,
+    context_cache_identity: Any = None,
+    context_cache_key: str | None = None,
 ) -> Any:
     """Return a checkpoint-aware copy of supported OpenAI SDK tools."""
-    if getattr(tool, "_kitaru_wrapped", False):
+    original_tool = getattr(tool, "_kitaru_original_tool", None)
+    if isinstance(original_tool, FunctionTool):
+        tool = original_tool
+    elif getattr(tool, "_kitaru_wrapped", False):
         return tool
     if isinstance(tool, FunctionTool):
         return _wrap_function_tool(
@@ -45,6 +50,8 @@ def kitaruify_openai_tool(
             agent_name=agent_name,
             tool_checkpoint_config=tool_checkpoint_config,
             tool_checkpoint_config_by_name=tool_checkpoint_config_by_name,
+            context_cache_identity=context_cache_identity,
+            context_cache_key=context_cache_key,
         )
     return tool
 
@@ -56,6 +63,8 @@ def kitaruify_openai_tools(
     agent_name: str,
     tool_checkpoint_config: CheckpointConfig | None = None,
     tool_checkpoint_config_by_name: ToolCheckpointOverrides | None = None,
+    context_cache_identity: Any = None,
+    context_cache_key: str | None = None,
 ) -> list[Any]:
     return [
         kitaruify_openai_tool(
@@ -64,6 +73,8 @@ def kitaruify_openai_tools(
             agent_name=agent_name,
             tool_checkpoint_config=tool_checkpoint_config,
             tool_checkpoint_config_by_name=tool_checkpoint_config_by_name,
+            context_cache_identity=context_cache_identity,
+            context_cache_key=context_cache_key,
         )
         for tool in tools
     ]
@@ -76,9 +87,16 @@ def _wrap_function_tool(
     agent_name: str,
     tool_checkpoint_config: CheckpointConfig | None,
     tool_checkpoint_config_by_name: ToolCheckpointOverrides | None,
+    context_cache_identity: Any = None,
+    context_cache_key: str | None = None,
 ) -> FunctionTool:
     original_callback = tool.on_invoke_tool
     tool_name = tool.name
+    resolved_context_cache_key = context_cache_key
+    if resolved_context_cache_key is None and context_cache_identity is not None:
+        resolved_context_cache_key = checkpoint_cache_key(
+            {"context": context_cache_identity}
+        )
 
     async def _wrapped_callback(context: Any, input_json: str) -> Any:
         checkpoint_config = resolve_tool_checkpoint_config(
@@ -125,19 +143,21 @@ def _wrap_function_tool(
                         input_envelope=input_envelope,
                     )
 
+            cache_payload = {
+                "tool_name": tool_name,
+                "tool_call_id": tool_call_id,
+                "fallback_sequence": fallback_sequence,
+                "tool_namespace": getattr(tool, "_tool_namespace", None),
+                "input_json": input_json,
+            }
+            if resolved_context_cache_key is not None:
+                cache_payload["context_cache_key"] = resolved_context_cache_key
+
             return await run_async_in_checkpoint(
                 config=with_default_type(checkpoint_config, "tool_call"),
                 step_name=safe_step_name(f"{agent_name}_{tool_name}_tool_call"),
                 body=_in_checkpoint,
-                cache_key=checkpoint_cache_key(
-                    {
-                        "tool_name": tool_name,
-                        "tool_call_id": tool_call_id,
-                        "fallback_sequence": fallback_sequence,
-                        "tool_namespace": getattr(tool, "_tool_namespace", None),
-                        "input_json": input_json,
-                    }
-                ),
+                cache_key=checkpoint_cache_key(cache_payload),
                 checkpoint_inputs=checkpoint_inputs,
             )
         return await _tracked_tool_call(
@@ -151,6 +171,7 @@ def _wrap_function_tool(
 
     wrapped = replace(tool, on_invoke_tool=_wrapped_callback)
     object.__setattr__(wrapped, "_kitaru_wrapped", True)
+    object.__setattr__(wrapped, "_kitaru_original_tool", tool)
     return wrapped
 
 

--- a/src/kitaru/adapters/openai_agents/_tools.py
+++ b/src/kitaru/adapters/openai_agents/_tools.py
@@ -2,7 +2,7 @@
 
 import json
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import replace
 from typing import Any
 
@@ -34,6 +34,12 @@ _GUARDRAIL_BEHAVIOR_REJECT_CONTENT = "reject_content"
 _GUARDRAIL_REQUESTED_EXCEPTION_MESSAGE = (
     "Tool input guardrail requested an exception before tool invocation."
 )
+_GUARDRAIL_ERROR_REDACTED_MESSAGE = (
+    "Tool input guardrail raised before tool invocation; details redacted "
+    "because OpenAICapturePolicy.save_input=False."
+)
+
+ContextCacheKeyFactory = Callable[[Any], str | None]
 
 
 def kitaruify_openai_tool(
@@ -45,6 +51,7 @@ def kitaruify_openai_tool(
     tool_checkpoint_config_by_name: ToolCheckpointOverrides | None = None,
     context_cache_identity: Any = None,
     context_cache_key: str | None = None,
+    context_cache_key_factory: ContextCacheKeyFactory | None = None,
 ) -> Any:
     """Return a checkpoint-aware copy of supported OpenAI SDK tools."""
     original_tool = getattr(tool, "_kitaru_original_tool", None)
@@ -61,6 +68,7 @@ def kitaruify_openai_tool(
             tool_checkpoint_config_by_name=tool_checkpoint_config_by_name,
             context_cache_identity=context_cache_identity,
             context_cache_key=context_cache_key,
+            context_cache_key_factory=context_cache_key_factory,
         )
     return tool
 
@@ -74,6 +82,7 @@ def kitaruify_openai_tools(
     tool_checkpoint_config_by_name: ToolCheckpointOverrides | None = None,
     context_cache_identity: Any = None,
     context_cache_key: str | None = None,
+    context_cache_key_factory: ContextCacheKeyFactory | None = None,
 ) -> list[Any]:
     return [
         kitaruify_openai_tool(
@@ -84,6 +93,7 @@ def kitaruify_openai_tools(
             tool_checkpoint_config_by_name=tool_checkpoint_config_by_name,
             context_cache_identity=context_cache_identity,
             context_cache_key=context_cache_key,
+            context_cache_key_factory=context_cache_key_factory,
         )
         for tool in tools
     ]
@@ -98,6 +108,7 @@ def _wrap_function_tool(
     tool_checkpoint_config_by_name: ToolCheckpointOverrides | None,
     context_cache_identity: Any = None,
     context_cache_key: str | None = None,
+    context_cache_key_factory: ContextCacheKeyFactory | None = None,
 ) -> FunctionTool:
     original_callback = tool.on_invoke_tool
     tool_name = tool.name
@@ -152,6 +163,12 @@ def _wrap_function_tool(
                         input_envelope=input_envelope,
                     )
 
+            effective_context_cache_key = resolved_context_cache_key
+            if effective_context_cache_key is None:
+                effective_context_cache_key = _callback_context_cache_key(
+                    context,
+                    context_cache_key_factory,
+                )
             cache_payload = {
                 "tool_name": tool_name,
                 "tool_call_id": tool_call_id,
@@ -159,8 +176,8 @@ def _wrap_function_tool(
                 "tool_namespace": getattr(tool, "_tool_namespace", None),
                 "input_json": input_json,
             }
-            if resolved_context_cache_key is not None:
-                cache_payload["context_cache_key"] = resolved_context_cache_key
+            if effective_context_cache_key is not None:
+                cache_payload["context_cache_key"] = effective_context_cache_key
 
             return await run_async_in_checkpoint(
                 config=with_default_type(checkpoint_config, "tool_call"),
@@ -190,6 +207,22 @@ def _wrap_function_tool(
     object.__setattr__(wrapped, "_kitaru_wrapped", True)
     object.__setattr__(wrapped, "_kitaru_original_tool", tool)
     return wrapped
+
+
+def _callback_context_cache_key(
+    callback_context: Any,
+    factory: ContextCacheKeyFactory | None,
+) -> str | None:
+    if factory is None:
+        return None
+    app_context = _sdk_application_context(callback_context)
+    if app_context is None:
+        return None
+    return factory(app_context)
+
+
+def _sdk_application_context(callback_context: Any) -> Any | None:
+    return getattr(callback_context, "context", None)
 
 
 def _wrap_tool_input_guardrails(
@@ -308,8 +341,21 @@ def _record_blocked_tool_input_guardrail_event(
             "guardrail_behavior": behavior_type,
         }
     )
-    if rejection_message is not None:
-        metadata["rejection_message"] = rejection_message
+    metadata.update(
+        _guardrail_rejection_metadata(
+            rejection_message,
+            capture=capture,
+        )
+    )
+
+    event_error = _guardrail_event_error(
+        error,
+        capture=capture,
+        behavior_type=behavior_type,
+    )
+    set_run_error = getattr(tracker, "set_run_error", None)
+    if status == "failed" and event_error is not None and callable(set_run_error):
+        set_run_error(event_error)
 
     tracker.record_event(
         event_id,
@@ -319,8 +365,33 @@ def _record_blocked_tool_input_guardrail_event(
         duration_ms=elapsed_ms(started_at),
         artifacts={},
         metadata=metadata,
-        error=error,
+        error=event_error,
     )
+
+
+def _guardrail_rejection_metadata(
+    rejection_message: str | None,
+    *,
+    capture: OpenAICapturePolicy,
+) -> dict[str, object]:
+    if rejection_message is None:
+        return {}
+    if capture.save_input:
+        return {"rejection_message": rejection_message}
+    return {"rejection_message_redacted": True}
+
+
+def _guardrail_event_error(
+    error: BaseException | None,
+    *,
+    capture: OpenAICapturePolicy,
+    behavior_type: str,
+) -> BaseException | None:
+    if error is None:
+        return None
+    if capture.save_input or behavior_type == _GUARDRAIL_BEHAVIOR_RAISE_EXCEPTION:
+        return error
+    return RuntimeError(_GUARDRAIL_ERROR_REDACTED_MESSAGE)
 
 
 def _should_record_tool_input_guardrail_event(

--- a/src/kitaru/adapters/openai_agents/_tools.py
+++ b/src/kitaru/adapters/openai_agents/_tools.py
@@ -2,6 +2,7 @@
 
 import json
 import time
+from collections.abc import Mapping
 from dataclasses import replace
 from typing import Any
 
@@ -9,6 +10,7 @@ from agents.tool import FunctionTool
 
 import kitaru
 
+from ._events import EventStatus
 from ._kitaru_internal import is_inside_checkpoint, is_inside_flow
 from ._policy import OpenAICapturePolicy
 from ._serialization import to_json_safe
@@ -24,6 +26,13 @@ from ._utils import (
     run_async_in_checkpoint,
     safe_step_name,
     with_default_type,
+)
+
+_GUARDRAIL_BEHAVIOR_EXCEPTION = "exception"
+_GUARDRAIL_BEHAVIOR_RAISE_EXCEPTION = "raise_exception"
+_GUARDRAIL_BEHAVIOR_REJECT_CONTENT = "reject_content"
+_GUARDRAIL_REQUESTED_EXCEPTION_MESSAGE = (
+    "Tool input guardrail requested an exception before tool invocation."
 )
 
 
@@ -169,10 +178,207 @@ def _wrap_function_tool(
             tool_call_id=tool_call_id,
         )
 
-    wrapped = replace(tool, on_invoke_tool=_wrapped_callback)
+    wrapped = replace(
+        tool,
+        on_invoke_tool=_wrapped_callback,
+        tool_input_guardrails=_wrap_tool_input_guardrails(
+            tool.tool_input_guardrails,
+            tool=tool,
+            capture=capture,
+        ),
+    )
     object.__setattr__(wrapped, "_kitaru_wrapped", True)
     object.__setattr__(wrapped, "_kitaru_original_tool", tool)
     return wrapped
+
+
+def _wrap_tool_input_guardrails(
+    guardrails: list[Any] | None,
+    *,
+    tool: FunctionTool,
+    capture: OpenAICapturePolicy,
+) -> list[Any] | None:
+    if not guardrails:
+        return guardrails
+    return [
+        _wrap_tool_input_guardrail(
+            guardrail,
+            tool=tool,
+            capture=capture,
+            guardrail_index=index,
+        )
+        for index, guardrail in enumerate(guardrails)
+    ]
+
+
+def _wrap_tool_input_guardrail(
+    guardrail: Any,
+    *,
+    tool: FunctionTool,
+    capture: OpenAICapturePolicy,
+    guardrail_index: int,
+) -> Any:
+    if getattr(guardrail, "_kitaru_wrapped_tool_input_guardrail", False):
+        return guardrail
+
+    async def _wrapped_guardrail_function(data: Any) -> Any:
+        if not _should_record_tool_input_guardrail_event(capture):
+            return await guardrail.run(data)
+
+        started_at = time.perf_counter()
+        try:
+            output = await guardrail.run(data)
+        except Exception as error:
+            _record_blocked_tool_input_guardrail_event(
+                data,
+                tool=tool,
+                capture=capture,
+                guardrail=guardrail,
+                guardrail_index=guardrail_index,
+                behavior_type=_GUARDRAIL_BEHAVIOR_EXCEPTION,
+                status="failed",
+                started_at=started_at,
+                error=error,
+            )
+            raise
+
+        behavior_type = _guardrail_behavior_type(output)
+        if behavior_type == _GUARDRAIL_BEHAVIOR_REJECT_CONTENT:
+            _record_blocked_tool_input_guardrail_event(
+                data,
+                tool=tool,
+                capture=capture,
+                guardrail=guardrail,
+                guardrail_index=guardrail_index,
+                behavior_type=behavior_type,
+                status="completed",
+                started_at=started_at,
+                rejection_message=_guardrail_rejection_message(output),
+            )
+        elif behavior_type == _GUARDRAIL_BEHAVIOR_RAISE_EXCEPTION:
+            _record_blocked_tool_input_guardrail_event(
+                data,
+                tool=tool,
+                capture=capture,
+                guardrail=guardrail,
+                guardrail_index=guardrail_index,
+                behavior_type=behavior_type,
+                status="failed",
+                started_at=started_at,
+                error=RuntimeError(_GUARDRAIL_REQUESTED_EXCEPTION_MESSAGE),
+            )
+        return output
+
+    wrapped = replace(guardrail, guardrail_function=_wrapped_guardrail_function)
+    object.__setattr__(wrapped, "_kitaru_wrapped_tool_input_guardrail", True)
+    object.__setattr__(wrapped, "_kitaru_original_tool_input_guardrail", guardrail)
+    return wrapped
+
+
+def _record_blocked_tool_input_guardrail_event(
+    data: Any,
+    *,
+    tool: FunctionTool,
+    capture: OpenAICapturePolicy,
+    guardrail: Any,
+    guardrail_index: int,
+    behavior_type: str,
+    status: EventStatus,
+    started_at: float,
+    rejection_message: str | None = None,
+    error: BaseException | None = None,
+) -> None:
+    tracker = get_current_tracker()
+    if tracker is None or not _should_record_tool_input_guardrail_event(
+        capture,
+        tracker=tracker,
+    ):
+        return
+
+    context = getattr(data, "context", None)
+    tool_call_id = _tool_call_id(context)
+    event_id, event_context = tracker.start_tool_event(tool_call_id=tool_call_id)
+    metadata = _tool_event_metadata(tool, tool_call_id=tool_call_id, context=context)
+    metadata.update(
+        {
+            "tool_invoked": False,
+            "blocked_by_guardrail": True,
+            "guardrail_index": guardrail_index,
+            "guardrail_name": _guardrail_name(guardrail),
+            "guardrail_behavior": behavior_type,
+        }
+    )
+    if rejection_message is not None:
+        metadata["rejection_message"] = rejection_message
+
+    tracker.record_event(
+        event_id,
+        event_context,
+        kind="tool_call",
+        status=status,
+        duration_ms=elapsed_ms(started_at),
+        artifacts={},
+        metadata=metadata,
+        error=error,
+    )
+
+
+def _should_record_tool_input_guardrail_event(
+    capture: OpenAICapturePolicy,
+    *,
+    tracker: Any | None = None,
+) -> bool:
+    current_tracker = tracker if tracker is not None else get_current_tracker()
+    return (
+        capture.emit_child_events
+        and current_tracker is not None
+        and (is_inside_flow() or is_inside_checkpoint())
+    )
+
+
+def _tool_event_metadata(
+    tool: FunctionTool,
+    *,
+    tool_call_id: str | None,
+    context: Any = None,
+) -> dict[str, object]:
+    return {
+        "tool_name": _metadata_tool_name(context, tool),
+        "tool_call_id": tool_call_id,
+        "is_agent_tool": bool(getattr(tool, "_is_agent_tool", False)),
+        "tool_namespace": getattr(context, "tool_namespace", None)
+        or getattr(tool, "_tool_namespace", None),
+    }
+
+
+def _metadata_tool_name(context: Any, tool: FunctionTool) -> str:
+    value = getattr(context, "tool_name", None)
+    return value if isinstance(value, str) and value else tool.name
+
+
+def _guardrail_name(guardrail: Any) -> str | None:
+    get_name = getattr(guardrail, "get_name", None)
+    if callable(get_name):
+        try:
+            value = get_name()
+        except Exception:
+            value = None
+        if isinstance(value, str) and value:
+            return value
+    value = getattr(guardrail, "name", None)
+    return value if isinstance(value, str) and value else None
+
+
+def _guardrail_behavior_type(output: Any) -> str | None:
+    behavior = getattr(output, "behavior", None)
+    value = _value_from_mapping_or_attr(behavior, "type")
+    return value if isinstance(value, str) and value else None
+
+
+def _guardrail_rejection_message(output: Any) -> str | None:
+    behavior = getattr(output, "behavior", None)
+    value = _value_from_mapping_or_attr(behavior, "message")
+    return value if isinstance(value, str) and value else None
 
 
 async def _tracked_tool_call(
@@ -220,7 +426,11 @@ async def _tracked_tool_call(
             status="failed",
             duration_ms=elapsed_ms(started_at),
             artifacts=artifacts,
-            metadata={"tool_name": tool.name, "tool_call_id": tool_call_id},
+            metadata=_tool_event_metadata(
+                tool,
+                tool_call_id=tool_call_id,
+                context=context,
+            ),
             error=error,
         )
         raise
@@ -240,14 +450,19 @@ async def _tracked_tool_call(
         status="completed",
         duration_ms=elapsed_ms(started_at),
         artifacts=artifacts,
-        metadata={
-            "tool_name": tool.name,
-            "tool_call_id": tool_call_id,
-            "is_agent_tool": bool(getattr(tool, "_is_agent_tool", False)),
-            "tool_namespace": getattr(tool, "_tool_namespace", None),
-        },
+        metadata=_tool_event_metadata(
+            tool,
+            tool_call_id=tool_call_id,
+            context=context,
+        ),
     )
     return result
+
+
+def _value_from_mapping_or_attr(value: Any, key: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return getattr(value, key, None)
 
 
 def _tool_input_envelope(

--- a/src/kitaru/adapters/openai_agents/_tracking.py
+++ b/src/kitaru/adapters/openai_agents/_tracking.py
@@ -239,10 +239,16 @@ class EventTracker:
                 )
             )
 
-    def set_run_error(self, error: BaseException) -> None:
+    def set_run_error(
+        self,
+        error: BaseException,
+        *,
+        overwrite: bool = True,
+    ) -> None:
         with self._lock:
             self._status = "failed"
-            self._error = error
+            if overwrite or self._error is None:
+                self._error = error
 
     def _build_run_summary_unlocked(
         self,
@@ -310,7 +316,7 @@ def tracker_scope(agent_name: str | None) -> Iterator[EventTracker]:
     try:
         yield tracker
     except Exception as error:
-        tracker.set_run_error(error)
+        tracker.set_run_error(error, overwrite=False)
         raise
     finally:
         try:

--- a/src/kitaru/adapters/openai_agents/_tracking.py
+++ b/src/kitaru/adapters/openai_agents/_tracking.py
@@ -247,6 +247,12 @@ class EventTracker:
     ) -> None:
         with self._lock:
             self._status = "failed"
+            if (
+                self._error is not None
+                and getattr(self._error, "_kitaru_redacted_run_error", False)
+                and not getattr(error, "_kitaru_redacted_run_error", False)
+            ):
+                return
             if overwrite or self._error is None:
                 self._error = error
 

--- a/tests/test_openai_agents_adapter_foundation.py
+++ b/tests/test_openai_agents_adapter_foundation.py
@@ -126,6 +126,20 @@ def test_kitaru_runner_requires_context_codec_pair(
         )
 
 
+def test_kitaru_runner_exposes_keyword_only_context(
+    openai_agents_adapter: types.ModuleType,
+) -> None:
+    run_signature = inspect.signature(openai_agents_adapter.KitaruRunner.run)
+    run_sync_signature = inspect.signature(openai_agents_adapter.KitaruRunner.run_sync)
+
+    assert run_signature.parameters["context"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert run_signature.parameters["context"].default is None
+    assert (
+        run_sync_signature.parameters["context"].kind is inspect.Parameter.KEYWORD_ONLY
+    )
+    assert run_sync_signature.parameters["context"].default is None
+
+
 def test_run_sync_rejects_running_event_loop(
     openai_agents_adapter: types.ModuleType,
 ) -> None:
@@ -204,6 +218,26 @@ def test_openai_run_request_start_and_resume_validation(
             pending_state=envelope,
             decision=decision,
         )
+    with pytest.raises(ValidationError):
+        openai_agents_adapter.OpenAIRunRequest(kind="start", input="hello", context={})
+
+
+def test_fresh_context_is_rejected_for_resume_request(
+    openai_agents_adapter: types.ModuleType,
+) -> None:
+    request = openai_agents_adapter.OpenAIRunRequest.resume(
+        openai_agents_adapter.OpenAIRunStateEnvelope(
+            agents_sdk_version="0.15.0",
+            state_json={"current_turn": 1},
+        ),
+        openai_agents_adapter.OpenAIApprovalDecision(approve=True),
+    )
+    runner = openai_agents_adapter.KitaruRunner(
+        SimpleNamespace(name="resume-agent"), checkpoint_strategy="runner_call"
+    )
+
+    with pytest.raises(KitaruUsageError, match="Fresh `context=`"):
+        runner.run_sync(request, context=SimpleNamespace(team_id="team-a"))
 
 
 def test_openai_run_request_rejects_arbitrary_input_object(

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -799,6 +799,156 @@ async def test_openai_tool_checkpoint_uses_structural_tool_args_and_output_refs(
     assert saved == []
 
 
+def test_calls_strategy_prepare_objects_wires_context_cache_key_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kitaru.adapters.openai_agents._tools as openai_tools
+
+    seen_kwargs: dict[str, Any] = {}
+    original_tools = [SimpleNamespace(name="lookup_customer")]
+
+    def fake_kitaruify_openai_tools(tools: list[Any], **kwargs: Any) -> list[Any]:
+        seen_kwargs.update(kwargs)
+        return tools
+
+    monkeypatch.setattr(
+        openai_tools,
+        "kitaruify_openai_tools",
+        fake_kitaruify_openai_tools,
+    )
+
+    runner = KitaruRunner(
+        Agent(
+            name="factory-wire-agent",
+            model="gpt-5-nano",
+            tools=cast(Any, original_tools),
+        ),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+        context_cache_identity=lambda ctx: {"team_id": ctx.team_id},
+    )
+    context = WorkerContext(
+        team_id="team-a",
+        user_id="user-1",
+        thread_id="thread-1",
+    )
+    context_identity = runner._context_cache_identity(context)
+    context_key = runner._context_cache_key(context_identity)
+
+    prepared_agent, _run_config = runner._prepare_execution_objects(
+        wrap_calls=True,
+        context_cache_identity=context_identity,
+        context_cache_key=context_key,
+    )
+
+    assert prepared_agent.tools == original_tools
+    assert seen_kwargs["context_cache_identity"] == context_identity
+    assert seen_kwargs["context_cache_key"] == context_key
+    factory = seen_kwargs["context_cache_key_factory"]
+    assert callable(factory)
+    assert factory(context) == context_key
+    assert (
+        factory(
+            WorkerContext(
+                team_id="team-b",
+                user_id="user-1",
+                thread_id="thread-1",
+            )
+        )
+        != context_key
+    )
+
+
+@pytest.mark.anyio
+async def test_openai_tool_checkpoint_uses_callback_context_key_for_resume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kitaru.adapters.openai_agents._tools as openai_tools
+    from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+    inside_checkpoint = False
+    seen_checkpoint_inputs: list[dict[str, Any] | None] = []
+    seen_cache_payloads: list[dict[str, Any]] = []
+    seen_team_ids: list[str] = []
+
+    from agents.tool import FunctionTool
+
+    async def invoke_tool(context: Any, _input_json: str) -> str:
+        seen_team_ids.append(context.context.team_id)
+        return f"team={context.context.team_id}"
+
+    tool = FunctionTool(
+        name="lookup_customer",
+        description="Look up a customer.",
+        params_json_schema={
+            "type": "object",
+            "properties": {"customer_id": {"type": "string"}},
+            "required": ["customer_id"],
+            "additionalProperties": False,
+        },
+        on_invoke_tool=invoke_tool,
+    )
+
+    async def fake_run_async_in_checkpoint(**kwargs: Any) -> Any:
+        nonlocal inside_checkpoint
+        seen_checkpoint_inputs.append(kwargs.get("checkpoint_inputs"))
+        inside_checkpoint = True
+        try:
+            return await kwargs["body"]()
+        finally:
+            inside_checkpoint = False
+
+    original_checkpoint_cache_key = openai_tools.checkpoint_cache_key
+
+    def fake_checkpoint_cache_key(payload: Any) -> str:
+        if isinstance(payload, dict) and payload.get("tool_name") == "lookup_customer":
+            seen_cache_payloads.append(payload)
+        return original_checkpoint_cache_key(payload)
+
+    monkeypatch.setattr(openai_tools, "checkpoint_cache_key", fake_checkpoint_cache_key)
+    monkeypatch.setattr(openai_tools, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(openai_tools, "is_inside_checkpoint", lambda: inside_checkpoint)
+    monkeypatch.setattr(
+        openai_tools,
+        "run_async_in_checkpoint",
+        fake_run_async_in_checkpoint,
+    )
+
+    wrapped = openai_tools._wrap_function_tool(
+        tool,
+        capture=OpenAICapturePolicy(save_final_output=False),
+        agent_name="resume_context_agent",
+        tool_checkpoint_config={},
+        tool_checkpoint_config_by_name=None,
+        context_cache_key_factory=lambda ctx: f"context-key:{ctx.team_id}",
+    )
+
+    for team_id in ("team-a", "team-b"):
+        result = await wrapped.on_invoke_tool(
+            cast(
+                Any,
+                SimpleNamespace(
+                    tool_call_id="call_lookup",
+                    context=WorkerContext(
+                        team_id=team_id,
+                        user_id="user-1",
+                        thread_id="thread-1",
+                    ),
+                ),
+            ),
+            '{"customer_id": "123"}',
+        )
+        assert result == f"team={team_id}"
+
+    assert seen_team_ids == ["team-a", "team-b"]
+    assert [payload["context_cache_key"] for payload in seen_cache_payloads] == [
+        "context-key:team-a",
+        "context-key:team-b",
+    ]
+    assert seen_cache_payloads[0] != seen_cache_payloads[1]
+    assert all("team-a" not in repr(inputs) for inputs in seen_checkpoint_inputs)
+    assert all("team-b" not in repr(inputs) for inputs in seen_checkpoint_inputs)
+
+
 @pytest.mark.anyio
 async def test_openai_tool_checkpoint_keeps_context_key_out_of_visible_inputs(
     monkeypatch: pytest.MonkeyPatch,
@@ -1053,6 +1203,162 @@ def test_calls_strategy_model_checkpoint_cache_skips_inner_model(
     second = cached_model_flow.run("stable prompt", "second")
     _wait_for_hydrated_run(second.exec_id)
     assert model.call_count == 1
+
+
+def test_tool_input_guardrail_rejection_metadata_redacts_when_input_capture_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kitaru.adapters.openai_agents._tools as openai_tools
+    from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+    @function_tool
+    def send_email(message: str) -> str:
+        """Send an email message."""
+        return message
+
+    recorded: list[dict[str, Any]] = []
+
+    class FakeTracker:
+        def start_tool_event(
+            self,
+            *,
+            tool_call_id: str | None = None,
+        ) -> tuple[str, SimpleNamespace]:
+            assert tool_call_id == "call_guarded_email"
+            return "event-1", SimpleNamespace(sequence_index=1)
+
+        def record_event(self, *_args: Any, **kwargs: Any) -> None:
+            recorded.append(kwargs)
+
+    monkeypatch.setattr(openai_tools, "get_current_tracker", lambda: FakeTracker())
+    monkeypatch.setattr(openai_tools, "is_inside_flow", lambda: True)
+
+    openai_tools._record_blocked_tool_input_guardrail_event(
+        SimpleNamespace(context=SimpleNamespace(tool_call_id="call_guarded_email")),
+        tool=send_email,
+        capture=OpenAICapturePolicy(save_input=False),
+        guardrail=SimpleNamespace(name="block_sensitive_input"),
+        guardrail_index=0,
+        behavior_type="reject_content",
+        status="completed",
+        started_at=0.0,
+        rejection_message="blocked SECRET_DO_NOT_LOG",
+    )
+
+    metadata = recorded[0]["metadata"]
+    assert "rejection_message" not in metadata
+    assert metadata["rejection_message_redacted"] is True
+    assert "SECRET_DO_NOT_LOG" not in repr(recorded[0])
+
+
+@pytest.mark.anyio
+async def test_tool_input_guardrail_exception_summary_redacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kitaru.adapters.openai_agents._tools as openai_tools
+    import kitaru.adapters.openai_agents._tracking as openai_tracking
+    from kitaru.adapters.openai_agents._constants import (
+        OPENAI_AGENTS_EVENTS_METADATA_KEY,
+        OPENAI_AGENTS_RUN_SUMMARIES_METADATA_KEY,
+    )
+    from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+    @tool_input_guardrail(name="explode_on_secret")
+    def explode_on_secret(_data: Any) -> ToolGuardrailFunctionOutput:
+        raise RuntimeError("guardrail saw SECRET_DO_NOT_LOG")
+
+    @function_tool
+    def send_email(message: str) -> str:
+        """Send an email message."""
+        return message
+
+    logged: dict[str, Any] = {}
+    monkeypatch.setattr(openai_tools, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(openai_tracking, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(
+        openai_tracking.kitaru,
+        "log",
+        lambda **kwargs: logged.update(kwargs),
+    )
+
+    wrapped_guardrail = openai_tools._wrap_tool_input_guardrail(
+        explode_on_secret,
+        tool=send_email,
+        capture=OpenAICapturePolicy(save_input=False),
+        guardrail_index=0,
+    )
+
+    with (
+        pytest.raises(RuntimeError, match="SECRET_DO_NOT_LOG"),
+        openai_tracking.tracker_scope("guardrail_summary_agent"),
+    ):
+        await wrapped_guardrail.run(
+            SimpleNamespace(
+                context=SimpleNamespace(tool_call_id="call_guarded_email"),
+            )
+        )
+
+    event_map = logged[OPENAI_AGENTS_EVENTS_METADATA_KEY]
+    summary_map = logged[OPENAI_AGENTS_RUN_SUMMARIES_METADATA_KEY]
+    serialized_events = repr(event_map)
+    serialized_summary = repr(summary_map)
+    assert "SECRET_DO_NOT_LOG" not in serialized_events
+    assert "SECRET_DO_NOT_LOG" not in serialized_summary
+
+    events = next(iter(event_map.values()))
+    summaries = next(iter(summary_map.values()))
+    event_error = events[0]["error"]
+    summary_error = summaries["error"]
+    assert event_error["exception_type"] == "RuntimeError"
+    assert summary_error["exception_type"] == "RuntimeError"
+    assert "details redacted" in event_error["message"]
+    assert "details redacted" in summary_error["message"]
+
+
+def test_tool_input_guardrail_error_metadata_redacts_when_input_capture_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kitaru.adapters.openai_agents._tools as openai_tools
+    from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+    @function_tool
+    def send_email(message: str) -> str:
+        """Send an email message."""
+        return message
+
+    recorded: list[dict[str, Any]] = []
+
+    class FakeTracker:
+        def start_tool_event(
+            self,
+            *,
+            tool_call_id: str | None = None,
+        ) -> tuple[str, SimpleNamespace]:
+            assert tool_call_id == "call_guarded_email"
+            return "event-1", SimpleNamespace(sequence_index=1)
+
+        def record_event(self, *_args: Any, **kwargs: Any) -> None:
+            recorded.append(kwargs)
+
+    monkeypatch.setattr(openai_tools, "get_current_tracker", lambda: FakeTracker())
+    monkeypatch.setattr(openai_tools, "is_inside_flow", lambda: True)
+
+    openai_tools._record_blocked_tool_input_guardrail_event(
+        SimpleNamespace(context=SimpleNamespace(tool_call_id="call_guarded_email")),
+        tool=send_email,
+        capture=OpenAICapturePolicy(save_input=False),
+        guardrail=SimpleNamespace(name="block_sensitive_input"),
+        guardrail_index=0,
+        behavior_type="exception",
+        status="failed",
+        started_at=0.0,
+        error=RuntimeError("guardrail saw SECRET_DO_NOT_LOG"),
+    )
+
+    error = recorded[0]["error"]
+    assert isinstance(error, RuntimeError)
+    assert "details redacted" in str(error)
+    assert "SECRET_DO_NOT_LOG" not in repr(recorded[0])
 
 
 def test_calls_strategy_tool_input_guardrail_reject_records_blocked_tool_event(

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -1314,6 +1314,17 @@ async def test_tool_input_guardrail_exception_summary_redacts(
     assert "details redacted" in event_error["message"]
     assert "details redacted" in summary_error["message"]
 
+    tracker = openai_tracking.EventTracker(agent_name="guardrail_summary_agent")
+    redacted_error = RuntimeError("details redacted")
+    redacted_error.__dict__["_kitaru_redacted_run_error"] = True
+    tracker.set_run_error(redacted_error)
+    tracker.set_run_error(RuntimeError("guardrail saw SECRET_DO_NOT_LOG"))
+    overwrite_summary = tracker.build_run_summary()
+    overwrite_error = cast(dict[str, Any], overwrite_summary["error"])
+    assert "SECRET_DO_NOT_LOG" not in repr(overwrite_summary)
+    assert overwrite_error is not None
+    assert "details redacted" in overwrite_error["message"]
+
 
 def test_tool_input_guardrail_error_metadata_redacts_when_input_capture_disabled(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -1,6 +1,7 @@
 """Focused tests for OpenAI Agents SDK call-level checkpointing."""
 
 import re
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, cast
 from uuid import uuid4
@@ -9,7 +10,7 @@ import pytest
 
 pytest.importorskip("agents")
 
-from agents import Agent, RunConfig, function_tool
+from agents import Agent, RunConfig, RunContextWrapper, function_tool
 from agents.items import ModelResponse
 from agents.models.interface import Model
 from agents.usage import Usage
@@ -67,6 +68,16 @@ class RepeatedToolCallingModel(Model):
         raise NotImplementedError
 
 
+@dataclass(frozen=True)
+class WorkerContext:
+    team_id: str
+    user_id: str
+    thread_id: str
+    worker_name: str = "support-worker"
+    message_id: str | None = None
+    doc_id: str | None = None
+
+
 class ToolCallingModel(Model):
     def __init__(self) -> None:
         self.call_count = 0
@@ -94,6 +105,47 @@ class ToolCallingModel(Model):
 
     def stream_response(self, *_args: Any, **_kwargs: Any) -> Any:
         raise NotImplementedError
+
+
+class ContextToolCallingModel(Model):
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def get_response(self, *_args: Any, **_kwargs: Any) -> ModelResponse:
+        self.call_count += 1
+        sdk_input = _args[1] if len(_args) > 1 else None
+        if _contains_function_call_output(sdk_input):
+            return _text_response(
+                "context tool complete", response_id="resp_context_final"
+            )
+        return ModelResponse(
+            output=[
+                ResponseFunctionToolCall(
+                    arguments="{}",
+                    call_id="call_context_tool",
+                    id="fc_context",
+                    name="team_label",
+                    status="completed",
+                    type="function_call",
+                )
+            ],
+            usage=Usage(requests=1, input_tokens=3, output_tokens=2, total_tokens=5),
+            response_id="resp_context_tool_call",
+        )
+
+    def stream_response(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
+def _contains_function_call_output(value: Any) -> bool:
+    if isinstance(value, list | tuple):
+        return any(_contains_function_call_output(item) for item in value)
+    if isinstance(value, dict):
+        if value.get("type") == "function_call_output":
+            return True
+        return any(_contains_function_call_output(item) for item in value.values())
+    item_type = getattr(value, "type", None)
+    return item_type == "function_call_output"
 
 
 def _text_response(text: str, *, response_id: str) -> ModelResponse:
@@ -598,6 +650,7 @@ async def test_openai_tool_checkpoint_uses_structural_tool_args_and_output_refs(
 
     inside_checkpoint = False
     seen_checkpoint_inputs: list[dict[str, Any] | None] = []
+    seen_cache_payloads: list[Any] = []
     recorded_artifacts: list[dict[str, str]] = []
     saved: list[tuple[str, str]] = []
 
@@ -640,6 +693,13 @@ async def test_openai_tool_checkpoint_uses_structural_tool_args_and_output_refs(
         finally:
             inside_checkpoint = False
 
+    original_checkpoint_cache_key = openai_tools.checkpoint_cache_key
+
+    def fake_checkpoint_cache_key(payload: Any) -> str:
+        seen_cache_payloads.append(payload)
+        return original_checkpoint_cache_key(payload)
+
+    monkeypatch.setattr(openai_tools, "checkpoint_cache_key", fake_checkpoint_cache_key)
     monkeypatch.setattr(openai_tools, "is_inside_flow", lambda: True)
     monkeypatch.setattr(openai_tools, "is_inside_checkpoint", lambda: inside_checkpoint)
     monkeypatch.setattr(openai_tools, "get_current_tracker", lambda: FakeTracker())
@@ -677,7 +737,74 @@ async def test_openai_tool_checkpoint_uses_structural_tool_args_and_output_refs(
         }
     ]
     assert recorded_artifacts == [{"input": "tool_args", "result": "output"}]
+    assert "context_cache_key" not in seen_cache_payloads[0]
     assert saved == []
+
+
+@pytest.mark.anyio
+async def test_openai_tool_checkpoint_keeps_context_key_out_of_visible_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kitaru.adapters.openai_agents._tools as openai_tools
+    from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
+
+    inside_checkpoint = False
+    seen_checkpoint_inputs: list[dict[str, Any] | None] = []
+
+    from agents.tool import FunctionTool
+
+    async def invoke_tool(_context: Any, _input_json: str) -> str:
+        return "ok"
+
+    tool = FunctionTool(
+        name="lookup_customer",
+        description="Look up a customer.",
+        params_json_schema={
+            "type": "object",
+            "properties": {"customer_id": {"type": "string"}},
+            "required": ["customer_id"],
+            "additionalProperties": False,
+        },
+        on_invoke_tool=invoke_tool,
+    )
+
+    async def fake_run_async_in_checkpoint(**kwargs: Any) -> Any:
+        nonlocal inside_checkpoint
+        seen_checkpoint_inputs.append(kwargs.get("checkpoint_inputs"))
+        inside_checkpoint = True
+        try:
+            return await kwargs["body"]()
+        finally:
+            inside_checkpoint = False
+
+    monkeypatch.setattr(openai_tools, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(openai_tools, "is_inside_checkpoint", lambda: inside_checkpoint)
+    monkeypatch.setattr(
+        openai_tools, "run_async_in_checkpoint", fake_run_async_in_checkpoint
+    )
+
+    wrapped = openai_tools._wrap_function_tool(
+        tool,
+        capture=OpenAICapturePolicy(save_final_output=False),
+        agent_name="context_agent",
+        tool_checkpoint_config={},
+        tool_checkpoint_config_by_name=None,
+        context_cache_identity={"team_id": "team-a", "user_id": "user-1"},
+    )
+
+    result = await wrapped.on_invoke_tool(
+        cast(Any, SimpleNamespace(tool_call_id="call_lookup")),
+        '{"customer_id": "123"}',
+    )
+
+    assert result == "ok"
+    checkpoint_inputs = seen_checkpoint_inputs[0]
+    assert checkpoint_inputs is not None
+    tool_args = checkpoint_inputs["tool_args"]
+    assert "context_cache_key" not in tool_args
+    assert "context_cache_identity" not in tool_args
+    assert "team-a" not in repr(tool_args)
+    assert "user-1" not in repr(tool_args)
 
 
 @pytest.mark.anyio
@@ -910,6 +1037,139 @@ def test_calls_strategy_function_tool_runs_inside_checkpoint_and_caches(
     _wait_for_hydrated_run(second.exec_id)
     assert side_effects == [4]
     assert model.call_count == 2
+
+
+def test_calls_strategy_function_tool_receives_fresh_context(
+    primed_zenml,
+) -> None:
+    seen_team_ids: list[str] = []
+
+    @function_tool
+    def team_label(ctx: RunContextWrapper[WorkerContext]) -> str:
+        """Return the current team label."""
+        seen_team_ids.append(ctx.context.team_id)
+        return f"team={ctx.context.team_id}"
+
+    model = ContextToolCallingModel()
+    agent_name = f"openai_context_tool_agent_{uuid4().hex[:8]}"
+    runner = KitaruRunner(
+        Agent(name=agent_name, model=model, tools=[team_label]),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    @flow
+    def context_tool_flow(prompt: str, nonce: str) -> str:
+        _ = nonce
+        result = runner.run_sync(
+            OpenAIRunRequest.start(prompt),
+            context=WorkerContext(
+                team_id="team-a",
+                user_id="user-1",
+                thread_id="thread-1",
+            ),
+        )
+        assert result.status == "completed"
+        return str(result.final_output)
+
+    first = context_tool_flow.run("please use the context tool", "first")
+    _wait_for_hydrated_run(first.exec_id)
+
+    assert seen_team_ids == ["team-a"]
+
+
+def test_calls_strategy_tool_cache_varies_by_context_identity(
+    primed_zenml,
+) -> None:
+    seen_team_ids: list[str] = []
+
+    @function_tool
+    def team_label(ctx: RunContextWrapper[WorkerContext]) -> str:
+        """Return the current team label."""
+        seen_team_ids.append(ctx.context.team_id)
+        return f"team={ctx.context.team_id}"
+
+    model = ContextToolCallingModel()
+    agent_name = f"openai_context_cache_agent_{uuid4().hex[:8]}"
+    runner = KitaruRunner(
+        Agent(name=agent_name, model=model, tools=[team_label]),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    @flow
+    def context_cache_flow(prompt: str, team_id: str, nonce: str) -> str:
+        _ = nonce
+        result = runner.run_sync(
+            OpenAIRunRequest.start(prompt),
+            context=WorkerContext(
+                team_id=team_id,
+                user_id="user-1",
+                thread_id="thread-1",
+            ),
+        )
+        assert result.status == "completed"
+        return str(result.final_output)
+
+    first = context_cache_flow.run("please use the context tool", "team-a", "first")
+    _wait_for_hydrated_run(first.exec_id)
+    second = context_cache_flow.run("please use the context tool", "team-b", "second")
+    _wait_for_hydrated_run(second.exec_id)
+
+    assert seen_team_ids == ["team-a", "team-b"]
+
+
+def test_calls_strategy_context_projection_can_reuse_tool_cache(
+    primed_zenml,
+) -> None:
+    seen_team_ids: list[str] = []
+
+    @function_tool
+    def team_label(ctx: RunContextWrapper[WorkerContext]) -> str:
+        """Return the current team label."""
+        seen_team_ids.append(ctx.context.team_id)
+        return f"team={ctx.context.team_id}"
+
+    model = ContextToolCallingModel()
+    agent_name = f"openai_context_projection_agent_{uuid4().hex[:8]}"
+    runner = KitaruRunner(
+        Agent(name=agent_name, model=model, tools=[team_label]),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+        context_cache_identity=lambda ctx: {
+            "team_id": ctx.team_id,
+            "user_id": ctx.user_id,
+            "thread_id": ctx.thread_id,
+            "worker_name": ctx.worker_name,
+        },
+    )
+
+    @flow
+    def projected_context_flow(prompt: str, message_id: str, doc_id: str) -> str:
+        result = runner.run_sync(
+            OpenAIRunRequest.start(prompt),
+            context=WorkerContext(
+                team_id="team-a",
+                user_id="user-1",
+                thread_id="thread-1",
+                message_id=message_id,
+                doc_id=doc_id,
+            ),
+        )
+        assert result.status == "completed"
+        return str(result.final_output)
+
+    first = projected_context_flow.run(
+        "please use the context tool",
+        "msg-1",
+        "doc-1",
+    )
+    _wait_for_hydrated_run(first.exec_id)
+    second = projected_context_flow.run(
+        "please use the context tool",
+        "msg-2",
+        "doc-2",
+    )
+    _wait_for_hydrated_run(second.exec_id)
+
+    assert seen_team_ids == ["team-a"]
 
 
 def test_same_args_tool_calls_without_visible_call_id_do_not_collide(

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -1251,8 +1251,7 @@ def test_tool_input_guardrail_rejection_metadata_redacts_when_input_capture_disa
     assert "SECRET_DO_NOT_LOG" not in repr(recorded[0])
 
 
-@pytest.mark.anyio
-async def test_tool_input_guardrail_exception_summary_redacts(
+def test_tool_input_guardrail_exception_summary_redacts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import kitaru.adapters.openai_agents._tools as openai_tools
@@ -1262,10 +1261,6 @@ async def test_tool_input_guardrail_exception_summary_redacts(
         OPENAI_AGENTS_RUN_SUMMARIES_METADATA_KEY,
     )
     from kitaru.adapters.openai_agents._policy import OpenAICapturePolicy
-
-    @tool_input_guardrail(name="explode_on_secret")
-    def explode_on_secret(_data: Any) -> ToolGuardrailFunctionOutput:
-        raise RuntimeError("guardrail saw SECRET_DO_NOT_LOG")
 
     @function_tool
     def send_email(message: str) -> str:
@@ -1281,21 +1276,18 @@ async def test_tool_input_guardrail_exception_summary_redacts(
         lambda **kwargs: logged.update(kwargs),
     )
 
-    wrapped_guardrail = openai_tools._wrap_tool_input_guardrail(
-        explode_on_secret,
-        tool=send_email,
-        capture=OpenAICapturePolicy(save_input=False),
-        guardrail_index=0,
-    )
-
-    with (
-        pytest.raises(RuntimeError, match="SECRET_DO_NOT_LOG"),
-        openai_tracking.tracker_scope("guardrail_summary_agent"),
-    ):
-        await wrapped_guardrail.run(
-            SimpleNamespace(
-                context=SimpleNamespace(tool_call_id="call_guarded_email"),
-            )
+    with openai_tracking.tracker_scope("guardrail_summary_agent") as tracker:
+        monkeypatch.setattr(openai_tools, "get_current_tracker", lambda: tracker)
+        openai_tools._record_blocked_tool_input_guardrail_event(
+            SimpleNamespace(context=SimpleNamespace(tool_call_id="call_guarded_email")),
+            tool=send_email,
+            capture=OpenAICapturePolicy(save_input=False),
+            guardrail=SimpleNamespace(name="explode_on_secret"),
+            guardrail_index=0,
+            behavior_type="exception",
+            status="failed",
+            started_at=0.0,
+            error=RuntimeError("guardrail saw SECRET_DO_NOT_LOG"),
         )
 
     event_map = logged[OPENAI_AGENTS_EVENTS_METADATA_KEY]

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -1,6 +1,7 @@
 """Focused tests for OpenAI Agents SDK call-level checkpointing."""
 
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, cast
@@ -11,14 +12,17 @@ import pytest
 pytest.importorskip("agents")
 
 from agents import Agent, RunConfig, RunContextWrapper, function_tool
+from agents.exceptions import ToolInputGuardrailTripwireTriggered
 from agents.items import ModelResponse
 from agents.models.interface import Model
+from agents.tool_guardrails import ToolGuardrailFunctionOutput, tool_input_guardrail
 from agents.usage import Usage
 from openai.types.responses import (
     ResponseFunctionToolCall,
     ResponseOutputMessage,
     ResponseOutputText,
 )
+from pydantic import BaseModel
 from zenml.client import Client
 
 from kitaru import flow
@@ -68,6 +72,11 @@ class RepeatedToolCallingModel(Model):
         raise NotImplementedError
 
 
+class StructuredSupportAnswer(BaseModel):
+    verdict: str
+    confidence: float
+
+
 @dataclass(frozen=True)
 class WorkerContext:
     team_id: str
@@ -107,6 +116,38 @@ class ToolCallingModel(Model):
         raise NotImplementedError
 
 
+class GuardrailToolCallingModel(Model):
+    def __init__(
+        self,
+        tool_calls: list[ResponseFunctionToolCall],
+        *,
+        final_text: str = "guardrail tool flow complete",
+    ) -> None:
+        self.tool_calls = tool_calls
+        self.final_text = final_text
+        self.call_count = 0
+        self.seen_function_call_outputs: list[str] = []
+
+    async def get_response(self, *_args: Any, **_kwargs: Any) -> ModelResponse:
+        self.call_count += 1
+        sdk_input = _args[1] if len(_args) > 1 else None
+        function_call_outputs = _function_call_outputs(sdk_input)
+        if function_call_outputs:
+            self.seen_function_call_outputs.extend(function_call_outputs)
+            return _text_response(
+                self.final_text,
+                response_id=f"resp_guardrail_final_{self.call_count}",
+            )
+        return ModelResponse(
+            output=cast(Any, self.tool_calls),
+            usage=Usage(requests=1, input_tokens=3, output_tokens=2, total_tokens=5),
+            response_id="resp_guardrail_tool_call",
+        )
+
+    def stream_response(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
 class ContextToolCallingModel(Model):
     def __init__(self) -> None:
         self.call_count = 0
@@ -138,14 +179,31 @@ class ContextToolCallingModel(Model):
 
 
 def _contains_function_call_output(value: Any) -> bool:
+    return next(_iter_function_call_outputs(value), None) is not None
+
+
+def _function_call_outputs(value: Any) -> list[str]:
+    return list(_iter_function_call_outputs(value))
+
+
+def _iter_function_call_outputs(value: Any) -> Iterator[str]:
     if isinstance(value, list | tuple):
-        return any(_contains_function_call_output(item) for item in value)
+        for item in value:
+            yield from _iter_function_call_outputs(item)
+        return
     if isinstance(value, dict):
         if value.get("type") == "function_call_output":
-            return True
-        return any(_contains_function_call_output(item) for item in value.values())
-    item_type = getattr(value, "type", None)
-    return item_type == "function_call_output"
+            output = value.get("output")
+            if isinstance(output, str):
+                yield output
+            return
+        for item in value.values():
+            yield from _iter_function_call_outputs(item)
+        return
+    if getattr(value, "type", None) == "function_call_output":
+        output = getattr(value, "output", None)
+        if isinstance(output, str):
+            yield output
 
 
 def _text_response(text: str, *, response_id: str) -> ModelResponse:
@@ -945,6 +1003,34 @@ def test_calls_strategy_model_call_runs_inside_checkpoint(primed_zenml) -> None:
     assert model.call_count == 1
 
 
+def test_calls_strategy_preserves_structured_final_output_and_model_event(
+    primed_zenml,
+) -> None:
+    model = StaticTextModel('{"verdict":"safe","confidence":0.91}')
+    agent_name = f"openai_structured_agent_{uuid4().hex[:8]}"
+    runner = KitaruRunner(
+        Agent(name=agent_name, model=model, output_type=StructuredSupportAnswer),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    @flow
+    def structured_output_flow(prompt: str, nonce: str) -> dict[str, Any]:
+        _ = nonce
+        result = runner.run_sync(OpenAIRunRequest.start(prompt))
+        assert result.status == "completed"
+        assert isinstance(result.final_output, StructuredSupportAnswer)
+        assert result.final_output.verdict == "safe"
+        assert result.final_output.confidence == 0.91
+        return result.final_output.model_dump()
+
+    handle = structured_output_flow.run("return structured safety result", "first")
+    hydrated = _wait_for_hydrated_run(handle.exec_id)
+
+    assert any("openai_model_call" in name for name in _step_names(hydrated))
+    events = _events(hydrated.run_metadata["openai_agents_events"])
+    assert any(event["kind"] == "llm_call" for event in events)
+
+
 def test_calls_strategy_model_checkpoint_cache_skips_inner_model(
     primed_zenml,
 ) -> None:
@@ -967,6 +1053,225 @@ def test_calls_strategy_model_checkpoint_cache_skips_inner_model(
     second = cached_model_flow.run("stable prompt", "second")
     _wait_for_hydrated_run(second.exec_id)
     assert model.call_count == 1
+
+
+def test_calls_strategy_tool_input_guardrail_reject_records_blocked_tool_event(
+    primed_zenml,
+) -> None:
+    side_effects: list[str] = []
+    seen_call_ids: list[str] = []
+
+    @tool_input_guardrail(name="block_sensitive_input")
+    def block_sensitive_input(data: Any) -> ToolGuardrailFunctionOutput:
+        seen_call_ids.append(data.context.tool_call_id)
+        return ToolGuardrailFunctionOutput.reject_content("blocked by policy")
+
+    @function_tool(tool_input_guardrails=[block_sensitive_input])
+    def send_email(message: str) -> str:
+        """Send an email message."""
+        side_effects.append(message)
+        return "sent"
+
+    model = GuardrailToolCallingModel(
+        [
+            ResponseFunctionToolCall(
+                arguments='{"message":"secret"}',
+                call_id="call_blocked_email",
+                id="fc_blocked_email",
+                name="send_email",
+                status="completed",
+                type="function_call",
+            )
+        ],
+    )
+    agent_name = f"openai_guardrail_reject_agent_{uuid4().hex[:8]}"
+    runner = KitaruRunner(
+        Agent(name=agent_name, model=model, tools=[send_email]),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    @flow
+    def guardrail_reject_flow(prompt: str, nonce: str) -> str:
+        _ = nonce
+        result = runner.run_sync(OpenAIRunRequest.start(prompt))
+        assert result.status == "completed"
+        return str(result.final_output)
+
+    handle = guardrail_reject_flow.run("send the email", "first")
+    hydrated = _wait_for_hydrated_run(handle.exec_id)
+
+    assert side_effects == []
+    assert seen_call_ids == ["call_blocked_email"]
+    assert model.seen_function_call_outputs == ["blocked by policy"]
+    assert not any("send_email_tool_call" in name for name in _step_names(hydrated))
+
+    events = _events(hydrated.run_metadata["openai_agents_events"])
+    tool_events = [event for event in events if event["kind"] == "tool_call"]
+    assert len(tool_events) == 1
+    blocked_event = tool_events[0]
+    assert blocked_event["status"] == "completed"
+    assert blocked_event["artifacts"] == {}
+    blocked_metadata = blocked_event["metadata"]
+    assert blocked_metadata["tool_name"] == "send_email"
+    assert blocked_metadata["tool_call_id"] == "call_blocked_email"
+    assert blocked_metadata["tool_invoked"] is False
+    assert blocked_metadata["blocked_by_guardrail"] is True
+    assert blocked_metadata["guardrail_index"] == 0
+    assert blocked_metadata["guardrail_name"] == "block_sensitive_input"
+    assert blocked_metadata["guardrail_behavior"] == "reject_content"
+    assert blocked_metadata["rejection_message"] == "blocked by policy"
+
+
+def test_calls_strategy_tool_input_guardrail_raise_records_failed_tool_event(
+    primed_zenml,
+) -> None:
+    side_effects: list[str] = []
+
+    @tool_input_guardrail(name="trip_sensitive_input")
+    def trip_sensitive_input(_data: Any) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.raise_exception(
+            output_info={"blocked": True}
+        )
+
+    @function_tool(tool_input_guardrails=[trip_sensitive_input])
+    def send_email(message: str) -> str:
+        """Send an email message."""
+        side_effects.append(message)
+        return "sent"
+
+    model = GuardrailToolCallingModel(
+        [
+            ResponseFunctionToolCall(
+                arguments='{"message":"secret"}',
+                call_id="call_tripped_email",
+                id="fc_tripped_email",
+                name="send_email",
+                status="completed",
+                type="function_call",
+            )
+        ],
+    )
+    agent_name = f"openai_guardrail_raise_agent_{uuid4().hex[:8]}"
+    runner = KitaruRunner(
+        Agent(name=agent_name, model=model, tools=[send_email]),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    @flow
+    def guardrail_raise_flow(prompt: str, nonce: str) -> str:
+        _ = nonce
+        try:
+            runner.run_sync(OpenAIRunRequest.start(prompt))
+        except ToolInputGuardrailTripwireTriggered as error:
+            return type(error).__name__
+        raise AssertionError("expected ToolInputGuardrailTripwireTriggered")
+
+    handle = guardrail_raise_flow.run("send the email", "first")
+    hydrated = _wait_for_hydrated_run(handle.exec_id)
+
+    assert side_effects == []
+    events = _events(hydrated.run_metadata["openai_agents_events"])
+    tool_events = [event for event in events if event["kind"] == "tool_call"]
+    assert len(tool_events) == 1
+    failed_event = tool_events[0]
+    assert failed_event["status"] == "failed"
+    assert failed_event["metadata"]["tool_name"] == "send_email"
+    assert failed_event["metadata"]["tool_call_id"] == "call_tripped_email"
+    assert failed_event["metadata"]["tool_invoked"] is False
+    assert failed_event["metadata"]["blocked_by_guardrail"] is True
+    assert failed_event["metadata"]["guardrail_name"] == "trip_sensitive_input"
+    assert failed_event["metadata"]["guardrail_behavior"] == "raise_exception"
+    assert failed_event["error"]["exception_type"] == "RuntimeError"
+    assert (
+        "requested an exception before tool invocation"
+        in failed_event["error"]["message"]
+    )
+
+
+def test_calls_strategy_allowed_and_blocked_guardrails_keep_tool_event_order(
+    primed_zenml,
+) -> None:
+    side_effects: list[int] = []
+
+    @tool_input_guardrail(name="allow_tool_input")
+    def allow_tool_input(_data: Any) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow(output_info={"checked": True})
+
+    @tool_input_guardrail(name="block_tool_input")
+    def block_tool_input(_data: Any) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.reject_content("blocked second tool")
+
+    @function_tool(tool_input_guardrails=[block_tool_input])
+    def blocked_value(value: int) -> str:
+        """A tool that should not run when the guardrail blocks it."""
+        side_effects.append(value)
+        return f"blocked={value}"
+
+    @function_tool(tool_input_guardrails=[allow_tool_input])
+    def allowed_value(value: int) -> str:
+        """A tool that should run when the guardrail allows it."""
+        side_effects.append(value)
+        return f"allowed={value}"
+
+    model = GuardrailToolCallingModel(
+        [
+            ResponseFunctionToolCall(
+                arguments='{"value":1}',
+                call_id="call_blocked_value",
+                id="fc_blocked_value",
+                name="blocked_value",
+                status="completed",
+                type="function_call",
+            ),
+            ResponseFunctionToolCall(
+                arguments='{"value":2}',
+                call_id="call_allowed_value",
+                id="fc_allowed_value",
+                name="allowed_value",
+                status="completed",
+                type="function_call",
+            ),
+        ],
+    )
+    agent_name = f"openai_guardrail_mixed_agent_{uuid4().hex[:8]}"
+    runner = KitaruRunner(
+        Agent(name=agent_name, model=model, tools=[blocked_value, allowed_value]),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    @flow
+    def guardrail_mixed_flow(prompt: str, nonce: str) -> str:
+        _ = nonce
+        result = runner.run_sync(OpenAIRunRequest.start(prompt))
+        assert result.status == "completed"
+        return str(result.final_output)
+
+    handle = guardrail_mixed_flow.run("use both tools", "first")
+    hydrated = _wait_for_hydrated_run(handle.exec_id)
+
+    assert side_effects == [2]
+    events = _events(hydrated.run_metadata["openai_agents_events"])
+    tool_events = [event for event in events if event["kind"] == "tool_call"]
+    assert [event["metadata"]["tool_call_id"] for event in tool_events] == [
+        "call_blocked_value",
+        "call_allowed_value",
+    ]
+    blocked_events = [
+        event
+        for event in tool_events
+        if event["metadata"].get("blocked_by_guardrail") is True
+    ]
+    assert len(blocked_events) == 1
+    assert blocked_events[0]["metadata"]["tool_invoked"] is False
+    allowed_events = [
+        event
+        for event in tool_events
+        if event["metadata"].get("tool_call_id") == "call_allowed_value"
+    ]
+    assert len(allowed_events) == 1
+    assert allowed_events[0]["metadata"].get("blocked_by_guardrail") is None
+    assert allowed_events[0]["artifacts"].get("input") == "tool_args"
+    assert allowed_events[0]["artifacts"].get("result") == "output"
 
 
 def test_calls_strategy_function_tool_runs_inside_checkpoint_and_caches(

--- a/tests/test_openai_agents_runner_call_strategy.py
+++ b/tests/test_openai_agents_runner_call_strategy.py
@@ -1,5 +1,6 @@
 """Focused tests for OpenAI runner-call checkpointing and RunState bridging."""
 
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
@@ -8,13 +9,14 @@ import pytest
 
 pytest.importorskip("agents")
 
-from agents import Agent, RunConfig, function_tool
+from agents import Agent, RunConfig, Runner, function_tool
 from agents.items import ModelResponse
 from agents.models.interface import Model
 from agents.usage import Usage
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 from zenml.client import Client
 
+import kitaru.adapters.openai_agents._runner as openai_runner
 from kitaru import flow
 from kitaru.adapters.openai_agents import (
     KitaruRunner,
@@ -69,6 +71,275 @@ def _wait_for_hydrated_run(exec_id: str) -> Any:
 
 def _step_names(hydrated_run: Any) -> set[str]:
     return set(hydrated_run.steps)
+
+
+@dataclass(frozen=True)
+class WorkerContext:
+    team_id: str
+    user_id: str
+    thread_id: str
+    worker_name: str = "support-worker"
+    is_background: bool = False
+    group_chat: bool = False
+    chat_mode: str | None = None
+    scope_user_id: str | None = None
+    scope_group_id: str | None = None
+    plugin: str | None = None
+    project_id: str | None = None
+    tool_settings: dict[str, Any] | None = None
+    message_id: str | None = None
+    doc_id: str | None = None
+
+
+@pytest.mark.anyio
+async def test_async_bridge_forwards_exact_context_to_sdk_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = WorkerContext(team_id="team-a", user_id="user-1", thread_id="thread-1")
+    seen_contexts: list[object] = []
+
+    async def fake_run(*_args: Any, **kwargs: Any) -> SimpleNamespace:
+        seen_contexts.append(kwargs["context"])
+        return SimpleNamespace(final_output="ok")
+
+    monkeypatch.setattr(Runner, "run", fake_run)
+
+    result = await openai_runner.run_openai_agent(
+        agent=SimpleNamespace(name="agent"),
+        input="hello",
+        max_turns=3,
+        run_config=RunConfig(tracing_disabled=True),
+        context=ctx,
+    )
+
+    assert result.final_output == "ok"
+    assert seen_contexts == [ctx]
+
+
+def test_sync_bridge_forwards_exact_context_to_sdk_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = WorkerContext(team_id="team-a", user_id="user-1", thread_id="thread-1")
+    seen_contexts: list[object] = []
+
+    def fake_run_sync(*_args: Any, **kwargs: Any) -> SimpleNamespace:
+        seen_contexts.append(kwargs["context"])
+        return SimpleNamespace(final_output="ok")
+
+    monkeypatch.setattr(Runner, "run_sync", fake_run_sync)
+
+    result = openai_runner.run_openai_agent_sync(
+        agent=SimpleNamespace(name="agent"),
+        input="hello",
+        max_turns=3,
+        run_config=RunConfig(tracing_disabled=True),
+        context=ctx,
+    )
+
+    assert result.final_output == "ok"
+    assert seen_contexts == [ctx]
+
+
+def test_runner_call_run_sync_forwards_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ctx = WorkerContext(team_id="team-a", user_id="user-1", thread_id="thread-1")
+    seen_contexts: list[object] = []
+
+    def fake_run_openai_agent_sync(**kwargs: Any) -> SimpleNamespace:
+        seen_contexts.append(kwargs["context"])
+        return SimpleNamespace(final_output="ok")
+
+    runner = KitaruRunner(
+        SimpleNamespace(name="context-agent"),
+        checkpoint_strategy="runner_call",
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+    monkeypatch.setitem(
+        runner._run_sdk_sync.__globals__,
+        "run_openai_agent_sync",
+        fake_run_openai_agent_sync,
+    )
+
+    result = runner.run_sync(OpenAIRunRequest.start("hello"), context=ctx)
+
+    assert result.final_output == "ok"
+    assert seen_contexts == [ctx]
+
+
+def test_runner_call_cache_key_omits_context_when_context_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import kitaru.adapters.openai_agents._agent as openai_agent_module
+
+    seen_payloads: list[dict[str, Any]] = []
+
+    def fake_checkpoint_cache_key(payload: dict[str, Any]) -> str:
+        seen_payloads.append(payload)
+        return "cache-key"
+
+    monkeypatch.setattr(
+        openai_agent_module,
+        "checkpoint_cache_key",
+        fake_checkpoint_cache_key,
+    )
+    runner = KitaruRunner(
+        SimpleNamespace(name="no-context-agent"),
+        checkpoint_strategy="runner_call",
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    cache_key = runner._runner_call_cache_key(
+        OpenAIRunRequest.start("hello"),
+        agent=runner.agent,
+        run_config=RunConfig(tracing_disabled=True),
+        context_cache_identity=None,
+    )
+
+    assert cache_key == "cache-key"
+    assert "context" not in seen_payloads[0]
+
+
+def test_runner_call_cache_identity_varies_by_structural_context() -> None:
+    runner = KitaruRunner(
+        SimpleNamespace(name="cache-agent"),
+        checkpoint_strategy="runner_call",
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+    request = OpenAIRunRequest.start("hello")
+    run_config = RunConfig(tracing_disabled=True)
+
+    team_a_key = runner._runner_call_cache_key(
+        request,
+        agent=runner.agent,
+        run_config=run_config,
+        context_cache_identity=runner._context_cache_identity(
+            WorkerContext(team_id="team-a", user_id="user-1", thread_id="thread-1")
+        ),
+    )
+    team_b_key = runner._runner_call_cache_key(
+        request,
+        agent=runner.agent,
+        run_config=run_config,
+        context_cache_identity=runner._context_cache_identity(
+            WorkerContext(team_id="team-b", user_id="user-1", thread_id="thread-1")
+        ),
+    )
+
+    assert team_a_key != team_b_key
+
+
+def test_custom_context_cache_identity_can_ignore_per_run_fields() -> None:
+    runner = KitaruRunner(
+        SimpleNamespace(name="projected-agent"),
+        checkpoint_strategy="runner_call",
+        context_cache_identity=lambda ctx: {
+            "team_id": ctx.team_id,
+            "user_id": ctx.user_id,
+            "thread_id": ctx.thread_id,
+            "worker_name": ctx.worker_name,
+            "is_background": ctx.is_background,
+            "group_chat": ctx.group_chat,
+            "chat_mode": ctx.chat_mode,
+            "scope_user_id": ctx.scope_user_id,
+            "scope_group_id": ctx.scope_group_id,
+            "plugin": ctx.plugin,
+            "project_id": ctx.project_id,
+            "tool_settings": ctx.tool_settings,
+        },
+    )
+
+    first = runner._context_cache_identity(
+        WorkerContext(
+            team_id="team-a",
+            user_id="user-1",
+            thread_id="thread-1",
+            tool_settings={"enabled": True, "limit": 3},
+            message_id="msg-1",
+            doc_id="doc-1",
+        )
+    )
+    second = runner._context_cache_identity(
+        WorkerContext(
+            team_id="team-a",
+            user_id="user-1",
+            thread_id="thread-1",
+            tool_settings={"enabled": True, "limit": 3},
+            message_id="msg-2",
+            doc_id="doc-2",
+        )
+    )
+
+    assert first == second
+    assert "message_id" not in first
+    assert "doc_id" not in first
+    assert first["tool_settings"] == {"enabled": True, "limit": 3}
+
+
+def test_default_context_cache_identity_uses_pure_data_structure() -> None:
+    runner = KitaruRunner(SimpleNamespace(name="data-agent"))
+
+    first = runner._context_cache_identity(
+        WorkerContext(team_id="team-a", user_id="user-1", thread_id="thread-1")
+    )
+    second = runner._context_cache_identity(
+        WorkerContext(team_id="team-a", user_id="user-1", thread_id="thread-1")
+    )
+
+    assert first == second
+    assert first["fields"]["team_id"] == "team-a"
+
+
+def test_context_cache_identity_sorts_sets_deterministically() -> None:
+    runner = KitaruRunner(SimpleNamespace(name="set-agent"))
+
+    first = runner._context_cache_identity({"enabled_tools": {"search", "crm"}})
+    second = runner._context_cache_identity({"enabled_tools": {"crm", "search"}})
+
+    assert first == second
+    assert first["enabled_tools"] == {
+        "collection_type": "set",
+        "items": ["crm", "search"],
+    }
+
+
+def test_context_cache_identity_is_cycle_safe() -> None:
+    runner = KitaruRunner(SimpleNamespace(name="cycle-agent"))
+    cycle: list[Any] = []
+    cycle.append(cycle)
+
+    identity = runner._context_cache_identity({"cycle": cycle})
+
+    cycle_item = identity["cycle"]["items"][0]
+    assert cycle_item["serialization_error"] == "cycle_detected"
+    assert "opaque_cache_token" in cycle_item
+
+
+def test_context_cache_identity_stops_before_oversized_collections() -> None:
+    from kitaru.adapters.openai_agents._serialization import stable_cache_identity
+
+    identity = stable_cache_identity(
+        ["first", "second", "third"],
+        opaque_objects_unique=True,
+        max_items=2,
+    )
+
+    assert identity["serialization_error"] == "max_items_exceeded"
+    assert "items" not in identity
+    assert "first" not in repr(identity)
+
+
+def test_opaque_context_cache_identity_is_distinct_per_object() -> None:
+    class OpaqueContext:
+        pass
+
+    runner = KitaruRunner(SimpleNamespace(name="opaque-agent"))
+
+    first = runner._context_cache_identity(OpaqueContext())
+    second = runner._context_cache_identity(OpaqueContext())
+
+    assert first["python_type"] == second["python_type"]
+    assert first != second
 
 
 def test_runner_call_strategy_checkpoints_outer_runner_and_caches(

--- a/tests/test_openai_agents_runner_call_strategy.py
+++ b/tests/test_openai_agents_runner_call_strategy.py
@@ -146,6 +146,44 @@ def test_sync_bridge_forwards_exact_context_to_sdk_runner(
     assert seen_contexts == [ctx]
 
 
+def test_runner_sync_threads_interruption_payload_capture_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kitaru.adapters.openai_agents import OpenAICapturePolicy, OpenAIRunResult
+
+    seen_save_payloads: list[bool] = []
+
+    def fake_run_openai_agent_sync(**_kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(final_output="ok")
+
+    def fake_build_run_result(_sdk_result: Any, **kwargs: Any) -> OpenAIRunResult:
+        seen_save_payloads.append(kwargs["save_interruption_payloads"])
+        return OpenAIRunResult(status="completed", final_output="ok")
+
+    runner = KitaruRunner(
+        SimpleNamespace(name="capture-agent"),
+        checkpoint_strategy="runner_call",
+        capture=OpenAICapturePolicy(save_interruption_payloads=False),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+    monkeypatch.setitem(
+        runner._run_sdk_sync.__globals__,
+        "run_openai_agent_sync",
+        fake_run_openai_agent_sync,
+    )
+    monkeypatch.setitem(
+        runner._run_sdk_sync.__globals__,
+        "build_run_result",
+        fake_build_run_result,
+    )
+
+    result = runner.run_sync(OpenAIRunRequest.start("hello"))
+
+    assert result.status == "completed"
+    assert result.final_output == "ok"
+    assert seen_save_payloads == [False]
+
+
 def test_runner_call_run_sync_forwards_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -442,6 +480,147 @@ def test_runner_call_strategy_does_not_invoke_calls_wrappers(
 
     assert result.status == "completed"
     assert result.final_output == "ok"
+
+
+def test_interruption_summary_omits_payloads_when_capture_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(openai_runner, "agents_sdk_version", lambda: "0.15.0")
+
+    class FakeState:
+        def to_json(self, **_kwargs: object) -> dict[str, object]:
+            return {"current_turn": 1}
+
+    interruption = {
+        "tool_name": "send_email",
+        "call_id": "call_sensitive_email",
+        "message": "approval required",
+        "arguments": {"message": "SECRET_DO_NOT_LOG"},
+    }
+    sdk_result = SimpleNamespace(
+        interruptions=[interruption],
+        to_state=lambda: FakeState(),
+        last_response_id="resp_interrupted",
+    )
+
+    result = openai_runner.build_run_result(
+        sdk_result,
+        strict_sdk_version=True,
+        save_interruption_payloads=False,
+    )
+
+    assert result.status == "interrupted"
+    summary = result.interruptions[0]
+    assert summary.tool_name == "send_email"
+    assert summary.call_id == "call_sensitive_email"
+    assert summary.message == "approval required"
+    assert summary.arguments is None
+    assert summary.arguments_preview is None
+    assert "SECRET_DO_NOT_LOG" not in result.model_dump_json()
+
+
+def test_interruption_summary_does_not_mine_nested_identity_when_redacted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(openai_runner, "agents_sdk_version", lambda: "0.15.0")
+
+    class FakeState:
+        def to_json(self, **_kwargs: object) -> dict[str, object]:
+            return {"current_turn": 1}
+
+    sdk_result = SimpleNamespace(
+        interruptions=[
+            {
+                "arguments": {
+                    "name": "SECRET_DO_NOT_LOG_NAME",
+                    "call_id": "SECRET_DO_NOT_LOG_CALL_ID",
+                },
+            }
+        ],
+        to_state=lambda: FakeState(),
+        last_response_id="resp_interrupted",
+    )
+
+    result = openai_runner.build_run_result(
+        sdk_result,
+        strict_sdk_version=True,
+        save_interruption_payloads=False,
+    )
+
+    summary = result.interruptions[0]
+    assert summary.tool_name is None
+    assert summary.call_id is None
+    assert summary.arguments is None
+    assert summary.arguments_preview is None
+    serialized = result.model_dump_json()
+    assert "SECRET_DO_NOT_LOG_NAME" not in serialized
+    assert "SECRET_DO_NOT_LOG_CALL_ID" not in serialized
+
+
+def test_interruption_summary_does_not_promote_argument_message_when_redacted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(openai_runner, "agents_sdk_version", lambda: "0.15.0")
+
+    class FakeState:
+        def to_json(self, **_kwargs: object) -> dict[str, object]:
+            return {"current_turn": 1}
+
+    sdk_result = SimpleNamespace(
+        interruptions=[
+            {
+                "tool_name": "send_email",
+                "call_id": "call_sensitive_email",
+                "arguments": {"message": "SECRET_DO_NOT_LOG"},
+            }
+        ],
+        to_state=lambda: FakeState(),
+        last_response_id="resp_interrupted",
+    )
+
+    result = openai_runner.build_run_result(
+        sdk_result,
+        strict_sdk_version=True,
+        save_interruption_payloads=False,
+    )
+
+    summary = result.interruptions[0]
+    assert summary.message is None
+    assert summary.arguments is None
+    assert summary.arguments_preview is None
+    assert "SECRET_DO_NOT_LOG" not in result.model_dump_json()
+
+
+def test_interruption_summary_keeps_payloads_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(openai_runner, "agents_sdk_version", lambda: "0.15.0")
+
+    class FakeState:
+        def to_json(self, **_kwargs: object) -> dict[str, object]:
+            return {"current_turn": 1}
+
+    interruption = {
+        "tool_name": "send_email",
+        "call_id": "call_sensitive_email",
+        "message": "approval required",
+        "arguments": {"message": "SECRET_VISIBLE"},
+    }
+    sdk_result = SimpleNamespace(
+        interruptions=[interruption],
+        to_state=lambda: FakeState(),
+        last_response_id="resp_interrupted",
+    )
+
+    result = openai_runner.build_run_result(
+        sdk_result,
+        strict_sdk_version=True,
+    )
+
+    summary = result.interruptions[0]
+    assert summary.arguments is not None
+    assert summary.arguments_preview is not None
+    assert "SECRET_VISIBLE" in result.model_dump_json()
 
 
 def test_run_state_envelope_serialization_and_approval_boundary(

--- a/tests/test_openai_agents_runner_call_strategy.py
+++ b/tests/test_openai_agents_runner_call_strategy.py
@@ -170,16 +170,14 @@ def test_runner_call_run_sync_forwards_context(
 def test_runner_call_cache_key_omits_context_when_context_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import kitaru.adapters.openai_agents._agent as openai_agent_module
-
     seen_payloads: list[dict[str, Any]] = []
 
     def fake_checkpoint_cache_key(payload: dict[str, Any]) -> str:
         seen_payloads.append(payload)
         return "cache-key"
 
-    monkeypatch.setattr(
-        openai_agent_module,
+    monkeypatch.setitem(
+        KitaruRunner._runner_call_cache_key.__globals__,
         "checkpoint_cache_key",
         fake_checkpoint_cache_key,
     )

--- a/tests/test_openai_agents_runner_call_strategy.py
+++ b/tests/test_openai_agents_runner_call_strategy.py
@@ -14,6 +14,7 @@ from agents.items import ModelResponse
 from agents.models.interface import Model
 from agents.usage import Usage
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+from pydantic import BaseModel
 from zenml.client import Client
 
 import kitaru.adapters.openai_agents._runner as openai_runner
@@ -24,6 +25,11 @@ from kitaru.adapters.openai_agents import (
     OpenAIRunRequest,
     OpenAIRunStateEnvelope,
 )
+
+
+class StructuredSupportAnswer(BaseModel):
+    verdict: str
+    confidence: float
 
 
 class StaticTextModel(Model):
@@ -338,6 +344,27 @@ def test_opaque_context_cache_identity_is_distinct_per_object() -> None:
 
     assert first["python_type"] == second["python_type"]
     assert first != second
+
+
+def test_runner_call_strategy_preserves_structured_final_output() -> None:
+    model = StaticTextModel('{"verdict":"safe","confidence":0.91}')
+    agent = Agent(
+        name="runner-structured",
+        model=model,
+        output_type=StructuredSupportAnswer,
+    )
+    runner = KitaruRunner(
+        agent,
+        checkpoint_strategy="runner_call",
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    result = runner.run_sync(OpenAIRunRequest.start("return structured result"))
+
+    assert result.status == "completed"
+    assert isinstance(result.final_output, StructuredSupportAnswer)
+    assert result.final_output.verdict == "safe"
+    assert result.final_output.confidence == 0.91
 
 
 def test_runner_call_strategy_checkpoints_outer_runner_and_caches(


### PR DESCRIPTION
## Summary

- Add fresh-run `context=` passthrough on `KitaruRunner.run(...)` and `run_sync(...)` for OpenAI Agents SDK runs.
- Include context-derived identity in runner/tool checkpoint cache keys, with an explicit `context_cache_identity=` projection hook for stable production contexts.
- Include restored callback context in resumed `checkpoint_strategy="calls"` tool cache keys, so approved tool calls after HITL resume cannot reuse stale same-args/different-context tool checkpoints.
- Keep raw context and derived context hashes out of visible tool artifacts, and document the fresh context vs interrupted `RunState` resume-context boundary.
- Record OpenAI Agents SDK tool-input guardrail blocks as existing `tool_call` events in `checkpoint_strategy="calls"`.
- Redact guardrail rejection/error metadata when `save_input=False`, and honor `save_interruption_payloads=False` for interrupted tool-call summaries.
- Add structured-output regression coverage for both supported OpenAI Agents checkpoint strategies.
- Update the OpenAI Agents adapter guide with the context, structured-output, guardrail-observability, privacy-capture, and nested-runner boundaries.

Closes #332.

## Why

OpenAI Agents SDK tools and guardrails can read request-scoped application state through `RunContextWrapper.context`. Kitaru previously wrapped the SDK runner but never forwarded fresh-run context, so tools that depended on local worker/request context could not run under the adapter without custom workarounds.

The cache-safety piece matters because two runs can have the same visible tool arguments but different local context. For example, two teams could both call `lookup_customer(customer_id="123")`. The cache key now includes a bounded, stable context identity when context is supplied, so Kitaru does not accidentally reuse one context's tool result for another.

There is a second cache-safety case on interrupted/resumed runs. Imagine a tool call is paused for approval, the process restarts, and Kitaru restores the OpenAI `RunState` context from the pending request. The approved tool call may execute only after resume. That resumed callback now derives its cache key from the restored callback context at execution time, not from the missing fresh-run `context=` argument from before deserialization.

Tool-input guardrails have a related observability gap. A guardrail can reject a tool call before Kitaru's normal tool wrapper gets to invoke the function. In that case the model requested a tool call, but the tool body never ran. Kitaru now records that blocked attempt as an existing `tool_call` event with guardrail metadata, without creating a new event type or saving rejected tool arguments as a tool checkpoint.

The privacy-capture settings now apply to those guardrail/interruption paths too. If input capture is disabled, Kitaru records the fact that a guardrail blocked or failed without storing the rejection text or raw exception message. If interruption payload capture is disabled, resumability metadata remains available while raw tool arguments/previews are omitted from the user-visible summary.

## Key implementation decisions

- `context=` lives on `KitaruRunner.run(...)` / `run_sync(...)`, not on `OpenAIRunRequest`, so the request model stays serializable and resume-focused.
- Passing fresh `context=` with a resume request raises `KitaruUsageError`; interrupted SDK `RunState` context still uses the existing `context_serializer=` / `context_deserializer=` hooks.
- `context_cache_identity=` lets callers project rich worker context down to stable cache fields while excluding per-run fields like message IDs.
- Context identity uses bounded structural serialization and opaque miss-safe fallbacks for large, cyclic, or non-serializable objects.
- Calls-strategy tool wrappers can derive the context cache key from the SDK callback context at tool execution time, which covers resumed `RunState` contexts restored after request validation.
- Visible tool input artifacts remain free of raw context and context-derived hashes; only hidden checkpoint cache-key payloads include the derived key.
- Guardrail-blocked tool attempts are recorded as existing `tool_call` events with `tool_invoked=false` and `blocked_by_guardrail=true`.
- Blocked guardrails do **not** create a tool checkpoint and do **not** save rejected args as tool-event artifacts.
- `OpenAICapturePolicy.save_input=False` redacts guardrail rejection text and unexpected exception details before they enter event metadata or run summaries.
- `OpenAICapturePolicy.save_interruption_payloads=False` omits raw interruption arguments/previews while preserving safe identifiers needed to understand and resume the interrupted run.
- Streaming remains intentionally out of scope for this PR.

## Reviewer Notes

Start in `src/kitaru/adapters/openai_agents/_agent.py`. The context story should read as: a caller passes `context=...` to the Kitaru runner, Kitaru validates that this is a fresh start, computes a cache identity once, then forwards the same context to the OpenAI SDK bridge in `_runner.py`.

The trickiest safety area is the cache identity path. Please look at `_serialization.py` and `_tools.py`: context objects are reduced to bounded identities for hidden cache keys, while visible tool artifacts still only contain normal tool arguments. If this is wrong, the bad outcomes are either stale cross-context cache hits or leaking request context into artifacts.

One important review fix is in `_tools.py`: for `checkpoint_strategy="calls"`, the tool wrapper now has a callback-time context-cache-key factory. That matters after a HITL resume because the fresh `context=` parameter is intentionally forbidden on resume, but the SDK callback context has already been restored from the serialized `RunState`. The cache key needs to include that restored context before the approved tool call runs.

The guardrail visibility path also lives in `_tools.py`. When Kitaru copies an OpenAI `FunctionTool`, it now also copies/wraps any tool-input guardrails. If a guardrail returns `reject_content` or `raise_exception`, Kitaru records a `tool_call` event with the SDK tool call id, guardrail name/index, and guardrail behavior. Normal allowed tool calls still go through the existing tool checkpoint path.

The important guardrail boundary is deliberate: Kitaru gives visibility that a model-requested tool call was blocked, but it does not persist rejected arguments as tool checkpoint inputs. In concrete terms: the UI/event log should show “the model tried to call this tool and the guardrail blocked it,” while the actual tool body never ran.

Please also check the privacy edges in `_tools.py`, `_tracking.py`, and `_runner.py`. With `save_input=False`, rejection text and unexpected guardrail exception messages should not be stored in event metadata or run summaries. `_tracking.py` now also prevents a later raw exception from overwriting an already-redacted run-summary error. With `save_interruption_payloads=False`, interrupted tool-call summaries should keep safe SDK ids/names but not recursively mine raw argument payloads for display values.

Structured outputs are covered as a regression rather than changing adapter behavior: `Agent(output_type=...)` should continue returning typed final outputs in both `calls` and `runner_call` strategies.

### Reproduction

For a focused local check of the context, cache, privacy, and guardrail behavior:

```bash
uv run pytest \
  tests/test_openai_agents_adapter_foundation.py \
  tests/test_openai_agents_runner_call_strategy.py \
  tests/test_openai_agents_calls_strategy.py
```

Expected result: the context passthrough, cache-identity, resume-validation, visible-artifact privacy, structured-output, interruption-payload, and guardrail-event tests pass.

For a narrower guardrail check, run:

```bash
uv run pytest \
  tests/test_openai_agents_calls_strategy.py::test_calls_strategy_tool_input_guardrail_reject_records_blocked_tool_event \
  tests/test_openai_agents_calls_strategy.py::test_calls_strategy_tool_input_guardrail_raise_records_failed_tool_event \
  tests/test_openai_agents_calls_strategy.py::test_calls_strategy_allowed_and_blocked_guardrails_keep_tool_event_order \
  tests/test_openai_agents_calls_strategy.py::test_tool_input_guardrail_rejection_metadata_redacts_when_input_capture_disabled \
  tests/test_openai_agents_calls_strategy.py::test_tool_input_guardrail_error_metadata_redacts_when_input_capture_disabled
```

Those tests prove that blocked tool attempts show up as `tool_call` events with `blocked_by_guardrail=true`, that allowed tools still record ordinary input/result artifacts, that `raise_exception` guardrails produce failed tool events, and that input-capture privacy settings redact guardrail messages that may contain user/tool input.

For the resumed-context cache fix, inspect or run:

```bash
uv run pytest \
  tests/test_openai_agents_calls_strategy.py::test_openai_tool_checkpoint_uses_callback_context_key_for_resume \
  tests/test_openai_agents_calls_strategy.py::test_calls_strategy_prepare_objects_wires_context_cache_key_factory
```

These tests exercise the concrete failure mode where a resumed approved tool call has no fresh `context=` argument at wrapper setup time, but does have restored SDK callback context when the tool actually executes.

For a manual docs/code-path read, inspect `docs/content/docs/guides/openai-agents-adapter.mdx`:

- “Fresh-run context” shows a `WorkerContext` passed to `runner.run_sync(..., context=...)`, where the tool receives it through `RunContextWrapper.context`.
- “Structured outputs, guardrails, and nested agents” describes the shipped guardrail-event boundary and the raw nested `agents.Runner.run(...)` limitation.
- The capture-policy section explains how `save_input` and `save_interruption_payloads` affect guardrail/interruption metadata.

### Local checks run

- `just check`
- `just test` → `1796 passed, 8 skipped`

