### PR TITLE
Add OpenAI guardrail visibility

### DIFF
--- a/docs/content/docs/guides/openai-agents-adapter.mdx
+++ b/docs/content/docs/guides/openai-agents-adapter.mdx
@@ -164,6 +164,35 @@ call in your own `@checkpoint` is **not** a workaround here — the adapter
 guards against it and will raise, because per-call checkpoints cannot be
 nested inside another Kitaru checkpoint.
 
+## Structured outputs, guardrails, and nested agents
+
+OpenAI Agents SDK structured outputs work through the adapter. If your agent is
+created with `Agent(output_type=...)`, Kitaru preserves the SDK result object and
+its typed `final_output` in both supported strategies:
+
+- `checkpoint_strategy="runner_call"` records the outer runner call and returns
+  the structured result from `.wait()` cleanly.
+- `checkpoint_strategy="calls"` records supported model and tool calls
+  individually, while the SDK still produces the typed final output for your
+  Python code.
+
+For tool-input guardrails, use `checkpoint_strategy="calls"` when you need to
+see blocked tool attempts. In that strategy, Kitaru records a rejected tool
+attempt as an existing `tool_call` event with guardrail metadata before the tool
+function runs. It does not create a new event type, and it does not save a tool
+checkpoint for arguments that the guardrail rejected.
+
+`checkpoint_strategy="runner_call"` still only sees the outer `Runner.run(...)`
+boundary. That is useful for a single durable result, but it cannot show each
+individual tool guardrail decision. Choose `"calls"` when per-tool guardrail
+observability matters.
+
+One more boundary to remember: raw nested `agents.Runner.run(...)` calls remain
+outside Kitaru unless you wrap that evaluator agent with its own `KitaruRunner`.
+Raw nested agents are fine for quick ephemeral checks. If their inputs, outputs,
+or guardrail decisions need Kitaru observability, run them through
+`KitaruRunner` too.
+
 ## Important guardrail
 
 `checkpoint_strategy="calls"` must run from flow scope (not from inside another

--- a/src/kitaru/adapters/openai_agents/_tools.py
+++ b/src/kitaru/adapters/openai_agents/_tools.py
@@ -2,6 +2,7 @@
 
 import json
 import time
+from collections.abc import Mapping
 from dataclasses import replace
 from typing import Any
 
@@ -9,6 +10,7 @@ from agents.tool import FunctionTool
 
 import kitaru
 
+from ._events import EventStatus
 from ._kitaru_internal import is_inside_checkpoint, is_inside_flow
 from ._policy import OpenAICapturePolicy
 from ._serialization import to_json_safe
@@ -24,6 +26,13 @@ from ._utils import (
     run_async_in_checkpoint,
     safe_step_name,
     with_default_type,
+)
+
+_GUARDRAIL_BEHAVIOR_EXCEPTION = "exception"
+_GUARDRAIL_BEHAVIOR_RAISE_EXCEPTION = "raise_exception"
+_GUARDRAIL_BEHAVIOR_REJECT_CONTENT = "reject_content"
+_GUARDRAIL_REQUESTED_EXCEPTION_MESSAGE = (
+    "Tool input guardrail requested an exception before tool invocation."
 )
 
 
@@ -169,10 +178,207 @@ def _wrap_function_tool(
             tool_call_id=tool_call_id,
         )
 
-    wrapped = replace(tool, on_invoke_tool=_wrapped_callback)
+    wrapped = replace(
+        tool,
+        on_invoke_tool=_wrapped_callback,
+        tool_input_guardrails=_wrap_tool_input_guardrails(
+            tool.tool_input_guardrails,
+            tool=tool,
+            capture=capture,
+        ),
+    )
     object.__setattr__(wrapped, "_kitaru_wrapped", True)
     object.__setattr__(wrapped, "_kitaru_original_tool", tool)
     return wrapped
+
+
+def _wrap_tool_input_guardrails(
+    guardrails: list[Any] | None,
+    *,
+    tool: FunctionTool,
+    capture: OpenAICapturePolicy,
+) -> list[Any] | None:
+    if not guardrails:
+        return guardrails
+    return [
+        _wrap_tool_input_guardrail(
+            guardrail,
+            tool=tool,
+            capture=capture,
+            guardrail_index=index,
+        )
+        for index, guardrail in enumerate(guardrails)
+    ]
+
+
+def _wrap_tool_input_guardrail(
+    guardrail: Any,
+    *,
+    tool: FunctionTool,
+    capture: OpenAICapturePolicy,
+    guardrail_index: int,
+) -> Any:
+    if getattr(guardrail, "_kitaru_wrapped_tool_input_guardrail", False):
+        return guardrail
+
+    async def _wrapped_guardrail_function(data: Any) -> Any:
+        if not _should_record_tool_input_guardrail_event(capture):
+            return await guardrail.run(data)
+
+        started_at = time.perf_counter()
+        try:
+            output = await guardrail.run(data)
+        except Exception as error:
+            _record_blocked_tool_input_guardrail_event(
+                data,
+                tool=tool,
+                capture=capture,
+                guardrail=guardrail,
+                guardrail_index=guardrail_index,
+                behavior_type=_GUARDRAIL_BEHAVIOR_EXCEPTION,
+                status="failed",
+                started_at=started_at,
+                error=error,
+            )
+            raise
+
+        behavior_type = _guardrail_behavior_type(output)
+        if behavior_type == _GUARDRAIL_BEHAVIOR_REJECT_CONTENT:
+            _record_blocked_tool_input_guardrail_event(
+                data,
+                tool=tool,
+                capture=capture,
+                guardrail=guardrail,
+                guardrail_index=guardrail_index,
+                behavior_type=behavior_type,
+                status="completed",
+                started_at=started_at,
+                rejection_message=_guardrail_rejection_message(output),
+            )
+        elif behavior_type == _GUARDRAIL_BEHAVIOR_RAISE_EXCEPTION:
+            _record_blocked_tool_input_guardrail_event(
+                data,
+                tool=tool,
+                capture=capture,
+                guardrail=guardrail,
+                guardrail_index=guardrail_index,
+                behavior_type=behavior_type,
+                status="failed",
+                started_at=started_at,
+                error=RuntimeError(_GUARDRAIL_REQUESTED_EXCEPTION_MESSAGE),
+            )
+        return output
+
+    wrapped = replace(guardrail, guardrail_function=_wrapped_guardrail_function)
+    object.__setattr__(wrapped, "_kitaru_wrapped_tool_input_guardrail", True)
+    object.__setattr__(wrapped, "_kitaru_original_tool_input_guardrail", guardrail)
+    return wrapped
+
+
+def _record_blocked_tool_input_guardrail_event(
+    data: Any,
+    *,
+    tool: FunctionTool,
+    capture: OpenAICapturePolicy,
+    guardrail: Any,
+    guardrail_index: int,
+    behavior_type: str,
+    status: EventStatus,
+    started_at: float,
+    rejection_message: str | None = None,
+    error: BaseException | None = None,
+) -> None:
+    tracker = get_current_tracker()
+    if tracker is None or not _should_record_tool_input_guardrail_event(
+        capture,
+        tracker=tracker,
+    ):
+        return
+
+    context = getattr(data, "context", None)
+    tool_call_id = _tool_call_id(context)
+    event_id, event_context = tracker.start_tool_event(tool_call_id=tool_call_id)
+    metadata = _tool_event_metadata(tool, tool_call_id=tool_call_id, context=context)
+    metadata.update(
+        {
+            "tool_invoked": False,
+            "blocked_by_guardrail": True,
+            "guardrail_index": guardrail_index,
+            "guardrail_name": _guardrail_name(guardrail),
+            "guardrail_behavior": behavior_type,
+        }
+    )
+    if rejection_message is not None:
+        metadata["rejection_message"] = rejection_message
+
+    tracker.record_event(
+        event_id,
+        event_context,
+        kind="tool_call",
+        status=status,
+        duration_ms=elapsed_ms(started_at),
+        artifacts={},
+        metadata=metadata,
+        error=error,
+    )
+
+
+def _should_record_tool_input_guardrail_event(
+    capture: OpenAICapturePolicy,
+    *,
+    tracker: Any | None = None,
+) -> bool:
+    current_tracker = tracker if tracker is not None else get_current_tracker()
+    return (
+        capture.emit_child_events
+        and current_tracker is not None
+        and (is_inside_flow() or is_inside_checkpoint())
+    )
+
+
+def _tool_event_metadata(
+    tool: FunctionTool,
+    *,
+    tool_call_id: str | None,
+    context: Any = None,
+) -> dict[str, object]:
+    return {
+        "tool_name": _metadata_tool_name(context, tool),
+        "tool_call_id": tool_call_id,
+        "is_agent_tool": bool(getattr(tool, "_is_agent_tool", False)),
+        "tool_namespace": getattr(context, "tool_namespace", None)
+        or getattr(tool, "_tool_namespace", None),
+    }
+
+
+def _metadata_tool_name(context: Any, tool: FunctionTool) -> str:
+    value = getattr(context, "tool_name", None)
+    return value if isinstance(value, str) and value else tool.name
+
+
+def _guardrail_name(guardrail: Any) -> str | None:
+    get_name = getattr(guardrail, "get_name", None)
+    if callable(get_name):
+        try:
+            value = get_name()
+        except Exception:
+            value = None
+        if isinstance(value, str) and value:
+            return value
+    value = getattr(guardrail, "name", None)
+    return value if isinstance(value, str) and value else None
+
+
+def _guardrail_behavior_type(output: Any) -> str | None:
+    behavior = getattr(output, "behavior", None)
+    value = _value_from_mapping_or_attr(behavior, "type")
+    return value if isinstance(value, str) and value else None
+
+
+def _guardrail_rejection_message(output: Any) -> str | None:
+    behavior = getattr(output, "behavior", None)
+    value = _value_from_mapping_or_attr(behavior, "message")
+    return value if isinstance(value, str) and value else None
 
 
 async def _tracked_tool_call(
@@ -220,7 +426,11 @@ async def _tracked_tool_call(
             status="failed",
             duration_ms=elapsed_ms(started_at),
             artifacts=artifacts,
-            metadata={"tool_name": tool.name, "tool_call_id": tool_call_id},
+            metadata=_tool_event_metadata(
+                tool,
+                tool_call_id=tool_call_id,
+                context=context,
+            ),
             error=error,
         )
         raise
@@ -240,14 +450,19 @@ async def _tracked_tool_call(
         status="completed",
         duration_ms=elapsed_ms(started_at),
         artifacts=artifacts,
-        metadata={
-            "tool_name": tool.name,
-            "tool_call_id": tool_call_id,
-            "is_agent_tool": bool(getattr(tool, "_is_agent_tool", False)),
-            "tool_namespace": getattr(tool, "_tool_namespace", None),
-        },
+        metadata=_tool_event_metadata(
+            tool,
+            tool_call_id=tool_call_id,
+            context=context,
+        ),
     )
     return result
+
+
+def _value_from_mapping_or_attr(value: Any, key: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return getattr(value, key, None)
 
 
 def _tool_input_envelope(

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -1,6 +1,7 @@
 """Focused tests for OpenAI Agents SDK call-level checkpointing."""
 
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, cast
@@ -11,14 +12,17 @@ import pytest
 pytest.importorskip("agents")
 
 from agents import Agent, RunConfig, RunContextWrapper, function_tool
+from agents.exceptions import ToolInputGuardrailTripwireTriggered
 from agents.items import ModelResponse
 from agents.models.interface import Model
+from agents.tool_guardrails import ToolGuardrailFunctionOutput, tool_input_guardrail
 from agents.usage import Usage
 from openai.types.responses import (
     ResponseFunctionToolCall,
     ResponseOutputMessage,
     ResponseOutputText,
 )
+from pydantic import BaseModel
 from zenml.client import Client
 
 from kitaru import flow
@@ -68,6 +72,11 @@ class RepeatedToolCallingModel(Model):
         raise NotImplementedError
 
 
+class StructuredSupportAnswer(BaseModel):
+    verdict: str
+    confidence: float
+
+
 @dataclass(frozen=True)
 class WorkerContext:
     team_id: str
@@ -107,6 +116,38 @@ class ToolCallingModel(Model):
         raise NotImplementedError
 
 
+class GuardrailToolCallingModel(Model):
+    def __init__(
+        self,
+        tool_calls: list[ResponseFunctionToolCall],
+        *,
+        final_text: str = "guardrail tool flow complete",
+    ) -> None:
+        self.tool_calls = tool_calls
+        self.final_text = final_text
+        self.call_count = 0
+        self.seen_function_call_outputs: list[str] = []
+
+    async def get_response(self, *_args: Any, **_kwargs: Any) -> ModelResponse:
+        self.call_count += 1
+        sdk_input = _args[1] if len(_args) > 1 else None
+        function_call_outputs = _function_call_outputs(sdk_input)
+        if function_call_outputs:
+            self.seen_function_call_outputs.extend(function_call_outputs)
+            return _text_response(
+                self.final_text,
+                response_id=f"resp_guardrail_final_{self.call_count}",
+            )
+        return ModelResponse(
+            output=cast(Any, self.tool_calls),
+            usage=Usage(requests=1, input_tokens=3, output_tokens=2, total_tokens=5),
+            response_id="resp_guardrail_tool_call",
+        )
+
+    def stream_response(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise NotImplementedError
+
+
 class ContextToolCallingModel(Model):
     def __init__(self) -> None:
         self.call_count = 0
@@ -138,14 +179,31 @@ class ContextToolCallingModel(Model):
 
 
 def _contains_function_call_output(value: Any) -> bool:
+    return next(_iter_function_call_outputs(value), None) is not None
+
+
+def _function_call_outputs(value: Any) -> list[str]:
+    return list(_iter_function_call_outputs(value))
+
+
+def _iter_function_call_outputs(value: Any) -> Iterator[str]:
     if isinstance(value, list | tuple):
-        return any(_contains_function_call_output(item) for item in value)
+        for item in value:
+            yield from _iter_function_call_outputs(item)
+        return
     if isinstance(value, dict):
         if value.get("type") == "function_call_output":
-            return True
-        return any(_contains_function_call_output(item) for item in value.values())
-    item_type = getattr(value, "type", None)
-    return item_type == "function_call_output"
+            output = value.get("output")
+            if isinstance(output, str):
+                yield output
+            return
+        for item in value.values():
+            yield from _iter_function_call_outputs(item)
+        return
+    if getattr(value, "type", None) == "function_call_output":
+        output = getattr(value, "output", None)
+        if isinstance(output, str):
+            yield output
 
 
 def _text_response(text: str, *, response_id: str) -> ModelResponse:
@@ -945,6 +1003,34 @@ def test_calls_strategy_model_call_runs_inside_checkpoint(primed_zenml) -> None:
     assert model.call_count == 1
 
 
+def test_calls_strategy_preserves_structured_final_output_and_model_event(
+    primed_zenml,
+) -> None:
+    model = StaticTextModel('{"verdict":"safe","confidence":0.91}')
+    agent_name = f"openai_structured_agent_{uuid4().hex[:8]}"
+    runner = KitaruRunner(
+        Agent(name=agent_name, model=model, output_type=StructuredSupportAnswer),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    @flow
+    def structured_output_flow(prompt: str, nonce: str) -> dict[str, Any]:
+        _ = nonce
+        result = runner.run_sync(OpenAIRunRequest.start(prompt))
+        assert result.status == "completed"
+        assert isinstance(result.final_output, StructuredSupportAnswer)
+        assert result.final_output.verdict == "safe"
+        assert result.final_output.confidence == 0.91
+        return result.final_output.model_dump()
+
+    handle = structured_output_flow.run("return structured safety result", "first")
+    hydrated = _wait_for_hydrated_run(handle.exec_id)
+
+    assert any("openai_model_call" in name for name in _step_names(hydrated))
+    events = _events(hydrated.run_metadata["openai_agents_events"])
+    assert any(event["kind"] == "llm_call" for event in events)
+
+
 def test_calls_strategy_model_checkpoint_cache_skips_inner_model(
     primed_zenml,
 ) -> None:
@@ -967,6 +1053,225 @@ def test_calls_strategy_model_checkpoint_cache_skips_inner_model(
     second = cached_model_flow.run("stable prompt", "second")
     _wait_for_hydrated_run(second.exec_id)
     assert model.call_count == 1
+
+
+def test_calls_strategy_tool_input_guardrail_reject_records_blocked_tool_event(
+    primed_zenml,
+) -> None:
+    side_effects: list[str] = []
+    seen_call_ids: list[str] = []
+
+    @tool_input_guardrail(name="block_sensitive_input")
+    def block_sensitive_input(data: Any) -> ToolGuardrailFunctionOutput:
+        seen_call_ids.append(data.context.tool_call_id)
+        return ToolGuardrailFunctionOutput.reject_content("blocked by policy")
+
+    @function_tool(tool_input_guardrails=[block_sensitive_input])
+    def send_email(message: str) -> str:
+        """Send an email message."""
+        side_effects.append(message)
+        return "sent"
+
+    model = GuardrailToolCallingModel(
+        [
+            ResponseFunctionToolCall(
+                arguments='{"message":"secret"}',
+                call_id="call_blocked_email",
+                id="fc_blocked_email",
+                name="send_email",
+                status="completed",
+                type="function_call",
+            )
+        ],
+    )
+    agent_name = f"openai_guardrail_reject_agent_{uuid4().hex[:8]}"
+    runner = KitaruRunner(
+        Agent(name=agent_name, model=model, tools=[send_email]),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    @flow
+    def guardrail_reject_flow(prompt: str, nonce: str) -> str:
+        _ = nonce
+        result = runner.run_sync(OpenAIRunRequest.start(prompt))
+        assert result.status == "completed"
+        return str(result.final_output)
+
+    handle = guardrail_reject_flow.run("send the email", "first")
+    hydrated = _wait_for_hydrated_run(handle.exec_id)
+
+    assert side_effects == []
+    assert seen_call_ids == ["call_blocked_email"]
+    assert model.seen_function_call_outputs == ["blocked by policy"]
+    assert not any("send_email_tool_call" in name for name in _step_names(hydrated))
+
+    events = _events(hydrated.run_metadata["openai_agents_events"])
+    tool_events = [event for event in events if event["kind"] == "tool_call"]
+    assert len(tool_events) == 1
+    blocked_event = tool_events[0]
+    assert blocked_event["status"] == "completed"
+    assert blocked_event["artifacts"] == {}
+    blocked_metadata = blocked_event["metadata"]
+    assert blocked_metadata["tool_name"] == "send_email"
+    assert blocked_metadata["tool_call_id"] == "call_blocked_email"
+    assert blocked_metadata["tool_invoked"] is False
+    assert blocked_metadata["blocked_by_guardrail"] is True
+    assert blocked_metadata["guardrail_index"] == 0
+    assert blocked_metadata["guardrail_name"] == "block_sensitive_input"
+    assert blocked_metadata["guardrail_behavior"] == "reject_content"
+    assert blocked_metadata["rejection_message"] == "blocked by policy"
+
+
+def test_calls_strategy_tool_input_guardrail_raise_records_failed_tool_event(
+    primed_zenml,
+) -> None:
+    side_effects: list[str] = []
+
+    @tool_input_guardrail(name="trip_sensitive_input")
+    def trip_sensitive_input(_data: Any) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.raise_exception(
+            output_info={"blocked": True}
+        )
+
+    @function_tool(tool_input_guardrails=[trip_sensitive_input])
+    def send_email(message: str) -> str:
+        """Send an email message."""
+        side_effects.append(message)
+        return "sent"
+
+    model = GuardrailToolCallingModel(
+        [
+            ResponseFunctionToolCall(
+                arguments='{"message":"secret"}',
+                call_id="call_tripped_email",
+                id="fc_tripped_email",
+                name="send_email",
+                status="completed",
+                type="function_call",
+            )
+        ],
+    )
+    agent_name = f"openai_guardrail_raise_agent_{uuid4().hex[:8]}"
+    runner = KitaruRunner(
+        Agent(name=agent_name, model=model, tools=[send_email]),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    @flow
+    def guardrail_raise_flow(prompt: str, nonce: str) -> str:
+        _ = nonce
+        try:
+            runner.run_sync(OpenAIRunRequest.start(prompt))
+        except ToolInputGuardrailTripwireTriggered as error:
+            return type(error).__name__
+        raise AssertionError("expected ToolInputGuardrailTripwireTriggered")
+
+    handle = guardrail_raise_flow.run("send the email", "first")
+    hydrated = _wait_for_hydrated_run(handle.exec_id)
+
+    assert side_effects == []
+    events = _events(hydrated.run_metadata["openai_agents_events"])
+    tool_events = [event for event in events if event["kind"] == "tool_call"]
+    assert len(tool_events) == 1
+    failed_event = tool_events[0]
+    assert failed_event["status"] == "failed"
+    assert failed_event["metadata"]["tool_name"] == "send_email"
+    assert failed_event["metadata"]["tool_call_id"] == "call_tripped_email"
+    assert failed_event["metadata"]["tool_invoked"] is False
+    assert failed_event["metadata"]["blocked_by_guardrail"] is True
+    assert failed_event["metadata"]["guardrail_name"] == "trip_sensitive_input"
+    assert failed_event["metadata"]["guardrail_behavior"] == "raise_exception"
+    assert failed_event["error"]["exception_type"] == "RuntimeError"
+    assert (
+        "requested an exception before tool invocation"
+        in failed_event["error"]["message"]
+    )
+
+
+def test_calls_strategy_allowed_and_blocked_guardrails_keep_tool_event_order(
+    primed_zenml,
+) -> None:
+    side_effects: list[int] = []
+
+    @tool_input_guardrail(name="allow_tool_input")
+    def allow_tool_input(_data: Any) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.allow(output_info={"checked": True})
+
+    @tool_input_guardrail(name="block_tool_input")
+    def block_tool_input(_data: Any) -> ToolGuardrailFunctionOutput:
+        return ToolGuardrailFunctionOutput.reject_content("blocked second tool")
+
+    @function_tool(tool_input_guardrails=[block_tool_input])
+    def blocked_value(value: int) -> str:
+        """A tool that should not run when the guardrail blocks it."""
+        side_effects.append(value)
+        return f"blocked={value}"
+
+    @function_tool(tool_input_guardrails=[allow_tool_input])
+    def allowed_value(value: int) -> str:
+        """A tool that should run when the guardrail allows it."""
+        side_effects.append(value)
+        return f"allowed={value}"
+
+    model = GuardrailToolCallingModel(
+        [
+            ResponseFunctionToolCall(
+                arguments='{"value":1}',
+                call_id="call_blocked_value",
+                id="fc_blocked_value",
+                name="blocked_value",
+                status="completed",
+                type="function_call",
+            ),
+            ResponseFunctionToolCall(
+                arguments='{"value":2}',
+                call_id="call_allowed_value",
+                id="fc_allowed_value",
+                name="allowed_value",
+                status="completed",
+                type="function_call",
+            ),
+        ],
+    )
+    agent_name = f"openai_guardrail_mixed_agent_{uuid4().hex[:8]}"
+    runner = KitaruRunner(
+        Agent(name=agent_name, model=model, tools=[blocked_value, allowed_value]),
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    @flow
+    def guardrail_mixed_flow(prompt: str, nonce: str) -> str:
+        _ = nonce
+        result = runner.run_sync(OpenAIRunRequest.start(prompt))
+        assert result.status == "completed"
+        return str(result.final_output)
+
+    handle = guardrail_mixed_flow.run("use both tools", "first")
+    hydrated = _wait_for_hydrated_run(handle.exec_id)
+
+    assert side_effects == [2]
+    events = _events(hydrated.run_metadata["openai_agents_events"])
+    tool_events = [event for event in events if event["kind"] == "tool_call"]
+    assert [event["metadata"]["tool_call_id"] for event in tool_events] == [
+        "call_blocked_value",
+        "call_allowed_value",
+    ]
+    blocked_events = [
+        event
+        for event in tool_events
+        if event["metadata"].get("blocked_by_guardrail") is True
+    ]
+    assert len(blocked_events) == 1
+    assert blocked_events[0]["metadata"]["tool_invoked"] is False
+    allowed_events = [
+        event
+        for event in tool_events
+        if event["metadata"].get("tool_call_id") == "call_allowed_value"
+    ]
+    assert len(allowed_events) == 1
+    assert allowed_events[0]["metadata"].get("blocked_by_guardrail") is None
+    assert allowed_events[0]["artifacts"].get("input") == "tool_args"
+    assert allowed_events[0]["artifacts"].get("result") == "output"
 
 
 def test_calls_strategy_function_tool_runs_inside_checkpoint_and_caches(

--- a/tests/test_openai_agents_runner_call_strategy.py
+++ b/tests/test_openai_agents_runner_call_strategy.py
@@ -14,6 +14,7 @@ from agents.items import ModelResponse
 from agents.models.interface import Model
 from agents.usage import Usage
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+from pydantic import BaseModel
 from zenml.client import Client
 
 import kitaru.adapters.openai_agents._runner as openai_runner
@@ -24,6 +25,11 @@ from kitaru.adapters.openai_agents import (
     OpenAIRunRequest,
     OpenAIRunStateEnvelope,
 )
+
+
+class StructuredSupportAnswer(BaseModel):
+    verdict: str
+    confidence: float
 
 
 class StaticTextModel(Model):
@@ -338,6 +344,27 @@ def test_opaque_context_cache_identity_is_distinct_per_object() -> None:
 
     assert first["python_type"] == second["python_type"]
     assert first != second
+
+
+def test_runner_call_strategy_preserves_structured_final_output() -> None:
+    model = StaticTextModel('{"verdict":"safe","confidence":0.91}')
+    agent = Agent(
+        name="runner-structured",
+        model=model,
+        output_type=StructuredSupportAnswer,
+    )
+    runner = KitaruRunner(
+        agent,
+        checkpoint_strategy="runner_call",
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    result = runner.run_sync(OpenAIRunRequest.start("return structured result"))
+
+    assert result.status == "completed"
+    assert isinstance(result.final_output, StructuredSupportAnswer)
+    assert result.final_output.verdict == "safe"
+    assert result.final_output.confidence == 0.91
 
 
 def test_runner_call_strategy_checkpoints_outer_runner_and_caches(


### PR DESCRIPTION
## What changed

- Added calls-strategy visibility for OpenAI Agents SDK tool-input guardrails that block before the tool function runs.
- Added structured-output regression coverage for both supported OpenAI Agents checkpoint strategies.
- Updated the OpenAI Agents adapter guide with the structured-output, guardrail-observability, and nested-runner boundaries.

## Why

Tool-input guardrails can reject a tool call before Kitaru's normal tool wrapper gets to invoke the function. Before this change, that meant the run could have a model-requested tool call but no tool-call-shaped Kitaru event for the blocked attempt. The adapter now records that blocked attempt as an existing `tool_call` event with guardrail metadata, without creating a new event type or saving rejected tool arguments as a tool checkpoint.

## Reviewer Notes

The core behavior lives in `src/kitaru/adapters/openai_agents/_tools.py`. When Kitaru copies an OpenAI `FunctionTool`, it now also copies/wraps any tool-input guardrails. If a guardrail returns `reject_content` or `raise_exception`, Kitaru records a `tool_call` event with `tool_invoked=false`, `blocked_by_guardrail=true`, the guardrail name/index, and the SDK tool call id. Normal allowed tool calls still go through the existing tool checkpoint path.

The important boundary is deliberate: blocked guardrails do **not** create a tool checkpoint and do **not** save rejected args as tool-event artifacts. This gives reviewers/users visibility that a model-requested tool call was blocked, while avoiding persistence of arguments that the guardrail rejected before tool execution.

Structured outputs are covered as a regression rather than changing adapter behavior: `Agent(output_type=...)` should continue returning typed final outputs in both `calls` and `runner_call` strategies.

### Reproduction

Run the focused OpenAI Agents tests:

```bash
uv run pytest \
  tests/test_openai_agents_calls_strategy.py::test_calls_strategy_tool_input_guardrail_reject_records_blocked_tool_event \
  tests/test_openai_agents_calls_strategy.py::test_calls_strategy_tool_input_guardrail_raise_records_failed_tool_event \
  tests/test_openai_agents_calls_strategy.py::test_calls_strategy_allowed_and_blocked_guardrails_keep_tool_event_order \
  tests/test_openai_agents_calls_strategy.py::test_calls_strategy_preserves_structured_final_output_and_model_event \
  tests/test_openai_agents_runner_call_strategy.py::test_runner_call_strategy_preserves_structured_final_output
```

The guardrail tests prove that blocked tool attempts show up as `tool_call` events with `blocked_by_guardrail=true`, that allowed tools still record the ordinary input/result artifacts, and that `raise_exception` guardrails produce failed tool events. The structured-output tests prove that typed final outputs still flow through both checkpoint strategies.

### Local checks run

- `just check`
- `just test`
