### PR TITLE
Fix PydanticAI HITL wait threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Bumped the minimum ZenML dependency, server image, and Helm subchart versions to `0.94.4` so Kitaru tracks the latest upstream ZenML release.
 
 ### Fixed
+- Fixed PydanticAI direct sync tool-body `kp.wait_for_input(...)` calls under ZenML `0.94.4` by keeping supported flow-scope tool runs on the ZenML pipeline thread instead of Pydantic AI's worker thread.
 - Fixed Kitaru flow return compatibility with ZenML `0.94.4` dynamic-pipeline output validation by persisting plain flow returns as internal artifacts while preserving user-facing Python return values and avoiding marker-shaped user dictionaries being mistaken for hidden tuple metadata.
 
 ## [0.12.0] - 2026-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Bumped the minimum ZenML dependency, server image, and Helm subchart versions to `0.94.4` so Kitaru tracks the latest upstream ZenML release.
 
 ### Fixed
-- Fixed PydanticAI direct sync tool-body `kp.wait_for_input(...)` calls under ZenML `0.94.4` by keeping supported flow-scope tool runs on the ZenML pipeline thread instead of Pydantic AI's worker thread.
+- Fixed PydanticAI direct sync tool-body `kp.wait_for_input(...)` calls under ZenML `0.94.4` with explicit `allow_sync_tool_body_waits=True` opt-in, keeping `tool_checkpoint_config_by_name={"tool": False}` as checkpoint-only configuration.
 - Fixed Kitaru flow return compatibility with ZenML `0.94.4` dynamic-pipeline output validation by persisting plain flow returns as internal artifacts while preserving user-facing Python return values and avoiding marker-shaped user dictionaries being mistaken for hidden tuple metadata.
 
 ## [0.12.0] - 2026-05-17

--- a/docs/content/docs/guides/pydantic-ai-adapter.mdx
+++ b/docs/content/docs/guides/pydantic-ai-adapter.mdx
@@ -93,7 +93,12 @@ Replay the flow with the original run ID to serve cached outputs for completed c
 
 `kp.wait_for_input(...)` is a thin adapter-namespaced wrapper around `kitaru.wait(...)`. The LLM can pick the question, the tool can return the human's typed answer, and the agent can continue with that value as the tool result — but the wait still has to be created at flow scope.
 
-That detail matters in default granular mode. A regular tool body usually runs inside an adapter-created `*_tool` checkpoint, and `kitaru.wait()` is intentionally rejected from checkpoint scope. If a regular tool body needs to call `kp.wait_for_input(...)`, opt that tool out of granular checkpointing:
+Two separate safety rules matter in default granular mode:
+
+1. A regular tool body usually runs inside an adapter-created `*_tool` checkpoint, and `kitaru.wait()` is intentionally rejected from checkpoint scope.
+2. Pydantic AI normally moves sync tool functions to a worker thread, while Kitaru waits must be created on the workflow thread.
+
+If a regular sync tool body needs to call `kp.wait_for_input(...)`, opt that tool out of granular checkpointing. Kitaru uses that opt-out as the signal to keep supported sync tools on the workflow thread for the agent run:
 
 ```python
 from typing import Literal
@@ -128,7 +133,7 @@ durable_agent = KitaruAgent(
 
 Both `question` and `schema` are ordinary arguments, so the tool body can compute them, branch on agent state, prepend context, or call multiple waits. The adapter attaches identifying metadata (`adapter=pydantic_ai`, `source=tool_body`) so these waits are distinguishable from hand-written `kitaru.wait()` calls in flow code.
 
-If you do not opt the tool out, the adapter fails early with an actionable `KitaruUsageError` rather than creating a checkpoint-contained wait that would be hard to resume safely. Another safe option is to move the human gate out of the tool body and call `kitaru.wait()` directly before or after the agent turn in your `@kitaru.flow` code.
+If you do not opt the tool out, the adapter fails early with an actionable `KitaruUsageError` rather than creating a checkpoint-contained wait that would be hard to resume safely. The opt-out does two jobs for a regular sync tool: it keeps the wait out of the synthetic `*_tool` checkpoint, and it lets Kitaru activate its Pydantic AI thread-compatibility layer while the agent run is active. That thread-compatibility layer applies to sync tools for the whole agent run, so Kitaru enables it only for this explicit opt-out shape. Another safe option is to move the human gate out of the tool body and call `kitaru.wait()` directly before or after the agent turn in your `@kitaru.flow` code.
 
 Running locally, Kitaru prompts in the terminal. Running against a deployed server, the execution pauses and can be resumed from anywhere:
 
@@ -139,7 +144,7 @@ kitaru executions resume <exec_id>
 
 ### Declarative sugar: `@hitl_tool`
 
-When a tool is *purely* a wait — nothing computed in the body, no branching — the `@hitl_tool` decorator is a compact alternative. The body is skipped entirely.
+When a tool is *purely* a wait — nothing computed in the body, no branching — prefer the `@hitl_tool` decorator. The body is skipped entirely, and the adapter creates the wait from its own flow-scope code instead of from the user sync tool body.
 
 ```python
 from kitaru.adapters.pydantic_ai import hitl_tool
@@ -184,7 +189,7 @@ Other PydanticAI deferred patterns also route through `kitaru.wait()` **when the
 - raising `pydantic_ai.exceptions.ApprovalRequired` or `CallDeferred` from a tool body
 - calling `kp.wait_for_input(...)` from a tool body
 
-In granular mode, `@hitl_tool` stays flow-scope safe because the adapter deliberately skips the synthetic `*_tool` checkpoint for that call. Regular tools that use native approval/deferred exceptions or `wait_for_input()` must either opt out with `tool_checkpoint_config_by_name={"tool_name": False}` or move the wait to explicit flow code.
+In granular mode, `@hitl_tool` stays flow-scope safe because the adapter deliberately skips the synthetic `*_tool` checkpoint for that call and creates the wait from adapter-managed code. Regular sync tools that call `wait_for_input()` must opt out with `tool_checkpoint_config_by_name={"tool_name": False}` so Kitaru can keep them on the workflow thread, or move the wait to explicit flow code. Regular tools that raise Pydantic AI approval/deferred exceptions also need the opt-out unless they use `@hitl_tool`.
 
 See [Wait, Input, and Resume](/guides/wait-and-resume) for how paused flows are resolved.
 

--- a/docs/content/docs/guides/pydantic-ai-adapter.mdx
+++ b/docs/content/docs/guides/pydantic-ai-adapter.mdx
@@ -98,7 +98,7 @@ Two separate safety rules matter in default granular mode:
 1. A regular tool body usually runs inside an adapter-created `*_tool` checkpoint, and `kitaru.wait()` is intentionally rejected from checkpoint scope.
 2. Pydantic AI normally moves sync tool functions to a worker thread, while Kitaru waits must be created on the workflow thread.
 
-If a regular sync tool body needs to call `kp.wait_for_input(...)`, opt that tool out of granular checkpointing. Kitaru uses that opt-out as the signal to keep supported sync tools on the workflow thread for the agent run:
+If a regular sync tool body needs to call `kp.wait_for_input(...)`, configure two separate things: opt that tool out of granular checkpointing, and explicitly opt into Pydantic AI sync-tool thread compatibility for the run:
 
 ```python
 from typing import Literal
@@ -122,18 +122,19 @@ def collect_bug_report() -> BugReport:
     )
 ```
 
-Then construct the durable agent with a per-tool checkpoint opt-out:
+Then construct the durable agent with a per-tool checkpoint opt-out and the explicit sync-tool wait compatibility flag:
 
 ```python
 durable_agent = KitaruAgent(
     agent,
     tool_checkpoint_config_by_name={"ask_user": False, "collect_bug_report": False},
+    allow_sync_tool_body_waits=True,
 )
 ```
 
 Both `question` and `schema` are ordinary arguments, so the tool body can compute them, branch on agent state, prepend context, or call multiple waits. The adapter attaches identifying metadata (`adapter=pydantic_ai`, `source=tool_body`) so these waits are distinguishable from hand-written `kitaru.wait()` calls in flow code.
 
-If you do not opt the tool out, the adapter fails early with an actionable `KitaruUsageError` rather than creating a checkpoint-contained wait that would be hard to resume safely. The opt-out does two jobs for a regular sync tool: it keeps the wait out of the synthetic `*_tool` checkpoint, and it lets Kitaru activate its Pydantic AI thread-compatibility layer while the agent run is active. That thread-compatibility layer applies to sync tools for the whole agent run, so Kitaru enables it only for this explicit opt-out shape. Another safe option is to move the human gate out of the tool body and call `kitaru.wait()` directly before or after the agent turn in your `@kitaru.flow` code.
+If you do not opt the tool out, the adapter fails early with an actionable `KitaruUsageError` rather than creating a checkpoint-contained wait that would be hard to resume safely. The opt-out is checkpoint-only: it keeps the wait out of the synthetic `*_tool` checkpoint. The `allow_sync_tool_body_waits=True` flag separately asks Pydantic AI to keep supported sync tools on the workflow thread while the agent run is active. That compatibility layer applies to sync tools for the whole agent run, so Kitaru only enables it when you ask for it explicitly. The trade-off is concrete: any supported sync tool in that run may execute inline instead of using Pydantic AI's normal worker-thread path, so avoid mixing this opt-in with slow/blocking sync tools if you rely on normal tool parallelism. Another safe option is to move the human gate out of the tool body and call `kitaru.wait()` directly before or after the agent turn in your `@kitaru.flow` code.
 
 Running locally, Kitaru prompts in the terminal. Running against a deployed server, the execution pauses and can be resumed from anywhere:
 
@@ -189,7 +190,7 @@ Other PydanticAI deferred patterns also route through `kitaru.wait()` **when the
 - raising `pydantic_ai.exceptions.ApprovalRequired` or `CallDeferred` from a tool body
 - calling `kp.wait_for_input(...)` from a tool body
 
-In granular mode, `@hitl_tool` stays flow-scope safe because the adapter deliberately skips the synthetic `*_tool` checkpoint for that call and creates the wait from adapter-managed code. Regular sync tools that call `wait_for_input()` must opt out with `tool_checkpoint_config_by_name={"tool_name": False}` so Kitaru can keep them on the workflow thread, or move the wait to explicit flow code. Regular tools that raise Pydantic AI approval/deferred exceptions also need the opt-out unless they use `@hitl_tool`.
+In granular mode, `@hitl_tool` stays flow-scope safe because the adapter deliberately skips the synthetic `*_tool` checkpoint for that call and creates the wait from adapter-managed code. Regular sync tools that call `wait_for_input()` need both `tool_checkpoint_config_by_name={"tool_name": False}` and `allow_sync_tool_body_waits=True`, or they should move the wait to explicit flow code. Regular tools that raise Pydantic AI approval/deferred exceptions also need the checkpoint opt-out unless they use `@hitl_tool`.
 
 See [Wait, Input, and Resume](/guides/wait-and-resume) for how paused flows are resolved.
 

--- a/examples/integrations/pydantic_ai_agent/pydantic_ai_adapter.py
+++ b/examples/integrations/pydantic_ai_agent/pydantic_ai_adapter.py
@@ -231,8 +231,12 @@ def demo_hitl_wiring() -> str:
     ``@hitl_tool`` is the safest default because the adapter routes it outside
     granular tool checkpoints. Native ``ApprovalRequired`` / ``CallDeferred``
     tools that may wait should be opted out of tool checkpointing. Ordinary sync
-    tools that call ``kp.wait_for_input(...)`` also need that opt-out so Kitaru
-    can keep the wait out of the tool checkpoint and on the workflow thread.
+    tools that call ``kp.wait_for_input(...)`` need that opt-out plus
+    ``allow_sync_tool_body_waits=True``: the opt-out keeps the wait out of the
+    tool checkpoint, and the explicit flag keeps supported sync tool bodies on
+    the workflow thread for the whole run. That means slow sync tools in the
+    same run can block the workflow thread instead of using Pydantic AI's normal
+    worker-thread path, so ``@hitl_tool`` remains the preferred pure-HITL shape.
     """
     agent = Agent(
         TestModel(call_tools=[]),
@@ -260,6 +264,7 @@ def demo_hitl_wiring() -> str:
             "deferred_side_effect": False,
             "ask_human_directly": False,
         },
+        allow_sync_tool_body_waits=True,
     )
 
     @flow

--- a/examples/integrations/pydantic_ai_agent/pydantic_ai_adapter.py
+++ b/examples/integrations/pydantic_ai_agent/pydantic_ai_adapter.py
@@ -18,6 +18,7 @@ from pydantic_ai.exceptions import ApprovalRequired, CallDeferred
 from pydantic_ai.models.test import TestModel
 
 from kitaru import checkpoint, flow
+from kitaru.adapters import pydantic_ai as kp
 from kitaru.adapters.pydantic_ai import CapturePolicy, KitaruAgent, hitl_tool
 
 # Fresh suffix per run so cached artifacts from prior runs don't collide.
@@ -229,7 +230,9 @@ def demo_hitl_wiring() -> str:
 
     ``@hitl_tool`` is the safest default because the adapter routes it outside
     granular tool checkpoints. Native ``ApprovalRequired`` / ``CallDeferred``
-    tools that may wait should be opted out of tool checkpointing.
+    tools that may wait should be opted out of tool checkpointing. Ordinary sync
+    tools that call ``kp.wait_for_input(...)`` also need that opt-out so Kitaru
+    can keep the wait out of the tool checkpoint and on the workflow thread.
     """
     agent = Agent(
         TestModel(call_tools=[]),
@@ -246,11 +249,16 @@ def demo_hitl_wiring() -> str:
     def deferred_side_effect() -> str:
         raise CallDeferred("Queued for async completion.")
 
+    @agent.tool_plain
+    def ask_human_directly(question: str = "What should happen next?") -> str:
+        return kp.wait_for_input(schema=str, question=question)
+
     wired = KitaruAgent(
         agent,
         tool_checkpoint_config_by_name={
             "approval_required": False,
             "deferred_side_effect": False,
+            "ask_human_directly": False,
         },
     )
 

--- a/src/kitaru/adapters/pydantic_ai/README.md
+++ b/src/kitaru/adapters/pydantic_ai/README.md
@@ -137,11 +137,11 @@ Other PydanticAI deferred patterns can also route through `kitaru.wait()` **when
 
 Durable waits need a stable Pydantic AI `tool_call_id`. The adapter uses that id to make the wait name deterministic, so a resumed run looks for the same human input instead of inventing a new wait. If Pydantic AI does not provide a stable, sanitizable `tool_call_id`, Kitaru raises rather than falling back to a random wait name.
 
-In the default granular mode, explicit `@hitl_tool` calls create a wait point directly at flow scope instead of first creating an empty `*_tool` checkpoint. Concretely, the timeline shows the human wait as the durable anchor for that call.
+In the default granular mode, explicit `@hitl_tool` calls create a wait point directly at flow scope instead of first creating an empty `*_tool` checkpoint. Concretely, the timeline shows the human wait as the durable anchor for that call. Prefer `@hitl_tool` for tools that are purely human-input gates.
 
-Regular tool bodies are different. A normal tool in granular mode usually runs inside an adapter-created `*_tool` checkpoint, and `kitaru.wait()` is intentionally rejected from checkpoint scope. `wait_for_input()` does not bypass this guard: if a regular tool body raises `ApprovalRequired` / `CallDeferred` or calls `wait_for_input()` from inside that checkpoint, Kitaru fails early with guidance instead of creating a confusing checkpoint-contained wait.
+Regular sync tool bodies are different. A normal tool in granular mode usually runs inside an adapter-created `*_tool` checkpoint, and Pydantic AI normally runs sync tools on a worker thread. Kitaru waits need both conditions to be safe: they must be outside the synthetic checkpoint and on the workflow thread. `wait_for_input()` does not bypass these guards: if a regular tool body raises `ApprovalRequired` / `CallDeferred` or calls `wait_for_input()` from inside that checkpoint, Kitaru fails early with guidance instead of creating a confusing checkpoint-contained wait.
 
-Use one of these safe patterns for regular tool-body waits:
+Use one of these safe patterns for regular tool-body waits. The per-tool `False` opt-out keeps the wait out of the synthetic `*_tool` checkpoint and lets Kitaru activate its Pydantic AI thread-compatibility layer for supported sync tools during the agent run. That compatibility layer is run-wide, so Kitaru only enables it for this explicit opt-out shape:
 
 ```python
 durable_agent = KitaruAgent(
@@ -151,6 +151,8 @@ durable_agent = KitaruAgent(
 ```
 
 Or move the human gate outside the tool entirely — for example, call `kitaru.wait()` before or after the agent turn in your `@kitaru.flow` code.
+
+If the compatibility layer is unavailable for a future Pydantic AI version, direct `wait_for_input()` calls from sync tool bodies fail with a Kitaru error that explains the worker-thread problem and points back to these patterns.
 
 This also affects where event details land. Flow-scope explicit HITL calls are still logged as adapter event metadata, but checkpoint artifacts such as `event_log`, `run_summary`, and captured tool args/results are only saved when there is an actual checkpoint scope to attach them to.
 

--- a/src/kitaru/adapters/pydantic_ai/README.md
+++ b/src/kitaru/adapters/pydantic_ai/README.md
@@ -141,18 +141,19 @@ In the default granular mode, explicit `@hitl_tool` calls create a wait point di
 
 Regular sync tool bodies are different. A normal tool in granular mode usually runs inside an adapter-created `*_tool` checkpoint, and Pydantic AI normally runs sync tools on a worker thread. Kitaru waits need both conditions to be safe: they must be outside the synthetic checkpoint and on the workflow thread. `wait_for_input()` does not bypass these guards: if a regular tool body raises `ApprovalRequired` / `CallDeferred` or calls `wait_for_input()` from inside that checkpoint, Kitaru fails early with guidance instead of creating a confusing checkpoint-contained wait.
 
-Use one of these safe patterns for regular tool-body waits. The per-tool `False` opt-out keeps the wait out of the synthetic `*_tool` checkpoint and lets Kitaru activate its Pydantic AI thread-compatibility layer for supported sync tools during the agent run. That compatibility layer is run-wide, so Kitaru only enables it for this explicit opt-out shape:
+Use one of these safe patterns for regular tool-body waits. The per-tool `False` opt-out keeps the wait out of the synthetic `*_tool` checkpoint. The separate `allow_sync_tool_body_waits=True` flag explicitly asks Kitaru to activate Pydantic AI thread compatibility for supported sync tools during the agent run. That compatibility layer is run-wide, so Kitaru only enables it when you ask for it directly. The trade-off is concrete: any supported sync tool in that run may execute inline instead of using Pydantic AI's normal worker-thread path, so avoid mixing this opt-in with slow/blocking sync tools if you rely on normal tool parallelism:
 
 ```python
 durable_agent = KitaruAgent(
     agent,
-    tool_checkpoint_config_by_name={"ask_user": False},  # this tool waits at flow scope
+    tool_checkpoint_config_by_name={"ask_user": False},  # checkpoint opt-out only
+    allow_sync_tool_body_waits=True,  # run sync tool bodies on the workflow thread
 )
 ```
 
 Or move the human gate outside the tool entirely — for example, call `kitaru.wait()` before or after the agent turn in your `@kitaru.flow` code.
 
-If the compatibility layer is unavailable for a future Pydantic AI version, direct `wait_for_input()` calls from sync tool bodies fail with a Kitaru error that explains the worker-thread problem and points back to these patterns.
+If the compatibility layer is unavailable for a future Pydantic AI version, Kitaru fails before the agent enters user sync tool bodies and includes installed-version details plus guidance to use `@hitl_tool(...)` or move the wait into explicit flow code.
 
 This also affects where event details land. Flow-scope explicit HITL calls are still logged as adapter event metadata, but checkpoint artifacts such as `event_log`, `run_summary`, and captured tool args/results are only saved when there is an actual checkpoint scope to attach them to.
 

--- a/src/kitaru/adapters/pydantic_ai/_agent.py
+++ b/src/kitaru/adapters/pydantic_ai/_agent.py
@@ -48,6 +48,7 @@ from ._mcp_server import has_running_mcp_toolset
 from ._model import KitaruModel, model_cache_run_context
 from ._policy import CapturePolicy
 from ._toolset import kitaruify_toolset
+from ._threading_compat import inline_sync_tool_execution
 from ._tracking import get_current_tracker, tracker_scope
 from ._utils import (
     CheckpointConfig,
@@ -803,6 +804,23 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             "Use `await agent.run(...)` instead."
         )
 
+    def _should_inline_sync_tools(self) -> bool:
+        """Return whether this agent run needs Pydantic AI sync tools inline.
+
+        This is deliberately run-wide rather than per-tool. Pydantic AI decides
+        whether to offload sync tools before Kitaru reaches an individual tool
+        body, so the safe compatibility seam is the agent run boundary. Keep the
+        predicate narrow to agents with explicit per-tool checkpoint opt-outs.
+        """
+        return bool(
+            self._granular_checkpoints
+            and self._tool_checkpoint_config_by_name
+            and any(
+                override is False
+                for override in self._tool_checkpoint_config_by_name.values()
+            )
+        )
+
     def _ensure_auto_flow_mcp_lifecycle_safe(
         self,
         *,
@@ -953,6 +971,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 self._kitaru_overrides(),
                 self._tracking_scope(),
                 self._allow_internal_iter(),
+                inline_sync_tool_execution(
+                    enabled=self._should_inline_sync_tools()
+                ),
                 model_cache_run_context(
                     conversation_id=conversation_id, message_history=effective_history
                 ),
@@ -1061,6 +1082,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 self._kitaru_overrides(),
                 self._tracking_scope(),
                 self._allow_internal_iter(),
+                inline_sync_tool_execution(
+                    enabled=self._should_inline_sync_tools()
+                ),
                 model_cache_run_context(
                     conversation_id=conversation_id, message_history=effective_history
                 ),

--- a/src/kitaru/adapters/pydantic_ai/_agent.py
+++ b/src/kitaru/adapters/pydantic_ai/_agent.py
@@ -48,7 +48,7 @@ from ._mcp_server import has_running_mcp_toolset
 from ._model import KitaruModel, model_cache_run_context
 from ._policy import CapturePolicy
 from ._toolset import kitaruify_toolset
-from ._threading_compat import inline_sync_tool_execution
+from ._threading_compat import inline_sync_tool_execution as _inline_sync_tool_execution
 from ._tracking import get_current_tracker, tracker_scope
 from ._utils import (
     CheckpointConfig,
@@ -90,6 +90,13 @@ _AUTO_FLOW_LOCK = threading.Lock()
 
 if f"src.{__name__}" not in sys.modules:
     sys.modules[f"src.{__name__}"] = sys.modules[__name__]
+
+
+def _has_tool_checkpoint_opt_out(
+    overrides: ToolCheckpointOverrides | None,
+) -> bool:
+    """Return whether any named tool explicitly opts out of checkpointing."""
+    return bool(overrides and any(override is False for override in overrides.values()))
 
 
 class _AutoFlowSlot:
@@ -291,6 +298,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         tool_checkpoint_config_by_name: ToolCheckpointOverrides | None = None,
         mcp_checkpoint_config: CheckpointConfig | None = None,
         persist_message_history: bool = False,
+        allow_sync_tool_body_waits: bool = False,
     ) -> None:
         """Wrap an agent so its runs become durable under Kitaru.
 
@@ -310,6 +318,16 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         **Turn mode** (``granular_checkpoints=False``): each run opens one
         ``@kitaru.checkpoint`` named after the agent; model/tool/MCP calls are
         recorded as child events under that checkpoint.
+
+        If an ordinary synchronous Pydantic AI tool body calls
+        ``kp.wait_for_input(...)`` directly, pass both
+        ``tool_checkpoint_config_by_name={"tool_name": False}`` and
+        ``allow_sync_tool_body_waits=True``. The ``False`` override only skips
+        the adapter-created tool checkpoint. The explicit
+        ``allow_sync_tool_body_waits`` flag asks Pydantic AI to keep supported
+        sync tool bodies on the workflow thread for the whole run, and Kitaru
+        fails before tool execution if that private compatibility hook is not
+        available.
 
         When ``persist_message_history=True``, the adapter remembers the final
         ``result.all_messages()`` of each run on the instance and auto-injects
@@ -367,6 +385,24 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             raise KitaruUsageError(
                 "Per-call checkpoint configs require `granular_checkpoints=True`."
             )
+        if allow_sync_tool_body_waits and not granular_checkpoints:
+            raise KitaruUsageError(
+                "`allow_sync_tool_body_waits=True` requires `granular_checkpoints=True` "
+                "and a matching checkpoint opt-out such as "
+                "`tool_checkpoint_config_by_name={\"tool_name\": False}`."
+            )
+        if allow_sync_tool_body_waits and not _has_tool_checkpoint_opt_out(
+            tool_checkpoint_config_by_name
+        ):
+            raise KitaruUsageError(
+                "`allow_sync_tool_body_waits=True` requires at least one per-tool "
+                "checkpoint opt-out such as "
+                "`tool_checkpoint_config_by_name={\"tool_name\": False}`. "
+                "The opt-out keeps `kp.wait_for_input(...)` out of a synthetic "
+                "tool checkpoint; the flag only controls Pydantic AI sync-tool "
+                "threading."
+            )
+        self._allow_sync_tool_body_waits = allow_sync_tool_body_waits
         if granular_checkpoints:
             self._model_checkpoint_config = (
                 validate_checkpoint_config(
@@ -416,6 +452,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 "toolset_count": len(self._toolsets),
                 "granular_checkpoints": granular_checkpoints,
                 "persist_message_history": persist_message_history,
+                "allow_sync_tool_body_waits": allow_sync_tool_body_waits,
             },
         )
 
@@ -805,21 +842,15 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         )
 
     def _should_inline_sync_tools(self) -> bool:
-        """Return whether this agent run needs Pydantic AI sync tools inline.
+        """Return whether the user explicitly requested inline sync tools.
 
         This is deliberately run-wide rather than per-tool. Pydantic AI decides
         whether to offload sync tools before Kitaru reaches an individual tool
-        body, so the safe compatibility seam is the agent run boundary. Keep the
-        predicate narrow to agents with explicit per-tool checkpoint opt-outs.
+        body, so the safe compatibility seam is the agent run boundary. The
+        checkpoint opt-out remains checkpoint-only; this separate flag controls
+        the private Pydantic AI threading compatibility path.
         """
-        return bool(
-            self._granular_checkpoints
-            and self._tool_checkpoint_config_by_name
-            and any(
-                override is False
-                for override in self._tool_checkpoint_config_by_name.values()
-            )
-        )
+        return self._allow_sync_tool_body_waits
 
     def _ensure_auto_flow_mcp_lifecycle_safe(
         self,
@@ -971,9 +1002,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 self._kitaru_overrides(),
                 self._tracking_scope(),
                 self._allow_internal_iter(),
-                inline_sync_tool_execution(
-                    enabled=self._should_inline_sync_tools()
-                ),
+                _inline_sync_tool_execution(enabled=self._should_inline_sync_tools()),
                 model_cache_run_context(
                     conversation_id=conversation_id, message_history=effective_history
                 ),
@@ -1082,9 +1111,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 self._kitaru_overrides(),
                 self._tracking_scope(),
                 self._allow_internal_iter(),
-                inline_sync_tool_execution(
-                    enabled=self._should_inline_sync_tools()
-                ),
+                _inline_sync_tool_execution(enabled=self._should_inline_sync_tools()),
                 model_cache_run_context(
                     conversation_id=conversation_id, message_history=effective_history
                 ),

--- a/src/kitaru/adapters/pydantic_ai/_threading_compat.py
+++ b/src/kitaru/adapters/pydantic_ai/_threading_compat.py
@@ -3,8 +3,8 @@
 Pydantic AI normally moves synchronous tool functions to a worker thread. That
 is safe for ordinary tools, but Kitaru waits must be created from the workflow
 thread. The upstream hook is run-scoped rather than per-tool-scoped, so callers
-should enable it only for run shapes that need direct tool-body waits. Keep the
-private Pydantic AI import isolated here so the rest of the adapter has one
+must enable it explicitly for run shapes that need direct tool-body waits. Keep
+the private Pydantic AI import isolated here so the rest of the adapter has one
 small seam to update if the upstream hook changes.
 """
 
@@ -12,33 +12,54 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from contextlib import ExitStack, contextmanager
+from importlib import metadata
 from typing import Any
 
-from ._logging import logger
+from kitaru.errors import KitaruUsageError
 
 _DISABLE_THREADS_ATTR = "disable_threads"
 
 
-def _resolve_disable_threads() -> Callable[[], Any] | None:
-    """Return Pydantic AI's inline-sync-tools hook if it is available."""
+def _pydantic_ai_version() -> str:
+    """Return installed Pydantic AI distribution details for error messages."""
+    versions: list[str] = []
+    for distribution in ("pydantic-ai-slim", "pydantic-ai"):
+        try:
+            versions.append(f"{distribution} {metadata.version(distribution)}")
+        except metadata.PackageNotFoundError:
+            continue
+    return ", ".join(versions) if versions else "unknown Pydantic AI version"
+
+
+def _compatibility_error(reason: str) -> KitaruUsageError:
+    version = _pydantic_ai_version()
+    return KitaruUsageError(
+        "`allow_sync_tool_body_waits=True` asks Kitaru to keep synchronous "
+        "Pydantic AI tool bodies on the workflow thread so direct "
+        "`kp.wait_for_input(...)` calls can create flow-scope waits safely. "
+        f"Kitaru could not enable that compatibility path because {reason}. "
+        f"Installed Pydantic AI: {version}. Use `@hitl_tool(...)`, move the "
+        "wait into explicit `@kitaru.flow` code, or install a Pydantic AI "
+        "version that still exposes `pydantic_ai._utils.disable_threads`."
+    )
+
+
+def _resolve_disable_threads() -> Callable[[], Any]:
+    """Return Pydantic AI's inline-sync-tools hook or raise guidance."""
     try:
         from pydantic_ai import _utils as pydantic_ai_utils
-    except Exception:  # pragma: no cover - adapter import already guards this
-        logger.debug(
-            "Could not import pydantic_ai._utils for Kitaru thread compatibility.",
-            exc_info=True,
-        )
-        return None
+    except Exception as exc:  # pragma: no cover - adapter import already guards this
+        raise _compatibility_error("`pydantic_ai._utils` could not be imported") from exc
 
     hook = getattr(pydantic_ai_utils, _DISABLE_THREADS_ATTR, None)
     if callable(hook):
         return hook
 
-    logger.debug(
-        "pydantic_ai._utils.disable_threads is unavailable; sync tools may run "
-        "on worker threads."
-    )
-    return None
+    if hook is None:
+        reason = "`pydantic_ai._utils.disable_threads` is missing"
+    else:
+        reason = "`pydantic_ai._utils.disable_threads` is not callable"
+    raise _compatibility_error(reason)
 
 
 @contextmanager
@@ -46,46 +67,38 @@ def inline_sync_tool_execution(*, enabled: bool) -> Iterator[bool]:
     """Temporarily ask Pydantic AI to run sync tools inline.
 
     Args:
-        enabled: Whether this run shape needs flow-thread-compatible sync tools.
+        enabled: Whether this run shape explicitly opted into flow-thread-
+            compatible sync tools.
 
     Yields:
         ``True`` when the Pydantic AI hook was entered, otherwise ``False``.
-        Missing or unusable hooks degrade to a no-op so ordinary non-HITL runs do
-        not fail at construction time. If a direct tool-body wait later reaches
-        the workflow runtime from a worker thread, ``wait_for_input()`` rewrites
-        that specific error into user-facing guidance.
+
+    Raises:
+        KitaruUsageError: If ``enabled`` is true but the private Pydantic AI
+            hook is missing, non-callable, or cannot be entered. This fails
+            before user sync tool bodies can run side effects on the wrong
+            thread.
     """
     if not enabled:
         yield False
         return
 
     hook = _resolve_disable_threads()
-    if hook is None:
-        yield False
-        return
 
     try:
         manager = hook()
-    except Exception:
-        logger.warning(
-            "Could not create Pydantic AI inline-sync-tools context; sync tools "
-            "may run on worker threads.",
-            exc_info=True,
-        )
-        yield False
-        return
+    except Exception as exc:
+        raise _compatibility_error(
+            "`pydantic_ai._utils.disable_threads()` could not create a context manager"
+        ) from exc
 
     stack = ExitStack()
     try:
         stack.enter_context(manager)
-    except Exception:
-        logger.warning(
-            "Could not enter Pydantic AI inline-sync-tools context; sync tools "
-            "may run on worker threads.",
-            exc_info=True,
-        )
-        yield False
-        return
+    except Exception as exc:
+        raise _compatibility_error(
+            "`pydantic_ai._utils.disable_threads()` could not be entered"
+        ) from exc
 
     with stack:
         yield True

--- a/src/kitaru/adapters/pydantic_ai/_threading_compat.py
+++ b/src/kitaru/adapters/pydantic_ai/_threading_compat.py
@@ -1,0 +1,91 @@
+"""Compatibility helpers for Pydantic AI sync-tool threading.
+
+Pydantic AI normally moves synchronous tool functions to a worker thread. That
+is safe for ordinary tools, but Kitaru waits must be created from the workflow
+thread. The upstream hook is run-scoped rather than per-tool-scoped, so callers
+should enable it only for run shapes that need direct tool-body waits. Keep the
+private Pydantic AI import isolated here so the rest of the adapter has one
+small seam to update if the upstream hook changes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import ExitStack, contextmanager
+from typing import Any
+
+from ._logging import logger
+
+_DISABLE_THREADS_ATTR = "disable_threads"
+
+
+def _resolve_disable_threads() -> Callable[[], Any] | None:
+    """Return Pydantic AI's inline-sync-tools hook if it is available."""
+    try:
+        from pydantic_ai import _utils as pydantic_ai_utils
+    except Exception:  # pragma: no cover - adapter import already guards this
+        logger.debug(
+            "Could not import pydantic_ai._utils for Kitaru thread compatibility.",
+            exc_info=True,
+        )
+        return None
+
+    hook = getattr(pydantic_ai_utils, _DISABLE_THREADS_ATTR, None)
+    if callable(hook):
+        return hook
+
+    logger.debug(
+        "pydantic_ai._utils.disable_threads is unavailable; sync tools may run "
+        "on worker threads."
+    )
+    return None
+
+
+@contextmanager
+def inline_sync_tool_execution(*, enabled: bool) -> Iterator[bool]:
+    """Temporarily ask Pydantic AI to run sync tools inline.
+
+    Args:
+        enabled: Whether this run shape needs flow-thread-compatible sync tools.
+
+    Yields:
+        ``True`` when the Pydantic AI hook was entered, otherwise ``False``.
+        Missing or unusable hooks degrade to a no-op so ordinary non-HITL runs do
+        not fail at construction time. If a direct tool-body wait later reaches
+        the workflow runtime from a worker thread, ``wait_for_input()`` rewrites
+        that specific error into user-facing guidance.
+    """
+    if not enabled:
+        yield False
+        return
+
+    hook = _resolve_disable_threads()
+    if hook is None:
+        yield False
+        return
+
+    try:
+        manager = hook()
+    except Exception:
+        logger.warning(
+            "Could not create Pydantic AI inline-sync-tools context; sync tools "
+            "may run on worker threads.",
+            exc_info=True,
+        )
+        yield False
+        return
+
+    stack = ExitStack()
+    try:
+        stack.enter_context(manager)
+    except Exception:
+        logger.warning(
+            "Could not enter Pydantic AI inline-sync-tools context; sync tools "
+            "may run on worker threads.",
+            exc_info=True,
+        )
+        yield False
+        return
+
+    with stack:
+        yield True

--- a/src/kitaru/adapters/pydantic_ai/_toolset.py
+++ b/src/kitaru/adapters/pydantic_ai/_toolset.py
@@ -74,10 +74,13 @@ def _raise_checkpoint_wait_not_supported(tool_name: str, kind: DeferredKind) -> 
         f"PydanticAI tool {tool_name!r} requested {kind!r} human input while "
         "running inside a checkpoint. Kitaru waits must be created at flow "
         "scope, not from checkpoint scope. Use `@hitl_tool` for pure wait "
-        "tools, disable checkpointing for this tool with "
-        '`tool_checkpoint_config_by_name={"tool_name": False}` while running '
-        "the agent in granular mode, or move the wait before/after the agent "
-        "call in flow code."
+        "tools. For ordinary tool bodies, disable checkpointing for this tool "
+        'with `tool_checkpoint_config_by_name={"tool_name": False}` while '
+        "running the agent in granular mode. If the ordinary sync tool body "
+        "calls `kp.wait_for_input(...)` directly, also pass "
+        "`allow_sync_tool_body_waits=True` so supported sync tool bodies run "
+        "on the workflow thread for the whole agent run. Or move the wait "
+        "before/after the agent call in flow code."
     )
 
 

--- a/src/kitaru/adapters/pydantic_ai/_wait_for_input.py
+++ b/src/kitaru/adapters/pydantic_ai/_wait_for_input.py
@@ -24,9 +24,10 @@ def wait_for_input(
 
     This is a thin metadata wrapper around ``kitaru.wait()``. Call it from
     flow scope, or from adapter paths that deliberately avoid a tool
-    checkpoint. If a tool body needs to wait for a human, prefer
-    ``@hitl_tool`` or opt that tool out of granular checkpointing with
-    ``tool_checkpoint_config_by_name={"tool_name": False}``.
+    checkpoint. If an ordinary sync tool body needs to wait for a human,
+    prefer ``@hitl_tool`` or pass both
+    ``tool_checkpoint_config_by_name={"tool_name": False}`` and
+    ``allow_sync_tool_body_waits=True`` to ``KitaruAgent``.
     """
     combined_metadata: dict[str, Any] = {
         **(metadata or {}),
@@ -49,13 +50,13 @@ def wait_for_input(
             "`kp.wait_for_input(...)` was called from a sync Pydantic AI tool "
             "body that ran on a worker thread, but Kitaru waits must be "
             "created on the workflow thread. For an ordinary tool body, keep "
-            "the agent in default granular mode and opt that tool out of the "
+            "the agent in default granular mode, opt that tool out of the "
             "synthetic tool checkpoint with "
-            "`tool_checkpoint_config_by_name={\"tool_name\": False}`; Kitaru "
-            "then keeps supported sync tools on the workflow thread while the "
-            "agent run is active. For a pure human-input tool, prefer "
-            "`@hitl_tool(...)`. Or move the wait to explicit `@kitaru.flow` "
-            "code before or after the agent turn. If you already configured "
-            "the opt-out, your installed Pydantic AI version may no longer "
-            "provide Kitaru's thread-compatibility hook."
+            "`tool_checkpoint_config_by_name={\"tool_name\": False}`, and "
+            "pass `allow_sync_tool_body_waits=True` to `KitaruAgent`. The "
+            "opt-out keeps the wait out of a checkpoint; the explicit flag "
+            "asks Pydantic AI to keep supported sync tools on the workflow "
+            "thread while the agent run is active. For a pure human-input "
+            "tool, prefer `@hitl_tool(...)`. Or move the wait to explicit "
+            "`@kitaru.flow` code before or after the agent turn."
         ) from error

--- a/src/kitaru/adapters/pydantic_ai/_wait_for_input.py
+++ b/src/kitaru/adapters/pydantic_ai/_wait_for_input.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from typing import Any
 
 import kitaru
+from kitaru.errors import KitaruUsageError
 
 from ._constants import ADAPTER_ID, ADAPTER_METADATA_KEY
 
 _SOURCE_METADATA_KEY = 'source'
 _SOURCE_TOOL_BODY = 'tool_body'
+_ZENML_WORKER_THREAD_ERROR = 'must be called from the pipeline thread'
 
 
 def wait_for_input(
@@ -32,10 +34,28 @@ def wait_for_input(
         _SOURCE_METADATA_KEY: _SOURCE_TOOL_BODY,
     }
 
-    return kitaru.wait(
-        schema=schema,
-        name=name,
-        question=question,
-        timeout=timeout,
-        metadata=combined_metadata,
-    )
+    try:
+        return kitaru.wait(
+            schema=schema,
+            name=name,
+            question=question,
+            timeout=timeout,
+            metadata=combined_metadata,
+        )
+    except RuntimeError as error:
+        if _ZENML_WORKER_THREAD_ERROR not in str(error):
+            raise
+        raise KitaruUsageError(
+            "`kp.wait_for_input(...)` was called from a sync Pydantic AI tool "
+            "body that ran on a worker thread, but Kitaru waits must be "
+            "created on the workflow thread. For an ordinary tool body, keep "
+            "the agent in default granular mode and opt that tool out of the "
+            "synthetic tool checkpoint with "
+            "`tool_checkpoint_config_by_name={\"tool_name\": False}`; Kitaru "
+            "then keeps supported sync tools on the workflow thread while the "
+            "agent run is active. For a pure human-input tool, prefer "
+            "`@hitl_tool(...)`. Or move the wait to explicit `@kitaru.flow` "
+            "code before or after the agent turn. If you already configured "
+            "the opt-out, your installed Pydantic AI version may no longer "
+            "provide Kitaru's thread-compatibility hook."
+        ) from error

--- a/src/kitaru/adapters/pydantic_ai/_wait_for_input.py
+++ b/src/kitaru/adapters/pydantic_ai/_wait_for_input.py
@@ -3,13 +3,28 @@ from __future__ import annotations
 from typing import Any
 
 import kitaru
-from kitaru.errors import KitaruUsageError
+from kitaru.errors import KitaruContextError, KitaruUsageError
+from kitaru.wait import _WAIT_INSIDE_CHECKPOINT_ERROR
 
 from ._constants import ADAPTER_ID, ADAPTER_METADATA_KEY
 
 _SOURCE_METADATA_KEY = 'source'
 _SOURCE_TOOL_BODY = 'tool_body'
 _ZENML_WORKER_THREAD_ERROR = 'must be called from the pipeline thread'
+
+
+def _tool_body_wait_guidance(*, prefix: str) -> KitaruUsageError:
+    return KitaruUsageError(
+        f"{prefix} For an ordinary tool body, keep the agent in default "
+        "granular mode, opt that tool out of the synthetic tool checkpoint "
+        "with `tool_checkpoint_config_by_name={\"tool_name\": False}`, and "
+        "pass `allow_sync_tool_body_waits=True` to `KitaruAgent`. The "
+        "opt-out keeps the wait out of a checkpoint; the explicit flag asks "
+        "Pydantic AI to keep supported sync tools on the workflow thread "
+        "while the agent run is active. For a pure human-input tool, prefer "
+        "`@hitl_tool(...)`. Or move the wait to explicit `@kitaru.flow` code "
+        "before or after the agent turn."
+    )
 
 
 def wait_for_input(
@@ -43,20 +58,23 @@ def wait_for_input(
             timeout=timeout,
             metadata=combined_metadata,
         )
+    except KitaruContextError as error:
+        if str(error) != _WAIT_INSIDE_CHECKPOINT_ERROR:
+            raise
+        raise _tool_body_wait_guidance(
+            prefix=(
+                "`kp.wait_for_input(...)` was called from a sync Pydantic AI "
+                "tool body while that tool was running inside an adapter-created "
+                "checkpoint, but Kitaru waits must be created at flow scope."
+            )
+        ) from error
     except RuntimeError as error:
         if _ZENML_WORKER_THREAD_ERROR not in str(error):
             raise
-        raise KitaruUsageError(
-            "`kp.wait_for_input(...)` was called from a sync Pydantic AI tool "
-            "body that ran on a worker thread, but Kitaru waits must be "
-            "created on the workflow thread. For an ordinary tool body, keep "
-            "the agent in default granular mode, opt that tool out of the "
-            "synthetic tool checkpoint with "
-            "`tool_checkpoint_config_by_name={\"tool_name\": False}`, and "
-            "pass `allow_sync_tool_body_waits=True` to `KitaruAgent`. The "
-            "opt-out keeps the wait out of a checkpoint; the explicit flag "
-            "asks Pydantic AI to keep supported sync tools on the workflow "
-            "thread while the agent run is active. For a pure human-input "
-            "tool, prefer `@hitl_tool(...)`. Or move the wait to explicit "
-            "`@kitaru.flow` code before or after the agent turn."
+        raise _tool_body_wait_guidance(
+            prefix=(
+                "`kp.wait_for_input(...)` was called from a sync Pydantic AI "
+                "tool body that ran on a worker thread, but Kitaru waits must "
+                "be created on the workflow thread."
+            )
         ) from error

--- a/tests/test_phase17_pydantic_ai_adapter.py
+++ b/tests/test_phase17_pydantic_ai_adapter.py
@@ -1,6 +1,7 @@
 """Integration tests for the PydanticAI adapter."""
 
 import asyncio
+import importlib
 import multiprocessing
 import re
 import time
@@ -124,7 +125,7 @@ def _assert_event_artifacts_use_display_names(
 _DIRECT_WAIT_AGENT: KitaruAgent[Any, str] | None = None
 _GUARDED_WAIT_AGENT: KitaruAgent[Any, str] | None = None
 _HITL_WAIT_AGENT: KitaruAgent[Any, str] | None = None
-_CHILD_EVENT_WAIT_INVOKED = "wait_invoked"
+_CHILD_EVENT_ZENML_WAIT_REACHED = "zenml_wait_reached"
 _CHILD_EVENT_COMPLETED = "completed"
 _CHILD_EVENT_ERROR = "error"
 
@@ -151,14 +152,41 @@ def _put_child_event(
     )
 
 
+def _install_child_wait_reached_event(queue: Any) -> Callable[[], None]:
+    """Report after `kitaru.wait()` passes guards and resolves ZenML's wait."""
+    wait_module = cast(Any, importlib.import_module("kitaru.wait"))
+    original_resolve = cast(
+        Callable[[], Callable[..., Any]],
+        wait_module._resolve_zenml_wait,
+    )
+
+    def recording_resolve() -> Callable[..., Any]:
+        zenml_wait = original_resolve()
+
+        def recording_wait(**kwargs: Any) -> Any:
+            _put_child_event(queue, _CHILD_EVENT_ZENML_WAIT_REACHED, kwargs.get("name"))
+            return zenml_wait(**kwargs)
+
+        return recording_wait
+
+    wait_module._resolve_zenml_wait = recording_resolve
+
+    def cleanup() -> None:
+        wait_module._resolve_zenml_wait = original_resolve
+
+    return cleanup
+
+
 def _run_flow_and_report(
     queue: Any,
     flow_definition: Any,
     cleanup: Callable[[], None],
 ) -> None:
     try:
-        flow_definition.run(cache=False)
-        _put_child_event(queue, _CHILD_EVENT_COMPLETED)
+        handle = flow_definition.run(cache=False)
+        _put_child_event(
+            queue, _CHILD_EVENT_COMPLETED, getattr(handle, "exec_id", None)
+        )
     except BaseException as exc:
         _put_child_event(queue, _CHILD_EVENT_ERROR, type(exc).__name__, str(exc))
     finally:
@@ -185,15 +213,7 @@ def pydantic_ai_hitl_wait_flow() -> str:
 
 def _run_direct_wait_flow_until_pause(queue: Any) -> None:
     global _DIRECT_WAIT_AGENT
-    import kitaru as kitaru_module
-
-    original_wait = kitaru_module.wait
-
-    def recording_wait(**kwargs: Any) -> Any:
-        _put_child_event(queue, _CHILD_EVENT_WAIT_INVOKED, kwargs.get("name"))
-        return original_wait(**kwargs)
-
-    kitaru_module.wait = cast(Any, recording_wait)
+    wait_cleanup = _install_child_wait_reached_event(queue)
 
     agent = Agent(
         TestModel(call_tools=["ask_user"]),
@@ -205,6 +225,7 @@ def _run_direct_wait_flow_until_pause(queue: Any) -> None:
     def ask_user() -> str:
         return kp.wait_for_input(
             schema=str,
+            name="direct_tool_wait",
             question="What context should the agent use?",
             timeout=0,
         )
@@ -212,11 +233,12 @@ def _run_direct_wait_flow_until_pause(queue: Any) -> None:
     _DIRECT_WAIT_AGENT = KitaruAgent(
         agent,
         tool_checkpoint_config_by_name={"ask_user": False},
+        allow_sync_tool_body_waits=True,
     )
 
     def cleanup() -> None:
         global _DIRECT_WAIT_AGENT
-        kitaru_module.wait = cast(Any, original_wait)
+        wait_cleanup()
         _DIRECT_WAIT_AGENT = None
 
     _run_flow_and_report(queue, pydantic_ai_direct_wait_flow, cleanup)
@@ -224,15 +246,7 @@ def _run_direct_wait_flow_until_pause(queue: Any) -> None:
 
 def _run_hitl_wait_flow_until_pause(queue: Any) -> None:
     global _HITL_WAIT_AGENT
-    from kitaru.adapters.pydantic_ai import _toolset
-
-    original_invoke_wait = _toolset.KitaruToolset._invoke_wait
-
-    def recording_invoke_wait(self: Any, **kwargs: Any) -> Any:
-        _put_child_event(queue, _CHILD_EVENT_WAIT_INVOKED, kwargs.get("wait_name"))
-        return original_invoke_wait(self, **kwargs)
-
-    _toolset.KitaruToolset._invoke_wait = cast(Any, recording_invoke_wait)
+    wait_cleanup = _install_child_wait_reached_event(queue)
 
     @hitl_tool(question="What should the tool return?", schema=str)
     def ask_human() -> str:
@@ -248,7 +262,7 @@ def _run_hitl_wait_flow_until_pause(queue: Any) -> None:
 
     def cleanup() -> None:
         global _HITL_WAIT_AGENT
-        _toolset.KitaruToolset._invoke_wait = cast(Any, original_invoke_wait)
+        wait_cleanup()
         _HITL_WAIT_AGENT = None
 
     _run_flow_and_report(queue, pydantic_ai_hitl_wait_flow, cleanup)
@@ -259,29 +273,75 @@ def _assert_child_flow_pauses(
     *,
     required_event: str,
     timeout: float = 30.0,
+    post_event_grace: float = 1.0,
 ) -> None:
-    # Use fork when available so the child inherits the xdist worker's already
-    # isolated ZenML/Kitaru environment. With spawn, the child re-imports this
-    # module from scratch; under pytest-xdist that can exit before our target
-    # function reports a structured error event.
-    start_method = (
-        "fork" if "fork" in multiprocessing.get_all_start_methods() else "spawn"
-    )
-    context = cast(Any, multiprocessing.get_context(start_method))
+    # Use fork so the child inherits the xdist worker's already isolated
+    # ZenML/Kitaru environment. Spawn re-imports this module from scratch and
+    # would need explicit per-child fixture paths to avoid cross-test state.
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("Child wait/pause tests require multiprocessing fork isolation.")
+    context = cast(Any, multiprocessing.get_context("fork"))
     queue = context.Queue()
     process = context.Process(target=target, args=(queue,), daemon=True)
     process.start()
 
     saw_required_event = False
+    grace_deadline: float | None = None
     deadline = time.time() + timeout
+
+    def assert_run_is_waiting(exec_id: str | None) -> None:
+        if exec_id is None:
+            pytest.fail(
+                "Child flow reached the real wait callable, then exited without "
+                "reporting an execution id to verify paused status."
+            )
+        status_deadline = time.time() + 5.0
+        last_status = "unknown"
+        while time.time() < status_deadline:
+            run = Client().get_pipeline_run(exec_id, allow_name_prefix_match=False)
+            last_status = str(getattr(run.status, "value", run.status))
+            if last_status == "paused":
+                return
+            time.sleep(0.2)
+        pytest.fail(
+            "Child flow reached the real wait callable and exited, but execution "
+            f"{exec_id} did not enter paused/waiting status; last status was "
+            f"{last_status!r}."
+        )
+
+    def handle_exit_after_wait() -> None:
+        try:
+            event = queue.get(timeout=0.5)
+        except Empty:
+            pytest.fail(
+                "Child flow exited after reaching the real wait callable, but no "
+                "structured error/completed event was reported."
+            )
+        if event.kind == _CHILD_EVENT_ERROR:
+            pytest.fail(
+                "Child flow reached the real wait callable, then failed instead "
+                f"of pausing: {event.detail}: {event.message}"
+            )
+        if event.kind == _CHILD_EVENT_COMPLETED:
+            assert_run_is_waiting(event.detail)
+            return
+        pytest.fail(
+            "Child flow exited after reaching the real wait callable with "
+            f"unexpected event {event.kind!r}."
+        )
+
     try:
         while time.time() < deadline:
             try:
                 event = queue.get(timeout=0.2)
             except Empty:
                 if saw_required_event:
-                    return
-                if not process.is_alive():
+                    assert grace_deadline is not None
+                    if process.is_alive() and time.time() >= grace_deadline:
+                        return
+                    if not process.is_alive():
+                        handle_exit_after_wait()
+                elif not process.is_alive():
                     pytest.fail(
                         "Child flow exited before pausing; required event "
                         f"{required_event!r} was not observed."
@@ -290,13 +350,20 @@ def _assert_child_flow_pauses(
 
             if event.kind == required_event:
                 saw_required_event = True
+                grace_deadline = time.time() + post_event_grace
                 continue
             if event.kind == _CHILD_EVENT_ERROR:
+                if saw_required_event:
+                    pytest.fail(
+                        "Child flow reached the real wait callable, then failed "
+                        f"instead of pausing: {event.detail}: {event.message}"
+                    )
                 pytest.fail(
                     f"Child flow failed before pausing: {event.detail}: {event.message}"
                 )
             if event.kind == _CHILD_EVENT_COMPLETED:
                 if saw_required_event:
+                    assert_run_is_waiting(event.detail)
                     return
                 pytest.fail(f"Child flow completed before reaching {required_event!r}.")
         pytest.fail(f"Child flow did not reach {required_event!r} before timeout.")
@@ -535,15 +602,15 @@ def test_phase17_turn_mode_omits_absent_prompt_and_history_inputs(
     assert any(name.startswith("llm_call_1_response__") for name in artifact_names)
 
 
-def test_phase17_direct_wait_tool_with_checkpoint_opt_out_reaches_wait(
+def test_phase17_direct_wait_tool_with_explicit_thread_opt_in_reaches_wait(
     primed_zenml,
 ) -> None:
-    """A normal sync tool-body wait should stay on the workflow thread."""
+    """A normal sync tool-body wait should opt into workflow-thread execution."""
     del primed_zenml
     _require_wait_support()
     _assert_child_flow_pauses(
         _run_direct_wait_flow_until_pause,
-        required_event=_CHILD_EVENT_WAIT_INVOKED,
+        required_event=_CHILD_EVENT_ZENML_WAIT_REACHED,
     )
 
 
@@ -570,8 +637,11 @@ def test_phase17_direct_wait_tool_without_opt_out_keeps_checkpoint_guard(
     global _GUARDED_WAIT_AGENT
     _GUARDED_WAIT_AGENT = KitaruAgent(agent)
     try:
-        with pytest.raises(KitaruUsageError, match="tool_checkpoint_config_by_name"):
+        with pytest.raises(KitaruUsageError) as exc_info:
             pydantic_ai_guarded_wait_flow.run(cache=False)
+        message = str(exc_info.value)
+        assert "tool_checkpoint_config_by_name" in message
+        assert "allow_sync_tool_body_waits=True" in message
     finally:
         _GUARDED_WAIT_AGENT = None
 
@@ -582,7 +652,7 @@ def test_phase17_hitl_tool_still_reaches_wait(primed_zenml) -> None:
     _require_wait_support()
     _assert_child_flow_pauses(
         _run_hitl_wait_flow_until_pause,
-        required_event=_CHILD_EVENT_WAIT_INVOKED,
+        required_event=_CHILD_EVENT_ZENML_WAIT_REACHED,
     )
 
 

--- a/tests/test_phase17_pydantic_ai_adapter.py
+++ b/tests/test_phase17_pydantic_ai_adapter.py
@@ -4,11 +4,13 @@ import asyncio
 import importlib
 import multiprocessing
 import re
+import sys
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, nullcontext
 from dataclasses import dataclass
+from pathlib import Path
 from queue import Empty
 from typing import Any, cast
 from uuid import uuid4
@@ -177,6 +179,16 @@ def _install_child_wait_reached_event(queue: Any) -> Callable[[], None]:
     return cleanup
 
 
+def _child_run_status(exec_id: str | None) -> str | None:
+    if exec_id is None:
+        return None
+    try:
+        run = Client().get_pipeline_run(exec_id, allow_name_prefix_match=False)
+    except Exception as exc:  # pragma: no cover - reported to parent for diagnostics
+        return f"lookup_failed:{type(exc).__name__}:{exc}"
+    return str(getattr(run.status, "value", run.status))
+
+
 def _run_flow_and_report(
     queue: Any,
     flow_definition: Any,
@@ -184,8 +196,12 @@ def _run_flow_and_report(
 ) -> None:
     try:
         handle = flow_definition.run(cache=False)
+        exec_id = getattr(handle, "exec_id", None)
         _put_child_event(
-            queue, _CHILD_EVENT_COMPLETED, getattr(handle, "exec_id", None)
+            queue,
+            _CHILD_EVENT_COMPLETED,
+            exec_id,
+            _child_run_status(exec_id),
         )
     except BaseException as exc:
         _put_child_event(queue, _CHILD_EVENT_ERROR, type(exc).__name__, str(exc))
@@ -272,15 +288,28 @@ def _assert_child_flow_pauses(
     target: Any,
     *,
     required_event: str,
-    timeout: float = 30.0,
+    timeout: float = 90.0,
     post_event_grace: float = 1.0,
 ) -> None:
-    # Use fork so the child inherits the xdist worker's already isolated
-    # ZenML/Kitaru environment. Spawn re-imports this module from scratch and
-    # would need explicit per-child fixture paths to avoid cross-test state.
-    if "fork" not in multiprocessing.get_all_start_methods():
-        pytest.skip("Child wait/pause tests require multiprocessing fork isolation.")
-    context = cast(Any, multiprocessing.get_context("fork"))
+    # Prefer forkserver over raw fork. Raw fork inherits the parent process's
+    # already-open ZenML/SQLite resources; if another test has already run a
+    # flow in this xdist worker, the child can fail with stale file descriptors
+    # before it reaches the wait. Forkserver still inherits the isolated test
+    # environment, but forks from a clean server process instead of the live
+    # pytest worker.
+    main = sys.modules.get("__main__")
+    if main is not None:
+        main_file = getattr(main, "__file__", None)
+        if main_file is None or Path(main_file).is_dir():
+            main.__file__ = __file__
+
+    start_methods = multiprocessing.get_all_start_methods()
+    if "forkserver" in start_methods:
+        context = cast(Any, multiprocessing.get_context("forkserver"))
+    elif "fork" in start_methods:
+        context = cast(Any, multiprocessing.get_context("fork"))
+    else:
+        pytest.skip("Child wait/pause tests require fork or forkserver isolation.")
     queue = context.Queue()
     process = context.Process(target=target, args=(queue,), daemon=True)
     process.start()
@@ -289,24 +318,18 @@ def _assert_child_flow_pauses(
     grace_deadline: float | None = None
     deadline = time.time() + timeout
 
-    def assert_run_is_waiting(exec_id: str | None) -> None:
-        if exec_id is None:
+    def assert_child_reported_waiting(event: _ChildEvent) -> None:
+        if event.detail is None:
             pytest.fail(
                 "Child flow reached the real wait callable, then exited without "
                 "reporting an execution id to verify paused status."
             )
-        status_deadline = time.time() + 5.0
-        last_status = "unknown"
-        while time.time() < status_deadline:
-            run = Client().get_pipeline_run(exec_id, allow_name_prefix_match=False)
-            last_status = str(getattr(run.status, "value", run.status))
-            if last_status == "paused":
-                return
-            time.sleep(0.2)
+        if event.message == "paused":
+            return
         pytest.fail(
             "Child flow reached the real wait callable and exited, but execution "
-            f"{exec_id} did not enter paused/waiting status; last status was "
-            f"{last_status!r}."
+            f"{event.detail} did not report paused/waiting status from the child; "
+            f"reported status was {event.message!r}."
         )
 
     def handle_exit_after_wait() -> None:
@@ -323,7 +346,7 @@ def _assert_child_flow_pauses(
                 f"of pausing: {event.detail}: {event.message}"
             )
         if event.kind == _CHILD_EVENT_COMPLETED:
-            assert_run_is_waiting(event.detail)
+            assert_child_reported_waiting(event)
             return
         pytest.fail(
             "Child flow exited after reaching the real wait callable with "
@@ -363,7 +386,7 @@ def _assert_child_flow_pauses(
                 )
             if event.kind == _CHILD_EVENT_COMPLETED:
                 if saw_required_event:
-                    assert_run_is_waiting(event.detail)
+                    assert_child_reported_waiting(event)
                     return
                 pytest.fail(f"Child flow completed before reaching {required_event!r}.")
         pytest.fail(f"Child flow did not reach {required_event!r} before timeout.")

--- a/tests/test_phase17_pydantic_ai_adapter.py
+++ b/tests/test_phase17_pydantic_ai_adapter.py
@@ -1,12 +1,15 @@
 """Integration tests for the PydanticAI adapter."""
 
 import asyncio
+import multiprocessing
 import re
 import time
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, nullcontext
 from dataclasses import dataclass
-from typing import Any
+from queue import Empty
+from typing import Any, cast
 from uuid import uuid4
 
 import pytest
@@ -20,7 +23,10 @@ from pydantic_ai.capabilities.hooks import Hooks
 from pydantic_ai.models.test import TestModel
 
 from kitaru import checkpoint, flow
-from kitaru.adapters.pydantic_ai import KitaruAgent, _tracking
+from kitaru.adapters import pydantic_ai as kp
+from kitaru.adapters.pydantic_ai import KitaruAgent, _tracking, hitl_tool
+from kitaru.errors import KitaruFeatureNotAvailableError, KitaruUsageError
+from kitaru.wait import _resolve_zenml_wait
 
 
 @dataclass(frozen=True)
@@ -82,6 +88,13 @@ def _wait_for_hydrated_run(exec_id: str) -> Any:
         time.sleep(0.2)
 
 
+def _require_wait_support() -> None:
+    try:
+        _resolve_zenml_wait()
+    except KitaruFeatureNotAvailableError:
+        pytest.skip("Installed ZenML build does not expose wait support yet.")
+
+
 def _metadata_dict_from_steps(hydrated_run: Any, key: str) -> dict[str, Any]:
     for step in hydrated_run.steps.values():
         if key in step.run_metadata:
@@ -106,6 +119,191 @@ def _assert_event_artifacts_use_display_names(
         for artifact_name in event.get("artifacts", {}).values():
             assert artifact_name in allowed
             assert not artifact_name.startswith(f"{event_id}_")
+
+
+_DIRECT_WAIT_AGENT: KitaruAgent[Any, str] | None = None
+_GUARDED_WAIT_AGENT: KitaruAgent[Any, str] | None = None
+_HITL_WAIT_AGENT: KitaruAgent[Any, str] | None = None
+_CHILD_EVENT_WAIT_INVOKED = "wait_invoked"
+_CHILD_EVENT_COMPLETED = "completed"
+_CHILD_EVENT_ERROR = "error"
+
+
+@dataclass(frozen=True)
+class _ChildEvent:
+    kind: str
+    detail: str | None = None
+    message: str | None = None
+
+
+def _put_child_event(
+    queue: Any,
+    kind: str,
+    detail: object | None = None,
+    message: object | None = None,
+) -> None:
+    queue.put(
+        _ChildEvent(
+            kind=kind,
+            detail=None if detail is None else str(detail),
+            message=None if message is None else str(message),
+        )
+    )
+
+
+def _run_flow_and_report(
+    queue: Any,
+    flow_definition: Any,
+    cleanup: Callable[[], None],
+) -> None:
+    try:
+        flow_definition.run(cache=False)
+        _put_child_event(queue, _CHILD_EVENT_COMPLETED)
+    except BaseException as exc:
+        _put_child_event(queue, _CHILD_EVENT_ERROR, type(exc).__name__, str(exc))
+    finally:
+        cleanup()
+
+
+@flow
+def pydantic_ai_direct_wait_flow() -> str:
+    assert _DIRECT_WAIT_AGENT is not None
+    return _DIRECT_WAIT_AGENT.run_sync("Ask the human for context.").output
+
+
+@flow
+def pydantic_ai_guarded_wait_flow() -> str:
+    assert _GUARDED_WAIT_AGENT is not None
+    return _GUARDED_WAIT_AGENT.run_sync("Ask the human for context.").output
+
+
+@flow
+def pydantic_ai_hitl_wait_flow() -> str:
+    assert _HITL_WAIT_AGENT is not None
+    return _HITL_WAIT_AGENT.run_sync("Ask the human for context.").output
+
+
+def _run_direct_wait_flow_until_pause(queue: Any) -> None:
+    global _DIRECT_WAIT_AGENT
+    import kitaru as kitaru_module
+
+    original_wait = kitaru_module.wait
+
+    def recording_wait(**kwargs: Any) -> Any:
+        _put_child_event(queue, _CHILD_EVENT_WAIT_INVOKED, kwargs.get("name"))
+        return original_wait(**kwargs)
+
+    kitaru_module.wait = cast(Any, recording_wait)
+
+    agent = Agent(
+        TestModel(call_tools=["ask_user"]),
+        name=f"direct_wait_agent_{uuid4().hex[:8]}",
+        output_type=str,
+    )
+
+    @agent.tool_plain
+    def ask_user() -> str:
+        return kp.wait_for_input(
+            schema=str,
+            question="What context should the agent use?",
+            timeout=0,
+        )
+
+    _DIRECT_WAIT_AGENT = KitaruAgent(
+        agent,
+        tool_checkpoint_config_by_name={"ask_user": False},
+    )
+
+    def cleanup() -> None:
+        global _DIRECT_WAIT_AGENT
+        kitaru_module.wait = cast(Any, original_wait)
+        _DIRECT_WAIT_AGENT = None
+
+    _run_flow_and_report(queue, pydantic_ai_direct_wait_flow, cleanup)
+
+
+def _run_hitl_wait_flow_until_pause(queue: Any) -> None:
+    global _HITL_WAIT_AGENT
+    from kitaru.adapters.pydantic_ai import _toolset
+
+    original_invoke_wait = _toolset.KitaruToolset._invoke_wait
+
+    def recording_invoke_wait(self: Any, **kwargs: Any) -> Any:
+        _put_child_event(queue, _CHILD_EVENT_WAIT_INVOKED, kwargs.get("wait_name"))
+        return original_invoke_wait(self, **kwargs)
+
+    _toolset.KitaruToolset._invoke_wait = cast(Any, recording_invoke_wait)
+
+    @hitl_tool(question="What should the tool return?", schema=str)
+    def ask_human() -> str:
+        return "body should not run"
+
+    agent = Agent(
+        TestModel(call_tools=["ask_human"]),
+        name=f"hitl_wait_agent_{uuid4().hex[:8]}",
+        output_type=str,
+        tools=[ask_human],
+    )
+    _HITL_WAIT_AGENT = KitaruAgent(agent)
+
+    def cleanup() -> None:
+        global _HITL_WAIT_AGENT
+        _toolset.KitaruToolset._invoke_wait = cast(Any, original_invoke_wait)
+        _HITL_WAIT_AGENT = None
+
+    _run_flow_and_report(queue, pydantic_ai_hitl_wait_flow, cleanup)
+
+
+def _assert_child_flow_pauses(
+    target: Any,
+    *,
+    required_event: str,
+    timeout: float = 30.0,
+) -> None:
+    # Use fork when available so the child inherits the xdist worker's already
+    # isolated ZenML/Kitaru environment. With spawn, the child re-imports this
+    # module from scratch; under pytest-xdist that can exit before our target
+    # function reports a structured error event.
+    start_method = (
+        "fork" if "fork" in multiprocessing.get_all_start_methods() else "spawn"
+    )
+    context = cast(Any, multiprocessing.get_context(start_method))
+    queue = context.Queue()
+    process = context.Process(target=target, args=(queue,), daemon=True)
+    process.start()
+
+    saw_required_event = False
+    deadline = time.time() + timeout
+    try:
+        while time.time() < deadline:
+            try:
+                event = queue.get(timeout=0.2)
+            except Empty:
+                if saw_required_event:
+                    return
+                if not process.is_alive():
+                    pytest.fail(
+                        "Child flow exited before pausing; required event "
+                        f"{required_event!r} was not observed."
+                    )
+                continue
+
+            if event.kind == required_event:
+                saw_required_event = True
+                continue
+            if event.kind == _CHILD_EVENT_ERROR:
+                pytest.fail(
+                    f"Child flow failed before pausing: {event.detail}: {event.message}"
+                )
+            if event.kind == _CHILD_EVENT_COMPLETED:
+                if saw_required_event:
+                    return
+                pytest.fail(f"Child flow completed before reaching {required_event!r}.")
+        pytest.fail(f"Child flow did not reach {required_event!r} before timeout.")
+    finally:
+        if process.is_alive():
+            process.terminate()
+        process.join(timeout=10.0)
 
 
 def test_phase17_event_artifact_names_use_short_display_shape() -> None:
@@ -335,6 +533,57 @@ def test_phase17_turn_mode_omits_absent_prompt_and_history_inputs(
     artifact_names = _artifact_names(hydrated_run)
     assert any(name.startswith("llm_call_1_prompt__") for name in artifact_names)
     assert any(name.startswith("llm_call_1_response__") for name in artifact_names)
+
+
+def test_phase17_direct_wait_tool_with_checkpoint_opt_out_reaches_wait(
+    primed_zenml,
+) -> None:
+    """A normal sync tool-body wait should stay on the workflow thread."""
+    del primed_zenml
+    _require_wait_support()
+    _assert_child_flow_pauses(
+        _run_direct_wait_flow_until_pause,
+        required_event=_CHILD_EVENT_WAIT_INVOKED,
+    )
+
+
+def test_phase17_direct_wait_tool_without_opt_out_keeps_checkpoint_guard(
+    primed_zenml,
+) -> None:
+    """Default granular checkpointing should still reject checkpoint-contained waits."""
+    del primed_zenml
+    _require_wait_support()
+    agent = Agent(
+        TestModel(call_tools=["ask_user"]),
+        name=f"guarded_wait_agent_{uuid4().hex[:8]}",
+        output_type=str,
+    )
+
+    @agent.tool_plain
+    def ask_user() -> str:
+        return kp.wait_for_input(
+            schema=str,
+            question="This should not be created inside a tool checkpoint.",
+            timeout=0,
+        )
+
+    global _GUARDED_WAIT_AGENT
+    _GUARDED_WAIT_AGENT = KitaruAgent(agent)
+    try:
+        with pytest.raises(KitaruUsageError, match="tool_checkpoint_config_by_name"):
+            pydantic_ai_guarded_wait_flow.run(cache=False)
+    finally:
+        _GUARDED_WAIT_AGENT = None
+
+
+def test_phase17_hitl_tool_still_reaches_wait(primed_zenml) -> None:
+    """The declarative HITL path should still pause through adapter-managed wait."""
+    del primed_zenml
+    _require_wait_support()
+    _assert_child_flow_pauses(
+        _run_hitl_wait_flow_until_pause,
+        required_event=_CHILD_EVENT_WAIT_INVOKED,
+    )
 
 
 def test_phase17_default_granular_mode_tracks_at_flow_scope(primed_zenml) -> None:

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -1277,6 +1277,131 @@ class TestModelMessageCacheSerialization:
         assert len(cached_responses) == 2
 
 
+class TestThreadingCompat:
+    """Compatibility wrapper for Pydantic AI sync-tool threading."""
+
+    def test_inline_sync_tool_execution_enters_available_hook(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pydantic_ai import _utils as pydantic_ai_utils
+
+        from kitaru.adapters.pydantic_ai._threading_compat import (
+            inline_sync_tool_execution,
+        )
+
+        events: list[str] = []
+
+        class Manager:
+            def __enter__(self) -> None:
+                events.append("enter")
+
+            def __exit__(self, *_exc_info: object) -> None:
+                events.append("exit")
+
+        monkeypatch.setattr(pydantic_ai_utils, "disable_threads", lambda: Manager())
+
+        with inline_sync_tool_execution(enabled=True) as active:
+            assert active is True
+            events.append("body")
+
+        assert events == ["enter", "body", "exit"]
+
+    def test_inline_sync_tool_execution_is_noop_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pydantic_ai import _utils as pydantic_ai_utils
+
+        from kitaru.adapters.pydantic_ai._threading_compat import (
+            inline_sync_tool_execution,
+        )
+
+        def fail_if_called() -> object:
+            raise AssertionError("hook should not be called")
+
+        monkeypatch.setattr(pydantic_ai_utils, "disable_threads", fail_if_called)
+
+        with inline_sync_tool_execution(enabled=False) as active:
+            assert active is False
+
+    def test_inline_sync_tool_execution_is_noop_when_hook_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pydantic_ai import _utils as pydantic_ai_utils
+
+        from kitaru.adapters.pydantic_ai._threading_compat import (
+            inline_sync_tool_execution,
+        )
+
+        monkeypatch.delattr(pydantic_ai_utils, "disable_threads", raising=False)
+
+        with inline_sync_tool_execution(enabled=True) as active:
+            assert active is False
+
+    def test_inline_sync_tool_execution_is_noop_when_hook_non_callable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pydantic_ai import _utils as pydantic_ai_utils
+
+        from kitaru.adapters.pydantic_ai._threading_compat import (
+            inline_sync_tool_execution,
+        )
+
+        monkeypatch.setattr(pydantic_ai_utils, "disable_threads", object())
+
+        with inline_sync_tool_execution(enabled=True) as active:
+            assert active is False
+
+    def test_inline_sync_tool_execution_is_noop_when_hook_entry_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pydantic_ai import _utils as pydantic_ai_utils
+
+        from kitaru.adapters.pydantic_ai._threading_compat import (
+            inline_sync_tool_execution,
+        )
+
+        class BrokenManager:
+            def __enter__(self) -> None:
+                raise RuntimeError("boom")
+
+            def __exit__(self, *_exc_info: object) -> None:
+                raise AssertionError("exit should not run after failed enter")
+
+        monkeypatch.setattr(
+            pydantic_ai_utils, "disable_threads", lambda: BrokenManager()
+        )
+
+        with inline_sync_tool_execution(enabled=True) as active:
+            assert active is False
+
+    def test_agent_requests_inline_sync_tools_only_for_false_tool_override(
+        self,
+    ) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+
+        opted_out = KitaruAgent(
+            Agent(TestModel(), name="inline_tools_agent"),
+            tool_checkpoint_config_by_name={"ask_user": False},
+        )
+        ordinary_granular = KitaruAgent(Agent(TestModel(), name="ordinary_tools_agent"))
+        configured_granular = KitaruAgent(
+            Agent(TestModel(), name="configured_tools_agent"),
+            tool_checkpoint_config_by_name={"lookup": {"cache": False}},
+        )
+        turn_mode = KitaruAgent(
+            Agent(TestModel(), name="turn_mode_agent"),
+            granular_checkpoints=False,
+        )
+
+        assert opted_out._should_inline_sync_tools() is True
+        assert ordinary_granular._should_inline_sync_tools() is False
+        assert configured_granular._should_inline_sync_tools() is False
+        assert turn_mode._should_inline_sync_tools() is False
+
+
 class TestWaitForInput:
     """Adapter-namespaced helper for calling wait from a tool body."""
 
@@ -1313,6 +1438,41 @@ class TestWaitForInput:
             "source": "tool_body",
             "extra": 1,
         }
+
+    def test_wait_for_input_rewrites_pipeline_thread_errors(self, monkeypatch) -> None:
+        import kitaru as kitaru_module
+        from kitaru.adapters.pydantic_ai import wait_for_input
+
+        def fake_wait(**_kwargs):
+            raise RuntimeError(
+                "`zenml.wait(...)` must be called from the pipeline thread, "
+                "not from a worker thread spawned inside the pipeline function."
+            )
+
+        monkeypatch.setattr(kitaru_module, "wait", fake_wait)
+
+        with pytest.raises(KitaruUsageError) as exc_info:
+            wait_for_input(schema=str, question="Need input?")
+
+        message = str(exc_info.value)
+        assert "sync Pydantic AI tool body" in message
+        assert "worker thread" in message
+        assert "tool_checkpoint_config_by_name" in message
+        assert "@hitl_tool" in message
+
+    def test_wait_for_input_does_not_rewrite_unrelated_runtime_errors(
+        self, monkeypatch
+    ) -> None:
+        import kitaru as kitaru_module
+        from kitaru.adapters.pydantic_ai import wait_for_input
+
+        def fake_wait(**_kwargs):
+            raise RuntimeError("different runtime failure")
+
+        monkeypatch.setattr(kitaru_module, "wait", fake_wait)
+
+        with pytest.raises(RuntimeError, match="different runtime failure"):
+            wait_for_input(schema=str, question="Need input?")
 
     def test_wait_for_input_adapter_metadata_wins_over_caller_metadata(
         self, monkeypatch

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -1323,7 +1323,7 @@ class TestThreadingCompat:
         with inline_sync_tool_execution(enabled=False) as active:
             assert active is False
 
-    def test_inline_sync_tool_execution_is_noop_when_hook_missing(
+    def test_inline_sync_tool_execution_fails_fast_when_hook_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from pydantic_ai import _utils as pydantic_ai_utils
@@ -1334,10 +1334,13 @@ class TestThreadingCompat:
 
         monkeypatch.delattr(pydantic_ai_utils, "disable_threads", raising=False)
 
-        with inline_sync_tool_execution(enabled=True) as active:
-            assert active is False
+        with (
+            pytest.raises(KitaruUsageError, match=r"disable_threads.*missing"),
+            inline_sync_tool_execution(enabled=True),
+        ):
+            raise AssertionError("body should not run")
 
-    def test_inline_sync_tool_execution_is_noop_when_hook_non_callable(
+    def test_inline_sync_tool_execution_fails_fast_when_hook_non_callable(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from pydantic_ai import _utils as pydantic_ai_utils
@@ -1348,10 +1351,33 @@ class TestThreadingCompat:
 
         monkeypatch.setattr(pydantic_ai_utils, "disable_threads", object())
 
-        with inline_sync_tool_execution(enabled=True) as active:
-            assert active is False
+        with (
+            pytest.raises(KitaruUsageError, match=r"disable_threads.*not callable"),
+            inline_sync_tool_execution(enabled=True),
+        ):
+            raise AssertionError("body should not run")
 
-    def test_inline_sync_tool_execution_is_noop_when_hook_entry_fails(
+    def test_inline_sync_tool_execution_fails_fast_when_hook_creation_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pydantic_ai import _utils as pydantic_ai_utils
+
+        from kitaru.adapters.pydantic_ai._threading_compat import (
+            inline_sync_tool_execution,
+        )
+
+        def broken_hook() -> object:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(pydantic_ai_utils, "disable_threads", broken_hook)
+
+        with (
+            pytest.raises(KitaruUsageError, match="could not create"),
+            inline_sync_tool_execution(enabled=True),
+        ):
+            raise AssertionError("body should not run")
+
+    def test_inline_sync_tool_execution_fails_fast_when_hook_entry_fails(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from pydantic_ai import _utils as pydantic_ai_utils
@@ -1371,10 +1397,13 @@ class TestThreadingCompat:
             pydantic_ai_utils, "disable_threads", lambda: BrokenManager()
         )
 
-        with inline_sync_tool_execution(enabled=True) as active:
-            assert active is False
+        with (
+            pytest.raises(KitaruUsageError, match="could not be entered"),
+            inline_sync_tool_execution(enabled=True),
+        ):
+            raise AssertionError("body should not run")
 
-    def test_agent_requests_inline_sync_tools_only_for_false_tool_override(
+    def test_agent_requests_inline_sync_tools_only_for_explicit_wait_opt_in(
         self,
     ) -> None:
         from pydantic_ai import Agent
@@ -1386,6 +1415,11 @@ class TestThreadingCompat:
             Agent(TestModel(), name="inline_tools_agent"),
             tool_checkpoint_config_by_name={"ask_user": False},
         )
+        opted_out_with_wait_compat = KitaruAgent(
+            Agent(TestModel(), name="inline_tools_wait_agent"),
+            tool_checkpoint_config_by_name={"ask_user": False},
+            allow_sync_tool_body_waits=True,
+        )
         ordinary_granular = KitaruAgent(Agent(TestModel(), name="ordinary_tools_agent"))
         configured_granular = KitaruAgent(
             Agent(TestModel(), name="configured_tools_agent"),
@@ -1396,10 +1430,37 @@ class TestThreadingCompat:
             granular_checkpoints=False,
         )
 
-        assert opted_out._should_inline_sync_tools() is True
+        assert opted_out._should_inline_sync_tools() is False
+        assert opted_out_with_wait_compat._should_inline_sync_tools() is True
         assert ordinary_granular._should_inline_sync_tools() is False
         assert configured_granular._should_inline_sync_tools() is False
         assert turn_mode._should_inline_sync_tools() is False
+
+    def test_sync_tool_body_wait_opt_in_requires_checkpoint_opt_out(self) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+
+        with pytest.raises(KitaruUsageError, match="requires at least one"):
+            KitaruAgent(
+                Agent(TestModel(), name="missing_tool_opt_out"),
+                allow_sync_tool_body_waits=True,
+            )
+
+    def test_sync_tool_body_wait_opt_in_requires_granular_mode(self) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+
+        with pytest.raises(KitaruUsageError, match="granular_checkpoints=True"):
+            KitaruAgent(
+                Agent(TestModel(), name="turn_mode_wait_compat"),
+                granular_checkpoints=False,
+                tool_checkpoint_config_by_name={"ask_user": False},
+                allow_sync_tool_body_waits=True,
+            )
 
 
 class TestWaitForInput:
@@ -1458,6 +1519,7 @@ class TestWaitForInput:
         assert "sync Pydantic AI tool body" in message
         assert "worker thread" in message
         assert "tool_checkpoint_config_by_name" in message
+        assert "allow_sync_tool_body_waits=True" in message
         assert "@hitl_tool" in message
 
     def test_wait_for_input_does_not_rewrite_unrelated_runtime_errors(

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -1517,7 +1517,27 @@ class TestWaitForInput:
 
         message = str(exc_info.value)
         assert "sync Pydantic AI tool body" in message
-        assert "worker thread" in message
+        assert "workflow thread" in message
+        assert "tool_checkpoint_config_by_name" in message
+        assert "allow_sync_tool_body_waits=True" in message
+        assert "@hitl_tool" in message
+
+    def test_wait_for_input_rewrites_checkpoint_scope_errors(self, monkeypatch) -> None:
+        import kitaru as kitaru_module
+        from kitaru.adapters.pydantic_ai import wait_for_input
+        from kitaru.errors import KitaruContextError
+        from kitaru.wait import _WAIT_INSIDE_CHECKPOINT_ERROR
+
+        def fake_wait(**_kwargs):
+            raise KitaruContextError(_WAIT_INSIDE_CHECKPOINT_ERROR)
+
+        monkeypatch.setattr(kitaru_module, "wait", fake_wait)
+
+        with pytest.raises(KitaruUsageError) as exc_info:
+            wait_for_input(schema=str, question="Need input?")
+
+        message = str(exc_info.value)
+        assert "adapter-created checkpoint" in message
         assert "tool_checkpoint_config_by_name" in message
         assert "allow_sync_tool_body_waits=True" in message
         assert "@hitl_tool" in message


### PR DESCRIPTION
## What changed

Fixes issue #347 for PydanticAI sync tool bodies that call `kp.wait_for_input(...)` under ZenML `0.94.4`.

- Added an internal PydanticAI threading compatibility helper that isolates use of `pydantic_ai._utils.disable_threads()`.
- Added an explicit `KitaruAgent(..., allow_sync_tool_body_waits=True)` opt-in for direct sync tool-body waits.
- Kept `tool_checkpoint_config_by_name={"tool": False}` as checkpoint-only configuration; it no longer implicitly enables the run-wide PydanticAI threading compatibility path.
- Rewrote the raw ZenML worker-thread `RuntimeError` and checkpoint-scope `KitaruContextError` into Kitaru-facing guidance when unsupported direct wait paths still hit them.
- Added real ZenML regression coverage plus unit coverage for the compatibility helper, opt-in validation, and fallback errors.
- Updated docs, README, example comments, and changelog to distinguish checkpoint opt-out from pipeline-thread safety and to call out the run-wide concurrency trade-off.

## Why it was needed

ZenML `0.94.4` added a stricter wait guard: `zenml.wait(...)` must run on the dynamic pipeline thread. PydanticAI normally offloads sync tool bodies to worker threads, so a tool body calling `kp.wait_for_input(...)` could carry Kitaru flow context into the worker thread but still fail ZenML's physical thread check.

The important plan change is that Kitaru now requires an explicit opt-in before it asks PydanticAI to run supported sync tool bodies inline. The checkpoint opt-out still solves only one problem — keeping the wait out of the synthetic `*_tool` checkpoint. The new flag solves the separate physical-thread problem.

## Key implementation decisions

- Keep direct sync tool-body waits supported, but only with both pieces of configuration: `tool_checkpoint_config_by_name={"tool_name": False}` and `allow_sync_tool_body_waits=True`.
- Isolate the private PydanticAI hook behind one helper so the compatibility risk is contained.
- Fail fast if the explicit opt-in is requested but PydanticAI no longer exposes an enterable `disable_threads()` context.
- Keep `@hitl_tool` as the preferred pure-HITL pattern because Kitaru creates that wait from adapter-managed code.
- Document the concrete trade-off: the compatibility scope is run-wide, so supported sync tools in that agent run may execute inline on the workflow thread instead of using PydanticAI's normal worker-thread path.

## Reviewer Notes

The important behavior now happens at the PydanticAI adapter run boundary. The old chain was: PydanticAI called a sync tool in a worker thread, the tool called `kp.wait_for_input(...)`, Kitaru's contextvars said “inside a flow,” and then ZenML rejected the wait because the actual OS thread was wrong.

The new chain is deliberately two-step: first, the named tool opts out of the synthetic tool checkpoint so the wait can be flow-scope; second, `allow_sync_tool_body_waits=True` tells Kitaru to enter PydanticAI's inline-sync-tool context for the whole agent run. That second step is not hidden behind the checkpoint opt-out because it can affect other supported sync tools in the same run.

The highest-risk area is the private PydanticAI compatibility hook in `src/kitaru/adapters/pydantic_ai/_threading_compat.py` and its use from `KitaruAgent`. Please check that private API usage stays isolated, that the opt-in validation does not make ordinary checkpoint opt-outs do extra work, and that the docs make the run-wide performance/concurrency trade-off clear. The tests in `tests/test_phase17_pydantic_ai_adapter.py` are intentionally real ZenML tests rather than monkeypatched wait tests, because the bug lived below Kitaru's context guard. The pause tests now use forkserver isolation when available so CI workers do not fork after ZenML/SQLite resources have already been opened by earlier tests.

### Reproduction

Before this fix, the direct sync wait shape fails under ZenML `0.94.4`:

1. Define a PydanticAI sync tool body that returns `kp.wait_for_input(schema=str, question=..., timeout=0)`.
2. Wrap the agent with `KitaruAgent(..., tool_checkpoint_config_by_name={"ask_user": False})`.
3. Call `durable_agent.run_sync(...)` inside an explicit `@kitaru.flow`.
4. The run reaches `zenml.wait(...)` from a worker thread and raises the pipeline-thread RuntimeError.

After this fix, the supported direct-wait shape is explicit:

```python
durable_agent = KitaruAgent(
    agent,
    tool_checkpoint_config_by_name={"ask_user": False},
    allow_sync_tool_body_waits=True,
)
```

Run:

```bash
uv run pytest -n 0 tests/test_pydantic_ai_adapter.py::TestWaitForInput tests/test_phase17_pydantic_ai_adapter.py::test_phase17_direct_wait_tool_with_explicit_thread_opt_in_reaches_wait tests/test_phase17_pydantic_ai_adapter.py::test_phase17_direct_wait_tool_without_opt_out_keeps_checkpoint_guard tests/test_phase17_pydantic_ai_adapter.py::test_phase17_hitl_tool_still_reaches_wait
uv run pytest tests/test_phase17_pydantic_ai_adapter.py
just check
just test
```

You should see the explicit direct-wait opt-in reach the real wait path, the missing opt-out still preserve Kitaru's friendly checkpoint-scope guard, and `@hitl_tool` still use the adapter-managed wait path.

Local checks run on the latest commit after rebasing on the updated PR branch:

- `uv run pytest -n 0 tests/test_pydantic_ai_adapter.py::TestWaitForInput tests/test_phase17_pydantic_ai_adapter.py::test_phase17_direct_wait_tool_with_explicit_thread_opt_in_reaches_wait tests/test_phase17_pydantic_ai_adapter.py::test_phase17_direct_wait_tool_without_opt_out_keeps_checkpoint_guard tests/test_phase17_pydantic_ai_adapter.py::test_phase17_hitl_tool_still_reaches_wait` — 9 passed
- `uv run pytest tests/test_phase17_pydantic_ai_adapter.py` — 14 passed
- `just check` — passed
- `just test` — 1811 passed, 8 skipped

Fixes #347.

