### PR TITLE
Make .wait() compose with granular adapter checkpoints, plus all-adapters showcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added an all-adapters showcase (`examples/integrations/all_adapters_showcase/`) that runs the same customer-support scenario through PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK and prints one consolidated comparison table — demonstrating per-adapter checkpoint granularity (typically 5/5/2/1) with one durable-flow boundary on a remote stack.
+
 ### Changed
 - Bumped the minimum ZenML dependency, server image, and Helm subchart versions to `0.94.4` so Kitaru tracks the latest upstream ZenML release.
 
 ### Fixed
 - Fixed Kitaru flow return compatibility with ZenML `0.94.4` dynamic-pipeline output validation by persisting plain flow returns as internal artifacts while preserving user-facing Python return values and avoiding marker-shaped user dictionaries being mistaken for hidden tuple metadata.
+- Fixed `.wait()` raising `_MultipleTerminalStepsOutputError` when a flow body returns a derived value alongside granular adapter checkpoints (PydanticAI granular, OpenAI Agents `checkpoint_strategy="calls"`, LangGraph `checkpoint_strategy="calls"`). The flow-return coercer now records the saved artifact id on the active pipeline run's metadata, and `_extract_flow_result` consults that breadcrumb before falling back to terminal-step extraction. Fixes #350.
 
 ## [0.12.0] - 2026-05-17
 

--- a/examples/integrations/all_adapters_showcase/README.md
+++ b/examples/integrations/all_adapters_showcase/README.md
@@ -1,0 +1,90 @@
+# All adapters showcase
+
+One customer-support scenario, four agent frameworks, one Kitaru durable-execution
+layer. The point of this example is to show that the `@flow` / `@checkpoint`
+boundary is identical no matter which agent harness a team picks — only the
+inner agent changes.
+
+## What it runs
+
+A single business task: *"Where is order ORD-1007? Look it up, apply the
+shipping policy, tell me what happens next."*
+
+The same task is executed through every adapter Kitaru ships today:
+
+| # | Adapter | Module |
+|---|---|---|
+| 1 | PydanticAI | `kitaru.adapters.pydantic_ai.KitaruAgent` |
+| 2 | OpenAI Agents SDK | `kitaru.adapters.openai_agents.KitaruRunner` |
+| 3 | LangGraph (calls mode) | `kitaru.adapters.langgraph.KitaruGraphRunner` |
+| 4 | Claude Agent SDK | `kitaru.adapters.claude_agent_sdk.KitaruClaudeRunner` |
+
+Each adapter is wrapped in the same `@flow` shape:
+
+```python
+@flow
+def some_framework_flow(question: str) -> str:
+    return runner.run_sync(question).output
+```
+
+That's the value: a single primitive (`@flow`) gives every adapter the same
+durable execution, checkpoint tracking, artifact persistence, and replay
+surface — without locking the team into any framework.
+
+## Running it
+
+```bash
+uv sync --extra local \
+        --extra pydantic-ai \
+        --extra openai-agents \
+        --extra langgraph-openai \
+        --extra claude-agent-sdk
+uv run kitaru init
+
+export OPENAI_API_KEY=sk-...
+export ANTHROPIC_API_KEY=sk-ant-...
+
+uv run python examples/integrations/all_adapters_showcase/all_adapters.py
+```
+
+Both keys are required: PydanticAI, OpenAI Agents, and LangGraph all call the
+OpenAI API by default; the Claude Agent SDK calls Anthropic.
+
+## What you see
+
+After all four runs the script prints a consolidated comparison table:
+
+```
+Adapter           Framework         Exec ID   Status     Ckpts  Took   Notes
+----------------  ----------------  --------  ---------  -----  -----  --------
+PydanticAI        pydantic-ai       cfc94bbf  completed  5      43.8s  -
+OpenAI Agents     openai-agents     2e6550a0  completed  5      46.2s  -
+LangGraph         langgraph         a9603542  completed  2      14.3s  checkpoint_strategy='calls'
+Claude Agent SDK  claude-agent-sdk  bdce99c5  completed  1      20.1s  tool-free invocation
+```
+
+…followed by each adapter's final answer text and the matching Kitaru
+`exec_id` so you can inspect any run in the dashboard or via
+`kitaru executions get <id>`.
+
+The checkpoint counts reflect each adapter's natural granularity:
+
+| Adapter | Checkpoints | Notes |
+|---|---|---|
+| PydanticAI (granular) | one per model request + one per tool call | hooks PydanticAI's native event surface |
+| OpenAI Agents (`calls`) | one per OpenAI model call + one per function tool call | hooks the Runner's per-turn boundary |
+| LangGraph (`calls`) | one per LangChain model call + one consolidating `langgraph_summary` checkpoint | via `KitaruLangGraphMiddleware` |
+| Claude Agent SDK | one per `query()` invocation | the SDK doesn't expose per-step extension points yet |
+
+## What to look at in the code
+
+- The four `run_*` functions are almost identical in shape: build the
+  framework's native agent, wrap it in the matching Kitaru adapter, and put
+  the call inside a one-line `@flow`.
+- `_lookup_order` and `_shipping_policy` are plain Python functions reused by
+  every framework's tool decorator. The business logic does not change with
+  the harness.
+- The flow body returns a single derived value in each case. Granular adapters
+  emit many sibling checkpoints; Kitaru's flow-return coercer records the
+  return value as a separate artifact so `.wait()` resolves cleanly without
+  needing a manual `finalize_*` sink.

--- a/examples/integrations/all_adapters_showcase/all_adapters.py
+++ b/examples/integrations/all_adapters_showcase/all_adapters.py
@@ -1,0 +1,484 @@
+"""Run one customer-support scenario through every Kitaru framework adapter.
+
+The point of this example is to show that Kitaru's durable-execution layer
+(``@flow``, ``@checkpoint``, runner adapters, artifact tracking) is the *same*
+regardless of which agent framework a team picks. The agent inside changes;
+the orchestration boundary does not.
+
+Scenario: a customer asks about a delayed order. The agent must look up the
+order and apply the relevant shipping policy before answering.
+
+Adapters exercised:
+  1. PydanticAI         (kitaru.adapters.pydantic_ai.KitaruAgent)
+  2. OpenAI Agents SDK  (kitaru.adapters.openai_agents.KitaruRunner)
+  3. LangGraph          (kitaru.adapters.langgraph.KitaruGraphRunner, calls mode)
+  4. Claude Agent SDK   (kitaru.adapters.claude_agent_sdk.KitaruClaudeRunner)
+
+Run:
+    uv sync --extra local \\
+            --extra pydantic-ai \\
+            --extra openai-agents \\
+            --extra langgraph-openai \\
+            --extra claude-agent-sdk
+    uv run kitaru init
+    export OPENAI_API_KEY=sk-...
+    export ANTHROPIC_API_KEY=sk-ant-...
+    uv run python examples/integrations/all_adapters_showcase/all_adapters.py
+"""
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, cast
+
+import kitaru
+from kitaru import flow
+
+# ---------------------------------------------------------------------------
+# Shared scenario
+# ---------------------------------------------------------------------------
+
+CUSTOMER_QUESTION = (
+    "Hi, where is order ORD-1007? Please look up the actual order status, "
+    "apply the relevant shipping policy, and tell me what happens next."
+)
+
+ORDERS: dict[str, dict[str, str]] = {
+    "ORD-1007": {
+        "status": "delayed_weather_hub",
+        "eta": "2026-05-08",
+        "last_scan": "Rotterdam Sort Center",
+        "carrier": "PostNL",
+    },
+}
+
+POLICIES: dict[str, str] = {
+    "delayed_weather_hub": (
+        "Weather delay policy: wait 48 hours after ETA before replacement. "
+        "If still not delivered, offer free replacement or full refund."
+    ),
+    "default": (
+        "General shipping policy: verify status, share ETA, "
+        "and escalate to a human agent."
+    ),
+}
+
+
+def _lookup_order(order_id: str) -> str:
+    order = ORDERS.get(order_id)
+    if order is None:
+        return f"Order {order_id} not found."
+    return (
+        f"Order {order_id}: status={order['status']}, eta={order['eta']}, "
+        f"last_scan={order['last_scan']}, carrier={order['carrier']}"
+    )
+
+
+def _shipping_policy(status: str) -> str:
+    return POLICIES.get(status.strip().lower(), POLICIES["default"])
+
+
+# ---------------------------------------------------------------------------
+# Result type — one row in the final comparison table
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AdapterResult:
+    adapter: str
+    framework: str
+    exec_id: str
+    status: str
+    checkpoints: int
+    duration_s: float
+    final_output: str
+    note: str = ""
+
+
+def _summarize_execution(exec_id: str) -> tuple[str, int]:
+    """Return (status, checkpoint count) for the given execution id."""
+    client = kitaru.KitaruClient()
+    execution = client.executions.get(exec_id)
+    return execution.status.value, len(execution.list_checkpoints())
+
+
+def _truncate(text: str, limit: int = 220) -> str:
+    text = " ".join(str(text).split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1] + "…"
+
+
+# ---------------------------------------------------------------------------
+# 1. PydanticAI
+# ---------------------------------------------------------------------------
+
+
+def run_pydantic_ai() -> AdapterResult:
+    from pydantic_ai import Agent
+
+    from kitaru.adapters.pydantic_ai import KitaruAgent
+
+    model = os.getenv("PYDANTIC_AI_MODEL", "openai:gpt-5-nano")
+
+    agent: Agent[None, str] = Agent(
+        model,
+        name="pydantic_support_agent",
+        output_type=str,
+        instructions=(
+            "You are a careful customer support assistant. "
+            "Always call lookup_order first when an order id is present, "
+            "then call shipping_policy using the returned order status, "
+            "and only then write the final answer."
+        ),
+    )
+
+    @agent.tool_plain
+    def lookup_order(order_id: str) -> str:
+        """Return the order's status, ETA, last scan, and carrier."""
+        return _lookup_order(order_id)
+
+    @agent.tool_plain
+    def shipping_policy(status: str) -> str:
+        """Return the support policy for a given order status."""
+        return _shipping_policy(status)
+
+    # Granular mode: KitaruAgent emits one Kitaru checkpoint per model
+    # request and per tool call. The flow body returns the answer string
+    # directly; `.wait()` finds the Kitaru-saved flow return value rather
+    # than getting confused by the adapter's sibling checkpoints.
+    wrapped = KitaruAgent(agent, granular_checkpoints=True)
+
+    @flow
+    def pydantic_ai_flow(question: str) -> str:
+        return wrapped.run_sync(question).output
+
+    started = time.monotonic()
+    handle = pydantic_ai_flow.run(CUSTOMER_QUESTION)
+    output = cast(str, handle.wait())
+    duration = time.monotonic() - started
+
+    status, checkpoints = _summarize_execution(handle.exec_id)
+    return AdapterResult(
+        adapter="PydanticAI",
+        framework="pydantic-ai",
+        exec_id=handle.exec_id,
+        status=status,
+        checkpoints=checkpoints,
+        duration_s=duration,
+        final_output=output,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. OpenAI Agents SDK
+# ---------------------------------------------------------------------------
+
+
+def run_openai_agents() -> AdapterResult:
+    from agents import Agent, RunConfig, function_tool
+
+    from kitaru.adapters.openai_agents import KitaruRunner, OpenAIRunRequest
+
+    @function_tool
+    def lookup_order(order_id: str) -> str:
+        """Return the order's status, ETA, last scan, and carrier."""
+        return _lookup_order(order_id)
+
+    @function_tool
+    def shipping_policy(status: str) -> str:
+        """Return the support policy for a given order status."""
+        return _shipping_policy(status)
+
+    agent = Agent(
+        name="openai_support_agent",
+        instructions=(
+            "You are a careful customer support assistant. "
+            "Always call lookup_order first, then shipping_policy with the "
+            "returned status, then write the final answer."
+        ),
+        model=os.getenv("OPENAI_AGENTS_MODEL", "gpt-5-nano"),
+        tools=[lookup_order, shipping_policy],
+    )
+
+    runner = KitaruRunner(
+        agent,
+        checkpoint_strategy="calls",
+        run_config_factory=lambda: RunConfig(tracing_disabled=True),
+    )
+
+    @flow
+    def openai_agents_flow(question: str) -> str:
+        # `calls` strategy: one Kitaru checkpoint per model + tool call.
+        # The flow body returns the answer string directly; `.wait()` picks
+        # up the Kitaru-saved return value rather than tripping over the
+        # adapter's sibling per-call checkpoints.
+        result = runner.run_sync(OpenAIRunRequest.start(question))
+        status = getattr(result, "status", None)
+        if status != "completed":
+            raise RuntimeError(
+                f"OpenAI Agents run did not complete (status={status!r})."
+            )
+        return str(result.final_output)
+
+    started = time.monotonic()
+    handle = openai_agents_flow.run(CUSTOMER_QUESTION)
+    output = cast(str, handle.wait())
+    duration = time.monotonic() - started
+
+    status, checkpoints = _summarize_execution(handle.exec_id)
+    return AdapterResult(
+        adapter="OpenAI Agents",
+        framework="openai-agents",
+        exec_id=handle.exec_id,
+        status=status,
+        checkpoints=checkpoints,
+        duration_s=duration,
+        final_output=output,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. LangGraph (calls strategy with a LangChain agent)
+# ---------------------------------------------------------------------------
+
+
+def run_langgraph() -> AdapterResult:
+    from langchain.agents import create_agent
+    from langchain_openai import ChatOpenAI
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    from kitaru.adapters.langgraph import KitaruGraphRunner, LangGraphRunRequest
+    from kitaru.adapters.langgraph.langchain import KitaruLangGraphMiddleware
+
+    def lookup_order_tool(order_id: str) -> str:
+        """Return the order's status, ETA, last scan, and carrier."""
+        return _lookup_order(order_id)
+
+    def shipping_policy_tool(status: str) -> str:
+        """Return the support policy for a given order status."""
+        return _shipping_policy(status)
+
+    runner_name = "langgraph_support_agent"
+    model = ChatOpenAI(model=os.getenv("LANGGRAPH_AGENT_MODEL", "gpt-5-nano"))
+    lc_agent = create_agent(
+        model=model,
+        tools=[lookup_order_tool, shipping_policy_tool],
+        middleware=[KitaruLangGraphMiddleware(graph_name=runner_name)],
+        checkpointer=InMemorySaver(),
+        name=runner_name,
+        system_prompt=(
+            "You are a careful customer support assistant. "
+            "Always call lookup_order_tool first, then shipping_policy_tool with "
+            "the returned status, then write the final answer including order "
+            "status, ETA, policy summary, and the next step."
+        ),
+    )
+
+    runner = KitaruGraphRunner(
+        lc_agent,
+        name=runner_name,
+        checkpoint_strategy="calls",
+    )
+
+    @flow
+    def langgraph_flow(question: str) -> str:
+        # `calls` strategy: one Kitaru checkpoint per LangChain model + tool
+        # call, plus a final consolidating `langgraph_summary` checkpoint.
+        result = runner.invoke(
+            LangGraphRunRequest.start(
+                {"messages": [{"role": "user", "content": question}]},
+                thread_id=f"showcase-{int(time.time())}",
+            )
+        )
+        status = getattr(result, "status", None)
+        if status != "completed":
+            raise RuntimeError(f"LangGraph run did not complete (status={status!r}).")
+        output = cast(dict[str, Any], result.output)
+        messages = output.get("messages") or []
+        final = messages[-1] if messages else None
+        return str(getattr(final, "content", final))
+
+    started = time.monotonic()
+    handle = langgraph_flow.run(CUSTOMER_QUESTION)
+    output = cast(str, handle.wait())
+    duration = time.monotonic() - started
+
+    status, checkpoints = _summarize_execution(handle.exec_id)
+    return AdapterResult(
+        adapter="LangGraph",
+        framework="langgraph",
+        exec_id=handle.exec_id,
+        status=status,
+        checkpoints=checkpoints,
+        duration_s=duration,
+        final_output=output,
+        note="checkpoint_strategy='calls'",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Claude Agent SDK
+# ---------------------------------------------------------------------------
+
+
+def run_claude_sdk() -> AdapterResult:
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    from kitaru.adapters.claude_agent_sdk import ClaudeRunRequest, KitaruClaudeRunner
+
+    # The Claude Agent SDK is intentionally exercised in tool-free mode so the
+    # example runs the same way on every machine. We bake the order facts into
+    # the prompt; what we are showcasing here is the *adapter*, not the SDK's
+    # built-in tools.
+    order_text = _lookup_order("ORD-1007")
+    policy_text = _shipping_policy("delayed_weather_hub")
+    prompt = (
+        f"A customer asks: {CUSTOMER_QUESTION}\n\n"
+        f"Order data: {order_text}\n"
+        f"Shipping policy: {policy_text}\n\n"
+        "Write a short final answer for the customer that names the status, "
+        "the ETA, the policy summary, and the next step. Do not use tools."
+    )
+
+    runner = KitaruClaudeRunner(
+        name="claude_support_agent",
+        options_factory=lambda request: ClaudeAgentOptions(
+            allowed_tools=[],
+            cwd=request.cwd,
+            resume=request.resume_session_id,
+            max_turns=request.max_turns,
+        ),
+        checkpoint_config={"cache": False},
+    )
+
+    @flow
+    def claude_sdk_flow(prompt_text: str) -> str:
+        # The runner produces one Kitaru checkpoint per invocation and
+        # materializes its result back into flow-body scope.
+        result = runner.run_sync(
+            ClaudeRunRequest.start(
+                prompt_text,
+                cwd=os.getcwd(),
+                max_turns=1,
+                metadata={"showcase": "all_adapters"},
+            )
+        )
+        # Attribute access rather than isinstance: on remote stacks the
+        # ClaudeRunResult class is re-imported with a fresh identity
+        # (see kitaru issue #348).
+        final_text = getattr(result, "final_text", None)
+        if final_text is None:
+            raise TypeError(f"Unexpected Claude result: {type(result).__name__}")
+        return final_text or "(empty)"
+
+    started = time.monotonic()
+    handle = claude_sdk_flow.run(prompt)
+    output = cast(str, handle.wait())
+    duration = time.monotonic() - started
+
+    status, checkpoints = _summarize_execution(handle.exec_id)
+    return AdapterResult(
+        adapter="Claude Agent SDK",
+        framework="claude-agent-sdk",
+        exec_id=handle.exec_id,
+        status=status,
+        checkpoints=checkpoints,
+        duration_s=duration,
+        final_output=output,
+        note="tool-free invocation; facts injected in prompt",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def _require_keys() -> None:
+    missing = [
+        name for name in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY") if not os.getenv(name)
+    ]
+    if missing:
+        raise SystemExit(
+            "Missing required credentials: "
+            + ", ".join(missing)
+            + ".\nExport both keys and rerun."
+        )
+
+
+def _print_table(results: list[AdapterResult]) -> None:
+    headers = ["Adapter", "Framework", "Exec ID", "Status", "Ckpts", "Took", "Notes"]
+    rows: list[list[str]] = [headers]
+    for result in results:
+        rows.append(
+            [
+                result.adapter,
+                result.framework,
+                result.exec_id[:8],
+                result.status,
+                str(result.checkpoints),
+                f"{result.duration_s:.1f}s",
+                result.note or "-",
+            ]
+        )
+
+    widths = [max(len(row[col]) for row in rows) for col in range(len(headers))]
+
+    def render(row: list[str]) -> str:
+        return "  ".join(cell.ljust(widths[col]) for col, cell in enumerate(row))
+
+    bar = "  ".join("-" * w for w in widths)
+    print()
+    print(render(rows[0]))
+    print(bar)
+    for row in rows[1:]:
+        print(render(row))
+
+
+def _print_final_outputs(results: list[AdapterResult]) -> None:
+    print("\nFinal outputs:")
+    for result in results:
+        print(f"\n[{result.adapter}]  exec_id={result.exec_id}")
+        print(f"  {_truncate(result.final_output)}")
+
+
+def main() -> None:
+    _require_keys()
+
+    adapters = [
+        ("PydanticAI", run_pydantic_ai),
+        ("OpenAI Agents", run_openai_agents),
+        ("LangGraph", run_langgraph),
+        ("Claude Agent SDK", run_claude_sdk),
+    ]
+
+    results: list[AdapterResult] = []
+    failures: list[tuple[str, Exception]] = []
+    for name, fn in adapters:
+        print(f"\n=== Running {name} adapter ===")
+        try:
+            result = fn()
+        except Exception as exc:
+            failures.append((name, exc))
+            print(f"  FAILED: {type(exc).__name__}: {exc}")
+            continue
+        results.append(result)
+        print(
+            f"  ok  exec_id={result.exec_id[:8]} "
+            f"status={result.status} checkpoints={result.checkpoints}"
+        )
+
+    if results:
+        _print_table(results)
+        _print_final_outputs(results)
+
+    if failures:
+        print(f"\n{len(failures)} adapter(s) failed:")
+        for name, exc in failures:
+            print(f"  - {name}: {type(exc).__name__}: {exc}")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from functools import update_wrapper, wraps
 from typing import Any, cast, overload
 from urllib.parse import quote
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from pydantic import ConfigDict, create_model
 from zenml.artifacts.utils import save_artifact
@@ -29,10 +29,11 @@ from zenml.config.docker_settings import DockerSettings
 from zenml.config.global_config import GlobalConfiguration
 from zenml.config.retry_config import StepRetryConfig
 from zenml.constants import DEFAULT_STACK_AND_COMPONENT_NAME
-from zenml.enums import ArtifactType
+from zenml.enums import ArtifactType, MetadataResourceTypes
 from zenml.execution.pipeline.dynamic.outputs import OutputArtifact
 from zenml.models import PipelineRunResponse
 from zenml.models.v2.core.artifact_version import ArtifactVersionResponse
+from zenml.models.v2.misc.run_metadata import RunMetadataResource
 from zenml.pipelines.pipeline_decorator import pipeline
 from zenml.pipelines.pipeline_definition import Pipeline
 
@@ -244,6 +245,10 @@ def _register_pipeline_source_alias(
 
 _FLOW_RESULT_ARTIFACT_NAME = "kitaru_flow_result"
 _FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME = "kitaru_flow_result_tuple_metadata"
+_FLOW_RESULT_ARTIFACT_NAMES = frozenset(
+    {_FLOW_RESULT_ARTIFACT_NAME, _FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME}
+)
+_FLOW_RESULT_ARTIFACT_IDS_RUN_METADATA_KEY = "kitaru_flow_result_artifact_ids"
 _FLOW_RESULT_TUPLE_METADATA_MARKER = "kitaru_flow_result_tuple_v1"
 _FLOW_RESULT_ROLE_METADATA_KEY = "kitaru_flow_result_role"
 _FLOW_RESULT_TUPLE_METADATA_ROLE = "tuple_metadata"
@@ -280,13 +285,22 @@ def _save_flow_result_artifact(
     name: str,
     user_metadata: Mapping[str, Any] | None = None,
 ) -> ArtifactVersionResponse:
-    """Persist one plain flow result value as a ZenML artifact."""
+    """Persist one plain flow result value as a ZenML artifact.
+
+    ``save_artifact`` is called from the pipeline body, after the user's flow
+    function has returned, so there is no active step context. ZenML therefore
+    cannot link the resulting artifact to a step, which means the artifact
+    will not show up in ``run.steps[*].outputs`` or in ``pipeline_spec.outputs``
+    later. We compensate by recording the produced artifact id on the active
+    pipeline run's metadata so ``_extract_outputs_from_kitaru_flow_result_artifacts``
+    can recover it without depending on DAG topology.
+    """
     metadata: dict[str, Any] = {"kitaru_artifact_type": "output"}
     if user_metadata is not None:
         metadata.update(user_metadata)
 
     try:
-        return save_artifact(
+        artifact = save_artifact(
             data=value,
             name=name,
             artifact_type=ArtifactType.DATA,
@@ -300,6 +314,55 @@ def _save_flow_result_artifact(
             "this flow body, non-idempotent side effects in the flow may run "
             f"again: {exc}"
         ) from exc
+
+    _record_flow_result_artifact_on_run(artifact, name=name)
+    return artifact
+
+
+def _record_flow_result_artifact_on_run(
+    artifact: ArtifactVersionResponse,
+    *,
+    name: str,
+) -> None:
+    """Attach an orphan flow-result artifact to the active pipeline run.
+
+    ``save_artifact`` outside a step context produces an artifact that is not
+    linked to any step or run. We stash a mapping of ``name -> artifact_id``
+    on the run's metadata so the harness can recover the flow's return value
+    when ZenML's own ``pipeline_spec.outputs`` is empty (common for dynamic
+    pipelines whose flow body returns derived/plain Python values).
+
+    Failures here are non-fatal: the artifact was already persisted, and the
+    terminal-step fallback can still try to surface a result.
+    """
+    from kitaru.runtime import _get_current_execution_id
+
+    execution_id = _get_current_execution_id()
+    if execution_id is None:
+        return
+
+    try:
+        execution_uuid = UUID(str(execution_id))
+    except (TypeError, ValueError):
+        return
+
+    try:
+        Client().create_run_metadata(
+            metadata={
+                _FLOW_RESULT_ARTIFACT_IDS_RUN_METADATA_KEY: {name: str(artifact.id)},
+            },
+            resources=[
+                RunMetadataResource(
+                    id=execution_uuid,
+                    type=MetadataResourceTypes.PIPELINE_RUN,
+                )
+            ],
+        )
+    except Exception as exc:
+        logger.debug(
+            "Failed to record kitaru_flow_result artifact id on pipeline run: %s",
+            exc,
+        )
 
 
 def _flow_result_tuple_metadata(length: int) -> dict[str, Any]:
@@ -904,6 +967,67 @@ def _tuple_metadata_length_from_output(output: _FlowResultOutput) -> int | None:
     return cast(int, output.value["length"])
 
 
+def _extract_outputs_from_kitaru_flow_result_artifacts(
+    run: PipelineRunResponse,
+) -> list[_FlowResultOutput]:
+    """Recover flow-result artifacts that Kitaru persisted out-of-band.
+
+    When a flow body returns a plain Python value, ``_coerce_flow_return_for_zenml``
+    saves it via ``save_artifact`` from the pipeline-body finalizer. There is no
+    active step context there, so ZenML cannot link the artifact to a step and
+    ``pipeline_spec.outputs`` stays empty. ``_save_flow_result_artifact``
+    compensates by writing the produced artifact ids into the run's metadata
+    under :data:`_FLOW_RESULT_ARTIFACT_IDS_RUN_METADATA_KEY`; this helper reads
+    them back.
+
+    Returns an empty list when the run has no such metadata, in which case the
+    caller falls back to terminal-step extraction.
+    """
+    hydrated_run = run.get_hydrated_version()
+    artifact_ids_by_name = _flow_result_artifact_ids_from_run(hydrated_run)
+    if not artifact_ids_by_name:
+        return []
+
+    client = Client()
+    outputs: list[_FlowResultOutput] = []
+    for artifact_name, artifact_id_str in artifact_ids_by_name.items():
+        try:
+            artifact_uuid = UUID(str(artifact_id_str))
+        except (TypeError, ValueError):
+            continue
+        try:
+            artifact = client.get_artifact_version(artifact_uuid, hydrate=True)
+        except Exception as exc:
+            logger.debug(
+                "Failed to load recorded flow-result artifact %s: %s",
+                artifact_id_str,
+                exc,
+            )
+            continue
+        outputs.append(
+            _FlowResultOutput(
+                step_name=_FLOW_RESULT_ARTIFACT_NAME,
+                output_name=str(artifact_name),
+                artifact=artifact,
+                value=artifact.load(),
+            )
+        )
+
+    return outputs
+
+
+def _flow_result_artifact_ids_from_run(run: PipelineRunResponse) -> dict[str, str]:
+    """Read the recorded flow-result artifact id mapping off the run's metadata."""
+    for attr_name in ("run_metadata", "metadata"):
+        candidate = getattr(run, attr_name, None)
+        if not isinstance(candidate, Mapping):
+            continue
+        recorded = candidate.get(_FLOW_RESULT_ARTIFACT_IDS_RUN_METADATA_KEY)
+        if isinstance(recorded, Mapping):
+            return {str(k): str(v) for k, v in recorded.items()}
+    return {}
+
+
 def _extract_flow_result(run: PipelineRunResponse) -> Any:
     """Extract user-facing flow return value from a finished pipeline run.
 
@@ -917,6 +1041,13 @@ def _extract_flow_result(run: PipelineRunResponse) -> Any:
         The flow result (`None`, a single value, or a tuple of values).
     """
     outputs = _extract_outputs_from_output_specs(run)
+    if not outputs:
+        # Prefer the Kitaru-saved flow return value when present. Without this
+        # step `_extract_outputs_from_terminal_steps` would refuse to pick when
+        # adapter-internal checkpoints (PydanticAI granular, LangGraph `calls`,
+        # OpenAI Agents `calls`) appear as sibling terminals to the actual
+        # user return value.
+        outputs = _extract_outputs_from_kitaru_flow_result_artifacts(run)
     if not outputs:
         outputs = _extract_outputs_from_terminal_steps(run)
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -168,6 +168,8 @@ class _DummyRun:
         traceback: str | None = None,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
+        run_metadata: Mapping[str, object] | None = None,
+        include_output_specs: bool = True,
     ) -> None:
         self.id = run_id or uuid4()
         self.pipeline_id = pipeline_id
@@ -179,6 +181,7 @@ class _DummyRun:
         self.exception_info = (
             SimpleNamespace(traceback=traceback) if traceback else None
         )
+        self.run_metadata = dict(run_metadata or {})
 
         outputs = outputs or []
         output_specs: list[SimpleNamespace] = []
@@ -205,7 +208,9 @@ class _DummyRun:
             )
 
         self.snapshot = SimpleNamespace(
-            pipeline_spec=SimpleNamespace(outputs=output_specs),
+            pipeline_spec=SimpleNamespace(
+                outputs=output_specs if include_output_specs else []
+            ),
             pipeline_id=snapshot_pipeline_id,
             pipeline=snapshot_pipeline,
         )
@@ -1405,6 +1410,58 @@ def test_flow_result_extraction_rejects_multiple_tuple_metadata_artifacts() -> N
 
     with pytest.raises(KitaruRuntimeError, match="multiple Kitaru tuple metadata"):
         _extract_flow_result(_as_pipeline_run(run))
+
+
+def test_flow_result_extraction_recovers_orphan_kitaru_flow_result_via_run_metadata() -> (
+    None
+):
+    """Recover the user's return value when adapter checkpoints fan out as siblings.
+
+    When the flow body returns a plain Python value, ``_coerce_flow_return_for_zenml``
+    saves it via ``save_artifact`` from the pipeline-body finalizer. There is no
+    active step context at that point, so the resulting artifact is not linked to
+    any step or pipeline output spec. ``_save_flow_result_artifact`` compensates
+    by recording the artifact id on the run's metadata; this test verifies the
+    extractor reads it back instead of erroring on the sibling adapter terminals.
+    """
+    from kitaru.flow import _FLOW_RESULT_ARTIFACT_IDS_RUN_METADATA_KEY
+
+    flow_result_artifact_id = uuid4()
+    recorded_value = "Order ORD-1007 is delayed; replacement available."
+
+    class _StubArtifact:
+        def load(self) -> str:
+            return recorded_value
+
+    class _StubClient:
+        def get_artifact_version(
+            self, artifact_id: object, *, hydrate: bool = False
+        ) -> _StubArtifact:
+            del hydrate  # accept but ignore
+            assert str(artifact_id) == str(flow_result_artifact_id)
+            return _StubArtifact()
+
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        # Three sibling terminal checkpoints, none feeding into another — the
+        # shape that PydanticAI / OpenAI Agents / LangGraph granular adapters
+        # produce. Without the run-metadata fallback this would raise
+        # ``_MultipleTerminalStepsOutputError``.
+        outputs=[
+            ("model_call_1", "output", "intermediate-1"),
+            ("tool_call_2", "output", "intermediate-2"),
+            ("model_call_3", "output", "intermediate-3"),
+        ],
+        include_output_specs=False,
+        run_metadata={
+            _FLOW_RESULT_ARTIFACT_IDS_RUN_METADATA_KEY: {
+                _FLOW_RESULT_ARTIFACT_NAME: str(flow_result_artifact_id),
+            },
+        },
+    )
+
+    with patch("kitaru.flow.Client", return_value=_StubClient()):
+        assert _extract_flow_result(_as_pipeline_run(run)) == recorded_value
 
 
 def test_flow_return_coercion_rejects_mixed_tuple_subclasses() -> None:


### PR DESCRIPTION
## Summary

Fixes #350 and ships the cross-framework showcase that goes with it.

When a flow body computes a derived value from an adapter's materialized result (e.g. `return str(result.final_output)`) and the adapter created its own granular Kitaru checkpoints, `.wait()` used to raise `_MultipleTerminalStepsOutputError` because each adapter-internal checkpoint appeared as a peer terminal with no DAG sink. After this PR, the user's `return` statement is the authoritative answer for `.wait()` — independent of how many granular checkpoints the adapter created.

## Reviewer Notes

The root cause was structural: `_coerce_flow_return_for_zenml` persists the flow's return value via `save_artifact` from the pipeline-body finalizer, where no step context is active. ZenML's internal `_link_artifact_version_to_the_step_and_model` silently no-ops in that case, so the artifact ends up orphaned — not attached to the run, not in `pipeline_spec.outputs`, not in `step.outputs`. The fallback `_extract_outputs_from_terminal_steps` then saw the granular sibling checkpoints and refused to pick.

The fix records the saved artifact id on the active pipeline run's metadata so the run becomes a discoverable bridge to the orphan artifact. `_get_current_execution_id()` is set by `_flow_scope` and is available throughout the wrapper body, including the post-return finalizer path.

Files to look at:

- `src/kitaru/flow.py`
  - `_save_flow_result_artifact` now also calls `_record_flow_result_artifact_on_run`, which writes `{name: artifact_id}` under a reserved key in the run's metadata. Failures here are non-fatal — the artifact was already saved.
  - `_extract_outputs_from_kitaru_flow_result_artifacts` reads that breadcrumb and rehydrates the artifact via `Client().get_artifact_version`.
  - `_extract_flow_result` inserts the new path *between* the pipeline-spec lookup and the terminal-step fallback, so the existing happy path (placeholder return) is unchanged.
- `tests/test_flow.py` — adds `test_flow_result_extraction_recovers_orphan_kitaru_flow_result_via_run_metadata`. `_DummyRun` gained an opt-in `run_metadata` and `include_output_specs=False` toggle to model the orphan case.

## Reproduction

```bash
uv sync --extra local \
        --extra pydantic-ai \
        --extra openai-agents \
        --extra langgraph-openai \
        --extra claude-agent-sdk
uv run kitaru init
export OPENAI_API_KEY=sk-...
export ANTHROPIC_API_KEY=sk-ant-...
uv run python examples/integrations/all_adapters_showcase/all_adapters.py
```

On a remote stack (e.g. `local_remote`), every adapter completes and the table prints. Before this PR, three of four adapters in their granular modes raised `_MultipleTerminalStepsOutputError`.

Observed locally on `local_remote`:

```
Adapter           Framework         Exec ID   Status     Ckpts  Took
----------------  ----------------  --------  ---------  -----  -----
PydanticAI        pydantic-ai       cfc94bbf  completed  5      43.8s
OpenAI Agents     openai-agents     2e6550a0  completed  5      46.2s
LangGraph         langgraph         a9603542  completed  2      14.3s
Claude Agent SDK  claude-agent-sdk  bdce99c5  completed  1      20.1s
```

Verify in the dashboard or `kitaru executions get <exec_id>` that each granular run has the expected per-model/per-tool checkpoints alongside its single resolved return value.

## Local checks run

- `uv run ruff check src/kitaru/flow.py examples/integrations/all_adapters_showcase/` — clean.
- `uv run pytest tests/test_flow.py -k "flow_result or extract_flow or terminal"` — 88 passed, including the new regression test.
- `uv run pytest tests/ --ignore=tests/mcp` — 1767 passed, 1 unrelated SQLite-lock flake in `tests/test_phase4_compliance_review_stage4.py::test_stage4_flow_waits_resumes_and_reuses_session` (about wait/resume sessions; reproduced before and after this change).

## Other notes

- Bumps a changelog entry under `### Added` (showcase) and `### Fixed` (the underlying fix).
- Does not address #348 (OpenAI Agents `isinstance` class-identity issue on remote) or #349 (placeholder leaks into Pydantic validators). The showcase uses `getattr` rather than `isinstance` for #348 — a documentation note rather than a fix.
- The showcase requires both `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` so it can run against real models. There is no mocked/no-keys mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)