### PR TITLE
Improve checkpoint handle validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Bumped the minimum ZenML dependency, server image, and Helm subchart versions to `0.94.4` so Kitaru tracks the latest upstream ZenML release.
 
 ### Fixed
+- Fixed Kitaru-owned request constructors to reject checkpoint output handles with guidance to call `.load()` instead of surfacing generic Pydantic string validation errors. (#349)
 - Fixed Kitaru flow return compatibility with ZenML `0.94.4` dynamic-pipeline output validation by persisting plain flow returns as internal artifacts while preserving user-facing Python return values and avoiding marker-shaped user dictionaries being mistaken for hidden tuple metadata.
 
 ## [0.12.0] - 2026-05-17

--- a/docs/content/docs/guides/claude-agent-sdk-adapter.mdx
+++ b/docs/content/docs/guides/claude-agent-sdk-adapter.mdx
@@ -219,6 +219,20 @@ request = ClaudeRunRequest.resume(
 )
 ```
 
+If the prompt comes from a previous checkpoint or from a flow-body
+`kitaru.llm()` call, remember that the value in the flow body is a Kitaru
+checkpoint output handle, not the concrete string yet. Load it before building a
+Claude request when Claude needs the actual text:
+
+```python
+prompt_text = render_prompt(topic).load()
+request = ClaudeRunRequest.start(prompt_text)
+```
+
+If you want to preserve Kitaru's durable data edge instead, pass the original
+handle into a downstream `@checkpoint` and build the `ClaudeRunRequest` inside
+that checkpoint.
+
 This uses Claude's native session mechanism. Kitaru records the session ID and
 passes it back through `ClaudeAgentOptions(resume=...)` when you resume.
 

--- a/src/kitaru/adapters/claude_agent_sdk/_types.py
+++ b/src/kitaru/adapters/claude_agent_sdk/_types.py
@@ -4,6 +4,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from kitaru.checkpoint import _raise_if_checkpoint_output_handle
+
 
 class ClaudeRunRequest(BaseModel):
     """Serializable input to ``KitaruClaudeRunner.run(...)`` / ``run_sync(...)``."""
@@ -63,11 +65,41 @@ class ClaudeRunRequest(BaseModel):
             raise ValueError("Claude run prompt must be non-empty.")
         return value
 
+    @field_validator("prompt", mode="before")
+    @classmethod
+    def _reject_prompt_checkpoint_handle(cls, value: Any) -> Any:
+        _raise_if_checkpoint_output_handle(
+            value,
+            field_name="ClaudeRunRequest.prompt",
+            expected="a materialized string prompt",
+        )
+        return value
+
     @field_validator("resume_session_id")
     @classmethod
     def _validate_resume_session_id(cls, value: str | None) -> str | None:
         if value is not None and not value.strip():
             raise ValueError("resume_session_id must be non-empty when provided.")
+        return value
+
+    @field_validator("resume_session_id", mode="before")
+    @classmethod
+    def _reject_resume_session_id_checkpoint_handle(cls, value: Any) -> Any:
+        _raise_if_checkpoint_output_handle(
+            value,
+            field_name="ClaudeRunRequest.resume_session_id",
+            expected="a materialized Claude session id string",
+        )
+        return value
+
+    @field_validator("cwd", mode="before")
+    @classmethod
+    def _reject_cwd_checkpoint_handle(cls, value: Any) -> Any:
+        _raise_if_checkpoint_output_handle(
+            value,
+            field_name="ClaudeRunRequest.cwd",
+            expected="a materialized filesystem path string",
+        )
         return value
 
     @field_validator("max_turns")

--- a/src/kitaru/adapters/openai_agents/_types.py
+++ b/src/kitaru/adapters/openai_agents/_types.py
@@ -5,6 +5,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from kitaru.checkpoint import _raise_if_checkpoint_output_handle_in_value
+
 
 class OpenAIRunStateEnvelope(BaseModel):
     """Checkpoint-safe wrapper around serialized OpenAI ``RunState``."""
@@ -110,6 +112,16 @@ class OpenAIRunRequest(BaseModel):
         if isinstance(value, list) and all(isinstance(item, dict) for item in value):
             return value
         raise ValueError("OpenAI run input must be a string or list of dictionaries.")
+
+    @field_validator("input", mode="before")
+    @classmethod
+    def _reject_input_checkpoint_handle(cls, value: Any) -> Any:
+        _raise_if_checkpoint_output_handle_in_value(
+            value,
+            field_name="OpenAIRunRequest.input",
+            expected="materialized OpenAI input content",
+        )
+        return value
 
     @model_validator(mode="after")
     def _validate_kind_contract(self) -> "OpenAIRunRequest":

--- a/src/kitaru/checkpoint.py
+++ b/src/kitaru/checkpoint.py
@@ -7,9 +7,10 @@ Successful outputs become artifacts; failures are recorded for retry.
 from __future__ import annotations
 
 import sys
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import ExitStack
 from functools import update_wrapper, wraps
+from itertools import islice
 from typing import Any, Literal, cast, overload
 
 from zenml.config.retry_config import StepRetryConfig
@@ -52,6 +53,107 @@ _CHECKPOINT_OUTPUT_HANDLE_MESSAGE = (
     "This is a Kitaru checkpoint output handle for `{checkpoint}.{output}`, "
     "not the materialized value. Call `.load()` to materialize the value."
 )
+
+
+def _is_checkpoint_output_handle(value: Any) -> bool:
+    return isinstance(value, OutputArtifact)
+
+
+def _checkpoint_output_handle_validation_message(
+    value: Any,
+    *,
+    field_name: str,
+    expected: str,
+) -> str:
+    checkpoint_name = getattr(value, "step_name", None)
+    output_name = getattr(value, "output_name", None)
+    handle_context = "a Kitaru checkpoint output handle"
+    if checkpoint_name and output_name:
+        handle_context = (
+            f"a Kitaru checkpoint output handle for `{checkpoint_name}.{output_name}`"
+        )
+
+    return (
+        f"{field_name} received {handle_context}, not {expected}. "
+        "In a flow body, call `.load()` before constructing this request when "
+        "you need the concrete value. To preserve the durable data edge, pass "
+        "the original handle into a downstream `@checkpoint` instead."
+    )
+
+
+def _raise_if_checkpoint_output_handle(
+    value: Any,
+    *,
+    field_name: str,
+    expected: str,
+) -> None:
+    if _is_checkpoint_output_handle(value):
+        raise ValueError(
+            _checkpoint_output_handle_validation_message(
+                value,
+                field_name=field_name,
+                expected=expected,
+            )
+        )
+
+
+_CHECKPOINT_HANDLE_SCAN_MAX_VALUES = 1_000
+
+
+def _raise_if_checkpoint_output_handle_in_value(
+    value: Any,
+    *,
+    field_name: str,
+    expected: str,
+) -> None:
+    stack: list[tuple[Any, str]] = [(value, field_name)]
+    seen_containers: set[int] = set()
+    visited_values = 0
+
+    while stack:
+        item, item_field_name = stack.pop()
+        visited_values += 1
+        if visited_values > _CHECKPOINT_HANDLE_SCAN_MAX_VALUES:
+            return
+
+        _raise_if_checkpoint_output_handle(
+            item,
+            field_name=item_field_name,
+            expected=expected,
+        )
+
+        if isinstance(item, Mapping):
+            container_id = id(item)
+            if container_id in seen_containers:
+                continue
+            seen_containers.add(container_id)
+
+            remaining_values = _CHECKPOINT_HANDLE_SCAN_MAX_VALUES - (
+                visited_values + len(stack)
+            )
+            if remaining_values <= 0:
+                return
+            children = list(islice(item.items(), remaining_values))
+            stack.extend(
+                (child, f"{item_field_name}.{key}") for key, child in reversed(children)
+            )
+            continue
+
+        if isinstance(item, (list, tuple)):
+            container_id = id(item)
+            if container_id in seen_containers:
+                continue
+            seen_containers.add(container_id)
+
+            remaining_values = _CHECKPOINT_HANDLE_SCAN_MAX_VALUES - (
+                visited_values + len(stack)
+            )
+            if remaining_values <= 0:
+                return
+            stack.extend(
+                (child, f"{item_field_name}[{index}]")
+                for index, child in reversed(list(enumerate(item[:remaining_values])))
+            )
 
 
 class _KitaruOutputArtifact(OutputArtifact):

--- a/src/kitaru/checkpoint.py
+++ b/src/kitaru/checkpoint.py
@@ -6,6 +6,7 @@ Successful outputs become artifacts; failures are recorded for retry.
 
 from __future__ import annotations
 
+import keyword
 import sys
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import ExitStack
@@ -100,6 +101,22 @@ def _raise_if_checkpoint_output_handle(
 _CHECKPOINT_HANDLE_SCAN_MAX_VALUES = 1_000
 
 
+def _format_checkpoint_value_path(parent: str, key: Any) -> str:
+    if isinstance(key, str) and key.isidentifier() and not keyword.iskeyword(key):
+        return f"{parent}.{key}"
+    return f"{parent}[{key!r}]"
+
+
+def _raise_checkpoint_handle_scan_limit_exceeded(field_name: str) -> None:
+    raise ValueError(
+        "Kitaru could not validate "
+        f"{field_name} for checkpoint output handles because the value contains "
+        f"more than {_CHECKPOINT_HANDLE_SCAN_MAX_VALUES} nested values. "
+        "Pass a smaller value, or load any checkpoint output handles with `.load()` "
+        "before passing the value here."
+    )
+
+
 def _raise_if_checkpoint_output_handle_in_value(
     value: Any,
     *,
@@ -109,12 +126,13 @@ def _raise_if_checkpoint_output_handle_in_value(
     stack: list[tuple[Any, str]] = [(value, field_name)]
     seen_containers: set[int] = set()
     visited_values = 0
+    scan_limit_exceeded = False
 
     while stack:
         item, item_field_name = stack.pop()
         visited_values += 1
         if visited_values > _CHECKPOINT_HANDLE_SCAN_MAX_VALUES:
-            return
+            _raise_checkpoint_handle_scan_limit_exceeded(field_name)
 
         _raise_if_checkpoint_output_handle(
             item,
@@ -132,10 +150,13 @@ def _raise_if_checkpoint_output_handle_in_value(
                 visited_values + len(stack)
             )
             if remaining_values <= 0:
-                return
+                scan_limit_exceeded = scan_limit_exceeded or bool(item)
+                continue
+            scan_limit_exceeded = scan_limit_exceeded or len(item) > remaining_values
             children = list(islice(item.items(), remaining_values))
             stack.extend(
-                (child, f"{item_field_name}.{key}") for key, child in reversed(children)
+                (child, _format_checkpoint_value_path(item_field_name, key))
+                for key, child in reversed(children)
             )
             continue
 
@@ -149,11 +170,16 @@ def _raise_if_checkpoint_output_handle_in_value(
                 visited_values + len(stack)
             )
             if remaining_values <= 0:
-                return
+                scan_limit_exceeded = scan_limit_exceeded or bool(item)
+                continue
+            scan_limit_exceeded = scan_limit_exceeded or len(item) > remaining_values
             stack.extend(
                 (child, f"{item_field_name}[{index}]")
                 for index, child in reversed(list(enumerate(item[:remaining_values])))
             )
+
+    if scan_limit_exceeded:
+        _raise_checkpoint_handle_scan_limit_exceeded(field_name)
 
 
 class _KitaruOutputArtifact(OutputArtifact):

--- a/src/kitaru/llm.py
+++ b/src/kitaru/llm.py
@@ -13,12 +13,16 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from kitaru._env import _temporary_env
 from kitaru._safe_save import _safe_save
 from kitaru.artifacts import save
-from kitaru.checkpoint import checkpoint
+from kitaru.checkpoint import (
+    _raise_if_checkpoint_output_handle,
+    _raise_if_checkpoint_output_handle_in_value,
+    checkpoint,
+)
 from kitaru.config import ResolvedModelSelection, resolve_model_selection
 from kitaru.errors import (
     KitaruBackendError,
@@ -67,6 +71,26 @@ class _LLMRequest(BaseModel):
     call_name: str
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @field_validator("prompt", mode="before")
+    @classmethod
+    def _reject_prompt_checkpoint_handle(cls, value: Any) -> Any:
+        _raise_if_checkpoint_output_handle_in_value(
+            value,
+            field_name="_LLMRequest.prompt",
+            expected="materialized prompt content",
+        )
+        return value
+
+    @field_validator("system", mode="before")
+    @classmethod
+    def _reject_system_checkpoint_handle(cls, value: Any) -> Any:
+        _raise_if_checkpoint_output_handle(
+            value,
+            field_name="_LLMRequest.system",
+            expected="a materialized system prompt string",
+        )
+        return value
 
 
 @dataclass(frozen=True)

--- a/tests/_checkpoint_handle_helpers.py
+++ b/tests/_checkpoint_handle_helpers.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from kitaru.checkpoint import _KitaruOutputArtifact
+
+
+def checkpoint_output_handle() -> _KitaruOutputArtifact:
+    return _KitaruOutputArtifact.model_construct(
+        id=uuid4(),
+        step_name="render_prompt",
+        output_name="output",
+    )
+
+
+def assert_checkpoint_handle_error(
+    exc_info: pytest.ExceptionInfo[ValidationError],
+    *,
+    field_name: str,
+) -> None:
+    message = str(exc_info.value)
+    assert field_name in message
+    assert "Kitaru checkpoint output handle" in message
+    assert "render_prompt.output" in message
+    assert ".load()" in message
+    assert "downstream `@checkpoint`" in message
+    assert "ArtifactVersionResponse" not in message
+    assert "ZenML" not in message

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -16,6 +16,7 @@ from zenml.enums import StepRuntime, StepType
 
 from kitaru.analytics import AnalyticsEvent
 from kitaru.checkpoint import (
+    _CHECKPOINT_HANDLE_SCAN_MAX_VALUES,
     _KitaruOutputArtifact,
     _raise_if_checkpoint_output_handle,
     _raise_if_checkpoint_output_handle_in_value,
@@ -690,6 +691,51 @@ def test_checkpoint_output_handle_validation_scans_prompt_containers() -> None:
     assert "DemoRequest.input[0].content[0].text" in message
     assert "Kitaru checkpoint output handle" in message
     assert "render_prompt.output" in message
+    assert ".load()" in message
+
+
+def test_checkpoint_output_handle_validation_formats_unusual_mapping_keys() -> None:
+    class WeirdKey:
+        def __repr__(self) -> str:
+            return "<weird key>"
+
+    handle = _KitaruOutputArtifact.model_construct(
+        id=uuid4(),
+        step_name="render_prompt",
+        output_name="output",
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        _raise_if_checkpoint_output_handle_in_value(
+            {"foo.bar": {1: {WeirdKey(): handle}}},
+            field_name="DemoRequest.input",
+            expected="materialized prompt content",
+        )
+
+    message = str(exc_info.value)
+    assert "DemoRequest.input['foo.bar'][1][<weird key>]" in message
+
+
+def test_checkpoint_output_handle_validation_errors_when_scan_limit_is_exceeded() -> (
+    None
+):
+    handle = _KitaruOutputArtifact.model_construct(
+        id=uuid4(),
+        step_name="render_prompt",
+        output_name="output",
+    )
+    value = [*range(_CHECKPOINT_HANDLE_SCAN_MAX_VALUES), handle]
+
+    with pytest.raises(ValueError) as exc_info:
+        _raise_if_checkpoint_output_handle_in_value(
+            value,
+            field_name="DemoRequest.input",
+            expected="materialized prompt content",
+        )
+
+    message = str(exc_info.value)
+    assert "Kitaru could not validate DemoRequest.input" in message
+    assert f"more than {_CHECKPOINT_HANDLE_SCAN_MAX_VALUES} nested values" in message
     assert ".load()" in message
 
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -8,13 +8,19 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 from zenml.config.retry_config import StepRetryConfig
 from zenml.enums import StepRuntime, StepType
 
 from kitaru.analytics import AnalyticsEvent
-from kitaru.checkpoint import checkpoint
+from kitaru.checkpoint import (
+    _KitaruOutputArtifact,
+    _raise_if_checkpoint_output_handle,
+    _raise_if_checkpoint_output_handle_in_value,
+    checkpoint,
+)
 from kitaru.errors import KitaruContextError, KitaruUsageError
 from kitaru.flow import flow
 from kitaru.runtime import (
@@ -640,3 +646,59 @@ def test_flow_body_output_handle_string_conversion_is_helpful(
         assert ".load()" in rendered
         assert "ArtifactVersionResponse" not in rendered
         assert "ZenML" not in rendered
+
+
+def test_checkpoint_output_handle_validation_message_is_helpful() -> None:
+    handle = _KitaruOutputArtifact.model_construct(
+        id=uuid4(),
+        step_name="render_prompt",
+        output_name="output",
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        _raise_if_checkpoint_output_handle(
+            handle,
+            field_name="DemoRequest.prompt",
+            expected="a materialized prompt string",
+        )
+
+    message = str(exc_info.value)
+    assert "DemoRequest.prompt" in message
+    assert "Kitaru checkpoint output handle" in message
+    assert "render_prompt.output" in message
+    assert ".load()" in message
+    assert "downstream `@checkpoint`" in message
+    assert "ArtifactVersionResponse" not in message
+    assert "ZenML" not in message
+
+
+def test_checkpoint_output_handle_validation_scans_prompt_containers() -> None:
+    handle = _KitaruOutputArtifact.model_construct(
+        id=uuid4(),
+        step_name="render_prompt",
+        output_name="output",
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        _raise_if_checkpoint_output_handle_in_value(
+            [{"role": "user", "content": [{"text": handle}]}],
+            field_name="DemoRequest.input",
+            expected="materialized prompt content",
+        )
+
+    message = str(exc_info.value)
+    assert "DemoRequest.input[0].content[0].text" in message
+    assert "Kitaru checkpoint output handle" in message
+    assert "render_prompt.output" in message
+    assert ".load()" in message
+
+
+def test_checkpoint_output_handle_validation_skips_cycles() -> None:
+    cyclic_value: dict[str, Any] = {"messages": []}
+    cyclic_value["self"] = cyclic_value
+
+    _raise_if_checkpoint_output_handle_in_value(
+        cyclic_value,
+        field_name="DemoRequest.input",
+        expected="materialized prompt content",
+    )

--- a/tests/test_claude_agent_sdk_adapter_foundation.py
+++ b/tests/test_claude_agent_sdk_adapter_foundation.py
@@ -8,12 +8,17 @@ import inspect
 import sys
 import types
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from pydantic import ValidationError
 
 from kitaru.analytics import AnalyticsEvent
 from kitaru.errors import KitaruFeatureNotAvailableError, KitaruUsageError
+from tests._checkpoint_handle_helpers import (
+    assert_checkpoint_handle_error,
+    checkpoint_output_handle,
+)
 
 
 def _purge_claude_adapter_modules(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -202,6 +207,46 @@ def test_claude_run_request_start_and_resume_validation(
         claude_adapter.ClaudeRunRequest(kind="resume", prompt="hello")
     with pytest.raises(ValidationError, match="positive"):
         claude_adapter.ClaudeRunRequest.start("hello", max_turns=0)
+
+
+def test_claude_run_request_rejects_checkpoint_handles(
+    claude_adapter: types.ModuleType,
+) -> None:
+    handle = checkpoint_output_handle()
+
+    with pytest.raises(ValidationError) as prompt_exc:
+        claude_adapter.ClaudeRunRequest.start(cast(str, handle))
+    assert_checkpoint_handle_error(
+        prompt_exc,
+        field_name="ClaudeRunRequest.prompt",
+    )
+
+    with pytest.raises(ValidationError) as resume_prompt_exc:
+        claude_adapter.ClaudeRunRequest.resume(
+            cast(str, handle),
+            "session-123",
+        )
+    assert_checkpoint_handle_error(
+        resume_prompt_exc,
+        field_name="ClaudeRunRequest.prompt",
+    )
+
+    with pytest.raises(ValidationError) as session_exc:
+        claude_adapter.ClaudeRunRequest.resume(
+            "continue",
+            cast(str, handle),
+        )
+    assert_checkpoint_handle_error(
+        session_exc,
+        field_name="ClaudeRunRequest.resume_session_id",
+    )
+
+    with pytest.raises(ValidationError) as cwd_exc:
+        claude_adapter.ClaudeRunRequest.start("hello", cwd=cast(str, handle))
+    assert_checkpoint_handle_error(
+        cwd_exc,
+        field_name="ClaudeRunRequest.cwd",
+    )
 
 
 def test_capture_policy_accepts_strict_capture_failure_knobs(

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from kitaru.analytics import AnalyticsEvent
 from kitaru.config import ResolvedModelSelection, register_model_alias
@@ -20,6 +21,7 @@ from kitaru.errors import (
 )
 from kitaru.flow import flow
 from kitaru.llm import (
+    _LLMRequest,
     _LLMUsage,
     _parse_provider_target,
     _ProviderCallResult,
@@ -27,6 +29,10 @@ from kitaru.llm import (
     llm,
 )
 from kitaru.runtime import _checkpoint_scope, _flow_scope
+from tests._checkpoint_handle_helpers import (
+    assert_checkpoint_handle_error,
+    checkpoint_output_handle,
+)
 
 
 def _flow_checkpoint_scope() -> tuple[str, str]:
@@ -95,6 +101,83 @@ def test_llm_raises_outside_flow() -> None:
     """`kitaru.llm()` should reject calls outside an active flow."""
     with pytest.raises(KitaruContextError, match=r"inside a @flow"):
         llm("hello")
+
+
+def test_llm_request_rejects_checkpoint_handles() -> None:
+    handle = checkpoint_output_handle()
+
+    with pytest.raises(ValidationError) as prompt_exc:
+        _LLMRequest(
+            prompt=cast(str, handle),
+            model="fast",
+            call_name="demo",
+        )
+    assert_checkpoint_handle_error(
+        prompt_exc,
+        field_name="_LLMRequest.prompt",
+    )
+
+    with pytest.raises(ValidationError) as system_exc:
+        _LLMRequest(
+            prompt="hello",
+            model="fast",
+            system=cast(str, handle),
+            call_name="demo",
+        )
+    assert_checkpoint_handle_error(
+        system_exc,
+        field_name="_LLMRequest.system",
+    )
+
+    with pytest.raises(ValidationError) as nested_exc:
+        _LLMRequest(
+            prompt=[{"role": "user", "content": [{"text": handle}]}],
+            model="fast",
+            call_name="demo",
+        )
+    assert_checkpoint_handle_error(
+        nested_exc,
+        field_name="_LLMRequest.prompt[0].content[0].text",
+    )
+
+    valid = _LLMRequest(
+        prompt=[{"role": "user", "content": "hello"}],
+        model="fast",
+        system="You are helpful.",
+        call_name="demo",
+    )
+    assert valid.prompt == [{"role": "user", "content": "hello"}]
+    assert valid.system == "You are helpful."
+
+
+def test_public_llm_rejects_checkpoint_handles_before_dispatch() -> None:
+    handle = checkpoint_output_handle()
+
+    with (
+        _flow_scope(name="demo_flow", execution_id=str(uuid4())),
+        patch("kitaru.llm._llm_checkpoint_call") as mock_synthetic,
+        pytest.raises(ValidationError) as prompt_exc,
+    ):
+        llm(cast(str, handle), model="fast", name="demo")
+
+    assert_checkpoint_handle_error(
+        prompt_exc,
+        field_name="_LLMRequest.prompt",
+    )
+    mock_synthetic.assert_not_called()
+
+    with (
+        _flow_scope(name="demo_flow", execution_id=str(uuid4())),
+        patch("kitaru.llm._llm_checkpoint_call") as mock_synthetic,
+        pytest.raises(ValidationError) as system_exc,
+    ):
+        llm("hello", model="fast", system=cast(str, handle), name="demo")
+
+    assert_checkpoint_handle_error(
+        system_exc,
+        field_name="_LLMRequest.system",
+    )
+    mock_synthetic.assert_not_called()
 
 
 def test_llm_uses_inline_execution_inside_checkpoint() -> None:

--- a/tests/test_openai_agents_adapter_foundation.py
+++ b/tests/test_openai_agents_adapter_foundation.py
@@ -7,12 +7,17 @@ import inspect
 import sys
 import types
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from pydantic import ValidationError
 
 from kitaru.analytics import AnalyticsEvent
 from kitaru.errors import KitaruUsageError
+from tests._checkpoint_handle_helpers import (
+    assert_checkpoint_handle_error,
+    checkpoint_output_handle,
+)
 
 
 @pytest.fixture
@@ -211,6 +216,33 @@ def test_openai_run_request_rejects_arbitrary_input_object(
 ) -> None:
     with pytest.raises(ValidationError):
         openai_agents_adapter.OpenAIRunRequest(kind="start", input={"role": "user"})
+
+
+def test_openai_run_request_rejects_checkpoint_handles(
+    openai_agents_adapter: types.ModuleType,
+) -> None:
+    handle = checkpoint_output_handle()
+
+    with pytest.raises(ValidationError) as direct_exc:
+        openai_agents_adapter.OpenAIRunRequest.start(cast(str, handle))
+    assert_checkpoint_handle_error(
+        direct_exc,
+        field_name="OpenAIRunRequest.input",
+    )
+
+    with pytest.raises(ValidationError) as nested_exc:
+        openai_agents_adapter.OpenAIRunRequest.start(
+            [{"role": "user", "content": handle}]
+        )
+    assert_checkpoint_handle_error(
+        nested_exc,
+        field_name="OpenAIRunRequest.input[0].content",
+    )
+
+    valid = openai_agents_adapter.OpenAIRunRequest.start(
+        [{"role": "user", "content": "hello"}]
+    )
+    assert valid.input == [{"role": "user", "content": "hello"}]
 
 
 def test_interrupted_result_requires_state_and_interruption(

--- a/uv.lock
+++ b/uv.lock
@@ -991,11 +991,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- Added Kitaru-aware checkpoint output handle validation for Kitaru-owned request constructors.
- Covered the direct issue #349 path in `ClaudeRunRequest`, plus the same proven shape in `OpenAIRunRequest.input` and native `kitaru.llm()` request construction.
- Added focused regression tests and a Claude adapter docs note explaining when to call `.load()`.
- Updated the changelog.

Fixes #349.

## Why it was needed

A flow-body checkpoint call returns a durable output handle, not the materialized string. Passing that handle into a Pydantic request constructor like `ClaudeRunRequest.start(...)` previously produced a generic `string_type` error before Kitaru could explain the real problem.

This keeps the failure, but moves it to a Kitaru-aware message: the user gets told they passed a checkpoint output handle and should call `.load()` when ordinary flow-body Python needs the concrete value.

## Key implementation decisions

- The guard lives at the Kitaru-owned Pydantic model boundary, not in runners. Runner code is too late because request construction has already happened.
- The helper detects ZenML/Kitaru output handles via `OutputArtifact`, not broad `.load()` duck typing.
- The prompt-container scan is iterative, cycle-safe, bounded to avoid pathological recursion, and fails closed if the scan limit is exceeded.
- The code does not auto-load handles and does not coerce them to strings, because that could accidentally send Kitaru’s handle-help text as an actual model prompt.
- LangGraph is intentionally out of scope because the reproduced failures were Claude/OpenAI/native LLM request inputs, while LangGraph `input` and `command` intentionally accept `Any`.

## Reviewer Notes

The important behavior now happens before Pydantic’s normal string validation. When a user accidentally passes a checkpoint output handle into `ClaudeRunRequest.prompt`, `OpenAIRunRequest.input`, or native `kitaru.llm()` prompt/system construction, Kitaru inspects the raw value first and raises a `ValidationError` with `.load()` guidance.

The risky part is the boundary: if this were implemented in the Claude/OpenAI runners, it would be too late because the request object would never exist. If this were implemented by coercing `str(handle)`, the downstream model could receive the explanatory handle text as its prompt. The helper in `checkpoint.py` is therefore intentionally conservative: it recognizes real output artifacts, formats the error without stringifying raw ZenML handles, and only scans prompt-like containers where the request models already accept nested message data.

Please pay special attention to:

- `src/kitaru/checkpoint.py` for helper behavior, cycle handling, and message wording.
- `src/kitaru/adapters/claude_agent_sdk/_types.py` for the direct issue #349 path.
- `src/kitaru/adapters/openai_agents/_types.py` and `src/kitaru/llm.py` for sibling surfaces using the shared helper.
- `tests/_checkpoint_handle_helpers.py` and the new regression tests for expected message shape.

### Reproduction

Before this change, a checkpoint output handle passed into `ClaudeRunRequest.start(...)` produced a generic Pydantic `string_type` error. After this change, the regression test demonstrates the intended user-facing behavior:

```bash
uv run pytest \
  tests/test_claude_agent_sdk_adapter_foundation.py::test_claude_run_request_rejects_checkpoint_handles \
  tests/test_openai_agents_adapter_foundation.py::test_openai_run_request_rejects_checkpoint_handles \
  tests/test_llm.py::test_public_llm_rejects_checkpoint_handles_before_dispatch
```

Expected result: the tests pass, and the asserted errors mention `Kitaru checkpoint output handle`, `.load()`, and the affected request field instead of exposing raw ZenML internals. Additional checkpoint tests cover cycle handling, unusual mapping-key path formatting, and scan-limit overflow.

Local checks run:

```bash
just check
just test
```

Results:

- `just check`: passed
- `just test`: `1771 passed, 8 skipped, 86 warnings`

