### PR TITLE
Fix adapter result identity after checkpoint load

### DIFF
--- a/examples/integrations/claude_agent_sdk_agent/claude_agent_sdk_adapter.py
+++ b/examples/integrations/claude_agent_sdk_agent/claude_agent_sdk_adapter.py
@@ -98,6 +98,9 @@ def _coerce_result(value: Any) -> ClaudeRunResult:
         return value
     if isinstance(value, dict):
         return ClaudeRunResult.model_validate(value)
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return ClaudeRunResult.model_validate(model_dump(mode="python"))
     raise TypeError(f"Expected ClaudeRunResult from flow, got {type(value).__name__}.")
 
 

--- a/examples/integrations/openai_agents_agent/openai_agents_adapter.py
+++ b/examples/integrations/openai_agents_agent/openai_agents_adapter.py
@@ -135,13 +135,28 @@ def _extract_final_output_from_envelope_text(text: str) -> str:
     return str(parsed)
 
 
-def _normalize_wait_output(value: Any) -> str:
+def _coerce_run_result(value: Any) -> OpenAIRunResult:
     if isinstance(value, OpenAIRunResult):
-        if value.status != "completed":
-            raise RuntimeError(f"Expected completed run, got status={value.status!r}.")
-        return str(value.final_output)
+        return value
+    if isinstance(value, dict):
+        return OpenAIRunResult.model_validate(value)
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return OpenAIRunResult.model_validate(model_dump(mode="python"))
+    raise TypeError(f"Expected OpenAIRunResult, got {type(value).__name__}.")
+
+
+def _normalize_wait_output(value: Any) -> str:
     if isinstance(value, ModelResponse):
         return _extract_model_response_text(value)
+    try:
+        result = _coerce_run_result(value)
+    except (TypeError, ValueError):
+        pass
+    else:
+        if result.status != "completed":
+            raise RuntimeError(f"Expected completed run, got status={result.status!r}.")
+        return str(result.final_output)
     text = str(value)
     return _extract_final_output_from_envelope_text(text)
 

--- a/src/kitaru/adapters/_result_identity.py
+++ b/src/kitaru/adapters/_result_identity.py
@@ -1,0 +1,29 @@
+"""Helpers for rebuilding adapter result objects with canonical class identity."""
+
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+ResultModelT = TypeVar("ResultModelT", bound=BaseModel)
+
+
+def canonicalize_result_model(
+    value: Any,
+    model_type: type[ResultModelT],
+) -> ResultModelT:
+    """Return ``value`` as an instance of the adapter's canonical model class.
+
+    Synthetic checkpoint materialization can return a Pydantic model instance
+    with the right fields but the wrong module/class identity, for example
+    ``src.kitaru...OpenAIRunResult`` instead of
+    ``kitaru...OpenAIRunResult``. Pydantic correctly refuses to validate that
+    foreign model instance directly, so we first turn Pydantic-like objects into
+    plain Python data and then validate that payload into the promised class.
+    """
+    if isinstance(value, model_type):
+        return value
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        return model_type.model_validate(model_dump(mode="python"))
+    return model_type.model_validate(value)

--- a/src/kitaru/adapters/claude_agent_sdk/_agent.py
+++ b/src/kitaru/adapters/claude_agent_sdk/_agent.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
+from kitaru.adapters._result_identity import canonicalize_result_model
 from kitaru.analytics import AnalyticsEvent, track
 from kitaru.errors import KitaruRuntimeError, KitaruUsageError
 
@@ -168,6 +169,7 @@ class KitaruClaudeRunner:
         self._require_invocation_scope("KitaruClaudeRunner.run()")
         try:
             result = await self._run_invocation_async(request)
+            result = canonicalize_result_model(result, ClaudeRunResult)
         except Exception:
             self._track_completed("run", status="failed", result=None)
             raise
@@ -188,6 +190,7 @@ class KitaruClaudeRunner:
         self._require_invocation_scope("KitaruClaudeRunner.run_sync()")
         try:
             result = self._run_invocation_sync(request)
+            result = canonicalize_result_model(result, ClaudeRunResult)
         except Exception:
             self._track_completed("run_sync", status="failed", result=None)
             raise

--- a/src/kitaru/adapters/langgraph/_agent.py
+++ b/src/kitaru/adapters/langgraph/_agent.py
@@ -7,6 +7,7 @@ from functools import lru_cache
 from importlib import metadata
 from typing import Any, cast
 
+from kitaru.adapters._result_identity import canonicalize_result_model
 from kitaru.analytics import AnalyticsEvent, track
 from kitaru.errors import KitaruUsageError
 
@@ -154,6 +155,7 @@ class KitaruGraphRunner:
             )
         else:
             result = _body()
+        result = canonicalize_result_model(result, LangGraphRunResult)
         self._track_result("invoke", result, request=request)
         return result
 
@@ -175,6 +177,7 @@ class KitaruGraphRunner:
             )
         else:
             result = await _body()
+        result = canonicalize_result_model(result, LangGraphRunResult)
         self._track_result("ainvoke", result, request=request)
         return result
 

--- a/src/kitaru/adapters/openai_agents/_agent.py
+++ b/src/kitaru/adapters/openai_agents/_agent.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import fields, is_dataclass, replace
 from typing import Any, cast
 
+from kitaru.adapters._result_identity import canonicalize_result_model
 from kitaru.analytics import AnalyticsEvent, track
 from kitaru.errors import KitaruUsageError
 
@@ -173,6 +174,7 @@ class KitaruRunner:
             result = await self._run_calls_async(request)
         else:
             result = await self._run_runner_call_async(request)
+        result = canonicalize_result_model(result, OpenAIRunResult)
         self._track_completed("run", result)
         return result
 
@@ -192,6 +194,7 @@ class KitaruRunner:
             result = self._run_calls_sync(request)
         else:
             result = self._run_runner_call_sync(request)
+        result = canonicalize_result_model(result, OpenAIRunResult)
         self._track_completed("run_sync", result)
         return result
 

--- a/tests/test_adapters_result_identity.py
+++ b/tests/test_adapters_result_identity.py
@@ -1,0 +1,73 @@
+"""Tests for adapter result identity canonicalization helpers."""
+
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from kitaru.adapters._result_identity import canonicalize_result_model
+
+
+class TargetResult(BaseModel):
+    """Canonical result model imported by user code."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    status: Literal["completed"]
+    final_output: str
+
+
+class ForeignResult(BaseModel):
+    """Same-shaped model from a different module/class identity."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    __module__ = "src.kitaru.adapters.fake._types"
+
+    schema_version: Literal[1] = 1
+    status: Literal["completed"]
+    final_output: str
+
+
+def test_canonical_result_instance_is_returned_unchanged() -> None:
+    result = TargetResult(status="completed", final_output="hello")
+
+    canonical = canonicalize_result_model(result, TargetResult)
+
+    assert canonical is result
+
+
+def test_foreign_pydantic_result_is_rebuilt_as_canonical_model() -> None:
+    foreign = ForeignResult(status="completed", final_output="hello")
+
+    canonical = canonicalize_result_model(foreign, TargetResult)
+
+    direct_validation_fails = False
+    try:
+        TargetResult.model_validate(foreign)
+    except ValidationError:
+        direct_validation_fails = True
+
+    assert direct_validation_fails is True
+    assert isinstance(canonical, TargetResult)
+    assert not isinstance(canonical, ForeignResult)
+    assert canonical.final_output == "hello"
+
+
+def test_dict_payload_validates_directly() -> None:
+    canonical = canonicalize_result_model(
+        {"status": "completed", "final_output": "hello"},
+        TargetResult,
+    )
+
+    assert isinstance(canonical, TargetResult)
+    assert canonical.final_output == "hello"
+
+
+def test_incompatible_payload_raises_validation_error() -> None:
+    with pytest.raises(ValidationError):
+        canonicalize_result_model(
+            {"status": "completed", "final_output": "hello", "extra": "nope"},
+            TargetResult,
+        )

--- a/tests/test_claude_agent_sdk_invocation_strategy.py
+++ b/tests/test_claude_agent_sdk_invocation_strategy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import sys
 import types
@@ -10,6 +11,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
+from pydantic import ValidationError
 
 from kitaru.errors import KitaruRuntimeError, KitaruUsageError
 
@@ -644,6 +646,113 @@ def test_emit_events_false_suppresses_event_artifacts_and_log(
     assert not any(name.startswith("event_log__") for name in saved)
     assert not any(name.startswith("run_summary__") for name in saved)
     assert logs == []
+
+
+class ForeignClaudeRunResult:
+    """Same-shaped Claude result with intentionally different class identity."""
+
+    def __init__(self, final_text: str | None = None) -> None:
+        self.schema_version = 1
+        self.status = "completed"
+        self.session_id = "session-foreign"
+        self.final_text = final_text
+        self.usage: dict[str, object] | None = None
+        self.warnings: list[str] = []
+        self.metadata: dict[str, object] = {}
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "python"
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status,
+            "session_id": self.session_id,
+            "final_text": self.final_text,
+            "usage": self.usage,
+            "warnings": self.warnings,
+            "metadata": self.metadata,
+        }
+
+
+class InvalidForeignClaudeRunResult(ForeignClaudeRunResult):
+    """Foreign Claude result whose dumped payload violates the schema."""
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        payload = super().model_dump(mode=mode)
+        payload["unexpected_field"] = "bad"
+        return payload
+
+
+def test_run_sync_canonicalizes_foreign_invocation_checkpoint_result(
+    claude_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.claude_agent_sdk._agent")
+    monkeypatch.setattr(agent_module, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(agent_module, "is_inside_checkpoint", lambda: False)
+    monkeypatch.setattr(
+        agent_module,
+        "run_sync_in_checkpoint",
+        lambda **_kwargs: ForeignClaudeRunResult(final_text="from checkpoint"),
+    )
+    runner = claude_adapter.KitaruClaudeRunner(name="claude")
+
+    result = runner.run_sync(claude_adapter.ClaudeRunRequest.start("hello"))
+
+    assert isinstance(result, claude_adapter.ClaudeRunResult)
+    assert not isinstance(result, ForeignClaudeRunResult)
+    assert result.final_text == "from checkpoint"
+
+
+def test_run_canonicalizes_foreign_invocation_checkpoint_result(
+    claude_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.claude_agent_sdk._agent")
+    monkeypatch.setattr(agent_module, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(agent_module, "is_inside_checkpoint", lambda: False)
+
+    async def fake_run_async_in_checkpoint(**_kwargs: object) -> object:
+        return ForeignClaudeRunResult(final_text="async checkpoint")
+
+    monkeypatch.setattr(
+        agent_module, "run_async_in_checkpoint", fake_run_async_in_checkpoint
+    )
+    runner = claude_adapter.KitaruClaudeRunner(name="claude")
+
+    async def call_run() -> object:
+        return await runner.run(claude_adapter.ClaudeRunRequest.start("hello"))
+
+    result = asyncio.run(call_run())
+
+    assert isinstance(result, claude_adapter.ClaudeRunResult)
+    assert not isinstance(result, ForeignClaudeRunResult)
+    assert result.final_text == "async checkpoint"
+
+
+def test_invalid_invocation_checkpoint_result_fails_before_success_tracking(
+    claude_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.claude_agent_sdk._agent")
+    monkeypatch.setattr(agent_module, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(agent_module, "is_inside_checkpoint", lambda: False)
+    monkeypatch.setattr(
+        agent_module,
+        "run_sync_in_checkpoint",
+        lambda **_kwargs: InvalidForeignClaudeRunResult(final_text="bad"),
+    )
+    runner = claude_adapter.KitaruClaudeRunner(name="claude")
+    track_calls: list[tuple[object, dict[str, object]]] = []
+    monkeypatch.setattr(
+        agent_module,
+        "track",
+        lambda event, metadata: track_calls.append((event, metadata)),
+    )
+
+    with pytest.raises(ValidationError):
+        runner.run_sync(claude_adapter.ClaudeRunRequest.start("hello"))
+
+    assert not any(metadata["status"] == "completed" for _, metadata in track_calls)
 
 
 def test_synthetic_checkpoint_is_used_from_flow_scope(

--- a/tests/test_langgraph_adapter_foundation.py
+++ b/tests/test_langgraph_adapter_foundation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import inspect
 import json
@@ -297,6 +298,156 @@ def test_outer_checkpoint_defaults_disable_cache_and_retries(
         "type": "graph_call",
         "runtime": "inline",
     }
+
+
+class ForeignLangGraphRunResult:
+    """Same-shaped LangGraph result with intentionally different identity."""
+
+    def __init__(self, *, thread_id: str = "thread-1") -> None:
+        interrupt = {"index": 0, "value": {"question": "continue?"}}
+        self.schema_version = 1
+        self.status = "interrupted"
+        self.output = None
+        self.thread_id = thread_id
+        self.latest_checkpoint_id = "checkpoint-1"
+        self.next_nodes = ["approval"]
+        self.interrupts = [interrupt]
+        self.pending_state = {
+            "thread_id": thread_id,
+            "checkpoint_id": "checkpoint-1",
+            "next_nodes": ["approval"],
+            "interrupts": [interrupt],
+        }
+        self.state_summary = {
+            "latest_checkpoint_id": "checkpoint-1",
+            "next_nodes": ["approval"],
+            "interrupts": [interrupt],
+        }
+        self.warnings: list[str] = []
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "python"
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status,
+            "output": self.output,
+            "thread_id": self.thread_id,
+            "latest_checkpoint_id": self.latest_checkpoint_id,
+            "next_nodes": self.next_nodes,
+            "interrupts": self.interrupts,
+            "pending_state": self.pending_state,
+            "state_summary": self.state_summary,
+            "warnings": self.warnings,
+        }
+
+
+class InvalidForeignLangGraphRunResult(ForeignLangGraphRunResult):
+    """Foreign LangGraph result whose dumped payload violates the schema."""
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        payload = super().model_dump(mode=mode)
+        payload["unexpected_field"] = "bad"
+        return payload
+
+
+class CheckpointableGraph:
+    name = "fake"
+    checkpointer = object()
+
+    def invoke(self, input: object, **_kwargs: object) -> object:
+        return input
+
+    async def ainvoke(self, input: object, **_kwargs: object) -> object:
+        return input
+
+
+def test_invoke_canonicalizes_foreign_graph_call_checkpoint_result(
+    langgraph_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.langgraph._agent")
+    monkeypatch.setattr(agent_module, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(agent_module, "is_inside_checkpoint", lambda: False)
+    monkeypatch.setattr(
+        agent_module,
+        "run_sync_in_checkpoint",
+        lambda **_kwargs: ForeignLangGraphRunResult(),
+    )
+
+    runner = langgraph_adapter.KitaruGraphRunner(CheckpointableGraph())
+    result = runner.invoke(
+        langgraph_adapter.LangGraphRunRequest.start({"count": 1}, thread_id="thread-1")
+    )
+
+    assert isinstance(result, langgraph_adapter.LangGraphRunResult)
+    assert not isinstance(result, ForeignLangGraphRunResult)
+    assert isinstance(result.pending_state, langgraph_adapter.LangGraphPendingState)
+    assert isinstance(
+        result.pending_state.interrupts[0],
+        langgraph_adapter.LangGraphInterruptSummary,
+    )
+    assert isinstance(result.interrupts[0], langgraph_adapter.LangGraphInterruptSummary)
+
+
+def test_ainvoke_canonicalizes_foreign_graph_call_checkpoint_result(
+    langgraph_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.langgraph._agent")
+    monkeypatch.setattr(agent_module, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(agent_module, "is_inside_checkpoint", lambda: False)
+
+    async def fake_run_async_in_checkpoint(**_kwargs: object) -> object:
+        return ForeignLangGraphRunResult()
+
+    monkeypatch.setattr(
+        agent_module, "run_async_in_checkpoint", fake_run_async_in_checkpoint
+    )
+
+    runner = langgraph_adapter.KitaruGraphRunner(CheckpointableGraph())
+
+    async def call_ainvoke() -> object:
+        return await runner.ainvoke(
+            langgraph_adapter.LangGraphRunRequest.start(
+                {"count": 1}, thread_id="thread-1"
+            )
+        )
+
+    result = asyncio.run(call_ainvoke())
+
+    assert isinstance(result, langgraph_adapter.LangGraphRunResult)
+    assert not isinstance(result, ForeignLangGraphRunResult)
+    assert isinstance(result.pending_state, langgraph_adapter.LangGraphPendingState)
+    assert isinstance(result.state_summary, langgraph_adapter.LangGraphStateSummary)
+
+
+def test_invalid_graph_call_checkpoint_result_fails_before_success_tracking(
+    langgraph_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.langgraph._agent")
+    monkeypatch.setattr(agent_module, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(agent_module, "is_inside_checkpoint", lambda: False)
+    monkeypatch.setattr(
+        agent_module,
+        "run_sync_in_checkpoint",
+        lambda **_kwargs: InvalidForeignLangGraphRunResult(),
+    )
+    runner = langgraph_adapter.KitaruGraphRunner(CheckpointableGraph())
+    track_calls: list[tuple[object, dict[str, object]]] = []
+    monkeypatch.setattr(
+        agent_module,
+        "track",
+        lambda event, metadata: track_calls.append((event, metadata)),
+    )
+    with pytest.raises(ValidationError):
+        runner.invoke(
+            langgraph_adapter.LangGraphRunRequest.start(
+                {"count": 1}, thread_id="thread-1"
+            )
+        )
+
+    assert track_calls == []
 
 
 def test_outer_checkpoint_overrides_are_honored(

--- a/tests/test_openai_agents_adapter_foundation.py
+++ b/tests/test_openai_agents_adapter_foundation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import inspect
 import sys
@@ -175,6 +176,190 @@ def test_runner_call_strategy_runs_without_calls_wrappers(
     assert result.status == "completed"
     assert result.final_output == "hello"
     assert calls == [agent]
+
+
+class ForeignOpenAIRunResult:
+    """Same-shaped OpenAI result with intentionally different class identity."""
+
+    def __init__(self, final_output: object | None = None) -> None:
+        self.schema_version = 1
+        self.status = "completed"
+        self.final_output = final_output
+        self.usage: dict[str, object] | None = None
+        self.interruptions: list[object] = []
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "python"
+        return {
+            "schema_version": self.schema_version,
+            "status": self.status,
+            "final_output": self.final_output,
+            "usage": self.usage,
+            "interruptions": self.interruptions,
+        }
+
+
+class InvalidForeignOpenAIRunResult(ForeignOpenAIRunResult):
+    """Foreign result whose dumped payload violates the canonical schema."""
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        payload = super().model_dump(mode=mode)
+        payload["unexpected_field"] = "bad"
+        return payload
+
+
+class ForeignInterruptedOpenAIRunResult:
+    """Foreign interrupted OpenAI result with nested same-shaped payloads."""
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "python"
+        return {
+            "schema_version": 1,
+            "status": "interrupted",
+            "pending_state": {
+                "schema_version": 1,
+                "agents_sdk_version": "0.15.0",
+                "state_json": {"current_turn": 1},
+            },
+            "interruptions": [
+                {
+                    "index": 0,
+                    "kind": "tool_approval",
+                    "tool_name": "publish",
+                    "call_id": "call_123",
+                }
+            ],
+        }
+
+
+def test_run_sync_canonicalizes_foreign_runner_call_checkpoint_result(
+    openai_agents_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.openai_agents._agent")
+    monkeypatch.setattr(agent_module, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(agent_module, "is_inside_checkpoint", lambda: False)
+    monkeypatch.setattr(
+        agent_module,
+        "run_sync_in_checkpoint",
+        lambda **_kwargs: ForeignOpenAIRunResult(final_output="from checkpoint"),
+    )
+    runner = openai_agents_adapter.KitaruRunner(
+        SimpleNamespace(name="agent"), checkpoint_strategy="runner_call"
+    )
+    monkeypatch.setattr(
+        runner,
+        "_prepare_execution_objects",
+        lambda *, wrap_calls: (SimpleNamespace(name="agent"), SimpleNamespace()),
+    )
+
+    result = runner.run_sync(openai_agents_adapter.OpenAIRunRequest.start("hello"))
+
+    assert isinstance(result, openai_agents_adapter.OpenAIRunResult)
+    assert not isinstance(result, ForeignOpenAIRunResult)
+    assert result.final_output == "from checkpoint"
+
+
+def test_run_sync_canonicalizes_foreign_interrupted_checkpoint_result(
+    openai_agents_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.openai_agents._agent")
+    monkeypatch.setattr(agent_module, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(agent_module, "is_inside_checkpoint", lambda: False)
+    monkeypatch.setattr(
+        agent_module,
+        "run_sync_in_checkpoint",
+        lambda **_kwargs: ForeignInterruptedOpenAIRunResult(),
+    )
+    runner = openai_agents_adapter.KitaruRunner(
+        SimpleNamespace(name="agent"), checkpoint_strategy="runner_call"
+    )
+    monkeypatch.setattr(
+        runner,
+        "_prepare_execution_objects",
+        lambda *, wrap_calls: (SimpleNamespace(name="agent"), SimpleNamespace()),
+    )
+
+    result = runner.run_sync(openai_agents_adapter.OpenAIRunRequest.start("hello"))
+
+    assert isinstance(result, openai_agents_adapter.OpenAIRunResult)
+    assert result.status == "interrupted"
+    assert isinstance(
+        result.pending_state, openai_agents_adapter.OpenAIRunStateEnvelope
+    )
+    assert isinstance(
+        result.interruptions[0],
+        openai_agents_adapter.OpenAIInterruptionSummary,
+    )
+    assert result.pending_state.agents_sdk_version == "0.15.0"
+    assert result.interruptions[0].tool_name == "publish"
+
+
+def test_run_canonicalizes_foreign_runner_call_checkpoint_result(
+    openai_agents_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.openai_agents._agent")
+    monkeypatch.setattr(agent_module, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(agent_module, "is_inside_checkpoint", lambda: False)
+
+    async def fake_run_async_in_checkpoint(**_kwargs: object) -> object:
+        return ForeignOpenAIRunResult(final_output="async checkpoint")
+
+    monkeypatch.setattr(
+        agent_module, "run_async_in_checkpoint", fake_run_async_in_checkpoint
+    )
+    runner = openai_agents_adapter.KitaruRunner(
+        SimpleNamespace(name="agent"), checkpoint_strategy="runner_call"
+    )
+    monkeypatch.setattr(
+        runner,
+        "_prepare_execution_objects",
+        lambda *, wrap_calls: (SimpleNamespace(name="agent"), SimpleNamespace()),
+    )
+
+    async def call_run() -> object:
+        return await runner.run(openai_agents_adapter.OpenAIRunRequest.start("hello"))
+
+    result = asyncio.run(call_run())
+
+    assert isinstance(result, openai_agents_adapter.OpenAIRunResult)
+    assert not isinstance(result, ForeignOpenAIRunResult)
+    assert result.final_output == "async checkpoint"
+
+
+def test_invalid_runner_call_checkpoint_result_fails_before_success_tracking(
+    openai_agents_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.openai_agents._agent")
+    monkeypatch.setattr(agent_module, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(agent_module, "is_inside_checkpoint", lambda: False)
+    monkeypatch.setattr(
+        agent_module,
+        "run_sync_in_checkpoint",
+        lambda **_kwargs: InvalidForeignOpenAIRunResult(final_output="bad"),
+    )
+    runner = openai_agents_adapter.KitaruRunner(
+        SimpleNamespace(name="agent"), checkpoint_strategy="runner_call"
+    )
+    monkeypatch.setattr(
+        runner,
+        "_prepare_execution_objects",
+        lambda *, wrap_calls: (SimpleNamespace(name="agent"), SimpleNamespace()),
+    )
+    track_calls: list[tuple[object, object]] = []
+    monkeypatch.setattr(
+        agent_module,
+        "track",
+        lambda event, metadata: track_calls.append((event, metadata)),
+    )
+
+    with pytest.raises(ValidationError):
+        runner.run_sync(openai_agents_adapter.OpenAIRunRequest.start("hello"))
+
+    assert track_calls == []
 
 
 def test_openai_run_request_start_and_resume_validation(


### PR DESCRIPTION
Fixes #348

## What changed

- Added an internal adapter result canonicalization helper that rebuilds foreign-but-shape-compatible Pydantic result envelopes as the canonical local result class.
- Applied that helper at the public return boundaries for:
  - OpenAI `KitaruRunner.run()` / `run_sync()`
  - Claude `KitaruClaudeRunner.run()` / `run_sync()`
  - LangGraph `KitaruGraphRunner.invoke()` / `ainvoke()`
- Added identity-drift regression tests for completed and interrupted/nested result shapes.
- Updated OpenAI and Claude examples that consume `FlowHandle.wait()` output so they can coerce Pydantic-like result envelopes without depending on internal helper modules.

## Reviewer Notes

The failure story is: a remote synthetic checkpoint can hand the flow back an object that looks exactly like `OpenAIRunResult(status="completed", ...)`, but Python sees it as a different class because it came from an alternate import path such as `src.kitaru...` rather than `kitaru...`. Attribute checks work, but `isinstance(result, OpenAIRunResult)` fails, so user code treats a successful run as failed.

The important behavior now happens at the adapter return boundary. Each adapter still lets the generic checkpoint helper do only one thing — unwrap artifact handles with `.load()` — and then the public runner rebuilds the result envelope as the canonical class before success tracking and before returning to user code. If the loaded payload has the wrong schema, validation still fails loudly instead of silently accepting a misleading object.

The highest-risk area to review is the boundary placement in the three adapter runners. The fix intentionally does not make `checkpoint.py`, `flow.py`, or adapter `materialize_step_output()` type-aware. Also check the tests that simulate a foreign result object with `model_dump(mode="python")`; those are the cheap stand-in for the remote artifact/import split.

### Reproduction

The regression tests exercise the issue without needing a remote LLM call:

1. A fake checkpoint returns a same-shaped object with `model_dump(mode="python")`, but it is not an instance of the canonical adapter result class.
2. The public runner method is called.
3. The returned value is asserted to satisfy `isinstance(..., OpenAIRunResult)` / `ClaudeRunResult` / `LangGraphRunResult`.

Useful targeted commands:

```bash
uv run pytest tests/test_adapters_result_identity.py
uv run pytest tests/test_openai_agents_adapter_foundation.py tests/test_openai_agents_runner_call_strategy.py
uv run pytest tests/test_claude_agent_sdk_adapter_foundation.py tests/test_claude_agent_sdk_invocation_strategy.py
uv run pytest tests/test_langgraph_adapter_foundation.py tests/test_langgraph_calls_strategy.py
```

Local checks run:

```bash
just check
just test
```

Full suite result: `1778 passed, 8 skipped, 83 warnings`.
