### PR TITLE
Fix wait result extraction for adapter checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Bumped the minimum ZenML dependency, server image, and Helm subchart versions to `0.94.4` so Kitaru tracks the latest upstream ZenML release.
 
 ### Fixed
+- Fixed adapter-created granular checkpoints being treated as flow-return candidates, so `flow.run(...).wait()` / `.get()` can return the user's final checkpoint result when adapters also produced model/tool checkpoints.
 - Fixed PydanticAI direct sync tool-body `kp.wait_for_input(...)` calls under ZenML `0.94.4` with explicit `allow_sync_tool_body_waits=True` opt-in, keeping `tool_checkpoint_config_by_name={"tool": False}` as checkpoint-only configuration.
 - Fixed Kitaru flow return compatibility with ZenML `0.94.4` dynamic-pipeline output validation by persisting plain flow returns as internal artifacts while preserving user-facing Python return values and avoiding marker-shaped user dictionaries being mistaken for hidden tuple metadata.
 

--- a/src/kitaru/adapters/claude_agent_sdk/_utils.py
+++ b/src/kitaru/adapters/claude_agent_sdk/_utils.py
@@ -163,7 +163,10 @@ def _build_checkpoint_step(
         return body()
 
     _call.__name__ = safe_step_name(step_name)
-    checkpoint_def = kitaru.checkpoint(**config)(_call)
+    checkpoint_def = kitaru.checkpoint(
+        **config,
+        _flow_result_candidate=False,
+    )(_call)
     step_obj = getattr(checkpoint_def, "_step", None)
     if step_obj is not None:
         alias = build_checkpoint_source_alias(_call.__name__)

--- a/src/kitaru/adapters/claude_agent_sdk/_utils.py
+++ b/src/kitaru/adapters/claude_agent_sdk/_utils.py
@@ -17,8 +17,8 @@ from typing import Any, Literal, cast
 from pydantic_core import to_jsonable_python
 from typing_extensions import TypedDict
 
-import kitaru
 from kitaru._source_aliases import build_checkpoint_source_alias
+from kitaru.checkpoint import _synthetic_checkpoint
 from kitaru.errors import KitaruUsageError
 
 CheckpointRuntime = Literal["inline", "isolated"]
@@ -163,9 +163,9 @@ def _build_checkpoint_step(
         return body()
 
     _call.__name__ = safe_step_name(step_name)
-    checkpoint_def = kitaru.checkpoint(
+    checkpoint_def = _synthetic_checkpoint(
         **config,
-        _flow_result_candidate=False,
+        flow_result_candidate=False,
     )(_call)
     step_obj = getattr(checkpoint_def, "_step", None)
     if step_obj is not None:

--- a/src/kitaru/adapters/langgraph/_utils.py
+++ b/src/kitaru/adapters/langgraph/_utils.py
@@ -267,7 +267,10 @@ def _build_checkpoint_step(
         )
 
     call.__name__ = safe_step_name(step_name)
-    checkpoint_def = kitaru.checkpoint(**config)(call)
+    checkpoint_def = kitaru.checkpoint(
+        **config,
+        _flow_result_candidate=False,
+    )(call)
     step_obj = getattr(checkpoint_def, "_step", None)
     if step_obj is not None:
         alias = build_checkpoint_source_alias(call.__name__)

--- a/src/kitaru/adapters/langgraph/_utils.py
+++ b/src/kitaru/adapters/langgraph/_utils.py
@@ -19,8 +19,8 @@ from typing import Any, Literal, cast
 from pydantic_core import to_jsonable_python
 from typing_extensions import TypedDict
 
-import kitaru
 from kitaru._source_aliases import build_checkpoint_source_alias
+from kitaru.checkpoint import _synthetic_checkpoint
 from kitaru.errors import KitaruUsageError
 
 CheckpointRuntime = Literal["inline", "isolated"]
@@ -267,9 +267,9 @@ def _build_checkpoint_step(
         )
 
     call.__name__ = safe_step_name(step_name)
-    checkpoint_def = kitaru.checkpoint(
+    checkpoint_def = _synthetic_checkpoint(
         **config,
-        _flow_result_candidate=False,
+        flow_result_candidate=False,
     )(call)
     step_obj = getattr(checkpoint_def, "_step", None)
     if step_obj is not None:

--- a/src/kitaru/adapters/openai_agents/_utils.py
+++ b/src/kitaru/adapters/openai_agents/_utils.py
@@ -20,8 +20,8 @@ from typing import Any, Literal, cast
 from pydantic_core import to_jsonable_python
 from typing_extensions import TypedDict
 
-import kitaru
 from kitaru._source_aliases import build_checkpoint_source_alias
+from kitaru.checkpoint import _synthetic_checkpoint
 from kitaru.errors import KitaruUsageError
 
 CheckpointRuntime = Literal["inline", "isolated"]
@@ -268,9 +268,9 @@ def _build_checkpoint_step(
         )
 
     call.__name__ = safe_step_name(step_name)
-    checkpoint_def = kitaru.checkpoint(
+    checkpoint_def = _synthetic_checkpoint(
         **config,
-        _flow_result_candidate=False,
+        flow_result_candidate=False,
     )(call)
     step_obj = getattr(checkpoint_def, "_step", None)
     if step_obj is not None:

--- a/src/kitaru/adapters/openai_agents/_utils.py
+++ b/src/kitaru/adapters/openai_agents/_utils.py
@@ -268,7 +268,10 @@ def _build_checkpoint_step(
         )
 
     call.__name__ = safe_step_name(step_name)
-    checkpoint_def = kitaru.checkpoint(**config)(call)
+    checkpoint_def = kitaru.checkpoint(
+        **config,
+        _flow_result_candidate=False,
+    )(call)
     step_obj = getattr(checkpoint_def, "_step", None)
     if step_obj is not None:
         alias = build_checkpoint_source_alias(call.__name__)

--- a/src/kitaru/adapters/pydantic_ai/_utils.py
+++ b/src/kitaru/adapters/pydantic_ai/_utils.py
@@ -257,7 +257,10 @@ def _build_checkpoint_step(
         )
 
     turn.__name__ = step_name
-    checkpoint_def = kitaru.checkpoint(**config)(turn)
+    checkpoint_def = kitaru.checkpoint(
+        **config,
+        _flow_result_candidate=False,
+    )(turn)
     step_obj = getattr(checkpoint_def, "_step", None)
     if step_obj is not None:
         alias = build_checkpoint_source_alias(turn.__name__)

--- a/src/kitaru/adapters/pydantic_ai/_utils.py
+++ b/src/kitaru/adapters/pydantic_ai/_utils.py
@@ -14,8 +14,8 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, Callable, Literal, TypedDict, cast
 
-import kitaru
 from kitaru._source_aliases import build_checkpoint_source_alias
+from kitaru.checkpoint import _synthetic_checkpoint
 from kitaru.errors import KitaruUsageError
 from pydantic_core import to_jsonable_python
 
@@ -257,9 +257,9 @@ def _build_checkpoint_step(
         )
 
     turn.__name__ = step_name
-    checkpoint_def = kitaru.checkpoint(
+    checkpoint_def = _synthetic_checkpoint(
         **config,
-        _flow_result_candidate=False,
+        flow_result_candidate=False,
     )(turn)
     step_obj = getattr(checkpoint_def, "_step", None)
     if step_obj is not None:

--- a/src/kitaru/checkpoint.py
+++ b/src/kitaru/checkpoint.py
@@ -52,6 +52,10 @@ _CHECKPOINT_OUTPUT_HANDLE_MESSAGE = (
     "This is a Kitaru checkpoint output handle for `{checkpoint}.{output}`, "
     "not the materialized value. Call `.load()` to materialize the value."
 )
+_KITARU_EXTRA_NAMESPACE = "kitaru"
+_CHECKPOINT_BOUNDARY_KEY = "boundary"
+_CHECKPOINT_BOUNDARY_VALUE = "checkpoint"
+_FLOW_RESULT_CANDIDATE_KEY = "flow_result_candidate"
 
 
 class _KitaruOutputArtifact(OutputArtifact):
@@ -110,12 +114,18 @@ def _to_retry_config(retries: int) -> StepRetryConfig | None:
     return StepRetryConfig(max_retries=retries)
 
 
-def _build_checkpoint_extra(checkpoint_type: str | None) -> dict[str, Any]:
+def _build_checkpoint_extra(
+    checkpoint_type: str | None,
+    *,
+    flow_result_candidate: bool | None = None,
+) -> dict[str, Any]:
     """Build namespaced step metadata for dashboard rendering."""
-    payload: dict[str, Any] = {"boundary": "checkpoint"}
+    payload: dict[str, Any] = {_CHECKPOINT_BOUNDARY_KEY: _CHECKPOINT_BOUNDARY_VALUE}
     if checkpoint_type is not None:
         payload["type"] = checkpoint_type
-    return {"kitaru": payload}
+    if flow_result_candidate is not None:
+        payload[_FLOW_RESULT_CANDIDATE_KEY] = flow_result_candidate
+    return {_KITARU_EXTRA_NAMESPACE: payload}
 
 
 _KNOWN_STEP_TYPES: dict[str, StepType] = {
@@ -129,6 +139,17 @@ def _to_step_type(checkpoint_type: str | None) -> StepType | None:
     if checkpoint_type is None:
         return None
     return _KNOWN_STEP_TYPES.get(checkpoint_type)
+
+
+def _normalize_flow_result_candidate(value: bool | None) -> bool | None:
+    """Validate the private terminal-result eligibility flag."""
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise KitaruUsageError(
+            "Checkpoint _flow_result_candidate must be a bool when provided."
+        )
+    return value
 
 
 _KNOWN_STEP_RUNTIMES: dict[str, StepRuntime] = {
@@ -212,6 +233,7 @@ class _CheckpointDefinition:
         checkpoint_type: str | None,
         runtime: StepRuntime | str | None,
         cache: bool | None,
+        flow_result_candidate: bool | None,
     ) -> None:
         """Initialize a Kitaru checkpoint wrapper."""
         self._func = func
@@ -220,6 +242,7 @@ class _CheckpointDefinition:
         self._runtime = _normalize_runtime(runtime)
         self._cache = cache
         self._cache_explicitly_set = cache is not None
+        flow_result_candidate = _normalize_flow_result_candidate(flow_result_candidate)
 
         wrapped_entrypoint = _wrap_entrypoint(
             func,
@@ -236,7 +259,10 @@ class _CheckpointDefinition:
             name=registration_name,
             retry=_to_retry_config(self._default_retries),
             enable_cache=self._cache,
-            extra=_build_checkpoint_extra(checkpoint_type),
+            extra=_build_checkpoint_extra(
+                checkpoint_type,
+                flow_result_candidate=flow_result_candidate,
+            ),
             step_type=_to_step_type(checkpoint_type),
             runtime=self._runtime,
         )(wrapped_entrypoint)
@@ -341,6 +367,7 @@ def checkpoint(
     type: str | None = None,
     runtime: str | None = None,
     cache: bool | None = None,
+    _flow_result_candidate: bool | None = None,
 ) -> Callable[[Callable[..., Any]], _CheckpointDefinition]: ...
 
 
@@ -351,6 +378,7 @@ def checkpoint(
     type: str | None = None,
     runtime: str | None = None,
     cache: bool | None = None,
+    _flow_result_candidate: bool | None = None,
 ) -> _CheckpointDefinition | Callable[[Callable[..., Any]], _CheckpointDefinition]:
     """Mark a function as a durable checkpoint.
 
@@ -382,11 +410,13 @@ def checkpoint(
             for this checkpoint, ``False`` disables it, and ``None`` defers to
             higher-level flow/default cache behavior. Useful for forcing one
             expensive step to re-run while the rest of the flow stays cached.
-
     Returns:
         The wrapped checkpoint object or a decorator that returns it.
     """
     checkpoint_type = type
+    # Internal escape hatch for adapter-created synthetic checkpoints. Keep it
+    # out of public adapter config types; normal user checkpoints should omit it
+    # so their metadata shape stays stable.
 
     def _decorate(target: Callable[..., Any]) -> _CheckpointDefinition:
         return _CheckpointDefinition(
@@ -395,6 +425,7 @@ def checkpoint(
             checkpoint_type=checkpoint_type,
             runtime=runtime,
             cache=cache,
+            flow_result_candidate=_flow_result_candidate,
         )
 
     if func is not None:

--- a/src/kitaru/checkpoint.py
+++ b/src/kitaru/checkpoint.py
@@ -147,7 +147,7 @@ def _normalize_flow_result_candidate(value: bool | None) -> bool | None:
         return None
     if not isinstance(value, bool):
         raise KitaruUsageError(
-            "Checkpoint _flow_result_candidate must be a bool when provided."
+            "Synthetic checkpoint flow_result_candidate must be a bool when provided."
         )
     return value
 
@@ -367,8 +367,35 @@ def checkpoint(
     type: str | None = None,
     runtime: str | None = None,
     cache: bool | None = None,
-    _flow_result_candidate: bool | None = None,
 ) -> Callable[[Callable[..., Any]], _CheckpointDefinition]: ...
+
+
+def _synthetic_checkpoint(
+    func: Callable[..., Any] | None = None,
+    *,
+    retries: int = 0,
+    type: str | None = None,
+    runtime: str | None = None,
+    cache: bool | None = None,
+    flow_result_candidate: bool | None = None,
+) -> _CheckpointDefinition | Callable[[Callable[..., Any]], _CheckpointDefinition]:
+    """Create a checkpoint with optional internal metadata."""
+    checkpoint_type = type
+
+    def _decorate(target: Callable[..., Any]) -> _CheckpointDefinition:
+        return _CheckpointDefinition(
+            target,
+            retries=retries,
+            checkpoint_type=checkpoint_type,
+            runtime=runtime,
+            cache=cache,
+            flow_result_candidate=flow_result_candidate,
+        )
+
+    if func is not None:
+        return _decorate(func)
+
+    return _decorate
 
 
 def checkpoint(
@@ -378,7 +405,6 @@ def checkpoint(
     type: str | None = None,
     runtime: str | None = None,
     cache: bool | None = None,
-    _flow_result_candidate: bool | None = None,
 ) -> _CheckpointDefinition | Callable[[Callable[..., Any]], _CheckpointDefinition]:
     """Mark a function as a durable checkpoint.
 
@@ -413,22 +439,10 @@ def checkpoint(
     Returns:
         The wrapped checkpoint object or a decorator that returns it.
     """
-    checkpoint_type = type
-    # Internal escape hatch for adapter-created synthetic checkpoints. Keep it
-    # out of public adapter config types; normal user checkpoints should omit it
-    # so their metadata shape stays stable.
-
-    def _decorate(target: Callable[..., Any]) -> _CheckpointDefinition:
-        return _CheckpointDefinition(
-            target,
-            retries=retries,
-            checkpoint_type=checkpoint_type,
-            runtime=runtime,
-            cache=cache,
-            flow_result_candidate=_flow_result_candidate,
-        )
-
-    if func is not None:
-        return _decorate(func)
-
-    return _decorate
+    return _synthetic_checkpoint(
+        func,
+        retries=retries,
+        type=type,
+        runtime=runtime,
+        cache=cache,
+    )

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -825,24 +825,38 @@ def _extract_outputs_from_terminal_steps(
         return []
     execution_id = str(hydrated_run.id)
     if len(terminal_step_names) > 1:
-        candidate_terminal_step_names = [
-            step_name
-            for step_name in terminal_step_names
-            if _is_flow_result_candidate_step(step_runs[step_name])
-        ]
-        if len(candidate_terminal_step_names) == 1:
-            terminal_step_names = candidate_terminal_step_names
-        else:
-            raise _MultipleTerminalStepsOutputError(
-                _ambiguous_terminal_message(
-                    execution_id,
-                    reason=(
-                        f"multiple terminal checkpoints were found "
-                        f"({len(terminal_step_names)}): "
-                        f"{', '.join(terminal_step_names)}"
-                    ),
-                )
+        eligible_terminal_step_names: list[str] = []
+        non_candidate_terminal_step_names: list[str] = []
+        for step_name in terminal_step_names:
+            if _is_flow_result_candidate_step(step_runs[step_name]):
+                eligible_terminal_step_names.append(step_name)
+            else:
+                non_candidate_terminal_step_names.append(step_name)
+
+        reason = (
+            f"multiple terminal checkpoints were found "
+            f"({len(terminal_step_names)}): "
+            f"{', '.join(terminal_step_names)}"
+        )
+        if eligible_terminal_step_names:
+            reason += (
+                ". Terminal checkpoints still eligible as flow results: "
+                f"{', '.join(eligible_terminal_step_names)}."
             )
+        if non_candidate_terminal_step_names:
+            reason += (
+                " Terminal checkpoints marked as adapter-created/non-result: "
+                f"{', '.join(non_candidate_terminal_step_names)}. These steps "
+                "also ended the graph, so Kitaru cannot safely ignore them; "
+                "add a final checkpoint that consumes all branches and returns "
+                "the value you want."
+            )
+        raise _MultipleTerminalStepsOutputError(
+            _ambiguous_terminal_message(
+                execution_id,
+                reason=reason,
+            )
+        )
 
     terminal_step_name = terminal_step_names[0]
     terminal_step = step_runs[terminal_step_name]

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -247,6 +247,8 @@ _FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME = "kitaru_flow_result_tuple_metadata"
 _FLOW_RESULT_TUPLE_METADATA_MARKER = "kitaru_flow_result_tuple_v1"
 _FLOW_RESULT_ROLE_METADATA_KEY = "kitaru_flow_result_role"
 _FLOW_RESULT_TUPLE_METADATA_ROLE = "tuple_metadata"
+_KITARU_EXTRA_NAMESPACE = "kitaru"
+_FLOW_RESULT_CANDIDATE_KEY = "flow_result_candidate"
 _FLOW_RESULT_COERCION_ENABLED: ContextVar[bool] = ContextVar(
     "kitaru_flow_result_coercion_enabled",
     default=True,
@@ -776,6 +778,26 @@ def _ambiguous_terminal_message(execution_id: str, *, reason: str) -> str:
     return "\n".join(lines)
 
 
+def _iter_step_kitaru_extras(step_run: Any) -> Iterator[Mapping[str, Any]]:
+    """Yield Kitaru step metadata from a hydrated step run, if present."""
+    for owner_name in ("config", "spec"):
+        owner = getattr(step_run, owner_name, None)
+        raw_extra = getattr(owner, "extra", None)
+        if not isinstance(raw_extra, Mapping):
+            continue
+        raw_kitaru = raw_extra.get(_KITARU_EXTRA_NAMESPACE)
+        if isinstance(raw_kitaru, Mapping):
+            yield raw_kitaru
+
+
+def _is_flow_result_candidate_step(step_run: Any) -> bool:
+    """Return whether a terminal step can be used as the fallback flow result."""
+    for raw_kitaru in _iter_step_kitaru_extras(step_run):
+        if _FLOW_RESULT_CANDIDATE_KEY in raw_kitaru:
+            return raw_kitaru[_FLOW_RESULT_CANDIDATE_KEY] is not False
+    return True
+
+
 def _extract_outputs_from_terminal_steps(
     run: PipelineRunResponse,
 ) -> list[_FlowResultOutput]:
@@ -803,16 +825,24 @@ def _extract_outputs_from_terminal_steps(
         return []
     execution_id = str(hydrated_run.id)
     if len(terminal_step_names) > 1:
-        raise _MultipleTerminalStepsOutputError(
-            _ambiguous_terminal_message(
-                execution_id,
-                reason=(
-                    f"multiple terminal checkpoints were found "
-                    f"({len(terminal_step_names)}): "
-                    f"{', '.join(terminal_step_names)}"
-                ),
+        candidate_terminal_step_names = [
+            step_name
+            for step_name in terminal_step_names
+            if _is_flow_result_candidate_step(step_runs[step_name])
+        ]
+        if len(candidate_terminal_step_names) == 1:
+            terminal_step_names = candidate_terminal_step_names
+        else:
+            raise _MultipleTerminalStepsOutputError(
+                _ambiguous_terminal_message(
+                    execution_id,
+                    reason=(
+                        f"multiple terminal checkpoints were found "
+                        f"({len(terminal_step_names)}): "
+                        f"{', '.join(terminal_step_names)}"
+                    ),
+                )
             )
-        )
 
     terminal_step_name = terminal_step_names[0]
     terminal_step = step_runs[terminal_step_name]

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -98,6 +98,7 @@ def _build_checkpoint(
     checkpoint_type: str | None = None,
     runtime: StepRuntime | str | None = None,
     cache: bool | None = None,
+    flow_result_candidate: bool | None = None,
 ) -> tuple[Any, dict[str, Any]]:
     """Create a checkpoint with a fake ZenML step decorator."""
     captured: dict[str, Any] = {}
@@ -131,6 +132,7 @@ def _build_checkpoint(
             type=checkpoint_type,
             runtime=runtime,
             cache=cache,
+            _flow_result_candidate=flow_result_candidate,
         )(func)
 
     return wrapped, captured
@@ -226,6 +228,31 @@ def test_none_type_produces_no_step_type() -> None:
     _, captured = _build_checkpoint(lambda: "ok", checkpoint_type=None)
     assert captured["step_type"] is None
     assert "type" not in captured["extra"]["kitaru"]
+    assert "flow_result_candidate" not in captured["extra"]["kitaru"]
+
+
+def test_checkpoint_private_flow_result_candidate_false_writes_metadata() -> None:
+    _, captured = _build_checkpoint(
+        lambda: "ok",
+        checkpoint_type="tool_call",
+        flow_result_candidate=False,
+    )
+
+    assert captured["extra"] == {
+        "kitaru": {
+            "boundary": "checkpoint",
+            "type": "tool_call",
+            "flow_result_candidate": False,
+        }
+    }
+
+
+def test_checkpoint_rejects_non_bool_flow_result_candidate() -> None:
+    with pytest.raises(
+        KitaruUsageError,
+        match="Checkpoint _flow_result_candidate must be a bool",
+    ):
+        checkpoint(_flow_result_candidate="false")(lambda: None)  # ty: ignore[invalid-argument-type]
 
 
 def test_checkpoint_passes_plain_name_to_zenml_step() -> None:

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import inspect
 import sys
 from collections.abc import Callable
 from contextlib import contextmanager
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -14,7 +15,7 @@ from zenml.config.retry_config import StepRetryConfig
 from zenml.enums import StepRuntime, StepType
 
 from kitaru.analytics import AnalyticsEvent
-from kitaru.checkpoint import checkpoint
+from kitaru.checkpoint import _synthetic_checkpoint, checkpoint
 from kitaru.errors import KitaruContextError, KitaruUsageError
 from kitaru.flow import flow
 from kitaru.runtime import (
@@ -127,12 +128,12 @@ def _build_checkpoint(
         return _decorate
 
     with patch("kitaru.checkpoint.step", side_effect=_fake_step):
-        wrapped = checkpoint(
+        wrapped = _synthetic_checkpoint(
             retries=retries,
             type=checkpoint_type,
             runtime=runtime,
             cache=cache,
-            _flow_result_candidate=flow_result_candidate,
+            flow_result_candidate=flow_result_candidate,
         )(func)
 
     return wrapped, captured
@@ -247,12 +248,21 @@ def test_checkpoint_private_flow_result_candidate_false_writes_metadata() -> Non
     }
 
 
+def test_checkpoint_public_signature_hides_flow_result_candidate() -> None:
+    signature = inspect.signature(checkpoint)
+
+    assert "_flow_result_candidate" not in signature.parameters
+    assert "flow_result_candidate" not in signature.parameters
+
+
 def test_checkpoint_rejects_non_bool_flow_result_candidate() -> None:
     with pytest.raises(
         KitaruUsageError,
-        match="Checkpoint _flow_result_candidate must be a bool",
+        match="Synthetic checkpoint flow_result_candidate must be a bool",
     ):
-        checkpoint(_flow_result_candidate="false")(lambda: None)  # ty: ignore[invalid-argument-type]
+        _synthetic_checkpoint(
+            flow_result_candidate=cast(Any, "false"),
+        )(lambda: None)
 
 
 def test_checkpoint_passes_plain_name_to_zenml_step() -> None:

--- a/tests/test_claude_agent_sdk_invocation_strategy.py
+++ b/tests/test_claude_agent_sdk_invocation_strategy.py
@@ -78,6 +78,41 @@ def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return sdk
 
 
+def test_synthetic_checkpoint_marks_flow_result_non_candidate(
+    fake_sdk: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utils = importlib.import_module("kitaru.adapters.claude_agent_sdk._utils")
+    captured: dict[str, Any] = {}
+
+    class FakeCheckpoint:
+        _step = object()
+
+    def fake_checkpoint(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+
+        def decorate(func: Any) -> FakeCheckpoint:
+            captured["decorated_name"] = func.__name__
+            return FakeCheckpoint()
+
+        return decorate
+
+    monkeypatch.setattr(utils.kitaru, "checkpoint", fake_checkpoint)
+
+    utils._build_checkpoint_step(
+        config={"type": "llm_call", "cache": False, "retries": 2},
+        step_name="claude invocation",
+        body=lambda: "ok",
+    )
+
+    assert fake_sdk
+    assert captured["_flow_result_candidate"] is False
+    assert captured["type"] == "llm_call"
+    assert captured["cache"] is False
+    assert captured["retries"] == 2
+    assert captured["decorated_name"] == "claude_invocation"
+
+
 @pytest.fixture
 def claude_adapter(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_claude_agent_sdk_invocation_strategy.py
+++ b/tests/test_claude_agent_sdk_invocation_strategy.py
@@ -99,7 +99,7 @@ def test_synthetic_checkpoint_marks_flow_result_non_candidate(
 
         return decorate
 
-    monkeypatch.setattr(utils.kitaru, "checkpoint", fake_checkpoint)
+    monkeypatch.setattr(utils, "_synthetic_checkpoint", fake_checkpoint)
 
     utils._build_checkpoint_step(
         config={"type": "llm_call", "cache": False, "retries": 2},
@@ -108,7 +108,7 @@ def test_synthetic_checkpoint_marks_flow_result_non_candidate(
     )
 
     assert fake_sdk
-    assert captured["_flow_result_candidate"] is False
+    assert captured["flow_result_candidate"] is False
     assert captured["type"] == "llm_call"
     assert captured["cache"] is False
     assert captured["retries"] == 2

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -62,6 +62,7 @@ from kitaru.flow import (
     _extract_run_pipeline_id,
     _guard_implicit_active_stack_fallback,
     _inject_model_registry_env,
+    _is_flow_result_candidate_step,
     _is_multiple_terminal_steps_output_error,
     _suspend_flow_return_coercion,
     _temporary_active_stack,
@@ -134,6 +135,8 @@ class _DummyOutput:
     value: object
     artifact_name: str | None = None
     run_metadata: Mapping[str, object] | None = None
+    config_extra: Mapping[str, object] | None = None
+    spec_extra: Mapping[str, object] | None = None
 
 
 class _DummyArtifact:
@@ -183,6 +186,8 @@ class _DummyRun:
         outputs = outputs or []
         output_specs: list[SimpleNamespace] = []
         step_outputs: dict[str, dict[str, _DummyArtifact]] = {}
+        step_config_extras: dict[str, Mapping[str, object] | None] = {}
+        step_spec_extras: dict[str, Mapping[str, object] | None] = {}
         for output in outputs:
             if isinstance(output, _DummyOutput):
                 step_name = output.step_name
@@ -190,6 +195,8 @@ class _DummyRun:
                 value = output.value
                 artifact_name = output.artifact_name or output_name
                 run_metadata = dict(output.run_metadata or {})
+                step_config_extras[step_name] = output.config_extra
+                step_spec_extras[step_name] = output.spec_extra
             else:
                 step_name, output_name, value = output
                 artifact_name = output_name
@@ -211,7 +218,14 @@ class _DummyRun:
         )
         self.resources = resources
         self.steps = {
-            step_name: SimpleNamespace(regular_outputs=regular_outputs)
+            step_name: SimpleNamespace(
+                regular_outputs=regular_outputs,
+                config=SimpleNamespace(extra=step_config_extras.get(step_name)),
+                spec=SimpleNamespace(
+                    extra=step_spec_extras.get(step_name),
+                    upstream_steps=[],
+                ),
+            )
             for step_name, regular_outputs in step_outputs.items()
         }
 
@@ -2387,6 +2401,173 @@ def test_flow_handle_get_falls_back_to_terminal_step_outputs() -> None:
         result = handle.get()
 
     assert result == "done"
+
+
+@pytest.mark.parametrize(
+    ("step_run", "expected"),
+    [
+        (SimpleNamespace(), True),
+        (
+            SimpleNamespace(
+                config=SimpleNamespace(
+                    extra={"kitaru": {"flow_result_candidate": False}}
+                )
+            ),
+            False,
+        ),
+        (
+            SimpleNamespace(
+                spec=SimpleNamespace(extra={"kitaru": {"flow_result_candidate": False}})
+            ),
+            False,
+        ),
+        (
+            SimpleNamespace(
+                config=SimpleNamespace(extra={"kitaru": "malformed"}),
+                spec=SimpleNamespace(
+                    extra={"kitaru": {"flow_result_candidate": False}}
+                ),
+            ),
+            False,
+        ),
+        (
+            SimpleNamespace(
+                config=SimpleNamespace(extra={"kitaru": {"type": "llm_call"}}),
+                spec=SimpleNamespace(
+                    extra={"kitaru": {"flow_result_candidate": False}}
+                ),
+            ),
+            False,
+        ),
+        (
+            SimpleNamespace(
+                config=SimpleNamespace(
+                    extra={"kitaru": {"flow_result_candidate": "false"}}
+                )
+            ),
+            True,
+        ),
+        (
+            SimpleNamespace(
+                config=SimpleNamespace(
+                    extra={"other": {"flow_result_candidate": False}}
+                )
+            ),
+            True,
+        ),
+    ],
+)
+def test_flow_result_candidate_step_reads_kitaru_extra(
+    step_run: object,
+    expected: bool,
+) -> None:
+    assert _is_flow_result_candidate_step(step_run) is expected
+
+
+def test_flow_handle_get_terminal_fallback_uses_single_remaining_candidate() -> None:
+    completed = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            _DummyOutput(
+                step_name="adapter_call",
+                output_name="output",
+                value="synthetic",
+                config_extra={"kitaru": {"flow_result_candidate": False}},
+            ),
+            ("finalize", "output", "done"),
+        ],
+    )
+    completed.snapshot.pipeline_spec.outputs = []
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = completed
+
+    handle = FlowHandle(_as_pipeline_run(completed))
+    with patch("kitaru.flow.Client", return_value=client_mock):
+        result = handle.get()
+
+    assert result == "done"
+
+
+def test_flow_handle_get_single_terminal_non_candidate_still_returns() -> None:
+    completed = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            _DummyOutput(
+                step_name="adapter_call",
+                output_name="output",
+                value="synthetic",
+                config_extra={"kitaru": {"flow_result_candidate": False}},
+            ),
+        ],
+    )
+    completed.snapshot.pipeline_spec.outputs = []
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = completed
+
+    handle = FlowHandle(_as_pipeline_run(completed))
+    with patch("kitaru.flow.Client", return_value=client_mock):
+        result = handle.get()
+
+    assert result == "synthetic"
+
+
+def test_flow_handle_get_raises_when_terminal_filter_leaves_zero_candidates() -> None:
+    completed = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            _DummyOutput(
+                step_name="adapter_a",
+                output_name="output",
+                value="a",
+                config_extra={"kitaru": {"flow_result_candidate": False}},
+            ),
+            _DummyOutput(
+                step_name="adapter_b",
+                output_name="output",
+                value="b",
+                spec_extra={"kitaru": {"flow_result_candidate": False}},
+            ),
+        ],
+    )
+    completed.snapshot.pipeline_spec.outputs = []
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = completed
+
+    handle = FlowHandle(_as_pipeline_run(completed))
+    with (
+        patch("kitaru.flow.Client", return_value=client_mock),
+        pytest.raises(KitaruAmbiguousFlowResultError) as exc_info,
+    ):
+        handle.get()
+
+    assert _is_multiple_terminal_steps_output_error(exc_info.value)
+
+
+def test_flow_handle_get_output_specs_ignore_candidate_metadata() -> None:
+    completed = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            _DummyOutput(
+                step_name="adapter_call",
+                output_name="output",
+                value="synthetic",
+                config_extra={"kitaru": {"flow_result_candidate": False}},
+            ),
+            ("finalize", "output", "done"),
+        ],
+    )
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = completed
+
+    handle = FlowHandle(_as_pipeline_run(completed))
+    with patch("kitaru.flow.Client", return_value=client_mock):
+        result = handle.get()
+
+    assert result == ("synthetic", "done")
 
 
 def test_flow_handle_get_raises_on_ambiguous_terminal_fallback() -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -137,6 +137,7 @@ class _DummyOutput:
     run_metadata: Mapping[str, object] | None = None
     config_extra: Mapping[str, object] | None = None
     spec_extra: Mapping[str, object] | None = None
+    upstream_steps: list[str] | None = None
 
 
 class _DummyArtifact:
@@ -188,6 +189,7 @@ class _DummyRun:
         step_outputs: dict[str, dict[str, _DummyArtifact]] = {}
         step_config_extras: dict[str, Mapping[str, object] | None] = {}
         step_spec_extras: dict[str, Mapping[str, object] | None] = {}
+        step_upstream_steps: dict[str, list[str]] = {}
         for output in outputs:
             if isinstance(output, _DummyOutput):
                 step_name = output.step_name
@@ -197,6 +199,7 @@ class _DummyRun:
                 run_metadata = dict(output.run_metadata or {})
                 step_config_extras[step_name] = output.config_extra
                 step_spec_extras[step_name] = output.spec_extra
+                step_upstream_steps[step_name] = list(output.upstream_steps or [])
             else:
                 step_name, output_name, value = output
                 artifact_name = output_name
@@ -223,7 +226,7 @@ class _DummyRun:
                 config=SimpleNamespace(extra=step_config_extras.get(step_name)),
                 spec=SimpleNamespace(
                     extra=step_spec_extras.get(step_name),
-                    upstream_steps=[],
+                    upstream_steps=step_upstream_steps.get(step_name, []),
                 ),
             )
             for step_name, regular_outputs in step_outputs.items()
@@ -2464,7 +2467,37 @@ def test_flow_result_candidate_step_reads_kitaru_extra(
     assert _is_flow_result_candidate_step(step_run) is expected
 
 
-def test_flow_handle_get_terminal_fallback_uses_single_remaining_candidate() -> None:
+def test_flow_handle_get_terminal_fallback_uses_graph_sink_candidate() -> None:
+    completed = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            _DummyOutput(
+                step_name="adapter_call",
+                output_name="output",
+                value="synthetic",
+                config_extra={"kitaru": {"flow_result_candidate": False}},
+            ),
+            _DummyOutput(
+                step_name="finalize",
+                output_name="output",
+                value="done",
+                upstream_steps=["adapter_call"],
+            ),
+        ],
+    )
+    completed.snapshot.pipeline_spec.outputs = []
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = completed
+
+    handle = FlowHandle(_as_pipeline_run(completed))
+    with patch("kitaru.flow.Client", return_value=client_mock):
+        result = handle.get()
+
+    assert result == "done"
+
+
+def test_flow_handle_get_keeps_ambiguity_when_filtering_discards_terminal() -> None:
     completed = _DummyRun(
         status=ExecutionStatus.COMPLETED,
         outputs=[
@@ -2483,10 +2516,17 @@ def test_flow_handle_get_terminal_fallback_uses_single_remaining_candidate() -> 
     client_mock.get_pipeline_run.return_value = completed
 
     handle = FlowHandle(_as_pipeline_run(completed))
-    with patch("kitaru.flow.Client", return_value=client_mock):
-        result = handle.get()
+    with (
+        patch("kitaru.flow.Client", return_value=client_mock),
+        pytest.raises(KitaruAmbiguousFlowResultError) as exc_info,
+    ):
+        handle.get()
 
-    assert result == "done"
+    assert _is_multiple_terminal_steps_output_error(exc_info.value)
+    message = str(exc_info.value)
+    assert "Terminal checkpoints still eligible as flow results: finalize" in message
+    assert "Terminal checkpoints marked as adapter-created/non-result" in message
+    assert "adapter_call" in message
 
 
 def test_flow_handle_get_single_terminal_non_candidate_still_returns() -> None:

--- a/tests/test_langgraph_adapter_foundation.py
+++ b/tests/test_langgraph_adapter_foundation.py
@@ -49,6 +49,41 @@ def test_public_import_surface(langgraph_adapter: types.ModuleType) -> None:
     assert not hasattr(langgraph_adapter.KitaruGraphRunner, "astream")
 
 
+def test_synthetic_checkpoint_marks_flow_result_non_candidate(
+    langgraph_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    utils = importlib.import_module("kitaru.adapters.langgraph._utils")
+    captured: dict[str, Any] = {}
+
+    class FakeCheckpoint:
+        _step = object()
+
+    def fake_checkpoint(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+
+        def decorate(func: Any) -> FakeCheckpoint:
+            captured["decorated_name"] = func.__name__
+            return FakeCheckpoint()
+
+        return decorate
+
+    monkeypatch.setattr(utils.kitaru, "checkpoint", fake_checkpoint)
+
+    utils._build_checkpoint_step(
+        config={"type": "llm_call", "cache": False, "retries": 2},
+        step_name="graph call",
+        body=lambda: "ok",
+    )
+
+    assert langgraph_adapter.KitaruGraphRunner
+    assert captured["_flow_result_candidate"] is False
+    assert captured["type"] == "llm_call"
+    assert captured["cache"] is False
+    assert captured["retries"] == 2
+    assert captured["decorated_name"] == "graph_call"
+
+
 def test_langgraph_analytics_events_exist() -> None:
     values = [
         event.value for event in AnalyticsEvent if event.name.startswith("LANGGRAPH_")

--- a/tests/test_langgraph_adapter_foundation.py
+++ b/tests/test_langgraph_adapter_foundation.py
@@ -69,7 +69,7 @@ def test_synthetic_checkpoint_marks_flow_result_non_candidate(
 
         return decorate
 
-    monkeypatch.setattr(utils.kitaru, "checkpoint", fake_checkpoint)
+    monkeypatch.setattr(utils, "_synthetic_checkpoint", fake_checkpoint)
 
     utils._build_checkpoint_step(
         config={"type": "llm_call", "cache": False, "retries": 2},
@@ -78,7 +78,7 @@ def test_synthetic_checkpoint_marks_flow_result_non_candidate(
     )
 
     assert langgraph_adapter.KitaruGraphRunner
-    assert captured["_flow_result_candidate"] is False
+    assert captured["flow_result_candidate"] is False
     assert captured["type"] == "llm_call"
     assert captured["cache"] is False
     assert captured["retries"] == 2

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -49,7 +49,7 @@ def test_synthetic_checkpoint_marks_flow_result_non_candidate(
 
         return decorate
 
-    monkeypatch.setattr(_utils.kitaru, "checkpoint", fake_checkpoint)
+    monkeypatch.setattr(_utils, "_synthetic_checkpoint", fake_checkpoint)
 
     _utils._build_checkpoint_step(
         config={"type": "tool_call", "retries": 2},
@@ -57,7 +57,7 @@ def test_synthetic_checkpoint_marks_flow_result_non_candidate(
         body=lambda: "ok",
     )
 
-    assert captured["_flow_result_candidate"] is False
+    assert captured["flow_result_candidate"] is False
     assert captured["type"] == "tool_call"
     assert captured["retries"] == 2
     assert captured["decorated_name"] == "tool_call"

--- a/tests/test_openai_agents_calls_strategy.py
+++ b/tests/test_openai_agents_calls_strategy.py
@@ -30,6 +30,39 @@ from kitaru.adapters.openai_agents import KitaruRunner, OpenAIRunRequest
 from kitaru.errors import KitaruUsageError
 
 
+def test_synthetic_checkpoint_marks_flow_result_non_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kitaru.adapters.openai_agents import _utils
+
+    captured: dict[str, Any] = {}
+
+    class FakeCheckpoint:
+        _step = object()
+
+    def fake_checkpoint(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+
+        def decorate(func: Any) -> FakeCheckpoint:
+            captured["decorated_name"] = func.__name__
+            return FakeCheckpoint()
+
+        return decorate
+
+    monkeypatch.setattr(_utils.kitaru, "checkpoint", fake_checkpoint)
+
+    _utils._build_checkpoint_step(
+        config={"type": "tool_call", "retries": 2},
+        step_name="tool call",
+        body=lambda: "ok",
+    )
+
+    assert captured["_flow_result_candidate"] is False
+    assert captured["type"] == "tool_call"
+    assert captured["retries"] == 2
+    assert captured["decorated_name"] == "tool_call"
+
+
 class StaticTextModel(Model):
     def __init__(self, text: str) -> None:
         self.text = text

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -48,7 +48,7 @@ def test_synthetic_checkpoint_marks_flow_result_non_candidate(
 
         return decorate
 
-    monkeypatch.setattr(_utils.kitaru, "checkpoint", fake_checkpoint)
+    monkeypatch.setattr(_utils, "_synthetic_checkpoint", fake_checkpoint)
 
     _utils._build_checkpoint_step(
         config={"type": "llm_call", "cache": False, "retries": 2},
@@ -56,7 +56,7 @@ def test_synthetic_checkpoint_marks_flow_result_non_candidate(
         body=lambda: "ok",
     )
 
-    assert captured["_flow_result_candidate"] is False
+    assert captured["flow_result_candidate"] is False
     assert captured["type"] == "llm_call"
     assert captured["cache"] is False
     assert captured["retries"] == 2

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -29,6 +29,40 @@ from kitaru.adapters.pydantic_ai._utils import (
 from kitaru.errors import KitaruRuntimeError, KitaruUsageError
 
 
+def test_synthetic_checkpoint_marks_flow_result_non_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from kitaru.adapters.pydantic_ai import _utils
+
+    captured: dict[str, Any] = {}
+
+    class FakeCheckpoint:
+        _step = object()
+
+    def fake_checkpoint(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+
+        def decorate(func: Any) -> FakeCheckpoint:
+            captured["decorated_name"] = func.__name__
+            return FakeCheckpoint()
+
+        return decorate
+
+    monkeypatch.setattr(_utils.kitaru, "checkpoint", fake_checkpoint)
+
+    _utils._build_checkpoint_step(
+        config={"type": "llm_call", "cache": False, "retries": 2},
+        step_name="model_call",
+        body=lambda: "ok",
+    )
+
+    assert captured["_flow_result_candidate"] is False
+    assert captured["type"] == "llm_call"
+    assert captured["cache"] is False
+    assert captured["retries"] == 2
+    assert captured["decorated_name"] == "model_call"
+
+
 def _with_tool_call_id(ctx: Any, tool_call_id: str = "call_123") -> Any:
     ctx.tool_call_id = tool_call_id
     return ctx


### PR DESCRIPTION
## Summary

- Marks adapter-created synthetic checkpoints so they do not masquerade as normal user result checkpoints.
- Keeps fallback flow-result extraction conservative: if multiple terminal graph endings remain, `.wait()` / `.get()` raises the existing ambiguity error instead of guessing from metadata alone.
- Hides the synthetic-checkpoint metadata knob from the public `kitaru.checkpoint(...)` signature and adds regression coverage across PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK.

Fixes #350.

## Reviewer Notes

The bug story is: a flow runs an adapter with granular checkpoints enabled, so the adapter creates internal model/tool checkpoints along the way. The user's final checkpoint may also exist. When `flow.run(...).wait()` / `.get()` tries to infer “which checkpoint is the flow result?”, Kitaru must avoid two bad outcomes:

1. treating adapter internals as if they were the user’s final answer, and
2. guessing a user checkpoint is the answer just because adapter internals were filtered away.

This PR handles both sides. Adapter-created checkpoints are marked internally via `_synthetic_checkpoint(...)`, but the terminal fallback still trusts graph structure first. If the graph has one terminal sink, Kitaru returns it. If the graph has multiple terminal endings — even if some are marked adapter-created/non-result — Kitaru keeps the result ambiguous and tells the user to add a final checkpoint that consumes all branches and returns the desired value.

Highest-signal review areas:

- `src/kitaru/flow.py`: terminal fallback behavior, especially the conservative multi-terminal branch and the updated ambiguity message.
- `src/kitaru/checkpoint.py`: public `checkpoint(...)` signature remains clean while `_synthetic_checkpoint(...)` can attach internal metadata.
- Adapter `_utils.py` files: synthetic adapter checkpoints now use `_synthetic_checkpoint(..., flow_result_candidate=False)` without exposing that knob in public adapter config.

This intentionally does not remove adapter granular checkpoints or change their replay/observability role. They are still saved and inspectable; they just carry enough internal metadata for Kitaru to explain ambiguity more clearly and avoid mistaking them for ordinary user-result checkpoints.

### Reproduction

Focused regression examples:

```bash
uv run pytest tests/test_flow.py::test_flow_handle_get_terminal_fallback_uses_graph_sink_candidate
uv run pytest tests/test_flow.py::test_flow_handle_get_keeps_ambiguity_when_filtering_discards_terminal
uv run pytest tests/test_flow.py::test_flow_handle_get_raises_when_terminal_filter_leaves_zero_candidates
uv run pytest tests/test_checkpoint.py::test_checkpoint_public_signature_hides_flow_result_candidate
uv run pytest tests/test_pydantic_ai_adapter.py::test_synthetic_checkpoint_marks_flow_result_non_candidate
uv run pytest tests/test_openai_agents_calls_strategy.py::test_synthetic_checkpoint_marks_flow_result_non_candidate
uv run pytest tests/test_langgraph_adapter_foundation.py::test_synthetic_checkpoint_marks_flow_result_non_candidate
uv run pytest tests/test_claude_agent_sdk_invocation_strategy.py::test_synthetic_checkpoint_marks_flow_result_non_candidate
```

Concrete behavior to inspect:

- If the user’s final checkpoint is the only terminal sink, `.wait()` can return it.
- If an adapter checkpoint and a user checkpoint are both separate terminal endings, `.wait()` does not guess; it raises the ambiguity error and names the eligible/non-result terminal checkpoints.

## Local checks run

```bash
uv run pytest tests/test_checkpoint.py tests/test_flow.py tests/test_pydantic_ai_adapter.py tests/test_openai_agents_calls_strategy.py tests/test_openai_agents_runner_call_strategy.py tests/test_langgraph_adapter_foundation.py tests/test_langgraph_calls_strategy.py tests/test_claude_agent_sdk_invocation_strategy.py
just check
just test
```
