### PR TITLE
Add Kitaru Pro release tag trigger

### DIFF
--- a/.claude/skills/kitaru-release/SKILL.md
+++ b/.claude/skills/kitaru-release/SKILL.md
@@ -280,6 +280,8 @@ On completion, verify release artifact exists:
 gh release view v<VERSION> --json name,tagName,isDraft,url,publishedAt
 ```
 
+For non-dry-run releases, the workflow also validates `CLOUD_PLUGINS_REPO_PAT` early, pins the current `zenml-io/zenml-cloud-plugins` `main` SHA, checks that `refs/tags/kitaru-<VERSION>` is either missing or already points at that SHA, then creates the tag after the Kitaru Helm chart has been pushed. That tag is the downstream trigger for the Kitaru Pro server image build; dry-runs skip it and should say so in the workflow summary.
+
 If `isDraft: false` and `publishedAt` is populated, the release succeeded. If the workflow failed, inspect job logs with `gh run view <RUN_ID> --log-failed` and stop — do not attempt the notes-editing step.
 
 ## Step 10: Draft release notes
@@ -344,6 +346,7 @@ Print a completion table with every artifact URL:
 | GitHub Release | `https://github.com/zenml-io/kitaru/releases/tag/v<VERSION>` |
 | PyPI | `https://pypi.org/project/kitaru/<VERSION>/` |
 | Docker Hub | `zenmldocker/kitaru:<VERSION>` + `:latest` |
+| Cloud plugins trigger | `https://github.com/zenml-io/zenml-cloud-plugins/tree/kitaru-<VERSION>` |
 | CHANGELOG on main | `https://github.com/zenml-io/kitaru/blob/main/CHANGELOG.md` |
 
 Mark any post-release follow-ups (social posts, docs sync) as user-driven. The skill is done at this point.
@@ -359,7 +362,8 @@ Mark any post-release follow-ups (social posts, docs sync) as user-driven. The s
 - **Concurrency group.** `release.yml` has `concurrency: group: release, cancel-in-progress: false` — a second release trigger queues rather than cancels. If something goes wrong mid-release, do not trigger a second run; wait for the first to finish, then reset from the resulting state.
 - **Dry-run environment.** Real publishes use the `pypi` GitHub environment (requires secrets + manual approval); dry-runs use the `dry-run` GitHub environment and skip the `pypi` approval gate. If the user wants a dry-run first, pass `-f dry-run=true` and loop back through Step 9 again for the real run after they approve.
 - **PyPI approval gate.** The `pypi` environment has required reviewers (`kitaru-admins` team, `prevent_self_review: false`). Every non-dry-run release pauses partway through awaiting approval. The triggering user can approve their own deployment if they're in `kitaru-admins`. If they're not, the release will sit waiting indefinitely until an admin approves — do not forget this step. `gh run watch` will show the run in `waiting` state while the gate is open; this is normal, not a hang.
-- **Non-dry-run releases require `RELEASE_GIT_TOKEN` for protected branch pushes.** `release.yml` now fails early if `secrets.RELEASE_GIT_TOKEN` is missing on a real release, before any PyPI/Docker/Helm side effects. The secret is only used for the protected branch pushes to `develop`, `main`, and `release/*`; checkout, GitHub API reads, and tag push still use the default `GITHUB_TOKEN`. If a later push step still gets a 403/permission error, check that the token's identity is actually allowed to bypass the `develop`/`main` rulesets and create `release/*` branches. Dry-runs do not require this secret.
+- **Non-dry-run releases require `RELEASE_GIT_TOKEN` for protected branch pushes.** `release.yml` now fails early if `secrets.RELEASE_GIT_TOKEN` is missing on a real release, before any PyPI/Docker/Helm side effects. The secret is only used for the protected branch pushes to `develop`, `main`, and `release/*`; checkout, GitHub API reads, and the Kitaru repo tag push still use the default `GITHUB_TOKEN`. If a later push step still gets a 403/permission error, check that the token's identity is actually allowed to bypass the `develop`/`main` rulesets and create `release/*` branches. Dry-runs do not require this secret.
+- **Non-dry-run releases require `CLOUD_PLUGINS_REPO_PAT` for the downstream Kitaru Pro trigger.** `release.yml` validates this secret before expensive publish work, pins the current `zenml-io/zenml-cloud-plugins` `main` SHA, and fails early if `refs/tags/kitaru-$VERSION` already exists somewhere else. After Docker and Helm have been published, the workflow creates that tag at the pinned SHA. The secret needs read access to `zenml-cloud-plugins/main` and permission to create Git tags in `zenml-io/zenml-cloud-plugins`. Existing matching tags are treated as recovery-safe and skipped; existing divergent tags fail the release and require manual investigation. Dry-runs do not require this secret and do not create the downstream tag.
 - **Recovery dispatch skips file mutations.** When `v$VERSION` already exists on origin, the workflow detects this pre-checkout, checks out the tag itself, and skips the "Bump version" / "Update CHANGELOG" / "Update lockfile" / "Commit release changes" steps. This is intentional: `uv lock` is not stable across time (it regenerates `exclude-newer` timestamps and may re-resolve transitive deps if newer versions have been released between the original tag push and the recovery dispatch), so running it would create a commit on top of the tagged SHA and fail the consistency check. Do not re-enable those steps for recovery — the tag is the authoritative identity anchor.
 - **The `prompt-exports/` directory** is commonly untracked in the working tree — ignore it when staging CHANGELOG commits.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,64 @@ jobs:
             echo "::error::Configure the secret or rerun with dry-run=true."
             exit 1
           fi
+      - name: Validate cloud-plugins tag token
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+        env:
+          CLOUD_PLUGINS_REPO_PAT: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "$CLOUD_PLUGINS_REPO_PAT" ]; then
+            echo "::error::secrets.CLOUD_PLUGINS_REPO_PAT is required for non-dry-run releases."
+            echo "::error::This workflow uses it to create kitaru-$VERSION in zenml-io/zenml-cloud-plugins after Helm publish."
+            echo "::error::The token needs read access to zenml-cloud-plugins/main and permission to create Git tags in zenml-io/zenml-cloud-plugins."
+            echo "::error::Configure the secret or rerun with dry-run=true."
+            exit 1
+          fi
+      # Pin the downstream repo SHA before expensive publish work starts. That
+      # makes the later cloud-plugins tag deterministic, and it fails early if
+      # the token cannot read the repo or an existing tag has already diverged.
+      - name: Pin cloud-plugins release tag target
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          github-token: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
+          script: |-
+            const owner = 'zenml-io';
+            const repo = 'zenml-cloud-plugins';
+            const tagName = `kitaru-${process.env.VERSION}`;
+            const fullRef = `refs/tags/${tagName}`;
+            const getRefName = `tags/${tagName}`;
+            const { data: branch } = await github.rest.repos.getBranch({
+              owner,
+              repo,
+              branch: 'main',
+            });
+            const expectedSha = branch.commit.sha;
+            core.exportVariable('CLOUD_PLUGINS_TAG_NAME', tagName);
+            core.exportVariable('CLOUD_PLUGINS_MAIN_SHA', expectedSha);
+            try {
+              const { data: existingRef } = await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: getRefName,
+              });
+              const existingSha = existingRef.object.sha;
+              if (existingSha === expectedSha) {
+                core.exportVariable('CLOUD_PLUGINS_TAG_EXISTS', 'true');
+                core.info(`${fullRef} already exists at pinned main SHA ${expectedSha} — later tag creation will skip`);
+                return;
+              }
+              throw new Error(
+                `${fullRef} exists at ${existingSha}, but pinned ${owner}/${repo}@main is ${expectedSha}. `
+                + 'Manual investigation is required before PyPI, Docker, or Helm publish.'
+              );
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+            core.exportVariable('CLOUD_PLUGINS_TAG_EXISTS', 'false');
+            core.info(`${fullRef} does not exist; later tag creation will use pinned main SHA ${expectedSha}`);
 
       # --- Install uv (needed before version bump to regenerate lockfile) ---
       - name: Install uv
@@ -500,6 +558,63 @@ jobs:
           helm push "${REPOSITORY}-${VERSION}.tgz" \
             "oci://${REGISTRY}/${REGISTRY_ALIAS}"
 
+      # This tag is the downstream "Kitaru release is ready for cloud-plugins"
+      # signal, so it runs after Helm publish rather than immediately after the
+      # Docker push. It uses the SHA pinned near the start of the job, so the
+      # downstream tag cannot drift if zenml-cloud-plugins/main moves while this
+      # release is publishing. Recovery follows the rest of this workflow's
+      # identity-based model: create a missing ref, accept an exact match, and
+      # fail loudly if an existing tag points somewhere else.
+      - name: Create cloud-plugins Kitaru release tag
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          github-token: ${{ secrets.CLOUD_PLUGINS_REPO_PAT }}
+          script: |-
+            const owner = 'zenml-io';
+            const repo = 'zenml-cloud-plugins';
+            const tagName = process.env.CLOUD_PLUGINS_TAG_NAME;
+            const expectedSha = process.env.CLOUD_PLUGINS_MAIN_SHA;
+            const fullRef = `refs/tags/${tagName}`;
+            const getRefName = `tags/${tagName}`;
+            async function assertExistingTagMatchesPinnedSha(context) {
+              const { data: existingRef } = await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: getRefName,
+              });
+              const existingSha = existingRef.object.sha;
+              if (existingSha === expectedSha) {
+                core.info(`${fullRef} already exists at pinned main SHA ${expectedSha} — skipping (${context})`);
+                return;
+              }
+              throw new Error(
+                `${fullRef} exists at ${existingSha}, but pinned ${owner}/${repo}@main is ${expectedSha}. `
+                + 'Manual investigation is required; the workflow will not move or overwrite the tag.'
+              );
+            }
+            if (process.env.CLOUD_PLUGINS_TAG_EXISTS === 'true') {
+              await assertExistingTagMatchesPinnedSha('matched during early validation');
+              return;
+            }
+            try {
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: fullRef,
+                sha: expectedSha,
+              });
+              core.info(`Created ${fullRef} at pinned ${owner}/${repo}@main SHA ${expectedSha}`);
+            } catch (error) {
+              // GitHub returns 422 if another actor created the ref after the
+              // early validation step. Treat that race as safe only if the tag
+              // now points at the exact SHA we pinned before publish work began.
+              if (error.status !== 422) {
+                throw error;
+              }
+              await assertExistingTagMatchesPinnedSha('created concurrently after early validation');
+            }
+
       # --- Dry-run summary ---
       - name: Dry-run summary
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true' }}
@@ -517,6 +632,9 @@ jobs:
             echo ""
             echo "### Helm chart"
             echo "Built (not pushed): kitaru-${VERSION}.tgz"
+            echo ""
+            echo "### Cloud plugins trigger"
+            echo "Skipped tag creation: zenml-io/zenml-cloud-plugins refs/tags/kitaru-$VERSION"
             echo ""
             echo "No changes were pushed, published, or tagged."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What changed

- Added a Kitaru release workflow step that creates `refs/tags/kitaru-<VERSION>` in `zenml-io/zenml-cloud-plugins` after the Kitaru Helm chart is pushed.
- Added early non-dry-run validation for `CLOUD_PLUGINS_REPO_PAT` and early pinning of the `zenml-cloud-plugins/main` SHA.
- Made downstream tag handling recovery-safe: matching existing tags are skipped, divergent tags fail before publish work, and concurrent tag creation is accepted only when it points at the pinned SHA.
- Updated the release operator skill with the new cloud-plugins trigger and secret requirement.

## Why it was needed

Kitaru Pro workspaces need a downstream Pro server image build in `zenml-cloud-plugins`. The tag created by this workflow is the doorbell: after a Kitaru release completes its own artifacts, `zenml-cloud-plugins` receives `kitaru-<VERSION>` and can build `kitaru-pro-server` from `zenmldocker/kitaru:<VERSION>`.

## Key implementation decisions

- The downstream tag is created after Helm publish, not immediately after Docker publish, so the Pro image build starts only once the Kitaru release has completed its own release artifacts.
- The workflow pins `zenml-cloud-plugins/main` early, before expensive release side effects, so the later tag does not drift if that repo's `main` branch moves during the release.
- The implementation mirrors Kitaru's existing identity-based recovery style: never move an existing divergent release ref automatically.

## Reviewer Notes

The important behavior lives in `.github/workflows/release.yml`. The release now does two cloud-plugin-specific things on non-dry-run runs.

First, near the existing release-token validation, it checks that `CLOUD_PLUGINS_REPO_PAT` is configured, uses that token to read `zenml-cloud-plugins/main`, and records the exact SHA it plans to tag later. If `kitaru-<VERSION>` already exists at that same SHA, the workflow records that and can skip later. If the tag exists somewhere else, the workflow fails before PyPI, Docker, or Helm publish happen.

Second, after Helm publish, the workflow creates the downstream tag at the pinned SHA. If another actor created the tag in the meantime, the workflow checks the tag again and only treats that race as safe if it points at the same pinned SHA. This is the main area to inspect: a mistake here would either fail recovery reruns unnecessarily or, worse, move the downstream build trigger to the wrong cloud-plugins commit.

The release skill update is operator-facing documentation only. Please check that the wording matches the actual release flow and does not imply dry-runs create any remote tags.
