### PR TITLE
Accept blocked PyJWT audit advisory

### DIFF
--- a/.github/pip-audit-ignored.txt
+++ b/.github/pip-audit-ignored.txt
@@ -3,12 +3,14 @@
 # Remove an entry once the upstream cause is resolved and a fresh
 # `uv lock --upgrade` no longer reports it.
 #
-# Format: one CVE ID per line. Lines starting with `#` and blank lines are
+# Format: one vulnerability ID per line, using a pip-audit-supported prefix
+# such as CVE-, GHSA-, or PYSEC-. Lines starting with `#` and blank lines are
 # ignored. Inline `#` comments after the ID are allowed and encouraged.
 
 # --- Blocked by zenml's `pyjwt==2.7.*` pin in the [server] extra. -----------
 # Tracked upstream: https://github.com/zenml-io/zenml/issues/4782
 CVE-2026-32597  # pyjwt 2.7 -> 2.12 (auth library; zenml hard-pins 2.7.*)
+PYSEC-2025-183  # pyjwt 2.7 disputed weak-key advisory; blocked by the same zenml pin
 CVE-2025-66416  # mcp 1.19 -> 1.23 (transitively blocked: mcp >=1.20 needs pyjwt >=2.10.1)
 
 # --- Transitive deps in zenml's FastAPI/Starlette server stack. ------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - run: uv sync --frozen
       - name: Run pip-audit (with documented ignore list)
         run: |
-          awk '/^CVE-|^GHSA-/ {printf "--ignore-vuln %s ", $1}' \
+          awk '/^(CVE|GHSA|PYSEC)-/ {printf "--ignore-vuln %s ", $1}' \
             .github/pip-audit-ignored.txt | xargs uv run pip-audit
   links:
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -60,7 +60,7 @@ zizmor:
 
 # Audit Python dependencies for known vulnerabilities (honors .github/pip-audit-ignored.txt)
 audit:
-    awk '/^CVE-|^GHSA-/ {printf "--ignore-vuln %s ", $1}' .github/pip-audit-ignored.txt | xargs uv run pip-audit
+    awk '/^(CVE|GHSA|PYSEC)-/ {printf "--ignore-vuln %s ", $1}' .github/pip-audit-ignored.txt | xargs uv run pip-audit
 
 # Check links in markdown files — offline only (requires lychee: brew install lychee)
 links:


### PR DESCRIPTION
## Summary

- Added the newly reported `PYSEC-2025-183` PyJWT advisory to the documented `pip-audit` ignore list.
- Updated both CI and local `just audit` parsing so `PYSEC-*` advisory IDs are passed through to `pip-audit --ignore-vuln`, matching the existing CVE/GHSA behavior.

## Reviewer Notes

The failing audit job was not caused by a new resolvable package version in Kitaru's lockfile. CI installed `pyjwt==2.7.0` via `zenml[server]==0.94.4`, then `pip-audit` reported `PYSEC-2025-183` as an unignored advisory.

I first tried the healthier path: force PyJWT upward. `uv` refused that resolution because `zenml[server]==0.94.4` still requires `pyjwt[crypto]==2.7.*`, and no newer ZenML release is currently available for the `zenml[server]>=0.94.4` constraint. So the practical fix here is to document and pass through the new advisory ID until ZenML widens that server dependency pin.

The important bit to review is that the ignore parser now accepts `PYSEC-*` IDs in exactly the same place as `CVE-*` and `GHSA-*`: `.github/workflows/ci.yml` for CI, and `Justfile` for local runs.

### Reproduction

Before this change, the linked CI job failed with:

```text
Found 1 known vulnerability, ignored 5 in 1 package
pyjwt 2.7.0   PYSEC-2025-183
```

With this branch, run:

```bash
just audit
```

Expected result:

```text
No known vulnerabilities found, 6 ignored
```

### Local checks run

```bash
uv sync --frozen
just audit
just yaml-check
just actions-lint
```
