### PR TITLE
Migrate Kitaru UI release bundling

### DIFF
--- a/.claude/skills/kitaru-release/SKILL.md
+++ b/.claude/skills/kitaru-release/SKILL.md
@@ -4,8 +4,9 @@ description: >-
   Guide the Kitaru release process end-to-end — diff develop against the
   last tag, classify commits (src / docs content / site / infra),
   filter site-only PRs out of the Python library CHANGELOG, check
-  zenml-io/kitaru-ui for a new UI release that will be bundled into the
-  server image, suggest a version bump, update CHANGELOG.md, run the
+  zenml-io/zenml-frontend-monorepo for the latest stable kitaru-ui-v*
+  release that will be bundled into the Python package and then copied
+  into the Docker image, suggest a version bump, update CHANGELOG.md, run the
   smoke test, trigger the release workflow via gh, and rewrite the
   auto-generated GitHub Release notes into structured
   Highlights / Changed / Fixed sections. Interactive — pauses for user
@@ -34,7 +35,7 @@ Copy and track progress in your todo / task list:
 ```
 - [ ] Step 1: Fetch + gather state
 - [ ] Step 2: Classify commits by scope
-- [ ] Step 3: Check kitaru-ui for a new release since last Kitaru release
+- [ ] Step 3: Check monorepo Kitaru UI stable releases since last Kitaru release
 - [ ] Step 4: ★ Pause — show summary, suggest version, await user confirmation
 - [ ] Step 5: Update CHANGELOG [Unreleased] block
 - [ ] Step 6: ★ Pause — show CHANGELOG diff, await confirmation, then commit + push
@@ -95,22 +96,26 @@ git show --stat <sha> | head -30
 
 Treat no-op pairs (add X / revert X in same unreleased window) as excluded — they net to nothing.
 
-## Step 3: Check kitaru-ui for new release
+## Step 3: Check monorepo Kitaru UI stable releases
 
-Kitaru's production Docker image bundles the `kitaru-ui` dashboard. The release workflow's `kitaru-ui-tag` input defaults to the latest kitaru-ui release, so if a new UI ships between Kitaru releases, the next Kitaru release bundles it automatically.
+Official Kitaru releases bundle a Kitaru UI release from `zenml-io/zenml-frontend-monorepo` into the Python package. The Docker image then copies that already-packaged UI from the installed `kitaru` package. Docker does **not** download UI assets or choose a UI tag itself.
 
-Fetch the last Kitaru release timestamp and the kitaru-ui releases:
+The release workflow's `kitaru-ui-tag` input accepts only `kitaru-ui-v<semver>` tags. If the input is empty, `scripts/download-ui.sh` selects the highest stable/full `kitaru-ui-v*` release. Drafts and prereleases are excluded. Prerelease UI tags are only for local testing and `.github/workflows/ui-prerelease-smoke.yml`.
+
+Fetch the last Kitaru release timestamp and the monorepo releases:
 
 ```bash
 LAST_KITARU_TS=$(gh release view "$LAST_TAG" -R zenml-io/kitaru --json publishedAt --jq .publishedAt)
-gh release list -R zenml-io/kitaru-ui --limit 10 \
-  --json tagName,publishedAt,isLatest,isDraft,isPrerelease
+gh release list -R zenml-io/zenml-frontend-monorepo --limit 50 \
+  --json tagName,publishedAt,isDraft,isPrerelease \
+  --jq '[.[] | select(.tagName | startswith("kitaru-ui-v"))]'
 ```
 
-From the JSON, find the latest non-draft, non-prerelease UI release and compare its `publishedAt` to `$LAST_KITARU_TS`:
+From the JSON, find the highest/version-latest non-draft, non-prerelease `kitaru-ui-v*` release and compare its `publishedAt` to `$LAST_KITARU_TS`:
 
 - If UI `publishedAt > $LAST_KITARU_TS` → a new UI will ship. **Remember the UI tag name** for release notes step 10.
 - If UI `publishedAt <= $LAST_KITARU_TS` → same UI as last release. Don't mention it.
+- If there is no full/non-prerelease `kitaru-ui-v*` release → stop and tell the user the official Kitaru release is blocked until frontend maintainers promote one.
 
 Do **not** fetch or summarize what's in the UI release — just note the tag if it's newer.
 
@@ -119,7 +124,7 @@ Do **not** fetch or summarize what's in the UI release — just note the tag if 
 Present a summary table to the user covering:
 
 1. Commits since last release with scope classification
-2. Whether a new kitaru-ui ships (tag only, no contents)
+2. Whether a new Kitaru UI bundle ships (tag only, no contents)
 3. File-level diff stats
 4. Version bump suggestion with reasoning
 
@@ -207,7 +212,7 @@ The script uses `set -uo pipefail` **without `-e`** deliberately — it continue
 
 Prefer running in the background with `run_in_background: true` and tail the log afterwards — the full output is verbose and not useful in conversation context.
 
-**If running from a git worktree:** the smoke test's local server will serve ZenML's stock dashboard rather than the Kitaru UI, because `src/kitaru/_ui/dist/` is gitignored and not populated in fresh worktrees. The smoke test outcome is unaffected (CLI/SDK/MCP/LLM checks are dashboard-independent). Surface this to the user so they don't mistake the ZenML fallback for a Kitaru regression. If they want the Kitaru UI locally in the worktree, `bash scripts/download-ui.sh` pulls it.
+**If running from a git worktree:** a fresh worktree may not have `src/kitaru/_ui/dist/` populated yet. If the user wants the Kitaru UI during smoke testing, run `just ui-bundle` followed by `just ui-smoke`, or run `bash scripts/download-ui.sh` before `./scripts/smoke-test.sh`. The direct override path is `KITARU_UI_DIST_PATH=/path/to/dist ./scripts/smoke-test.sh --keep-server`.
 
 ## Step 8: ★ Pause — verify smoke test
 
@@ -224,8 +229,8 @@ Only when `Failed: 0` and the user confirms, proceed.
 ```bash
 gh workflow run release.yml --ref develop \
   -f version=<AGREED_VERSION> \
-  [-f kitaru-ui-tag=<UI_TAG>]   # only if pinning a specific UI version
-  [-f dry-run=true]             # only if user requested
+  [-f kitaru-ui-tag=kitaru-ui-v<X.Y.Z>]  # only if pinning a specific stable/full UI version
+  [-f dry-run=true]                      # only if user requested
 ```
 
 Confirm the trigger succeeded:
@@ -358,7 +363,8 @@ Mark any post-release follow-ups (social posts, docs sync) as user-driven. The s
 - **Main is force-pushed.** Always diff against the last tag, never against `origin/main`. `git fetch --tags` is mandatory before every invocation.
 - **CHANGELOG PR references drift.** Draft PR numbers get renumbered at merge. Cross-check every `(#N)` against `git log`.
 - **Site vs library changelog.** `site/` changes deploy on their own cadence via `site.yml`. They do not belong in the Python library CHANGELOG even when they land on the same `develop` branch.
-- **UI tag default.** The release workflow defaults `kitaru-ui-tag` to the latest kitaru-ui release. Only pass `-f kitaru-ui-tag=v<X>` if the user explicitly wants to pin to an older UI.
+- **UI tag default.** The release workflow defaults `kitaru-ui-tag` to the highest stable/full `kitaru-ui-v*` release from `zenml-io/zenml-frontend-monorepo`. Only pass `-f kitaru-ui-tag=kitaru-ui-v<X.Y.Z>` if the user explicitly wants to pin to a specific stable UI. Official releases reject prerelease UI tags.
+- **Prerelease UI smoke.** To validate a prerelease UI, use Actions → `UI prerelease smoke` with a required `ui-tag` such as `kitaru-ui-v0.3.0-rc.1`. That workflow sets `KITARU_UI_ALLOW_PRERELEASE=true`, builds/verifies locally, and publishes nothing.
 - **Concurrency group.** `release.yml` has `concurrency: group: release, cancel-in-progress: false` — a second release trigger queues rather than cancels. If something goes wrong mid-release, do not trigger a second run; wait for the first to finish, then reset from the resulting state.
 - **Dry-run environment.** Real publishes use the `pypi` GitHub environment (requires secrets + manual approval); dry-runs use the `dry-run` GitHub environment and skip the `pypi` approval gate. If the user wants a dry-run first, pass `-f dry-run=true` and loop back through Step 9 again for the real run after they approve.
 - **PyPI approval gate.** The `pypi` environment has required reviewers (`kitaru-admins` team, `prevent_self_review: false`). Every non-dry-run release pauses partway through awaiting approval. The triggering user can approve their own deployment if they're in `kitaru-admins`. If they're not, the release will sit waiting indefinitely until an admin approves — do not forget this step. `gh run watch` will show the run in `waiting` state while the gate is open; this is normal, not a hang.
@@ -374,7 +380,7 @@ Release workflow inputs (`release.yml`):
 | Input | Required | Default | Notes |
 |---|---|---|---|
 | `version` | yes | — | Semver without `v` prefix, e.g. `0.4.1` |
-| `kitaru-ui-tag` | no | latest | `v` prefix required, e.g. `v0.2.0` |
+| `kitaru-ui-tag` | no | latest stable/full `kitaru-ui-v*` | Optional stable UI pin, e.g. `kitaru-ui-v0.2.0`; prereleases are rejected |
 | `dry-run` | no | `false` | Skips PyPI/Docker/tag pushes |
 
 Useful state-inspection commands:
@@ -390,7 +396,8 @@ sed -n '/## \[Unreleased\]/,/## \[/p' CHANGELOG.md | head -50
 gh run list --workflow=release.yml --limit 5 \
   --json databaseId,status,conclusion,displayTitle,createdAt
 
-# Latest kitaru-ui release tag
-gh release list -R zenml-io/kitaru-ui --limit 1 \
-  --json tagName,publishedAt --jq '.[0]'
+# Latest Kitaru UI releases in the frontend monorepo
+gh release list -R zenml-io/zenml-frontend-monorepo --limit 50 \
+  --json tagName,publishedAt,isDraft,isPrerelease \
+  --jq '[.[] | select(.tagName | startswith("kitaru-ui-v"))]'
 ```

--- a/.claude/skills/kitaru-release/SKILL.md
+++ b/.claude/skills/kitaru-release/SKILL.md
@@ -100,6 +100,8 @@ Treat no-op pairs (add X / revert X in same unreleased window) as excluded — t
 
 Official Kitaru releases bundle a Kitaru UI release from `zenml-io/zenml-frontend-monorepo` into the Python package. The Docker image then copies that already-packaged UI from the installed `kitaru` package. Docker does **not** download UI assets or choose a UI tag itself.
 
+Before changing UI bundle selection, frontend smoke testing, Docker dashboard packaging, or release UI workflow behavior, read `FRONTEND-TESTING.md`. It is the canonical runbook for stable/prerelease `kitaru-ui-v*` testing and token/trusted-event boundaries.
+
 The release workflow's `kitaru-ui-tag` input accepts only `kitaru-ui-v<semver>` tags. If the input is empty, `scripts/download-ui.sh` selects the highest stable/full `kitaru-ui-v*` release. Drafts and prereleases are excluded. Prerelease UI tags are only for local testing and `.github/workflows/ui-prerelease-smoke.yml`.
 
 Fetch the last Kitaru release timestamp and the monorepo releases:
@@ -363,7 +365,7 @@ Mark any post-release follow-ups (social posts, docs sync) as user-driven. The s
 - **Main is force-pushed.** Always diff against the last tag, never against `origin/main`. `git fetch --tags` is mandatory before every invocation.
 - **CHANGELOG PR references drift.** Draft PR numbers get renumbered at merge. Cross-check every `(#N)` against `git log`.
 - **Site vs library changelog.** `site/` changes deploy on their own cadence via `site.yml`. They do not belong in the Python library CHANGELOG even when they land on the same `develop` branch.
-- **UI tag default.** The release workflow defaults `kitaru-ui-tag` to the highest stable/full `kitaru-ui-v*` release from `zenml-io/zenml-frontend-monorepo`. Only pass `-f kitaru-ui-tag=kitaru-ui-v<X.Y.Z>` if the user explicitly wants to pin to a specific stable UI. Official releases reject prerelease UI tags.
+- **UI tag default.** The release workflow defaults `kitaru-ui-tag` to the highest stable/full `kitaru-ui-v*` release from `zenml-io/zenml-frontend-monorepo`. Only pass `-f kitaru-ui-tag=kitaru-ui-v<X.Y.Z>` if the user explicitly wants to pin to a specific stable UI. Official releases reject prerelease UI tags. Read `FRONTEND-TESTING.md` before touching this path.
 - **Prerelease UI smoke.** To validate a prerelease UI, use Actions → `UI prerelease smoke` with a required `ui-tag` such as `kitaru-ui-v0.3.0-rc.1`. That workflow sets `KITARU_UI_ALLOW_PRERELEASE=true`, builds/verifies locally, and publishes nothing.
 - **Concurrency group.** `release.yml` has `concurrency: group: release, cancel-in-progress: false` — a second release trigger queues rather than cancels. If something goes wrong mid-release, do not trigger a second run; wait for the first to finish, then reset from the resulting state.
 - **Dry-run environment.** Real publishes use the `pypi` GitHub environment (requires secrets + manual approval); dry-runs use the `dry-run` GitHub environment and skip the `pypi` approval gate. If the user wants a dry-run first, pass `-f dry-run=true` and loop back through Step 9 again for the real run after they approve.

--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,15 @@ build/
 *.whl
 *.tar.gz
 
+# Local UI bundle cache used by Justfile helpers. Source Docker builds should
+# only receive the generated package UI files explicitly allow-listed below.
+.kitaru-ui-bundles/
+
+# Generated package UI included in source-based Docker builds.
+!src/kitaru/_ui/dist/
+!src/kitaru/_ui/dist/**
+!src/kitaru/_ui/bundle_manifest.json
+
 # IDE
 .vscode/
 .idea/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,19 +75,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   docker-smoke:
+    # UI release assets may require KITARU_UI_RELEASE_TOKEN, which is not exposed to fork PRs.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name
+      == github.repository
     runs-on: ubuntu-latest
     env:
       ZENML_SERVER_TAG: 0.94.4
-      KITARU_UI_TAG: latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+      - name: Download stable Kitaru UI
+        run: bash scripts/download-ui.sh
+        env:
+          KITARU_UI_RELEASE_TOKEN: ${{ secrets.KITARU_UI_RELEASE_TOKEN }}
       - name: Build server image
         run: >-
           docker build -f docker/Dockerfile --target server
           --build-arg ZENML_SERVER_TAG=${{ env.ZENML_SERVER_TAG }}
-          --build-arg KITARU_UI_TAG=${{ env.KITARU_UI_TAG }}
           -t kitaru-ci-server .
       - name: Start server container
         run: docker run -d --rm --name kitaru-ci-server -p 18080:8080 kitaru-ci-server
@@ -104,10 +109,8 @@ jobs:
           echo "Server did not become healthy in time." >&2
           docker logs kitaru-ci-server || true
           exit 1
-      - name: Verify bundled dashboard assets exist in the installed package
-        run: |
-          set -euo pipefail
-          docker exec kitaru-ci-server sh -c 'python -c "import zenml, os; d=os.path.join(zenml.__path__[0],\"zen_server/dashboard/index.html\"); assert os.path.isfile(d), f\"missing: {d}\"; print(\"OK:\", d)"'
+      - name: Verify bundled and copied dashboard assets
+        run: bash scripts/verify-server-ui.sh kitaru-ci-server
       - name: Smoke test root route serves dashboard HTML
         run: |
           set -euo pipefail
@@ -139,6 +142,9 @@ jobs:
         if: always()
         run: docker rm -f kitaru-ci-server || true
   wheel-packaging:
+    # UI release assets may require KITARU_UI_RELEASE_TOKEN, which is not exposed to fork PRs.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name
+      == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -147,28 +153,16 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           python-version: '3.12'
-      - name: Download Kitaru UI
+      - name: Download stable Kitaru UI
         run: bash scripts/download-ui.sh
+        env:
+          KITARU_UI_RELEASE_TOKEN: ${{ secrets.KITARU_UI_RELEASE_TOKEN }}
       - name: Build wheel
         run: uv build --wheel
       - name: Verify Kitaru UI in wheel
         run: |
           WHEEL=$(ls dist/*.whl)
-          python -c "
-          import zipfile, sys
-          names = zipfile.ZipFile('$WHEEL').namelist()
-          missing = []
-          if not any('_ui/dist/index.html' in n for n in names):
-              missing.append('kitaru/_ui/dist/index.html')
-          if not any('_ui/bundle_manifest.json' in n for n in names):
-              missing.append('kitaru/_ui/bundle_manifest.json')
-          if missing:
-              for m in missing:
-                  print(f'::error::{m} missing from wheel')
-              sys.exit(1)
-          ui_files = sum(1 for n in names if '_ui/dist/' in n)
-          print(f'Kitaru UI verified: {ui_files} asset files in $WHEEL')
-          "
+          uv run --no-project scripts/verify-ui-wheel.py "$WHEEL"
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   docker-smoke:
-    # UI release assets may require KITARU_UI_RELEASE_TOKEN, which is not exposed to fork PRs.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name
-      == github.repository
+    # UI release assets may require KITARU_UI_RELEASE_TOKEN; never expose it to PR code.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
       ZENML_SERVER_TAG: 0.94.4
@@ -142,9 +141,8 @@ jobs:
         if: always()
         run: docker rm -f kitaru-ci-server || true
   wheel-packaging:
-    # UI release assets may require KITARU_UI_RELEASE_TOKEN, which is not exposed to fork PRs.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name
-      == github.repository
+    # UI release assets may require KITARU_UI_RELEASE_TOKEN; never expose it to PR code.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ on:
         required: true
         type: string
       kitaru-ui-tag:
-        description: Kitaru UI release tag (e.g. v0.1.0). Defaults to latest kitaru-ui
-          release.
+        description: Kitaru UI release tag (e.g. kitaru-ui-v0.1.0). Defaults to the
+          highest stable kitaru-ui-v* release.
         required: false
         type: string
         default: ''
@@ -48,27 +48,6 @@ jobs:
             exit 1
           fi
           printf 'VERSION=%s\n' "$VERSION_CANDIDATE" >> "$GITHUB_ENV"
-      - name: Set Kitaru UI tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_TAG: ${{ github.event.inputs.kitaru-ui-tag }}
-        run: |
-          set -euo pipefail
-          validate_tag() {
-            local tag="$1"
-            if ! printf '%s' "$tag" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then
-              echo "::error::Invalid Kitaru UI tag: $tag"
-              exit 1
-            fi
-          }
-          if [ -n "$INPUT_TAG" ]; then
-            KITARU_UI_TAG_VALUE="$INPUT_TAG"
-          else
-            KITARU_UI_TAG_VALUE=$(gh release view --repo zenml-io/kitaru-ui --json tagName -q '.tagName')
-            echo "Using latest Kitaru UI release: $KITARU_UI_TAG_VALUE"
-          fi
-          validate_tag "$KITARU_UI_TAG_VALUE"
-          printf 'KITARU_UI_TAG=%s\n' "$KITARU_UI_TAG_VALUE" >> "$GITHUB_ENV"
       # --- Determine checkout ref (dispatch only) ---
       # Normally checks out `develop`. If v$VERSION already exists on origin,
       # this is a partial-recovery dispatch and we must check out that tag so
@@ -289,10 +268,32 @@ jobs:
         run: uv run pytest --ignore=tests/mcp
 
       # --- Bundle Kitaru UI ---
-      - name: Download Kitaru UI
+      - name: Download stable Kitaru UI
         run: bash scripts/download-ui.sh
         env:
-          TAG: ${{ env.KITARU_UI_TAG }}
+          TAG: ${{ github.event.inputs.kitaru-ui-tag || '' }}
+          KITARU_UI_RELEASE_TOKEN: ${{ secrets.KITARU_UI_RELEASE_TOKEN }}
+      - name: Record Kitaru UI bundle identity
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          manifest = json.loads(Path("src/kitaru/_ui/bundle_manifest.json").read_text())
+          values = {
+              "KITARU_UI_REPO": manifest["repo"],
+              "KITARU_UI_TAG": manifest["tag"],
+              "KITARU_UI_CHECKSUM": manifest["checksum"],
+          }
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+              for key, value in values.items():
+                  env_file.write(f"{key}={value}\n")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("## Kitaru UI bundle\n")
+              summary.write(f"Repo: `{values['KITARU_UI_REPO']}`\n\n")
+              summary.write(f"Tag: `{values['KITARU_UI_TAG']}`\n\n")
+              summary.write(f"Checksum: `{values['KITARU_UI_CHECKSUM']}`\n\n")
+          PY
 
       # --- Build ---
       - name: Build package
@@ -300,20 +301,7 @@ jobs:
       - name: Verify Kitaru UI in wheel
         run: |
           WHEEL=$(ls dist/*.whl)
-          python -c "
-          import zipfile, sys
-          names = zipfile.ZipFile('$WHEEL').namelist()
-          missing = []
-          if not any('_ui/dist/index.html' in n for n in names):
-              missing.append('kitaru/_ui/dist/index.html')
-          if not any('_ui/bundle_manifest.json' in n for n in names):
-              missing.append('kitaru/_ui/bundle_manifest.json')
-          if missing:
-              for m in missing:
-                  print(f'::error::{m} missing from wheel')
-              sys.exit(1)
-          print('Kitaru UI assets verified in $WHEEL')
-          "
+          uv run --no-project scripts/verify-ui-wheel.py "$WHEEL"
       - name: List build artifacts
         run: ls -lh dist/
 
@@ -358,6 +346,49 @@ jobs:
           done
           echo "::error::kitaru==$VERSION did not appear on PyPI within 5 minutes"
           exit 1
+      - name: Verify PyPI artifacts match local build
+        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import sys
+          import urllib.request
+          from pathlib import Path
+          version = os.environ["VERSION"]
+          metadata_url = f"https://pypi.org/pypi/kitaru/{version}/json"
+          with urllib.request.urlopen(metadata_url, timeout=30) as response:
+              metadata = json.load(response)
+          remote_files = {
+              item["filename"]: item["digests"]["sha256"]
+              for item in metadata.get("urls", [])
+              if "filename" in item and "digests" in item and "sha256" in item["digests"]
+          }
+          failures = []
+          for artifact in sorted(Path("dist").iterdir()):
+              if not artifact.is_file():
+                  continue
+              expected = remote_files.get(artifact.name)
+              if expected is None:
+                  failures.append(f"{artifact.name} is missing from PyPI metadata")
+                  continue
+              actual = hashlib.sha256(artifact.read_bytes()).hexdigest()
+              if actual != expected:
+                  failures.append(
+                      f"{artifact.name} hash mismatch: local={actual} pypi={expected}"
+                  )
+          if failures:
+              for failure in failures:
+                  print(f"::error::{failure}")
+              print(
+                  "::error::Local dist artifacts differ from PyPI. This prevents "
+                  "a recovery run from publishing GitHub/Docker/Helm artifacts "
+                  "built with a different UI bundle than the already-published package."
+              )
+              sys.exit(1)
+          print("PyPI artifacts match local dist/ build outputs.")
+          PY
 
       # --- Push release commit to develop (dispatch only, skip on dry-run) ---
       - name: Push release commit to develop
@@ -506,7 +537,6 @@ jobs:
           push: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
           build-args: |
             ZENML_SERVER_TAG=0.94.4
-            KITARU_UI_TAG=${{ env.KITARU_UI_TAG }}
             ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') && format('KITARU_VERSION={0}', env.VERSION) || '' }}
           tags: |
             zenmldocker/kitaru:${{ env.VERSION }}
@@ -628,7 +658,8 @@ jobs:
             echo ""
             echo "### Docker image"
             echo "Built (not pushed): zenmldocker/kitaru:$VERSION"
-            echo "Kitaru UI tag: $KITARU_UI_TAG"
+            echo "Kitaru UI bundle: $KITARU_UI_REPO@$KITARU_UI_TAG"
+            echo "Kitaru UI checksum: $KITARU_UI_CHECKSUM"
             echo ""
             echo "### Helm chart"
             echo "Built (not pushed): kitaru-${VERSION}.tgz"

--- a/.github/workflows/ui-prerelease-smoke.yml
+++ b/.github/workflows/ui-prerelease-smoke.yml
@@ -1,0 +1,136 @@
+---
+name: UI prerelease smoke
+on:
+  workflow_dispatch:
+    inputs:
+      ui-tag:
+        description: Kitaru UI prerelease tag to test (e.g. kitaru-ui-v0.1.8)
+        required: true
+        type: string
+      kitaru-ref:
+        description: Kitaru git ref to test
+        required: false
+        type: string
+        default: develop
+      docker-smoke:
+        description: Also build and smoke-test the production Docker image locally
+        required: false
+        type: boolean
+        default: true
+permissions:
+  contents: read
+concurrency:
+  group: ui-prerelease-smoke-${{ github.ref }}-${{ inputs.ui-tag }}
+  cancel-in-progress: false
+env:
+  ZENML_SERVER_TAG: 0.94.4
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted workflow ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          path: trusted
+          persist-credentials: false
+      - name: Checkout Kitaru ref under test
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ inputs.kitaru-ref }}
+          path: kitaru
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          python-version: '3.12'
+      - name: Download selected Kitaru UI prerelease
+        working-directory: kitaru
+        run: bash ../trusted/scripts/download-ui.sh
+        env:
+          TAG: ${{ inputs.ui-tag }}
+          KITARU_UI_ALLOW_PRERELEASE: 'true'
+          KITARU_UI_RELEASE_TOKEN: ${{ secrets.KITARU_UI_RELEASE_TOKEN }}
+      - name: Build wheel
+        working-directory: kitaru
+        run: uv build --wheel
+      - name: Verify Kitaru UI in wheel
+        working-directory: kitaru
+        run: |
+          WHEEL=$(ls dist/*.whl)
+          uv run --no-project ../trusted/scripts/verify-ui-wheel.py "$WHEEL"
+      - name: Record smoke identity
+        working-directory: kitaru
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+          manifest = json.loads(Path("src/kitaru/_ui/bundle_manifest.json").read_text())
+          ref = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("## UI prerelease smoke inputs\n")
+              summary.write(f"Kitaru ref: `{ref}`\n\n")
+              summary.write(f"UI repo: `{manifest['repo']}`\n\n")
+              summary.write(f"UI tag: `{manifest['tag']}`\n\n")
+              summary.write(f"UI checksum: `{manifest['checksum']}`\n\n")
+              summary.write("No PyPI package, Docker image, Git tag, GitHub release, or Helm chart was published.\n")
+          PY
+      - name: Build server image
+        if: ${{ inputs.docker-smoke }}
+        working-directory: kitaru
+        run: >-
+          docker build -f docker/Dockerfile --target server
+          --build-arg ZENML_SERVER_TAG=${{ env.ZENML_SERVER_TAG }}
+          -t kitaru-ui-prerelease-smoke .
+      - name: Start server container
+        if: ${{ inputs.docker-smoke }}
+        run: docker run -d --rm --name kitaru-ui-prerelease-smoke -p 18080:8080 kitaru-ui-prerelease-smoke
+      - name: Wait for health endpoint
+        if: ${{ inputs.docker-smoke }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:18080/health >/tmp/kitaru-health.txt; then
+              cat /tmp/kitaru-health.txt
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Server did not become healthy in time." >&2
+          docker logs kitaru-ui-prerelease-smoke || true
+          exit 1
+      - name: Verify package UI and copied dashboard assets
+        if: ${{ inputs.docker-smoke }}
+        run: bash trusted/scripts/verify-server-ui.sh kitaru-ui-prerelease-smoke
+      - name: Smoke test root route serves dashboard HTML
+        if: ${{ inputs.docker-smoke }}
+        run: |
+          set -euo pipefail
+          status=$(curl -sS -o /tmp/root-response.txt -w '%{http_code}' 'http://127.0.0.1:18080/')
+          test "$status" = "200"
+          grep -qi '<!doctype html\|<html' /tmp/root-response.txt || {
+            echo "Root route did not return HTML." >&2
+            cat /tmp/root-response.txt >&2
+            exit 1
+          }
+      - name: Smoke test device verification route
+        if: ${{ inputs.docker-smoke }}
+        run: |
+          set -euo pipefail
+          status=$(curl -sS -o /tmp/device-verify-response.txt -w '%{http_code}' 'http://127.0.0.1:18080/devices/verify?device_id=test&user_code=test')
+          test "$status" = "200"
+          if grep -q 'An unexpected error occurred' /tmp/device-verify-response.txt; then
+            echo "Device verification route returned the generic unexpected-error payload." >&2
+            cat /tmp/device-verify-response.txt >&2
+            exit 1
+          fi
+          if docker logs kitaru-ui-prerelease-smoke 2>&1 | grep -q 'TemplateNotFound'; then
+            echo "TemplateNotFound appeared in container logs after hitting /devices/verify." >&2
+            exit 1
+          fi
+      - name: Dump container logs on failure
+        if: ${{ failure() && inputs.docker-smoke }}
+        run: docker logs kitaru-ui-prerelease-smoke || true
+      - name: Stop server container
+        if: ${{ always() && inputs.docker-smoke }}
+        run: docker rm -f kitaru-ui-prerelease-smoke || true

--- a/.gitignore
+++ b/.gitignore
@@ -259,6 +259,7 @@ docker/kitaru-ui-dist/
 # Bundled Kitaru UI (generated at build time by scripts/download-ui.sh)
 src/kitaru/_ui/dist/
 src/kitaru/_ui/bundle_manifest.json
+.kitaru-ui-bundles/
 
 # Codex
 .codex/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,9 @@ docs/                 # FumaDocs Next.js app — documentation at kitaru.ai/docs
   app/                # Next.js app routes, layout, metadata
 site/                 # Astro landing page + runtime shell at kitaru.ai/
   src/pages/api/      # Server-side API routes (e.g. /api/waitlist with KV)
-scripts/              # Doc generation, site merge, and smoke test scripts
+scripts/              # Doc generation, site merge, smoke test, and UI bundle scripts
+FRONTEND-TESTING.md   # Internal runbook for Kitaru UI bundle/frontend testing
+                         and stable/prerelease release validation
 docker/               # Dockerfiles (production server, server-dev, and dev flow images)
 design/               # Design docs, meeting notes (gitignored, never commit)
 wrangler.toml         # Unified Cloudflare Worker deployment config
@@ -158,6 +160,8 @@ When adding a new CLI command, MCP tool, or SDK feature:
 ### Python CI (`ci.yml`)
 
 Runs on push/PR to `develop`. Jobs: lint + format check + yaml check, typos, type check, dependency audit, link check, Docker server smoke test, wheel-packaging check, base tests (Python 3.11 + 3.12 + 3.13), and additional test lanes with `kitaru[mcp]` installed (3.11 + 3.12).
+
+When changing Kitaru UI bundling, frontend smoke testing, Docker dashboard packaging, or release UI selection, read `FRONTEND-TESTING.md` first. It is the runbook for stable vs prerelease `kitaru-ui-v*` bundle testing and the trusted-event/token boundaries.
 
 ### Site CI (`site.yml`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,13 @@ docs/                 # FumaDocs Next.js app — documentation at kitaru.ai/docs
 site/                 # Astro landing page + Cloudflare runtime shell at kitaru.ai/
   src/pages/api/      # Server-side API routes (/api/waitlist with KV)
 scripts/              # Doc generation + site merge scripts
+  download-ui.sh             # Bundles stable/prerelease Kitaru UI releases into the package tree
   generate_cli_docs.py       # Generates CLI reference MDX from cyclopts introspection
   generate_changelog_docs.py # Generates changelog MDX from CHANGELOG.md
   generate_sdk_docs.py       # Extracts Python SDK API to JSON (griffe → docs/.generated/sdk-api.json)
   merge_site.sh              # Merges docs static export into Astro build output
   smoke-test.sh              # Pre-release end-to-end sanity check (CLI, flows, MCP, LLM)
+FRONTEND-TESTING.md   # Internal runbook for stable/prerelease Kitaru UI bundle testing
 docker/               # Dockerfiles — see docker/CLAUDE.md for full architecture details
   Dockerfile          # Production server (FROM zenmldocker/zenml-server + Kitaru + Kitaru UI)
   Dockerfile.server-dev  # Dev server for local UI testing (local source + local UI dist)
@@ -122,7 +124,7 @@ Copy `.env.example` to `.env` and fill in R2 credentials. The site build does NO
 3. Run the smoke test: `./scripts/smoke-test.sh` (or `./scripts/smoke-test.sh -s` to skip reinstall). This exercises CLI, SDK flows, MCP tools, and LLM integration against a local server. Set `OPENAI_API_KEY` to include LLM tests. Use `-k` to keep the server running and inspect the dashboard afterward.
 4. Go to Actions > Release > Run workflow (or push a `vX.Y.Z` tag).
 5. Enter the version (e.g. `0.2.0`); optionally enable dry-run.
-6. The workflow bumps version, runs CI, publishes to PyPI, builds and pushes the Docker image (`zenmldocker/kitaru:<version>` + `latest`), builds and pushes the Helm chart to Amazon ECR Public as an OCI chart, creates `release/X.Y.Z`, updates `main`, tags, and creates a GitHub Release with auto-generated notes.
+6. The workflow bundles the highest stable/full `kitaru-ui-v*` release from `zenml-io/zenml-frontend-monorepo` into the Python package, bumps version, runs CI, publishes to PyPI, builds and pushes the Docker image (`zenmldocker/kitaru:<version>` + `latest`), builds and pushes the Helm chart to Amazon ECR Public as an OCI chart, creates `release/X.Y.Z`, updates `main`, tags, and creates a GitHub Release with auto-generated notes. Docker copies the UI from the installed Kitaru package; it does not download UI assets itself.
 7. After the workflow completes, edit the GitHub Release notes (`gh release edit vX.Y.Z --notes ...`) to replace the auto-generated PR list with a structured changelog: a **Highlights** section for the most notable changes, then **Added/Changed/Fixed/Infrastructure** categories mirroring the changelog.
 
 ## Development commands
@@ -182,12 +184,19 @@ just site                             # Preview landing page dev server (localho
 just site-build-only                  # Build landing page only (no docs merge)
 just site-build                       # Full unified build (generate + build + merge)
 
+# Kitaru UI bundle testing
+just ui-bundle                                # Download latest stable/full kitaru-ui-v* bundle
+just UI_TAG=kitaru-ui-v0.2.0 ui-bundle        # Download a specific stable UI bundle
+just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease  # Explicit prerelease opt-in
+just ui-login                                 # Start local Kitaru with prepared bundle
+just ui-smoke                                 # Smoke test prepared bundle and keep server running
+
 # Docker
-just server-image                              # Build production server image (zenmldocker/kitaru:latest)
-just DOCKER_TAG=v0.2.0 server-image            # Build with specific tag
-just UI_TAG=v0.1.0 server-image                # Build with specific Kitaru UI release
-just server-image-push               # Build + push to Docker Hub
-just server-dev-image                # Build dev server image (requires docker/kitaru-ui-dist/)
+just server-image                              # Build production server image (bundles latest stable UI first)
+just DOCKER_TAG=v0.2.0 server-image            # Build with specific image tag
+just UI_TAG=kitaru-ui-v0.2.0 server-image      # Build with specific stable Kitaru UI release
+just server-image-push                         # Build + push to Docker Hub
+just server-dev-image                          # Build dev server image (requires docker/kitaru-ui-dist/)
 
 # Manual deploy to Cloudflare
 unset CF_API_TOKEN CLOUDFLARE_API_TOKEN  # Clear stale tokens (use wrangler login credentials)
@@ -200,7 +209,8 @@ just site-build && npx wrangler deploy   # Build + deploy
 |---|---|---|
 | `ci.yml` | Push/PR to `develop` | Python checks: lint, format, yaml, typos, typecheck, dependency audit, links, Docker server smoke, wheel packaging, and tests across base installs (3.11 + 3.12 + 3.13) plus additional `kitaru[mcp]` test lanes |
 | `site.yml` | Manual dispatch; push to `main`; selected docs/site/script PR paths | Build + deploy unified site; PR preview Workers for same-repo PRs; preview cleanup on PR close |
-| `release.yml` | Workflow dispatch or `v*` tag | Version/changelog/lock handling for dispatch releases, PyPI publish, Docker image publish, Helm OCI chart publish, release branch/main update, GitHub Release |
+| `release.yml` | Workflow dispatch or `v*` tag | Stable Kitaru UI bundling, version/changelog/lock handling for dispatch releases, PyPI publish, Docker image publish, Helm OCI chart publish, release branch/main update, GitHub Release |
+| `ui-prerelease-smoke.yml` | Manual dispatch | Tests an explicit prerelease Kitaru UI bundle against a Kitaru ref without publishing PyPI, Docker, Helm, tags, or releases |
 | `spellcheck.yml` | Manual/reusable runs, push to `develop`, non-draft PRs | Separate typo/spell checking |
 | `image-optimiser.yml` | PRs changing JPG/JPEG/PNG/WebP files | Image compression for same-repo non-draft PRs, with `site/public/dashboard.png` ignored |
 | `zizmor.yml` | Workflow/dependabot changes, weekly schedule, manual runs | GitHub Actions security analysis |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ scripts/              # Doc generation + site merge scripts
   generate_sdk_docs.py       # Extracts Python SDK API to JSON (griffe → docs/.generated/sdk-api.json)
   merge_site.sh              # Merges docs static export into Astro build output
   smoke-test.sh              # Pre-release end-to-end sanity check (CLI, flows, MCP, LLM)
-FRONTEND-TESTING.md   # Internal runbook for stable/prerelease Kitaru UI bundle testing
+FRONTEND-TESTING.md   # Read first for Kitaru UI bundle/frontend testing,
+                       # stable/prerelease release validation, and token boundaries
 docker/               # Dockerfiles — see docker/CLAUDE.md for full architecture details
   Dockerfile          # Production server (FROM zenmldocker/zenml-server + Kitaru + Kitaru UI)
   Dockerfile.server-dev  # Dev server for local UI testing (local source + local UI dist)
@@ -185,6 +186,7 @@ just site-build-only                  # Build landing page only (no docs merge)
 just site-build                       # Full unified build (generate + build + merge)
 
 # Kitaru UI bundle testing
+# Read FRONTEND-TESTING.md before changing UI bundle, frontend smoke, Docker dashboard, or release UI workflows.
 just ui-bundle                                # Download latest stable/full kitaru-ui-v* bundle
 just UI_TAG=kitaru-ui-v0.2.0 ui-bundle        # Download a specific stable UI bundle
 just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease  # Explicit prerelease opt-in

--- a/FRONTEND-TESTING.md
+++ b/FRONTEND-TESTING.md
@@ -1,0 +1,218 @@
+# Frontend testing guide for Kitaru maintainers
+
+This is the internal runbook for testing the Kitaru UI from the Kitaru repo.
+It covers two different jobs that are easy to mix up:
+
+1. **Official Kitaru releases** bundle only stable/full Kitaru UI releases from
+   `zenml-io/zenml-frontend-monorepo`.
+2. **Local testing** can choose a UI bundle explicitly, including prerelease UI
+   tags, by pointing a local Kitaru server at a downloaded `dist/` directory.
+
+The safety rule is simple: Docker does not pick a UI release anymore. The Kitaru
+package already contains the UI, and Docker copies that packaged UI into the
+ZenML dashboard directory during image build.
+
+## Mental model
+
+Think of the UI like a printed booklet that gets put inside the Kitaru box.
+
+- `scripts/download-ui.sh` chooses the booklet and puts it into
+  `src/kitaru/_ui/dist/`.
+- `uv build` packs that booklet into the Python wheel.
+- `docker/Dockerfile` installs Kitaru and copies the booklet from the installed
+  package into the server dashboard.
+
+That means there is one official UI choice per Kitaru build. There is no second
+hidden UI download during Docker build.
+
+## Stable local UI bundle
+
+Use this when you want to test the same class of UI bundle that an official
+Kitaru release is allowed to use.
+
+```bash
+just ui-bundle
+```
+
+What happens:
+
+- Kitaru resolves the highest stable/full `kitaru-ui-v*` GitHub release from
+  `zenml-io/zenml-frontend-monorepo`.
+- The archive checksum is verified.
+- Files are extracted to `.kitaru-ui-bundles/current/dist/`.
+- A `bundle_manifest.json` is written next to the dist directory.
+
+If the monorepo release assets require authentication, make sure your shell has
+access to a read token first:
+
+```bash
+export KITARU_UI_RELEASE_TOKEN=<token-with-contents-read>
+just ui-bundle
+```
+
+## Stable pinned UI bundle
+
+Use this when you need to test one specific stable UI release.
+
+```bash
+just UI_TAG=kitaru-ui-v0.2.0 ui-bundle
+```
+
+The tag must use the monorepo Kitaru UI shape: `kitaru-ui-v<semver>`.
+Old bare tags like `v0.2.0` are intentionally rejected.
+
+If that tag is a prerelease, this command fails. That failure is the release
+safety rail: the normal stable lane should not accidentally consume prerelease
+UI.
+
+## Prerelease UI bundle
+
+Use this when Bart/frontend maintainers have published a prerelease UI and want
+Kitaru maintainers to validate it before promoting it to a full GitHub release.
+
+```bash
+just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease
+```
+
+This is deliberately more explicit than `ui-bundle` because it sets
+`KITARU_UI_ALLOW_PRERELEASE=true` under the hood. That opt-in belongs in local
+or smoke testing only, never in the official Kitaru release workflow.
+
+## Start local Kitaru with the prepared UI
+
+After preparing a bundle, start the local server with:
+
+```bash
+just ui-login
+```
+
+For a pinned bundle:
+
+```bash
+just UI_TAG=kitaru-ui-v0.2.0 ui-login
+```
+
+For a prerelease bundle:
+
+```bash
+just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-login
+```
+
+`ui-login` looks for the prepared bundle under `.kitaru-ui-bundles/.../dist` and
+runs `kitaru login` with `KITARU_UI_DIST_PATH` set.
+
+Important: `KITARU_UI_DIST_PATH` only matters when the local server starts. If a
+local server is already running, restart it before testing a different UI:
+
+```bash
+kitaru logout
+just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-login
+```
+
+## Direct local override without Just
+
+If you already have a UI `dist/` directory, point Kitaru at it directly:
+
+```bash
+KITARU_UI_DIST_PATH=/absolute/path/to/dist kitaru login
+```
+
+When working from this source checkout, the equivalent is usually:
+
+```bash
+KITARU_UI_DIST_PATH=/absolute/path/to/dist uv run kitaru login
+```
+
+The directory must contain `index.html`. If it does not, Kitaru raises a
+user-facing error instead of silently falling back to the stock ZenML dashboard.
+
+## Run the Kitaru smoke test against a selected UI
+
+Use this before asking someone to click around manually:
+
+```bash
+just ui-smoke
+```
+
+For a prerelease:
+
+```bash
+just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease
+just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-smoke
+```
+
+`ui-smoke` runs:
+
+```bash
+KITARU_UI_DIST_PATH=<prepared-dist> ./scripts/smoke-test.sh --keep-server
+```
+
+The `--keep-server` flag leaves the local server running after the automated
+checks finish, so you can open the dashboard and inspect the selected UI in a
+browser.
+
+## Prerelease smoke workflow in GitHub Actions
+
+Use `.github/workflows/ui-prerelease-smoke.yml` when you want automation to test
+a prerelease UI without publishing anything.
+
+From GitHub:
+
+1. Open **Actions → UI prerelease smoke → Run workflow**.
+2. Set `ui-tag` to a prerelease tag, for example `kitaru-ui-v0.3.0-rc.1`.
+3. Set `kitaru-ref` if you need a branch other than `develop`.
+4. Leave `docker-smoke` enabled unless you only need wheel validation.
+
+What the workflow does:
+
+- checks out the requested Kitaru ref;
+- downloads the selected UI with `KITARU_UI_ALLOW_PRERELEASE=true`;
+- builds the Kitaru wheel and verifies the UI files are inside it;
+- optionally builds the Docker image from local source;
+- checks that the Docker image contains both the packaged Kitaru UI and the
+  copied ZenML dashboard files;
+- publishes nothing: no PyPI package, no Docker image, no Helm chart, no Git tag,
+  and no GitHub Release.
+
+## Docker testing notes
+
+For release-like Docker testing from this repo, use:
+
+```bash
+just server-image
+```
+
+This downloads a stable UI into `src/kitaru/_ui/dist/` first, installs Kitaru in
+the image, and then Docker copies the installed package UI into the dashboard.
+
+For a specific stable UI:
+
+```bash
+just UI_TAG=kitaru-ui-v0.2.0 server-image
+```
+
+For an unarchived local frontend build, use the separate dev-server image path:
+
+```bash
+cp -r /path/to/zenml-frontend-monorepo/apps/kitaru-ui/dist/ docker/kitaru-ui-dist/
+just server-dev-image
+```
+
+Keep these two Docker paths separate:
+
+- `server-image` tests packaged Kitaru UI, like release builds.
+- `server-dev-image` tests a raw local frontend `dist/` copied into the Docker
+  build context.
+
+## Quick checklist for prerelease validation
+
+```bash
+export KITARU_UI_RELEASE_TOKEN=<token-if-needed>
+just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease
+just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-smoke
+```
+
+Then open the dashboard URL printed by `kitaru login` / the smoke test and click
+through the UI. If the UI is good, frontend maintainers can promote the
+`kitaru-ui-v*` release from prerelease to a full GitHub release. Only after that
+can an official Kitaru release bundle it by default.

--- a/FRONTEND-TESTING.md
+++ b/FRONTEND-TESTING.md
@@ -37,7 +37,8 @@ just ui-bundle
 What happens:
 
 - Kitaru resolves the highest stable/full `kitaru-ui-v*` GitHub release from
-  `zenml-io/zenml-frontend-monorepo`.
+  `zenml-io/zenml-frontend-monorepo`, searching across paginated GitHub release
+  results instead of trusting only the first page.
 - The archive checksum is verified.
 - Files are extracted to `.kitaru-ui-bundles/current/dist/`.
 - A `bundle_manifest.json` is written next to the dist directory.
@@ -63,7 +64,9 @@ Old bare tags like `v0.2.0` are intentionally rejected.
 
 If that tag is a prerelease, this command fails. That failure is the release
 safety rail: the normal stable lane should not accidentally consume prerelease
-UI.
+UI. Tags like `kitaru-ui-v0.3.0-rc.1` are treated as prereleases from their
+semver shape even if GitHub release metadata incorrectly says they are full
+releases.
 
 ## Prerelease UI bundle
 
@@ -77,6 +80,8 @@ just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease
 This is deliberately more explicit than `ui-bundle` because it sets
 `KITARU_UI_ALLOW_PRERELEASE=true` under the hood. That opt-in belongs in local
 or smoke testing only, never in the official Kitaru release workflow.
+Tokened UI bundle jobs in CI must run only on trusted events such as `push`, not
+on `pull_request` code.
 
 ## Start local Kitaru with the prepared UI
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -234,24 +234,34 @@ image with Kitaru and the Kitaru UI layered on top.
 ### 1. Build the server image locally
 
 ```bash
-just server-image REPO=kitaru-local TAG=dev UI_TAG=v0.1.0
-# or, if you do not have `just` installed:
-docker build -f docker/Dockerfile --target server \
-    --build-arg KITARU_UI_TAG=v0.1.0 \
-    -t kitaru-local:dev .
+just DOCKER_REPO=kitaru-local DOCKER_TAG=dev server-image
 ```
-
-> Replace `v0.1.0` with the desired Kitaru UI release tag. Without an
-> explicit tag, the build defaults to `latest` (the most recent GitHub release).
 
 This creates a local image tag called `kitaru-local:dev`.
 
-For local UI development (without a published Kitaru UI release), use
-the dev server image instead:
+The `server-image` recipe first bundles a stable Kitaru UI release into the
+Kitaru package tree, then Docker copies that packaged UI into the server image.
+Docker no longer downloads UI release assets itself.
+
+If you do not have `just` installed, run the two steps explicitly:
+
+```bash
+bash scripts/download-ui.sh
+docker build -f docker/Dockerfile --target server -t kitaru-local:dev .
+```
+
+To test a specific stable UI release in the release-like image path:
+
+```bash
+just UI_TAG=kitaru-ui-v0.2.0 DOCKER_REPO=kitaru-local DOCKER_TAG=dev server-image
+```
+
+For local UI development with an unarchived frontend build, use the dev server
+image instead:
 
 ```bash
 # Build kitaru-ui first, then copy dist/ into the build context:
-cp -r /path/to/kitaru-ui/dist/ docker/kitaru-ui-dist/
+cp -r /path/to/zenml-frontend-monorepo/apps/kitaru-ui/dist/ docker/kitaru-ui-dist/
 just server-dev-image
 ```
 
@@ -285,8 +295,8 @@ This uses browser-based device authorization. A few practical notes:
   manually.
 - If the browser page shows `{"detail":"An unexpected error occurred."}`
   or the CLI keeps polling with `authorization_pending`, the image likely
-  does not contain the bundled dashboard assets. Rebuild the image from
-  the current branch or switch to a newer published tag.
+  does not contain the bundled dashboard assets. Rebuild from source after
+  running `bash scripts/download-ui.sh`, or switch to a newer published tag.
 - If login stalls, `docker logs kitaru-server` is the first place to look.
 
 After login, `uv run kitaru status` should show the server connection.
@@ -302,6 +312,49 @@ locally.
 ```bash
 docker stop kitaru-server && docker rm kitaru-server
 ```
+
+## Maintainer UI testing
+
+Most users should not need this section. It is for Kitaru/backend maintainers
+and frontend maintainers validating a Kitaru UI bundle before a release.
+
+The key safety rule: official Kitaru builds only bundle stable/full UI releases
+from `zenml-io/zenml-frontend-monorepo`. Prerelease UI testing is explicit and
+local; it does not publish a Kitaru package or image.
+
+```bash
+# Download the latest stable/full UI bundle for local testing
+just ui-bundle
+
+# Download a specific stable UI bundle
+just UI_TAG=kitaru-ui-v0.2.0 ui-bundle
+
+# Download a prerelease UI bundle, explicitly opting into prereleases
+just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease
+
+# Start local Kitaru with the prepared bundle
+just ui-login
+
+# Run the smoke test with the prepared bundle and keep the server running
+just ui-smoke
+```
+
+You can also bypass `just` and point Kitaru at any built UI `dist/` directory:
+
+```bash
+KITARU_UI_DIST_PATH=/absolute/path/to/dist uv run kitaru login
+KITARU_UI_DIST_PATH=/absolute/path/to/dist ./scripts/smoke-test.sh --keep-server
+```
+
+If a local server is already running, restart it before changing
+`KITARU_UI_DIST_PATH`:
+
+```bash
+uv run kitaru logout
+KITARU_UI_DIST_PATH=/absolute/path/to/dist uv run kitaru login
+```
+
+For the full internal runbook, see `FRONTEND-TESTING.md`.
 
 ## Useful CLI commands
 

--- a/Justfile
+++ b/Justfile
@@ -5,6 +5,7 @@ ZENML_SERVER_TAG := "0.94.4"
 DOCKER_REPO := "zenmldocker/kitaru"
 DOCKER_TAG := "latest"
 UI_TAG := "latest"
+UI_BUNDLE_ROOT := ".kitaru-ui-bundles"
 
 # List available recipes
 default:
@@ -84,6 +85,56 @@ test *ARGS:
 build:
     uv build
 
+# Download/extract a local Kitaru UI bundle for manual login/smoke testing.
+# Defaults to the latest stable kitaru-ui-v* release.
+# Pass UI_TAG=kitaru-ui-v0.2.0 to pin a stable release.
+ui-bundle:
+    @set -e; \
+    if [ "{{ UI_TAG }}" = "latest" ]; then \
+        dest="{{ UI_BUNDLE_ROOT }}/current"; \
+        printf 'Downloading latest stable Kitaru UI bundle into %s/dist\n' "$dest"; \
+        KITARU_UI_INSTALL_DIR="$dest" bash scripts/download-ui.sh; \
+    else \
+        dest="{{ UI_BUNDLE_ROOT }}/{{ UI_TAG }}"; \
+        printf 'Downloading Kitaru UI bundle {{ UI_TAG }} into %s/dist\n' "$dest"; \
+        KITARU_UI_INSTALL_DIR="$dest" TAG="{{ UI_TAG }}" bash scripts/download-ui.sh; \
+    fi; \
+    printf '\nUse with: KITARU_UI_DIST_PATH=%s/dist uv run kitaru login\n' "$dest"
+
+# Download/extract an explicit prerelease Kitaru UI bundle for local testing.
+ui-bundle-prerelease:
+    @set -e; \
+    if [ "{{ UI_TAG }}" = "latest" ]; then \
+        printf 'Error: pass an explicit prerelease tag, e.g. UI_TAG=kitaru-ui-v0.3.0-rc.1\n' >&2; \
+        exit 1; \
+    fi; \
+    dest="{{ UI_BUNDLE_ROOT }}/{{ UI_TAG }}"; \
+    printf 'Downloading prerelease Kitaru UI bundle {{ UI_TAG }} into %s/dist\n' "$dest"; \
+    KITARU_UI_ALLOW_PRERELEASE=true KITARU_UI_INSTALL_DIR="$dest" TAG="{{ UI_TAG }}" bash scripts/download-ui.sh; \
+    printf '\nUse with: KITARU_UI_DIST_PATH=%s/dist uv run kitaru login\n' "$dest"
+
+# Start local Kitaru with a prepared UI bundle.
+ui-login:
+    @set -e; \
+    if [ "{{ UI_TAG }}" = "latest" ]; then \
+        dist="{{ UI_BUNDLE_ROOT }}/current/dist"; \
+    else \
+        dist="{{ UI_BUNDLE_ROOT }}/{{ UI_TAG }}/dist"; \
+    fi; \
+    test -f "$dist/index.html" || { printf 'Error: %s/index.html not found. Run just ui-bundle first.\n' "$dist" >&2; exit 1; }; \
+    KITARU_UI_DIST_PATH="$dist" uv run kitaru login
+
+# Run smoke tests against a prepared UI bundle and keep the server for inspection.
+ui-smoke:
+    @set -e; \
+    if [ "{{ UI_TAG }}" = "latest" ]; then \
+        dist="{{ UI_BUNDLE_ROOT }}/current/dist"; \
+    else \
+        dist="{{ UI_BUNDLE_ROOT }}/{{ UI_TAG }}/dist"; \
+    fi; \
+    test -f "$dist/index.html" || { printf 'Error: %s/index.html not found. Run just ui-bundle first.\n' "$dist" >&2; exit 1; }; \
+    KITARU_UI_DIST_PATH="$dist" ./scripts/smoke-test.sh --keep-server
+
 # Build dev base image for remote stack testing (K8s, etc.)
 # The image bakes in kitaru from local source + ZenML from PyPI.
 # Pass REPO to override the target registry/image.
@@ -93,15 +144,20 @@ dev-image REPO="strickvl/kitaru-dev":
     docker push {{ REPO }}:latest
     @printf 'Dev image pushed to {{ REPO }}:latest\n'
 
-# Build production server image (ZenML server base + Kitaru + Kitaru UI).
+# Build production server image (ZenML server base + Kitaru + packaged Kitaru UI).
 # Override variables on the command line:
-#   just server-image                          # defaults
-#   just UI_TAG=v0.1.0 server-image            # specific UI release
-#   just DOCKER_TAG=v0.2.0 server-image        # specific image tag
+#   just server-image                                  # bundle latest stable UI
+#   just UI_TAG=kitaru-ui-v0.2.0 server-image          # bundle specific stable UI
+#   just DOCKER_TAG=v0.2.0 server-image                # specific image tag
 server-image:
+    @set -e; \
+    if [ "{{ UI_TAG }}" = "latest" ]; then \
+        bash scripts/download-ui.sh; \
+    else \
+        TAG="{{ UI_TAG }}" bash scripts/download-ui.sh; \
+    fi
     docker build -f docker/Dockerfile --target server \
         --build-arg ZENML_SERVER_TAG={{ ZENML_SERVER_TAG }} \
-        --build-arg KITARU_UI_TAG={{ UI_TAG }} \
         -t kitaru-server .
     docker tag kitaru-server {{ DOCKER_REPO }}:{{ DOCKER_TAG }}
     @printf 'Server image built: {{ DOCKER_REPO }}:{{ DOCKER_TAG }}\n'

--- a/docker/CLAUDE.md
+++ b/docker/CLAUDE.md
@@ -7,48 +7,56 @@ The main project `CLAUDE.md` links here for Docker-specific guidance.
 
 | Dockerfile | Purpose | Base image | Installs Kitaru from | UI source |
 |---|---|---|---|---|
-| `Dockerfile` | Production server (API + UI) | `zenmldocker/zenml-server:<tag>` | Local source | Released `kitaru-ui.tar.gz` from GitHub |
+| `Dockerfile` | Production server (API + UI) | `zenmldocker/zenml-server:<tag>` | PyPI when `KITARU_VERSION` is set; local source otherwise | Installed `kitaru` package (`kitaru/_ui/dist`) |
 | `Dockerfile.server-dev` | Local server + UI development | `zenmldocker/zenml-server:<tag>` | Local source | Local `docker/kitaru-ui-dist/` directory |
 | `Dockerfile.dev` | Remote flow execution (K8s, etc.) | `python:3.12-slim-bookworm` | Local source | N/A (no UI) |
 
 ## How the UI gets into the server image
 
 The ZenML server serves a dashboard from `<zenml_package>/zen_server/dashboard/`.
-Both server Dockerfiles replace that directory with Kitaru UI files:
+Both server Dockerfiles replace that directory with Kitaru UI files, but they do
+it from different sources:
 
-- **Production** (`Dockerfile`): Downloads `kitaru-ui.tar.gz` + `.sha256` from
-  the `kitaru-ui` GitHub releases, verifies the checksum, extracts into the
-  dashboard directory.
-- **Dev** (`Dockerfile.server-dev`): Copies from `docker/kitaru-ui-dist/` which
-  the developer populates from a local `kitaru-ui` build (`pnpm build`).
+- **Production** (`Dockerfile`): installs Kitaru first, resolves
+  `kitaru/_ui/dist` from the installed package with Python, verifies
+  `index.html`, and copies those files into ZenML's dashboard directory.
+  Docker must not download a UI release itself.
+- **Dev** (`Dockerfile.server-dev`): copies from `docker/kitaru-ui-dist/`, which
+  the developer populates from a local Kitaru UI build (`pnpm build`).
 
-Both verify that `index.html` exists after extraction/copy (build sentinel).
+The safety story is: the Kitaru wheel decides the official UI bundle, and Docker
+only consumes that package. This prevents the wheel and Docker image from
+silently using different UI releases.
+
+Both server Dockerfiles verify that `index.html` exists after extraction/copy
+(build sentinel).
 
 ## ZenML server base image
 
 The `ZENML_SERVER_TAG` build arg controls which ZenML server version is used.
-This is pinned to a specific version (see the `ARG ZENML_SERVER_TAG` default
-in `Dockerfile`), not `latest`. Both Dockerfiles must use the same pinned
-tag — a contract test enforces alignment.
+This is pinned to a specific version (see the `ARG ZENML_SERVER_TAG` default in
+`Dockerfile`), not `latest`. Both Dockerfiles must use the same pinned tag — a
+contract test enforces alignment.
 
 The base image provides:
+
 - ZenML with all server + cloud extras
 - Non-root user `zenml` (UID 1000) as the runtime user
 - Entrypoint and CMD (uvicorn)
 - Dashboard directory structure
 
-Kitaru layers on top without overriding the entrypoint or CMD.
-Both server Dockerfiles use `USER root` for build steps (package installation,
-file operations) and switch back to `USER zenml` at the end. This is required
-because the base image's non-root user cannot delete root-owned files created
-by `COPY` instructions.
+Kitaru layers on top without overriding the entrypoint or CMD. Both server
+Dockerfiles use `USER root` for build steps (package installation, file
+operations) and switch back to `USER zenml` at the end. This is required because
+the base image's non-root user cannot delete root-owned files created by `COPY`
+instructions.
 
 All three Dockerfiles use [uv](https://docs.astral.sh/uv/) for Python package
-installation instead of pip. uv is copied as a static binary from the
-distroless image (`ghcr.io/astral-sh/uv`) — no pip install or apt-get needed.
-The base image sets `VIRTUAL_ENV=/opt/venv`, so `uv pip install` targets the
-venv automatically in the server Dockerfiles. `Dockerfile.dev` uses
-`UV_SYSTEM_PYTHON=1` instead (no venv).
+installation instead of pip. uv is copied as a static binary from the distroless
+image (`ghcr.io/astral-sh/uv`) — no pip install or apt-get needed. The base image
+sets `VIRTUAL_ENV=/opt/venv`, so `uv pip install` targets the venv automatically
+in the server Dockerfiles. `Dockerfile.dev` uses `UV_SYSTEM_PYTHON=1` instead
+(no venv).
 
 ## Build args
 
@@ -57,9 +65,10 @@ venv automatically in the server Dockerfiles. `Dockerfile.dev` uses
 | Arg | Default | Description |
 |-----|---------|-------------|
 | `ZENML_SERVER_TAG` | *(pinned, see Dockerfile)* | ZenML server Docker image tag |
-| `KITARU_UI_TAG` | `latest` | Kitaru UI GitHub release tag |
-| `KITARU_UI_REPO_URL` | `https://github.com/zenml-io/kitaru-ui` | Kitaru UI repo for release downloads |
 | `KITARU_VERSION` | *(empty)* | If set, install Kitaru from PyPI (`kitaru==<version>`); if empty, install from local source |
+
+There is intentionally no `KITARU_UI_TAG` Docker build arg. Select the UI before
+building the package or source tree, not inside Docker.
 
 ### `Dockerfile.server-dev` (dev)
 
@@ -71,14 +80,19 @@ venv automatically in the server Dockerfiles. `Dockerfile.dev` uses
 
 ### Testing with local UI changes (no release needed)
 
+Use this path when you have an unarchived local frontend build and want Docker to
+serve exactly those files:
+
 ```bash
-# 1. Build kitaru-ui
-cd /path/to/kitaru-ui
+# 1. Build Kitaru UI in the frontend monorepo
+cd /path/to/zenml-frontend-monorepo/apps/kitaru-ui
 pnpm install --frozen-lockfile
 pnpm build
 
-# 2. Copy dist/ into the kitaru Docker build context
-cp -r dist/ /path/to/kitaru/docker/kitaru-ui-dist/
+# 2. Copy dist/ into the Kitaru Docker build context
+cd /path/to/kitaru
+rm -rf docker/kitaru-ui-dist
+cp -r /path/to/zenml-frontend-monorepo/apps/kitaru-ui/dist/ docker/kitaru-ui-dist/
 
 # 3. Build the dev server image
 just server-dev-image
@@ -91,36 +105,63 @@ The `docker/kitaru-ui-dist/` directory is gitignored.
 
 ### Building a release-like image
 
+Use this path when you want Docker to behave like the official release path:
+
 ```bash
-just UI_TAG=v0.1.0 server-image
+just server-image
 ```
+
+That command first downloads the highest stable/full `kitaru-ui-v*` release into
+`src/kitaru/_ui/dist/`, then builds the server image. Docker copies the UI from
+the installed Kitaru package.
+
+To pin a specific stable UI release:
+
+```bash
+just UI_TAG=kitaru-ui-v0.2.0 server-image
+```
+
+Prerelease UI belongs in the local bundle-selector and prerelease smoke workflow,
+not in official Docker release builds.
 
 ### CI and release
 
-- **CI** (`docker-smoke` in `ci.yml`): Builds `Dockerfile --target server`
-  with explicit build args. Checks `/health`, dashboard sentinel, root route
-  HTML, and `/devices/verify`.
-- **Release** (`release.yml`): Builds and pushes `zenmldocker/kitaru:<version>`
-  with `KITARU_UI_TAG=v<version>`.
+- **CI** (`docker-smoke` in `ci.yml`): runs `scripts/download-ui.sh` first, then
+  builds `Dockerfile --target server` without UI build args. It checks `/health`,
+  package UI files, copied dashboard files, root route HTML, and
+  `/devices/verify`.
+- **Release** (`release.yml`): downloads a stable/full Kitaru UI release from
+  `zenml-io/zenml-frontend-monorepo`, builds the Python package, then builds and
+  pushes `zenmldocker/kitaru:<version>` using that package UI.
+- **Prerelease smoke** (`ui-prerelease-smoke.yml`): explicitly enables
+  `KITARU_UI_ALLOW_PRERELEASE=true` for automation-only validation and publishes
+  nothing.
 
 ## Release dependency chain
 
-```
+```text
 ZenML server release (zenmldocker/zenml-server:X.Y.Z on DockerHub)
-    → Kitaru UI release (kitaru-ui.tar.gz on GitHub Releases)
-        → Kitaru release (builds zenmldocker/kitaru:X.Y.Z)
+    → stable/full Kitaru UI release (kitaru-ui-v* in zenml-io/zenml-frontend-monorepo)
+        → Kitaru release (wheel bundles UI, Docker copies from installed package)
 ```
 
-The `ZENML_SERVER_TAG` and `KITARU_UI_TAG` must both be updated before
-cutting a Kitaru release.
+Before cutting a Kitaru release, make sure:
+
+- `ZENML_SERVER_TAG` is correct and aligned across Dockerfiles/workflows.
+- At least one full, non-prerelease `kitaru-ui-v*` release exists in
+  `zenml-io/zenml-frontend-monorepo`.
+- The `KITARU_UI_RELEASE_TOKEN` secret can read the frontend monorepo release
+  assets if the repository requires authentication.
 
 ## Contract tests
 
 `tests/test_dockerfile_contract.py` validates:
+
 - `pyproject.toml` has no ZenML git direct references or direct-reference allowance
 - Production Dockerfile uses `zenmldocker/zenml-server` as base with a pinned tag
-- Production Dockerfile installs Kitaru from local source
-- Kitaru UI is downloaded with checksum verification and `curl --fail`
+- Production Dockerfile installs Kitaru from local source or PyPI depending on `KITARU_VERSION`
+- Production Dockerfile does not download Kitaru UI releases directly
+- Production Dockerfile resolves package UI with Python, verifies `index.html`, and copies into ZenML's dashboard directory
 - Dashboard sentinel is checked
 - No legacy git-clone / install-dashboard.sh remains
 - Server-dev Dockerfile exists, uses the same base, and copies from `docker/kitaru-ui-dist/`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,21 +17,15 @@ ARG ZENML_SERVER_TAG=0.94.4
 
 FROM zenmldocker/zenml-server:${ZENML_SERVER_TAG} AS server
 
-ARG KITARU_UI_TAG=latest
-ARG KITARU_UI_REPO_URL=https://github.com/zenml-io/kitaru-ui
 ARG KITARU_VERSION=""
 
 # The base image runs as non-root user "zenml" (UID 1000).
 # Switch to root for package installation and file operations.
 USER root
 
-# Install uv (fast Python package installer) and curl (for downloading
-# release assets). uv is copied as a static binary from the distroless
-# image; curl is not in the slim base image so needs apt-get.
+# Install uv (fast Python package installer). uv is copied as a static
+# binary from the distroless image.
 COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /uvx /bin/
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/*
 
 # Install Kitaru. When KITARU_VERSION is set (release builds), install from
 # PyPI for provenance. Otherwise install from the checked-out source tree
@@ -44,29 +38,19 @@ RUN if [ -n "$KITARU_VERSION" ]; then \
     fi \
     && rm -rf /tmp/kitaru
 
-# Replace the ZenML dashboard with the Kitaru UI.
-# Downloads the released archive, verifies its checksum, and extracts
-# into the installed ZenML package's dashboard directory.
-# When KITARU_UI_TAG is "latest", uses GitHub's latest-release URL shortcut.
+# Replace the ZenML dashboard with the Kitaru UI already bundled inside the
+# installed Kitaru package. The release workflow is responsible for downloading
+# the stable UI before building the wheel; Docker must not download a second UI.
 RUN set -eux \
+    && KITARU_UI_DIST="$(python -c 'from pathlib import Path; import kitaru; print(Path(kitaru.__file__).parent / "_ui" / "dist")')" \
+    && test -f "$KITARU_UI_DIST/index.html" \
+       || { echo "Kitaru package UI assets missing: index.html not found in $KITARU_UI_DIST" >&2; exit 1; } \
     && DASHBOARD_DIR="$(python -c 'import zenml; print(zenml.__path__[0])')/zen_server/dashboard" \
     && rm -rf "$DASHBOARD_DIR" \
     && mkdir -p "$DASHBOARD_DIR" \
-    && if [ "$KITARU_UI_TAG" = "latest" ]; then \
-         BASE_URL="$KITARU_UI_REPO_URL/releases/latest/download"; \
-       else \
-         BASE_URL="$KITARU_UI_REPO_URL/releases/download/$KITARU_UI_TAG"; \
-       fi \
-    && curl -fSsL "$BASE_URL/kitaru-ui.tar.gz" -o /tmp/kitaru-ui.tar.gz \
-    && curl -fSsL "$BASE_URL/kitaru-ui.tar.gz.sha256" -o /tmp/kitaru-ui.tar.gz.sha256 \
-    && cd /tmp && sha256sum -c kitaru-ui.tar.gz.sha256 \
-    && tar xzf /tmp/kitaru-ui.tar.gz -C "$DASHBOARD_DIR" \
-    && rm -f /tmp/kitaru-ui.tar.gz /tmp/kitaru-ui.tar.gz.sha256
-
-# Verify the dashboard sentinel file exists (separate RUN so download/checksum
-# failures above surface their own error messages via set -e).
-RUN test -f "$(python -c 'import zenml; print(zenml.__path__[0])')/zen_server/dashboard/index.html" \
-    || { echo "Kitaru UI assets missing: index.html not found in dashboard directory" >&2; exit 1; }
+    && cp -a "$KITARU_UI_DIST/." "$DASHBOARD_DIR/" \
+    && { test -f "$DASHBOARD_DIR/index.html" \
+         || { echo "Kitaru UI assets missing: index.html not found in dashboard directory" >&2; exit 1; }; }
 
 # Switch back to non-root user (matches base image).
 USER zenml

--- a/docs/content/docs/deploy/docker.mdx
+++ b/docs/content/docs/deploy/docker.mdx
@@ -26,7 +26,8 @@ docker run -d --platform linux/amd64 --name kitaru-server -p 8080:8080 zenmldock
 
 <Callout type="info">
   Use a version-pinned tag (e.g. `zenmldocker/kitaru:0.2.0`) that matches your
-  client SDK version to avoid API incompatibilities.
+  client SDK version to avoid API incompatibilities. The official image already
+  includes the Kitaru UI bundled with that Kitaru release.
 </Callout>
 
 The server initializes an internal SQLite database on first startup. Wait for
@@ -78,7 +79,7 @@ docker run -d --platform linux/amd64 --name kitaru-server -p 8080:8080 \
 
 ### Building from source
 
-If you are testing changes from a local checkout:
+If you are testing changes from a local checkout, use `just` when possible:
 
 <Tabs items={["just (recommended)", "Docker"]}>
   <Tab value="just (recommended)">
@@ -88,10 +89,17 @@ If you are testing changes from a local checkout:
   </Tab>
   <Tab value="Docker">
     ```bash
+    bash scripts/download-ui.sh
     docker build -f docker/Dockerfile --target server -t kitaru-local:dev .
     ```
   </Tab>
 </Tabs>
+
+The important detail is that the UI is selected before Docker builds. The
+`server-image` recipe runs `scripts/download-ui.sh`, which bundles a stable/full
+Kitaru UI release into the Kitaru package tree. Docker then installs Kitaru and
+copies the packaged UI into the server dashboard. There is no Docker build arg
+for choosing a UI release tag.
 
 Then run it:
 
@@ -367,8 +375,8 @@ Common causes:
 - Ensure the `/health` endpoint returns 200 before attempting login.
   The server takes ~20 seconds on first startup to initialize the database.
 - If the browser shows `{"detail":"An unexpected error occurred."}`, the
-  dashboard assets may be missing from the image. Rebuild from source or use a
-  newer image tag.
+  dashboard assets may be missing from the image. Rebuild from source after
+  running `bash scripts/download-ui.sh`, or use a newer published image tag.
 - If the CLI keeps printing `authorization_pending`, the server may not be
   fully initialized. Wait and retry.
 - Port **8383** belongs to bare `kitaru login` local-server mode. To connect

--- a/docs/content/docs/deploy/helm.mdx
+++ b/docs/content/docs/deploy/helm.mdx
@@ -30,7 +30,8 @@ helm install kitaru-server oci://public.ecr.aws/zenml/kitaru \
 ```
 
 This starts a single Kitaru server pod with a local SQLite database persisted
-via a PersistentVolumeClaim.
+via a PersistentVolumeClaim. The chart uses the official Kitaru server image, so
+it inherits the Kitaru UI bundled into that image at release time.
 
 Once the pod is ready, port-forward and connect:
 
@@ -73,10 +74,11 @@ Snapshot-backed deployment execution (`kitaru invoke`,
 `KitaruClient().deployments.invoke(...)`, and
 `kitaru flow deployments curl`) requires server workload-manager support.
 
-The default Kitaru chart/image path already includes this support. If you
-override the image (for example using plain `zenmldocker/zenml-server`) or
-replace environment settings, preserve a compatible workload-manager
-configuration explicitly under `kitaru.server.environment`.
+The default Kitaru chart/image path already includes this support and the
+release-bundled Kitaru UI. If you override the image (for example using plain
+`zenmldocker/zenml-server`) or replace environment settings, preserve a
+compatible workload-manager configuration explicitly under
+`kitaru.server.environment`.
 
 ```yaml
 kitaru:

--- a/scripts/download-ui.sh
+++ b/scripts/download-ui.sh
@@ -99,6 +99,52 @@ validate_tag_shape() {
     fi
 }
 
+fetch_release_pages() {
+    local releases_file="$1"
+    local page=1
+    local page_count=0
+    local -a page_files=()
+
+    while true; do
+        local page_file="$TMP_DIR/releases-page-$page.json"
+        github_api "$GITHUB_API_URL/repos/$UI_RELEASE_REPO/releases?per_page=100&page=$page" > "$page_file"
+        page_files+=("$page_file")
+        page_count=$("$PYTHON_BIN" - "$page_file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    releases = json.load(handle)
+if not isinstance(releases, list):
+    print("Error: GitHub releases response was not a JSON array.", file=sys.stderr)
+    raise SystemExit(1)
+print(len(releases))
+PY
+)
+        if [ "$page_count" -lt 100 ]; then
+            break
+        fi
+        page=$((page + 1))
+    done
+
+    "$PYTHON_BIN" - "$releases_file" "${page_files[@]}" <<'PY'
+import json
+import sys
+
+output_file = sys.argv[1]
+all_releases: list[object] = []
+for page_file in sys.argv[2:]:
+    with open(page_file, encoding="utf-8") as handle:
+        releases = json.load(handle)
+    if not isinstance(releases, list):
+        print("Error: GitHub releases response was not a JSON array.", file=sys.stderr)
+        raise SystemExit(1)
+    all_releases.extend(releases)
+with open(output_file, "w", encoding="utf-8") as handle:
+    json.dump(all_releases, handle)
+PY
+}
+
 select_latest_stable_tag() {
     local releases_file="$1"
     "$PYTHON_BIN" - "$releases_file" <<'PY'
@@ -141,7 +187,7 @@ resolve_tag() {
 
     echo "No TAG or KITARU_UI_TAG set; resolving highest stable Kitaru UI release..."
     local releases_file="$TMP_DIR/releases.json"
-    github_api "$GITHUB_API_URL/repos/$UI_RELEASE_REPO/releases?per_page=100" > "$releases_file"
+    fetch_release_pages "$releases_file"
     TAG=$(select_latest_stable_tag "$releases_file")
     echo "Resolved stable tag: $TAG"
 }
@@ -150,6 +196,7 @@ load_release_metadata() {
     local release_file="$1" metadata_file="$2"
     "$PYTHON_BIN" - "$release_file" "$TAG" "$ALLOW_PRERELEASE" "$ARCHIVE_NAME" <<'PY' > "$metadata_file"
 import json
+import re
 import shlex
 import sys
 
@@ -160,7 +207,9 @@ if release.get("draft"):
     print(f"Error: release {tag} is a draft and cannot be bundled.", file=sys.stderr)
     raise SystemExit(1)
 
-is_prerelease = bool(release.get("prerelease"))
+metadata_prerelease = bool(release.get("prerelease"))
+tag_prerelease = bool(re.match(r"^kitaru-ui-v\d+\.\d+\.\d+-", tag))
+is_prerelease = metadata_prerelease or tag_prerelease
 if is_prerelease and allow_prerelease != "true":
     print(
         f"Error: release {tag} is a prerelease. Set "

--- a/scripts/download-ui.sh
+++ b/scripts/download-ui.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
-# Download and bundle Kitaru UI assets for wheel inclusion.
+# Download and bundle Kitaru UI assets for wheel inclusion or local testing.
 #
-# Fetches kitaru-ui.tar.gz from the kitaru-ui GitHub releases,
-# verifies its SHA256 checksum, extracts it into src/kitaru/_ui/dist/,
-# and writes a bundle_manifest.json for runtime idempotence checks.
+# Fetches kitaru-ui.tar.gz from zenml-io/zenml-frontend-monorepo GitHub
+# releases, verifies its SHA256 checksum, extracts it into a Kitaru UI package
+# directory, and writes a bundle_manifest.json for runtime identity checks.
 #
 # Environment variables:
-#   TAG                 — explicit release tag (e.g. v0.2.0); if unset, uses latest
-#   KITARU_UI_TAG       — alias for TAG (used by release.yml)
-#   VERIFY_CHECKSUM     — set to "false" to skip checksum verification (default: true)
+#   TAG                         — explicit release tag (kitaru-ui-v<semver>)
+#   KITARU_UI_TAG               — alias for TAG (used by release workflows)
+#   KITARU_UI_ALLOW_PRERELEASE  — set to "true" to allow prerelease tags
+#   KITARU_UI_RELEASE_TOKEN     — GitHub token with Contents: read access
+#   KITARU_UI_INSTALL_DIR       — destination parent dir (default: src/kitaru/_ui)
+#   VERIFY_CHECKSUM             — set to "false" to skip checksum verification
+#   PYTHON_BIN                  — Python executable for JSON/semver parsing
 #
 # Usage:
-#   bash scripts/download-ui.sh          # download latest release
-#   TAG=v0.2.0 bash scripts/download-ui.sh  # download specific tag
+#   bash scripts/download-ui.sh
+#   TAG=kitaru-ui-v0.2.0 bash scripts/download-ui.sh
+#   KITARU_UI_ALLOW_PRERELEASE=true TAG=kitaru-ui-v0.3.0-rc.1 bash scripts/download-ui.sh
 
 set -euo pipefail
 
@@ -20,40 +25,168 @@ TMP_DIR=""
 cleanup() { [ -n "$TMP_DIR" ] && rm -rf "$TMP_DIR"; }
 trap cleanup EXIT
 
-REPO_URL="https://github.com/zenml-io/kitaru-ui"
+UI_RELEASE_REPO="${KITARU_UI_RELEASE_REPO:-zenml-io/zenml-frontend-monorepo}"
+GITHUB_API_URL="${GITHUB_API_URL:-https://api.github.com}"
 ARCHIVE_NAME="kitaru-ui.tar.gz"
-INSTALL_DIR="./src/kitaru/_ui"
+INSTALL_DIR="${KITARU_UI_INSTALL_DIR:-./src/kitaru/_ui}"
 DIST_DIR="$INSTALL_DIR/dist"
 MANIFEST_FILE="$INSTALL_DIR/bundle_manifest.json"
 VERIFY_CHECKSUM="${VERIFY_CHECKSUM:-true}"
+ALLOW_PRERELEASE="${KITARU_UI_ALLOW_PRERELEASE:-false}"
+TAG_PATTERN='^kitaru-ui-v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z][0-9A-Za-z.-]*)?$'
 
-# --- Tag resolution ---
+find_python() {
+    if [ -n "${PYTHON_BIN:-}" ]; then
+        echo "$PYTHON_BIN"
+        return
+    fi
+    if command -v python3 &>/dev/null; then
+        echo "python3"
+        return
+    fi
+    if command -v python &>/dev/null; then
+        echo "python"
+        return
+    fi
+    echo "Error: python3 or python required" >&2
+    exit 1
+}
+
+PYTHON_BIN="$(find_python)"
+
+# --- GitHub helpers ---
+
+github_headers() {
+    printf '%s\0%s\0' \
+        -H 'Accept: application/vnd.github+json' \
+        -H 'X-GitHub-Api-Version: 2022-11-28'
+    if [ -n "${KITARU_UI_RELEASE_TOKEN:-}" ]; then
+        printf '%s\0%s\0' -H "Authorization: Bearer ${KITARU_UI_RELEASE_TOKEN}"
+    fi
+}
+
+github_api() {
+    local url="$1"
+    local -a headers=()
+    while IFS= read -r -d '' item; do
+        headers+=("$item")
+    done < <(github_headers)
+    curl -fSsL "${headers[@]}" "$url"
+}
+
+download_github_asset() {
+    local url="$1" dest="$2"
+    local -a headers=(
+        -H 'Accept: application/octet-stream'
+        -H 'X-GitHub-Api-Version: 2022-11-28'
+    )
+    if [ -n "${KITARU_UI_RELEASE_TOKEN:-}" ]; then
+        headers+=(-H "Authorization: Bearer ${KITARU_UI_RELEASE_TOKEN}")
+    fi
+    echo "Downloading $url"
+    curl -fSsL "${headers[@]}" "$url" -o "$dest"
+}
+
+# --- Tag and release resolution ---
+
+validate_tag_shape() {
+    local tag="$1"
+    if [[ ! "$tag" =~ $TAG_PATTERN ]]; then
+        echo "Error: Kitaru UI release tags must use kitaru-ui-v<semver> shape." >&2
+        echo "Received: $tag" >&2
+        echo "Example: kitaru-ui-v0.2.0" >&2
+        exit 1
+    fi
+}
+
+select_latest_stable_tag() {
+    local releases_file="$1"
+    "$PYTHON_BIN" - "$releases_file" <<'PY'
+import json
+import re
+import sys
+
+releases = json.loads(open(sys.argv[1], encoding="utf-8").read())
+pattern = re.compile(r"^kitaru-ui-v(\d+)\.(\d+)\.(\d+)(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$")
+valid: list[tuple[tuple[int, int, int], str]] = []
+for release in releases:
+    tag = str(release.get("tag_name", ""))
+    match = pattern.match(tag)
+    if not match:
+        continue
+    if release.get("draft") or release.get("prerelease"):
+        continue
+    valid.append(((int(match.group(1)), int(match.group(2)), int(match.group(3))), tag))
+if not valid:
+    print(
+        "Error: no stable kitaru-ui-v<semver> releases found in zenml-frontend-monorepo.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+print(max(valid)[1])
+PY
+}
 
 resolve_tag() {
-    # Prefer explicit TAG, then KITARU_UI_TAG, then resolve latest from GitHub.
+    # Prefer explicit TAG, then KITARU_UI_TAG, then resolve highest stable release.
     if [ -n "${TAG:-}" ]; then
+        validate_tag_shape "$TAG"
         return
     fi
     if [ -n "${KITARU_UI_TAG:-}" ]; then
         TAG="$KITARU_UI_TAG"
+        validate_tag_shape "$TAG"
         return
     fi
-    echo "No TAG or KITARU_UI_TAG set; resolving latest release..."
-    TAG=$(curl -Ls -o /dev/null -w '%{url_effective}' "$REPO_URL/releases/latest" \
-        | grep -oE "[^/]+$")
-    if [ -z "$TAG" ]; then
-        echo "Error: could not resolve latest release tag" >&2
-        exit 1
-    fi
-    echo "Resolved latest tag: $TAG"
+
+    echo "No TAG or KITARU_UI_TAG set; resolving highest stable Kitaru UI release..."
+    local releases_file="$TMP_DIR/releases.json"
+    github_api "$GITHUB_API_URL/repos/$UI_RELEASE_REPO/releases?per_page=100" > "$releases_file"
+    TAG=$(select_latest_stable_tag "$releases_file")
+    echo "Resolved stable tag: $TAG"
 }
 
-# --- Download ---
+load_release_metadata() {
+    local release_file="$1" metadata_file="$2"
+    "$PYTHON_BIN" - "$release_file" "$TAG" "$ALLOW_PRERELEASE" "$ARCHIVE_NAME" <<'PY' > "$metadata_file"
+import json
+import shlex
+import sys
 
-download_file() {
-    local url="$1" dest="$2"
-    echo "Downloading $url"
-    curl -fSsL "$url" -o "$dest"
+release_file, tag, allow_prerelease, archive_name = sys.argv[1:]
+release = json.loads(open(release_file, encoding="utf-8").read())
+
+if release.get("draft"):
+    print(f"Error: release {tag} is a draft and cannot be bundled.", file=sys.stderr)
+    raise SystemExit(1)
+
+is_prerelease = bool(release.get("prerelease"))
+if is_prerelease and allow_prerelease != "true":
+    print(
+        f"Error: release {tag} is a prerelease. Set "
+        "KITARU_UI_ALLOW_PRERELEASE=true for local/smoke testing.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+assets = {asset.get("name"): asset for asset in release.get("assets", [])}
+archive = assets.get(archive_name)
+checksum = assets.get(f"{archive_name}.sha256")
+missing = [name for name, asset in ((archive_name, archive), (f"{archive_name}.sha256", checksum)) if not asset]
+if missing:
+    print(f"Error: release {tag} is missing required assets: {', '.join(missing)}", file=sys.stderr)
+    raise SystemExit(1)
+
+archive_url = archive.get("url") or archive.get("browser_download_url")
+checksum_url = checksum.get("url") or checksum.get("browser_download_url")
+if not archive_url or not checksum_url:
+    print(f"Error: release {tag} assets do not expose download URLs.", file=sys.stderr)
+    raise SystemExit(1)
+
+print(f"ASSET_SOURCE_URL={shlex.quote(str(archive_url))}")
+print(f"CHECKSUM_SOURCE_URL={shlex.quote(str(checksum_url))}")
+print(f"RELEASE_PRERELEASE={shlex.quote(str(is_prerelease).lower())}")
+PY
 }
 
 # --- Checksum verification ---
@@ -92,31 +225,48 @@ verify_checksum() {
 # --- Manifest generation ---
 
 write_manifest() {
-    local sha256="$1" tag="$2" source_url="$3" dest="$4"
-    cat > "$dest" <<EOF
-{
+    local sha256="$1" tag="$2" asset_source_url="$3" checksum_source_url="$4" dest="$5"
+    mkdir -p "$(dirname "$dest")"
+    "$PYTHON_BIN" - "$UI_RELEASE_REPO" "$tag" "$asset_source_url" "$checksum_source_url" "$sha256" "$dest" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+repo, tag, asset_source_url, checksum_source_url, sha256, dest = sys.argv[1:]
+manifest = {
     "schema_version": 1,
-    "ui_version": "$tag",
-    "bundle_sha256": "$sha256",
-    "source": "$source_url"
+    "ui_version": tag,
+    "repo": repo,
+    "tag": tag,
+    "bundle_sha256": sha256,
+    "checksum": sha256,
+    "source": asset_source_url,
+    "asset_source_url": asset_source_url,
+    "checksum_source_url": checksum_source_url,
 }
-EOF
+Path(dest).write_text(json.dumps(manifest, indent=4) + "\n", encoding="utf-8")
+PY
     echo "Wrote manifest: $dest"
 }
 
 # --- Main ---
 
 main() {
+    TMP_DIR=$(mktemp -d -t kitaru-ui-XXXXXX)
     resolve_tag
 
-    local base_url="$REPO_URL/releases/download/$TAG"
-    TMP_DIR=$(mktemp -d -t kitaru-ui-XXXXXX)
+    local release_file="$TMP_DIR/release.json"
+    local metadata_file="$TMP_DIR/release.env"
+    github_api "$GITHUB_API_URL/repos/$UI_RELEASE_REPO/releases/tags/$TAG" > "$release_file"
+    load_release_metadata "$release_file" "$metadata_file"
+    # shellcheck source=/dev/null
+    . "$metadata_file"
 
     local archive="$TMP_DIR/$ARCHIVE_NAME"
     local checksum_file="$TMP_DIR/$ARCHIVE_NAME.sha256"
 
-    download_file "$base_url/$ARCHIVE_NAME" "$archive"
-    download_file "$base_url/$ARCHIVE_NAME.sha256" "$checksum_file"
+    download_github_asset "$ASSET_SOURCE_URL" "$archive"
+    download_github_asset "$CHECKSUM_SOURCE_URL" "$checksum_file"
     verify_checksum "$archive" "$checksum_file"
 
     local bundle_sha256
@@ -136,7 +286,7 @@ main() {
     fi
 
     # Write bundle manifest.
-    write_manifest "$bundle_sha256" "$TAG" "$base_url/$ARCHIVE_NAME" "$MANIFEST_FILE"
+    write_manifest "$bundle_sha256" "$TAG" "$ASSET_SOURCE_URL" "$CHECKSUM_SOURCE_URL" "$MANIFEST_FILE"
 
     echo ""
     echo "Kitaru UI $TAG bundled successfully into $DIST_DIR"

--- a/scripts/verify-server-ui.sh
+++ b/scripts/verify-server-ui.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <container>" >&2
+    exit 2
+fi
+
+container="$1"
+
+docker exec "$container" python -c '
+from pathlib import Path
+import kitaru
+
+path = Path(kitaru.__file__).parent / "_ui" / "dist" / "index.html"
+assert path.is_file(), f"missing: {path}"
+print("OK package UI:", path)
+'
+
+docker exec "$container" python -c '
+from pathlib import Path
+import zenml
+
+path = Path(zenml.__path__[0]) / "zen_server" / "dashboard" / "index.html"
+assert path.is_file(), f"missing: {path}"
+print("OK ZenML dashboard:", path)
+'

--- a/scripts/verify-ui-wheel.py
+++ b/scripts/verify-ui-wheel.py
@@ -1,0 +1,53 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Verify that a built Kitaru wheel contains the bundled UI assets."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import zipfile
+from pathlib import Path
+
+_EXPECTED_FILES = (
+    "kitaru/_ui/dist/index.html",
+    "kitaru/_ui/bundle_manifest.json",
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify that a Kitaru wheel includes packaged UI assets."
+    )
+    parser.add_argument("wheel", type=Path, help="Path to a built .whl file.")
+    return parser.parse_args()
+
+
+def _missing_ui_files(names: set[str]) -> list[str]:
+    return [expected for expected in _EXPECTED_FILES if expected not in names]
+
+
+def main() -> int:
+    args = _parse_args()
+    wheel = args.wheel
+    if not wheel.is_file():
+        print(f"::error::Wheel not found: {wheel}", file=sys.stderr)
+        return 1
+
+    with zipfile.ZipFile(wheel) as archive:
+        names = set(archive.namelist())
+
+    missing = _missing_ui_files(names)
+    if missing:
+        for path in missing:
+            print(f"::error::{path} missing from wheel")
+        return 1
+
+    ui_files = sum(name.startswith("kitaru/_ui/dist/") for name in names)
+    print(f"Kitaru UI verified: {ui_files} asset files in {wheel}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kitaru/_local_server.py
+++ b/src/kitaru/_local_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -15,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_LOCAL_SERVER_HOST = "127.0.0.1"
 _DEFAULT_LOCAL_SERVER_PORT = 8383
+_KITARU_UI_DIST_PATH_ENV = "KITARU_UI_DIST_PATH"
 _LOCAL_INSTALL_GUIDANCE = "\n".join(
     [
         "Local server requires additional dependencies.",
@@ -52,6 +54,60 @@ def _resolve_bundled_ui_dir() -> Path | None:
     if ui_dir.is_dir() and (ui_dir / "index.html").is_file():
         return ui_dir
     return None
+
+
+def _resolve_env_ui_dist_path() -> Path | None:
+    """Return the validated KITARU_UI_DIST_PATH override, if configured."""
+    raw_path = os.environ.get(_KITARU_UI_DIST_PATH_ENV)
+    if not raw_path:
+        return None
+
+    ui_dir = Path(raw_path).expanduser().resolve()
+    if not ui_dir.is_dir():
+        raise KitaruUsageError(
+            "\n".join(
+                [
+                    f"{_KITARU_UI_DIST_PATH_ENV} points to a missing directory:",
+                    f"  {ui_dir}",
+                    "Set it to a built Kitaru UI dist directory that "
+                    "contains index.html.",
+                ]
+            )
+        )
+    if not (ui_dir / "index.html").is_file():
+        raise KitaruUsageError(
+            "\n".join(
+                [
+                    f"{_KITARU_UI_DIST_PATH_ENV} must point to a UI dist "
+                    "directory containing index.html.",
+                    f"Checked: {ui_dir}",
+                ]
+            )
+        )
+    return ui_dir
+
+
+def _resolve_kitaru_ui_dir() -> Path | None:
+    """Return the UI dist directory Kitaru should ask ZenML to serve."""
+    return _resolve_env_ui_dist_path() or _resolve_bundled_ui_dir()
+
+
+def _local_server_ui_override_running_error(
+    *, existing_url: str, ui_dir: Path
+) -> KitaruUsageError:
+    """Build the error for an already-running server and UI override."""
+    return KitaruUsageError(
+        "\n".join(
+            [
+                f"A local Kitaru server is already running at {existing_url}.",
+                f"{_KITARU_UI_DIST_PATH_ENV} only applies when the local "
+                "server starts, so this running server cannot pick up:",
+                f"  {ui_dir}",
+                "Restart the local server with the override, for example:",
+                f"  kitaru logout && {_KITARU_UI_DIST_PATH_ENV}={ui_dir} kitaru login",
+            ]
+        )
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -185,12 +241,12 @@ def _deploy_and_connect(
         port=port,
     )
     env_overlay = {ZENML_DEFAULT_ANALYTICS_SOURCE_ENV: "kitaru-api"}
-    if ui_dir := _resolve_bundled_ui_dir():
+    if ui_dir := _resolve_kitaru_ui_dir():
         env_overlay["ZENML_SERVER_DASHBOARD_FILES_PATH"] = str(ui_dir)
         logger.info("Kitaru UI directory: %s", ui_dir)
     else:
         logger.debug(
-            "No bundled Kitaru UI found (expected at %s); "
+            "No Kitaru UI override or bundled UI found (expected bundled UI at %s); "
             "server will use default ZenML dashboard",
             Path(__file__).parent / "_ui" / "dist",
         )
@@ -239,6 +295,7 @@ def start_or_connect_local_server(
 
     deployer = local_server_deployer_cls()
     local_server = get_local_server()
+    ui_override_dir = _resolve_env_ui_dist_path()
 
     if local_server is not None:
         existing_url = _existing_local_server_url(local_server)
@@ -246,6 +303,12 @@ def start_or_connect_local_server(
         is_running = _is_server_running(local_server) and bool(existing_url)
 
         if is_running and (port is None or port == existing_port):
+            if ui_override_dir is not None:
+                assert existing_url is not None
+                raise _local_server_ui_override_running_error(
+                    existing_url=existing_url,
+                    ui_dir=ui_override_dir,
+                )
             if _resolve_bundled_ui_dir() is not None:
                 logger.debug(
                     "Connecting to existing server; dashboard may differ "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ _EARLY_TEST_ENV_VARS = (
     "KITARU_CONFIG_PATH",
     "KITARU_DEBUG",
     "KITARU_ANALYTICS_OPT_IN",
+    "KITARU_UI_DIST_PATH",
     "ZENML_CONFIG_PATH",
     "ZENML_ACTIVE_PROJECT_ID",
     "ZENML_DEBUG",
@@ -134,6 +135,7 @@ def isolated_zenml_global_config(
         KITARU_CONFIG_PATH_ENV,
         KITARU_DEBUG_ENV,
         KITARU_ANALYTICS_OPT_IN_ENV,
+        "KITARU_UI_DIST_PATH",
     ):
         monkeypatch.delenv(env_name, raising=False)
     monkeypatch.delenv("KITARU_RUNNER", raising=False)

--- a/tests/test_dockerfile_contract.py
+++ b/tests/test_dockerfile_contract.py
@@ -127,11 +127,34 @@ def test_dockerfile_installs_kitaru() -> None:
     assert "KITARU_VERSION" in dockerfile
 
 
-def test_dockerfile_downloads_kitaru_ui() -> None:
-    """The image should download the Kitaru UI release archive."""
+def test_dockerfile_copies_packaged_kitaru_ui() -> None:
+    """The image should copy UI files from the installed Kitaru package."""
     dockerfile = _read_dockerfile()
-    assert "kitaru-ui.tar.gz" in dockerfile
-    assert "sha256sum" in dockerfile or "sha256" in dockerfile
+    assert "KITARU_UI_DIST" in dockerfile
+    assert "Path(kitaru.__file__).parent" in dockerfile
+    assert '"_ui" / "dist"' in dockerfile
+    assert "Kitaru package UI assets missing" in dockerfile
+    assert 'cp -a "$KITARU_UI_DIST/." "$DASHBOARD_DIR/"' in dockerfile
+
+
+def test_dockerfile_does_not_download_kitaru_ui_release_assets() -> None:
+    """Docker must not have a second hidden UI release download path."""
+    dockerfile = _read_dockerfile()
+    forbidden_markers = [
+        "ARG KITARU_UI_TAG",
+        "KITARU_UI_REPO_URL",
+        "zenml-io/kitaru-ui",
+        "kitaru-ui.tar.gz",
+        "releases/latest/download",
+        "releases/download",
+        "curl ",
+        "sha256sum",
+    ]
+    for marker in forbidden_markers:
+        assert marker not in dockerfile, (
+            f"Dockerfile still contains UI download marker {marker!r}. "
+            "Bundle UI into the Kitaru package before Docker builds instead."
+        )
 
 
 def test_dockerfile_configures_workload_manager_for_deployments() -> None:
@@ -382,14 +405,25 @@ def test_dockerfile_dev_zenml_minimum_matches_package_contract() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_dockerfile_uses_curl_fail_flag() -> None:
-    """curl must use --fail (-f) so HTTP errors are not silently ignored."""
-    dockerfile = _read_dockerfile()
-    for line in dockerfile.splitlines():
-        if "curl " in line and "-o " in line:
-            assert re.search(r"-[a-zA-Z]*f", line) or "--fail" in line, (
-                f"curl download missing --fail flag: {line.strip()}"
-            )
+def test_dockerignore_allows_generated_package_ui() -> None:
+    """Source Docker builds must include generated package UI but not local caches."""
+    dockerignore = _read_file(".dockerignore")
+    assert "dist/" in dockerignore
+    assert "!src/kitaru/_ui/dist/" in dockerignore
+    assert "!src/kitaru/_ui/dist/**" in dockerignore
+    assert "!src/kitaru/_ui/bundle_manifest.json" in dockerignore
+    assert ".kitaru-ui-bundles/" in dockerignore
+
+
+def test_just_server_image_bundles_ui_before_docker_build() -> None:
+    """Local source server builds should prepare package UI before Docker runs."""
+    justfile = _read_file("Justfile")
+    server_image_recipe = justfile.split("\nserver-image:", maxsplit=1)[1].split(
+        "\n# Build and push production server image",
+        maxsplit=1,
+    )[0]
+    assert "bash scripts/download-ui.sh" in server_image_recipe
+    assert "--build-arg KITARU_UI_TAG" not in server_image_recipe
 
 
 def test_server_dockerfiles_switch_to_root_for_build() -> None:

--- a/tests/test_local_server.py
+++ b/tests/test_local_server.py
@@ -15,11 +15,13 @@ from kitaru._local_server import (
     LocalServerConnectionResult,
     _deploy_and_connect,
     _resolve_bundled_ui_dir,
+    _resolve_env_ui_dist_path,
+    _resolve_kitaru_ui_dir,
     _track_local_server_started,
     start_or_connect_local_server,
 )
 from kitaru.analytics import AnalyticsEvent
-from kitaru.errors import KitaruBackendError
+from kitaru.errors import KitaruBackendError, KitaruUsageError
 
 # ---------------------------------------------------------------------------
 # Test-local helpers
@@ -105,6 +107,71 @@ class TestResolveBundledUiDir:
 
 
 # ---------------------------------------------------------------------------
+# KITARU_UI_DIST_PATH resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveUiDistPathOverride:
+    def test_valid_override_path_wins_over_bundled_ui(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        override_dist = tmp_path / "override" / "dist"
+        override_dist.mkdir(parents=True)
+        (override_dist / "index.html").write_text("<html>override</html>")
+        bundled_dist = tmp_path / "pkg" / "_ui" / "dist"
+        bundled_dist.mkdir(parents=True)
+        (bundled_dist / "index.html").write_text("<html>bundled</html>")
+        monkeypatch.setenv("KITARU_UI_DIST_PATH", str(override_dist))
+        monkeypatch.setattr(
+            ls_mod, "__file__", str(tmp_path / "pkg" / "_local_server.py")
+        )
+
+        assert _resolve_env_ui_dist_path() == override_dist
+        assert _resolve_kitaru_ui_dir() == override_dist
+
+    def test_relative_override_path_resolves_to_absolute_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        override_dist = tmp_path / "relative" / "dist"
+        override_dist.mkdir(parents=True)
+        (override_dist / "index.html").write_text("<html>override</html>")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("KITARU_UI_DIST_PATH", "relative/dist")
+
+        assert _resolve_env_ui_dist_path() == override_dist.resolve()
+
+    def test_invalid_override_path_raises_user_facing_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        missing_dist = tmp_path / "missing" / "dist"
+        monkeypatch.setenv("KITARU_UI_DIST_PATH", str(missing_dist))
+
+        with pytest.raises(KitaruUsageError, match="KITARU_UI_DIST_PATH"):
+            _resolve_env_ui_dist_path()
+
+    def test_override_without_index_html_raises_user_facing_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        override_dist = tmp_path / "override" / "dist"
+        override_dist.mkdir(parents=True)
+        monkeypatch.setenv("KITARU_UI_DIST_PATH", str(override_dist))
+
+        with pytest.raises(KitaruUsageError, match=r"index\.html"):
+            _resolve_env_ui_dist_path()
+
+    def test_no_override_and_no_bundle_falls_back_to_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_pkg = tmp_path / "pkg"
+        fake_pkg.mkdir()
+        monkeypatch.delenv("KITARU_UI_DIST_PATH", raising=False)
+        monkeypatch.setattr(ls_mod, "__file__", str(fake_pkg / "_local_server.py"))
+
+        assert _resolve_env_ui_dist_path() is None
+        assert _resolve_kitaru_ui_dir() is None
+
+
+# ---------------------------------------------------------------------------
 # _track_local_server_started
 # ---------------------------------------------------------------------------
 
@@ -168,6 +235,43 @@ class TestDeployAndConnect:
             url="http://127.0.0.1:9090", action="started"
         )
         deployer.connect_to_server.assert_called_once()
+
+    def test_env_override_sets_dashboard_path_and_wins_over_bundled_ui(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ZENML_SERVER_DASHBOARD_FILES_PATH", raising=False)
+        monkeypatch.delenv("ZENML_DEFAULT_ANALYTICS_SOURCE", raising=False)
+        override_dist = tmp_path / "override" / "dist"
+        override_dist.mkdir(parents=True)
+        (override_dist / "index.html").write_text("<html>override</html>")
+        monkeypatch.setenv("KITARU_UI_DIST_PATH", str(override_dist))
+
+        captured_env: dict[str, str | None] = {}
+
+        def capture_env_during_deploy(_config: Any, **_kw: Any) -> SimpleNamespace:
+            captured_env["dashboard"] = os.environ.get(
+                "ZENML_SERVER_DASHBOARD_FILES_PATH"
+            )
+            return SimpleNamespace(status=SimpleNamespace(url="http://127.0.0.1:9090"))
+
+        deployer = MagicMock()
+        deployer.deploy_server.side_effect = capture_env_during_deploy
+
+        with patch.object(
+            ls_mod, "_resolve_bundled_ui_dir", return_value=Path("/fake/bundled/dist")
+        ):
+            _deploy_and_connect(
+                deployer=deployer,
+                deployment_config_cls=_FakeDeploymentConfig,
+                provider_type=_FAKE_PROVIDER,
+                port=9090,
+                timeout=30,
+                action="started",
+            )
+
+        assert captured_env["dashboard"] == str(override_dist)
+        assert os.environ.get("ZENML_SERVER_DASHBOARD_FILES_PATH") is None
+        assert os.environ.get("KITARU_UI_DIST_PATH") == str(override_dist)
 
     def test_restores_preexisting_env_vars_after_success(
         self, monkeypatch: pytest.MonkeyPatch
@@ -447,6 +551,27 @@ class TestStartOrConnectLocalServer:
         deployer.connect_to_server.assert_called_once()
         deployer.remove_server.assert_not_called()
         mock_track.assert_called_once_with(result)
+
+    def test_existing_running_server_with_ui_override_raises_restart_guidance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        override_dist = tmp_path / "override" / "dist"
+        override_dist.mkdir(parents=True)
+        (override_dist / "index.html").write_text("<html>override</html>")
+        monkeypatch.setenv("KITARU_UI_DIST_PATH", str(override_dist))
+        deployer = MagicMock()
+        local_server = _make_local_server("http://127.0.0.1:8383", is_running=True)
+        runtime = _make_runtime_tuple(deployer, local_server)
+
+        with (
+            patch(f"{_PATCH_PREFIX}._ensure_local_server_dependencies"),
+            patch(f"{_PATCH_PREFIX}._load_local_server_runtime", return_value=runtime),
+            pytest.raises(KitaruUsageError, match="kitaru logout"),
+        ):
+            start_or_connect_local_server(port=None, timeout=30)
+
+        deployer.connect_to_server.assert_not_called()
+        deployer.remove_server.assert_not_called()
 
     def test_existing_running_server_logs_stale_ui_warning(self) -> None:
         deployer = MagicMock()

--- a/tests/test_ui_download_script.py
+++ b/tests/test_ui_download_script.py
@@ -48,7 +48,7 @@ import json
 import os
 import shutil
 import sys
-from urllib.parse import unquote
+from urllib.parse import parse_qs, unquote, urlparse
 
 args = sys.argv[1:]
 log_path = os.environ.get("FAKE_CURL_LOG")
@@ -78,8 +78,18 @@ if not url:
     print("fake curl: no URL", file=sys.stderr)
     raise SystemExit(2)
 
-if url.endswith("/releases?per_page=100"):
-    sys.stdout.write(os.environ["FAKE_RELEASES_JSON"])
+if "/releases" in url and "/releases/tags/" not in url:
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    page = params.get("page", ["1"])[0]
+    releases_json = os.environ.get(
+        f"FAKE_RELEASES_JSON_PAGE_{page}",
+        os.environ.get("FAKE_RELEASES_JSON", "[]" if page != "1" else None),
+    )
+    if releases_json is None:
+        print("fake curl: missing FAKE_RELEASES_JSON", file=sys.stderr)
+        raise SystemExit(4)
+    sys.stdout.write(releases_json)
     raise SystemExit(0)
 
 if "/releases/tags/" in url:
@@ -201,6 +211,39 @@ def test_download_ui_defaults_to_highest_stable_kitaru_ui_release(
     assert "Authorization: Bearer secret-token" in curl_log
 
 
+def test_download_ui_finds_stable_release_on_later_page(tmp_path: Path) -> None:
+    """Default selection searches past a full page of non-Kitaru releases."""
+    page_1 = [
+        {
+            "tag_name": f"other-product-v{index}.0.0",
+            "draft": False,
+            "prerelease": False,
+        }
+        for index in range(100)
+    ]
+    page_2 = [{"tag_name": "kitaru-ui-v0.12.0", "draft": False, "prerelease": False}]
+
+    result = _run_download_script(
+        tmp_path,
+        extra_env={
+            "FAKE_RELEASES_JSON_PAGE_1": json.dumps(page_1),
+            "FAKE_RELEASES_JSON_PAGE_2": json.dumps(page_2),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    manifest = json.loads(
+        (
+            tmp_path / "repo" / "src" / "kitaru" / "_ui" / "bundle_manifest.json"
+        ).read_text()
+    )
+    assert manifest["tag"] == "kitaru-ui-v0.12.0"
+
+    curl_log = (tmp_path / "curl.log").read_text()
+    assert "releases?per_page=100&page=1" in curl_log
+    assert "releases?per_page=100&page=2" in curl_log
+
+
 def test_download_ui_rejects_bare_v_tag_before_downloading(tmp_path: Path) -> None:
     """Old bare v* tags should fail clearly under the monorepo policy."""
     result = _run_download_script(tmp_path, extra_env={"TAG": "v0.10.0"})
@@ -218,6 +261,20 @@ def test_download_ui_rejects_prerelease_without_opt_in(tmp_path: Path) -> None:
             "TAG": "kitaru-ui-v0.11.0-rc.1",
             "FAKE_PRERELEASE_TAGS": "kitaru-ui-v0.11.0-rc.1",
         },
+    )
+
+    assert result.returncode != 0
+    assert "KITARU_UI_ALLOW_PRERELEASE=true" in result.stderr
+    assert not (tmp_path / "repo" / "src" / "kitaru" / "_ui" / "dist").exists()
+
+
+def test_download_ui_rejects_prerelease_tag_shape_without_metadata(
+    tmp_path: Path,
+) -> None:
+    """Semver prerelease-looking tags are rejected even if release metadata is wrong."""
+    result = _run_download_script(
+        tmp_path,
+        extra_env={"TAG": "kitaru-ui-v0.11.0-rc.1"},
     )
 
     assert result.returncode != 0

--- a/tests/test_ui_download_script.py
+++ b/tests/test_ui_download_script.py
@@ -1,0 +1,246 @@
+"""Focused contract tests for scripts/download-ui.sh release selection."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DOWNLOAD_SCRIPT = _REPO_ROOT / "scripts" / "download-ui.sh"
+_JUSTFILE = _REPO_ROOT / "Justfile"
+
+
+def _make_ui_archive(tmp_path: Path) -> tuple[Path, Path, str]:
+    """Create a tiny valid Kitaru UI archive and checksum file."""
+    source_dir = tmp_path / "ui-source"
+    source_dir.mkdir()
+    (source_dir / "index.html").write_text("<html>Kitaru UI</html>\n")
+    assets_dir = source_dir / "assets"
+    assets_dir.mkdir()
+    (assets_dir / "app.js").write_text("console.log('kitaru');\n")
+
+    archive = tmp_path / "kitaru-ui.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        for path in sorted(source_dir.rglob("*")):
+            tar.add(path, arcname=path.relative_to(source_dir))
+
+    digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+    checksum = tmp_path / "kitaru-ui.tar.gz.sha256"
+    checksum.write_text(f"{digest}  kitaru-ui.tar.gz\n")
+    return archive, checksum, digest
+
+
+def _write_fake_curl(tmp_path: Path) -> Path:
+    """Write a fake curl that serves release JSON and local asset files."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    curl = bin_dir / "curl"
+    curl.write_text(
+        r"""#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from urllib.parse import unquote
+
+args = sys.argv[1:]
+log_path = os.environ.get("FAKE_CURL_LOG")
+if log_path:
+    with open(log_path, "a", encoding="utf-8") as log:
+        log.write(json.dumps(args) + "\n")
+
+dest = None
+url = None
+skip_next = False
+for index, arg in enumerate(args):
+    if skip_next:
+        skip_next = False
+        continue
+    if arg in {"-o", "--output"}:
+        dest = args[index + 1]
+        skip_next = True
+        continue
+    if arg in {"-H", "--header", "-w"}:
+        skip_next = True
+        continue
+    if arg.startswith("-"):
+        continue
+    url = arg
+
+if not url:
+    print("fake curl: no URL", file=sys.stderr)
+    raise SystemExit(2)
+
+if url.endswith("/releases?per_page=100"):
+    sys.stdout.write(os.environ["FAKE_RELEASES_JSON"])
+    raise SystemExit(0)
+
+if "/releases/tags/" in url:
+    tag = unquote(url.rsplit("/", 1)[-1])
+    prerelease_tags = set(
+        filter(None, os.environ.get("FAKE_PRERELEASE_TAGS", "").split(","))
+    )
+    release = {
+        "tag_name": tag,
+        "draft": False,
+        "prerelease": tag in prerelease_tags,
+        "assets": [
+            {
+                "name": "kitaru-ui.tar.gz",
+                "url": f"https://api.github.test/assets/archive-{tag}",
+                "browser_download_url": f"https://github.test/download/{tag}/kitaru-ui.tar.gz",
+            },
+            {
+                "name": "kitaru-ui.tar.gz.sha256",
+                "url": f"https://api.github.test/assets/checksum-{tag}",
+                "browser_download_url": f"https://github.test/download/{tag}/kitaru-ui.tar.gz.sha256",
+            },
+        ],
+    }
+    sys.stdout.write(json.dumps(release))
+    raise SystemExit(0)
+
+if dest and "/assets/archive-" in url:
+    shutil.copyfile(os.environ["FAKE_ARCHIVE"], dest)
+    raise SystemExit(0)
+
+if dest and "/assets/checksum-" in url:
+    shutil.copyfile(os.environ["FAKE_CHECKSUM"], dest)
+    raise SystemExit(0)
+
+print(f"fake curl: unexpected URL {url}", file=sys.stderr)
+raise SystemExit(3)
+""",
+        encoding="utf-8",
+    )
+    curl.chmod(0o755)
+    return bin_dir
+
+
+def _run_download_script(
+    tmp_path: Path,
+    *,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run download-ui.sh in an isolated fake repository."""
+    archive, checksum, _digest = _make_ui_archive(tmp_path)
+    fake_bin = _write_fake_curl(tmp_path)
+    workdir = tmp_path / "repo"
+    (workdir / "src" / "kitaru" / "_ui").mkdir(parents=True)
+    log_path = tmp_path / "curl.log"
+
+    releases = [
+        {"tag_name": "kitaru-ui-v0.9.0", "draft": False, "prerelease": False},
+        {"tag_name": "kitaru-ui-v0.10.0", "draft": False, "prerelease": False},
+        {"tag_name": "kitaru-ui-v0.11.0", "draft": False, "prerelease": True},
+        {"tag_name": "other-product-v9.0.0", "draft": False, "prerelease": False},
+    ]
+
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "PYTHON_BIN": sys.executable,
+        "FAKE_ARCHIVE": str(archive),
+        "FAKE_CHECKSUM": str(checksum),
+        "FAKE_CURL_LOG": str(log_path),
+        "FAKE_RELEASES_JSON": json.dumps(releases),
+    }
+    if extra_env:
+        env.update(extra_env)
+
+    return subprocess.run(
+        ["bash", str(_DOWNLOAD_SCRIPT)],
+        cwd=workdir,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_justfile_exposes_local_ui_bundle_helpers() -> None:
+    """Local helper recipes should use the prepared bundle via KITARU_UI_DIST_PATH."""
+    justfile = _JUSTFILE.read_text()
+
+    for recipe_name in ("ui-bundle", "ui-bundle-prerelease", "ui-login", "ui-smoke"):
+        assert f"\n{recipe_name}:" in justfile
+    assert "KITARU_UI_INSTALL_DIR" in justfile
+    assert "KITARU_UI_ALLOW_PRERELEASE=true" in justfile
+    assert "KITARU_UI_DIST_PATH" in justfile
+    assert "./scripts/smoke-test.sh --keep-server" in justfile
+
+
+def test_download_ui_defaults_to_highest_stable_kitaru_ui_release(
+    tmp_path: Path,
+) -> None:
+    """Default selection ignores prereleases and non-Kitaru releases."""
+    result = _run_download_script(
+        tmp_path,
+        extra_env={"KITARU_UI_RELEASE_TOKEN": "secret-token"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    workdir = tmp_path / "repo"
+    manifest = json.loads(
+        (workdir / "src" / "kitaru" / "_ui" / "bundle_manifest.json").read_text()
+    )
+    assert manifest["repo"] == "zenml-io/zenml-frontend-monorepo"
+    assert manifest["tag"] == "kitaru-ui-v0.10.0"
+    assert manifest["ui_version"] == "kitaru-ui-v0.10.0"
+    assert manifest["asset_source_url"].endswith("archive-kitaru-ui-v0.10.0")
+    assert (workdir / "src" / "kitaru" / "_ui" / "dist" / "index.html").is_file()
+
+    curl_log = (tmp_path / "curl.log").read_text()
+    assert "Authorization: Bearer secret-token" in curl_log
+
+
+def test_download_ui_rejects_bare_v_tag_before_downloading(tmp_path: Path) -> None:
+    """Old bare v* tags should fail clearly under the monorepo policy."""
+    result = _run_download_script(tmp_path, extra_env={"TAG": "v0.10.0"})
+
+    assert result.returncode != 0
+    assert "kitaru-ui-v<semver>" in result.stderr
+    assert not (tmp_path / "repo" / "src" / "kitaru" / "_ui" / "dist").exists()
+
+
+def test_download_ui_rejects_prerelease_without_opt_in(tmp_path: Path) -> None:
+    """Explicit prerelease tags require KITARU_UI_ALLOW_PRERELEASE=true."""
+    result = _run_download_script(
+        tmp_path,
+        extra_env={
+            "TAG": "kitaru-ui-v0.11.0-rc.1",
+            "FAKE_PRERELEASE_TAGS": "kitaru-ui-v0.11.0-rc.1",
+        },
+    )
+
+    assert result.returncode != 0
+    assert "KITARU_UI_ALLOW_PRERELEASE=true" in result.stderr
+    assert not (tmp_path / "repo" / "src" / "kitaru" / "_ui" / "dist").exists()
+
+
+def test_download_ui_allows_prerelease_with_explicit_opt_in(tmp_path: Path) -> None:
+    """Local/smoke lanes can opt into a prerelease tag explicitly."""
+    result = _run_download_script(
+        tmp_path,
+        extra_env={
+            "TAG": "kitaru-ui-v0.11.0-rc.1",
+            "KITARU_UI_ALLOW_PRERELEASE": "true",
+            "FAKE_PRERELEASE_TAGS": "kitaru-ui-v0.11.0-rc.1",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    manifest = json.loads(
+        (
+            tmp_path / "repo" / "src" / "kitaru" / "_ui" / "bundle_manifest.json"
+        ).read_text()
+    )
+    assert manifest["tag"] == "kitaru-ui-v0.11.0-rc.1"
+    assert manifest["checksum"] == manifest["bundle_sha256"]

--- a/tests/test_ui_release_contract.py
+++ b/tests/test_ui_release_contract.py
@@ -46,8 +46,10 @@ def test_ci_bundles_ui_before_source_docker_smoke() -> None:
     assert "KITARU_UI_RELEASE_TOKEN" in workflow
     assert "--build-arg KITARU_UI_TAG" not in workflow
     assert "KITARU_UI_TAG: latest" not in workflow
-    assert "github.event.pull_request.head.repo.full_name" in workflow
-    assert "== github.repository" in workflow
+    assert "github.event_name == 'push'" in workflow
+    assert "github.event.pull_request.head.repo.full_name" not in workflow
+    assert "== github.repository" not in workflow
+    assert "never expose it to PR code" in workflow
     assert "bash scripts/verify-server-ui.sh kitaru-ci-server" in workflow
     assert "uv run --no-project scripts/verify-ui-wheel.py" in workflow
 

--- a/tests/test_ui_release_contract.py
+++ b/tests/test_ui_release_contract.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (_REPO_ROOT / relative_path).read_text()
+
+
+def _workflow_step_block(workflow: str, step_name: str) -> str:
+    marker = f"      - name: {step_name}\n"
+    start = workflow.index(marker)
+    remainder = workflow[start + len(marker) :]
+    next_step = remainder.find("\n      - name: ")
+    if next_step == -1:
+        return workflow[start:]
+    return workflow[start : start + len(marker) + next_step]
+
+
+def test_release_workflow_uses_stable_monorepo_ui_bundling() -> None:
+    """Official releases bundle stable monorepo UI before package/Docker publish."""
+    workflow = _read(".github/workflows/release.yml")
+
+    assert "zenml-io/kitaru-ui" not in workflow
+    assert "kitaru-ui-v0.1.0" in workflow
+    assert "KITARU_UI_RELEASE_TOKEN" in workflow
+    assert "KITARU_UI_ALLOW_PRERELEASE" not in workflow
+    assert "bash scripts/download-ui.sh" in workflow
+    assert "src/kitaru/_ui/bundle_manifest.json" in workflow
+    assert "uv run --no-project scripts/verify-ui-wheel.py" in workflow
+    assert "Verify PyPI artifacts match local build" in workflow
+    assert "Local dist artifacts differ from PyPI" in workflow
+
+    docker_step = _workflow_step_block(workflow, "Build and push Docker image")
+    assert "KITARU_UI_TAG=" not in docker_step
+    assert "KITARU_VERSION=" in docker_step
+    assert "ZENML_SERVER_TAG=0.94.4" in docker_step
+
+
+def test_ci_bundles_ui_before_source_docker_smoke() -> None:
+    """CI Docker smoke should exercise the bundled-then-build path."""
+    workflow = _read(".github/workflows/ci.yml")
+
+    assert "KITARU_UI_RELEASE_TOKEN" in workflow
+    assert "--build-arg KITARU_UI_TAG" not in workflow
+    assert "KITARU_UI_TAG: latest" not in workflow
+    assert "github.event.pull_request.head.repo.full_name" in workflow
+    assert "== github.repository" in workflow
+    assert "bash scripts/verify-server-ui.sh kitaru-ci-server" in workflow
+    assert "uv run --no-project scripts/verify-ui-wheel.py" in workflow
+
+    download_index = workflow.index("Download stable Kitaru UI")
+    docker_build_index = workflow.index(
+        "docker build -f docker/Dockerfile --target server"
+    )
+    assert download_index < docker_build_index
+
+    server_ui_script = _read("scripts/verify-server-ui.sh")
+    assert "Path(kitaru.__file__).parent" in server_ui_script
+    assert "zen_server" in server_ui_script
+    assert "dashboard" in server_ui_script
+
+
+def test_prerelease_smoke_workflow_is_manual_and_non_publishing() -> None:
+    """The prerelease lane can opt in to prerelease UI but must not publish."""
+    workflow = _read(".github/workflows/ui-prerelease-smoke.yml")
+
+    assert "workflow_dispatch" in workflow
+    assert "ui-tag:" in workflow
+    assert "kitaru-ref:" in workflow
+    assert "docker-smoke:" in workflow
+    assert "Checkout trusted workflow ref" in workflow
+    assert "path: trusted" in workflow
+    assert "path: kitaru" in workflow
+    assert "working-directory: kitaru" in workflow
+    assert "bash ../trusted/scripts/download-ui.sh" in workflow
+    assert "uv run --no-project ../trusted/scripts/verify-ui-wheel.py" in workflow
+    assert "bash trusted/scripts/verify-server-ui.sh" in workflow
+    assert "KITARU_UI_ALLOW_PRERELEASE: 'true'" in workflow
+    assert "KITARU_UI_RELEASE_TOKEN" in workflow
+    assert "uv build --wheel" in workflow
+    assert "docker build -f docker/Dockerfile --target server" in workflow
+    assert "--build-arg KITARU_UI_TAG" not in workflow
+
+    forbidden_publish_markers = [
+        "pypa/gh-action-pypi-publish",
+        "docker/login-action",
+        "docker push",
+        "push: true",
+        "gh release create",
+        "gh release upload",
+        "helm push",
+        "git push",
+    ]
+    for marker in forbidden_publish_markers:
+        assert marker not in workflow


### PR DESCRIPTION
## What changed

This migrates Kitaru UI bundling from the old `zenml-io/kitaru-ui` release source to `zenml-io/zenml-frontend-monorepo` and makes the Python package the single source of truth for production UI assets.

Key changes:

- `scripts/download-ui.sh` now resolves `kitaru-ui-v*` releases from the frontend monorepo, selects the highest stable/full release by default, supports `KITARU_UI_RELEASE_TOKEN`, and requires explicit `KITARU_UI_ALLOW_PRERELEASE=true` for prerelease tags.
- `kitaru login` supports `KITARU_UI_DIST_PATH` for local UI bundle testing.
- `Justfile` adds local bundle/test helpers: `ui-bundle`, `ui-bundle-prerelease`, `ui-login`, and `ui-smoke`.
- Production Docker no longer downloads UI assets. It installs Kitaru and copies `kitaru/_ui/dist` from the installed package into ZenML's dashboard directory.
- CI/release workflows now bundle UI before wheel/Docker validation, and a manual `ui-prerelease-smoke.yml` workflow supports safe prerelease validation without publishing anything.
- Added `FRONTEND-TESTING.md` as the committed maintainer guide for day-to-day frontend/backend UI testing.

## Why it was needed

The frontend team now releases Kitaru UI from `zenml-frontend-monorepo`, not the old `kitaru-ui` repo. The previous Kitaru release/Docker flow assumed a public standalone UI repo and had two separate UI download paths: one for the wheel and one inside Docker. That could let the Python package and Docker image accidentally serve different UI bundles.

This PR makes the story boring and checkable: official Kitaru releases bundle one stable UI into the wheel, and Docker serves exactly that package UI. Prerelease/local testing remains possible, but it has to be explicit.

## Key implementation decisions

- Official Kitaru releases reject prerelease UI tags. Local/prerelease smoke testing opts in with `KITARU_UI_ALLOW_PRERELEASE=true`.
- Default UI selection filters monorepo releases to `kitaru-ui-v*`, excludes drafts/prereleases, parses semver, and chooses the highest stable version.
- `KITARU_UI_DIST_PATH` is the Kitaru-facing local override; `ZENML_SERVER_DASHBOARD_FILES_PATH` remains the internal ZenML mechanism.
- Docker resolves package paths with Python instead of hardcoding `site-packages` paths.
- Reusable helpers (`scripts/verify-ui-wheel.py`, `scripts/verify-server-ui.sh`) keep workflow UI checks consistent.

## Reviewer Notes

The important behavior now happens in three places.

First, `scripts/download-ui.sh` is the gatekeeper for UI releases. It talks to the frontend monorepo, chooses a stable `kitaru-ui-v*` release by default, and refuses prereleases unless the caller clearly opts in. If this is wrong, the bad outcome is simple: Kitaru could accidentally ship a UI candidate that Bart only meant to test.

Second, Docker no longer has its own appetite for UI artifacts. Before, the wheel downloaded UI and Docker downloaded UI again. Now Docker installs Kitaru, asks Python where the installed `kitaru/_ui/dist` directory is, and copies those files into ZenML's dashboard folder. If this is wrong, Docker either fails fast because `index.html` is missing, or it serves a different dashboard than the wheel carries.

Third, local human testing is now a small switchboard rather than a CI-only story. Bart or a Kitaru maintainer can prepare latest stable UI, a named stable UI, or an explicit prerelease UI, then run local Kitaru with `KITARU_UI_DIST_PATH`. That path is documented in `FRONTEND-TESTING.md` and wired through the new Justfile recipes.

### Reproduction

Local mechanical checks run for this PR:

```bash
just check
just test
```

Focused UI/release checks also passed:

```bash
bash -n scripts/download-ui.sh scripts/verify-server-ui.sh
uv run ruff format --check scripts/verify-ui-wheel.py tests/test_ui_download_script.py tests/test_ui_release_contract.py tests/test_local_server.py tests/conftest.py src/kitaru/_local_server.py
uv run ruff check scripts/verify-ui-wheel.py tests/test_ui_download_script.py tests/test_ui_release_contract.py tests/test_local_server.py tests/conftest.py src/kitaru/_local_server.py
uv run pytest tests/test_ui_download_script.py tests/test_local_server.py tests/test_dockerfile_contract.py tests/test_ui_release_contract.py -q
```

Manual flows to inspect after review, once `KITARU_UI_RELEASE_TOKEN` and at least one stable `kitaru-ui-v*` monorepo release are available:

```bash
# latest stable UI bundle
just ui-bundle
just ui-login

# explicit prerelease UI bundle, for local testing only
just UI_TAG=kitaru-ui-v0.1.8 ui-bundle-prerelease
just ui-login

# normal smoke script using the prepared UI, leaving server up for manual dashboard checks
just ui-smoke
```

For CI-only prerelease validation, run the new manual workflow:

```text
UI Prerelease Smoke
```

with a `kitaru-ui-v*` tag and a Kitaru ref.

## Notes / follow-up

The frontend monorepo should get a companion docs/helper cleanup PR:

- `apps/kitaru-ui/README.md` should point maintainers to the Kitaru-side bundle selector and prerelease smoke workflow.
- `apps/kitaru-ui/scripts/install-kitaru-branch.sh` appears stale/misleading: it says it installs a Kitaru branch but installs `zenml[dev,server,templates]` from `zenml-io/zenml`.
