### PR TITLE
Fix release PyPI verification to ignore non-distribution files in `dist/`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,10 +365,21 @@ jobs:
               for item in metadata.get("urls", [])
               if "filename" in item and "digests" in item and "sha256" in item["digests"]
           }
+          # PyPI only lists built distributions (sdist + wheels). The local
+          # dist/ directory also holds files PyPI never serves as separate
+          # downloads: uv writes a dist/.gitignore, and the publish step drops
+          # PEP 740 *.publish.attestation sidecars next to each artifact. Those
+          # must not be treated as missing from PyPI.
+          dist_artifacts = [
+              path
+              for path in sorted(Path("dist").iterdir())
+              if path.is_file() and path.name.endswith((".whl", ".tar.gz"))
+          ]
+          if not dist_artifacts:
+              print("::error::No .whl or .tar.gz artifacts found in dist/ to verify")
+              sys.exit(1)
           failures = []
-          for artifact in sorted(Path("dist").iterdir()):
-              if not artifact.is_file():
-                  continue
+          for artifact in dist_artifacts:
               expected = remote_files.get(artifact.name)
               if expected is None:
                   failures.append(f"{artifact.name} is missing from PyPI metadata")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -540,7 +540,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: .
           file: docker/Dockerfile


### PR DESCRIPTION
## What this does

Two release-workflow CI fixes, both in `.github/workflows/release.yml`:

1. **Restricts the "Verify PyPI artifacts match local build" step** to compare only actual Python distributions (`*.whl`, `*.tar.gz`) against PyPI, instead of every file in `dist/`.
2. **Pins the `docker/build-push-action` version comment to the exact `# v7.1.0`** (from the floating `# v7`) to satisfy zizmor. Comment-only — same action SHA runs.

## Why (1) — the verify step

During the `v0.13.1` release, this step failed *after* PyPI publish, aborting the run before Docker, Helm, the GitHub Release, the `main` update, and the cloud-plugins trigger ran. The wheel and sdist matched PyPI perfectly — the step tripped on three files PyPI does not list as separate downloads:

- `dist/.gitignore` — written by `uv build` so build output is never committed.
- `kitaru-0.13.1-py3-none-any.whl.publish.attestation` and `kitaru-0.13.1.tar.gz.publish.attestation` — PEP 740 attestation sidecars the PyPI publish action drops next to each artifact. PyPI attaches attestations to the artifact rather than listing them as standalone files, so they never appear in the `urls` metadata the step reads.

The old loop iterated all of `dist/` and flagged any name absent from PyPI metadata as "missing", so these three always failed a real (non-dry-run) release. The dry run did not catch it because the publish/verify steps are skipped on dry runs.

The fix filters to `*.whl` / `*.tar.gz` before comparing, and fails if no distributions are found (so the check still catches a genuinely missing or mismatched distribution). The SHA256 comparison itself is unchanged.

## Why (2) — the docker pin comment

zizmor runs unpinned (`uvx zizmor`, currently v1.25.2) and now flags `docker/build-push-action@bcafcacb…  # v7`: the pinned SHA is specifically `v7.1.0`, but the floating `v7` tag has since moved to a different commit, so the comment is considered mismatched. This is **pre-existing on `develop`** — it only surfaced here because `zizmor.yml` re-scans only on workflow-file changes, and this is the first such change since zizmor tightened the rule. Comment-only fix, no behavior change.

## Reviewer Notes

The risky line is the file selection inside the `Verify PyPI artifacts match local build` step. Before, it walked `Path("dist").iterdir()` unconditionally; now it pre-filters to real distributions. If the filter were too loose, an attacker-substituted or corrupted wheel would still be caught (the hash check is intact); if it were too strict (e.g. excluded a wheel), the new "no artifacts found" guard fails the step rather than passing vacuously.

This `v0.13.1` release was completed via a recovery dispatch from this branch (the workflow checks out the tag to build but runs the YAML from the dispatched ref), which is why `develop` currently still carries the buggy step — this PR lands the fix for future releases.

### Reproduction

The filter logic was verified locally against the exact failed `dist/` contents:

```
uv run --no-project python - <<'PY'
from pathlib import Path
import tempfile
with tempfile.TemporaryDirectory() as d:
    for n in [".gitignore", "kitaru-0.13.1-py3-none-any.whl", "kitaru-0.13.1.tar.gz",
              "kitaru-0.13.1-py3-none-any.whl.publish.attestation",
              "kitaru-0.13.1.tar.gz.publish.attestation"]:
        Path(d, n).write_text("x")
    selected = sorted(p.name for p in sorted(Path(d).iterdir())
                       if p.is_file() and p.name.endswith((".whl", ".tar.gz")))
    assert selected == ["kitaru-0.13.1-py3-none-any.whl", "kitaru-0.13.1.tar.gz"], selected
    print("only real dists selected:", selected)
PY
```

End-to-end proof: the `v0.13.1` recovery release run (dispatched from this branch) reached **Verify PyPI artifacts match local build → success** and then completed every downstream publish step.

### Local checks run

`just actions-lint` (exit 0), `just yaml-check` (0 fixed, 9 unchanged), and `uvx zizmor --config=.github/zizmor.yml .github/workflows/release.yml` (exit 0, no findings) all pass.