### PR TITLE
Skip expensive PR workflows while draft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [develop]
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,6 +23,7 @@ env:
   ZENML_ENABLE_RICH_TRACEBACK: false
 jobs:
   lint:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -29,6 +36,7 @@ jobs:
       - run: find .github -type f \( -name '*.yml' -o -name '*.yaml' \) ! -name dependabot.yml
           -print0 | xargs -0 uv run yamlfix --check
   typos:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -36,6 +44,7 @@ jobs:
           persist-credentials: false
       - uses: crate-ci/typos@5374cbf686e897b15713110e233094e2874de7ef  # v1.46.1
   typecheck:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -45,6 +54,7 @@ jobs:
       - run: uv sync --frozen
       - run: uv run ty check
   audit:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -57,6 +67,7 @@ jobs:
           awk '/^(CVE|GHSA|PYSEC)-/ {printf "--ignore-vuln %s ", $1}' \
             .github/pip-audit-ignored.txt | xargs uv run pip-audit
   links:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -162,6 +173,7 @@ jobs:
           WHEEL=$(ls dist/*.whl)
           uv run --no-project scripts/verify-ui-wheel.py "$WHEEL"
   test:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/image-optimiser.yml
+++ b/.github/workflows/image-optimiser.yml
@@ -2,6 +2,12 @@
 name: Compress Images
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
     # Run Image Actions when JPG, JPEG, PNG or WebP files are added or changed.
     # See https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths for reference.
     paths: ['**.jpg', '**.jpeg', '**.png', '**.webp']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -535,7 +535,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
       - name: Log in to Docker Hub
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -5,7 +5,12 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
     paths:
       - site/**
       - docs/**
@@ -23,7 +28,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build-deploy:
-    if: github.event_name != 'pull_request_target'
+    if: ${{ github.event_name != 'pull_request_target' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,6 +8,12 @@ on:
       - .github/zizmor.yml
       - .github/dependabot.yml
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
     paths:
       - .github/workflows/**
       - .github/zizmor.yml
@@ -22,7 +28,7 @@ jobs:
     name: Scan workflows with zizmor
     runs-on: ubuntu-latest
     # Only run on the main repo, not forks (scheduled runs would fail on forks).
-    if: github.repository == 'zenml-io/kitaru'
+    if: ${{ github.repository == 'zenml-io/kitaru' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     permissions:
       contents: read
       actions: read


### PR DESCRIPTION
## What changed

- Added explicit `pull_request` activity types to draft-gated workflows so they respond to `ready_for_review` and `converted_to_draft`.
- Added job-level draft guards to expensive PR jobs in CI, Site, and Zizmor workflows.
- Preserved push-only, scheduled, manual, and preview-cleanup behavior.

## Why

Draft PRs are often used to share work-in-progress without asking CI/deploy workflows to burn runner time. GitHub may still create a workflow run for draft PR activity, but these changes make the expensive jobs stop immediately at the job condition.

## Key implementation decisions

- Used job-level `if:` guards rather than trying to skip whole workflows, because skipped jobs report successfully while fully skipped workflows can leave required checks pending.
- Kept `docker-smoke` and `wheel-packaging` push-only.
- Left Site preview cleanup ungated so closing a PR can still remove any preview Worker that already exists.
- Included `converted_to_draft` intentionally: when a ready PR is converted back to draft, a cheap skipped run can supersede/cancel in-flight expensive work where workflow concurrency applies.

## Reviewer Notes

The main behavior now lives in the job-level conditions in `.github/workflows/ci.yml`, `.github/workflows/site.yml`, and `.github/workflows/zizmor.yml`. The important thing to inspect is that non-PR events short-circuit the draft check: push, schedule, workflow dispatch, and cleanup flows should still behave as before.

The riskiest area is CI's matrixed `test` job. The job name is preserved as `test (${{ matrix.name }})`, and the current `develop` ruleset requires `lint`, `typecheck`, `typos`, `test (py311-base)`, `test (py312-base)`, and `test (py313-base)`. This PR is opened as a draft first so we can inspect how GitHub reports those required matrix contexts when the parent job is skipped before matrix expansion.

### Reproduction

1. Open this PR as draft.
2. Confirm draft PR workflow runs may appear, but the guarded jobs skip before checkout/install/build/test/deploy/scan work starts.
3. In particular, inspect the required CI contexts and confirm they are not stranded in a permanently pending state while the PR is draft.
4. Mark the PR ready for review.
5. Confirm the `ready_for_review` event runs the relevant workflows normally on the current commit.
6. Optional: convert the PR back to draft and confirm `converted_to_draft` creates a cheap skipped run that can cancel/supersede in-flight expensive work.

Local checks run:

- `yamlfix` format pass
- `yamlfix --check`
- `just actions-lint`
- `just check`
- simplify review pass: no reuse/quality issues; efficiency pass added `converted_to_draft`
- thermonuclear review pass: no structural blockers
- final Oracle review: no code blockers


### Draft PR check result

Observed after opening this PR as a draft:

- Guarded GitHub Actions jobs report `SKIPPED` / `COMPLETED` before doing runner-heavy work.
- External security checks completed successfully.
- The PR remains blocked because it is intentionally still a draft.
- The matrix job appears as the skipped parent check `test (${{ matrix.name }})`; mark this PR ready for review to trigger the real matrix checks before merge.


### Follow-up: Zizmor release workflow pin

After marking the PR ready for review, Zizmor v1.25.2 failed on an existing release workflow pin/comment mismatch:

- `docker/login-action@4907a6d...  # v4`

The `v4` tag now resolves to `650006c6eb7dba73a995cc03b0b2d7f5ca915bee`, so this PR updates the pinned SHA to match the documented `# v4` version comment.

Additional local checks after this fix:

- `GH_TOKEN=$(gh auth token) uvx zizmor --format=github --config=.github/zizmor.yml .github/workflows/ .github/dependabot.yml`
- `just check`
