### PR TITLE
Fix docs GitHub source links

### DIFF
--- a/docs/app/(docs)/[[...slug]]/page.tsx
+++ b/docs/app/(docs)/[[...slug]]/page.tsx
@@ -24,7 +24,7 @@ export default async function Page(props: PageProps<'/[[...slug]]'>) {
         <LLMCopyButton markdownUrl={markdownUrl} />
         <ViewOptions
           markdownUrl={markdownUrl}
-          githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/content/docs/${page.path}`}
+          githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/docs/content/docs/${page.path}`}
         />
       </div>
       <DocsBody>


### PR DESCRIPTION
## What changed?

Fixed the docs page “Open in GitHub” action so it links to source files under `docs/content/docs/...` in the Kitaru repository.

## Why?

The docs content directory is `content/docs` relative to the `docs/` app, but GitHub blob URLs are relative to the repository root. The old URL omitted the leading `docs/` path segment.

## Reviewer Notes

The important behavior lives in `docs/app/(docs)/[[...slug]]/page.tsx`, where each Fumadocs page is turned into the GitHub source-file URL passed to `ViewOptions`.

Before this change, the docs homepage tried to open `content/docs/index.mdx` at the repository root, which does not exist. After this change, it opens `docs/content/docs/index.mdx`, which matches the real source tree.

`ViewOptions` intentionally remains unchanged because it only renders the URL it receives.

### Reproduction

Open the docs homepage, choose **Open → Open in GitHub**, and confirm the link points to:

`https://github.com/zenml-io/kitaru/blob/develop/docs/content/docs/index.mdx`

For nested docs pages, confirm the URL keeps the same pattern under:

`docs/content/docs/...`

## Local checks run

- `cd docs && pnpm run lint` *(fails on pre-existing unrelated docs lint/config/CSS diagnostics, including `app/global.css`, `biome.json`, and `components/provider.tsx`)*
- `cd docs && pnpm run types:check`
- `cd docs && pnpm run build`
