### PR TITLE
Bump base ZenML version to `0.94.6`

### DIFF
--- a/.github/pip-audit-ignored.txt
+++ b/.github/pip-audit-ignored.txt
@@ -11,6 +11,9 @@
 # Tracked upstream: https://github.com/zenml-io/zenml/issues/4782
 CVE-2026-32597  # pyjwt 2.7 -> 2.12 (auth library; zenml hard-pins 2.7.*)
 PYSEC-2025-183  # pyjwt 2.7 disputed weak-key advisory; blocked by the same zenml pin
+PYSEC-2026-175  # pyjwt 2.7 -> 2.13.0; blocked by the same zenml pin
+PYSEC-2026-177  # pyjwt 2.7 -> 2.13.0; blocked by the same zenml pin
+PYSEC-2026-179  # pyjwt 2.7 -> 2.13.0; blocked by the same zenml pin
 CVE-2025-66416  # mcp 1.19 -> 1.23 (transitively blocked: mcp >=1.20 needs pyjwt >=2.10.1)
 
 # --- Transitive deps in zenml's FastAPI/Starlette server stack. ------------
@@ -20,3 +23,4 @@ CVE-2025-66416  # mcp 1.19 -> 1.23 (transitively blocked: mcp >=1.20 needs pyjwt
 CVE-2025-67221  # orjson 3.10 -> 3.11
 CVE-2025-54121  # starlette 0.45 -> 0.47
 CVE-2025-62727  # starlette 0.45 -> 0.49
+PYSEC-2026-161  # starlette 0.45 -> 1.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
-      ZENML_SERVER_TAG: 0.94.4
+      ZENML_SERVER_TAG: 0.94.6
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -532,7 +532,7 @@ jobs:
 
       # --- Docker image ---
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
       - name: Log in to Docker Hub
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -547,7 +547,7 @@ jobs:
           target: server
           push: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
           build-args: |
-            ZENML_SERVER_TAG=0.94.4
+            ZENML_SERVER_TAG=0.94.6
             ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') && format('KITARU_VERSION={0}', env.VERSION) || '' }}
           tags: |
             zenmldocker/kitaru:${{ env.VERSION }}

--- a/.github/workflows/ui-prerelease-smoke.yml
+++ b/.github/workflows/ui-prerelease-smoke.yml
@@ -23,7 +23,7 @@ concurrency:
   group: ui-prerelease-smoke-${{ github.ref }}-${{ inputs.ui-tag }}
   cancel-in-progress: false
 env:
-  ZENML_SERVER_TAG: 0.94.4
+  ZENML_SERVER_TAG: 0.94.6
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Standardized adapter docs and examples around the shared `checkpoint_strategy` concept while keeping framework-specific boundary names such as PydanticAI `"turn"`, OpenAI Agents `"runner_call"`, LangGraph `"graph_call"`, and Claude Agent SDK `"invocation"`.
+- Bumped the minimum ZenML dependency, server image, and Helm subchart versions to `0.94.6` so Kitaru tracks the latest upstream ZenML release.
 
 ## [0.13.1] - 2026-05-21
 

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 # Pinned ZenML server image version — bump here when upgrading.
 # Must match pyproject.toml, uv.lock, the server Dockerfiles, CI/release
 # workflow pins, and helm/Chart.yaml; contract tests enforce alignment.
-ZENML_SERVER_TAG := "0.94.4"
+ZENML_SERVER_TAG := "0.94.6"
 DOCKER_REPO := "zenmldocker/kitaru"
 DOCKER_TAG := "latest"
 UI_TAG := "latest"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 # Published to: zenmldocker/kitaru
 
-ARG ZENML_SERVER_TAG=0.94.4
+ARG ZENML_SERVER_TAG=0.94.6
 
 FROM zenmldocker/zenml-server:${ZENML_SERVER_TAG} AS server
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -19,10 +19,10 @@ COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /uvx /bin/
 ENV UV_SYSTEM_PYTHON=1
 
 # Install kitaru from local source. Its pyproject.toml pulls
-# zenml[local]>=0.94.4 from PyPI automatically.
+# zenml[local]>=0.94.6 from PyPI automatically.
 COPY . /tmp/kitaru
 RUN cd /tmp/kitaru && uv pip install . && rm -rf /tmp/kitaru
 
 # Layer on cloud extras for remote artifact stores and connectors.
 RUN uv pip install \
-    "zenml[s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure]>=0.94.4"
+    "zenml[s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure]>=0.94.6"

--- a/docker/Dockerfile.server-dev
+++ b/docker/Dockerfile.server-dev
@@ -13,7 +13,7 @@
 #   4. Run:
 #        docker run -p 8080:8080 kitaru-server-dev
 
-ARG ZENML_SERVER_TAG=0.94.4
+ARG ZENML_SERVER_TAG=0.94.6
 
 FROM zenmldocker/zenml-server:${ZENML_SERVER_TAG} AS server
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://kitaru.ai/kitaru-logo.svg
 
 dependencies:
   - name: zenml
-    version: "0.94.4"
+    version: "0.94.6"
     repository: "oci://public.ecr.aws/zenml"
     alias: kitaru

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "cyclopts>=3.0",
     "pydantic>=2.0",
     "rich>=12.0.0",
-    "zenml[local]>=0.94.4",
+    "zenml[local]>=0.94.6",
 ]
 
 [project.optional-dependencies]
@@ -57,7 +57,7 @@ llm = [
     "kitaru[anthropic]",
 ]
 local = [
-    "zenml[server]>=0.94.4",
+    "zenml[server]>=0.94.6",
 ]
 pydantic-ai = [
     "pydantic-ai-slim>=1.89.0,<1.97.0",
@@ -118,7 +118,7 @@ dev = [
     "ruff>=0.11",
     "ty>=0.0.1a7",
     "yamlfix",
-    "zenml[server]>=0.94.4",
+    "zenml[server]>=0.94.6",
     "pytest>=8.0",
     "pytest-randomly",
     "pytest-clarity",

--- a/src/kitaru/_terminal_logging.py
+++ b/src/kitaru/_terminal_logging.py
@@ -360,7 +360,7 @@ def install_terminal_log_intercept() -> None:
     ``importlib.reload(kitaru._terminal_logging)``, converges the root logger
     to one Kitaru terminal handler plus any preserved non-console handlers.
     """
-    from zenml.logger import ConsoleFormatter, ZenMLLoggingHandler
+    from zenml.logger import ZenMLConsoleFormatter, ZenMLLoggingHandler
 
     root = logging.getLogger()
 
@@ -377,7 +377,7 @@ def install_terminal_log_intercept() -> None:
             continue
         if isinstance(handler, ZenMLLoggingHandler):
             continue
-        if isinstance(getattr(handler, "formatter", None), ConsoleFormatter):
+        if isinstance(getattr(handler, "formatter", None), ZenMLConsoleFormatter):
             zenml_console_indices.append(i)
 
     kitaru_handler = existing_kitaru or _KitaruTerminalHandler()

--- a/tests/test_terminal_logging.py
+++ b/tests/test_terminal_logging.py
@@ -41,12 +41,12 @@ def _kitaru_handlers(root: logging.Logger) -> list[logging.Handler]:
 
 def _console_handlers(root: logging.Logger) -> list[logging.Handler]:
     """Return root handlers using ZenML's console formatter."""
-    from zenml.logger import ConsoleFormatter
+    from zenml.logger import ZenMLConsoleFormatter
 
     return [
         handler
         for handler in root.handlers
-        if isinstance(getattr(handler, "formatter", None), ConsoleFormatter)
+        if isinstance(getattr(handler, "formatter", None), ZenMLConsoleFormatter)
     ]
 
 
@@ -497,13 +497,13 @@ class TestHandlerSwap:
     """Handler installation logic."""
 
     def test_swap_replaces_console_handler_keeps_storage(self) -> None:
-        from zenml.logger import ConsoleFormatter, ZenMLLoggingHandler
+        from zenml.logger import ZenMLConsoleFormatter, ZenMLLoggingHandler
 
         root = logging.getLogger()
 
         # Set up mock handlers like ZenML's init_logging() would
         console_handler = logging.StreamHandler()
-        console_handler.setFormatter(ConsoleFormatter())
+        console_handler.setFormatter(ZenMLConsoleFormatter())
         storage_handler = ZenMLLoggingHandler()
 
         root.handlers = [console_handler, storage_handler]
@@ -522,12 +522,12 @@ class TestHandlerSwap:
         assert storage_handlers[0] is storage_handler
 
     def test_swap_is_idempotent(self) -> None:
-        from zenml.logger import ConsoleFormatter, ZenMLLoggingHandler
+        from zenml.logger import ZenMLConsoleFormatter, ZenMLLoggingHandler
 
         root = logging.getLogger()
 
         console_handler = logging.StreamHandler()
-        console_handler.setFormatter(ConsoleFormatter())
+        console_handler.setFormatter(ZenMLConsoleFormatter())
         storage_handler = ZenMLLoggingHandler()
         root.handlers = [console_handler, storage_handler]
 
@@ -569,12 +569,12 @@ class TestHandlerSwap:
         assert storage_handler in root.handlers
 
     def test_reload_replaces_console_without_duplicating_kitaru(self) -> None:
-        from zenml.logger import ConsoleFormatter, ZenMLLoggingHandler
+        from zenml.logger import ZenMLConsoleFormatter, ZenMLLoggingHandler
 
         root = logging.getLogger()
 
         console_handler = logging.StreamHandler()
-        console_handler.setFormatter(ConsoleFormatter())
+        console_handler.setFormatter(ZenMLConsoleFormatter())
         storage_handler = ZenMLLoggingHandler()
         old_kitaru_handler = terminal_logging._KitaruTerminalHandler()
         old_handler_class = old_kitaru_handler.__class__

--- a/tests/test_ui_release_contract.py
+++ b/tests/test_ui_release_contract.py
@@ -36,7 +36,7 @@ def test_release_workflow_uses_stable_monorepo_ui_bundling() -> None:
     docker_step = _workflow_step_block(workflow, "Build and push Docker image")
     assert "KITARU_UI_TAG=" not in docker_step
     assert "KITARU_VERSION=" in docker_step
-    assert "ZENML_SERVER_TAG=0.94.4" in docker_step
+    assert "ZENML_SERVER_TAG=0.94.6" in docker_step
 
 
 def test_ci_bundles_ui_before_source_docker_smoke() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-30T13:45:34.340384Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -1297,8 +1297,8 @@ requires-dist = [
     { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=1.89.0,<1.97.0" },
     { name = "rich", specifier = ">=12.0.0" },
     { name = "typing-extensions", marker = "extra == 'pydantic-ai'", specifier = ">=4.12" },
-    { name = "zenml", extras = ["local"], specifier = ">=0.94.4" },
-    { name = "zenml", extras = ["server"], marker = "extra == 'local'", specifier = ">=0.94.4" },
+    { name = "zenml", extras = ["local"], specifier = ">=0.94.6" },
+    { name = "zenml", extras = ["server"], marker = "extra == 'local'", specifier = ">=0.94.6" },
 ]
 provides-extras = ["openai", "anthropic", "llm", "local", "pydantic-ai", "openai-agents", "langgraph", "langgraph-openai", "langgraph-anthropic", "claude-agent-sdk", "mcp"]
 
@@ -1322,7 +1322,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11" },
     { name = "ty", specifier = ">=0.0.1a7" },
     { name = "yamlfix" },
-    { name = "zenml", extras = ["server"], specifier = ">=0.94.4" },
+    { name = "zenml", extras = ["server"], specifier = ">=0.94.6" },
 ]
 
 [[package]]
@@ -3106,6 +3106,15 @@ wheels = [
 ]
 
 [[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3934,7 +3943,7 @@ wheels = [
 
 [[package]]
 name = "zenml"
-version = "0.94.4"
+version = "0.94.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
@@ -3952,10 +3961,11 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "setuptools" },
+    { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/19/6947d4b33761475b681e59229cdc3e052b869ff673046fe64ebdae9c9f57/zenml-0.94.4.tar.gz", hash = "sha256:71e2a3b919b42235fd7746853244b3e9bf7c5b75cfdeb3ab32f7e8db15da54cb", size = 7169262, upload-time = "2026-05-12T15:01:11.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/a5/3ff5662537f6dffad0a125222d85e9d848e19e6ef4a39d1e4aceca34fe7e/zenml-0.94.6.tar.gz", hash = "sha256:8d62a97c5a6e2baa1c24a9a168f0e7a87a363f32412845cf54b8f995d8ef1675", size = 7216327, upload-time = "2026-06-02T10:47:56.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/e3/21a7dd71780b7581160f707e39be1ccc75ba0f5dcc72aa9b8d33ad6c8739/zenml-0.94.4-py3-none-any.whl", hash = "sha256:a660adc70205919cb41ca6344ae2a94b6c0b430257c6d8c79f8a5089a30102ef", size = 8322261, upload-time = "2026-05-12T15:01:08.748Z" },
+    { url = "https://files.pythonhosted.org/packages/08/57/3d79e95ad2953d60e9967919e1e356fa462ab3d59f7c4d8ba82ac589246b/zenml-0.94.6-py3-none-any.whl", hash = "sha256:05f6d4253e86624e9e60095e41cec8ba6cadeb5d725c5aa9d0d78e76d64acd62", size = 8386626, upload-time = "2026-06-02T10:47:53.682Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What this does

Bumps the base ZenML dependency from `0.94.4` to the freshly-released `0.94.6` across every pinned surface, and adapts Kitaru to one breaking change that 0.94.6 introduced.

### Version pins (commit 1)
- `pyproject.toml` — `zenml[local]` + `zenml[server]` (local extra and dev group)
- `docker/Dockerfile`, `Dockerfile.server-dev` — `ARG ZENML_SERVER_TAG`
- `docker/Dockerfile.dev` — flow-execution image floor (+ comment)
- `.github/workflows/{ci,release,ui-prerelease-smoke}.yml` — `ZENML_SERVER_TAG`
- `Justfile`, `helm/Chart.yaml`
- `tests/test_ui_release_contract.py` — hardcoded tag assertion
- `CHANGELOG.md`

### 0.94.6 compatibility (commit 2)
- **Logger symbol rename:** ZenML 0.94.6 renamed `zenml.logger.ConsoleFormatter` → `ZenMLConsoleFormatter` (part of its move onto `structlog`). Kitaru calls `install_terminal_log_intercept()` at *import time*, so the stale import broke `import kitaru` outright under 0.94.6 — which cascaded into conftest collection failure and took down every test / typecheck / MCP job. Fixed the import and the `isinstance` console-handler check in `src/kitaru/_terminal_logging.py`, plus the mirroring fixtures in `tests/test_terminal_logging.py`.
- **`uv.lock` regenerated** against the published `zenml==0.94.6` (pulls in ZenML's new `structlog` dep). This also satisfies the `test_zenml_python_dependency_surfaces_are_aligned` contract test.
- **pip-audit ignores refreshed:** added new pyjwt (`PYSEC-2026-175/177/179`) and starlette (`PYSEC-2026-161`) advisories. These are fresh advisories against versions Kitaru can't move off — ZenML 0.94.6 still hard-pins `pyjwt[crypto]==2.7.*` and constrains its Starlette stack to 0.45, so the fixed releases are unreachable until ZenML widens those pins ([zenml-io/zenml#4782](https://github.com/zenml-io/zenml/issues/4782)). The versions are unchanged by this bump, so this failure also affects `develop`.

## Reviewer Notes

The risky part isn't the version-string churn — the contract tests in `tests/test_dockerfile_contract.py` mechanically enforce that all pins agree, so a missed surface fails loudly. The interesting part is the **import-time logger swap** in `_terminal_logging.py`. Because it runs during `import kitaru`, a wrong symbol name there isn't a localized failure — it makes the entire package unimportable. That's why a one-line rename was enough to turn the whole CI suite red, and why the fix is the highest-leverage change in this PR. Worth a sanity check that `ZenMLConsoleFormatter` is the right replacement for detecting ZenML's console handler (it is — ZenML's console handler still uses that formatter type; the 61 `test_terminal_logging.py` tests exercise the swap/idempotence/reload paths).

The pip-audit additions follow the existing documented pattern in `.github/pip-audit-ignored.txt` (same `zenml-io/zenml#4782` keystone pin).

### Reproduction

```bash
git checkout bump-zenml-0.94.6
uv sync --extra local --extra llm --extra mcp   # installs zenml 0.94.6
uv run --no-sync python -c "import kitaru; print('ok')"   # was ImportError before the fix
just test          # 1898 passed, 8 skipped
just test tests/mcp # 125 passed
just audit         # No known vulnerabilities found, 10 ignored
```

### Local checks run

`just check` (format/lint/typecheck/typos/yaml/actions all green; `links` only flags stale local `docs/out/` generated artifacts that CI doesn't see — tracked-file links are clean), `just test`, `just test tests/mcp`, `just audit`.