### PR TITLE
Restore docs production deploy from a dispatched branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,8 +71,10 @@ jobs:
         run: pnpm run validate:export
         working-directory: docs
       - name: Deploy production docs
-        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name
-          == 'workflow_dispatch')
+        # Push deploys only from main; a manual workflow_dispatch deploys whichever
+        # branch it runs against, so docs can be shipped to production from develop.
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name
+          == 'workflow_dispatch'
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0  # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## What this does

Restores the ability to deploy docs to **production** by manually dispatching the `Docs` workflow against any branch (e.g. `develop`), without waiting for a release to land on `main`.

## Why

The site→docs workflow migration (#380) rewrote the production deploy step's `if:` condition. The two versions look like the same idea rearranged, but they are not logically equivalent:

| | Condition | Dispatch from `develop` deploys? |
|---|---|---|
| **Old `site.yml`** | `(push && main) \|\| dispatch` | ✅ yes |
| **New `docs.yml` (#380)** | `main && (push \|\| dispatch)` | ❌ no — skipped |

Factoring the `main` check "out front" so it applies to both event types silently added a main-only requirement to `workflow_dispatch`. The result: dispatching `Docs` from `develop` runs the full build + validate, goes green, and then **skips the deploy step** — shipping nothing while looking successful.

This was collateral damage from the refactor, not an intentional removal of the capability.

This PR reverts the condition to its original form:

```yaml
if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
```

Push still only deploys from `main`; a manual dispatch now deploys whichever branch it runs against. The preview-on-PR path is unchanged.

## Reviewer Notes

The entire change is the `if:` on the `Deploy production docs` step in `.github/workflows/docs.yml`, plus a comment documenting the intent so the next refactor doesn't re-break it. The risk surface is purely *who/what can deploy to production*: the new condition intentionally lets any `workflow_dispatch` (any branch) deploy to the live `kitaru-site` Worker — the same trade-off the old `site.yml` accepted. If that is now considered too permissive, the alternative is a guarded dispatch (e.g. a `confirm` input), but this PR deliberately restores prior behavior faithfully rather than changing the security posture.

### Reproduction

The "before" is already on record: run https://github.com/zenml-io/kitaru/actions/runs/26891361945 was a `workflow_dispatch` on `develop` — `build-deploy` is green, but `Deploy production docs` and `Deploy preview docs` both show as **skipped**.

After this merges, dispatch `Actions → Docs → Run workflow → Branch: develop` and confirm the `Deploy production docs` step now **runs** (not skipped) and `kitaru.ai/docs` reflects develop's content.

### Local checks run

`just actions-lint` and `just zizmor` both pass clean (no new findings).