### PR TITLE
Refactor to rationalise client by adding client backend gateway

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,22 @@ These require Node 22+ and pnpm.
 - Put helpers on the class when tied to its behavior; use standalone utils only for generic cross-module functions.
 - Prefer Pydantic models for data structures; checkpoint return values must be serializable.
 
+## Internal backend routing
+
+- `KitaruClient` creates a private `KitaruBackendGateway` at `client._backend`.
+  Client namespaces such as `executions`, `artifacts`, `deployments`, and
+  `auth` validate public inputs and map backend models to Kitaru DTOs. Backend
+  calls to ZenML clients, REST stores, logs, events, snapshots, stack
+  operations, and API-key local activation should go through the gateway.
+- CLI and MCP stack commands should route through their dependency gateway
+  methods while preserving the existing monkeypatch bridges in tests. Do not add
+  a public `KitaruClient().stacks` namespace.
+- `flow.py` and gateway retry/resume both use
+  `kitaru._stack_binding.temporary_active_stack(...)` for temporary stack
+  activation. If you need to activate a stack temporarily, reuse that helper so
+  concurrent submissions and retry/resume share the same lock and restore
+  behavior.
+
 ## CLI
 
 The `kitaru` console script is defined in `pyproject.toml` under `[project.scripts]`. `src/kitaru/cli.py` is the thin facade / entrypoint, while command implementations live in `src/kitaru/_cli/`. Add new subcommands in the appropriate `src/kitaru/_cli/_*.py` module and register them on the shared Cyclopts app there. When testing CLI commands, always pass an explicit arg list (`app(["--help"])`, not bare `app()`). CLI invocations raise `SystemExit(0)` on success.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,18 @@ When working with Python, invoke the relevant /astral:<skill> for uv, ty, and ru
 
 ### Key design patterns
 
+- **Internal backend routing:** `KitaruClient` creates a private
+  `KitaruBackendGateway` at `client._backend`. Client namespaces validate public
+  inputs and map backend models to Kitaru DTOs; backend calls to ZenML clients,
+  REST stores, logs, events, snapshots, stack operations, and API-key local
+  activation should go through the gateway. CLI and MCP stack commands should
+  route through their dependency gateway methods while preserving existing
+  monkeypatch bridges in tests. Do not add a public `KitaruClient().stacks`
+  namespace.
+- **Temporary stack activation:** `flow.py` and gateway retry/resume both use
+  `kitaru._stack_binding.temporary_active_stack(...)`. Reuse that helper for
+  temporary stack activation so concurrent submissions and retry/resume share the
+  same lock and restore behavior.
 - **Flows are top-level orchestration boundaries** — direct flow calls are blocked; start executions with `.run()`
 - **Nested checkpoint calls are blocked in the current MVP implementation**
 - **Concurrency** uses `.submit()` + `.result()` (ZenML futures), not a dedicated primitive

--- a/src/kitaru/_cli/_dependencies.py
+++ b/src/kitaru/_cli/_dependencies.py
@@ -16,6 +16,7 @@ from zenml.client import Client
 from zenml.config.global_config import GlobalConfiguration
 from zenml.login.credentials_store import get_credentials_store
 
+from kitaru._client._backend_gateway import KitaruBackendGateway
 from kitaru._interface_secrets import resolve_secret_exact as _resolve_secret_exact
 from kitaru._local_server import (
     start_or_connect_local_server,
@@ -101,6 +102,13 @@ class CLIDependencies:
         """Return the active Kitaru SDK client."""
         return self._legacy_attr("KitaruClient", KitaruClient)()
 
+    def backend_gateway(self) -> KitaruBackendGateway:
+        """Return the CLI backend gateway."""
+        return KitaruBackendGateway(
+            project=None,
+            client_factory=self.zenml_client,
+        )
+
     def auth_management_client(self) -> Any:
         """Return the SDK client configured for auth-management commands."""
         return self._legacy_attr("KitaruClient", KitaruClient).for_auth_management()
@@ -185,43 +193,52 @@ class CLIDependencies:
 
     def get_current_stack(self) -> Any:
         """Return the active stack."""
-        return self._legacy_attr("get_current_stack", get_current_stack)()
+        patched = self._legacy_attr("get_current_stack", _MISSING)
+        if patched is not _MISSING:
+            return patched()
+        return self.backend_gateway().current_stack()
 
     def get_available_stacks(self) -> Any:
         """Return all available stacks."""
-        return self._legacy_attr("get_available_stacks", get_available_stacks)()
+        patched = self._legacy_attr("get_available_stacks", _MISSING)
+        if patched is not _MISSING:
+            return patched()
+        return self.backend_gateway().list_stacks()
 
     def set_active_stack(self, *args: Any, **kwargs: Any) -> Any:
         """Set the active stack."""
-        return self._legacy_attr("set_active_stack", set_active_stack)(
-            *args,
-            **kwargs,
-        )
+        patched = self._legacy_attr("set_active_stack", _MISSING)
+        if patched is not _MISSING:
+            return patched(*args, **kwargs)
+        return self.backend_gateway().use_stack(*args, **kwargs)
 
     def list_stack_entries(self) -> Any:
         """Return stack list entries."""
-        return self._legacy_attr("_list_stack_entries", _list_stack_entries)()
+        patched = self._legacy_attr("_list_stack_entries", _MISSING)
+        if patched is not _MISSING:
+            return patched()
+        return self.backend_gateway().list_stack_entries()
 
     def show_stack_operation(self, *args: Any, **kwargs: Any) -> Any:
         """Return stack details for a stack name or ID."""
-        return self._legacy_attr("_show_stack_operation", _show_stack_operation)(
-            *args,
-            **kwargs,
-        )
+        patched = self._legacy_attr("_show_stack_operation", _MISSING)
+        if patched is not _MISSING:
+            return patched(*args, **kwargs)
+        return self.backend_gateway().show_stack_operation(*args, **kwargs)
 
     def create_stack_operation(self, *args: Any, **kwargs: Any) -> Any:
         """Create a stack from CLI inputs."""
-        return self._legacy_attr("_create_stack_operation", _create_stack_operation)(
-            *args,
-            **kwargs,
-        )
+        patched = self._legacy_attr("_create_stack_operation", _MISSING)
+        if patched is not _MISSING:
+            return patched(*args, **kwargs)
+        return self.backend_gateway().create_stack_operation(*args, **kwargs)
 
     def delete_stack_operation(self, *args: Any, **kwargs: Any) -> Any:
         """Delete a stack from CLI inputs."""
-        return self._legacy_attr("_delete_stack_operation", _delete_stack_operation)(
-            *args,
-            **kwargs,
-        )
+        patched = self._legacy_attr("_delete_stack_operation", _MISSING)
+        if patched is not _MISSING:
+            return patched(*args, **kwargs)
+        return self.backend_gateway().delete_stack_operation(*args, **kwargs)
 
     def register_model_alias(self, *args: Any, **kwargs: Any) -> Any:
         """Persist a model alias."""

--- a/src/kitaru/_client/_backend_gateway.py
+++ b/src/kitaru/_client/_backend_gateway.py
@@ -1,0 +1,1089 @@
+"""Internal gateway for backend-facing Kitaru client operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+from pydantic import ValidationError
+from zenml.login.credentials_store import get_credentials_store
+from zenml.models import PipelineRunResponse
+from zenml.models.v2.core.artifact_version import ArtifactVersionResponse
+from zenml.utils.run_utils import stop_run
+from zenml.zen_stores.rest_zen_store import RestZenStore
+
+from kitaru._client._events import (
+    QueryParams,
+    StreamingStore,
+    open_rest_sse_stream,
+)
+from kitaru._client._logs import (
+    _is_empty_log_result_error,
+    _is_log_endpoint_version_skew_error,
+    _is_otel_log_retrieval_error,
+)
+from kitaru._config import _stacks as stack_ops
+from kitaru._stack_binding import temporary_active_stack
+from kitaru.config import active_stack_log_store, resolve_log_store
+from kitaru.errors import (
+    KitaruBackendError,
+    KitaruLogRetrievalError,
+    KitaruRuntimeError,
+    KitaruStateError,
+    KitaruWaitValidationError,
+)
+
+_ORIGINAL_STACK_OPERATIONS: dict[str, Any] = {
+    "current_stack": stack_ops.current_stack,
+    "list_stack_entries": stack_ops._list_stack_entries,
+    "show_stack_operation": stack_ops._show_stack_operation,
+    "create_stack_operation": stack_ops._create_stack_operation,
+    "create_local_stack_operation": stack_ops._create_local_stack_operation,
+    "create_kubernetes_stack_operation": stack_ops._create_kubernetes_stack_operation,
+    "create_vertex_stack_operation": stack_ops._create_vertex_stack_operation,
+    "create_sagemaker_stack_operation": stack_ops._create_sagemaker_stack_operation,
+    "create_azureml_stack_operation": stack_ops._create_azureml_stack_operation,
+    "delete_stack_operation": stack_ops._delete_stack_operation,
+    "use_stack": stack_ops.use_stack,
+}
+
+
+@dataclass(frozen=True)
+class LocalCredentialSnapshot:
+    """Previous locally persisted API-key state for rollback attempts."""
+
+    server_url: str | None
+    previous_api_key: str | None = field(default=None, repr=False)
+    reason_unavailable: str | None = None
+
+    @property
+    def previous_api_key_available(self) -> bool:
+        """Return whether rollback has a previous API key to restore."""
+        return self.server_url is not None and self.previous_api_key is not None
+
+
+@dataclass(frozen=True)
+class LocalKeyActivationStatus:
+    """Result of best-effort local API-key activation."""
+
+    succeeded: bool
+    error: str | None = None
+    rollback_attempted: bool = False
+    rollback_succeeded: bool | None = None
+    rollback_error: str | None = None
+    rollback_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class APIKeyOperationResult:
+    """Backend API-key operation result plus optional local activation status."""
+
+    api_key: Any
+    local_key_activation: LocalKeyActivationStatus | None = None
+
+
+def _api_key_raw_value(api_key: Any) -> str:
+    """Return the one-time API-key value or raise the public backend error."""
+    raw_key = getattr(api_key, "key", None)
+    if not isinstance(raw_key, str) or not raw_key:
+        raise KitaruBackendError(
+            "The server did not return the one-time API key value for this "
+            "create/rotate operation."
+        )
+    return raw_key
+
+
+def _redact_auth_error_text(text: str, *, secrets: list[str]) -> str:
+    """Return error text without leaking known sensitive credential values."""
+    redacted = text
+    for secret in secrets:
+        if secret:
+            redacted = redacted.replace(secret, "[redacted]")
+    return redacted
+
+
+def _sanitize_local_key_activation_error(
+    exc: Exception,
+    *,
+    raw_key: str,
+    previous_key: str | None = None,
+) -> str:
+    """Return local activation error text without leaking API-key values."""
+    message = str(exc) or type(exc).__name__
+    return _redact_auth_error_text(
+        message,
+        secrets=[raw_key, previous_key or ""],
+    )
+
+
+def _capture_previous_local_api_key(zenml_client: Any) -> LocalCredentialSnapshot:
+    """Return the previous persisted API key if it can be restored safely."""
+    server_url = getattr(getattr(zenml_client, "zen_store", None), "url", None)
+    if not isinstance(server_url, str) or not server_url:
+        return LocalCredentialSnapshot(
+            server_url=None,
+            reason_unavailable=(
+                "Kitaru could not determine the active remote server URL, so "
+                "there was no previous persisted credential to restore."
+            ),
+        )
+
+    try:
+        credentials_store = get_credentials_store()
+        previous_api_key = credentials_store.get_api_key(server_url=server_url)
+    except Exception as exc:
+        return LocalCredentialSnapshot(
+            server_url=server_url,
+            reason_unavailable=(
+                "Kitaru could not read the previous persisted local API key for "
+                f"{server_url!r}, so rollback was not possible: {exc}"
+            ),
+        )
+
+    if not previous_api_key:
+        return LocalCredentialSnapshot(
+            server_url=server_url,
+            reason_unavailable=(
+                "No previous persisted local API key was available to restore. "
+                "Environment credentials, if any, were not modified."
+            ),
+        )
+
+    return LocalCredentialSnapshot(
+        server_url=server_url,
+        previous_api_key=previous_api_key,
+    )
+
+
+class KitaruBackendGateway:
+    """Private access point for backend operations used by Kitaru clients."""
+
+    def __init__(
+        self,
+        *,
+        project: str | None,
+        client_factory: Callable[[], Any],
+        active_stack_log_store_getter: Callable[[], Any] = active_stack_log_store,
+        resolve_log_store_getter: Callable[[], Any] = resolve_log_store,
+    ) -> None:
+        self._project = project
+        self._client_factory = client_factory
+        self._active_stack_log_store_getter = active_stack_log_store_getter
+        self._resolve_log_store_getter = resolve_log_store_getter
+
+    @property
+    def project(self) -> str | None:
+        """Return the active Kitaru project, if one is required for this client."""
+        return self._project
+
+    def zenml_client(self) -> Any:
+        """Return a fresh ZenML client instance."""
+        return self._client_factory()
+
+    def get_pipeline_run(self, exec_id: str, *, hydrate: bool) -> PipelineRunResponse:
+        """Fetch a run by execution ID with strict ID matching."""
+        try:
+            return self.zenml_client().get_pipeline_run(
+                name_id_or_prefix=exec_id,
+                allow_name_prefix_match=False,
+                project=self._project,
+                hydrate=hydrate,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to load execution '{exec_id}': {exc}"
+            ) from exc
+
+    def get_snapshot(self, snapshot_id: str, *, hydrate: bool) -> Any:
+        """Fetch a snapshot by ID with strict ID matching."""
+        try:
+            return self.zenml_client().get_snapshot(
+                name_id_or_prefix=snapshot_id,
+                allow_prefix_match=False,
+                project=self._project,
+                hydrate=hydrate,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to load deployment snapshot '{snapshot_id}': {exc}"
+            ) from exc
+
+    def get_artifact_version(
+        self,
+        artifact_id: str,
+        *,
+        hydrate: bool,
+    ) -> ArtifactVersionResponse:
+        """Fetch an artifact version by ID."""
+        try:
+            return self.zenml_client().get_artifact_version(
+                name_id_or_prefix=artifact_id,
+                project=self._project,
+                hydrate=hydrate,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to load artifact '{artifact_id}': {exc}"
+            ) from exc
+
+    def list_pipeline_runs(self, *, page: int, size: int) -> Any:
+        """List pipeline runs for the active project."""
+        return self.zenml_client().list_pipeline_runs(
+            sort_by="desc:created",
+            page=page,
+            size=size,
+            project=self._project,
+            hydrate=True,
+        )
+
+    def list_run_steps(self, *, run_id: Any, page: int, size: int) -> Any:
+        """List step runs for a pipeline run."""
+        try:
+            return self.zenml_client().list_run_steps(
+                sort_by="asc:created",
+                page=page,
+                size=size,
+                pipeline_run_id=run_id,
+                project=self._project,
+                exclude_retried=False,
+                hydrate=True,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to fetch checkpoint attempts for execution {run_id}: {exc}"
+            ) from exc
+
+    def get_run_step(self, step_id: Any, *, hydrate: bool) -> Any:
+        """Fetch one run-step model."""
+        return self.zenml_client().get_run_step(step_id, hydrate=hydrate)
+
+    def list_run_wait_conditions(
+        self,
+        *,
+        run_id: Any,
+        status: str | None = None,
+    ) -> list[Any]:
+        """Return wait-condition models for an execution."""
+        try:
+            wait_conditions_page = self.zenml_client().list_run_wait_conditions(
+                pipeline_run=run_id,
+                project=self._project,
+                status=status,
+                hydrate=True,
+                sort_by="asc:created",
+                size=200,
+            )
+        except AttributeError:
+            return []
+        except Exception as exc:
+            operation = "pending waits" if status == "pending" else "waits"
+            raise KitaruBackendError(
+                f"Failed to list {operation} for execution {run_id}: {exc}"
+            ) from exc
+
+        return list(wait_conditions_page.items)
+
+    def resolve_run_wait_condition(
+        self,
+        *,
+        run_wait_condition_id: Any,
+        resolution: Any,
+        result: Any | None,
+        wait_name: str,
+        exec_id: str,
+    ) -> None:
+        """Resolve a pending wait condition."""
+        try:
+            self.zenml_client().resolve_run_wait_condition(
+                run_wait_condition_id=run_wait_condition_id,
+                resolution=resolution,
+                result=result,
+            )
+        except (ValidationError, TypeError, ValueError) as exc:
+            raise KitaruWaitValidationError(
+                "Wait input failed validation for "
+                f"'{wait_name}' on execution '{exec_id}': {exc}"
+            ) from exc
+        except Exception as exc:
+            raise KitaruBackendError(
+                "Failed to resolve wait condition "
+                f"'{wait_name}' for execution '{exec_id}': {exc}"
+            ) from exc
+
+    def cancel_run(
+        self,
+        run: PipelineRunResponse,
+        *,
+        stop_run_fn: Callable[..., Any] = stop_run,
+    ) -> None:
+        """Cancel an execution through the backend runtime helper."""
+        stop_run_fn(run=run, graceful=False)
+
+    def restart_run_from_snapshot(
+        self,
+        *,
+        run: PipelineRunResponse,
+        operation_name: str,
+    ) -> None:
+        """Restart an execution from its stored snapshot metadata."""
+        snapshot = run.snapshot
+        if snapshot is None:
+            raise KitaruRuntimeError(
+                f"Unable to {operation_name} execution because snapshot metadata "
+                "is missing."
+            )
+        if snapshot.stack is None:
+            raise KitaruRuntimeError(
+                f"Unable to {operation_name} execution because snapshot stack "
+                "metadata is missing."
+            )
+
+        try:
+            with temporary_active_stack(
+                str(snapshot.stack.id),
+                client_factory=self.zenml_client,
+            ) as stack_client:
+                assert stack_client is not None
+                active_stack = stack_client.active_stack
+                active_stack.orchestrator.resume_run(
+                    snapshot=snapshot,
+                    run=run,
+                    stack=active_stack,
+                )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to {operation_name} execution '{run.id}': {exc}"
+            ) from exc
+
+    def require_rest_store(self, unavailable_error: Exception) -> RestZenStore:
+        """Return the active REST store or raise the caller-specific error."""
+        zen_store = self.zenml_client().zen_store
+        if isinstance(zen_store, RestZenStore):
+            return zen_store
+        raise unavailable_error
+
+    def resolve_log_endpoint_hint(self) -> str | None:
+        """Resolve a best-effort endpoint hint for log-retrieval errors."""
+        active_log_store = self._active_stack_log_store_getter()
+        if active_log_store is not None and active_log_store.endpoint:
+            return active_log_store.endpoint
+
+        try:
+            preferred_log_store = self._resolve_log_store_getter()
+        except ValueError:
+            return None
+
+        return preferred_log_store.endpoint
+
+    def fetch_log_payload(
+        self,
+        *,
+        path: str,
+        source: str,
+        store: RestZenStore,
+    ) -> list[Mapping[str, Any]]:
+        """Call a log endpoint and normalize the response payload shape."""
+        try:
+            payload = store.get(path, params={"source": source})
+        except Exception as exc:
+            error_message = str(exc)
+            if _is_empty_log_result_error(error_message):
+                return []
+
+            if _is_otel_log_retrieval_error(error_message):
+                endpoint_hint = self.resolve_log_endpoint_hint()
+                message = (
+                    "Logs for this execution are stored in an OTEL backend and "
+                    "cannot be fetched via the Kitaru log retrieval API."
+                )
+                if endpoint_hint:
+                    message += f" View them in your OTEL backend at: {endpoint_hint}."
+                raise KitaruLogRetrievalError(message) from exc
+
+            if _is_log_endpoint_version_skew_error(error_message):
+                raise KitaruLogRetrievalError(
+                    "Unable to retrieve runtime logs because the server log "
+                    "endpoint is incompatible with this Kitaru client. This "
+                    "usually means the client and server are running different "
+                    "Kitaru versions. Upgrade the server runtime or align the "
+                    "client and server versions, then retry `kitaru executions "
+                    "logs`."
+                ) from exc
+
+            raise KitaruLogRetrievalError(
+                f"Failed to retrieve runtime logs for source '{source}': {exc}"
+            ) from exc
+
+        if not isinstance(payload, list):
+            raise KitaruLogRetrievalError(
+                "Unexpected response while retrieving runtime logs: "
+                "expected a list payload."
+            )
+
+        normalized_payload: list[Mapping[str, Any]] = []
+        for entry in payload:
+            if not isinstance(entry, Mapping):
+                raise KitaruLogRetrievalError(
+                    "Unexpected log entry payload type returned by the server."
+                )
+            normalized_payload.append(entry)
+
+        return normalized_payload
+
+    def execution_event_stream_factory(
+        self,
+        *,
+        store: RestZenStore,
+        path: str,
+        params: QueryParams,
+    ) -> Callable[[str | None], Any]:
+        """Build the authenticated SSE stream opener used by event watching."""
+
+        def _open_stream(last_event_id: str | None) -> Any:
+            return open_rest_sse_stream(
+                cast(StreamingStore, store),
+                path=path,
+                params=params,
+                last_event_id=last_event_id,
+            )
+
+        return _open_stream
+
+    def list_deployment_snapshots(self) -> list[Any]:
+        """List all snapshots visible to the active project."""
+        client = self.zenml_client()
+        snapshots: list[Any] = []
+        page = 1
+        page_size = 100
+        try:
+            while True:
+                snapshot_page = client.list_snapshots(
+                    sort_by="asc:created",
+                    page=page,
+                    size=page_size,
+                    project=self._project,
+                    named_only=True,
+                    hydrate=True,
+                )
+                items = list(snapshot_page.items)
+                snapshots.extend(items)
+                if len(items) < page_size:
+                    break
+                page += 1
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to list deployment snapshots: {exc}"
+            ) from exc
+
+        return snapshots
+
+    def update_snapshot_tags(
+        self,
+        *,
+        deployment_id: str,
+        add_tags: list[str] | None = None,
+        remove_tags: list[str] | None = None,
+    ) -> Any:
+        """Apply native tag updates to a snapshot."""
+        try:
+            return self.zenml_client().update_snapshot(
+                name_id_or_prefix=deployment_id,
+                project=self._project,
+                add_tags=add_tags or None,
+                remove_tags=remove_tags or None,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to update deployment '{deployment_id}': {exc}"
+            ) from exc
+
+    def delete_snapshot(self, *, deployment_id: str) -> None:
+        """Delete a snapshot through the backend."""
+        try:
+            self.zenml_client().delete_snapshot(
+                name_id_or_prefix=deployment_id,
+                project=self._project,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to delete deployment '{deployment_id}': {exc}"
+            ) from exc
+
+    def name_source_snapshot(
+        self,
+        *,
+        source_snapshot: Any,
+        name: str,
+        tags: list[str],
+    ) -> Any:
+        """Name an existing snapshot as a deployment snapshot."""
+        source_snapshot_id = getattr(source_snapshot, "id", source_snapshot)
+        return self.zenml_client().update_snapshot(
+            name_id_or_prefix=source_snapshot_id,
+            project=self._project,
+            name=name,
+            replace=False,
+            add_tags=tags,
+        )
+
+    def get_deployment_stack(
+        self,
+        *,
+        stack_name_or_id: str,
+        flow: str,
+        version: int,
+    ) -> Any:
+        """Load a deployment's referenced stack by name or ID."""
+        try:
+            return self.zenml_client().get_stack(
+                name_id_or_prefix=stack_name_or_id,
+                allow_name_prefix_match=False,
+                hydrate=True,
+            )
+        except Exception as exc:
+            raise KitaruStateError(
+                f"Deployment {flow!r} v{version} references stack "
+                f"{stack_name_or_id!r}, but Kitaru could not load that stack "
+                "to verify whether the server can execute it remotely. "
+                "Rebuild the deployment using a stack the Kitaru server can "
+                "execute remotely and try again."
+            ) from exc
+
+    def zen_store(self) -> Any:
+        """Return the active backend store from a fresh client."""
+        return self.zenml_client().zen_store
+
+    def trigger_deployment(
+        self,
+        *,
+        deployment_id: str,
+        flow: str,
+        version: int,
+        run_configuration: Any,
+    ) -> Any:
+        """Trigger a deployment snapshot and return the backend run model."""
+        zenml_client = self.zenml_client()
+        trigger_pipeline = getattr(zenml_client, "trigger_pipeline", None)
+        if not callable(trigger_pipeline):
+            raise KitaruBackendError(
+                "This ZenML backend does not expose snapshot invocation via "
+                "Client.trigger_pipeline(...). Upgrade ZenML or invoke the "
+                "snapshot through a backend-supported route."
+            )
+
+        try:
+            run = trigger_pipeline(
+                snapshot_name_or_id=deployment_id,
+                run_configuration=run_configuration,
+                project=self._project,
+                synchronous=False,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to invoke deployment {flow!r} v{version}: {exc}"
+            ) from exc
+
+        if run is None:
+            raise KitaruBackendError(
+                "Deployment invocation did not produce a pipeline run."
+            )
+        return run
+
+    def create_service_account(
+        self,
+        *,
+        name: str,
+        full_name: str | None,
+        description: str,
+    ) -> Any:
+        """Create a service account."""
+        try:
+            return self.zenml_client().create_service_account(
+                name=name,
+                full_name=full_name,
+                description=description,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to create service account {name!r}: {exc}"
+            ) from exc
+
+    def get_service_account(self, *, name_or_id: str) -> Any:
+        """Get one service account by exact name or ID."""
+        try:
+            return self.zenml_client().get_service_account(
+                name_id_or_prefix=name_or_id,
+                allow_name_prefix_match=False,
+                hydrate=True,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to load service account {name_or_id!r}: {exc}"
+            ) from exc
+
+    def list_service_accounts(
+        self,
+        *,
+        active: bool | None,
+        name: str | None,
+        page: int,
+        size: int,
+    ) -> Any:
+        """List service accounts."""
+        try:
+            return self.zenml_client().list_service_accounts(
+                name=name,
+                active=active,
+                page=page,
+                size=size,
+                hydrate=True,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(f"Failed to list service accounts: {exc}") from exc
+
+    def update_service_account(
+        self,
+        *,
+        name_or_id: str,
+        name: str | None,
+        description: str | None,
+        active: bool | None,
+    ) -> Any:
+        """Update mutable service-account metadata."""
+        try:
+            return self.zenml_client().update_service_account(
+                name_id_or_prefix=name_or_id,
+                updated_name=name,
+                description=description,
+                active=active,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to update service account {name_or_id!r}: {exc}"
+            ) from exc
+
+    def delete_service_account(self, *, name_or_id: str) -> None:
+        """Delete a service account."""
+        try:
+            self.zenml_client().delete_service_account(name_id_or_prefix=name_or_id)
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to delete service account {name_or_id!r}: {exc}"
+            ) from exc
+
+    def create_api_key(
+        self,
+        *,
+        service_account: str,
+        name: str,
+        description: str,
+        set_key: bool = False,
+    ) -> APIKeyOperationResult:
+        """Create an API key and optionally set it as the local credential."""
+        zenml_client = self.zenml_client()
+        try:
+            api_key = zenml_client.create_api_key(
+                service_account_name_id_or_prefix=service_account,
+                name=name,
+                description=description,
+                set_key=False,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to create API key {name!r} for service "
+                f"account {service_account!r}: {exc}"
+            ) from exc
+
+        activation_status = None
+        if set_key:
+            activation_status = self._activate_local_api_key(
+                api_key=api_key,
+                zenml_client=zenml_client,
+                operation="create",
+            )
+        return APIKeyOperationResult(
+            api_key=api_key,
+            local_key_activation=activation_status,
+        )
+
+    def get_api_key(self, *, service_account: str, name_or_id: str) -> Any:
+        """Get metadata for one API key by exact name or ID."""
+        try:
+            return self.zenml_client().get_api_key(
+                service_account_name_id_or_prefix=service_account,
+                name_id_or_prefix=name_or_id,
+                allow_name_prefix_match=False,
+                hydrate=True,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to load API key {name_or_id!r} for service "
+                f"account {service_account!r}: {exc}"
+            ) from exc
+
+    def list_api_keys(
+        self,
+        *,
+        service_account: str,
+        active: bool | None,
+        name: str | None,
+        page: int,
+        size: int,
+    ) -> Any:
+        """List metadata for API keys owned by a service account."""
+        try:
+            return self.zenml_client().list_api_keys(
+                service_account_name_id_or_prefix=service_account,
+                name=name,
+                active=active,
+                page=page,
+                size=size,
+                hydrate=True,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                "Failed to list API keys for service account "
+                f"{service_account!r}: {exc}"
+            ) from exc
+
+    def update_api_key(
+        self,
+        *,
+        service_account: str,
+        name_or_id: str,
+        name: str | None,
+        description: str | None,
+        active: bool | None,
+    ) -> Any:
+        """Update mutable API-key metadata."""
+        try:
+            return self.zenml_client().update_api_key(
+                service_account_name_id_or_prefix=service_account,
+                name_id_or_prefix=name_or_id,
+                name=name,
+                description=description,
+                active=active,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to update API key {name_or_id!r} for service "
+                f"account {service_account!r}: {exc}"
+            ) from exc
+
+    def rotate_api_key(
+        self,
+        *,
+        service_account: str,
+        name_or_id: str,
+        retain_period_minutes: int,
+        set_key: bool = False,
+    ) -> APIKeyOperationResult:
+        """Rotate an API key and optionally set it as the local credential."""
+        zenml_client = self.zenml_client()
+        try:
+            api_key = zenml_client.rotate_api_key(
+                service_account_name_id_or_prefix=service_account,
+                name_id_or_prefix=name_or_id,
+                retain_period_minutes=retain_period_minutes,
+                set_key=False,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to rotate API key {name_or_id!r} for service "
+                f"account {service_account!r}: {exc}"
+            ) from exc
+
+        activation_status = None
+        if set_key:
+            activation_status = self._activate_local_api_key(
+                api_key=api_key,
+                zenml_client=zenml_client,
+                operation="rotate",
+            )
+        return APIKeyOperationResult(
+            api_key=api_key,
+            local_key_activation=activation_status,
+        )
+
+    def delete_api_key(self, *, service_account: str, name_or_id: str) -> None:
+        """Delete an API key."""
+        try:
+            self.zenml_client().delete_api_key(
+                service_account_name_id_or_prefix=service_account,
+                name_id_or_prefix=name_or_id,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to delete API key {name_or_id!r} for service "
+                f"account {service_account!r}: {exc}"
+            ) from exc
+
+    def _activate_local_api_key(
+        self,
+        *,
+        api_key: Any,
+        zenml_client: Any,
+        operation: Literal["create", "rotate"],
+    ) -> LocalKeyActivationStatus:
+        """Best-effort local activation that never discards the one-time key."""
+        raw_key = _api_key_raw_value(api_key)
+        previous_credential = _capture_previous_local_api_key(zenml_client)
+        try:
+            zenml_client.set_api_key(key=raw_key)
+        except Exception as exc:
+            action = "created" if operation == "create" else "rotated"
+            sanitized_error = _sanitize_local_key_activation_error(
+                exc,
+                raw_key=raw_key,
+                previous_key=previous_credential.previous_api_key,
+            )
+            base_error = (
+                f"API key was {action}, but Kitaru could not set it as the "
+                f"active local credential: {sanitized_error}."
+            )
+            if not previous_credential.previous_api_key_available:
+                rollback_reason = previous_credential.reason_unavailable or (
+                    "No previous persisted local API key was available to restore."
+                )
+                return LocalKeyActivationStatus(
+                    succeeded=False,
+                    error=f"{base_error} Rollback was not possible: {rollback_reason}",
+                    rollback_attempted=False,
+                    rollback_succeeded=None,
+                    rollback_reason=rollback_reason,
+                )
+
+            assert previous_credential.previous_api_key is not None
+            try:
+                zenml_client.set_api_key(key=previous_credential.previous_api_key)
+            except Exception as rollback_exc:
+                rollback_error = _sanitize_local_key_activation_error(
+                    rollback_exc,
+                    raw_key=raw_key,
+                    previous_key=previous_credential.previous_api_key,
+                )
+                return LocalKeyActivationStatus(
+                    succeeded=False,
+                    error=(
+                        f"{base_error} Kitaru also tried to restore the previous "
+                        "local credential, but that rollback failed. The server-side "
+                        f"API key was still {action}; local credentials may need "
+                        "manual repair."
+                    ),
+                    rollback_attempted=True,
+                    rollback_succeeded=False,
+                    rollback_error=rollback_error,
+                )
+
+            return LocalKeyActivationStatus(
+                succeeded=False,
+                error=(
+                    f"{base_error} Kitaru restored the previous local credential, "
+                    "so this machine should still be using the credential that was "
+                    "active before the attempted activation."
+                ),
+                rollback_attempted=True,
+                rollback_succeeded=True,
+            )
+        return LocalKeyActivationStatus(succeeded=True)
+
+    @staticmethod
+    def _stack_operation_is_patched(name: str, operation: Any) -> bool:
+        """Return whether a stack terminal function has been monkeypatched."""
+        return operation is not _ORIGINAL_STACK_OPERATIONS[name]
+
+    def _call_stack_operation(
+        self,
+        name: str,
+        operation: Any,
+        *,
+        patched_call: Callable[[], Any],
+        default_call: Callable[[], Any],
+    ) -> Any:
+        """Call a patched stack operation unchanged, otherwise inject gateway deps."""
+        if self._stack_operation_is_patched(name, operation):
+            return patched_call()
+        return default_call()
+
+    def current_stack(self) -> Any:
+        """Return the currently active stack."""
+        operation = stack_ops.current_stack
+        return self._call_stack_operation(
+            "current_stack",
+            operation,
+            patched_call=lambda: operation(),
+            default_call=lambda: operation(client_factory=self.zenml_client),
+        )
+
+    def list_stack_entries(self) -> list[Any]:
+        """List stacks with active + managed metadata for structured output."""
+        operation = stack_ops._list_stack_entries
+        return self._call_stack_operation(
+            "list_stack_entries",
+            operation,
+            patched_call=lambda: operation(),
+            default_call=lambda: operation(client_factory=self.zenml_client),
+        )
+
+    def show_stack_operation(self, name_or_id: str) -> Any:
+        """Inspect one stack and translate its component metadata."""
+        operation = stack_ops._show_stack_operation
+        return self._call_stack_operation(
+            "show_stack_operation",
+            operation,
+            patched_call=lambda: operation(name_or_id),
+            default_call=lambda: operation(
+                name_or_id,
+                client_factory=self.zenml_client,
+            ),
+        )
+
+    def _remote_stack_create_overrides(self) -> dict[Any, Callable[..., Any]]:
+        """Build stack-type dispatch functions using this gateway's client factory."""
+        return {
+            stack_ops.StackType.LOCAL: self.create_local_stack_operation,
+            stack_ops.StackType.KUBERNETES: self.create_kubernetes_stack_operation,
+            stack_ops.StackType.VERTEX: self.create_vertex_stack_operation,
+            stack_ops.StackType.SAGEMAKER: self.create_sagemaker_stack_operation,
+            stack_ops.StackType.AZUREML: self.create_azureml_stack_operation,
+        }
+
+    def create_stack_operation(self, name: str, **kwargs: Any) -> Any:
+        """Create a stack by dispatching to the requested stack type flow."""
+        operation = stack_ops._create_stack_operation
+        result = self._call_stack_operation(
+            "create_stack_operation",
+            operation,
+            patched_call=lambda: operation(name, **kwargs),
+            default_call=lambda: operation(
+                name,
+                **kwargs,
+                operation_overrides=self._remote_stack_create_overrides(),
+            ),
+        )
+        if self._stack_operation_is_patched("create_stack_operation", operation):
+            return result
+
+        from kitaru.analytics import AnalyticsEvent, track
+
+        track(
+            AnalyticsEvent.STACK_CREATED,
+            {
+                "stack_type": kwargs.get("stack_type", stack_ops.StackType.LOCAL).value,
+                "activate_requested": kwargs.get("activate", True),
+            },
+        )
+        return result
+
+    def create_local_stack_operation(self, name: str, **kwargs: Any) -> Any:
+        """Create a new local stack and return operation details."""
+        operation = stack_ops._create_local_stack_operation
+        return self._call_stack_operation(
+            "create_local_stack_operation",
+            operation,
+            patched_call=lambda: operation(name, **kwargs),
+            default_call=lambda: operation(
+                name,
+                **kwargs,
+                client_factory=self.zenml_client,
+                current_stack_getter=self.current_stack,
+            ),
+        )
+
+    def create_kubernetes_stack_operation(self, name: str, **kwargs: Any) -> Any:
+        """Create a Kubernetes-backed stack."""
+        operation = stack_ops._create_kubernetes_stack_operation
+        return self._call_stack_operation(
+            "create_kubernetes_stack_operation",
+            operation,
+            patched_call=lambda: operation(name, **kwargs),
+            default_call=lambda: operation(
+                name,
+                **kwargs,
+                client_factory=self.zenml_client,
+            ),
+        )
+
+    def create_vertex_stack_operation(self, name: str, **kwargs: Any) -> Any:
+        """Create a Vertex AI stack."""
+        operation = stack_ops._create_vertex_stack_operation
+        return self._call_stack_operation(
+            "create_vertex_stack_operation",
+            operation,
+            patched_call=lambda: operation(name, **kwargs),
+            default_call=lambda: operation(
+                name,
+                **kwargs,
+                client_factory=self.zenml_client,
+            ),
+        )
+
+    def create_sagemaker_stack_operation(self, name: str, **kwargs: Any) -> Any:
+        """Create a SageMaker stack."""
+        operation = stack_ops._create_sagemaker_stack_operation
+        return self._call_stack_operation(
+            "create_sagemaker_stack_operation",
+            operation,
+            patched_call=lambda: operation(name, **kwargs),
+            default_call=lambda: operation(
+                name,
+                **kwargs,
+                client_factory=self.zenml_client,
+            ),
+        )
+
+    def create_azureml_stack_operation(self, name: str, **kwargs: Any) -> Any:
+        """Create an AzureML stack."""
+        operation = stack_ops._create_azureml_stack_operation
+        return self._call_stack_operation(
+            "create_azureml_stack_operation",
+            operation,
+            patched_call=lambda: operation(name, **kwargs),
+            default_call=lambda: operation(
+                name,
+                **kwargs,
+                client_factory=self.zenml_client,
+            ),
+        )
+
+    def delete_stack_operation(self, name_or_id: str, **kwargs: Any) -> Any:
+        """Delete a stack and return operation details."""
+        operation = stack_ops._delete_stack_operation
+        return self._call_stack_operation(
+            "delete_stack_operation",
+            operation,
+            patched_call=lambda: operation(name_or_id, **kwargs),
+            default_call=lambda: operation(
+                name_or_id,
+                **kwargs,
+                client_factory=self.zenml_client,
+                current_stack_getter=self.current_stack,
+            ),
+        )
+
+    def list_stacks(self) -> list[Any]:
+        """List stacks visible to the current user and mark the active one."""
+        return [entry.stack for entry in self.list_stack_entries()]
+
+    def use_stack(self, name_or_id: str) -> Any:
+        """Set the active stack and return the resulting stack info."""
+        operation = stack_ops.use_stack
+        result = self._call_stack_operation(
+            "use_stack",
+            operation,
+            patched_call=lambda: operation(name_or_id),
+            default_call=lambda: operation(
+                name_or_id,
+                client_factory=self.zenml_client,
+                current_stack_getter=self.current_stack,
+            ),
+        )
+
+        from kitaru.analytics import AnalyticsEvent, track
+
+        track(AnalyticsEvent.STACK_ACTIVATED, {})
+        return result
+
+
+__all__ = ["APIKeyOperationResult", "KitaruBackendGateway", "LocalKeyActivationStatus"]

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -181,31 +181,22 @@ def _list_checkpoint_attempts_for_run(
     page = 1
     page_size = 200
 
-    try:
-        while True:
-            step_page = client._client().list_run_steps(
-                sort_by="asc:created",
-                page=page,
-                size=page_size,
-                pipeline_run_id=run.id,
-                project=client._project,
-                exclude_retried=False,
-                hydrate=True,
-            )
-            step_items = list(step_page.items)
-            if not step_items:
-                break
+    while True:
+        step_page = client._backend.list_run_steps(
+            run_id=run.id,
+            page=page,
+            size=page_size,
+        )
+        step_items = list(step_page.items)
+        if not step_items:
+            break
 
-            for step in step_items:
-                grouped_attempts[_checkpoint_lineage_key(step)].append(step)
+        for step in step_items:
+            grouped_attempts[_checkpoint_lineage_key(step)].append(step)
 
-            if len(step_items) < page_size:
-                break
-            page += 1
-    except Exception as exc:
-        raise KitaruBackendError(
-            f"Failed to fetch checkpoint attempts for execution {run.id}: {exc}"
-        ) from exc
+        if len(step_items) < page_size:
+            break
+        page += 1
 
     return dict(grouped_attempts)
 
@@ -394,26 +385,10 @@ def _list_run_wait_conditions(
     status: str | None = None,
 ) -> list[Any]:
     """Return wait-condition models for an execution."""
-    try:
-        wait_conditions_page = cast(Any, client._client()).list_run_wait_conditions(
-            pipeline_run=run.id,
-            project=client._project,
-            status=status,
-            hydrate=True,
-            sort_by="asc:created",
-            size=200,
-        )
-    except AttributeError:
-        return []
-    except Exception as exc:
-        operation = (
-            "pending waits" if status == _WAIT_CONDITION_STATUS_PENDING else "waits"
-        )
-        raise KitaruBackendError(
-            f"Failed to list {operation} for execution {run.id}: {exc}"
-        ) from exc
-
-    return list(wait_conditions_page.items)
+    return client._backend.list_run_wait_conditions(
+        run_id=run.id,
+        status=status,
+    )
 
 
 def _list_pending_wait_conditions(

--- a/src/kitaru/_stack_binding.py
+++ b/src/kitaru/_stack_binding.py
@@ -1,0 +1,34 @@
+"""Shared helpers for temporarily binding the active ZenML stack."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Any
+
+STACK_BINDING_LOCK = threading.RLock()
+
+
+@contextmanager
+def temporary_active_stack(
+    stack_name_or_id: str | None,
+    *,
+    client_factory: Callable[[], Any],
+) -> Iterator[Any | None]:
+    """Temporarily activate a stack while holding the process stack lock."""
+    with STACK_BINDING_LOCK:
+        if not stack_name_or_id:
+            yield None
+            return
+
+        client = client_factory()
+        old_stack_id = client.active_stack_model.id
+        client.activate_stack(stack_name_or_id)
+        try:
+            yield client
+        finally:
+            client.activate_stack(old_stack_id)
+
+
+__all__ = ["STACK_BINDING_LOCK", "temporary_active_stack"]

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -23,21 +23,22 @@ import threading
 import warnings
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast, runtime_checkable
 
-from pydantic import ValidationError
 from zenml.client import Client
 from zenml.config.pipeline_run_configuration import PipelineRunConfiguration
 from zenml.enums import ExecutionStatus as ZenMLExecutionStatus
 from zenml.exceptions import EntityExistsError
-from zenml.login.credentials_store import get_credentials_store
 from zenml.models import PipelineRunResponse
 from zenml.models.v2.core.artifact_version import ArtifactVersionResponse
 from zenml.utils.run_utils import stop_run
 from zenml.zen_stores.rest_zen_store import RestZenStore
 
+from kitaru._client._backend_gateway import (
+    KitaruBackendGateway,
+    LocalKeyActivationStatus,
+)
 from kitaru._client._deployments import (
     DEFAULT_DEPLOYMENT_TAG,
     build_deployment_snapshot_name,
@@ -51,11 +52,7 @@ from kitaru._client._deployments import (
     validate_deployment_tag,
     validate_deployment_version,
 )
-from kitaru._client._events import (
-    StreamingStore,
-    open_rest_sse_stream,
-    watch_execution_events,
-)
+from kitaru._client._events import watch_execution_events
 from kitaru._client._logs import (
     _coerce_log_level,
     _coerce_log_lineno,
@@ -139,7 +136,6 @@ from kitaru.errors import (
     KitaruRuntimeError,
     KitaruStateError,
     KitaruUsageError,
-    KitaruWaitValidationError,
     classify_failure_origin,
     execution_error_from_failure,
 )
@@ -177,6 +173,7 @@ _CLIENT_FACADE_LINT_ANCHOR = (
     _first_pending_wait,
     _get_active_wait_condition,
     _is_empty_log_result_error,
+    _is_log_endpoint_version_skew_error,
     _is_otel_log_retrieval_error,
     _list_checkpoint_attempts_for_run,
     _list_run_wait_conditions,
@@ -274,175 +271,23 @@ def _map_auth_api_key_with_value(api_key: Any) -> AuthAPIKeyWithValue:
     )
 
 
-@dataclass(frozen=True)
-class _LocalCredentialSnapshot:
-    """Best-effort snapshot of the previous persisted API-key credential."""
-
-    server_url: str | None
-    previous_api_key: str | None = field(default=None, repr=False)
-    reason_unavailable: str | None = None
-
-    @property
-    def previous_api_key_available(self) -> bool:
-        """Whether this snapshot contains a rollback candidate."""
-        return bool(self.previous_api_key)
-
-
-def _redact_auth_error_text(text: str, *, secrets: list[str]) -> str:
-    """Return error text without leaking known sensitive credential values."""
-    redacted = text
-    for secret in secrets:
-        if secret:
-            redacted = redacted.replace(secret, "[redacted]")
-    return redacted
-
-
-def _sanitize_local_key_activation_error(
-    exc: Exception,
-    *,
-    raw_key: str,
-    previous_key: str | None = None,
-) -> str:
-    """Return local activation error text without leaking API-key values."""
-    message = str(exc) or type(exc).__name__
-    return _redact_auth_error_text(
-        message,
-        secrets=[raw_key, previous_key or ""],
-    )
-
-
-def _capture_previous_local_api_key(zenml_client: Any) -> _LocalCredentialSnapshot:
-    """Return the previous persisted API key if it can be restored safely."""
-    server_url = getattr(getattr(zenml_client, "zen_store", None), "url", None)
-    if not isinstance(server_url, str) or not server_url:
-        return _LocalCredentialSnapshot(
-            server_url=None,
-            reason_unavailable=(
-                "Kitaru could not determine the active remote server URL, so "
-                "there was no previous persisted credential to restore."
-            ),
-        )
-
-    try:
-        credentials_store = get_credentials_store()
-        previous_api_key = credentials_store.get_api_key(server_url=server_url)
-    except Exception as exc:
-        return _LocalCredentialSnapshot(
-            server_url=server_url,
-            reason_unavailable=(
-                "Kitaru could not read the previous persisted local API key for "
-                f"{server_url!r}, so rollback was not possible: {exc}"
-            ),
-        )
-
-    if not previous_api_key:
-        return _LocalCredentialSnapshot(
-            server_url=server_url,
-            reason_unavailable=(
-                "No previous persisted local API key was available to restore. "
-                "Environment credentials, if any, were not modified."
-            ),
-        )
-
-    return _LocalCredentialSnapshot(
-        server_url=server_url,
-        previous_api_key=previous_api_key,
-    )
-
-
 def _with_local_key_activation_status(
     result: AuthAPIKeyWithValue,
     *,
-    succeeded: bool,
-    error: str | None = None,
-    rollback_attempted: bool = False,
-    rollback_succeeded: bool | None = None,
-    rollback_error: str | None = None,
-    rollback_reason: str | None = None,
+    status: LocalKeyActivationStatus,
 ) -> AuthAPIKeyWithValue:
     """Return an API-key result annotated with local activation status."""
     return AuthAPIKeyWithValue(
         api_key=result.api_key,
         key=result.key,
         local_key_activation_requested=True,
-        local_key_activation_succeeded=succeeded,
-        local_key_activation_error=error,
-        local_key_rollback_attempted=rollback_attempted,
-        local_key_rollback_succeeded=rollback_succeeded,
-        local_key_rollback_error=rollback_error,
-        local_key_rollback_reason=rollback_reason,
+        local_key_activation_succeeded=status.succeeded,
+        local_key_activation_error=status.error,
+        local_key_rollback_attempted=status.rollback_attempted,
+        local_key_rollback_succeeded=status.rollback_succeeded,
+        local_key_rollback_error=status.rollback_error,
+        local_key_rollback_reason=status.rollback_reason,
     )
-
-
-def _attempt_local_key_activation(
-    result: AuthAPIKeyWithValue,
-    *,
-    zenml_client: Any,
-    operation: Literal["create", "rotate"],
-) -> AuthAPIKeyWithValue:
-    """Best-effort local activation that never discards the one-time key."""
-    previous_credential = _capture_previous_local_api_key(zenml_client)
-    try:
-        zenml_client.set_api_key(key=result.key)
-    except Exception as exc:
-        action = "created" if operation == "create" else "rotated"
-        sanitized_error = _sanitize_local_key_activation_error(
-            exc,
-            raw_key=result.key,
-            previous_key=previous_credential.previous_api_key,
-        )
-        base_error = (
-            f"API key was {action}, but Kitaru could not set it as the "
-            f"active local credential: {sanitized_error}."
-        )
-        if not previous_credential.previous_api_key_available:
-            rollback_reason = previous_credential.reason_unavailable or (
-                "No previous persisted local API key was available to restore."
-            )
-            return _with_local_key_activation_status(
-                result,
-                succeeded=False,
-                error=f"{base_error} Rollback was not possible: {rollback_reason}",
-                rollback_attempted=False,
-                rollback_succeeded=None,
-                rollback_reason=rollback_reason,
-            )
-
-        assert previous_credential.previous_api_key is not None
-        try:
-            zenml_client.set_api_key(key=previous_credential.previous_api_key)
-        except Exception as rollback_exc:
-            rollback_error = _sanitize_local_key_activation_error(
-                rollback_exc,
-                raw_key=result.key,
-                previous_key=previous_credential.previous_api_key,
-            )
-            return _with_local_key_activation_status(
-                result,
-                succeeded=False,
-                error=(
-                    f"{base_error} Kitaru also tried to restore the previous "
-                    "local credential, but that rollback failed. The server-side "
-                    f"API key was still {action}; local credentials may need "
-                    "manual repair."
-                ),
-                rollback_attempted=True,
-                rollback_succeeded=False,
-                rollback_error=rollback_error,
-            )
-
-        return _with_local_key_activation_status(
-            result,
-            succeeded=False,
-            error=(
-                f"{base_error} Kitaru restored the previous local credential, "
-                "so this machine should still be using the credential that was "
-                "active before the attempted activation."
-            ),
-            rollback_attempted=True,
-            rollback_succeeded=True,
-        )
-    return _with_local_key_activation_status(result, succeeded=True)
 
 
 @runtime_checkable
@@ -457,22 +302,6 @@ class _ReplayFlowLike(Protocol):
         overrides: dict[str, Any] | None = None,
         **flow_inputs: Any,
     ) -> Any: ...
-
-
-@contextmanager
-def _temporary_active_stack(stack_name_or_id: str | None) -> Iterator[None]:
-    """Temporarily activate a stack while running an operation."""
-    if not stack_name_or_id:
-        yield
-        return
-
-    client = Client()
-    old_stack_id = client.active_stack_model.id
-    client.activate_stack(stack_name_or_id)
-    try:
-        yield
-    finally:
-        client.activate_stack(old_stack_id)
 
 
 def _snapshot_source_parts(run: PipelineRunResponse) -> tuple[str, str | None]:
@@ -730,31 +559,7 @@ def _restart_run_from_snapshot(
     operation_name: str,
 ) -> None:
     """Restart an execution from its stored snapshot metadata."""
-    snapshot = run.snapshot
-    if snapshot is None:
-        raise KitaruRuntimeError(
-            f"Unable to {operation_name} execution because snapshot metadata "
-            "is missing."
-        )
-    if snapshot.stack is None:
-        raise KitaruRuntimeError(
-            f"Unable to {operation_name} execution because snapshot stack "
-            "metadata is missing."
-        )
-
-    try:
-        with _temporary_active_stack(str(snapshot.stack.id)):
-            active_stack = client._client().active_stack
-            orchestrator = cast(Any, active_stack.orchestrator)
-            orchestrator.resume_run(
-                snapshot=snapshot,
-                run=run,
-                stack=active_stack,
-            )
-    except Exception as exc:
-        raise KitaruBackendError(
-            f"Failed to {operation_name} execution '{run.id}': {exc}"
-        ) from exc
+    client._backend.restart_run_from_snapshot(run=run, operation_name=operation_name)
 
 
 def _validate_event_filter_values(
@@ -821,10 +626,7 @@ class _ExecutionsAPI:
 
     def _require_rest_store(self, unavailable_error: Exception) -> RestZenStore:
         """Return the active REST store or raise the caller-specific error."""
-        zen_store = self._client_ref._client().zen_store
-        if isinstance(zen_store, RestZenStore):
-            return zen_store
-        raise unavailable_error
+        return self._client_ref._backend.require_rest_store(unavailable_error)
 
     def _rest_store(self) -> RestZenStore:
         """Return a REST-backed zen store required for runtime log retrieval."""
@@ -847,16 +649,7 @@ class _ExecutionsAPI:
 
     def _resolve_log_endpoint_hint(self) -> str | None:
         """Resolve a best-effort endpoint hint for log-retrieval errors."""
-        active_log_store = active_stack_log_store()
-        if active_log_store is not None and active_log_store.endpoint:
-            return active_log_store.endpoint
-
-        try:
-            preferred_log_store = resolve_log_store()
-        except ValueError:
-            return None
-
-        return preferred_log_store.endpoint
+        return self._client_ref._backend.resolve_log_endpoint_hint()
 
     def _fetch_log_payload(
         self,
@@ -865,54 +658,11 @@ class _ExecutionsAPI:
         source: str,
     ) -> builtins.list[Mapping[str, Any]]:
         """Call a log endpoint and normalize the response payload shape."""
-        store = self._rest_store()
-
-        try:
-            payload = store.get(path, params={"source": source})
-        except Exception as exc:
-            error_message = str(exc)
-            if _is_empty_log_result_error(error_message):
-                return []
-
-            if _is_otel_log_retrieval_error(error_message):
-                endpoint_hint = self._resolve_log_endpoint_hint()
-                message = (
-                    "Logs for this execution are stored in an OTEL backend and "
-                    "cannot be fetched via the Kitaru log retrieval API."
-                )
-                if endpoint_hint:
-                    message += f" View them in your OTEL backend at: {endpoint_hint}."
-                raise KitaruLogRetrievalError(message) from exc
-
-            if _is_log_endpoint_version_skew_error(error_message):
-                raise KitaruLogRetrievalError(
-                    "Unable to retrieve runtime logs because the server log "
-                    "endpoint is incompatible with this Kitaru client. This "
-                    "usually means the client and server are running different "
-                    "Kitaru versions. Upgrade the server runtime or align the "
-                    "client and server versions, then retry `kitaru executions "
-                    "logs`."
-                ) from exc
-
-            raise KitaruLogRetrievalError(
-                f"Failed to retrieve runtime logs for source '{source}': {exc}"
-            ) from exc
-
-        if not isinstance(payload, list):
-            raise KitaruLogRetrievalError(
-                "Unexpected response while retrieving runtime logs: "
-                "expected a list payload."
-            )
-
-        normalized_payload: builtins.list[Mapping[str, Any]] = []
-        for entry in payload:
-            if not isinstance(entry, Mapping):
-                raise KitaruLogRetrievalError(
-                    "Unexpected log entry payload type returned by the server."
-                )
-            normalized_payload.append(entry)
-
-        return normalized_payload
+        return self._client_ref._backend.fetch_log_payload(
+            path=path,
+            source=source,
+            store=self._rest_store(),
+        )
 
     def logs(
         self,
@@ -1043,16 +793,12 @@ class _ExecutionsAPI:
 
         path = f"/runs/{run.id}/events/stream"
 
-        def _open_stream(last_event_id: str | None) -> Any:
-            return open_rest_sse_stream(
-                cast(StreamingStore, store),
+        return watch_execution_events(
+            open_stream=self._client_ref._backend.execution_event_stream_factory(
+                store=store,
                 path=path,
                 params=params,
-                last_event_id=last_event_id,
-            )
-
-        return watch_execution_events(
-            open_stream=_open_stream,
+            ),
             fallback_exec_id=str(run.id),
             checkpoint=normalized_checkpoint,
             reconnect=reconnect,
@@ -1092,22 +838,13 @@ class _ExecutionsAPI:
             pending_conditions=pending_conditions,
         )
 
-        try:
-            cast(Any, self._client_ref._client()).resolve_run_wait_condition(
-                run_wait_condition_id=condition.id,
-                resolution=cast(Any, resolution),
-                result=value,
-            )
-        except (ValidationError, TypeError, ValueError) as exc:
-            raise KitaruWaitValidationError(
-                "Wait input failed validation for "
-                f"'{condition.name}' on execution '{exec_id}': {exc}"
-            ) from exc
-        except Exception as exc:
-            raise KitaruBackendError(
-                "Failed to resolve wait condition "
-                f"'{condition.name}' for execution '{exec_id}': {exc}"
-            ) from exc
+        self._client_ref._backend.resolve_run_wait_condition(
+            run_wait_condition_id=condition.id,
+            resolution=cast(Any, resolution),
+            result=value,
+            wait_name=condition.name,
+            exec_id=exec_id,
+        )
 
         track(
             AnalyticsEvent.WAIT_RESOLVED,
@@ -1341,12 +1078,9 @@ class _ExecutionsAPI:
             page_size = 50
 
         while True:
-            run_page = self._client_ref._client().list_pipeline_runs(
-                sort_by="desc:created",
+            run_page = self._client_ref._backend.list_pipeline_runs(
                 page=backend_page,
                 size=page_size,
-                project=self._client_ref._project,
-                hydrate=True,
             )
             runs = list(run_page.items)
             if not runs:
@@ -1398,7 +1132,7 @@ class _ExecutionsAPI:
     def cancel(self, exec_id: str) -> Execution:
         """Cancel an execution if supported by the backend state."""
         run = self._client_ref._get_pipeline_run(exec_id, hydrate=True)
-        stop_run(run=run, graceful=False)
+        self._client_ref._backend.cancel_run(run, stop_run_fn=stop_run)
         track(AnalyticsEvent.EXECUTION_CANCELLED, {})
         return self.get(exec_id)
 
@@ -1449,7 +1183,7 @@ class _ArtifactsAPI:
 
         producing_call: str | None = None
         if artifact.producer_step_run_id is not None:
-            step = self._client_ref._client().get_run_step(
+            step = self._client_ref._backend.get_run_step(
                 artifact.producer_step_run_id,
                 hydrate=True,
             )
@@ -1470,31 +1204,7 @@ class _DeploymentsAPI:
 
     def _list_snapshots(self) -> builtins.list[Any]:
         """List all snapshots visible to the active project."""
-        client = self._client_ref._client()
-        snapshots: builtins.list[Any] = []
-        page = 1
-        page_size = 100
-        try:
-            while True:
-                snapshot_page = client.list_snapshots(
-                    sort_by="asc:created",
-                    page=page,
-                    size=page_size,
-                    project=self._client_ref._project,
-                    named_only=True,
-                    hydrate=True,
-                )
-                items = list(snapshot_page.items)
-                snapshots.extend(items)
-                if len(items) < page_size:
-                    break
-                page += 1
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to list deployment snapshots: {exc}"
-            ) from exc
-
-        return snapshots
+        return self._client_ref._backend.list_deployment_snapshots()
 
     def _update_snapshot_tags(
         self,
@@ -1504,29 +1214,17 @@ class _DeploymentsAPI:
         remove_tags: builtins.list[str] | None = None,
     ) -> Any:
         """Apply native tag updates to a snapshot."""
-        try:
-            return self._client_ref._client().update_snapshot(
-                name_id_or_prefix=deployment.deployment_id,
-                project=self._client_ref._project,
-                add_tags=add_tags or None,
-                remove_tags=remove_tags or None,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to update deployment '{deployment.deployment_id}': {exc}"
-            ) from exc
+        return self._client_ref._backend.update_snapshot_tags(
+            deployment_id=deployment.deployment_id,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
+        )
 
     def _delete_snapshot(self, deployment: DeploymentRecord) -> None:
         """Delete a snapshot through the backend."""
-        try:
-            self._client_ref._client().delete_snapshot(
-                name_id_or_prefix=deployment.deployment_id,
-                project=self._client_ref._project,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to delete deployment '{deployment.deployment_id}': {exc}"
-            ) from exc
+        self._client_ref._backend.delete_snapshot(
+            deployment_id=deployment.deployment_id,
+        )
 
     def _name_source_snapshot(
         self,
@@ -1536,13 +1234,10 @@ class _DeploymentsAPI:
         tags: Mapping[str, bool] | None,
     ) -> Any:
         """Name an existing ZenML snapshot as the requested deployment snapshot."""
-        source_snapshot_id = getattr(source_snapshot, "id", source_snapshot)
-        return self._client_ref._client().update_snapshot(
-            name_id_or_prefix=source_snapshot_id,
-            project=self._client_ref._project,
+        return self._client_ref._backend.name_source_snapshot(
+            source_snapshot=source_snapshot,
             name=name,
-            replace=False,
-            add_tags=deployment_native_tags(tags),
+            tags=deployment_native_tags(tags),
         )
 
     def _list_records(
@@ -1648,21 +1343,11 @@ class _DeploymentsAPI:
             build = getattr(snapshot, "build", None)
             stack = getattr(build, "stack", None) if build is not None else None
         if stack is None and deployment_record.stack is not None:
-            try:
-                stack = self._client_ref._client().get_stack(
-                    name_id_or_prefix=deployment_record.stack,
-                    allow_name_prefix_match=False,
-                    hydrate=True,
-                )
-            except Exception as exc:
-                raise KitaruStateError(
-                    f"Deployment {deployment_record.flow!r} "
-                    f"v{deployment_record.version} references stack "
-                    f"{deployment_record.stack!r}, but Kitaru could not load "
-                    "that stack to verify whether the server can execute it remotely. "
-                    "Rebuild the deployment using a stack the Kitaru server can "
-                    "execute remotely and try again."
-                ) from exc
+            stack = self._client_ref._backend.get_deployment_stack(
+                stack_name_or_id=deployment_record.stack,
+                flow=deployment_record.flow,
+                version=deployment_record.version,
+            )
         if stack is None:
             raise KitaruStateError(
                 f"Deployment {deployment_record.flow!r} "
@@ -1683,7 +1368,7 @@ class _DeploymentsAPI:
         deployment_record = self._unwrap_deployment_record(deployment)
         stack = self._resolve_deployment_stack(deployment_record)
         ensure_stack_is_server_runnable(
-            zen_store=self._client_ref._client().zen_store,
+            zen_store=self._client_ref._backend.zen_store(),
             stack=stack,
             operation=operation,
             flow=deployment_record.flow,
@@ -1749,36 +1434,16 @@ class _DeploymentsAPI:
         )
         deployment_metadata = deployment_metadata_for_stack_model(deployment_stack)
 
-        zenml_client = self._client_ref._client()
-        trigger_pipeline = getattr(zenml_client, "trigger_pipeline", None)
-        if not callable(trigger_pipeline):
-            raise KitaruBackendError(
-                "This ZenML backend does not expose snapshot invocation via "
-                "Client.trigger_pipeline(...). Upgrade ZenML or invoke the "
-                "snapshot through a backend-supported route."
-            )
-
         run_inputs = dict(inputs or {})
         run_configuration = (
             PipelineRunConfiguration(parameters=run_inputs) if run_inputs else None
         )
-        try:
-            run = trigger_pipeline(
-                snapshot_name_or_id=deployment.deployment_id,
-                run_configuration=run_configuration,
-                project=self._client_ref._project,
-                synchronous=False,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                "Failed to invoke deployment "
-                f"{deployment.flow!r} v{deployment.version}: {exc}"
-            ) from exc
-
-        if run is None:
-            raise KitaruBackendError(
-                "Deployment invocation did not produce a pipeline run."
-            )
+        run = self._client_ref._backend.trigger_deployment(
+            deployment_id=deployment.deployment_id,
+            flow=deployment.flow,
+            version=deployment.version,
+            run_configuration=run_configuration,
+        )
         return FlowHandle(
             run,
             analytics_metadata=deployment_metadata,
@@ -2050,16 +1715,11 @@ class _ServiceAccountsAPI:
     ) -> AuthServiceAccount:
         """Create a service account."""
         validated_name = _validate_non_empty_auth_value(name, name="name")
-        try:
-            service_account = self._client_ref._client().create_service_account(
-                name=validated_name,
-                full_name=full_name,
-                description=description,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to create service account {validated_name!r}: {exc}"
-            ) from exc
+        service_account = self._client_ref._backend.create_service_account(
+            name=validated_name,
+            full_name=full_name,
+            description=description,
+        )
         return _map_auth_service_account(service_account)
 
     def get(self, name_or_id: str) -> AuthServiceAccount:
@@ -2068,16 +1728,9 @@ class _ServiceAccountsAPI:
             name_or_id,
             name="name_or_id",
         )
-        try:
-            service_account = self._client_ref._client().get_service_account(
-                name_id_or_prefix=validated_name_or_id,
-                allow_name_prefix_match=False,
-                hydrate=True,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to load service account {validated_name_or_id!r}: {exc}"
-            ) from exc
+        service_account = self._client_ref._backend.get_service_account(
+            name_or_id=validated_name_or_id,
+        )
         return _map_auth_service_account(service_account)
 
     def list(
@@ -2095,16 +1748,12 @@ class _ServiceAccountsAPI:
             page=page,
             size=size,
         )
-        try:
-            service_accounts = self._client_ref._client().list_service_accounts(
-                name=name,
-                active=active,
-                page=backend_page,
-                size=backend_size,
-                hydrate=True,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(f"Failed to list service accounts: {exc}") from exc
+        service_accounts = self._client_ref._backend.list_service_accounts(
+            name=name,
+            active=active,
+            page=backend_page,
+            size=backend_size,
+        )
         return [_map_auth_service_account(item) for item in service_accounts.items]
 
     def update(
@@ -2120,17 +1769,12 @@ class _ServiceAccountsAPI:
             name_or_id,
             name="name_or_id",
         )
-        try:
-            service_account = self._client_ref._client().update_service_account(
-                name_id_or_prefix=validated_name_or_id,
-                updated_name=name,
-                description=description,
-                active=active,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to update service account {validated_name_or_id!r}: {exc}"
-            ) from exc
+        service_account = self._client_ref._backend.update_service_account(
+            name_or_id=validated_name_or_id,
+            name=name,
+            description=description,
+            active=active,
+        )
         return _map_auth_service_account(service_account)
 
     def delete(self, name_or_id: str) -> None:
@@ -2139,14 +1783,9 @@ class _ServiceAccountsAPI:
             name_or_id,
             name="name_or_id",
         )
-        try:
-            self._client_ref._client().delete_service_account(
-                name_id_or_prefix=validated_name_or_id
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to delete service account {validated_name_or_id!r}: {exc}"
-            ) from exc
+        self._client_ref._backend.delete_service_account(
+            name_or_id=validated_name_or_id,
+        )
 
 
 class _APIKeysAPI:
@@ -2169,26 +1808,18 @@ class _APIKeysAPI:
             name="service_account",
         )
         validated_name = _validate_non_empty_auth_value(name, name="name")
-        try:
-            zenml_client = self._client_ref._client()
-            api_key = zenml_client.create_api_key(
-                service_account_name_id_or_prefix=validated_service_account,
-                name=validated_name,
-                description=description,
-                set_key=False,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to create API key {validated_name!r} for service "
-                f"account {validated_service_account!r}: {exc}"
-            ) from exc
+        backend_result = self._client_ref._backend.create_api_key(
+            service_account=validated_service_account,
+            name=validated_name,
+            description=description,
+            set_key=set_key,
+        )
 
-        result = _map_auth_api_key_with_value(api_key)
-        if set_key:
-            return _attempt_local_key_activation(
+        result = _map_auth_api_key_with_value(backend_result.api_key)
+        if backend_result.local_key_activation is not None:
+            return _with_local_key_activation_status(
                 result,
-                zenml_client=zenml_client,
-                operation="create",
+                status=backend_result.local_key_activation,
             )
         return result
 
@@ -2202,18 +1833,10 @@ class _APIKeysAPI:
             name_or_id,
             name="name_or_id",
         )
-        try:
-            api_key = self._client_ref._client().get_api_key(
-                service_account_name_id_or_prefix=validated_service_account,
-                name_id_or_prefix=validated_name_or_id,
-                allow_name_prefix_match=False,
-                hydrate=True,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to load API key {validated_name_or_id!r} for service "
-                f"account {validated_service_account!r}: {exc}"
-            ) from exc
+        api_key = self._client_ref._backend.get_api_key(
+            service_account=validated_service_account,
+            name_or_id=validated_name_or_id,
+        )
         return _map_auth_api_key(api_key)
 
     def list(
@@ -2236,20 +1859,13 @@ class _APIKeysAPI:
             service_account,
             name="service_account",
         )
-        try:
-            api_keys = self._client_ref._client().list_api_keys(
-                service_account_name_id_or_prefix=validated_service_account,
-                name=name,
-                active=active,
-                page=backend_page,
-                size=backend_size,
-                hydrate=True,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to list API keys for service account "
-                f"{validated_service_account!r}: {exc}"
-            ) from exc
+        api_keys = self._client_ref._backend.list_api_keys(
+            service_account=validated_service_account,
+            name=name,
+            active=active,
+            page=backend_page,
+            size=backend_size,
+        )
         return [_map_auth_api_key(item) for item in api_keys.items]
 
     def update(
@@ -2270,19 +1886,13 @@ class _APIKeysAPI:
             name_or_id,
             name="name_or_id",
         )
-        try:
-            api_key = self._client_ref._client().update_api_key(
-                service_account_name_id_or_prefix=validated_service_account,
-                name_id_or_prefix=validated_name_or_id,
-                name=name,
-                description=description,
-                active=active,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to update API key {validated_name_or_id!r} for service "
-                f"account {validated_service_account!r}: {exc}"
-            ) from exc
+        api_key = self._client_ref._backend.update_api_key(
+            service_account=validated_service_account,
+            name_or_id=validated_name_or_id,
+            name=name,
+            description=description,
+            active=active,
+        )
         return _map_auth_api_key(api_key)
 
     def rotate(
@@ -2304,26 +1914,18 @@ class _APIKeysAPI:
             name_or_id,
             name="name_or_id",
         )
-        try:
-            zenml_client = self._client_ref._client()
-            api_key = zenml_client.rotate_api_key(
-                service_account_name_id_or_prefix=validated_service_account,
-                name_id_or_prefix=validated_name_or_id,
-                retain_period_minutes=retain_period_minutes,
-                set_key=False,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to rotate API key {validated_name_or_id!r} for service "
-                f"account {validated_service_account!r}: {exc}"
-            ) from exc
+        backend_result = self._client_ref._backend.rotate_api_key(
+            service_account=validated_service_account,
+            name_or_id=validated_name_or_id,
+            retain_period_minutes=retain_period_minutes,
+            set_key=set_key,
+        )
 
-        result = _map_auth_api_key_with_value(api_key)
-        if set_key:
-            return _attempt_local_key_activation(
+        result = _map_auth_api_key_with_value(backend_result.api_key)
+        if backend_result.local_key_activation is not None:
+            return _with_local_key_activation_status(
                 result,
-                zenml_client=zenml_client,
-                operation="rotate",
+                status=backend_result.local_key_activation,
             )
         return result
 
@@ -2337,16 +1939,10 @@ class _APIKeysAPI:
             name_or_id,
             name="name_or_id",
         )
-        try:
-            self._client_ref._client().delete_api_key(
-                service_account_name_id_or_prefix=validated_service_account,
-                name_id_or_prefix=validated_name_or_id,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to delete API key {validated_name_or_id!r} for service "
-                f"account {validated_service_account!r}: {exc}"
-            ) from exc
+        self._client_ref._backend.delete_api_key(
+            service_account=validated_service_account,
+            name_or_id=validated_name_or_id,
+        )
 
 
 class KitaruClient:
@@ -2393,6 +1989,12 @@ class KitaruClient:
             require_project=_require_project,
         )
         self._project = resolved_connection.project
+        self._backend = KitaruBackendGateway(
+            project=self._project,
+            client_factory=lambda: Client(),
+            active_stack_log_store_getter=active_stack_log_store,
+            resolve_log_store_getter=resolve_log_store,
+        )
 
         self.auth = _AuthAPI(self)
         self.executions = _ExecutionsAPI(self)
@@ -2412,7 +2014,7 @@ class KitaruClient:
 
     def _client(self) -> Client:
         """Return a ZenML client instance."""
-        return Client()
+        return cast(Client, self._backend.zenml_client())
 
     def _get_pipeline_run(
         self,
@@ -2421,17 +2023,7 @@ class KitaruClient:
         hydrate: bool,
     ) -> PipelineRunResponse:
         """Fetch a run by execution ID with strict ID matching."""
-        try:
-            return self._client().get_pipeline_run(
-                name_id_or_prefix=exec_id,
-                allow_name_prefix_match=False,
-                project=self._project,
-                hydrate=hydrate,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to load execution '{exec_id}': {exc}"
-            ) from exc
+        return self._backend.get_pipeline_run(exec_id, hydrate=hydrate)
 
     def _get_snapshot(
         self,
@@ -2440,17 +2032,7 @@ class KitaruClient:
         hydrate: bool,
     ) -> Any:
         """Fetch a snapshot by ID with strict ID matching."""
-        try:
-            return self._client().get_snapshot(
-                name_id_or_prefix=snapshot_id,
-                allow_prefix_match=False,
-                project=self._project,
-                hydrate=hydrate,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to load deployment snapshot '{snapshot_id}': {exc}"
-            ) from exc
+        return self._backend.get_snapshot(snapshot_id, hydrate=hydrate)
 
     def _get_artifact_version(
         self,
@@ -2459,16 +2041,7 @@ class KitaruClient:
         hydrate: bool,
     ) -> ArtifactVersionResponse:
         """Fetch an artifact version by ID."""
-        try:
-            return self._client().get_artifact_version(
-                name_id_or_prefix=artifact_id,
-                project=self._project,
-                hydrate=hydrate,
-            )
-        except Exception as exc:
-            raise KitaruBackendError(
-                f"Failed to load artifact '{artifact_id}': {exc}"
-            ) from exc
+        return self._backend.get_artifact_version(artifact_id, hydrate=hydrate)
 
 
 __all__ = [

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import inspect
 import logging
 import sys
-import threading
 import time
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
@@ -56,6 +55,9 @@ from kitaru._source_aliases import (
     build_pipeline_source_alias,
     callable_name,
 )
+from kitaru._stack_binding import (
+    temporary_active_stack as _shared_temporary_active_stack,
+)
 from kitaru._telemetry import (
     deployment_metadata_for_stack as _deployment_metadata_for_stack,
 )
@@ -93,7 +95,6 @@ from kitaru.replay import build_replay_plan
 from kitaru.runtime import _flow_scope
 
 ImageSetting = ImageInput
-_STACK_BINDING_LOCK = threading.RLock()
 logger = logging.getLogger(__name__)
 
 
@@ -105,18 +106,11 @@ def _temporary_active_stack(stack_name_or_id: str | None) -> Iterator[None]:
         stack_name_or_id: Optional stack name or ID. When ``None``, the
             currently active ZenML stack is used unchanged.
     """
-    with _STACK_BINDING_LOCK:
-        if not stack_name_or_id:
-            yield
-            return
-
-        client = Client()
-        old_stack_id = client.active_stack_model.id
-        client.activate_stack(stack_name_or_id)
-        try:
-            yield
-        finally:
-            client.activate_stack(old_stack_id)
+    with _shared_temporary_active_stack(
+        stack_name_or_id,
+        client_factory=Client,
+    ):
+        yield
 
 
 def _preflight_active_stack_implementation_hydration(

--- a/src/kitaru/mcp/server.py
+++ b/src/kitaru/mcp/server.py
@@ -18,11 +18,11 @@ import kitaru._interface_stacks as stack_interface
 import kitaru.client as client_api
 import kitaru.inspection as inspection
 import kitaru.secrets as secrets_api
+from kitaru._client._backend_gateway import KitaruBackendGateway
 from kitaru._client._deployments import (
     DEFAULT_DEPLOYMENT_TAG,
     resolve_deployment_exclusive,
 )
-from kitaru._config import _stacks as stack_ops
 from kitaru._flow_loading import _load_deployable_flow_target
 from kitaru._interface_deployments import (
     build_deployment_deploy_kwargs,
@@ -529,13 +529,21 @@ def kitaru_status() -> dict[str, Any]:
     return run_with_mcp_error_boundary(_status)
 
 
+def _mcp_backend_gateway() -> KitaruBackendGateway:
+    """Return the backend gateway used by MCP stack tools."""
+    return KitaruBackendGateway(
+        project=None,
+        client_factory=lambda: client_api.Client(),
+    )
+
+
 @tracked_mcp_tool
 def kitaru_stacks_list() -> list[dict[str, Any]]:
     """List available stacks from the active connection context."""
     return run_with_mcp_error_boundary(
         lambda: [
             inspection.serialize_stack(entry.stack, is_managed=entry.is_managed)
-            for entry in stack_ops._list_stack_entries()
+            for entry in _mcp_backend_gateway().list_stack_entries()
         ]
     )
 
@@ -588,12 +596,19 @@ def manage_stack(
             verify=verify,
         )
 
+        gateway = _mcp_backend_gateway()
         if isinstance(request, stack_interface.ManageStackCreateRequest):
-            result = stack_interface.execute_stack_create_request(request)
+            result = stack_interface.execute_stack_create_request(
+                request,
+                create_stack_operation=gateway.create_stack_operation,
+            )
             return inspection.serialize_stack_create_result(result)
 
         assert isinstance(request, stack_interface.ManageStackDeleteRequest)
-        result = stack_interface.execute_stack_delete_request(request)
+        result = stack_interface.execute_stack_delete_request(
+            request,
+            delete_stack_operation=gateway.delete_stack_operation,
+        )
         return inspection.serialize_stack_delete_result(result)
 
     return run_with_mcp_error_boundary(_manage_stack)

--- a/tests/test_backend_gateway.py
+++ b/tests/test_backend_gateway.py
@@ -1,0 +1,263 @@
+"""Regression tests for the private Kitaru backend gateway."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import Mock, call, patch
+
+import pytest
+from zenml.models import PipelineRunResponse
+
+from kitaru._cli._dependencies import CLIDependencies
+from kitaru._client._backend_gateway import KitaruBackendGateway
+from kitaru._config._stacks import StackInfo, StackType
+from kitaru.client import KitaruClient
+from kitaru.errors import KitaruFeatureNotAvailableError, KitaruLogRetrievalError
+
+
+def test_gateway_uses_injected_client_factory_without_caching() -> None:
+    """Every gateway client request should ask the injected factory again."""
+    created_clients: list[object] = []
+
+    def _client_factory() -> object:
+        client = object()
+        created_clients.append(client)
+        return client
+
+    gateway = KitaruBackendGateway(project="project-id", client_factory=_client_factory)
+
+    first = gateway.zenml_client()
+    second = gateway.zenml_client()
+
+    assert first is created_clients[0]
+    assert second is created_clients[1]
+    assert first is not second
+
+
+def test_kitaru_client_client_wrapper_delegates_to_gateway() -> None:
+    """The compatibility `_client()` wrapper should use the gateway."""
+    backend_client = object()
+    with patch(
+        "kitaru.client.resolve_connection_config",
+        return_value=SimpleNamespace(project="project-id"),
+    ):
+        client = KitaruClient()
+
+    zenml_client = Mock(return_value=backend_client)
+    client._backend = cast(
+        KitaruBackendGateway,
+        SimpleNamespace(zenml_client=zenml_client),
+    )
+
+    assert client._client() is backend_client
+    zenml_client.assert_called_once_with()
+
+
+def test_kitaru_client_preserves_client_patch_point_for_gateway_factory() -> None:
+    """Patching `kitaru.client.Client` should still affect backend client creation."""
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=SimpleNamespace(project="project-id"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client = KitaruClient()
+        assert client._client() is client_cls.return_value
+
+    client_cls.assert_called_once_with()
+
+
+def test_gateway_rest_store_preserves_caller_specific_error_type() -> None:
+    """Logs and events pass different errors through the same REST-store check."""
+    gateway = KitaruBackendGateway(
+        project="project-id",
+        client_factory=lambda: SimpleNamespace(zen_store=object()),
+    )
+    unavailable_error = KitaruFeatureNotAvailableError("events need REST")
+
+    with pytest.raises(KitaruFeatureNotAvailableError) as exc_info:
+        gateway.require_rest_store(unavailable_error)
+
+    assert exc_info.value is unavailable_error
+
+
+def test_gateway_restart_uses_the_activated_client_active_stack() -> None:
+    """Retry/resume should activate and resume through the same locked client."""
+    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=Mock()))
+    zenml_client = SimpleNamespace(
+        active_stack_model=SimpleNamespace(id="old-stack"),
+        active_stack=active_stack,
+        activate_stack=Mock(),
+    )
+    run = SimpleNamespace(
+        id="run-1",
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id="retry-stack")),
+    )
+    client_factory = Mock(return_value=zenml_client)
+    gateway = KitaruBackendGateway(project="project-id", client_factory=client_factory)
+
+    gateway.restart_run_from_snapshot(
+        run=cast(PipelineRunResponse, run),
+        operation_name="retry",
+    )
+
+    client_factory.assert_called_once_with()
+    zenml_client.activate_stack.assert_has_calls(
+        [call("retry-stack"), call("old-stack")]
+    )
+    active_stack.orchestrator.resume_run.assert_called_once_with(
+        snapshot=run.snapshot,
+        run=run,
+        stack=active_stack,
+    )
+
+
+def test_gateway_fetch_log_payload_uses_owned_log_store_helpers() -> None:
+    """OTEL log errors should use gateway-held log helper dependencies."""
+    store = Mock()
+    store.get.side_effect = RuntimeError(
+        "NotImplementedError: OTEL log store fetch is not implemented"
+    )
+    gateway = KitaruBackendGateway(
+        project="project-id",
+        client_factory=Mock(),
+        active_stack_log_store_getter=Mock(
+            return_value=SimpleNamespace(endpoint="https://logs.example.com")
+        ),
+        resolve_log_store_getter=Mock(side_effect=AssertionError("unused")),
+    )
+
+    with pytest.raises(KitaruLogRetrievalError) as exc_info:
+        gateway.fetch_log_payload(
+            path="/runs/run-1/logs",
+            source="runner",
+            store=store,
+        )
+
+    assert "OTEL backend" in str(exc_info.value)
+    assert "https://logs.example.com" in str(exc_info.value)
+    store.get.assert_called_once_with(
+        "/runs/run-1/logs",
+        params={"source": "runner"},
+    )
+
+
+def test_gateway_api_key_create_handles_local_activation_internally() -> None:
+    """API-key create should not require callers to pass a backend client around."""
+    api_key = SimpleNamespace(key="raw-secret")
+    zenml_client = SimpleNamespace(
+        create_api_key=Mock(return_value=api_key),
+        set_api_key=Mock(),
+        zen_store=SimpleNamespace(url="https://server.example.com"),
+    )
+    credentials_store = SimpleNamespace(get_api_key=Mock(return_value=None))
+    gateway = KitaruBackendGateway(
+        project="project-id",
+        client_factory=Mock(return_value=zenml_client),
+    )
+
+    with patch(
+        "kitaru._client._backend_gateway.get_credentials_store",
+        return_value=credentials_store,
+    ):
+        result = gateway.create_api_key(
+            service_account="ci-runner",
+            name="default",
+            description="Default CI key",
+            set_key=True,
+        )
+
+    assert result.api_key is api_key
+    assert result.local_key_activation is not None
+    assert result.local_key_activation.succeeded is True
+    zenml_client.create_api_key.assert_called_once_with(
+        service_account_name_id_or_prefix="ci-runner",
+        name="default",
+        description="Default CI key",
+        set_key=False,
+    )
+    zenml_client.set_api_key.assert_called_once_with(key="raw-secret")
+    credentials_store.get_api_key.assert_called_once_with(
+        server_url="https://server.example.com"
+    )
+
+
+def test_gateway_stack_list_calls_terminal_stack_operation_not_config_wrapper() -> None:
+    """Gateway stack methods should call `_config._stacks`, not `config.py` wrappers."""
+    entry = SimpleNamespace(
+        stack=StackInfo(id="stack-id", name="dev", is_active=True),
+        is_managed=True,
+    )
+    gateway = KitaruBackendGateway(project=None, client_factory=Mock())
+
+    with (
+        patch("kitaru.config._list_stack_entries", side_effect=AssertionError),
+        patch(
+            "kitaru._config._stacks._list_stack_entries",
+            return_value=[entry],
+        ) as terminal_list,
+    ):
+        assert gateway.list_stack_entries() == [entry]
+
+    terminal_list.assert_called_once_with()
+
+
+def test_gateway_patched_stack_create_bridge_keeps_existing_call_shape() -> None:
+    """Patched terminal stack operations should still receive the old arguments."""
+    result = SimpleNamespace(stack=StackInfo(id="stack-id", name="dev", is_active=True))
+    gateway = KitaruBackendGateway(project=None, client_factory=Mock())
+
+    with patch(
+        "kitaru._config._stacks._create_stack_operation",
+        return_value=result,
+    ) as terminal_create:
+        assert (
+            gateway.create_stack_operation(
+                "dev",
+                stack_type=StackType.LOCAL,
+                activate=True,
+                remote_spec=None,
+            )
+            is result
+        )
+
+    terminal_create.assert_called_once_with(
+        "dev",
+        stack_type=StackType.LOCAL,
+        activate=True,
+        remote_spec=None,
+    )
+
+
+def test_legacy_cli_stack_patch_point_overrides_gateway_default() -> None:
+    """Existing `kitaru.cli.*` stack patches should still beat gateway defaults."""
+    patched_entries = [SimpleNamespace(stack="patched-stack", is_managed=False)]
+    dependencies = CLIDependencies()
+
+    with (
+        patch(
+            "kitaru.cli._list_stack_entries",
+            return_value=patched_entries,
+        ) as patched,
+        patch.object(
+            CLIDependencies,
+            "backend_gateway",
+            side_effect=AssertionError("gateway should not be used"),
+        ),
+    ):
+        assert dependencies.list_stack_entries() == patched_entries
+
+    patched.assert_called_once_with()
+
+
+def test_kitaru_client_does_not_expose_public_stacks_namespace() -> None:
+    """The gateway adds internal stack routing without adding `client.stacks`."""
+    with patch(
+        "kitaru.client.resolve_connection_config",
+        return_value=SimpleNamespace(project="project-id"),
+    ):
+        client = KitaruClient()
+
+    assert not hasattr(client, "stacks")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -598,7 +598,10 @@ def test_auth_api_key_create_set_key_failure_returns_sanitized_key_result() -> N
             "kitaru.client.resolve_connection_config",
             return_value=_resolved_connection(),
         ),
-        patch("kitaru.client.get_credentials_store", return_value=credentials_store),
+        patch(
+            "kitaru._client._backend_gateway.get_credentials_store",
+            return_value=credentials_store,
+        ),
         patch("kitaru.client.Client") as client_cls,
     ):
         zenml_client = client_cls.return_value
@@ -644,7 +647,10 @@ def test_auth_api_key_rotate_set_key_failure_returns_sanitized_key_result() -> N
             "kitaru.client.resolve_connection_config",
             return_value=_resolved_connection(),
         ),
-        patch("kitaru.client.get_credentials_store", return_value=credentials_store),
+        patch(
+            "kitaru._client._backend_gateway.get_credentials_store",
+            return_value=credentials_store,
+        ),
         patch("kitaru.client.Client") as client_cls,
     ):
         zenml_client = client_cls.return_value
@@ -692,7 +698,10 @@ def test_auth_api_key_create_set_key_failure_rolls_back_previous_key() -> None:
             "kitaru.client.resolve_connection_config",
             return_value=_resolved_connection(),
         ),
-        patch("kitaru.client.get_credentials_store", return_value=credentials_store),
+        patch(
+            "kitaru._client._backend_gateway.get_credentials_store",
+            return_value=credentials_store,
+        ),
         patch("kitaru.client.Client") as client_cls,
     ):
         zenml_client = client_cls.return_value
@@ -738,7 +747,10 @@ def test_auth_api_key_create_set_key_failure_reports_rollback_failure() -> None:
             "kitaru.client.resolve_connection_config",
             return_value=_resolved_connection(),
         ),
-        patch("kitaru.client.get_credentials_store", return_value=credentials_store),
+        patch(
+            "kitaru._client._backend_gateway.get_credentials_store",
+            return_value=credentials_store,
+        ),
         patch("kitaru.client.Client") as client_cls,
     ):
         zenml_client = client_cls.return_value


### PR DESCRIPTION
## What changed

- Added a private `KitaruBackendGateway` for backend-facing SDK operations.
- Routed execution, artifact, deployment, auth, log/event, CLI stack, and MCP stack backend calls through that gateway while keeping the public SDK/CLI/MCP shapes unchanged.
- Extracted shared temporary stack activation into `kitaru._stack_binding.temporary_active_stack(...)` so flow submission and retry/resume use the same locked stack-switching behavior.
- Added focused gateway regression tests and short contributor guidance in `AGENTS.md` / `CLAUDE.md`.

## Why it was needed

`KitaruClient` had become both the public SDK facade and the place where many raw ZenML client calls lived. The result was that changing backend behavior meant hunting across `client.py`, mapper helpers, CLI stack dependencies, and MCP stack tools. This refactor keeps the user-facing API where it is, but gives backend calls one private place to live.

## Key implementation decisions

- `KitaruClient` still owns the public namespaces (`executions`, `artifacts`, `deployments`, `auth`). Those namespaces validate inputs and map outputs; backend calls go through `client._backend`.
- The gateway does **not** cache `zenml.client.Client()`, preserving the existing “fresh client per backend operation” behavior.
- No public `KitaruClient().stacks` namespace was added. Stack CLI/MCP paths route through gateway methods while preserving legacy monkeypatch bridges.
- `_rest_store()` and `_event_rest_store()` remain patchable, and the gateway still receives caller-specific error instances so logs and events keep their distinct error types.

## Reviewer Notes

The important story is in the call chain. Before this change, `client.py` methods often reached straight into `Client()` or `RestZenStore`: execution logs opened REST endpoints, deployment methods listed and updated snapshots, auth methods called service-account/API-key methods, and mapper code fetched run steps. After this change, those public methods still exist and still return the same public DTOs, but they ask `KitaruBackendGateway` to perform the backend operation.

The two riskiest spots are:

1. **Retry/resume active stack handling.** Retry/resume temporarily activates the source snapshot's stack before asking the orchestrator to resume the run. That now uses the same locked helper as flow submission. If this is wrong, retry/resume could resume with the wrong active stack or leave the process on the wrong stack afterward.
2. **Patch-point preservation.** Existing tests and integrations patch `kitaru.client.Client`, `_ExecutionsAPI._rest_store`, `_ExecutionsAPI._event_rest_store`, `kitaru.cli.*` stack helpers, and `_config._stacks` functions. The new gateway keeps bridge behavior for those names rather than forcing all callers to patch the new private object.

Please especially inspect:

- `src/kitaru/_client/_backend_gateway.py` for the new backend operation boundary.
- `src/kitaru/client.py` to confirm public namespaces still validate/map and do not expose new public API.
- `src/kitaru/_stack_binding.py` + `src/kitaru/flow.py` for the shared stack-switching helper.
- `tests/test_backend_gateway.py` for regression coverage around the compatibility promises.

### Reproduction

A concrete reviewer flow:

1. Run `just check`.
2. Run `just test`.
3. To spot-check the behavioral contract manually, run the focused gateway tests:
   ```bash
   uv run pytest tests/test_backend_gateway.py
   ```
   You should see tests covering fresh client factories, no public `KitaruClient().stacks`, REST-store error preservation, stack patch bridges, retry/resume stack activation, log helper ownership, and API-key local activation.

### Local checks run

- Simplify review loop with three review agents: reuse, quality, efficiency.
- Follow-up fixes from simplify review.
- Oracle review: no blocking or important issues; marked ready to commit.
- `just check` ✅
- `just test` ✅ (`2211 passed, 8 skipped`)
