### PR TITLE
Bump `pip` to 26.1.2 to clear `pip-audit` failure

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-04T17:17:33.151997Z"
 exclude-newer-span = "P3D"
 
 [options.exclude-newer-package]
@@ -2098,11 +2098,11 @@ bcrypt = [
 
 [[package]]
 name = "pip"
-version = "26.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

`just audit` (the `pip-audit` job in `ci.yml`) is failing on `develop`. `pip-audit` flags **PYSEC-2026-196** against **`pip` 26.1**, with a fix in **26.1.2**:

```
Found 1 known vulnerability, ignored 12 in 1 package
Name Version ID             Fix Versions
---- ------- -------------- ------------
pip  26.1    PYSEC-2026-196 26.1.2
```

`pip` is not a direct Kitaru dependency — it rides into the lockfile transitively through `pip-api` (the library `pip-audit` itself uses to read installed packages). Nothing pins `pip` to an old version, so a targeted lockfile refresh pulls the patched release cleanly.

The fix is a single targeted lockfile bump:

```
uv lock --upgrade-package pip   # pip 26.1 -> 26.1.2
```

## Why not add it to the ignore list

The existing entries in `.github/pip-audit-ignored.txt` are vulnerabilities we *can't* fix because zenml hard-pins the affected versions (`pyjwt==2.7.*`, the FastAPI/Starlette server stack). This one is different — there's a patched `pip` available and no pin blocking it, so the right move is to upgrade rather than suppress.

## Reviewer Notes

The entire change is `uv.lock`. Two lines move:

1. **The `pip` package block** — version `26.1` → `26.1.2`, with new sdist/wheel hashes. This is the actual fix.
2. **The `exclude-newer` timestamp** under `[options]` — the placeholder gets replaced with a concrete resolution timestamp. This repo sets `exclude-newer-span = "P3D"`, so every honest `uv lock` run stamps the absolute date it resolved against. It's expected, not an accidental edit.

No `pyproject.toml` change, no other dependency moved (`git diff uv.lock` touches only the `pip` block plus that timestamp line). If the bump were wrong, `uv lock --check` would fail or some other package would have shifted — neither happened.

### Reproduction

On `develop`:

```bash
just audit
# -> Found 1 known vulnerability ... pip 26.1 PYSEC-2026-196 ... exit 1
```

On this branch:

```bash
just audit
# -> No known vulnerabilities found, 12 ignored ... exit 0
```

### Local checks run

`just check` ✅ · `just test` ✅ (2200 passed, 8 skipped) · `uv lock --check` ✅