### PR TITLE
Fix LangGraph durability without checkpointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a LangGraph adapter crash when running graphs without a LangGraph checkpointer under Kitaru's default durability policy. (#403)
+
 ## [0.15.0] - 2026-06-04
 
 ### Added

--- a/src/kitaru/adapters/langgraph/_agent.py
+++ b/src/kitaru/adapters/langgraph/_agent.py
@@ -1431,6 +1431,7 @@ class KitaruGraphRunner:
             "checkpointer_type": self._checkpointer_label(),
             "store_type": self._store_label(),
             "durability": self._resolved_durability(request),
+            "forwarded_durability": self._forwarded_durability(request),
             "capture": self._capture_summary,
             "config": redact_config(config) if self._capture.save_config else None,
             "context": redact_config(context) if self._capture.save_context else None,
@@ -1468,6 +1469,7 @@ class KitaruGraphRunner:
         return {
             "kind": request.kind,
             "durability": self._resolved_durability(request),
+            "forwarded_durability": self._forwarded_durability(request),
             "has_checkpointer": self._checkpointer_label() is not None,
             "has_store": self._store_label() is not None,
             "thread_id_present": bool(request.thread_id),
@@ -1488,6 +1490,7 @@ class KitaruGraphRunner:
             "method": method,
             "status": status,
             "durability": self._resolved_durability(request),
+            "forwarded_durability": self._forwarded_durability(request),
             "has_checkpointer": self._checkpointer_label() is not None,
             "has_store": self._store_label() is not None,
             "captured_state": captured_state,

--- a/src/kitaru/adapters/langgraph/_agent.py
+++ b/src/kitaru/adapters/langgraph/_agent.py
@@ -112,6 +112,7 @@ class KitaruGraphRunner:
         self._config_factory = config_factory
         self._context_factory = context_factory
         self._cost_calculator = cost_calculator
+        self._checkpointer_saver_value = self._resolve_checkpointer_saver()
         self._checkpointer_label_value = self._resolve_checkpointer_label()
         self._store_label_value = self._resolve_store_label()
         self._graph_identity_value = self._build_graph_identity()
@@ -904,6 +905,11 @@ class KitaruGraphRunner:
     def _resolved_durability(self, request: LangGraphRunRequest) -> str:
         return request.durability or self._durability.mode
 
+    def _forwarded_durability(self, request: LangGraphRunRequest) -> str | None:
+        if not self._has_checkpointer_saver():
+            return None
+        return self._resolved_durability(request)
+
     def _graph_call_kwargs(
         self,
         request: LangGraphRunRequest,
@@ -911,7 +917,10 @@ class KitaruGraphRunner:
         context: Any | None,
         method_name: str,
     ) -> dict[str, Any]:
-        kwargs: dict[str, Any] = {"durability": self._resolved_durability(request)}
+        kwargs: dict[str, Any] = {}
+        forwarded_durability = self._forwarded_durability(request)
+        if forwarded_durability is not None:
+            kwargs["durability"] = forwarded_durability
         if context is not None:
             kwargs["context"] = context
         return self._filter_kwargs_for_graph_method(method_name, kwargs)
@@ -1056,7 +1065,7 @@ class KitaruGraphRunner:
             raise KitaruUsageError(
                 f"Wrapped LangGraph object does not expose `{required_method}(...)`."
             )
-        if self._durability.require_checkpointer and self._checkpointer_label() is None:
+        if self._durability.require_checkpointer and not self._has_checkpointer_saver():
             raise KitaruUsageError(
                 "LangGraph durability policy requires a graph checkpointer, but "
                 "none was detected on the wrapped graph."
@@ -1145,10 +1154,19 @@ class KitaruGraphRunner:
         return self._checkpointer_label_value
 
     def _resolve_checkpointer_label(self) -> str | None:
-        checkpointer = getattr(self._graph, "checkpointer", None)
+        checkpointer = self._checkpointer_saver_value
         if checkpointer is None:
             return None
         return _type_label(checkpointer)
+
+    def _has_checkpointer_saver(self) -> bool:
+        return self._checkpointer_saver_value is not None
+
+    def _resolve_checkpointer_saver(self) -> Any | None:
+        checkpointer = getattr(self._graph, "checkpointer", None)
+        if checkpointer is None or isinstance(checkpointer, bool):
+            return None
+        return checkpointer
 
     def _store_label(self) -> str | None:
         return self._store_label_value

--- a/src/kitaru/adapters/langgraph/_agent.py
+++ b/src/kitaru/adapters/langgraph/_agent.py
@@ -11,6 +11,7 @@ from kitaru.adapters._result_identity import canonicalize_result_model
 from kitaru.analytics import AnalyticsEvent, track
 from kitaru.errors import KitaruUsageError
 
+from ._constants import LANGGRAPH_CONFIG_CHECKPOINTER_KEY
 from ._kitaru_internal import is_inside_checkpoint, is_inside_flow
 from ._policy import (
     LangGraphCallCheckpointPolicy,
@@ -160,8 +161,11 @@ class KitaruGraphRunner:
         """Invoke the wrapped graph synchronously."""
         self._validate_request(request, required_method="invoke")
 
+        config = self._prepared_config(request)
+        self._validate_checkpointer_requirement(config)
+
         def _body() -> LangGraphRunResult:
-            return self._invoke_graph_sync(request)
+            return self._invoke_graph_sync(request, config=config)
 
         if self._checkpoint_strategy == "calls":
             result = _body()
@@ -175,15 +179,18 @@ class KitaruGraphRunner:
         else:
             result = _body()
         result = canonicalize_result_model(result, LangGraphRunResult)
-        self._track_result("invoke", result, request=request)
+        self._track_result("invoke", result, request=request, config=config)
         return result
 
     async def ainvoke(self, request: LangGraphRunRequest) -> LangGraphRunResult:
         """Invoke the wrapped graph asynchronously when the graph supports it."""
         self._validate_request(request, required_method="ainvoke")
 
+        config = self._prepared_config(request)
+        self._validate_checkpointer_requirement(config)
+
         async def _body() -> LangGraphRunResult:
-            return await self._invoke_graph_async(request)
+            return await self._invoke_graph_async(request, config=config)
 
         if self._checkpoint_strategy == "calls":
             result = await _body()
@@ -197,7 +204,7 @@ class KitaruGraphRunner:
         else:
             result = await _body()
         result = canonicalize_result_model(result, LangGraphRunResult)
-        self._track_result("ainvoke", result, request=request)
+        self._track_result("ainvoke", result, request=request, config=config)
         return result
 
     def stream(
@@ -215,9 +222,11 @@ class KitaruGraphRunner:
             policy=self._stream_policy,
             subgraphs=subgraphs,
         )
+        config = self._prepared_config(request)
+        self._validate_checkpointer_requirement(config)
 
         def _body() -> LangGraphRunResult:
-            return self._stream_graph_sync(request, options=options)
+            return self._stream_graph_sync(request, config=config, options=options)
 
         if is_inside_flow() and not is_inside_checkpoint():
             result = run_sync_in_checkpoint(
@@ -236,7 +245,7 @@ class KitaruGraphRunner:
         else:
             result = _body()
         result = canonicalize_result_model(result, LangGraphRunResult)
-        self._track_result("stream", result, request=request)
+        self._track_result("stream", result, request=request, config=config)
         return result
 
     async def astream(
@@ -254,9 +263,13 @@ class KitaruGraphRunner:
             policy=self._stream_policy,
             subgraphs=subgraphs,
         )
+        config = self._prepared_config(request)
+        self._validate_checkpointer_requirement(config)
 
         async def _body() -> LangGraphRunResult:
-            return await self._stream_graph_async(request, options=options)
+            return await self._stream_graph_async(
+                request, config=config, options=options
+            )
 
         if is_inside_flow() and not is_inside_checkpoint():
             result = await run_async_in_checkpoint(
@@ -275,12 +288,12 @@ class KitaruGraphRunner:
         else:
             result = await _body()
         result = canonicalize_result_model(result, LangGraphRunResult)
-        self._track_result("astream", result, request=request)
+        self._track_result("astream", result, request=request, config=config)
         return result
 
-    def _invoke_graph_sync(self, request: LangGraphRunRequest) -> LangGraphRunResult:
-        config = self._prepared_config(request)
-        self._validate_checkpointer_requirement(config)
+    def _invoke_graph_sync(
+        self, request: LangGraphRunRequest, *, config: dict[str, Any]
+    ) -> LangGraphRunResult:
         context = self._prepared_context(request)
         kwargs = self._graph_call_kwargs(
             request,
@@ -333,7 +346,7 @@ class KitaruGraphRunner:
             return result
 
     async def _invoke_graph_async(
-        self, request: LangGraphRunRequest
+        self, request: LangGraphRunRequest, *, config: dict[str, Any]
     ) -> LangGraphRunResult:
         ainvoke = getattr(self._graph, "ainvoke", None)
         if not callable(ainvoke):
@@ -342,8 +355,6 @@ class KitaruGraphRunner:
                 "`invoke(...)` or wrap a graph that supports async invocation."
             )
 
-        config = self._prepared_config(request)
-        self._validate_checkpointer_requirement(config)
         context = self._prepared_context(request)
         kwargs = self._graph_call_kwargs(
             request,
@@ -399,10 +410,9 @@ class KitaruGraphRunner:
         self,
         request: LangGraphRunRequest,
         *,
+        config: dict[str, Any],
         options: LangGraphStreamOptions,
     ) -> LangGraphRunResult:
-        config = self._prepared_config(request)
-        self._validate_checkpointer_requirement(config)
         context = self._prepared_context(request)
         kwargs = self._graph_stream_kwargs(
             request,
@@ -468,6 +478,7 @@ class KitaruGraphRunner:
         self,
         request: LangGraphRunRequest,
         *,
+        config: dict[str, Any],
         options: LangGraphStreamOptions,
     ) -> LangGraphRunResult:
         astream = getattr(self._graph, "astream", None)
@@ -477,8 +488,6 @@ class KitaruGraphRunner:
                 "`stream(...)` or wrap a graph that supports async streaming."
             )
 
-        config = self._prepared_config(request)
-        self._validate_checkpointer_requirement(config)
         context = self._prepared_context(request)
         kwargs = self._graph_stream_kwargs(
             request,
@@ -1189,7 +1198,7 @@ class KitaruGraphRunner:
         configurable = (
             _mapping_get(config, "configurable") if config is not None else None
         )
-        checkpointer = _mapping_get(configurable, "__pregel_checkpointer")
+        checkpointer = _mapping_get(configurable, LANGGRAPH_CONFIG_CHECKPOINTER_KEY)
         if checkpointer is None or isinstance(checkpointer, bool):
             return None
         return checkpointer
@@ -1536,6 +1545,7 @@ class KitaruGraphRunner:
         method: str,
         *,
         request: LangGraphRunRequest,
+        config: Mapping[str, Any],
         status: str,
         captured_state: bool,
     ) -> dict[str, object]:
@@ -1543,8 +1553,8 @@ class KitaruGraphRunner:
             "method": method,
             "status": status,
             "durability": self._resolved_durability(request),
-            "forwarded_durability": self._forwarded_durability(request),
-            "has_checkpointer": self._checkpointer_label() is not None,
+            "forwarded_durability": self._forwarded_durability(request, config=config),
+            "has_checkpointer": self._has_effective_checkpointer_saver(config),
             "has_store": self._store_label() is not None,
             "captured_state": captured_state,
         }
@@ -1555,10 +1565,12 @@ class KitaruGraphRunner:
         result: LangGraphRunResult,
         *,
         request: LangGraphRunRequest,
+        config: Mapping[str, Any],
     ) -> None:
         metadata = self._analytics_metadata(
             method,
             request=request,
+            config=config,
             status=result.status,
             captured_state=result.state_summary is not None,
         )

--- a/src/kitaru/adapters/langgraph/_agent.py
+++ b/src/kitaru/adapters/langgraph/_agent.py
@@ -280,14 +280,16 @@ class KitaruGraphRunner:
 
     def _invoke_graph_sync(self, request: LangGraphRunRequest) -> LangGraphRunResult:
         config = self._prepared_config(request)
+        self._validate_checkpointer_requirement(config)
         context = self._prepared_context(request)
         kwargs = self._graph_call_kwargs(
             request,
+            config=config,
             context=context,
             method_name="invoke",
         )
         input_or_command = request.input if request.kind == "start" else request.command
-        warnings = self._checkpointer_warnings()
+        warnings = self._checkpointer_warnings(config=config)
 
         with tracker_scope(
             self._name,
@@ -341,14 +343,16 @@ class KitaruGraphRunner:
             )
 
         config = self._prepared_config(request)
+        self._validate_checkpointer_requirement(config)
         context = self._prepared_context(request)
         kwargs = self._graph_call_kwargs(
             request,
+            config=config,
             context=context,
             method_name="ainvoke",
         )
         input_or_command = request.input if request.kind == "start" else request.command
-        warnings = self._checkpointer_warnings()
+        warnings = self._checkpointer_warnings(config=config)
 
         with tracker_scope(
             self._name,
@@ -398,15 +402,17 @@ class KitaruGraphRunner:
         options: LangGraphStreamOptions,
     ) -> LangGraphRunResult:
         config = self._prepared_config(request)
+        self._validate_checkpointer_requirement(config)
         context = self._prepared_context(request)
         kwargs = self._graph_stream_kwargs(
             request,
+            config=config,
             context=context,
             method_name="stream",
             options=options,
         )
         input_or_command = request.input if request.kind == "start" else request.command
-        warnings = self._checkpointer_warnings()
+        warnings = self._checkpointer_warnings(config=config)
         publisher, stats = self._new_stream_publisher(request, options)
 
         with tracker_scope(self._name) as tracker:
@@ -472,15 +478,17 @@ class KitaruGraphRunner:
             )
 
         config = self._prepared_config(request)
+        self._validate_checkpointer_requirement(config)
         context = self._prepared_context(request)
         kwargs = self._graph_stream_kwargs(
             request,
+            config=config,
             context=context,
             method_name="astream",
             options=options,
         )
         input_or_command = request.input if request.kind == "start" else request.command
-        warnings = self._checkpointer_warnings()
+        warnings = self._checkpointer_warnings(config=config)
         publisher, stats = self._new_stream_publisher(request, options)
 
         with tracker_scope(self._name) as tracker:
@@ -905,8 +913,13 @@ class KitaruGraphRunner:
     def _resolved_durability(self, request: LangGraphRunRequest) -> str:
         return request.durability or self._durability.mode
 
-    def _forwarded_durability(self, request: LangGraphRunRequest) -> str | None:
-        if not self._has_checkpointer_saver():
+    def _forwarded_durability(
+        self,
+        request: LangGraphRunRequest,
+        *,
+        config: Mapping[str, Any] | None = None,
+    ) -> str | None:
+        if not self._has_effective_checkpointer_saver(config):
             return None
         return self._resolved_durability(request)
 
@@ -914,11 +927,12 @@ class KitaruGraphRunner:
         self,
         request: LangGraphRunRequest,
         *,
+        config: Mapping[str, Any],
         context: Any | None,
         method_name: str,
     ) -> dict[str, Any]:
         kwargs: dict[str, Any] = {}
-        forwarded_durability = self._forwarded_durability(request)
+        forwarded_durability = self._forwarded_durability(request, config=config)
         if forwarded_durability is not None:
             kwargs["durability"] = forwarded_durability
         if context is not None:
@@ -929,12 +943,14 @@ class KitaruGraphRunner:
         self,
         request: LangGraphRunRequest,
         *,
+        config: Mapping[str, Any],
         context: Any | None,
         method_name: str,
         options: LangGraphStreamOptions,
     ) -> dict[str, Any]:
         kwargs = self._graph_call_kwargs(
             request,
+            config=config,
             context=context,
             method_name=method_name,
         )
@@ -1065,10 +1081,15 @@ class KitaruGraphRunner:
             raise KitaruUsageError(
                 f"Wrapped LangGraph object does not expose `{required_method}(...)`."
             )
-        if self._durability.require_checkpointer and not self._has_checkpointer_saver():
+
+    def _validate_checkpointer_requirement(self, config: Mapping[str, Any]) -> None:
+        if (
+            self._durability.require_checkpointer
+            and not self._has_effective_checkpointer_saver(config)
+        ):
             raise KitaruUsageError(
                 "LangGraph durability policy requires a graph checkpointer, but "
-                "none was detected on the wrapped graph."
+                "none was detected on the wrapped graph or prepared config."
             )
 
     def _effective_call_checkpoint_policy(self) -> LangGraphCallCheckpointPolicy:
@@ -1162,6 +1183,36 @@ class KitaruGraphRunner:
     def _has_checkpointer_saver(self) -> bool:
         return self._checkpointer_saver_value is not None
 
+    def _config_checkpointer_saver(
+        self, config: Mapping[str, Any] | None
+    ) -> Any | None:
+        configurable = (
+            _mapping_get(config, "configurable") if config is not None else None
+        )
+        checkpointer = _mapping_get(configurable, "__pregel_checkpointer")
+        if checkpointer is None or isinstance(checkpointer, bool):
+            return None
+        return checkpointer
+
+    def _has_effective_checkpointer_saver(
+        self, config: Mapping[str, Any] | None = None
+    ) -> bool:
+        return (
+            self._has_checkpointer_saver()
+            or self._config_checkpointer_saver(config) is not None
+        )
+
+    def _effective_checkpointer_label(
+        self, config: Mapping[str, Any] | None = None
+    ) -> str | None:
+        graph_label = self._checkpointer_label()
+        if graph_label is not None:
+            return graph_label
+        config_checkpointer = self._config_checkpointer_saver(config)
+        if config_checkpointer is None:
+            return None
+        return _type_label(config_checkpointer)
+
     def _resolve_checkpointer_saver(self) -> Any | None:
         checkpointer = getattr(self._graph, "checkpointer", None)
         if checkpointer is None or isinstance(checkpointer, bool):
@@ -1177,9 +1228,11 @@ class KitaruGraphRunner:
             return None
         return _type_label(store)
 
-    def _checkpointer_warnings(self) -> list[str]:
+    def _checkpointer_warnings(
+        self, *, config: Mapping[str, Any] | None = None
+    ) -> list[str]:
         warnings: list[str] = []
-        checkpointer_label = self._checkpointer_label()
+        checkpointer_label = self._effective_checkpointer_label(config)
         if checkpointer_label is None:
             if self._durability.warn_without_checkpointer:
                 warnings.append(
@@ -1428,10 +1481,10 @@ class KitaruGraphRunner:
             "graph_name": self._name,
             "thread_id": request.thread_id,
             "thread_id_present": bool(request.thread_id),
-            "checkpointer_type": self._checkpointer_label(),
+            "checkpointer_type": self._effective_checkpointer_label(config),
             "store_type": self._store_label(),
             "durability": self._resolved_durability(request),
-            "forwarded_durability": self._forwarded_durability(request),
+            "forwarded_durability": self._forwarded_durability(request, config=config),
             "capture": self._capture_summary,
             "config": redact_config(config) if self._capture.save_config else None,
             "context": redact_config(context) if self._capture.save_context else None,
@@ -1469,8 +1522,8 @@ class KitaruGraphRunner:
         return {
             "kind": request.kind,
             "durability": self._resolved_durability(request),
-            "forwarded_durability": self._forwarded_durability(request),
-            "has_checkpointer": self._checkpointer_label() is not None,
+            "forwarded_durability": self._forwarded_durability(request, config=config),
+            "has_checkpointer": self._has_effective_checkpointer_saver(config),
             "has_store": self._store_label() is not None,
             "thread_id_present": bool(request.thread_id),
             "configurable_keys": _safe_key_labels(

--- a/src/kitaru/adapters/langgraph/_constants.py
+++ b/src/kitaru/adapters/langgraph/_constants.py
@@ -3,5 +3,7 @@
 ADAPTER_ID = "langgraph"
 ADAPTER_VERSION = 1
 
+LANGGRAPH_CONFIG_CHECKPOINTER_KEY = "__pregel_checkpointer"
+
 LANGGRAPH_EVENTS_METADATA_KEY = "langgraph_events"
 LANGGRAPH_RUN_SUMMARIES_METADATA_KEY = "langgraph_run_summaries"

--- a/tests/test_langgraph_adapter_foundation.py
+++ b/tests/test_langgraph_adapter_foundation.py
@@ -19,6 +19,15 @@ from kitaru.analytics import AnalyticsEvent
 from kitaru.errors import KitaruRuntimeError, KitaruUsageError
 
 
+def _config_with_injected_checkpointer(
+    checkpointer: object,
+) -> dict[str, dict[str, object]]:
+    agent_module = importlib.import_module("kitaru.adapters.langgraph._agent")
+    return {
+        "configurable": {agent_module.LANGGRAPH_CONFIG_CHECKPOINTER_KEY: checkpointer}
+    }
+
+
 @pytest.fixture
 def langgraph_adapter(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     """Import the adapter with a fake optional SDK module installed."""
@@ -1027,6 +1036,32 @@ def test_request_durability_is_not_forwarded_without_checkpointer(
     assert any("No LangGraph checkpointer" in warning for warning in result.warnings)
 
 
+def test_request_durability_is_not_forwarded_for_explicit_none_checkpointer(
+    langgraph_adapter: types.ModuleType,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class FakeGraph:
+        name = "fake"
+        checkpointer = None
+
+        def invoke(self, input: object, **kwargs: object) -> object:
+            seen.update(kwargs)
+            return input
+
+    result = langgraph_adapter.KitaruGraphRunner(FakeGraph()).invoke(
+        langgraph_adapter.LangGraphRunRequest.start(
+            {"count": 1},
+            thread_id="thread-1",
+            durability="sync",
+        )
+    )
+
+    assert result.status == "completed"
+    assert "durability" not in seen
+    assert any("No LangGraph checkpointer" in warning for warning in result.warnings)
+
+
 def test_request_durability_is_forwarded_for_config_injected_checkpointer(
     langgraph_adapter: types.ModuleType,
 ) -> None:
@@ -1043,9 +1078,9 @@ def test_request_durability_is_forwarded_for_config_injected_checkpointer(
 
     runner = langgraph_adapter.KitaruGraphRunner(
         FakeGraph(),
-        config_factory=lambda _request: {
-            "configurable": {"__pregel_checkpointer": config_checkpointer}
-        },
+        config_factory=lambda _request: _config_with_injected_checkpointer(
+            config_checkpointer
+        ),
     )
     result = runner.invoke(
         langgraph_adapter.LangGraphRunRequest.start(
@@ -1076,9 +1111,9 @@ def test_strict_durability_policy_accepts_config_injected_checkpointer(
 
     runner = langgraph_adapter.KitaruGraphRunner(
         FakeGraph(),
-        config_factory=lambda _request: {
-            "configurable": {"__pregel_checkpointer": config_checkpointer}
-        },
+        config_factory=lambda _request: _config_with_injected_checkpointer(
+            config_checkpointer
+        ),
         durability=langgraph_adapter.LangGraphDurabilityPolicy(
             require_checkpointer=True
         ),
@@ -1092,6 +1127,51 @@ def test_strict_durability_policy_accepts_config_injected_checkpointer(
     )
 
     assert result.status == "completed"
+
+
+def test_analytics_metadata_records_config_injected_checkpointer(
+    langgraph_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.langgraph._agent")
+    config_checkpointer = object()
+    track_calls: list[tuple[object, dict[str, object]]] = []
+
+    class FakeGraph:
+        name = "fake"
+        checkpointer = None
+
+        def invoke(self, input: object, **_kwargs: object) -> object:
+            return input
+
+    monkeypatch.setattr(
+        agent_module,
+        "track",
+        lambda event, metadata: track_calls.append((event, metadata)),
+    )
+
+    runner = langgraph_adapter.KitaruGraphRunner(
+        FakeGraph(),
+        config_factory=lambda _request: _config_with_injected_checkpointer(
+            config_checkpointer
+        ),
+    )
+    result = runner.invoke(
+        langgraph_adapter.LangGraphRunRequest.start(
+            {"count": 1},
+            thread_id="thread-1",
+            durability="sync",
+        )
+    )
+
+    assert result.status == "completed"
+    analytics_metadata = next(
+        metadata
+        for _event, metadata in track_calls
+        if metadata.get("method") == "invoke"
+    )
+    assert analytics_metadata["forwarded_durability"] == "sync"
+    assert analytics_metadata["has_checkpointer"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_langgraph_adapter_foundation.py
+++ b/tests/test_langgraph_adapter_foundation.py
@@ -1027,6 +1027,77 @@ def test_request_durability_is_not_forwarded_without_checkpointer(
     assert any("No LangGraph checkpointer" in warning for warning in result.warnings)
 
 
+@pytest.mark.parametrize(
+    ("checkpointer", "expected_forwarded_durability"),
+    [(None, None), (object(), "sync")],
+)
+def test_metadata_records_forwarded_durability(
+    langgraph_adapter: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    checkpointer: object | None,
+    expected_forwarded_durability: str | None,
+) -> None:
+    agent_module = importlib.import_module("kitaru.adapters.langgraph._agent")
+    tracking = importlib.import_module("kitaru.adapters.langgraph._tracking")
+    saved: list[tuple[str, object, str]] = []
+    track_calls: list[tuple[object, dict[str, object]]] = []
+
+    class FakeGraph:
+        name = "fake"
+        checkpointer: object | None
+
+        def __init__(self, checkpointer: object | None) -> None:
+            self.checkpointer = checkpointer
+
+        def invoke(self, input: object, **_kwargs: object) -> object:
+            return input
+
+    monkeypatch.setattr(tracking, "is_inside_flow", lambda: True)
+    monkeypatch.setattr(tracking, "is_inside_checkpoint", lambda: True)
+    monkeypatch.setattr(
+        tracking.kitaru,
+        "save",
+        lambda name, value, *, type: saved.append((name, value, type)),
+    )
+    monkeypatch.setattr(tracking.kitaru, "log", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        agent_module,
+        "track",
+        lambda event, metadata: track_calls.append((event, metadata)),
+    )
+
+    runner = langgraph_adapter.KitaruGraphRunner(FakeGraph(checkpointer))
+    result = runner.invoke(
+        langgraph_adapter.LangGraphRunRequest.start(
+            {"count": 1},
+            thread_id="thread-1",
+        )
+    )
+
+    assert result.status == "completed"
+    event_log = cast(list[dict[str, object]], saved[0][1])
+    run_summary = cast(dict[str, object], saved[1][1])
+    analytics_metadata = next(
+        metadata
+        for _event, metadata in track_calls
+        if metadata.get("method") == "invoke"
+    )
+
+    assert run_summary["durability"] == "sync"
+    assert run_summary["forwarded_durability"] == expected_forwarded_durability
+    assert event_log[0]["metadata"] == {
+        "kind": "start",
+        "durability": "sync",
+        "forwarded_durability": expected_forwarded_durability,
+        "has_checkpointer": checkpointer is not None,
+        "has_store": False,
+        "thread_id_present": True,
+        "configurable_keys": ["thread_id"],
+    }
+    assert analytics_metadata["durability"] == "sync"
+    assert analytics_metadata["forwarded_durability"] == expected_forwarded_durability
+
+
 @pytest.mark.parametrize("checkpointer", [False, True])
 def test_default_durability_is_not_forwarded_for_boolean_checkpointer_sentinel(
     langgraph_adapter: types.ModuleType,

--- a/tests/test_langgraph_adapter_foundation.py
+++ b/tests/test_langgraph_adapter_foundation.py
@@ -978,6 +978,118 @@ def test_durability_policy_supplies_default_graph_durability(
     assert seen["durability"] == "exit"
 
 
+def test_default_durability_is_not_forwarded_without_checkpointer(
+    langgraph_adapter: types.ModuleType,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class FakeGraph:
+        name = "fake"
+
+        def invoke(self, input: object, **kwargs: object) -> object:
+            seen.update(kwargs)
+            return input
+
+    result = langgraph_adapter.KitaruGraphRunner(FakeGraph()).invoke(
+        langgraph_adapter.LangGraphRunRequest.start(
+            {"count": 1},
+            thread_id="thread-1",
+        )
+    )
+
+    assert result.status == "completed"
+    assert "durability" not in seen
+    assert any("No LangGraph checkpointer" in warning for warning in result.warnings)
+
+
+def test_request_durability_is_not_forwarded_without_checkpointer(
+    langgraph_adapter: types.ModuleType,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class FakeGraph:
+        name = "fake"
+
+        def invoke(self, input: object, **kwargs: object) -> object:
+            seen.update(kwargs)
+            return input
+
+    result = langgraph_adapter.KitaruGraphRunner(FakeGraph()).invoke(
+        langgraph_adapter.LangGraphRunRequest.start(
+            {"count": 1},
+            thread_id="thread-1",
+            durability="sync",
+        )
+    )
+
+    assert result.status == "completed"
+    assert "durability" not in seen
+    assert any("No LangGraph checkpointer" in warning for warning in result.warnings)
+
+
+@pytest.mark.parametrize("checkpointer", [False, True])
+def test_default_durability_is_not_forwarded_for_boolean_checkpointer_sentinel(
+    langgraph_adapter: types.ModuleType,
+    checkpointer: bool,
+) -> None:
+    seen: dict[str, object] = {}
+
+    class FakeGraph:
+        name = "fake"
+        checkpointer: bool
+
+        def __init__(self, checkpointer: bool) -> None:
+            self.checkpointer = checkpointer
+
+        def invoke(self, input: object, **kwargs: object) -> object:
+            seen.update(kwargs)
+            return input
+
+    result = langgraph_adapter.KitaruGraphRunner(FakeGraph(checkpointer)).invoke(
+        langgraph_adapter.LangGraphRunRequest.start(
+            {"count": 1},
+            thread_id="thread-1",
+        )
+    )
+
+    assert result.status == "completed"
+    assert "durability" not in seen
+    assert any("No LangGraph checkpointer" in warning for warning in result.warnings)
+
+
+def test_strict_durability_policy_requires_actual_checkpointer_before_execution(
+    langgraph_adapter: types.ModuleType,
+) -> None:
+    class FakeGraph:
+        name = "fake"
+        checkpointer = False
+
+        def __init__(self) -> None:
+            self.executed = False
+
+        def invoke(self, input: object, **_kwargs: object) -> object:
+            self.executed = True
+            return input
+
+    graph = FakeGraph()
+    runner = langgraph_adapter.KitaruGraphRunner(
+        graph,
+        durability=langgraph_adapter.LangGraphDurabilityPolicy(
+            require_checkpointer=True
+        ),
+    )
+
+    with pytest.raises(KitaruUsageError, match="requires a graph checkpointer"):
+        runner.invoke(
+            langgraph_adapter.LangGraphRunRequest.start(
+                {"count": 1},
+                thread_id="thread-1",
+            )
+        )
+
+    assert graph.executed is False
+
+
 def test_capture_policy_can_disable_state_snapshot_inspection(
     langgraph_adapter: types.ModuleType,
 ) -> None:

--- a/tests/test_langgraph_adapter_foundation.py
+++ b/tests/test_langgraph_adapter_foundation.py
@@ -1027,6 +1027,73 @@ def test_request_durability_is_not_forwarded_without_checkpointer(
     assert any("No LangGraph checkpointer" in warning for warning in result.warnings)
 
 
+def test_request_durability_is_forwarded_for_config_injected_checkpointer(
+    langgraph_adapter: types.ModuleType,
+) -> None:
+    seen: dict[str, object] = {}
+    config_checkpointer = object()
+
+    class FakeGraph:
+        name = "fake"
+        checkpointer = None
+
+        def invoke(self, input: object, **kwargs: object) -> object:
+            seen.update(kwargs)
+            return input
+
+    runner = langgraph_adapter.KitaruGraphRunner(
+        FakeGraph(),
+        config_factory=lambda _request: {
+            "configurable": {"__pregel_checkpointer": config_checkpointer}
+        },
+    )
+    result = runner.invoke(
+        langgraph_adapter.LangGraphRunRequest.start(
+            {"count": 1},
+            thread_id="thread-1",
+            durability="sync",
+        )
+    )
+
+    assert result.status == "completed"
+    assert seen["durability"] == "sync"
+    assert not any(
+        "No LangGraph checkpointer" in warning for warning in result.warnings
+    )
+
+
+def test_strict_durability_policy_accepts_config_injected_checkpointer(
+    langgraph_adapter: types.ModuleType,
+) -> None:
+    config_checkpointer = object()
+
+    class FakeGraph:
+        name = "fake"
+        checkpointer = None
+
+        def invoke(self, input: object, **_kwargs: object) -> object:
+            return input
+
+    runner = langgraph_adapter.KitaruGraphRunner(
+        FakeGraph(),
+        config_factory=lambda _request: {
+            "configurable": {"__pregel_checkpointer": config_checkpointer}
+        },
+        durability=langgraph_adapter.LangGraphDurabilityPolicy(
+            require_checkpointer=True
+        ),
+    )
+
+    result = runner.invoke(
+        langgraph_adapter.LangGraphRunRequest.start(
+            {"count": 1},
+            thread_id="thread-1",
+        )
+    )
+
+    assert result.status == "completed"
+
+
 @pytest.mark.parametrize(
     ("checkpointer", "expected_forwarded_durability"),
     [(None, None), (object(), "sync")],

--- a/tests/test_langgraph_runner.py
+++ b/tests/test_langgraph_runner.py
@@ -48,7 +48,7 @@ class CountState(TypedDict):
     count: int
 
 
-def _count_graph():
+def _count_graph(*, with_checkpointer: bool = True):
     builder = StateGraph(cast(Any, CountState))
 
     def add_one(state: CountState) -> CountState:
@@ -57,6 +57,8 @@ def _count_graph():
     builder.add_node("add_one", add_one)
     builder.add_edge(START, "add_one")
     builder.add_edge("add_one", END)
+    if not with_checkpointer:
+        return builder.compile()
     return builder.compile(checkpointer=InMemorySaver())
 
 
@@ -75,6 +77,19 @@ def test_invoke_runs_deterministic_local_graph_with_thread_id() -> None:
     assert result.state_summary is not None
     assert result.state_summary.values is None
     assert any("InMemorySaver" in warning for warning in result.warnings)
+
+
+def test_invoke_runs_graph_without_langgraph_checkpointer() -> None:
+    graph = _count_graph(with_checkpointer=False)
+    runner = KitaruGraphRunner(graph, name="counter")
+
+    result = runner.invoke(
+        LangGraphRunRequest.start({"count": 1}, thread_id="counter-no-checkpointer")
+    )
+
+    assert result.status == "completed"
+    assert result.output == {"count": 2}
+    assert any("No LangGraph checkpointer" in warning for warning in result.warnings)
 
 
 def test_full_state_values_are_opt_in() -> None:

--- a/tests/test_langgraph_streaming.py
+++ b/tests/test_langgraph_streaming.py
@@ -54,7 +54,7 @@ class CountState(TypedDict):
     count: int
 
 
-def _count_graph():
+def _count_graph(*, with_checkpointer: bool = True):
     builder = StateGraph(cast(Any, CountState))
 
     def add_one(state: CountState) -> CountState:
@@ -63,6 +63,8 @@ def _count_graph():
     builder.add_node("add_one", add_one)
     builder.add_edge(START, "add_one")
     builder.add_edge("add_one", END)
+    if not with_checkpointer:
+        return builder.compile()
     return builder.compile(checkpointer=InMemorySaver())
 
 
@@ -202,6 +204,22 @@ def test_stream_returns_result_from_final_values_and_extracts_usage() -> None:
 
     assert result.status == "completed"
     assert result.output == {"count": 2}
+
+
+def test_stream_runs_graph_without_langgraph_checkpointer() -> None:
+    runner = KitaruGraphRunner(_count_graph(with_checkpointer=False), name="counter")
+
+    result = runner.stream(
+        LangGraphRunRequest.start(
+            {"count": 1},
+            thread_id="stream-no-checkpointer-thread",
+        ),
+        stream_mode="updates",
+    )
+
+    assert result.status == "completed"
+    assert result.output == {"count": 2}
+    assert any("No LangGraph checkpointer" in warning for warning in result.warnings)
 
 
 class UsageGraph:


### PR DESCRIPTION
## What changed

- Fixed the LangGraph adapter crash when Kitaru wraps a graph compiled without a usable LangGraph checkpointer under the default durability policy.
- Kitaru now normalizes the wrapped graph's checkpointer once at runner initialization and only forwards LangGraph `durability` when either the graph or prepared LangGraph config supplies an actual checkpointer saver.
- Added fake-graph and real LangGraph regression coverage for no-checkpointer invoke/stream paths.
- Added a changelog entry under `[Unreleased]`.

Closes #403.

## Why it was needed

Kitaru defaulted LangGraph durability to `sync` and forwarded that kwarg even for graphs with no LangGraph checkpointer. With `langgraph==1.2.0`, that path warns that durability has no effect, then still waits on a checkpoint future that was never created, raising `_put_checkpoint_fut`.

## Key implementation decisions

- No dependency pin: LangGraph 1.2 works for saver-backed graphs and no-checkpointer graphs when Kitaru does not send ineffective durability kwargs.
- Treat `None`, missing `.checkpointer`, `False`, and root-graph `True` as no usable saver.
- Preserve `require_checkpointer=True` by checking the same effective saver state before graph execution, including inherited checkpointers supplied through LangGraph config.
- Keep `durability` as requested/resolved Kitaru durability and add `forwarded_durability` so run/event/analytics metadata also records the kwarg actually sent to LangGraph.

## Reviewer Notes

The important behavior now happens in `KitaruGraphRunner`'s kwarg construction. Before this change, a graph without a saver still got `durability="sync"`; LangGraph then tried to wait for checkpoint work that could not exist. Now Kitaru first asks whether the wrapped graph has a real saver object, or whether the prepared LangGraph config contains an inherited `__pregel_checkpointer` saver. If neither exists, it simply does not send a durability kwarg, and LangGraph runs the no-checkpointer graph normally while Kitaru still records the outer graph call.

The highest-risk part to inspect is the effective checkpointer detection in `src/kitaru/adapters/langgraph/_agent.py`: boolean sentinels are deliberately treated as no saver, while config-injected saver objects preserve requested durability. The test coverage in `tests/test_langgraph_adapter_foundation.py` pins the fake-graph kwarg behavior, while `tests/test_langgraph_runner.py` and `tests/test_langgraph_streaming.py` prove real LangGraph no-checkpointer invoke and stream paths complete under the current LangGraph 1.2 lock.

### Reproduction

To see the fixed behavior end to end:

1. In an environment with the current lockfile (`langgraph==1.2.0`), compile a tiny `StateGraph` with `builder.compile()` and no `checkpointer=...`.
2. Wrap it with `KitaruGraphRunner(graph)`.
3. Call `runner.invoke(LangGraphRunRequest.start({"count": 1}, thread_id="no-checkpointer"))`.
4. The run should complete with `output == {"count": 2}` and include Kitaru's existing no-checkpointer warning instead of crashing with `_put_checkpoint_fut`.

The added regression tests cover the same flow:

```bash
just test tests/test_langgraph_runner.py::test_invoke_runs_graph_without_langgraph_checkpointer
just test tests/test_langgraph_streaming.py::test_stream_runs_graph_without_langgraph_checkpointer
```

Local checks run:

```bash
just check
just test tests/test_langgraph_adapter_foundation.py
just test tests/test_langgraph_runner.py tests/test_langgraph_streaming.py tests/test_langgraph_calls_strategy.py
```

Earlier full-suite result on this PR branch before the final metadata-only follow-up: `2207 passed, 8 skipped, 100 warnings`.



