### PR TITLE
Fix chatbot history persistence

### DIFF
--- a/examples/chatbot/README.md
+++ b/examples/chatbot/README.md
@@ -8,15 +8,19 @@
 This example takes that idea literally. We model the entire conversation as **one PydanticAI agent** with one human-in-the-loop tool. When the agent wants to talk to the user, it calls the tool. The tool calls `kitaru.wait(...)` under the hood, the underlying compute is freed, and the run sleeps. When the user replies, Kitaru spins the pod back up and the agent picks up exactly where it left off.
 
 ```python
+@kitaru.checkpoint(cache=False)
+def persist_history(history: list[Message]) -> None:
+    kitaru.save("history", history)
+
+
 @agent.tool
 def say_and_wait(ctx: RunContext[Conversation], message: str) -> str:
-    """Send MESSAGE to the user and return whatever they reply.
-
-    Internally: kitaru.save("history", …) → kitaru.wait(...) → save → return.
-    """
+    """Send MESSAGE to the user and return whatever they reply."""
 ```
 
 That's the whole loop. Greeting, every assistant turn, and "goodbye" are all the LLM choosing to call `say_and_wait`. When it stops calling it, the conversation ends.
+
+There is one important implementation detail. `say_and_wait` is intentionally not wrapped in the adapter's synthetic tool checkpoint because `wait_for_input()` must run at flow scope. So the tool appends the assistant message, calls `persist_history(...)` to save the `history` artifact inside a small explicit checkpoint, returns to flow scope, waits for the user, appends the reply, and calls `persist_history(...)` again.
 
 In this paradigm — where the runtime is smart enough to release compute during the human's turn — every chatbot is a long-horizon agent. A session can last months until the user is satisfied, and you only pay for the seconds the model is actually thinking.
 
@@ -58,15 +62,16 @@ Open `http://127.0.0.1:7860`, click **Start a new chat**, and start talking. Clo
 | --- | --- |
 | [`chatbot.py`](chatbot.py) | One `@flow` containing one `KitaruAgent` with one `say_and_wait` tool. ~120 lines. |
 | [`ui.py`](ui.py) | Gradio UI: invokes the deployment, polls for waits, pipes the user's text back via `executions.input(...)`. |
+| [`history_artifacts.py`](history_artifacts.py) | Small pure helpers that load candidate `history` artifacts and choose the longest usable transcript. |
 
-The flow stores the full message list as a single `history` artifact, updated on every turn. The UI rehydrates a session by loading the latest one — no exec-ID pasting, no clever bookkeeping.
+The flow stores the full message list as a single versioned `history` artifact, updated on every turn through `persist_history(...)`. The UI rehydrates a session by loading usable `history` artifacts and choosing the longest transcript — no exec-ID pasting, no metadata assumptions, no clever bookkeeping.
 
 ## What to look for
 
 After a few turns, open the Kitaru dashboard for the execution:
 
-- **The agent's synthetic checkpoint per LLM call** — `KitaruAgent` wraps every model request, tool call, and wait under its own replay boundary.
-- **The `history` artifact, versioned per turn** — every `say_and_wait` body call appends and saves; replay reuses the latest one.
+- **The agent's synthetic checkpoints around LLM work** — `KitaruAgent` wraps model requests for replay, while `say_and_wait` opts out so it can create waits at flow scope.
+- **The `history` artifact, versioned per turn** — every `say_and_wait` body call appends a message and then calls `persist_history(...)`, which saves from checkpoint scope.
 - **Multiple completed `wait`s** — one per user turn, each with the question the LLM asked and the user's reply.
 
 If you kill the pod between turns, the execution stays `WAITING` indefinitely. When the user finally sends another message, the server schedules a fresh pod and the run resumes from the wait — same checkpoints, same artifacts, no replay of completed turns.
@@ -80,3 +85,5 @@ The agent loop is generic. To make this a real product:
 3. **Plug in a real frontend.** The UI here is Gradio for demo speed; in production the contract is just `client.deployments.invoke(...)` to start a session and `client.executions.input(...)` to feed each user message.
 
 That's the whole pattern. One agent, one HITL tool, durable runtime — chat sessions that live as long as your users care to keep them.
+
+This example does not change the public `kitaru.save()` rule: artifact writes still happen inside checkpoints. Broader flow-scope `kitaru.save()` support would need product decisions about where execution-level artifacts live, how clients list them, how replay treats them, and how the dashboard displays them.

--- a/examples/chatbot/chatbot.py
+++ b/examples/chatbot/chatbot.py
@@ -6,9 +6,10 @@ the whole conversation: every time it wants to talk to the user it calls
 returns whatever the user typed back. The agent stops calling the tool when
 the conversation is over.
 
-No turn loop, no manual checkpoint boundaries, no per-turn bookkeeping — the
-KitaruAgent adapter wraps each model + tool call in a synthetic checkpoint
-for replay, and the tool body saves the running ``history`` artifact so any
+No turn loop, no manual per-turn bookkeeping — the KitaruAgent adapter
+wraps model calls in checkpoints for replay. The ``say_and_wait`` tool itself
+stays at flow scope because waits must be created outside checkpoints, and a
+small explicit checkpoint helper saves the running ``history`` artifact so any
 UI can rehydrate a session by loading the latest one.
 
 Recommended workflow:
@@ -32,6 +33,11 @@ import kitaru
 from kitaru import ImageSettings, flow
 from kitaru.adapters.pydantic_ai import KitaruAgent, wait_for_input
 
+try:
+    from .history_artifacts import HISTORY_ARTIFACT_NAME
+except ImportError:  # pragma: no cover - direct ``python chatbot.py`` execution
+    from history_artifacts import HISTORY_ARTIFACT_NAME
+
 CHATBOT_IMAGE = ImageSettings(
     requirements=["pydantic-ai", "openai"],
     # Injects the secret's keys (here: ``OPENAI_API_KEY``) into the runtime
@@ -50,6 +56,12 @@ SYSTEM_PROMPT = (
 )
 
 Message = dict[str, str]  # {"role": "user" | "assistant", "content": ...}
+
+
+@kitaru.checkpoint(cache=False)
+def persist_history(history: list[Message]) -> None:
+    """Save a snapshot of the conversation history as a versioned artifact."""
+    kitaru.save(HISTORY_ARTIFACT_NAME, history)
 
 
 @dataclass
@@ -80,7 +92,7 @@ def chatbot() -> str:
         """
         conv = ctx.deps
         conv.history.append({"role": "assistant", "content": message})
-        kitaru.save("history", list(conv.history))
+        persist_history(list(conv.history))
 
         user_reply = wait_for_input(
             schema=str,
@@ -90,7 +102,7 @@ def chatbot() -> str:
         )
         conv.turn += 1
         conv.history.append({"role": "user", "content": user_reply})
-        kitaru.save("history", list(conv.history))
+        persist_history(list(conv.history))
         return user_reply
 
     # ``say_and_wait`` opts out of the adapter's synthetic tool checkpoint so

--- a/examples/chatbot/history_artifacts.py
+++ b/examples/chatbot/history_artifacts.py
@@ -1,0 +1,97 @@
+"""Pure helpers for selecting chatbot history artifacts.
+
+The Gradio UI imports these helpers, but they deliberately know nothing about
+Gradio or the Kitaru client. Tests can pass small fake artifact objects with a
+``name`` attribute and a ``load()`` method.
+"""
+
+import logging
+from collections.abc import Iterable
+from typing import Any, Protocol
+
+HISTORY_ARTIFACT_NAME = "history"
+Message = dict[str, str]
+_LOGGER = logging.getLogger(__name__)
+
+
+class HistoryArtifact(Protocol):
+    """Small contract needed to inspect and load an artifact candidate."""
+
+    name: str
+
+    def load(self) -> Any:
+        """Return the stored artifact value."""
+        ...
+
+
+def normalize_history(raw: Any) -> list[Message] | None:
+    """Normalize a loaded history value, or return ``None`` if it is malformed.
+
+    A candidate history artifact is malformed if any item lacks readable
+    ``role`` and ``content`` values. Valid values are coerced to strings to
+    preserve the original UI behavior.
+    """
+    if raw is None:
+        return []
+
+    try:
+        iterator = iter(raw)
+    except TypeError:
+        return None
+
+    normalized: list[Message] = []
+    for item in iterator:
+        message = _normalize_message(item)
+        if message is None:
+            return None
+        normalized.append(message)
+    return normalized
+
+
+def load_longest_usable_history(artifacts: Iterable[HistoryArtifact]) -> list[Message]:
+    """Load history artifacts and return the longest usable transcript.
+
+    Unloadable artifacts and malformed loaded values are ignored. When two
+    usable histories have the same length, the later candidate wins so a newer
+    equal-length retry/replay can replace an older candidate without metadata.
+    """
+    best: list[Message] = []
+    for artifact in artifacts:
+        if artifact.name != HISTORY_ARTIFACT_NAME:
+            continue
+        try:
+            raw = artifact.load()
+        except Exception:
+            _LOGGER.debug("Skipping unloadable history artifact.", exc_info=True)
+            continue
+        history = normalize_history(raw)
+        if history is None:
+            _LOGGER.debug("Skipping malformed history artifact.")
+            continue
+        if len(history) >= len(best):
+            best = history
+    return best
+
+
+def _normalize_message(item: Any) -> Message | None:
+    role = _read_message_value(item, "role")
+    content = _read_message_value(item, "content")
+    if role is None or content is None:
+        return None
+    return {"role": role, "content": content}
+
+
+def _read_message_value(item: Any, field: str) -> str | None:
+    if isinstance(item, dict):
+        if field not in item:
+            return None
+        value = item[field]
+    else:
+        try:
+            value = getattr(item, field)
+        except Exception:
+            return None
+
+    if value is None:
+        return None
+    return str(value)

--- a/examples/chatbot/history_artifacts.py
+++ b/examples/chatbot/history_artifacts.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 from typing import Any, Protocol
 
 HISTORY_ARTIFACT_NAME = "history"
+_ALLOWED_ROLES = {"assistant", "user"}
 Message = dict[str, str]
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,8 +53,9 @@ def load_longest_usable_history(artifacts: Iterable[HistoryArtifact]) -> list[Me
     """Load history artifacts and return the longest usable transcript.
 
     Unloadable artifacts and malformed loaded values are ignored. When two
-    usable histories have the same length, the later candidate wins so a newer
-    equal-length retry/replay can replace an older candidate without metadata.
+    usable histories have the same length, the first encountered candidate wins.
+    ``ArtifactRef`` does not expose reliable freshness metadata, so equal-length
+    candidates are treated as ties rather than "newer" or "older" versions.
     """
     best: list[Message] = []
     for artifact in artifacts:
@@ -68,7 +70,7 @@ def load_longest_usable_history(artifacts: Iterable[HistoryArtifact]) -> list[Me
         if history is None:
             _LOGGER.debug("Skipping malformed history artifact.")
             continue
-        if len(history) >= len(best):
+        if len(history) > len(best):
             best = history
     return best
 
@@ -76,7 +78,7 @@ def load_longest_usable_history(artifacts: Iterable[HistoryArtifact]) -> list[Me
 def _normalize_message(item: Any) -> Message | None:
     role = _read_message_value(item, "role")
     content = _read_message_value(item, "content")
-    if role is None or content is None:
+    if role is None or content is None or role not in _ALLOWED_ROLES:
         return None
     return {"role": role, "content": content}
 

--- a/examples/chatbot/history_artifacts.py
+++ b/examples/chatbot/history_artifacts.py
@@ -37,11 +37,18 @@ def normalize_history(raw: Any) -> list[Message] | None:
 
     try:
         iterator = iter(raw)
-    except TypeError:
+    except Exception:
         return None
 
     normalized: list[Message] = []
-    for item in iterator:
+    while True:
+        try:
+            item = next(iterator)
+        except StopIteration:
+            break
+        except Exception:
+            return None
+
         message = _normalize_message(item)
         if message is None:
             return None
@@ -96,4 +103,7 @@ def _read_message_value(item: Any, field: str) -> str | None:
 
     if value is None:
         return None
-    return str(value)
+    try:
+        return str(value)
+    except Exception:
+        return None

--- a/examples/chatbot/ui.py
+++ b/examples/chatbot/ui.py
@@ -18,7 +18,6 @@ Then:
 import sys
 import time
 from pathlib import Path
-from typing import Any
 
 import gradio as gr
 
@@ -27,6 +26,11 @@ from kitaru.client import ArtifactRef, Execution, ExecutionStatus, KitaruClient
 _REPO_ROOT = str(Path(__file__).resolve().parents[2])
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
+
+from examples.chatbot.history_artifacts import (  # noqa: E402
+    HISTORY_ARTIFACT_NAME,
+    load_longest_usable_history,
+)
 
 FLOW_NAME = "chatbot"
 DEPLOYMENT_TAG = "prod"
@@ -85,32 +89,8 @@ def _poll_until_ready(exec_id: str) -> Execution | None:
 
 
 # ---------------------------------------------------------------------------
-# History (single source of truth: the latest 'history' artifact)
+# History (single source of truth: the best usable 'history' artifact)
 # ---------------------------------------------------------------------------
-
-
-def _history_length(a: ArtifactRef) -> int:
-    """Saved history length is monotonically increasing — use it as a turn index.
-
-    ``producing_call`` is just ``"greet"`` / ``"chat_turn"`` (no per-call digit
-    suffix), so we can't extract a turn index from it. Each saved history is
-    strictly longer than the previous one (greet=1, then +2 per chat_turn).
-    """
-    raw = (a.metadata or {}).get("length") if isinstance(a.metadata, dict) else None
-    return raw if isinstance(raw, int) else 0
-
-
-def _normalize_history(raw: Any) -> list[dict[str, str]]:
-    """Normalize a loaded history artifact value to messages-format dicts."""
-    if not raw:
-        return []
-    out: list[dict[str, str]] = []
-    for m in raw:
-        if isinstance(m, dict):
-            out.append({"role": str(m["role"]), "content": str(m["content"])})
-        else:
-            out.append({"role": str(m.role), "content": str(m.content)})
-    return out
 
 
 def _load_history(
@@ -120,24 +100,36 @@ def _load_history(
     retries: int = 1,
     retry_sleep: float = 0.5,
 ) -> list[dict[str, str]]:
-    """Load the latest ``history`` artifact given an ``exec_id`` or pre-fetched arts.
+    """Load the best usable ``history`` artifact for an execution.
 
     Pass ``arts`` when the caller already has a hydrated Execution (saves a
     ~1.5s artifacts.list roundtrip). Otherwise pass ``exec_id`` and we fetch.
     Use ``retries`` > 1 right after a flow first transitions to WAITING — the
     artifact list can briefly trail the status update.
     """
+    current_arts = arts
     for attempt in range(retries):
-        if arts is None:
+        if current_arts is None:
             try:
-                arts = client.artifacts.list(exec_id, name="history") if exec_id else []
+                current_arts = (
+                    client.artifacts.list(exec_id, name=HISTORY_ARTIFACT_NAME)
+                    if exec_id
+                    else []
+                )
             except Exception:
-                arts = []
-        history_arts = [a for a in arts if a.name == "history"]
+                current_arts = []
+
+        history_arts = [a for a in current_arts if a.name == HISTORY_ARTIFACT_NAME]
         if history_arts:
-            latest = max(history_arts, key=_history_length)
-            return _normalize_history(latest.load())
-        arts = None  # force re-fetch on next attempt
+            history = load_longest_usable_history(history_arts)
+            if history:
+                return history
+
+        # If the hydrated Execution had a stale artifact list, fetch a fresh
+        # list on the next attempt. If the caller only supplied artifact refs,
+        # retrying can still help when ``ArtifactRef.load()`` was transiently
+        # unavailable.
+        current_arts = None if exec_id else current_arts
         if attempt + 1 < retries:
             time.sleep(retry_sleep)
     return []
@@ -261,7 +253,12 @@ def new_chat():
         )
         return
 
-    history = _load_history(arts=ex.artifacts, retries=10, retry_sleep=0.5)
+    history = _load_history(
+        exec_id=ex.exec_id,
+        arts=ex.artifacts,
+        retries=10,
+        retry_sleep=0.5,
+    )
     wait_id = ex.pending_wait.wait_id if ex.pending_wait else None
     # NOTE: refresh sidebar choices but DON'T set `value=ex.exec_id` here — that
     # would fire `sessions.change → load_session`, racing with the state we just
@@ -283,7 +280,12 @@ def load_session(
     ex = _try_get(exec_id)
     if ex is None:
         return [], {}, gr.Textbox(interactive=False), "Could not load session."
-    history = _load_history(arts=ex.artifacts, retries=5, retry_sleep=0.4)
+    history = _load_history(
+        exec_id=ex.exec_id,
+        arts=ex.artifacts,
+        retries=5,
+        retry_sleep=0.4,
+    )
     wait_id = ex.pending_wait.wait_id if ex.pending_wait else None
     state = {"exec_id": exec_id, "wait_id": wait_id}
     status = (
@@ -366,7 +368,15 @@ def respond(message: str, history: list[dict], state: dict):
         new_history, next_wait_id = pending, None
     else:
         next_wait_id = ex.pending_wait.wait_id if ex.pending_wait else None
-        new_history = _load_history(arts=ex.artifacts) or pending
+        new_history = (
+            _load_history(
+                exec_id=ex.exec_id,
+                arts=ex.artifacts,
+                retries=3,
+                retry_sleep=0.3,
+            )
+            or pending
+        )
 
     yield (
         new_history,

--- a/examples/chatbot/ui.py
+++ b/examples/chatbot/ui.py
@@ -377,16 +377,24 @@ def respond(message: str, history: list[dict], state: dict):
         min_history_length = (
             len(pending) + 1 if next_wait_id is not None else len(pending)
         )
-        new_history = (
-            _load_history(
-                exec_id=ex.exec_id,
-                arts=ex.artifacts,
-                retries=3,
-                retry_sleep=0.3,
-                min_length=min_history_length,
-            )
-            or pending
+        loaded_history = _load_history(
+            exec_id=ex.exec_id,
+            arts=ex.artifacts,
+            retries=3,
+            retry_sleep=0.3,
+            min_length=min_history_length,
         )
+        if loaded_history:
+            new_history = loaded_history
+        else:
+            wait_question = getattr(ex.pending_wait, "question", None)
+            if next_wait_id is not None and wait_question:
+                new_history = [
+                    *pending,
+                    {"role": "assistant", "content": wait_question},
+                ]
+            else:
+                new_history = pending
 
     yield (
         new_history,

--- a/examples/chatbot/ui.py
+++ b/examples/chatbot/ui.py
@@ -99,15 +99,19 @@ def _load_history(
     arts: list[ArtifactRef] | None = None,
     retries: int = 1,
     retry_sleep: float = 0.5,
+    min_length: int = 0,
 ) -> list[dict[str, str]]:
     """Load the best usable ``history`` artifact for an execution.
 
     Pass ``arts`` when the caller already has a hydrated Execution (saves a
     ~1.5s artifacts.list roundtrip). Otherwise pass ``exec_id`` and we fetch.
     Use ``retries`` > 1 right after a flow first transitions to WAITING — the
-    artifact list can briefly trail the status update.
+    artifact list can briefly trail the status update. Pass ``min_length`` when
+    the caller already knows the shortest acceptable transcript length; this
+    prevents a stale non-empty artifact from replacing a locally pending turn.
     """
     current_arts = arts
+    best_short_history: list[dict[str, str]] = []
     for attempt in range(retries):
         if current_arts is None:
             try:
@@ -122,8 +126,10 @@ def _load_history(
         history_arts = [a for a in current_arts if a.name == HISTORY_ARTIFACT_NAME]
         if history_arts:
             history = load_longest_usable_history(history_arts)
-            if history:
+            if len(history) >= min_length and history:
                 return history
+            if len(history) > len(best_short_history):
+                best_short_history = history
 
         # If the hydrated Execution had a stale artifact list, fetch a fresh
         # list on the next attempt. If the caller only supplied artifact refs,
@@ -132,7 +138,7 @@ def _load_history(
         current_arts = None if exec_id else current_arts
         if attempt + 1 < retries:
             time.sleep(retry_sleep)
-    return []
+    return [] if min_length else best_short_history
 
 
 # ---------------------------------------------------------------------------
@@ -368,12 +374,16 @@ def respond(message: str, history: list[dict], state: dict):
         new_history, next_wait_id = pending, None
     else:
         next_wait_id = ex.pending_wait.wait_id if ex.pending_wait else None
+        min_history_length = (
+            len(pending) + 1 if next_wait_id is not None else len(pending)
+        )
         new_history = (
             _load_history(
                 exec_id=ex.exec_id,
                 arts=ex.artifacts,
                 retries=3,
                 retry_sleep=0.3,
+                min_length=min_history_length,
             )
             or pending
         )

--- a/tests/test_chatbot_example_contract.py
+++ b/tests/test_chatbot_example_contract.py
@@ -1,0 +1,95 @@
+import ast
+from pathlib import Path
+
+CHATBOT_SOURCE = (
+    Path(__file__).resolve().parents[1] / "examples" / "chatbot" / "chatbot.py"
+)
+
+
+def _module() -> ast.Module:
+    return ast.parse(CHATBOT_SOURCE.read_text())
+
+
+def _is_kitaru_call(node: ast.AST, method: str) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == method
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "kitaru"
+    )
+
+
+def _kitaru_checkpoint_decorator(function: ast.FunctionDef) -> ast.Call | None:
+    for decorator in function.decorator_list:
+        if isinstance(decorator, ast.Call) and _is_kitaru_call(decorator, "checkpoint"):
+            return decorator
+    return None
+
+
+def _module_level_function(module: ast.Module, name: str) -> ast.FunctionDef:
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"No module-level function named {name!r}")
+
+
+def _nested_function(module: ast.Module, name: str) -> ast.FunctionDef:
+    for node in ast.walk(module):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"No function named {name!r}")
+
+
+def test_say_and_wait_does_not_call_kitaru_save_directly() -> None:
+    say_and_wait = _nested_function(_module(), "say_and_wait")
+
+    direct_saves = [
+        node for node in ast.walk(say_and_wait) if _is_kitaru_call(node, "save")
+    ]
+
+    assert direct_saves == []
+
+
+def test_history_persistence_helper_is_explicit_checkpoint() -> None:
+    persist_history = _module_level_function(_module(), "persist_history")
+    checkpoint = _kitaru_checkpoint_decorator(persist_history)
+
+    assert checkpoint is not None
+    cache_keyword = next(
+        (keyword for keyword in checkpoint.keywords if keyword.arg == "cache"),
+        None,
+    )
+    assert isinstance(cache_keyword, ast.keyword)
+    assert isinstance(cache_keyword.value, ast.Constant)
+    assert cache_keyword.value.value is False
+    assert any(_is_kitaru_call(node, "save") for node in ast.walk(persist_history))
+
+
+def test_say_and_wait_still_opts_out_of_adapter_tool_checkpoint() -> None:
+    module = _module()
+    kitaru_agent_calls = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "KitaruAgent"
+    ]
+
+    assert len(kitaru_agent_calls) == 1
+    call = kitaru_agent_calls[0]
+    keywords = {keyword.arg: keyword.value for keyword in call.keywords}
+
+    allow_waits = keywords.get("allow_sync_tool_body_waits")
+    assert isinstance(allow_waits, ast.Constant)
+    assert allow_waits.value is True
+
+    tool_overrides = keywords.get("tool_checkpoint_config_by_name")
+    assert isinstance(tool_overrides, ast.Dict)
+    assert any(
+        isinstance(key, ast.Constant)
+        and key.value == "say_and_wait"
+        and isinstance(value, ast.Constant)
+        and value.value is False
+        for key, value in zip(tool_overrides.keys, tool_overrides.values, strict=True)
+    )

--- a/tests/test_chatbot_history_artifacts.py
+++ b/tests/test_chatbot_history_artifacts.py
@@ -21,6 +21,19 @@ class FakeArtifact:
         return self.value
 
 
+class BadIterator:
+    def __iter__(self) -> "BadIterator":
+        return self
+
+    def __next__(self) -> Any:
+        raise RuntimeError("iterator broke")
+
+
+class BadString:
+    def __str__(self) -> str:
+        raise RuntimeError("string conversion broke")
+
+
 def test_selects_longest_loaded_history_without_length_metadata() -> None:
     short_history = [{"role": "assistant", "content": "hello"}]
     longer_history = [
@@ -81,6 +94,8 @@ def test_skips_unloadable_and_malformed_history_candidates() -> None:
         [
             FakeArtifact("history", error=RuntimeError("not ready yet")),
             FakeArtifact("history", [{"role": "assistant"}]),
+            FakeArtifact("history", BadIterator()),
+            FakeArtifact("history", [{"role": "assistant", "content": BadString()}]),
             FakeArtifact(
                 "not-history", [{"role": "assistant", "content": "ignore me"}]
             ),
@@ -127,6 +142,10 @@ def test_normalize_history_accepts_generator_input() -> None:
     ]
 
 
+def test_normalize_history_rejects_iterator_that_raises() -> None:
+    assert normalize_history(BadIterator()) is None
+
+
 def test_normalize_history_rejects_message_missing_role_or_content() -> None:
     assert normalize_history([{"role": "assistant"}]) is None
     assert normalize_history([SimpleNamespace(role="user")]) is None
@@ -139,3 +158,7 @@ def test_normalize_history_rejects_unsupported_roles() -> None:
     assert (
         normalize_history([SimpleNamespace(role="tool", content="raw output")]) is None
     )
+
+
+def test_normalize_history_rejects_value_when_string_conversion_raises() -> None:
+    assert normalize_history([{"role": "assistant", "content": BadString()}]) is None

--- a/tests/test_chatbot_history_artifacts.py
+++ b/tests/test_chatbot_history_artifacts.py
@@ -38,18 +38,37 @@ def test_selects_longest_loaded_history_without_length_metadata() -> None:
     assert result == longer_history
 
 
-def test_equal_length_history_candidates_prefer_later_artifact() -> None:
-    earlier_history = [{"role": "assistant", "content": "older"}]
-    later_history = [{"role": "assistant", "content": "newer"}]
+def test_equal_length_history_candidates_keep_first_artifact() -> None:
+    first_history = [{"role": "assistant", "content": "first"}]
+    second_history = [{"role": "assistant", "content": "second"}]
 
     result = load_longest_usable_history(
         [
-            FakeArtifact("history", earlier_history),
-            FakeArtifact("history", later_history),
+            FakeArtifact("history", first_history),
+            FakeArtifact("history", second_history),
         ]
     )
 
-    assert result == later_history
+    assert result == first_history
+
+
+def test_skips_history_candidate_with_unsupported_message_role() -> None:
+    usable_history = [{"role": "assistant", "content": "What can I help with?"}]
+
+    result = load_longest_usable_history(
+        [
+            FakeArtifact(
+                "history",
+                [
+                    {"role": "assistant", "content": "Valid start."},
+                    {"role": "system", "content": "Not usable by Gradio chat."},
+                ],
+            ),
+            FakeArtifact("history", usable_history),
+        ]
+    )
+
+    assert result == usable_history
 
 
 def test_skips_unloadable_and_malformed_history_candidates() -> None:
@@ -111,3 +130,12 @@ def test_normalize_history_accepts_generator_input() -> None:
 def test_normalize_history_rejects_message_missing_role_or_content() -> None:
     assert normalize_history([{"role": "assistant"}]) is None
     assert normalize_history([SimpleNamespace(role="user")]) is None
+
+
+def test_normalize_history_rejects_unsupported_roles() -> None:
+    assert (
+        normalize_history([{"role": "system", "content": "hidden instruction"}]) is None
+    )
+    assert (
+        normalize_history([SimpleNamespace(role="tool", content="raw output")]) is None
+    )

--- a/tests/test_chatbot_history_artifacts.py
+++ b/tests/test_chatbot_history_artifacts.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+from examples.chatbot.history_artifacts import (
+    load_longest_usable_history,
+    normalize_history,
+)
+
+
+@dataclass
+class FakeArtifact:
+    name: str
+    value: Any = None
+    metadata: dict[str, Any] | None = None
+    error: Exception | None = None
+
+    def load(self) -> Any:
+        if self.error is not None:
+            raise self.error
+        return self.value
+
+
+def test_selects_longest_loaded_history_without_length_metadata() -> None:
+    short_history = [{"role": "assistant", "content": "hello"}]
+    longer_history = [
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "hi"},
+    ]
+
+    result = load_longest_usable_history(
+        [
+            FakeArtifact("history", short_history, metadata={"length": 100}),
+            FakeArtifact("history", longer_history, metadata={}),
+        ]
+    )
+
+    assert result == longer_history
+
+
+def test_equal_length_history_candidates_prefer_later_artifact() -> None:
+    earlier_history = [{"role": "assistant", "content": "older"}]
+    later_history = [{"role": "assistant", "content": "newer"}]
+
+    result = load_longest_usable_history(
+        [
+            FakeArtifact("history", earlier_history),
+            FakeArtifact("history", later_history),
+        ]
+    )
+
+    assert result == later_history
+
+
+def test_skips_unloadable_and_malformed_history_candidates() -> None:
+    usable_history = [
+        {"role": "assistant", "content": "What can I help with?"},
+        {"role": "user", "content": "A deploy question."},
+    ]
+
+    result = load_longest_usable_history(
+        [
+            FakeArtifact("history", error=RuntimeError("not ready yet")),
+            FakeArtifact("history", [{"role": "assistant"}]),
+            FakeArtifact(
+                "not-history", [{"role": "assistant", "content": "ignore me"}]
+            ),
+            FakeArtifact("history", usable_history),
+        ]
+    )
+
+    assert result == usable_history
+
+
+def test_returns_empty_when_no_history_candidate_is_usable() -> None:
+    result = load_longest_usable_history(
+        [
+            FakeArtifact("history", error=RuntimeError("boom")),
+            FakeArtifact("history", [{"content": "missing role"}]),
+            FakeArtifact("not-history", [{"role": "assistant", "content": "ignored"}]),
+        ]
+    )
+
+    assert result == []
+
+
+def test_normalize_history_accepts_dicts_and_objects_and_coerces_values() -> None:
+    raw = [
+        {"role": "assistant", "content": 42},
+        SimpleNamespace(role="user", content="hello"),
+    ]
+
+    assert normalize_history(raw) == [
+        {"role": "assistant", "content": "42"},
+        {"role": "user", "content": "hello"},
+    ]
+
+
+def test_normalize_history_accepts_generator_input() -> None:
+    raw = (
+        {"role": role, "content": content}
+        for role, content in [("assistant", "hello"), ("user", "hi")]
+    )
+
+    assert normalize_history(raw) == [
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "hi"},
+    ]
+
+
+def test_normalize_history_rejects_message_missing_role_or_content() -> None:
+    assert normalize_history([{"role": "assistant"}]) is None
+    assert normalize_history([SimpleNamespace(role="user")]) is None

--- a/tests/test_chatbot_ui_history.py
+++ b/tests/test_chatbot_ui_history.py
@@ -1,0 +1,214 @@
+import importlib
+import sys
+from dataclasses import dataclass
+from types import ModuleType, SimpleNamespace
+from typing import Any
+
+
+@dataclass
+class FakeArtifact:
+    name: str
+    value: list[dict[str, str]]
+
+    def load(self) -> list[dict[str, str]]:
+        return self.value
+
+
+class _FakeComponent:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def __enter__(self) -> "_FakeComponent":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+    def change(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def click(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def load(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def launch(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def submit(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class _FakeTheme:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def set(self, *args: Any, **kwargs: Any) -> "_FakeTheme":
+        return self
+
+
+class _FakeStatus:
+    def __init__(self, is_finished: bool = False) -> None:
+        self.is_finished = is_finished
+
+
+class _FakeKitaruClient:
+    def __init__(self) -> None:
+        self.artifacts = SimpleNamespace(list=lambda *args, **kwargs: [])
+        self.executions = SimpleNamespace(
+            input=lambda *args, **kwargs: None,
+            list=lambda *args, **kwargs: [],
+        )
+
+
+def _fake_gradio_module() -> ModuleType:
+    module = ModuleType("gradio")
+    module_any: Any = module
+    module_any.Blocks = _FakeComponent
+    module_any.Button = _FakeComponent
+    module_any.Chatbot = _FakeComponent
+    module_any.Column = _FakeComponent
+    module_any.Dropdown = _FakeComponent
+    module_any.HTML = _FakeComponent
+    module_any.Markdown = _FakeComponent
+    module_any.Row = _FakeComponent
+    module_any.State = _FakeComponent
+    module_any.Textbox = _FakeComponent
+    module_any.skip = lambda: None
+    module_any.themes = SimpleNamespace(
+        Color=_FakeTheme,
+        Default=_FakeTheme,
+        GoogleFont=lambda name: name,
+        sizes=SimpleNamespace(radius_md="radius_md"),
+    )
+    return module
+
+
+def _fake_kitaru_client_module() -> ModuleType:
+    module = ModuleType("kitaru.client")
+    module_any: Any = module
+    module_any.ArtifactRef = object
+    module_any.Execution = object
+    module_any.ExecutionStatus = SimpleNamespace(
+        COMPLETED=_FakeStatus(is_finished=True),
+        RUNNING=_FakeStatus(),
+        WAITING=_FakeStatus(),
+    )
+    module_any.KitaruClient = _FakeKitaruClient
+    return module
+
+
+def _import_ui_with_fakes(monkeypatch: Any) -> ModuleType:
+    sys.modules.pop("examples.chatbot.ui", None)
+    monkeypatch.setitem(sys.modules, "gradio", _fake_gradio_module())
+    monkeypatch.setitem(sys.modules, "kitaru.client", _fake_kitaru_client_module())
+    module = importlib.import_module("examples.chatbot.ui")
+    sys.modules.pop("examples.chatbot.ui", None)
+    return module
+
+
+def test_load_history_retries_when_history_is_shorter_than_min_length(
+    monkeypatch: Any,
+) -> None:
+    ui = _import_ui_with_fakes(monkeypatch)
+    stale = [
+        {"role": "assistant", "content": "Hello."},
+        {"role": "user", "content": "First reply."},
+    ]
+    fresh = [
+        *stale,
+        {"role": "assistant", "content": "Second reply."},
+    ]
+    fetched: list[tuple[str, str]] = []
+
+    def list_artifacts(exec_id: str, *, name: str) -> list[FakeArtifact]:
+        fetched.append((exec_id, name))
+        return [FakeArtifact("history", fresh)]
+
+    ui.client.artifacts.list = list_artifacts
+
+    result = ui._load_history(
+        exec_id="exec-1",
+        arts=[FakeArtifact("history", stale)],
+        retries=2,
+        retry_sleep=0,
+        min_length=len(fresh),
+    )
+
+    assert result == fresh
+    assert fetched == [("exec-1", "history")]
+
+
+def test_load_history_returns_empty_instead_of_short_stale_history(
+    monkeypatch: Any,
+) -> None:
+    ui = _import_ui_with_fakes(monkeypatch)
+    stale = [{"role": "assistant", "content": "Hello."}]
+    ui.client.artifacts.list = lambda *args, **kwargs: [FakeArtifact("history", stale)]
+
+    result = ui._load_history(
+        exec_id="exec-1",
+        arts=[FakeArtifact("history", stale)],
+        retries=2,
+        retry_sleep=0,
+        min_length=2,
+    )
+
+    assert result == []
+
+
+def test_respond_expects_next_assistant_message_when_next_wait_exists(
+    monkeypatch: Any,
+) -> None:
+    ui: Any = _import_ui_with_fakes(monkeypatch)
+    seen_min_lengths: list[int] = []
+    history = [{"role": "assistant", "content": "Hello."}]
+
+    def load_history(*args: Any, **kwargs: Any) -> list[dict[str, str]]:
+        seen_min_lengths.append(kwargs["min_length"])
+        return []
+
+    ui._load_history = load_history
+    ui._poll_until_ready = lambda exec_id: SimpleNamespace(
+        exec_id=exec_id,
+        artifacts=[],
+        pending_wait=SimpleNamespace(wait_id="next-wait"),
+    )
+
+    updates = list(
+        ui.respond("Can you help?", history, {"exec_id": "exec-1", "wait_id": "wait-1"})
+    )
+
+    assert seen_min_lengths == [3]
+    assert updates[-1][0] == [
+        *history,
+        {"role": "user", "content": "Can you help?"},
+    ]
+
+
+def test_respond_accepts_pending_history_length_when_conversation_ended(
+    monkeypatch: Any,
+) -> None:
+    ui: Any = _import_ui_with_fakes(monkeypatch)
+    seen_min_lengths: list[int] = []
+    history = [{"role": "assistant", "content": "Hello."}]
+
+    def load_history(*args: Any, **kwargs: Any) -> list[dict[str, str]]:
+        seen_min_lengths.append(kwargs["min_length"])
+        return []
+
+    ui._load_history = load_history
+    ui._poll_until_ready = lambda exec_id: SimpleNamespace(
+        exec_id=exec_id,
+        artifacts=[],
+        pending_wait=None,
+    )
+
+    updates = list(
+        ui.respond("Goodbye", history, {"exec_id": "exec-1", "wait_id": "wait-1"})
+    )
+
+    assert seen_min_lengths == [2]
+    assert updates[-1][0] == [*history, {"role": "user", "content": "Goodbye"}]
+    assert updates[-1][3] == "Conversation ended."

--- a/tests/test_chatbot_ui_history.py
+++ b/tests/test_chatbot_ui_history.py
@@ -16,7 +16,8 @@ class FakeArtifact:
 
 class _FakeComponent:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        pass
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
     def __enter__(self) -> "_FakeComponent":
         return self
@@ -158,7 +159,7 @@ def test_load_history_returns_empty_instead_of_short_stale_history(
     assert result == []
 
 
-def test_respond_expects_next_assistant_message_when_next_wait_exists(
+def test_respond_renders_wait_question_when_next_history_is_missing(
     monkeypatch: Any,
 ) -> None:
     ui: Any = _import_ui_with_fakes(monkeypatch)
@@ -173,7 +174,10 @@ def test_respond_expects_next_assistant_message_when_next_wait_exists(
     ui._poll_until_ready = lambda exec_id: SimpleNamespace(
         exec_id=exec_id,
         artifacts=[],
-        pending_wait=SimpleNamespace(wait_id="next-wait"),
+        pending_wait=SimpleNamespace(
+            wait_id="next-wait",
+            question="What should I do next?",
+        ),
     )
 
     updates = list(
@@ -184,7 +188,32 @@ def test_respond_expects_next_assistant_message_when_next_wait_exists(
     assert updates[-1][0] == [
         *history,
         {"role": "user", "content": "Can you help?"},
+        {"role": "assistant", "content": "What should I do next?"},
     ]
+    assert updates[-1][2].interactive is True
+
+
+def test_respond_falls_back_to_pending_when_next_wait_has_no_question(
+    monkeypatch: Any,
+) -> None:
+    ui: Any = _import_ui_with_fakes(monkeypatch)
+    history = [{"role": "assistant", "content": "Hello."}]
+    ui._load_history = lambda *args, **kwargs: []
+    ui._poll_until_ready = lambda exec_id: SimpleNamespace(
+        exec_id=exec_id,
+        artifacts=[],
+        pending_wait=SimpleNamespace(wait_id="next-wait"),
+    )
+
+    updates = list(
+        ui.respond("Can you help?", history, {"exec_id": "exec-1", "wait_id": "wait-1"})
+    )
+
+    assert updates[-1][0] == [
+        *history,
+        {"role": "user", "content": "Can you help?"},
+    ]
+    assert updates[-1][2].interactive is True
 
 
 def test_respond_accepts_pending_history_length_when_conversation_ended(


### PR DESCRIPTION
Closes #404.

## What changed

- Moved chatbot `history` artifact writes into a module-level `@kitaru.checkpoint(cache=False)` helper.
- Kept `say_and_wait` opted out of the adapter's synthetic tool checkpoint so `wait_for_input()` still runs at flow scope.
- Added pure example-local helpers for loading candidate `history` artifacts and choosing the longest usable transcript without relying on `length` metadata.
- Updated the Gradio UI to use those helpers and retry briefly after submitting input while artifacts hydrate.
- Hardened history loading so pending UI state is not replaced by stale shorter server history after submit.
- Added a UI fallback that renders the next wait question when the execution has advanced but the persisted history artifact is still missing or too short.
- Made history normalization skip malformed artifacts whose iterators or string conversion fail.
- Updated the chatbot README and added regression tests for the source contract, artifact selection, role validation, and UI stale-history retry behavior.

## Why it was needed

The chatbot example was asking one tool body to do two incompatible things under Kitaru's current scope rules: `wait_for_input()` needs flow scope, but `kitaru.save()` needs checkpoint scope. The tool correctly opted out of synthetic checkpointing for the wait, but then direct `kitaru.save("history", ...)` calls crashed with `KitaruContextError`.

## Key implementation decisions

- This PR keeps artifact semantics checkpoint-scoped. I considered allowing `kitaru.save()` at flow scope, but deferred it because that would need broader product/API decisions about execution-level artifacts, listing/loading behavior, replay semantics, and dashboard display.
- The example UI now loads usable `history` artifacts and chooses the longest transcript instead of trusting `metadata["length"]`, since Kitaru's `save()` path does not guarantee that metadata.
- Equal-length history artifacts are treated as deterministic ties, not as freshness signals, because `ArtifactRef` does not expose reliable creation/version ordering.
- The new tests intentionally preserve the existing global rules: `save()` remains checkpoint-only, and the direct tool wait still relies on `tool_checkpoint_config_by_name={"say_and_wait": False}` plus `allow_sync_tool_body_waits=True`.

## Reviewer Notes

The main behavior to inspect is in `examples/chatbot/chatbot.py`: `say_and_wait` still runs as the flow-scope wait tool, but its history writes now happen by calling `persist_history(...)`, which is a normal Kitaru checkpoint. If that helper is wrong, the example either crashes on save again or records history in a replay/cache-sensitive way.

The second area to inspect is `examples/chatbot/history_artifacts.py` plus `_load_history()` in `examples/chatbot/ui.py`. The UI used to rank artifacts by `length` metadata; now it loads candidate `history` artifacts, skips unusable candidates, and chooses the longest normalized transcript. After submit, `_load_history(min_length=...)` prevents stale non-empty history from replacing the locally pending user turn. If the execution has advanced to a next wait, the UI expects one more assistant message before accepting the loaded history. If that assistant message is not available yet but the server already exposes the next wait question, `respond()` temporarily renders that question so the textbox is not re-enabled without telling the user what to answer.

### Reproduction

1. Deploy the chatbot example to a remote-capable stack:
   ```bash
   cd examples/chatbot
   kitaru deploy chatbot.py:chatbot --tag prod --stack <remote-stack> --exclusive
   ```
2. Start the Gradio UI:
   ```bash
   uv run python ui.py
   ```
3. Click **Start a new chat**.
4. Expected: the first assistant message appears while the execution is waiting for input; it should not crash with `KitaruContextError: kitaru.save() can only be called inside a @checkpoint.`
5. Submit a user reply. Expected: the UI does not regress to stale shorter server history while artifacts hydrate; if the next wait is known before the saved transcript catches up, the UI still shows the next assistant question.
6. Reload the UI and select the session. Expected: the transcript rehydrates from the saved `history` artifacts.

Local checks run:

```bash
uv run pytest tests/test_chatbot_history_artifacts.py tests/test_chatbot_example_contract.py tests/test_chatbot_ui_history.py
just check
just test
```

Final full test result: `2219 passed, 8 skipped`.

