### PR TITLE
Fix chatbot image PydanticAI deps

### DIFF
--- a/docs/book/getting-started/quickstart.md
+++ b/docs/book/getting-started/quickstart.md
@@ -157,13 +157,18 @@ parameter:
     stack="prod-k8s",
     image={
         "base_image": "python:3.12-slim",
-        "requirements": ["httpx", "pydantic-ai"],
+        "requirements": ["kitaru[pydantic-ai,openai]", "httpx"],
         "apt_packages": ["git"],
     },
 )
 def research_agent(topic: str) -> str:
     ...
 ```
+
+This example includes `kitaru[pydantic-ai,openai]` explicitly because setting
+`base_image` means you control the image contents. Kitaru can auto-add plain
+`kitaru` when it builds the requirements list for you, but it does not guess
+optional extras such as the PydanticAI/OpenAI adapter dependencies.
 
 See the [Containerization guide](../guides/containerization.md) for the full set of
 image options, custom Dockerfiles, and how Kitaru packages your source code.

--- a/docs/book/guides/containerization.md
+++ b/docs/book/guides/containerization.md
@@ -31,7 +31,7 @@ import kitaru
 @flow(
     image=kitaru.ImageSettings(
         base_image="python:3.12-slim",
-        requirements=["httpx", "pydantic-ai"],
+        requirements=["kitaru[pydantic-ai,openai]", "httpx"],
         apt_packages=["git"],
         environment={"MY_VAR": "value"},
     ),
@@ -46,7 +46,7 @@ Or as a dictionary:
 @flow(
     image={
         "base_image": "python:3.12-slim",
-        "requirements": ["httpx", "pydantic-ai"],
+        "requirements": ["kitaru[pydantic-ai,openai]", "httpx"],
     },
 )
 def my_agent(topic: str) -> str:
@@ -72,12 +72,13 @@ def my_agent(topic: str) -> str:
 
 ## Automatic Kitaru injection
 
-Kitaru automatically adds itself to the container requirements so your flow code
-can import and run `kitaru` at execution time. You do not need to add `kitaru` to
-your `requirements` list manually.
+Kitaru can automatically add plain `kitaru` to image requirements when it builds
+the requirements list for you. It does not infer optional extras from packages
+like `pydantic-ai`. If your code imports a Kitaru adapter, include the matching
+Kitaru extra explicitly, for example `kitaru[pydantic-ai,openai]`.
 
-If you already include `kitaru` (with or without a version pin), it is not
-duplicated:
+If you already include `kitaru` (with or without a version pin or extras), it is
+not duplicated:
 
 ```python
 @flow(
@@ -91,8 +92,10 @@ def my_agent(topic: str) -> str:
 ```
 
 {% hint style="warning" %}
-If you provide a custom `base_image` or `dockerfile`, Kitaru does **not**
-auto-inject the SDK. Your image must already include `kitaru`.
+If you provide a custom `base_image` or `dockerfile`, Kitaru assumes you control
+the image and does **not** auto-inject the SDK. Your image must already include
+`kitaru`, or a Kitaru extra such as `kitaru[pydantic-ai,openai]` if your code
+imports an adapter.
 {% endhint %}
 
 ## Replicating your local environment

--- a/examples/chatbot/README.md
+++ b/examples/chatbot/README.md
@@ -28,7 +28,7 @@ In this paradigm — where the runtime is smart enough to release compute during
 
 ```bash
 cd examples/chatbot
-uv sync --extra pydantic-ai
+uv sync --extra pydantic-ai --extra openai
 uv add --dev gradio
 ```
 

--- a/examples/chatbot/chatbot.py
+++ b/examples/chatbot/chatbot.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover - direct ``python chatbot.py`` execution
     from history_artifacts import HISTORY_ARTIFACT_NAME
 
 CHATBOT_IMAGE = ImageSettings(
-    requirements=["pydantic-ai", "openai"],
+    requirements=["kitaru[pydantic-ai,openai]"],
     # Injects the secret's keys (here: ``OPENAI_API_KEY``) into the runtime
     # environment of every checkpoint pod.
     secret_environment_from=["openai-creds"],

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -4,7 +4,8 @@ Introspects the cyclopts App object, extracts command metadata, and writes
 structured MDX files with frontmatter + meta.json files for FumaDocs navigation.
 
 Output directory: docs/content/docs/cli/
-Generated files are gitignored and should be regenerated locally before docs builds or after CLI changes.
+Generated files are gitignored and should be regenerated locally before docs
+builds or after CLI changes.
 
 Usage:
     uv run python scripts/generate_cli_docs.py

--- a/tests/test_chatbot_example_contract.py
+++ b/tests/test_chatbot_example_contract.py
@@ -41,6 +41,32 @@ def _nested_function(module: ast.Module, name: str) -> ast.FunctionDef:
     raise AssertionError(f"No function named {name!r}")
 
 
+def test_chatbot_image_uses_supported_kitaru_extras() -> None:
+    module = _module()
+    assignment = next(
+        (
+            node
+            for node in module.body
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "CHATBOT_IMAGE"
+                for target in node.targets
+            )
+        ),
+        None,
+    )
+
+    assert assignment is not None
+    assert isinstance(assignment.value, ast.Call)
+    assert isinstance(assignment.value.func, ast.Name)
+    assert assignment.value.func.id == "ImageSettings"
+
+    keywords = {keyword.arg: keyword.value for keyword in assignment.value.keywords}
+
+    assert ast.literal_eval(keywords["requirements"]) == ["kitaru[pydantic-ai,openai]"]
+    assert ast.literal_eval(keywords["secret_environment_from"]) == ["openai-creds"]
+
+
 def test_say_and_wait_does_not_call_kitaru_save_directly() -> None:
     say_and_wait = _nested_function(_module(), "say_and_wait")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3958,6 +3958,24 @@ def test_kitaru_not_duplicated_when_pinned_version_in_requirements() -> None:
     assert docker_settings.requirements == ["kitaru>=0.2.0", "httpx"]
 
 
+@pytest.mark.parametrize(
+    "requirement",
+    [
+        "kitaru[pydantic-ai]",
+        "kitaru[pydantic-ai,openai]",
+    ],
+)
+def test_kitaru_not_duplicated_when_extras_in_requirements(
+    requirement: str,
+) -> None:
+    """Kitaru should not be added if a requirement already includes extras."""
+    image_settings = ImageSettings(requirements=[requirement])
+
+    docker_settings = image_settings_to_docker_settings(image_settings)
+
+    assert docker_settings.requirements == [requirement]
+
+
 def test_kitaru_not_duplicated_when_git_url_in_requirements() -> None:
     """Kitaru should not be added if a git direct reference is already present."""
     git_ref = "kitaru @ git+https://github.com/zenml-io/kitaru.git@develop"


### PR DESCRIPTION
## What changed

Fixes #424.

The chatbot example image now installs Kitaru with its supported PydanticAI and OpenAI extras:

```python
requirements=["kitaru[pydantic-ai,openai]"]
```

instead of installing bare `pydantic-ai` and `openai`. This keeps the deployed image under Kitaru's adapter-tested dependency bounds and prevents resolver backtracking to incompatible PydanticAI versions.

I also added regression coverage for Kitaru extras in image requirements, updated the chatbot README local setup command to install both needed extras, and updated the GitBook docs so they no longer teach bare `pydantic-ai` image requirements.

## Why it was needed

The chatbot image previously resolved to `pydantic-ai`, `openai`, and auto-added plain `kitaru`. Plain `kitaru` does not install `kitaru[pydantic-ai]`, so the deployment image could choose a PydanticAI package outside Kitaru's supported adapter range. The reported failure happens before checkpoints because `examples/chatbot/chatbot.py` imports `kitaru.adapters.pydantic_ai` at module import time.

The local README setup also needed to include the OpenAI extra because the chatbot model is `openai:gpt-4o-mini`.

## Key implementation decisions

- Reused the existing image requirement conversion logic. `_requirements_include_kitaru()` already treats `kitaru[...]` extras as Kitaru requirements, so no production config code needed to change.
- Added regression tests for both `kitaru[pydantic-ai]` and `kitaru[pydantic-ai,openai]` to ensure plain `kitaru` is not appended again.
- Kept `news_scout` dependency compatibility and improved PydanticAI import diagnostics out of this PR; they are related follow-ups with separate dependency/adapter decisions.

## Reviewer Notes

The important behavior now happens in the example image declaration and the existing image conversion path. The chatbot asks for `kitaru[pydantic-ai,openai]`; when Kitaru converts that `ImageSettings` into Docker requirements, it sees the requirement already names Kitaru and leaves it alone. If this is wrong, a built chatbot image would either fall back to bare `pydantic-ai` again or add a duplicate plain `kitaru` requirement.

The main files to inspect are:

- `examples/chatbot/chatbot.py` for the fixed image requirement.
- `examples/chatbot/README.md` for matching local setup instructions.
- `tests/test_config.py` for the no-duplicate Kitaru-extra regression coverage.
- `tests/test_chatbot_example_contract.py` for the source-level chatbot contract test. It intentionally uses AST inspection so the test does not need to import the optional-dependency-heavy chatbot module just to check constants.
- `docs/book/guides/containerization.md` for the docs explanation that auto-injection adds plain `kitaru`, not optional extras.

### Reproduction

To see the fixed behavior end to end without building a remote image, run:

```bash
uv run python - <<'PY'
from examples.chatbot.chatbot import CHATBOT_IMAGE
from kitaru.config import image_settings_to_docker_settings
print(image_settings_to_docker_settings(CHATBOT_IMAGE).requirements)
PY
```

Expected output:

```text
['kitaru[pydantic-ai,openai]']
```

That proves the chatbot image now keeps the Kitaru extras requirement and does not auto-append a second plain `kitaru`.

Local checks run:

```bash
uv run pytest tests/test_config.py tests/test_chatbot_example_contract.py
just check
just test
```

Latest focused checks after the README update:

- `uv run pytest tests/test_config.py tests/test_chatbot_example_contract.py`: `215 passed, 20 warnings`
- `just check`: passed

Earlier full-suite result on this branch: `just test` → `2385 passed, 8 skipped, 86 warnings`.
