### PR TITLE
Fix streaming wait tools

### DIFF
--- a/src/kitaru/adapters/pydantic_ai/_agent.py
+++ b/src/kitaru/adapters/pydantic_ai/_agent.py
@@ -60,7 +60,9 @@ from ._utils import (
     CheckpointConfig,
     CheckpointStrategy,
     ToolCheckpointOverrides,
+    adapter_streaming_fallback_checkpoint,
     checkpoint_input_value,
+    has_any_explicit_tool_checkpoint_opt_out,
     run_async_in_checkpoint,
     run_sync_in_checkpoint,
     turn_cache_key,
@@ -95,6 +97,7 @@ class _TurnCheckpointCallConfig:
     checkpoint_inputs: dict[str, Any]
     checkpoint_config: CheckpointConfig
     force_turn_checkpoint: bool
+    mark_streaming_fallback_checkpoint: bool
 
 
 # Auto-flow bodies keyed by uuid. The @kitaru.flow entrypoint must be module-
@@ -109,13 +112,6 @@ _AUTO_FLOW_LOCK = threading.Lock()
 
 if f"src.{__name__}" not in sys.modules:
     sys.modules[f"src.{__name__}"] = sys.modules[__name__]
-
-
-def _has_tool_checkpoint_opt_out(
-    overrides: ToolCheckpointOverrides | None,
-) -> bool:
-    """Return whether any named tool explicitly opts out of checkpointing."""
-    return bool(overrides and any(override is False for override in overrides.values()))
 
 
 def _strategy_from_granular_checkpoints(
@@ -474,7 +470,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 "`granular_checkpoints=True`, and a matching checkpoint opt-out "
                 'such as `tool_checkpoint_config_by_name={"tool_name": False}`.'
             )
-        if allow_sync_tool_body_waits and not _has_tool_checkpoint_opt_out(
+        if allow_sync_tool_body_waits and not has_any_explicit_tool_checkpoint_opt_out(
             tool_checkpoint_config_by_name
         ):
             raise KitaruUsageError(
@@ -794,6 +790,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 disable_cache=force_turn_checkpoint,
             ),
             force_turn_checkpoint=force_turn_checkpoint,
+            mark_streaming_fallback_checkpoint=(
+                force_turn_checkpoint and self._uses_calls_strategy
+            ),
         )
 
     async def _auto_checkpoint_async(
@@ -803,11 +802,23 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         cache_key: str | None = None,
         checkpoint_inputs: Mapping[str, Any] | None = None,
         checkpoint_config: CheckpointConfig | None = None,
+        mark_streaming_fallback_checkpoint: bool = False,
     ) -> Any:
+        checkpoint_body = body
+        if mark_streaming_fallback_checkpoint:
+
+            async def _marked_body() -> Any:
+                with adapter_streaming_fallback_checkpoint(
+                    allow_sync_tool_body_waits=self._allow_sync_tool_body_waits
+                ):
+                    return await body()
+
+            checkpoint_body = _marked_body
+
         return await run_async_in_checkpoint(
             config=checkpoint_config or self._turn_checkpoint_config,
             step_name=self._name or "agent",
-            body=body,
+            body=checkpoint_body,
             cache_key=cache_key,
             checkpoint_inputs=checkpoint_inputs,
         )
@@ -819,11 +830,23 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         cache_key: str | None = None,
         checkpoint_inputs: Mapping[str, Any] | None = None,
         checkpoint_config: CheckpointConfig | None = None,
+        mark_streaming_fallback_checkpoint: bool = False,
     ) -> Any:
+        checkpoint_body = body
+        if mark_streaming_fallback_checkpoint:
+
+            def _marked_body() -> Any:
+                with adapter_streaming_fallback_checkpoint(
+                    allow_sync_tool_body_waits=self._allow_sync_tool_body_waits
+                ):
+                    return body()
+
+            checkpoint_body = _marked_body
+
         return run_sync_in_checkpoint(
             config=checkpoint_config or self._turn_checkpoint_config,
             step_name=self._name or "agent",
-            body=body,
+            body=checkpoint_body,
             cache_key=cache_key,
             checkpoint_inputs=checkpoint_inputs,
         )
@@ -958,9 +981,10 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
 
         This is deliberately run-wide rather than per-tool. Pydantic AI decides
         whether to offload sync tools before Kitaru reaches an individual tool
-        body, so the safe compatibility seam is the agent run boundary. The
-        checkpoint opt-out remains checkpoint-only; this separate flag controls
-        the private Pydantic AI threading compatibility path.
+        body, so Kitaru enables or disables the private threading hook around
+        the whole agent run. The checkpoint opt-out remains checkpoint-only;
+        this separate flag controls the private Pydantic AI threading
+        compatibility path.
         """
         return self._allow_sync_tool_body_waits
 
@@ -999,6 +1023,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         checkpoint_inputs: Mapping[str, Any] | None = None,
         checkpoint_config: CheckpointConfig | None = None,
         auto_flow_toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
+        mark_streaming_fallback_checkpoint: bool = False,
     ) -> Any:
         if is_inside_flow():
             if is_inside_checkpoint() or self._use_granular(force_turn_checkpoint):
@@ -1008,6 +1033,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 cache_key=cache_key,
                 checkpoint_inputs=checkpoint_inputs,
                 checkpoint_config=checkpoint_config,
+                mark_streaming_fallback_checkpoint=mark_streaming_fallback_checkpoint,
             )
 
         self._ensure_auto_flow_mcp_lifecycle_safe(call_toolsets=auto_flow_toolsets)
@@ -1023,6 +1049,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 checkpoint_inputs=checkpoint_inputs,
                 checkpoint_config=checkpoint_config,
                 auto_flow_toolsets=auto_flow_toolsets,
+                mark_streaming_fallback_checkpoint=mark_streaming_fallback_checkpoint,
             )
 
         loop = asyncio.get_running_loop()
@@ -1040,6 +1067,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
         checkpoint_inputs: Mapping[str, Any] | None = None,
         checkpoint_config: CheckpointConfig | None = None,
         auto_flow_toolsets: Sequence[AbstractToolset[AgentDepsT]] | None = None,
+        mark_streaming_fallback_checkpoint: bool = False,
     ) -> Any:
         if is_inside_flow():
             if is_inside_checkpoint() or self._use_granular(force_turn_checkpoint):
@@ -1049,6 +1077,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 cache_key=cache_key,
                 checkpoint_inputs=checkpoint_inputs,
                 checkpoint_config=checkpoint_config,
+                mark_streaming_fallback_checkpoint=mark_streaming_fallback_checkpoint,
             )
         self._ensure_auto_flow_mcp_lifecycle_safe(call_toolsets=auto_flow_toolsets)
         return self._invoke_in_auto_flow(
@@ -1059,6 +1088,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 checkpoint_inputs=checkpoint_inputs,
                 checkpoint_config=checkpoint_config,
                 auto_flow_toolsets=auto_flow_toolsets,
+                mark_streaming_fallback_checkpoint=mark_streaming_fallback_checkpoint,
             )
         )
 
@@ -1179,6 +1209,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 checkpoint_inputs=turn_call_config.checkpoint_inputs,
                 checkpoint_config=turn_call_config.checkpoint_config,
                 auto_flow_toolsets=prepared_toolsets,
+                mark_streaming_fallback_checkpoint=(
+                    turn_call_config.mark_streaming_fallback_checkpoint
+                ),
             )
             self._remember_messages(result)
             return result
@@ -1298,6 +1331,9 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
                 checkpoint_inputs=turn_call_config.checkpoint_inputs,
                 checkpoint_config=turn_call_config.checkpoint_config,
                 auto_flow_toolsets=prepared_toolsets,
+                mark_streaming_fallback_checkpoint=(
+                    turn_call_config.mark_streaming_fallback_checkpoint
+                ),
             )
             self._remember_messages(result)
             return result
@@ -1351,6 +1387,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             self._kitaru_overrides(),
             self._tracking_scope(),
             stream_surface("run_stream"),
+            _inline_sync_tool_execution(enabled=self._should_inline_sync_tools()),
             model_cache_run_context(
                 conversation_id=conversation_id, message_history=message_history
             ),
@@ -1428,6 +1465,7 @@ class KitaruAgent(WrapperAgent[AgentDepsT, OutputDataT]):
             self._kitaru_overrides(),
             self._tracking_scope(),
             stream_surface("iter"),
+            _inline_sync_tool_execution(enabled=self._should_inline_sync_tools()),
             model_cache_run_context(
                 conversation_id=conversation_id, message_history=message_history
             ),

--- a/src/kitaru/adapters/pydantic_ai/_threading_compat.py
+++ b/src/kitaru/adapters/pydantic_ai/_threading_compat.py
@@ -4,8 +4,8 @@ Pydantic AI normally moves synchronous tool functions to a worker thread. That
 is safe for ordinary tools, but Kitaru waits must be created from the workflow
 thread. The upstream hook is run-scoped rather than per-tool-scoped, so callers
 must enable it explicitly for run shapes that need direct tool-body waits. Keep
-the private Pydantic AI import isolated here so the rest of the adapter has one
-small seam to update if the upstream hook changes.
+the private Pydantic AI import isolated here so a future upstream hook rename
+requires changing this module rather than every agent run wrapper.
 """
 
 from __future__ import annotations

--- a/src/kitaru/adapters/pydantic_ai/_toolset.py
+++ b/src/kitaru/adapters/pydantic_ai/_toolset.py
@@ -18,8 +18,10 @@ from pydantic_ai.toolsets import (
     ToolsetTool,
     WrapperToolset,
 )
+from pydantic_ai.toolsets.function import FunctionToolsetTool
 
 from kitaru.errors import KitaruContextError, KitaruUsageError
+from kitaru.runtime import _suspend_checkpoint_scope
 from kitaru.wait import _WAIT_INSIDE_CHECKPOINT_ERROR
 
 from ._constants import (
@@ -44,6 +46,8 @@ from ._utils import (
     checkpoint_cache_key,
     checkpoint_input_value,
     get_adapter_checkpoint_artifact_refs,
+    get_adapter_streaming_fallback_checkpoint,
+    has_explicit_tool_checkpoint_opt_out,
     resolve_tool_checkpoint_config,
     run_async_in_checkpoint,
     with_default_type,
@@ -67,6 +71,11 @@ def _json_safe(value: Any) -> Any:
             "python_type": value.__class__.__name__,
             "serialization_error": "json_safe_failed",
         }
+
+
+def _is_ordinary_sync_function_tool(tool: ToolsetTool[Any]) -> bool:
+    """Return whether ``tool`` is a plain sync PydanticAI function tool."""
+    return isinstance(tool, FunctionToolsetTool) and tool.is_async is False
 
 
 def _raise_checkpoint_wait_not_supported(tool_name: str, kind: DeferredKind) -> None:
@@ -146,6 +155,30 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             and not is_inside_checkpoint()
         )
 
+    def _should_suspend_streaming_fallback_checkpoint_scope(
+        self,
+        *,
+        name: str,
+        tool: ToolsetTool[AgentDepsT],
+    ) -> bool:
+        """Return whether an opted-out sync tool may run at flow scope.
+
+        PydanticAI may execute several tool calls concurrently. This helper stays
+        intentionally narrow: it is used only under Kitaru's private marker for a
+        streamed calls-strategy fallback turn, and only for function tools whose
+        sync body is forced inline by ``allow_sync_tool_body_waits=True``.
+        """
+        marker = get_adapter_streaming_fallback_checkpoint()
+        return (
+            marker is not None
+            and marker.allow_sync_tool_body_waits
+            and is_inside_checkpoint()
+            and has_explicit_tool_checkpoint_opt_out(
+                name, self.tool_checkpoint_config_by_name
+            )
+            and _is_ordinary_sync_function_tool(tool)
+        )
+
     async def call_tool(
         self,
         name: str,
@@ -164,6 +197,14 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             default=self.tool_checkpoint_config,
             by_name=self.tool_checkpoint_config_by_name,
         )
+        if self._should_suspend_streaming_fallback_checkpoint_scope(
+            name=name,
+            tool=tool,
+        ):
+            with _suspend_checkpoint_scope():
+                return await self._call_tool_tracked(
+                    name, tool_args, ctx, tool, hitl_config
+                )
         if self._should_use_tool_checkpoint(
             name=name,
             ctx=ctx,

--- a/src/kitaru/adapters/pydantic_ai/_toolset.py
+++ b/src/kitaru/adapters/pydantic_ai/_toolset.py
@@ -4,6 +4,7 @@ import inspect
 import re
 import time
 from collections.abc import Callable
+from contextlib import nullcontext
 from dataclasses import dataclass, field, replace
 from typing import Any
 from typing import get_type_hints
@@ -197,14 +198,6 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             default=self.tool_checkpoint_config,
             by_name=self.tool_checkpoint_config_by_name,
         )
-        if self._should_suspend_streaming_fallback_checkpoint_scope(
-            name=name,
-            tool=tool,
-        ):
-            with _suspend_checkpoint_scope():
-                return await self._call_tool_tracked(
-                    name, tool_args, ctx, tool, hitl_config
-                )
         if self._should_use_tool_checkpoint(
             name=name,
             ctx=ctx,
@@ -269,6 +262,13 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
         safe_args: Any | None = None,
     ) -> Any:
         capture_mode = self.capture.capture_mode_for_tool(name)
+        suspend_tool_body_checkpoint_scope = (
+            hitl_config is None
+            and self._should_suspend_streaming_fallback_checkpoint_scope(
+                name=name,
+                tool=tool,
+            )
+        )
         tracker = get_current_tracker()
         if tracker is None or capture_mode is None:
             return await self._call_with_hitl(
@@ -280,6 +280,9 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
                 hitl_config=hitl_config,
                 tracker=tracker,
                 capture_mode=capture_mode,
+                suspend_tool_body_checkpoint_scope=(
+                    suspend_tool_body_checkpoint_scope
+                ),
             )
 
         event_id, event_context = tracker.start_tool_event(
@@ -295,7 +298,11 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
 
         artifacts: dict[str, str] = {}
         adapter_refs = get_adapter_checkpoint_artifact_refs()
-        if capture_mode == "full" and is_inside_checkpoint():
+        if (
+            capture_mode == "full"
+            and is_inside_checkpoint()
+            and not suspend_tool_body_checkpoint_scope
+        ):
             if (
                 adapter_refs is not None
                 and ARTIFACT_ROLE_ARGS in adapter_refs.input_artifacts
@@ -319,6 +326,9 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
                 hitl_config=hitl_config,
                 tracker=tracker,
                 capture_mode=capture_mode,
+                suspend_tool_body_checkpoint_scope=(
+                    suspend_tool_body_checkpoint_scope
+                ),
             )
         except Exception as error:
             tracker.record_tool_event(
@@ -336,7 +346,11 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             raise
 
         duration_ms = _elapsed_ms(started_at)
-        if capture_mode == "full" and is_inside_checkpoint():
+        if (
+            capture_mode == "full"
+            and is_inside_checkpoint()
+            and not suspend_tool_body_checkpoint_scope
+        ):
             if (
                 adapter_refs is not None
                 and ARTIFACT_ROLE_RESULT in adapter_refs.output_artifacts
@@ -373,6 +387,7 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
         hitl_config: HitlConfig | None,
         tracker: EventTracker | None,
         capture_mode: str | None,
+        suspend_tool_body_checkpoint_scope: bool,
     ) -> Any:
         def _call_suffix() -> str:
             return _wait_call_suffix(getattr(ctx, "tool_call_id", None))
@@ -399,12 +414,21 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             )
 
         try:
-            return await super().call_tool(name, tool_args, ctx, tool)
+            return await self._call_wrapped_tool(
+                name=name,
+                tool_args=tool_args,
+                ctx=ctx,
+                tool=tool,
+                suspend_checkpoint_scope=suspend_tool_body_checkpoint_scope,
+            )
         except KitaruContextError as error:
             if is_inside_checkpoint() and str(error) == _WAIT_INSIDE_CHECKPOINT_ERROR:
                 _raise_checkpoint_wait_not_supported(name, "hitl")
             raise
         except ApprovalRequired as error:
+            # Scope is suspended only while the ordinary sync tool body runs.
+            # Native deferred/approval handling resumes under the enclosing
+            # checkpoint and remains unsupported for this focused PR.
             if is_inside_checkpoint():
                 _raise_checkpoint_wait_not_supported(name, "approval_required")
             call_suffix = _call_suffix()
@@ -417,6 +441,8 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
                 run_after_wait=True,
             )
         except CallDeferred as error:
+            # See the ApprovalRequired branch above: this PR supports direct
+            # tool-body waits only, not native deferred/approval waits.
             if is_inside_checkpoint():
                 _raise_checkpoint_wait_not_supported(name, "call_deferred")
             call_suffix = _call_suffix()
@@ -438,6 +464,23 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
             tracker=tracker,
             capture_mode=capture_mode,
         )
+
+    async def _call_wrapped_tool(
+        self,
+        *,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[AgentDepsT],
+        tool: ToolsetTool[AgentDepsT],
+        suspend_checkpoint_scope: bool,
+    ) -> Any:
+        checkpoint_scope = (
+            _suspend_checkpoint_scope()
+            if suspend_checkpoint_scope
+            else nullcontext()
+        )
+        with checkpoint_scope:
+            return await super().call_tool(name, tool_args, ctx, tool)
 
     async def _handle_deferred(
         self,

--- a/src/kitaru/adapters/pydantic_ai/_toolset.py
+++ b/src/kitaru/adapters/pydantic_ai/_toolset.py
@@ -4,7 +4,6 @@ import inspect
 import re
 import time
 from collections.abc import Callable
-from contextlib import nullcontext
 from dataclasses import dataclass, field, replace
 from typing import Any
 from typing import get_type_hints
@@ -51,6 +50,7 @@ from ._utils import (
     has_explicit_tool_checkpoint_opt_out,
     resolve_tool_checkpoint_config,
     run_async_in_checkpoint,
+    suspend_adapter_streaming_fallback_checkpoint,
     with_default_type,
 )
 
@@ -474,13 +474,13 @@ class KitaruToolset(WrapperToolset[AgentDepsT]):
         tool: ToolsetTool[AgentDepsT],
         suspend_checkpoint_scope: bool,
     ) -> Any:
-        checkpoint_scope = (
-            _suspend_checkpoint_scope()
-            if suspend_checkpoint_scope
-            else nullcontext()
-        )
-        with checkpoint_scope:
-            return await super().call_tool(name, tool_args, ctx, tool)
+        if suspend_checkpoint_scope:
+            with (
+                _suspend_checkpoint_scope(),
+                suspend_adapter_streaming_fallback_checkpoint(),
+            ):
+                return await super().call_tool(name, tool_args, ctx, tool)
+        return await super().call_tool(name, tool_args, ctx, tool)
 
     async def _handle_deferred(
         self,

--- a/src/kitaru/adapters/pydantic_ai/_utils.py
+++ b/src/kitaru/adapters/pydantic_ai/_utils.py
@@ -122,6 +122,16 @@ def get_adapter_streaming_fallback_checkpoint() -> (
     return _ADAPTER_STREAMING_FALLBACK_CHECKPOINT.get()
 
 
+@contextmanager
+def suspend_adapter_streaming_fallback_checkpoint() -> Iterator[None]:
+    """Temporarily hide the streamed fallback marker from nested user code."""
+    token = _ADAPTER_STREAMING_FALLBACK_CHECKPOINT.set(None)
+    try:
+        yield
+    finally:
+        _ADAPTER_STREAMING_FALLBACK_CHECKPOINT.reset(token)
+
+
 def has_explicit_tool_checkpoint_opt_out(
     tool_name: str,
     by_name: ToolCheckpointOverrides | None,

--- a/src/kitaru/adapters/pydantic_ai/_utils.py
+++ b/src/kitaru/adapters/pydantic_ai/_utils.py
@@ -52,9 +52,19 @@ class AdapterCheckpointArtifactRefs:
     output_artifacts: Mapping[str, str]
 
 
+@dataclass(frozen=True)
+class AdapterStreamingFallbackCheckpoint:
+    """Private marker for adapter-owned streamed calls-strategy fallback turns."""
+
+    allow_sync_tool_body_waits: bool
+
+
 _ADAPTER_CHECKPOINT_ARTIFACT_REFS: ContextVar[AdapterCheckpointArtifactRefs | None] = (
     ContextVar("kitaru_adapter_checkpoint_artifact_refs", default=None)
 )
+_ADAPTER_STREAMING_FALLBACK_CHECKPOINT: ContextVar[
+    AdapterStreamingFallbackCheckpoint | None
+] = ContextVar("kitaru_adapter_streaming_fallback_checkpoint", default=None)
 
 if f"src.{__name__}" not in sys.modules:
     sys.modules[f"src.{__name__}"] = sys.modules[__name__]
@@ -90,6 +100,49 @@ def get_adapter_checkpoint_artifact_refs() -> AdapterCheckpointArtifactRefs | No
     return _ADAPTER_CHECKPOINT_ARTIFACT_REFS.get()
 
 
+@contextmanager
+def adapter_streaming_fallback_checkpoint(
+    *, allow_sync_tool_body_waits: bool
+) -> Iterator[AdapterStreamingFallbackCheckpoint]:
+    """Mark an adapter-owned whole-turn checkpoint created for streaming fallback."""
+    marker = AdapterStreamingFallbackCheckpoint(
+        allow_sync_tool_body_waits=allow_sync_tool_body_waits
+    )
+    token = _ADAPTER_STREAMING_FALLBACK_CHECKPOINT.set(marker)
+    try:
+        yield marker
+    finally:
+        _ADAPTER_STREAMING_FALLBACK_CHECKPOINT.reset(token)
+
+
+def get_adapter_streaming_fallback_checkpoint() -> (
+    AdapterStreamingFallbackCheckpoint | None
+):
+    """Return the active streamed calls-strategy fallback marker, if any."""
+    return _ADAPTER_STREAMING_FALLBACK_CHECKPOINT.get()
+
+
+def has_explicit_tool_checkpoint_opt_out(
+    tool_name: str,
+    by_name: ToolCheckpointOverrides | None,
+) -> bool:
+    """Return whether ``tool_name`` has an explicit per-tool ``False`` override."""
+    return bool(by_name and by_name.get(tool_name) is False)
+
+
+def has_any_explicit_tool_checkpoint_opt_out(
+    by_name: ToolCheckpointOverrides | None,
+) -> bool:
+    """Return whether any named tool has an explicit per-tool ``False`` override."""
+    return bool(
+        by_name
+        and any(
+            has_explicit_tool_checkpoint_opt_out(tool_name, by_name)
+            for tool_name in by_name
+        )
+    )
+
+
 def resolve_tool_checkpoint_config(
     tool_name: str,
     *,
@@ -101,9 +154,11 @@ def resolve_tool_checkpoint_config(
     Per-tool override in ``by_name`` wins (``False`` opts the tool out entirely);
     otherwise falls back to ``default``, or ``None`` when neither is set.
     """
+    if has_explicit_tool_checkpoint_opt_out(tool_name, by_name):
+        return None
     if by_name and tool_name in by_name:
         override = by_name[tool_name]
-        return None if override is False else override
+        return cast(CheckpointConfig, override)
     return default
 
 

--- a/tests/test_phase17_pydantic_ai_adapter.py
+++ b/tests/test_phase17_pydantic_ai_adapter.py
@@ -125,6 +125,7 @@ def _assert_event_artifacts_use_display_names(
 
 
 _DIRECT_WAIT_AGENT: KitaruAgent[Any, str] | None = None
+_STREAMING_WAIT_AGENT: KitaruAgent[Any, str] | None = None
 _GUARDED_WAIT_AGENT: KitaruAgent[Any, str] | None = None
 _HITL_WAIT_AGENT: KitaruAgent[Any, str] | None = None
 _CHILD_EVENT_ZENML_WAIT_REACHED = "zenml_wait_reached"
@@ -209,10 +210,29 @@ def _run_flow_and_report(
         cleanup()
 
 
+@checkpoint(cache=False)
+def pydantic_ai_streaming_wait_persist_history(history: list[str]) -> list[str]:
+    return history
+
+
+async def _consume_event_stream(_ctx: Any, stream: Any) -> None:
+    async for _event in stream:
+        pass
+
+
 @flow
 def pydantic_ai_direct_wait_flow() -> str:
     assert _DIRECT_WAIT_AGENT is not None
     return _DIRECT_WAIT_AGENT.run_sync("Ask the human for context.").output
+
+
+@flow
+def pydantic_ai_streaming_wait_flow() -> str:
+    assert _STREAMING_WAIT_AGENT is not None
+    return _STREAMING_WAIT_AGENT.run_sync(
+        "Ask the human for context.",
+        event_stream_handler=_consume_event_stream,
+    ).output
 
 
 @flow
@@ -258,6 +278,40 @@ def _run_direct_wait_flow_until_pause(queue: Any) -> None:
         _DIRECT_WAIT_AGENT = None
 
     _run_flow_and_report(queue, pydantic_ai_direct_wait_flow, cleanup)
+
+
+def _run_streaming_wait_flow_until_pause(queue: Any) -> None:
+    global _STREAMING_WAIT_AGENT
+    wait_cleanup = _install_child_wait_reached_event(queue)
+
+    agent = Agent(
+        TestModel(call_tools=["ask_user"]),
+        name=f"streaming_wait_agent_{uuid4().hex[:8]}",
+        output_type=str,
+    )
+
+    @agent.tool_plain
+    def ask_user() -> str:
+        pydantic_ai_streaming_wait_persist_history(["before_wait"])
+        return kp.wait_for_input(
+            schema=str,
+            name="streaming_tool_wait",
+            question="What context should the streamed agent use?",
+            timeout=0,
+        )
+
+    _STREAMING_WAIT_AGENT = KitaruAgent(
+        agent,
+        tool_checkpoint_config_by_name={"ask_user": False},
+        allow_sync_tool_body_waits=True,
+    )
+
+    def cleanup() -> None:
+        global _STREAMING_WAIT_AGENT
+        wait_cleanup()
+        _STREAMING_WAIT_AGENT = None
+
+    _run_flow_and_report(queue, pydantic_ai_streaming_wait_flow, cleanup)
 
 
 def _run_hitl_wait_flow_until_pause(queue: Any) -> None:
@@ -636,6 +690,18 @@ def test_phase17_direct_wait_tool_with_explicit_thread_opt_in_reaches_wait(
     _require_wait_support()
     _assert_child_flow_pauses(
         _run_direct_wait_flow_until_pause,
+        required_event=_CHILD_EVENT_ZENML_WAIT_REACHED,
+    )
+
+
+def test_phase17_streaming_wait_tool_with_checkpoint_reaches_wait(
+    primed_zenml,
+) -> None:
+    """Issue #425: streamed fallback must let opted-out sync tools run at flow scope."""
+    del primed_zenml
+    _require_wait_support()
+    _assert_child_flow_pauses(
+        _run_streaming_wait_flow_until_pause,
         required_event=_CHILD_EVENT_ZENML_WAIT_REACHED,
     )
 

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -19,7 +19,10 @@ pytest.importorskip("pydantic_ai")
 
 from kitaru.adapters.pydantic_ai._utils import (
     CheckpointConfig,
+    adapter_streaming_fallback_checkpoint,
     checkpoint_cache_key,
+    get_adapter_streaming_fallback_checkpoint,
+    has_explicit_tool_checkpoint_opt_out,
     reject_isolated_runtime,
     resolve_tool_checkpoint_config,
     turn_cache_key,
@@ -551,6 +554,27 @@ class TestRejectIsolatedRuntime:
         reject_isolated_runtime({})
 
 
+class TestAdapterStreamingFallbackCheckpointMarker:
+    def test_marker_is_visible_only_inside_context(self) -> None:
+        assert get_adapter_streaming_fallback_checkpoint() is None
+
+        with adapter_streaming_fallback_checkpoint(allow_sync_tool_body_waits=True):
+            marker = get_adapter_streaming_fallback_checkpoint()
+            assert marker is not None
+            assert marker.allow_sync_tool_body_waits is True
+
+        assert get_adapter_streaming_fallback_checkpoint() is None
+
+    def test_marker_resets_after_exception(self) -> None:
+        with (
+            pytest.raises(RuntimeError, match="boom"),
+            adapter_streaming_fallback_checkpoint(allow_sync_tool_body_waits=False),
+        ):
+            raise RuntimeError("boom")
+
+        assert get_adapter_streaming_fallback_checkpoint() is None
+
+
 class TestResolveToolCheckpointConfig:
     def test_default_used_when_no_override(self) -> None:
         default: CheckpointConfig = {"retries": 2}
@@ -586,6 +610,23 @@ class TestResolveToolCheckpointConfig:
             by_name={"foo": False},
         )
         assert resolved == default
+
+    def test_explicit_false_helper_distinguishes_default_none(self) -> None:
+        assert has_explicit_tool_checkpoint_opt_out("ask_user", None) is False
+        assert has_explicit_tool_checkpoint_opt_out("ask_user", {}) is False
+        assert (
+            has_explicit_tool_checkpoint_opt_out("ask_user", {"ask_user": False})
+            is True
+        )
+        assert (
+            has_explicit_tool_checkpoint_opt_out(
+                "ask_user", {"ask_user": {"cache": False}}
+            )
+            is False
+        )
+        assert (
+            has_explicit_tool_checkpoint_opt_out("ask_user", {"other": False}) is False
+        )
 
 
 class TestWithDefaultType:
@@ -1586,6 +1627,57 @@ class TestThreadingCompat:
         assert 'checkpoint_strategy="calls"' in message
         assert "granular_checkpoints=True" in message
 
+    @pytest.mark.anyio
+    async def test_stream_context_managers_enter_inline_sync_tool_context(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from contextlib import asynccontextmanager, contextmanager
+
+        from pydantic_ai import Agent
+        from pydantic_ai.agent.abstract import AbstractAgent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+        from kitaru.adapters.pydantic_ai import _agent as agent_module
+
+        agent = KitaruAgent(
+            Agent(TestModel(), name="stream_inline_tools_agent"),
+            tool_checkpoint_config_by_name={"ask_user": False},
+            allow_sync_tool_body_waits=True,
+        )
+        entered: list[bool] = []
+        streamed_result = object()
+        iter_result = object()
+
+        @contextmanager
+        def fake_inline_sync_tool_execution(*, enabled: bool):
+            entered.append(enabled)
+            yield enabled
+
+        @asynccontextmanager
+        async def fake_run_stream(*_args: Any, **_kwargs: Any):
+            yield streamed_result
+
+        @asynccontextmanager
+        async def fake_iter(*_args: Any, **_kwargs: Any):
+            yield iter_result
+
+        monkeypatch.setattr(
+            agent_module,
+            "_inline_sync_tool_execution",
+            fake_inline_sync_tool_execution,
+        )
+        monkeypatch.setattr(agent, "_require_explicit_checkpoint", lambda _method: None)
+        monkeypatch.setattr(AbstractAgent, "run_stream", fake_run_stream)
+        monkeypatch.setattr(agent.wrapped, "iter", fake_iter)
+
+        async with agent.run_stream("hello") as result:
+            assert result is streamed_result
+        async with agent.iter("hello") as result:
+            assert result is iter_result
+
+        assert entered == [True, True]
+
 
 class TestWaitForInput:
     """Adapter-namespaced helper for calling wait from a tool body."""
@@ -2585,6 +2677,352 @@ async def test_non_hitl_tool_still_uses_calls_strategy_tool_checkpoint(
 
     assert result == "ordinary result"
     assert checkpoint_steps == ["ordinary_tool_tool"]
+
+
+@pytest.mark.anyio
+async def test_streaming_fallback_suspends_scope_for_opted_out_sync_function_tool() -> (
+    None
+):
+    from pydantic_ai import FunctionToolset
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+    from zenml.steps.step_context import StepContext
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._toolset import kitaruify_toolset
+    from kitaru.runtime import (
+        _checkpoint_scope,
+        _flow_scope,
+        _get_step_context_var,
+        _is_inside_checkpoint,
+    )
+
+    observed_body_scope: list[tuple[bool, bool]] = []
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    @toolset.tool_plain
+    def ask_user() -> str:
+        observed_body_scope.append((_is_inside_checkpoint(), StepContext.is_active()))
+        return "human answer"
+
+    wrapped = kitaruify_toolset(
+        toolset,
+        capture=CapturePolicy(correlate_otel_spans=False),
+        tool_checkpoint_config_by_name={"ask_user": False},
+    )
+    ctx = _with_tool_call_id(RunContext(deps=None, model=TestModel(), usage=RunUsage()))
+    tool = (await wrapped.get_tools(ctx))["ask_user"]
+    step_context_var = _get_step_context_var()
+    step_context_token = step_context_var.set(cast(Any, object()))
+    try:
+        with (
+            _flow_scope(name="demo_flow", flow_id="flow-1", execution_id="exec-1"),
+            _checkpoint_scope(
+                name="streamed_turn",
+                checkpoint_type="llm_call",
+                execution_id="exec-1",
+                checkpoint_id="checkpoint-1",
+            ),
+            adapter_streaming_fallback_checkpoint(allow_sync_tool_body_waits=True),
+        ):
+            assert _is_inside_checkpoint()
+            assert StepContext.is_active()
+            result = await wrapped.call_tool("ask_user", {}, ctx, tool)
+            assert _is_inside_checkpoint()
+            assert StepContext.is_active()
+    finally:
+        step_context_var.reset(step_context_token)
+
+    assert result == "human answer"
+    assert observed_body_scope == [(False, False)]
+
+
+@pytest.mark.anyio
+async def test_streaming_fallback_suspend_eligibility_is_tightly_scoped() -> None:
+    from pydantic import TypeAdapter
+    from pydantic_ai import FunctionToolset
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext, ToolDefinition
+    from pydantic_ai.toolsets import ToolsetTool
+    from pydantic_ai.usage import RunUsage
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._toolset import KitaruToolset, kitaruify_toolset
+    from kitaru.runtime import _checkpoint_scope, _flow_scope
+
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    @toolset.tool_plain
+    def sync_tool() -> str:
+        return "sync"
+
+    @toolset.tool_plain
+    async def async_tool() -> str:
+        return "async"
+
+    wrapped = kitaruify_toolset(
+        toolset,
+        capture=CapturePolicy(correlate_otel_spans=False),
+        tool_checkpoint_config_by_name={"sync_tool": False},
+    )
+    assert isinstance(wrapped, KitaruToolset)
+    ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+    tools = await wrapped.get_tools(ctx)
+    sync_function_tool = tools["sync_tool"]
+    async_function_tool = tools["async_tool"]
+    generic_tool: ToolsetTool[None] = ToolsetTool(
+        toolset=cast(Any, wrapped),
+        tool_def=ToolDefinition(name="sync_tool"),
+        max_retries=1,
+        args_validator=cast(Any, TypeAdapter(dict[str, Any]).validator),
+    )
+
+    with (
+        _flow_scope(name="demo_flow"),
+        _checkpoint_scope(name="streamed_turn", checkpoint_type="llm_call"),
+    ):
+        # A user-created or otherwise unmarked checkpoint must not be treated as
+        # Kitaru's streamed calls-strategy fallback checkpoint.
+        assert not wrapped._should_suspend_streaming_fallback_checkpoint_scope(
+            name="sync_tool", tool=sync_function_tool
+        )
+
+        with adapter_streaming_fallback_checkpoint(allow_sync_tool_body_waits=False):
+            assert not wrapped._should_suspend_streaming_fallback_checkpoint_scope(
+                name="sync_tool", tool=sync_function_tool
+            )
+
+        with adapter_streaming_fallback_checkpoint(allow_sync_tool_body_waits=True):
+            assert wrapped._should_suspend_streaming_fallback_checkpoint_scope(
+                name="sync_tool", tool=sync_function_tool
+            )
+            assert not wrapped._should_suspend_streaming_fallback_checkpoint_scope(
+                name="missing_override", tool=sync_function_tool
+            )
+            wrapped.tool_checkpoint_config_by_name = {"sync_tool": {"cache": False}}
+            assert not wrapped._should_suspend_streaming_fallback_checkpoint_scope(
+                name="sync_tool", tool=sync_function_tool
+            )
+            wrapped.tool_checkpoint_config_by_name = {"sync_tool": False}
+            assert not wrapped._should_suspend_streaming_fallback_checkpoint_scope(
+                name="async_tool", tool=async_function_tool
+            )
+            assert not wrapped._should_suspend_streaming_fallback_checkpoint_scope(
+                name="sync_tool", tool=cast(Any, generic_tool)
+            )
+
+
+@pytest.mark.anyio
+async def test_streaming_fallback_does_not_suspend_hitl_tool() -> None:
+    from pydantic_ai import FunctionToolset
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy, hitl_tool
+    from kitaru.adapters.pydantic_ai._toolset import kitaruify_toolset
+    from kitaru.runtime import _checkpoint_scope, _flow_scope
+
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    @toolset.tool_plain
+    @hitl_tool(schema=str, question="Need human input")
+    def ask_human() -> str:
+        return "never reached"
+
+    wrapped = kitaruify_toolset(
+        toolset,
+        capture=CapturePolicy(correlate_otel_spans=False),
+        tool_checkpoint_config_by_name={"ask_human": False},
+    )
+    ctx = _with_tool_call_id(RunContext(deps=None, model=TestModel(), usage=RunUsage()))
+    tool = (await wrapped.get_tools(ctx))["ask_human"]
+
+    with (
+        _flow_scope(name="demo_flow"),
+        _checkpoint_scope(name="streamed_turn", checkpoint_type="llm_call"),
+        adapter_streaming_fallback_checkpoint(allow_sync_tool_body_waits=True),
+        pytest.raises(KitaruUsageError, match="Kitaru waits must be created"),
+    ):
+        await wrapped.call_tool("ask_human", {}, ctx, tool)
+
+
+@pytest.mark.anyio
+async def test_streaming_fallback_suspension_restores_scope_after_tool_error() -> None:
+    from pydantic_ai import FunctionToolset
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+    from zenml.steps.step_context import StepContext
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._toolset import kitaruify_toolset
+    from kitaru.runtime import (
+        _checkpoint_scope,
+        _flow_scope,
+        _get_step_context_var,
+        _is_inside_checkpoint,
+    )
+
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    @toolset.tool_plain
+    def exploding_tool() -> str:
+        assert not _is_inside_checkpoint()
+        assert not StepContext.is_active()
+        raise RuntimeError("tool exploded")
+
+    wrapped = kitaruify_toolset(
+        toolset,
+        capture=CapturePolicy(correlate_otel_spans=False),
+        tool_checkpoint_config_by_name={"exploding_tool": False},
+    )
+    ctx = _with_tool_call_id(RunContext(deps=None, model=TestModel(), usage=RunUsage()))
+    tool = (await wrapped.get_tools(ctx))["exploding_tool"]
+    step_context_var = _get_step_context_var()
+    step_context_token = step_context_var.set(cast(Any, object()))
+    try:
+        with (
+            _flow_scope(name="demo_flow", flow_id="flow-1", execution_id="exec-1"),
+            _checkpoint_scope(
+                name="streamed_turn",
+                checkpoint_type="llm_call",
+                execution_id="exec-1",
+                checkpoint_id="checkpoint-1",
+            ),
+            adapter_streaming_fallback_checkpoint(allow_sync_tool_body_waits=True),
+        ):
+            with pytest.raises(RuntimeError, match="tool exploded"):
+                await wrapped.call_tool("exploding_tool", {}, ctx, tool)
+            assert _is_inside_checkpoint()
+            assert StepContext.is_active()
+    finally:
+        step_context_var.reset(step_context_token)
+
+
+@pytest.mark.anyio
+async def test_streaming_fallback_suspension_restores_scope_after_wait_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from pydantic_ai import FunctionToolset
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+    from zenml.steps.step_context import StepContext
+
+    from kitaru.adapters import pydantic_ai as kp
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._toolset import kitaruify_toolset
+    from kitaru.runtime import (
+        _checkpoint_scope,
+        _flow_scope,
+        _get_step_context_var,
+        _is_inside_checkpoint,
+    )
+
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    @toolset.tool_plain
+    def ask_user() -> str:
+        assert not _is_inside_checkpoint()
+        assert not StepContext.is_active()
+        return kp.wait_for_input(schema=str, name="unit_wait")
+
+    def fake_wait(**_kwargs: Any) -> str:
+        raise RuntimeError("wait paused")
+
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._wait_for_input.kitaru.wait", fake_wait
+    )
+    wrapped = kitaruify_toolset(
+        toolset,
+        capture=CapturePolicy(correlate_otel_spans=False),
+        tool_checkpoint_config_by_name={"ask_user": False},
+    )
+    ctx = _with_tool_call_id(RunContext(deps=None, model=TestModel(), usage=RunUsage()))
+    tool = (await wrapped.get_tools(ctx))["ask_user"]
+    step_context_var = _get_step_context_var()
+    step_context_token = step_context_var.set(cast(Any, object()))
+    try:
+        with (
+            _flow_scope(name="demo_flow", flow_id="flow-1", execution_id="exec-1"),
+            _checkpoint_scope(
+                name="streamed_turn",
+                checkpoint_type="llm_call",
+                execution_id="exec-1",
+                checkpoint_id="checkpoint-1",
+            ),
+            adapter_streaming_fallback_checkpoint(allow_sync_tool_body_waits=True),
+        ):
+            with pytest.raises(RuntimeError, match="wait paused"):
+                await wrapped.call_tool("ask_user", {}, ctx, tool)
+            assert _is_inside_checkpoint()
+            assert StepContext.is_active()
+    finally:
+        step_context_var.reset(step_context_token)
+
+
+@pytest.mark.anyio
+async def test_streaming_fallback_suspension_restores_scope_after_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import asyncio
+
+    from pydantic_ai import FunctionToolset
+    from pydantic_ai.models.test import TestModel
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+    from zenml.steps.step_context import StepContext
+
+    from kitaru.adapters.pydantic_ai import CapturePolicy
+    from kitaru.adapters.pydantic_ai._toolset import kitaruify_toolset
+    from kitaru.runtime import (
+        _checkpoint_scope,
+        _flow_scope,
+        _get_step_context_var,
+        _is_inside_checkpoint,
+    )
+
+    toolset: FunctionToolset[None] = FunctionToolset()
+
+    @toolset.tool_plain
+    def ask_user() -> str:
+        return "body replaced by monkeypatch"
+
+    wrapped = kitaruify_toolset(
+        toolset,
+        capture=CapturePolicy(correlate_otel_spans=False),
+        tool_checkpoint_config_by_name={"ask_user": False},
+    )
+    ctx = _with_tool_call_id(RunContext(deps=None, model=TestModel(), usage=RunUsage()))
+    tool = (await wrapped.get_tools(ctx))["ask_user"]
+
+    async def fake_call_tool_tracked(*_args: Any, **_kwargs: Any) -> Any:
+        assert not _is_inside_checkpoint()
+        assert not StepContext.is_active()
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(wrapped, "_call_tool_tracked", fake_call_tool_tracked)
+    step_context_var = _get_step_context_var()
+    step_context_token = step_context_var.set(cast(Any, object()))
+    try:
+        with (
+            _flow_scope(name="demo_flow", flow_id="flow-1", execution_id="exec-1"),
+            _checkpoint_scope(
+                name="streamed_turn",
+                checkpoint_type="llm_call",
+                execution_id="exec-1",
+                checkpoint_id="checkpoint-1",
+            ),
+            adapter_streaming_fallback_checkpoint(allow_sync_tool_body_waits=True),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await wrapped.call_tool("ask_user", {}, ctx, tool)
+            assert _is_inside_checkpoint()
+            assert StepContext.is_active()
+    finally:
+        step_context_var.reset(step_context_token)
 
 
 @pytest.mark.anyio

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -574,6 +574,69 @@ class TestAdapterStreamingFallbackCheckpointMarker:
 
         assert get_adapter_streaming_fallback_checkpoint() is None
 
+    @pytest.mark.anyio
+    async def test_marker_provenance_tracks_adapter_owned_streaming_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+        from kitaru.adapters.pydantic_ai import _agent as agent_module
+        from kitaru.runtime import _checkpoint_scope, _flow_scope
+
+        observations: list[tuple[str, bool]] = []
+
+        async def fake_checkpoint(*, body: Any, step_name: str, **_kwargs: Any) -> Any:
+            with _checkpoint_scope(name=step_name, checkpoint_type="llm_call"):
+                return await body()
+
+        async def observe(label: str) -> str:
+            observations.append(
+                (label, get_adapter_streaming_fallback_checkpoint() is not None)
+            )
+            return label
+
+        monkeypatch.setattr(
+            agent_module,
+            "run_async_in_checkpoint",
+            fake_checkpoint,
+        )
+        calls_agent = KitaruAgent(Agent(TestModel(), name="calls_marker_agent"))
+        turn_agent = KitaruAgent(
+            Agent(TestModel(), name="turn_marker_agent"),
+            checkpoint_strategy="turn",
+        )
+
+        with _flow_scope(name="demo_flow"):
+            await calls_agent._run_async(
+                lambda: observe("calls/no streaming"),
+                force_turn_checkpoint=False,
+            )
+            await calls_agent._run_async(
+                lambda: observe("calls/streaming"),
+                force_turn_checkpoint=True,
+                mark_streaming_fallback_checkpoint=True,
+            )
+            await turn_agent._run_async(
+                lambda: observe("turn/streaming"),
+                force_turn_checkpoint=True,
+                mark_streaming_fallback_checkpoint=False,
+            )
+            with _checkpoint_scope(name="user_checkpoint", checkpoint_type="custom"):
+                await calls_agent._run_async(
+                    lambda: observe("already inside checkpoint"),
+                    force_turn_checkpoint=True,
+                    mark_streaming_fallback_checkpoint=True,
+                )
+
+        assert observations == [
+            ("calls/no streaming", False),
+            ("calls/streaming", True),
+            ("turn/streaming", False),
+            ("already inside checkpoint", False),
+        ]
+
 
 class TestResolveToolCheckpointConfig:
     def test_default_used_when_no_override(self) -> None:
@@ -1678,6 +1741,65 @@ class TestThreadingCompat:
 
         assert entered == [True, True]
 
+    @pytest.mark.anyio
+    async def test_stream_context_manager_wait_for_input_still_uses_checkpoint_guard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from contextlib import asynccontextmanager, nullcontext
+
+        from pydantic_ai import Agent
+        from pydantic_ai.agent.abstract import AbstractAgent
+        from pydantic_ai.models.test import TestModel
+
+        from kitaru.adapters import pydantic_ai as kp
+        from kitaru.adapters.pydantic_ai import KitaruAgent
+        from kitaru.runtime import _checkpoint_scope, _flow_scope
+
+        agent = KitaruAgent(
+            Agent(TestModel(), name="stream_context_wait_guard_agent"),
+            tool_checkpoint_config_by_name={"ask_user": False},
+            allow_sync_tool_body_waits=True,
+        )
+        streamed_result = object()
+        iter_result = object()
+
+        @asynccontextmanager
+        async def fake_run_stream(*_args: Any, **_kwargs: Any):
+            yield streamed_result
+
+        @asynccontextmanager
+        async def fake_iter(*_args: Any, **_kwargs: Any):
+            yield iter_result
+
+        monkeypatch.setattr(agent, "_tracking_scope", nullcontext)
+        monkeypatch.setattr(AbstractAgent, "run_stream", fake_run_stream)
+        monkeypatch.setattr(agent.wrapped, "iter", fake_iter)
+
+        def assert_checkpoint_wait_guidance(
+            exc_info: pytest.ExceptionInfo[Any],
+        ) -> None:
+            message = str(exc_info.value)
+            assert "adapter-created checkpoint" in message
+            assert "tool_checkpoint_config_by_name" in message
+            assert "allow_sync_tool_body_waits=True" in message
+
+        with _flow_scope(name="demo_flow"):
+            with _checkpoint_scope(
+                name="run_stream_checkpoint", checkpoint_type="custom"
+            ):
+                with pytest.raises(KitaruUsageError) as stream_exc:
+                    async with agent.run_stream("hello") as result:
+                        assert result is streamed_result
+                        kp.wait_for_input(schema=str, name="run_stream_wait")
+                assert_checkpoint_wait_guidance(stream_exc)
+
+            with _checkpoint_scope(name="iter_checkpoint", checkpoint_type="custom"):
+                with pytest.raises(KitaruUsageError) as iter_exc:
+                    async with agent.iter("hello") as result:
+                        assert result is iter_result
+                        kp.wait_for_input(schema=str, name="iter_wait")
+                assert_checkpoint_wait_guidance(iter_exc)
+
 
 class TestWaitForInput:
     """Adapter-namespaced helper for calling wait from a tool body."""
@@ -2680,9 +2802,9 @@ async def test_non_hitl_tool_still_uses_calls_strategy_tool_checkpoint(
 
 
 @pytest.mark.anyio
-async def test_streaming_fallback_suspends_scope_for_opted_out_sync_function_tool() -> (
-    None
-):
+async def test_streaming_fallback_suspends_scope_for_opted_out_sync_function_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from pydantic_ai import FunctionToolset
     from pydantic_ai.models.test import TestModel
     from pydantic_ai.tools import RunContext
@@ -2691,6 +2813,7 @@ async def test_streaming_fallback_suspends_scope_for_opted_out_sync_function_too
 
     from kitaru.adapters.pydantic_ai import CapturePolicy
     from kitaru.adapters.pydantic_ai._toolset import kitaruify_toolset
+    from kitaru.adapters.pydantic_ai._tracking import EventTracker
     from kitaru.runtime import (
         _checkpoint_scope,
         _flow_scope,
@@ -2699,6 +2822,8 @@ async def test_streaming_fallback_suspends_scope_for_opted_out_sync_function_too
     )
 
     observed_body_scope: list[tuple[bool, bool]] = []
+    saved_artifacts: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    tracker = EventTracker(agent_name="streaming_tool_agent", run_label="unit")
     toolset: FunctionToolset[None] = FunctionToolset()
 
     @toolset.tool_plain
@@ -2713,6 +2838,14 @@ async def test_streaming_fallback_suspends_scope_for_opted_out_sync_function_too
     )
     ctx = _with_tool_call_id(RunContext(deps=None, model=TestModel(), usage=RunUsage()))
     tool = (await wrapped.get_tools(ctx))["ask_user"]
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._toolset.get_current_tracker",
+        lambda: tracker,
+    )
+    monkeypatch.setattr(
+        "kitaru.adapters.pydantic_ai._toolset.kitaru.save",
+        lambda *args, **kwargs: saved_artifacts.append((args, kwargs)),
+    )
     step_context_var = _get_step_context_var()
     step_context_token = step_context_var.set(cast(Any, object()))
     try:
@@ -2736,6 +2869,13 @@ async def test_streaming_fallback_suspends_scope_for_opted_out_sync_function_too
 
     assert result == "human answer"
     assert observed_body_scope == [(False, False)]
+    tool_events = [event for event in tracker.events if event.kind == "tool_call"]
+    assert len(tool_events) == 1
+    tool_event = cast(Any, tool_events[0])
+    assert tool_event.checkpoint_name == "streamed_turn"
+    assert tool_event.checkpoint_id == "checkpoint-1"
+    assert tool_event.artifacts == {}
+    assert saved_artifacts == []
 
 
 @pytest.mark.anyio
@@ -2972,6 +3112,7 @@ async def test_streaming_fallback_suspension_restores_scope_after_cancellation(
     from pydantic_ai import FunctionToolset
     from pydantic_ai.models.test import TestModel
     from pydantic_ai.tools import RunContext
+    from pydantic_ai.toolsets import WrapperToolset
     from pydantic_ai.usage import RunUsage
     from zenml.steps.step_context import StepContext
 
@@ -2998,12 +3139,12 @@ async def test_streaming_fallback_suspension_restores_scope_after_cancellation(
     ctx = _with_tool_call_id(RunContext(deps=None, model=TestModel(), usage=RunUsage()))
     tool = (await wrapped.get_tools(ctx))["ask_user"]
 
-    async def fake_call_tool_tracked(*_args: Any, **_kwargs: Any) -> Any:
+    async def fake_call_tool(*_args: Any, **_kwargs: Any) -> Any:
         assert not _is_inside_checkpoint()
         assert not StepContext.is_active()
         raise asyncio.CancelledError()
 
-    monkeypatch.setattr(wrapped, "_call_tool_tracked", fake_call_tool_tracked)
+    monkeypatch.setattr(WrapperToolset, "call_tool", fake_call_tool)
     step_context_var = _get_step_context_var()
     step_context_token = step_context_var.set(cast(Any, object()))
     try:

--- a/tests/test_pydantic_ai_adapter.py
+++ b/tests/test_pydantic_ai_adapter.py
@@ -25,6 +25,7 @@ from kitaru.adapters.pydantic_ai._utils import (
     has_explicit_tool_checkpoint_opt_out,
     reject_isolated_runtime,
     resolve_tool_checkpoint_config,
+    suspend_adapter_streaming_fallback_checkpoint,
     turn_cache_key,
     validate_checkpoint_config,
     validate_checkpoint_strategy,
@@ -564,6 +565,16 @@ class TestAdapterStreamingFallbackCheckpointMarker:
             assert marker.allow_sync_tool_body_waits is True
 
         assert get_adapter_streaming_fallback_checkpoint() is None
+
+    def test_suspending_marker_restores_outer_marker(self) -> None:
+        with adapter_streaming_fallback_checkpoint(allow_sync_tool_body_waits=True):
+            outer_marker = get_adapter_streaming_fallback_checkpoint()
+            assert outer_marker is not None
+
+            with suspend_adapter_streaming_fallback_checkpoint():
+                assert get_adapter_streaming_fallback_checkpoint() is None
+
+            assert get_adapter_streaming_fallback_checkpoint() is outer_marker
 
     def test_marker_resets_after_exception(self) -> None:
         with (
@@ -2821,14 +2832,20 @@ async def test_streaming_fallback_suspends_scope_for_opted_out_sync_function_too
         _is_inside_checkpoint,
     )
 
-    observed_body_scope: list[tuple[bool, bool]] = []
+    observed_body_scope: list[tuple[bool, bool, bool]] = []
     saved_artifacts: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
     tracker = EventTracker(agent_name="streaming_tool_agent", run_label="unit")
     toolset: FunctionToolset[None] = FunctionToolset()
 
     @toolset.tool_plain
     def ask_user() -> str:
-        observed_body_scope.append((_is_inside_checkpoint(), StepContext.is_active()))
+        observed_body_scope.append(
+            (
+                _is_inside_checkpoint(),
+                StepContext.is_active(),
+                get_adapter_streaming_fallback_checkpoint() is not None,
+            )
+        )
         return "human answer"
 
     wrapped = kitaruify_toolset(
@@ -2859,16 +2876,19 @@ async def test_streaming_fallback_suspends_scope_for_opted_out_sync_function_too
             ),
             adapter_streaming_fallback_checkpoint(allow_sync_tool_body_waits=True),
         ):
+            outer_marker = get_adapter_streaming_fallback_checkpoint()
+            assert outer_marker is not None
             assert _is_inside_checkpoint()
             assert StepContext.is_active()
             result = await wrapped.call_tool("ask_user", {}, ctx, tool)
+            assert get_adapter_streaming_fallback_checkpoint() is outer_marker
             assert _is_inside_checkpoint()
             assert StepContext.is_active()
     finally:
         step_context_var.reset(step_context_token)
 
     assert result == "human answer"
-    assert observed_body_scope == [(False, False)]
+    assert observed_body_scope == [(False, False, False)]
     tool_events = [event for event in tracker.events if event.kind == "tool_call"]
     assert len(tool_events) == 1
     tool_event = cast(Any, tool_events[0])


### PR DESCRIPTION
Fixes #425

## What changed

This PR fixes the PydanticAI adapter path where `event_stream_handler` forced a whole-turn adapter checkpoint and left explicitly opted-out sync tool bodies running inside that checkpoint.

The change adds a private streaming-fallback marker for adapter-created turn checkpoints, then allows only an explicitly opted-out ordinary sync `FunctionToolsetTool` to run with checkpoint scope temporarily suspended. This keeps the existing public rules intact: `checkpoint()` still rejects real nested checkpoints, and `wait()` still requires flow scope.

It also makes `run_stream(...)` and `iter(...)` enter the same inline sync-tool execution context as `run(...)` / `run_sync(...)` when `allow_sync_tool_body_waits=True`.

## Why it was needed

The durable chatbot pattern uses a sync tool like `say_and_wait` to persist history and then wait for user input. The tool opts out of Kitaru's synthetic tool checkpoint with `tool_checkpoint_config_by_name={"say_and_wait": False}` and opts into workflow-thread sync execution with `allow_sync_tool_body_waits=True`.

Without this fix, adding `event_stream_handler` caused Kitaru to open one large adapter turn checkpoint around the upstream PydanticAI run. The tool skipped only its own synthetic checkpoint; it still ran inside the larger adapter checkpoint. Then `persist_history(...)` failed as a nested checkpoint, and `wait_for_input(...)` would fail next because waits cannot be created inside checkpoint scope.

## Key implementation decisions

- The escape is private to the PydanticAI adapter; no core checkpoint or wait guard was weakened.
- The suspension is narrow: active streaming-fallback marker, `allow_sync_tool_body_waits=True`, explicit per-tool `False`, currently inside checkpoint scope, and `FunctionToolsetTool.is_async is False`.
- Generic toolsets, async tools, and `@hitl_tool` remain out of scope for this PR.
- The private marker is set only for calls-strategy runs that are forced into whole-turn checkpointing by streaming/event-handler behavior.

## Reviewer Notes

The important behavior starts in `KitaruAgent._run_sync(...)` / `_run_async(...)`. When a calls-strategy run is forced into whole-turn checkpointing because of streaming hooks, Kitaru marks that adapter-owned checkpoint. Later, when PydanticAI calls a tool, `KitaruToolset.call_tool(...)` checks whether this exact tool is an explicitly opted-out sync `FunctionToolsetTool`. If so, it briefly clears Kitaru checkpoint scope and ZenML `StepContext` while that one tool body runs.

The thing to inspect carefully is the guard around that suspension. If it is too broad, Kitaru could accidentally make arbitrary checkpoint-contained waits legal. If it is too narrow, the chatbot pattern still fails. The new unit tests in `tests/test_pydantic_ai_adapter.py` cover the positive path and the negative cases: no marker, default config, dict config, `allow_sync_tool_body_waits=False`, async function tools, generic tool objects, HITL tools, and user-created checkpoint contexts.

The full issue reproduction is in the new phase17 integration test. It runs an event-handler agent turn, calls an explicit `@kitaru.checkpoint(cache=False)` helper from the opted-out sync tool, then reaches the real ZenML wait.

### Reproduction

Run the focused regression test:

```bash
uv run pytest -q tests/test_phase17_pydantic_ai_adapter.py::test_phase17_direct_wait_tool_with_event_stream_handler_reaches_wait
```

Expected result: the child process reports that it reached the real ZenML wait instead of failing with nested checkpoint / checkpoint-contained wait errors.

For the narrow guard behavior, run:

```bash
uv run pytest -q tests/test_pydantic_ai_adapter.py -k 'streaming_fallback or inline_sync_tool_context'
```

Expected result: the eligible sync `FunctionToolsetTool` sees flow scope, while generic, async, HITL, and non-opted-out tools do not get the suspension.

### Local checks run

```bash
just check
just test
```

`just test` result: `2393 passed, 8 skipped, 97 warnings in 90.79s`.
