### PR TITLE
Fix agent instruction drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Kitaru docs live on three surfaces — know which one a task touches:
 2. **Generated SDK + CLI reference → `sdkdocs.kitaru.ai`.** The FumaDocs app in `docs/` is now reference-only (generated `content/docs/cli/` + `content/docs/reference/python/` + a landing). Built/deployed to the `kitaru-sdkdocs` worker (root `wrangler.toml`). See `docs/CLAUDE.md`.
 3. **`kitaru.ai/docs` → redirects.** The `kitaru-site` worker (`docs/worker/redirect.mjs`, `wrangler.redirect.toml`) 301-redirects old `kitaru.ai/docs/*` URLs to GitBook / `sdkdocs.kitaru.ai` / the changelog.
 
-Do not add hand-written pages to the FumaDocs app (`docs/content/docs/`) — they belong in `docs/book/`. The changelog is owned by the changelog repo (`docs.zenml.io/changelog`).
+Do not add hand-written pages to the FumaDocs app (`docs/content/docs/`) — they belong in `docs/book/`. The public changelog is owned by the changelog repo (`docs.zenml.io/changelog`); this repo may still generate a gitignored `docs/content/docs/changelog.mdx` for local/reference builds, but agents should not hand-edit or commit it.
 
 The public marketing/runtime site for Kitaru now lives in `zenml-io-v2`. If a task involves Astro pages, public site assets, marketing Cloudflare Pages deployment, or runtime web APIs such as waitlist/get-started/newsletter endpoints, switch to that repository instead of adding that code back here.
 
@@ -157,13 +157,13 @@ When adding a new CLI command, MCP tool, or SDK feature:
 
 ### Python CI (`ci.yml`)
 
-Runs on push/PR to `develop`. Jobs: lint + format check + yaml check, typos, type check, dependency audit, link check, Docker server smoke test, wheel-packaging check, base tests (Python 3.11 + 3.12 + 3.13), and additional test lanes with `kitaru[mcp]` installed (3.11 + 3.12).
+Runs on push/PR to `develop`. PR jobs run lint + format check + yaml check, typos, type check, dependency audit, link check, base tests (Python 3.11 + 3.12 + 3.13), and additional test lanes with `kitaru[mcp]` installed (3.11 + 3.12). Push jobs also run Docker server smoke and wheel-packaging checks, because those paths may need trusted UI release credentials.
 
 When changing Kitaru UI bundling, frontend smoke testing, Docker dashboard packaging, or release UI selection, read `FRONTEND-TESTING.md` first. It is the runbook for stable vs prerelease `kitaru-ui-v*` bundle testing and the trusted-event/token boundaries.
 
 ### Docs CI (`docs.yml`)
 
-Runs on manual dispatch, `main` pushes, and PRs touching `docs/**`, docs generation scripts, SDK source, `CHANGELOG.md`, `pyproject.toml`, `uv.lock`, or `wrangler.toml`. It generates the CLI/SDK reference, builds the FumaDocs static export, and deploys the **SDK+CLI reference site to `sdkdocs.kitaru.ai`** (worker `kitaru-sdkdocs`) plus the **`kitaru.ai/docs` redirect worker** (`kitaru-site`, `wrangler.redirect.toml`); it also creates/cleans same-repo PR preview Workers. Hand-written docs (`docs/book/`) publish separately to `docs.zenml.io/kitaru` via GitBook Git Sync (not this workflow). Marketing site deployment is handled from `zenml-io-v2`.
+Runs on manual dispatch, `main` pushes, and PRs touching `docs/**`, docs generation scripts, SDK source, `CHANGELOG.md`, `pyproject.toml`, `uv.lock`, or Wrangler config. It regenerates the CLI/SDK reference and builds the FumaDocs static export on all runs. It deploys the **SDK+CLI reference site to `sdkdocs.kitaru.ai`** (worker `kitaru-sdkdocs`) plus the **`kitaru.ai/docs` redirect worker** (`kitaru-site`, `wrangler.redirect.toml`) only on `main` push or manual dispatch; PRs build only and do not create preview Workers. Hand-written docs (`docs/book/`) publish separately to `docs.zenml.io/kitaru` via GitBook Git Sync (not this workflow). Marketing site deployment is handled from `zenml-io-v2`.
 
 ### Other workflows
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,11 @@ Kitaru docs live on three surfaces — know which one a task touches:
    `kitaru.ai/docs/*` URLs to GitBook / `sdkdocs.kitaru.ai` / the changelog.
 
 Do **not** add hand-written pages to the FumaDocs app (`docs/content/docs/`) —
-they belong in `docs/book/` (GitBook). The changelog is owned by the changelog
-repo (published to `docs.zenml.io/changelog`), not by either surface here.
+they belong in `docs/book/` (GitBook). The public changelog is owned by the
+changelog repo (published to `docs.zenml.io/changelog`), not by either docs
+surface here. This repo may still generate a gitignored
+`docs/content/docs/changelog.mdx` for local/reference builds; do not hand-edit
+or commit that generated output.
 
 The public marketing/runtime site for Kitaru lives in the sibling `zenml-io-v2`
 repository. If a task involves Astro pages, public site assets, marketing
@@ -186,8 +189,8 @@ just server-dev-image                          # Build dev server image (require
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | Push/PR to `develop` | Python checks: lint, format, yaml, typos, typecheck, dependency audit, links, Docker server smoke, wheel packaging, and tests across base installs (3.11 + 3.12 + 3.13) plus additional `kitaru[mcp]` test lanes |
-| `docs.yml` | Manual dispatch; push to `main`; selected docs/script/source PR paths | Generate, build, and deploy the SDK+CLI reference site (`sdkdocs.kitaru.ai`, worker `kitaru-sdkdocs`) plus the `kitaru.ai/docs` redirect worker (`kitaru-site`); create/clean same-repo PR preview Workers. Hand-written docs (`docs/book/`) publish separately via GitBook Git Sync. |
+| `ci.yml` | Push/PR to `develop` | PRs run Python checks: lint, format, yaml, typos, typecheck, dependency audit, links, and tests across base installs (3.11 + 3.12 + 3.13) plus additional `kitaru[mcp]` test lanes. Pushes also run Docker server smoke and wheel packaging because those jobs may need trusted UI release credentials. |
+| `docs.yml` | Manual dispatch; push to `main`; selected docs/script/source PR paths | Regenerate the CLI/SDK reference and build the static docs app on every run. Deploy the SDK+CLI reference site (`sdkdocs.kitaru.ai`, worker `kitaru-sdkdocs`) plus the `kitaru.ai/docs` redirect worker (`kitaru-site`) only on `main` push or manual dispatch. PRs build only and do not create preview Workers. Hand-written docs (`docs/book/`) publish separately via GitBook Git Sync. |
 | `release.yml` | Workflow dispatch or `v*` tag | Stable Kitaru UI bundling, version/changelog/lock handling for dispatch releases, PyPI publish, Docker image publish, Helm OCI chart publish, release branch/main update, GitHub Release |
 | `ui-prerelease-smoke.yml` | Manual dispatch | Tests an explicit prerelease Kitaru UI bundle against a Kitaru ref without publishing PyPI, Docker, Helm, tags, or releases |
 | `spellcheck.yml` | Manual/reusable runs, push to `develop`, non-draft PRs | Separate typo/spell checking |

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -41,14 +41,15 @@ Python tooling except for the generated reference content. The static export in
 
 **Automatic (the normal path):** the `SDK Reference Docs` workflow
 (`.github/workflows/docs.yml`) regenerates the CLI + SDK reference, builds the
-static export, and `wrangler deploy`s it to `kitaru-sdkdocs`, then deploys the
-`kitaru-site` redirect worker. It runs on:
+static export, and tests the redirect worker on every run. It `wrangler deploy`s
+the reference site to `kitaru-sdkdocs`, then deploys the `kitaru-site` redirect
+worker, only on:
 
 - **push to `main`** (i.e. at release time), and
 - **manual `workflow_dispatch`** (Actions → "SDK Reference Docs" → Run workflow)
   — deploys whichever branch it runs against, so you can ship from `develop`.
 
-PRs get an ephemeral preview Worker (`kitaru-sdkdocs-preview-<PR#>`).
+PRs build and test only; they do not deploy or create preview Workers. The workflow does not run `scripts/generate_changelog_docs.py`; public changelog traffic is handled by the redirect worker.
 
 **Manual (from a clone, needs Cloudflare creds via `wrangler login`):**
 
@@ -70,12 +71,15 @@ changes when redirect rules in `docs/worker/redirect.mjs` change.
   no root `node_modules`, no workspace config.
 - **Never hand-edit generated files:** `content/docs/cli.mdx` (or `cli/`),
   `content/docs/changelog.mdx`, and `content/docs/reference/` are created by
-  generation scripts and gitignored. SDK reference uses a two-step pipeline:
+  generation scripts and gitignored. The public changelog is hosted at
+  `docs.zenml.io/changelog`; the local `changelog.mdx` is only generated for
+  local/reference builds. SDK reference uses a two-step pipeline:
   `scripts/generate_sdk_docs.py` (Python extraction) + `docs/scripts/convert-sdk-docs.mjs`
   (Node MDX conversion via fumadocs-python).
 - **CLI reference fixes belong in the generator/source:** if command syntax is
-  wrong in generated CLI docs, fix `scripts/generate_cli_docs.py` and/or
-  `src/kitaru/cli.py`, then regenerate. Never hand-edit generated CLI pages.
+  wrong in generated CLI docs, fix `scripts/generate_cli_docs.py` and/or the
+  relevant `src/kitaru/_cli/_*.py` module. Use `src/kitaru/cli.py` only for
+  facade/bootstrap issues. Then regenerate. Never hand-edit generated CLI pages.
 - **Respect static export constraints:** No server-side features (middleware,
   rewrites, cookies, ISR). All content must be buildable at build time.
 - **Only document shipped features.** No "Coming Soon" sections for unimplemented
@@ -94,12 +98,10 @@ changes when redirect rules in `docs/worker/redirect.mjs` change.
 ```
 content/docs/
   meta.json              # Top-level sidebar ordering
-  index.mdx              # "What is Kitaru?" overview
-  getting-started/       # Installation + quickstart
-  cli.mdx                # AUTO-GENERATED (flat; becomes cli/ when subcommands exist)
-  contributing.mdx       # Links to repo CONTRIBUTING.md
-  changelog.mdx          # AUTO-GENERATED from CHANGELOG.md
-  reference/             # AUTO-GENERATED (gitignored, SDK reference via fumadocs-python)
+  index.mdx              # Reference-site landing page
+  cli/                   # AUTO-GENERATED, gitignored CLI reference
+  changelog.mdx          # AUTO-GENERATED, gitignored local/reference changelog page
+  reference/python/      # AUTO-GENERATED, gitignored SDK reference via fumadocs-python
 ```
 
 ## Available MDX Components
@@ -131,18 +133,20 @@ pnpm run lint       # Biome lint
 pnpm run format     # Biome format
 ```
 
-**Important:** Generated content (CLI reference, changelog, SDK reference) is gitignored.
+**Important:** Generated content (CLI reference, the local/reference changelog page, and SDK reference) is gitignored.
 On a fresh clone, run `just generate-docs` before `just docs` or `just docs-build`,
-otherwise those pages will be missing from the sidebar. SDK reference generation
-requires `fumapy` — `just generate-docs` auto-installs it from
+otherwise generated pages will be missing from the sidebar. The deployed public
+changelog still lives at `docs.zenml.io/changelog`; the generated
+`changelog.mdx` here is not the public changelog source. SDK reference
+generation requires `fumapy` — `just generate-docs` auto-installs it from
 `docs/node_modules/fumadocs-python` (requires `pnpm install` in `docs/` first).
 
 ## File Responsibilities
 
 | File | Owner |
 |---|---|
-| `content/docs/**/*.mdx` | Python developers (content) |
-| `content/docs/**/meta.json` | Python developers (navigation) |
+| `content/docs/index.mdx`, `content/docs/meta.json` | Python/docs developers (reference-site landing + top-level navigation) |
+| `content/docs/cli/**`, `content/docs/changelog.mdx`, `content/docs/reference/**` | Generation scripts — do not hand-edit or commit generated output |
 | `app/`, `components/`, `lib/` | Designer / frontend (layout, theme, routes, metadata) |
 | `global.css` | Designer (branding) |
 | `mdx-components.tsx` | Shared (component registration) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 This directory contains two documentation surfaces:
 
 1. `book/` — the hand-written GitBook docs source, published at `docs.zenml.io/kitaru`.
-2. the FumaDocs reference app — generated CLI, changelog, and SDK reference pages, published at `sdkdocs.kitaru.ai`.
+2. the FumaDocs reference app — generated CLI and SDK reference pages, published at `sdkdocs.kitaru.ai`. It can also materialize a gitignored local changelog page, but the public changelog lives at `docs.zenml.io/changelog`.
 
 Hand-written user docs belong in `docs/book/` as plain Markdown. Do not add new hand-written product docs to `docs/content/docs/`; that directory is for generated reference content and FumaDocs app wiring.
 
@@ -68,7 +68,7 @@ If generated CLI syntax is wrong, fix `scripts/generate_cli_docs.py` and/or the 
 
 The GitBook docs in `book/` are synced by GitBook Git Sync.
 
-The FumaDocs reference app is built from `docs/` and deployed separately as the SDK/reference docs surface. CI runs doc generation automatically before building. Locally, run `just generate-docs` before `just docs-build` when generated content may have changed.
+The FumaDocs reference app is built from `docs/` and deployed separately as the SDK/reference docs surface. CI regenerates the CLI and SDK reference before building; it does not run the local changelog generator. Locally, run `just generate-docs` before `just docs-build` when generated content may have changed; that local recipe also materializes the gitignored changelog page.
 
 To build and validate the reference app locally:
 

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -4,7 +4,7 @@ Introspects the cyclopts App object, extracts command metadata, and writes
 structured MDX files with frontmatter + meta.json files for FumaDocs navigation.
 
 Output directory: docs/content/docs/cli/
-Generated files are tracked in git and should be regenerated after CLI changes.
+Generated files are gitignored and should be regenerated locally before docs builds or after CLI changes.
 
 Usage:
     uv run python scripts/generate_cli_docs.py

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -50,7 +50,7 @@ Extra installation notes:
 2. redirects config and home-directory lookups into `tmp_path`
 3. resets global Kitaru and ZenML client/config singletons between tests
 
-That means the suite is designed to avoid touching a real local config directory or real user state. Keep it that way.
+That means the suite is designed to avoid touching a real local config directory or real user state. Keep it that way. When you need exact fixture names, config paths, or the environment-variable denylist, read `tests/conftest.py` and `tests/mcp/conftest.py`; this file intentionally keeps the rule at a higher level.
 
 When writing new tests:
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -18,8 +18,8 @@ Tests run with `pytest-xdist` (`-n auto`) by default via `pyproject.toml` addopt
 
 Every test gets an isolated ZenML + Kitaru environment automatically via the `isolated_zenml_global_config` autouse fixture in `conftest.py`. This fixture:
 
-- Creates a fresh `tmp_path/.zenml/` config directory and redirects `ENV_ZENML_CONFIG_PATH` to it
-- Strips all `KITARU_*` and `ZENML_*` environment variables
+- Creates a fresh `tmp_path/kitaru-config/` config directory and redirects `ENV_ZENML_CONFIG_PATH` to it
+- Strips the Kitaru/ZenML environment variables listed in `tests/conftest.py`, plus any variables with the ZenML store prefix
 - Resets ZenML singletons (`GlobalConfiguration._reset_instance()`, `Client._reset_instance()`)
 - Resets Kitaru's runtime configuration (`_reset_runtime_configuration()`)
 - Redirects `Path.home()` and `click.get_app_dir()` into `tmp_path` so file-based config never touches real user state
@@ -68,7 +68,7 @@ These files import and run real example flows from the `examples/` directory. Th
 
 ### MCP tests (`tests/mcp/`)
 
-- Separate `conftest.py` with `mock_kitaru_client`, `sample_execution`, `sample_artifact` fixtures
+- Separate `conftest.py` with `mock_kitaru_client`, `sample_execution`, `sample_deployment`, and `sample_artifact` fixtures
 - Run in a dedicated CI lane with `kitaru[mcp]` installed
 - Import from `kitaru.mcp.server` — tests verify tool functions return correct dict shapes
 
@@ -120,6 +120,6 @@ class TestBuildPipelineRegistrationName:
 ## Gotchas
 
 - `pythonpath = ["scripts"]` in pytest config means `scripts/` modules are importable. Any module-level `sys.exit()` in scripts will crash pytest collection.
-- Environment variables are stripped at **module load time** in `conftest.py` (before fixtures run), not just inside fixtures. This prevents leakage from the host shell into test discovery.
+- The baseline Kitaru/ZenML environment variables are stripped at **module load time** in `conftest.py` (before fixtures run), not just inside fixtures. This prevents leakage from the host shell into test discovery. Treat `tests/conftest.py` as the source of truth for the exact list.
 - The `_SRC_PATH` insertion in `conftest.py` ensures `import kitaru` resolves to the local `src/kitaru/` even when running from the tests directory.
 - `primed_zenml` tests are slower and shouldn't be mixed into unit test files — keep them in `test_phase*` files.


### PR DESCRIPTION
## What changed?

- Updated root `AGENTS.md` and `CLAUDE.md` so CI/docs workflow guidance matches current workflow behavior.
- Clarified the docs/changelog split: public changelog traffic goes to `docs.zenml.io/changelog`, while this repo may still materialize a gitignored local/reference changelog page.
- Corrected `docs/CLAUDE.md` and `docs/README.md` around docs CI, generated reference content, generated file ownership, and current `docs/content/docs/` structure.
- Fixed `scripts/generate_cli_docs.py` wording so it no longer claims generated CLI docs are tracked in git.
- Refreshed test guidance in `tests/CLAUDE.md` / `tests/AGENTS.md` to match the current fixture source of truth.

## Why?

The agent instruction files had a few factual drifts from the current repo. The important ones were: docs PR preview Workers are no longer created, Docker/wheel CI jobs are push-only because trusted UI credentials may be involved, generated CLI docs are gitignored, and some test fixture details had changed.

This keeps the harness-specific `AGENTS.md` / `CLAUDE.md` files in place while correcting the facts that would otherwise send agents toward stale commands, wrong generated-file handling, or outdated fixture assumptions.

## Reviewer Notes

The important behavior is mostly in the repo’s source-of-truth files, not in these instruction files. For example, `.github/workflows/docs.yml` now builds PRs without deploying preview Workers, and `.github/workflows/ci.yml` keeps Docker smoke / wheel packaging on trusted push events only. The updated prose now says that plainly instead of implying PR preview infrastructure or PR Docker packaging checks exist.

The trickiest wording is the changelog split. Public changelog links are still owned by `docs.zenml.io/changelog` and routed there by the redirect worker. At the same time, the local `just generate-docs` path can still create `docs/content/docs/changelog.mdx` as gitignored generated output. The new wording tries to describe both facts without making agents think they should hand-edit or commit that page.

The test guidance remains duplicated across harness files on purpose. The change does not delete `tests/AGENTS.md` or `tests/CLAUDE.md`; it just updates stale details and points exact fixture details back to `tests/conftest.py` / `tests/mcp/conftest.py`.
