### PR TITLE
Fail CI when adapter frameworks are missing

### DIFF
--- a/tests/test_adapter_frameworks_present.py
+++ b/tests/test_adapter_frameworks_present.py
@@ -1,0 +1,42 @@
+"""CI guard: adapter frameworks must be importable when running in CI.
+
+Adapter test suites are gated by module-level ``pytest.importorskip`` so
+local contributors without every framework installed get skips, not
+failures. The cost of that convenience is that CI would also skip them
+silently if a dependency-group or lockfile change ever dropped a framework.
+This module turns that silent skip into a hard CI failure. Outside CI the
+whole module skips, preserving the contributor experience.
+"""
+
+import importlib
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("CI", "").lower() not in ("true", "1"),
+    reason="Presence guard only enforced on CI runners.",
+)
+
+# (import name, distribution name in pyproject [dependency-groups] dev)
+_FRAMEWORKS = [
+    ("pydantic_ai", "pydantic-ai-slim"),
+    ("agents", "openai-agents"),
+    ("langgraph", "langgraph"),
+    ("claude_agent_sdk", "claude-agent-sdk"),
+    ("google.genai", "google-genai"),
+]
+
+
+@pytest.mark.parametrize(("import_name", "distribution"), _FRAMEWORKS)
+def test_adapter_framework_importable(import_name: str, distribution: str) -> None:
+    try:
+        importlib.import_module(import_name)
+    except ImportError as exc:
+        pytest.fail(
+            f"Adapter framework `{import_name}` (distribution `{distribution}`) "
+            "is not installed in this CI environment. Adapter test suites gated "
+            "by `pytest.importorskip` are now silently skipping. Restore the "
+            "distribution to the `dev` dependency group in pyproject.toml "
+            f"(import error: {exc})."
+        )


### PR DESCRIPTION
## What changed

Added `tests/test_adapter_frameworks_present.py`, a CI-only guard that imports the five adapter framework packages Kitaru expects to have available in CI:

- `pydantic_ai` / `pydantic-ai-slim`
- `agents` / `openai-agents`
- `langgraph` / `langgraph`
- `claude_agent_sdk` / `claude-agent-sdk`
- `google.genai` / `google-genai`

Outside CI, the parametrized test cases skip so local contributors who do not install every adapter framework keep the current experience.

## Why it was needed

Adapter test modules use `pytest.importorskip(...)`. That is useful locally, but it creates a CI risk: if a future dependency edit removes one adapter framework from the dev environment, the corresponding adapter tests would silently skip and CI could stay green. This guard turns that situation into a clear CI failure.

## Reviewer Notes

The important behavior is in `tests/test_adapter_frameworks_present.py`. The test checks `CI`; when CI is truthy (`true` or `1`), it imports each framework directly. It deliberately imports the framework packages rather than Kitaru adapter modules, so this only checks dependency presence and does not duplicate adapter import-error behavior.

The failure message names both the import name and the distribution name. If a framework disappears from CI, the failed case should tell the next person exactly which dependency to restore to the `dev` dependency group.

### Reproduction

To see the intended behavior end to end:

```bash
CI=true uv run pytest tests/test_adapter_frameworks_present.py -v
```

Expected: five parametrized cases pass.

```bash
env -u CI uv run pytest tests/test_adapter_frameworks_present.py -v
```

Expected: five parametrized cases skip with the CI-only reason.

To prove the guard fails when a framework is missing, run this one-process simulation. The `-n0` disables xdist so the `sys.modules` fault injection is visible to the test process:

```bash
CI=true uv run python -c "import sys; sys.modules['langgraph'] = None; import pytest; raise SystemExit(pytest.main(['tests/test_adapter_frameworks_present.py', '-v', '-n0']))"
```

Expected: the `langgraph` parametrization fails with the guard message; the other four pass.

## Local checks run

- `uv run kitaru init` in the fresh worktree
- `CI=true uv run pytest tests/test_adapter_frameworks_present.py -v` → 5 passed
- `env -u CI uv run pytest tests/test_adapter_frameworks_present.py -v` → 5 skipped
- manual hidden-`langgraph` simulation with `-n0` → expected 1 failed, 4 passed
- `just check` → passed
- `just test` → 2411 passed, 13 skipped

## Review process

Oracle review found no issues. I also applied the simplify review directly because the final diff is a single small test file; no reuse, quality, or efficiency changes were needed.
