### PR TITLE
Document `wait()` flow-scope constraint

### DIFF
--- a/docs/book/concepts/wait-and-input.md
+++ b/docs/book/concepts/wait-and-input.md
@@ -59,6 +59,55 @@ keeps the durable data flow between checkpoints intact. See
 [In flow bodies](../guides/artifacts.md#in-flow-bodies) for more on when to
 materialize checkpoint outputs in orchestration code.
 
+## Where wait() can be called
+
+`kitaru.wait()` must be called at flow scope. In practice, that means inside the
+`@flow` function body, before or after checkpoint calls, not inside a
+`@checkpoint` function.
+
+A wait pauses the whole run. Kitaru records each checkpoint call as a step. If
+`wait()` pauses from inside that step, the flow can stop before the checkpoint
+has completed cleanly. That can leave the run in a confusing state where the
+flow is waiting but the checkpoint step appears failed. To avoid that state,
+Kitaru raises this error immediately:
+
+```text
+wait() cannot run inside a @checkpoint. Move the wait to flow scope, before or after checkpoint calls.
+```
+
+The companion rule is that `wait()` needs a running flow. If you call it outside
+a `@flow`, Kitaru raises `wait() can only run inside a @flow.`
+
+If you need input halfway through a larger operation, split the operation into
+two checkpoints and put the wait between them:
+
+```python
+@checkpoint
+def draft_report(topic: str) -> str:
+    return kitaru.llm(f"Draft a report about {topic}.")
+
+@checkpoint
+def revise_report(draft: str, reviewer_note: str) -> str:
+    return kitaru.llm(f"Revise this report using {reviewer_note}:\n\n{draft}")
+
+@flow
+def reviewed_report(topic: str) -> str:
+    draft = draft_report(topic)
+    draft_text = draft.load()
+
+    reviewer_note = kitaru.wait(
+        name="review_draft",
+        question=f"Review this draft:\n\n{draft_text}",
+        schema=str,
+    )
+
+    return revise_report(draft, reviewer_note)
+```
+
+The `draft.load()` call is only there so the reviewer can see the draft text in
+the wait question. The original `draft` checkpoint output still flows into the
+next checkpoint.
+
 When execution reaches `kitaru.wait()`:
 
 1. The flow suspends and the execution moves to `waiting` status

--- a/docs/book/concepts/wait-and-input.md
+++ b/docs/book/concepts/wait-and-input.md
@@ -65,11 +65,11 @@ materialize checkpoint outputs in orchestration code.
 `@flow` function body, before or after checkpoint calls, not inside a
 `@checkpoint` function.
 
-A wait pauses the whole run. Kitaru records each checkpoint call as a step. If
-`wait()` pauses from inside that step, the flow can stop before the checkpoint
-has completed cleanly. That can leave the run in a confusing state where the
-flow is waiting but the checkpoint step appears failed. To avoid that state,
-Kitaru raises this error immediately:
+A wait pauses the whole run. If `wait()` pauses from inside a checkpoint, the
+run can stop before that checkpoint call has completed cleanly. That can leave
+things in a confusing state where the run is waiting for input, but the
+checkpoint call is marked failed. To avoid that state, Kitaru raises this error
+immediately:
 
 ```text
 wait() cannot run inside a @checkpoint. Move the wait to flow scope, before or after checkpoint calls.

--- a/docs/book/guides/wait-and-resume.md
+++ b/docs/book/guides/wait-and-resume.md
@@ -49,6 +49,11 @@ This is useful when a flow needs to print follow-up CLI commands, name
 per-execution side resources, or attach the execution ID to application logs.
 Outside a running Kitaru flow or checkpoint, it returns `None`.
 
+`kitaru.wait()` itself must run at flow scope, before or after checkpoint calls,
+not inside a `@checkpoint`. For why this rule exists and how to split work
+around a wait, see
+[Where wait() can be called](../concepts/wait-and-input.md#where-wait-can-be-called).
+
 ## Timeout behavior
 
 By default, `kitaru.wait(...)` gives the runner up to 600 seconds to receive


### PR DESCRIPTION
## What changed

- Documented that `kitaru.wait()` must be called at flow scope, not inside a `@checkpoint`.
- Added the exact runtime error text to the wait concept page so users can search for it.
- Added a small recipe for splitting one checkpoint into two checkpoints when input is needed mid-flow.
- Linked the wait/resume guide to the new concept-page section.

## Why it was needed

A user can reasonably think `wait()` behaves like other Kitaru primitives and can be called from inside a checkpoint. At runtime Kitaru rejects that placement, but the docs did not warn users before they hit the error.

## Key implementation decisions

- Kept the change in the hand-written GitBook docs under `docs/book/`.
- Did not touch generated reference docs, runtime code, navigation, or the changelog.
- Used the existing runtime error messages as the wording source of truth.

## Reviewer Notes

The important behavior is explained in `docs/book/concepts/wait-and-input.md` under `Where wait() can be called`. That section now tells the story directly: the flow is allowed to pause, but a checkpoint is recorded as one succeed-or-fail step. If the pause signal is raised inside that step, the run may pause while the checkpoint is recorded as failed. The docs now tell users to put `wait()` before or after checkpoint calls instead.

Please focus on whether the new wording fits the surrounding GitBook voice and whether the split-checkpoint example is clear enough for someone who tried to put `wait()` in the middle of a checkpoint.

### Reproduction

To review the documented behavior end to end:

1. Open `docs/book/concepts/wait-and-input.md`.
2. Find `Where wait() can be called`.
3. Confirm it states that `kitaru.wait()` belongs inside the `@flow` function body, before or after checkpoint calls, never inside a `@checkpoint`.
4. Confirm the section includes this exact searchable runtime error: `wait() cannot run inside a @checkpoint. Move the wait to flow scope, before or after checkpoint calls.`
5. Open `docs/book/guides/wait-and-resume.md` and confirm the guide links to that concept section with a relative `.md` link.

Local checks run:

- `uv run kitaru init`
- `just links`
- `just check`
- targeted grep checks for the new error text and guide cross-link
