### PR TITLE
Redact LLM provider error credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added count-based execution statistics through `KitaruClient().executions.statistics(...)`, `kitaru executions statistics`, and the `kitaru_executions_statistics` MCP tool, with grouping by status, flow, stack, tag, time bucket, and execution metadata.
 
 ### Fixed
+- Redact credential values from LLM provider error messages raised by `kitaru.llm()`.
 - Fixed a LangGraph adapter crash when running graphs without a LangGraph checkpointer under Kitaru's default durability policy. (#403)
 
 ## [0.15.0] - 2026-06-04

--- a/src/kitaru/llm.py
+++ b/src/kitaru/llm.py
@@ -286,6 +286,39 @@ def _normalize_messages(
 # ---------------------------------------------------------------------------
 
 
+def _redact_provider_error_text(
+    text: str,
+    *,
+    env_overlay: Mapping[str, str],
+    env_names: Sequence[str] = (),
+    extra_secrets: Sequence[str | None] = (),
+) -> str:
+    """Strip known credential values from provider SDK error text.
+
+    Provider SDK exceptions can echo request credentials, so any value Kitaru
+    supplied to the call is replaced before the text reaches a Kitaru error
+    message.
+    """
+    secrets: list[str] = [value for value in env_overlay.values() if value]
+    for candidate in extra_secrets:
+        if candidate and candidate != _OLLAMA_DUMMY_API_KEY:
+            secrets.append(candidate)
+    # Ambient env values for provider credential names also count as values this
+    # process supplied to the provider SDK.
+    for name in set(env_overlay) | set(env_names):
+        ambient = os.environ.get(name)
+        if ambient:
+            secrets.append(ambient)
+
+    unique_secrets: list[str] = sorted(
+        set(secrets), key=lambda secret: len(secret), reverse=True
+    )
+    redacted = text
+    for secret in unique_secrets:
+        redacted = redacted.replace(secret, "[redacted]")
+    return redacted
+
+
 def _call_openai(
     *,
     model: str,
@@ -327,9 +360,15 @@ def _call_openai(
         try:
             response = client.chat.completions.create(**kwargs)
         except Exception as exc:
+            safe_text = _redact_provider_error_text(
+                str(exc),
+                env_overlay=env_overlay,
+                env_names=_MODEL_PROVIDER_HINTS.get(provider_label, ()),
+                extra_secrets=(api_key,),
+            )
             raise KitaruBackendError(
                 f"kitaru.llm() failed while calling {provider_label} for "
-                f"model `{provider_label}/{model}`: {exc}"
+                f"model `{provider_label}/{model}`: {safe_text}"
             ) from exc
 
     return _ProviderCallResult(
@@ -389,9 +428,14 @@ def _call_anthropic(
         try:
             response = client.messages.create(**kwargs)
         except Exception as exc:
+            safe_text = _redact_provider_error_text(
+                str(exc),
+                env_overlay=env_overlay,
+                env_names=_MODEL_PROVIDER_HINTS["anthropic"],
+            )
             raise KitaruBackendError(
                 f"kitaru.llm() failed while calling Anthropic for model "
-                f"`anthropic/{model}`: {exc}"
+                f"`anthropic/{model}`: {safe_text}"
             ) from exc
 
     return _ProviderCallResult(

--- a/src/kitaru/llm.py
+++ b/src/kitaru/llm.py
@@ -43,6 +43,15 @@ _OLLAMA_HOST_ENV = "OLLAMA_HOST"
 _OLLAMA_DEFAULT_HOST = "http://localhost:11434"
 _OLLAMA_DUMMY_API_KEY = "ollama"  # Ollama needs no auth; prevents OpenAI SDK env lookup
 _OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+_MIN_REDACTABLE_SECRET_LENGTH = 8
+_CREDENTIAL_KEY_PARTS = {
+    "CREDENTIAL",
+    "CREDENTIALS",
+    "KEY",
+    "PASSWORD",
+    "SECRET",
+    "TOKEN",
+}
 
 _SUPPORTED_PROVIDERS = ("openai", "anthropic", "ollama", "openrouter")
 
@@ -286,6 +295,22 @@ def _normalize_messages(
 # ---------------------------------------------------------------------------
 
 
+def _looks_like_credential_name(name: str) -> bool:
+    """Return whether an environment-style name usually carries credentials."""
+    normalized = name.upper()
+    parts = set(re.split(r"[^A-Z0-9]+", normalized))
+    return bool(parts & _CREDENTIAL_KEY_PARTS) or "APIKEY" in normalized
+
+
+def _redactable_secret(value: str | None) -> str | None:
+    """Return a value only when redacting it is unlikely to erase harmless text."""
+    if value is None or value == _OLLAMA_DUMMY_API_KEY:
+        return None
+    if len(value) < _MIN_REDACTABLE_SECRET_LENGTH:
+        return None
+    return value
+
+
 def _redact_provider_error_text(
     text: str,
     *,
@@ -295,20 +320,25 @@ def _redact_provider_error_text(
 ) -> str:
     """Strip known credential values from provider SDK error text.
 
-    Provider SDK exceptions can echo request credentials, so any value Kitaru
-    supplied to the call is replaced before the text reaches a Kitaru error
-    message.
+    Provider SDK exceptions can echo request credentials. Kitaru only redacts
+    values from credential-like overlay keys, explicit provider credential names,
+    or explicit SDK credential arguments so ordinary secret fields do not hide
+    useful provider diagnostics.
     """
-    secrets: list[str] = [value for value in env_overlay.values() if value]
+    credential_names = {
+        name
+        for name in set(env_overlay) | set(env_names)
+        if _looks_like_credential_name(name)
+    }
+    secrets: list[str] = []
+    for name in credential_names:
+        if secret := _redactable_secret(env_overlay.get(name)):
+            secrets.append(secret)
+        if secret := _redactable_secret(os.environ.get(name)):
+            secrets.append(secret)
     for candidate in extra_secrets:
-        if candidate and candidate != _OLLAMA_DUMMY_API_KEY:
-            secrets.append(candidate)
-    # Ambient env values for provider credential names also count as values this
-    # process supplied to the provider SDK.
-    for name in set(env_overlay) | set(env_names):
-        ambient = os.environ.get(name)
-        if ambient:
-            secrets.append(ambient)
+        if secret := _redactable_secret(candidate):
+            secrets.append(secret)
 
     unique_secrets: list[str] = sorted(
         set(secrets), key=lambda secret: len(secret), reverse=True
@@ -356,8 +386,8 @@ def _call_openai(
         client_kwargs["api_key"] = api_key
 
     with _temporary_env(env_overlay):
-        client = OpenAI(**client_kwargs)
         try:
+            client = OpenAI(**client_kwargs)
             response = client.chat.completions.create(**kwargs)
         except Exception as exc:
             safe_text = _redact_provider_error_text(
@@ -424,8 +454,8 @@ def _call_anthropic(
         kwargs["temperature"] = temperature
 
     with _temporary_env(env_overlay):
-        client = Anthropic()
         try:
+            client = Anthropic()
             response = client.messages.create(**kwargs)
         except Exception as exc:
             safe_text = _redact_provider_error_text(

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -626,6 +626,34 @@ def test_openrouter_uses_api_key_from_secret_overlay(
     assert mock_call.call_args.kwargs["api_key"] == "secret-or-key"
 
 
+def test_llm_redacts_openrouter_key_through_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenRouter failures should redact keys after provider dispatch."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    secret = "or-test-dispatch-secret"
+    provider_exc = RuntimeError(f"OpenRouter rejected API key {secret}")
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = provider_exc
+    mock_openai_cls = MagicMock(return_value=mock_client)
+
+    with (
+        _llm_execution_scope(
+            model_selection=_simple_selection("openrouter/openai/gpt-4o"),
+            credential_overlay=({"OPENROUTER_API_KEY": secret}, "secret"),
+        ),
+        patch.dict("sys.modules", {"openai": MagicMock(OpenAI=mock_openai_cls)}),
+        pytest.raises(KitaruBackendError) as raised,
+    ):
+        llm("hello", model="openrouter/openai/gpt-4o", name="test")
+
+    message = str(raised.value)
+    assert "openrouter" in message
+    assert "[redacted]" in message
+    assert secret not in message
+    assert raised.value.__cause__ is provider_exc
+
+
 # ---------------------------------------------------------------------------
 # Credential resolution for new providers
 # ---------------------------------------------------------------------------
@@ -1211,6 +1239,32 @@ def test_call_openai_redacts_overlay_secrets_from_provider_errors() -> None:
     assert secret not in message
 
 
+def test_call_openai_redacts_client_construction_errors() -> None:
+    """OpenAI client construction errors should use the same redaction path."""
+    from kitaru.llm import _call_openai
+
+    secret = "sk-test-client-construction"
+    provider_exc = RuntimeError(f"Client rejected API key {secret}")
+    mock_openai_cls = MagicMock(side_effect=provider_exc)
+
+    with (
+        patch.dict("sys.modules", {"openai": MagicMock(OpenAI=mock_openai_cls)}),
+        pytest.raises(KitaruBackendError) as raised,
+    ):
+        _call_openai(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=None,
+            max_tokens=None,
+            env_overlay={"OPENAI_API_KEY": secret},
+        )
+
+    message = str(raised.value)
+    assert "[redacted]" in message
+    assert secret not in message
+    assert raised.value.__cause__ is provider_exc
+
+
 def test_call_openai_redacts_process_env_secret_from_provider_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1303,6 +1357,34 @@ def test_call_anthropic_redacts_overlay_secrets_from_provider_errors() -> None:
     assert secret not in message
 
 
+def test_call_anthropic_redacts_client_construction_errors() -> None:
+    """Anthropic client construction errors should use the same redaction path."""
+    from kitaru.llm import _call_anthropic
+
+    secret = "sk-test-anthropic-client"
+    provider_exc = RuntimeError(f"Client rejected API key {secret}")
+    mock_anthropic_cls = MagicMock(side_effect=provider_exc)
+
+    with (
+        patch.dict(
+            "sys.modules", {"anthropic": MagicMock(Anthropic=mock_anthropic_cls)}
+        ),
+        pytest.raises(KitaruBackendError) as raised,
+    ):
+        _call_anthropic(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=None,
+            max_tokens=None,
+            env_overlay={"ANTHROPIC_API_KEY": secret},
+        )
+
+    message = str(raised.value)
+    assert "[redacted]" in message
+    assert secret not in message
+    assert raised.value.__cause__ is provider_exc
+
+
 def test_call_openai_leaves_non_secret_provider_error_text_unchanged() -> None:
     """Provider error text without known credentials should pass through."""
     from kitaru.llm import _call_openai
@@ -1359,6 +1441,37 @@ def test_redact_provider_error_text_handles_empty_and_ambient_secrets(
     )
 
 
+def test_redact_provider_error_text_skips_unrelated_and_short_values() -> None:
+    """Benign overlay values should not erase useful provider diagnostics."""
+    from kitaru.llm import _redact_provider_error_text
+
+    assert (
+        _redact_provider_error_text(
+            "provider project alpha failed with key sk",
+            env_overlay={"PROJECT_NAME": "alpha", "OPENAI_API_KEY": "sk"},
+        )
+        == "provider project alpha failed with key sk"
+    )
+
+
+def test_redact_provider_error_text_handles_overlapping_secrets() -> None:
+    """Longer credential values should be redacted before shorter prefixes."""
+    from kitaru.llm import _redact_provider_error_text
+
+    message = "primary sk-test12345 fallback sk-test1"
+
+    assert (
+        _redact_provider_error_text(
+            message,
+            env_overlay={
+                "OPENAI_API_KEY": "sk-test12345",
+                "BACKUP_API_KEY": "sk-test1",
+            },
+        )
+        == "primary [redacted] fallback [redacted]"
+    )
+
+
 def test_call_openai_redacts_message_but_preserves_original_cause() -> None:
     """Kitaru messages are redacted while exception chaining stays intact."""
     from kitaru.llm import _call_openai
@@ -1384,6 +1497,8 @@ def test_call_openai_redacts_message_but_preserves_original_cause() -> None:
     assert secret not in str(raised.value)
     assert "[redacted]" in str(raised.value)
     assert raised.value.__cause__ is provider_exc
+    # Kitaru redacts its own message, but preserves the provider exception for
+    # debug tracebacks; the original cause may still contain raw provider text.
     assert secret in str(raised.value.__cause__)
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -16,6 +16,7 @@ from kitaru._llm_usage import LLM_USAGE_METADATA_KEY
 from kitaru.analytics import AnalyticsEvent
 from kitaru.config import ResolvedModelSelection, register_model_alias
 from kitaru.errors import (
+    KitaruBackendError,
     KitaruContextError,
     KitaruRuntimeError,
     KitaruUsageError,
@@ -1180,6 +1181,210 @@ def test_resolve_credential_overlay_errors_without_known_credentials(
 # ---------------------------------------------------------------------------
 # Direct provider SDK integration (verifies correct SDK invocation)
 # ---------------------------------------------------------------------------
+
+
+def test_call_openai_redacts_overlay_secrets_from_provider_errors() -> None:
+    """OpenAI provider errors should not leak env-overlay credentials."""
+    from kitaru.llm import _call_openai
+
+    secret = "sk-test-overlay-value"
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = RuntimeError(
+        f"Incorrect API key provided: {secret}"
+    )
+    mock_openai_cls = MagicMock(return_value=mock_client)
+
+    with (
+        patch.dict("sys.modules", {"openai": MagicMock(OpenAI=mock_openai_cls)}),
+        pytest.raises(KitaruBackendError) as raised,
+    ):
+        _call_openai(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=None,
+            max_tokens=None,
+            env_overlay={"OPENAI_API_KEY": secret},
+        )
+
+    message = str(raised.value)
+    assert "[redacted]" in message
+    assert secret not in message
+
+
+def test_call_openai_redacts_process_env_secret_from_provider_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider errors should redact credentials read from os.environ."""
+    from kitaru.llm import _call_openai
+
+    secret = "sk-test-process-env-value"
+    monkeypatch.setenv("OPENAI_API_KEY", secret)
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = RuntimeError(
+        f"Incorrect API key provided: {secret}"
+    )
+    mock_openai_cls = MagicMock(return_value=mock_client)
+
+    with (
+        patch.dict("sys.modules", {"openai": MagicMock(OpenAI=mock_openai_cls)}),
+        pytest.raises(KitaruBackendError) as raised,
+    ):
+        _call_openai(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=None,
+            max_tokens=None,
+            env_overlay={},
+        )
+
+    message = str(raised.value)
+    assert "[redacted]" in message
+    assert secret not in message
+
+
+def test_call_openai_redacts_explicit_api_key_from_provider_errors() -> None:
+    """OpenAI-compatible provider errors should not leak explicit API keys."""
+    from kitaru.llm import _call_openai
+
+    secret = "sk-test-explicit-value"
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = RuntimeError(
+        f"Incorrect API key provided: {secret}"
+    )
+    mock_openai_cls = MagicMock(return_value=mock_client)
+
+    with (
+        patch.dict("sys.modules", {"openai": MagicMock(OpenAI=mock_openai_cls)}),
+        pytest.raises(KitaruBackendError) as raised,
+    ):
+        _call_openai(
+            model="openai/gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=None,
+            max_tokens=None,
+            env_overlay={},
+            base_url="https://openrouter.ai/api/v1",
+            api_key=secret,
+            provider_label="openrouter",
+        )
+
+    message = str(raised.value)
+    assert "[redacted]" in message
+    assert secret not in message
+
+
+def test_call_anthropic_redacts_overlay_secrets_from_provider_errors() -> None:
+    """Anthropic provider errors should not leak env-overlay credentials."""
+    from kitaru.llm import _call_anthropic
+
+    secret = "sk-test-anthropic-overlay"
+    mock_client = MagicMock()
+    mock_client.messages.create.side_effect = RuntimeError(
+        f"Authentication failed for key {secret}"
+    )
+    mock_anthropic_cls = MagicMock(return_value=mock_client)
+
+    with (
+        patch.dict(
+            "sys.modules", {"anthropic": MagicMock(Anthropic=mock_anthropic_cls)}
+        ),
+        pytest.raises(KitaruBackendError) as raised,
+    ):
+        _call_anthropic(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=None,
+            max_tokens=None,
+            env_overlay={"ANTHROPIC_API_KEY": secret},
+        )
+
+    message = str(raised.value)
+    assert "[redacted]" in message
+    assert secret not in message
+
+
+def test_call_openai_leaves_non_secret_provider_error_text_unchanged() -> None:
+    """Provider error text without known credentials should pass through."""
+    from kitaru.llm import _call_openai
+
+    provider_error = "provider timeout without credential details"
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = RuntimeError(provider_error)
+    mock_openai_cls = MagicMock(return_value=mock_client)
+
+    with (
+        patch.dict("sys.modules", {"openai": MagicMock(OpenAI=mock_openai_cls)}),
+        pytest.raises(KitaruBackendError) as raised,
+    ):
+        _call_openai(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=None,
+            max_tokens=None,
+            env_overlay={},
+        )
+
+    message = str(raised.value)
+    assert provider_error in message
+    assert "[redacted]" not in message
+
+
+def test_redact_provider_error_text_handles_empty_and_ambient_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper should be a no-op unless Kitaru knows the credential value."""
+    from kitaru.llm import _redact_provider_error_text
+
+    assert (
+        _redact_provider_error_text(
+            "provider timeout", env_overlay={}, extra_secrets=()
+        )
+        == "provider timeout"
+    )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-ambient-value")
+
+    assert (
+        _redact_provider_error_text(
+            "Incorrect API key provided: sk-test-ambient-value",
+            env_overlay={"OPENAI_API_KEY": ""},
+        )
+        == "Incorrect API key provided: [redacted]"
+    )
+    assert (
+        _redact_provider_error_text(
+            "ollama server unavailable", env_overlay={}, extra_secrets=("ollama",)
+        )
+        == "ollama server unavailable"
+    )
+
+
+def test_call_openai_redacts_message_but_preserves_original_cause() -> None:
+    """Kitaru messages are redacted while exception chaining stays intact."""
+    from kitaru.llm import _call_openai
+
+    secret = "sk-test-cause-value"
+    provider_exc = RuntimeError(f"Incorrect API key provided: {secret}")
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.side_effect = provider_exc
+    mock_openai_cls = MagicMock(return_value=mock_client)
+
+    with (
+        patch.dict("sys.modules", {"openai": MagicMock(OpenAI=mock_openai_cls)}),
+        pytest.raises(KitaruBackendError) as raised,
+    ):
+        _call_openai(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            temperature=None,
+            max_tokens=None,
+            env_overlay={"OPENAI_API_KEY": secret},
+        )
+
+    assert secret not in str(raised.value)
+    assert "[redacted]" in str(raised.value)
+    assert raised.value.__cause__ is provider_exc
+    assert secret in str(raised.value.__cause__)
 
 
 def test_call_openai_passes_correct_parameters() -> None:


### PR DESCRIPTION
## What changed

- Redacts credential values before `kitaru.llm()` wraps provider SDK client-construction or request exceptions in `KitaruBackendError`.
- Covers OpenAI/OpenAI-compatible calls and Anthropic calls.
- Preserves `raise ... from exc`, so local debugging still has access to the original provider exception.
- Adds regression tests for overlay secrets, ambient environment secrets, explicit OpenAI-compatible `api_key` values, client-construction failures, OpenRouter dispatch failures, overlapping secret values, non-secret error text, Ollama dummy-key behavior, and the chained-cause boundary.
- Adds a changelog entry under `[Unreleased]`.

## Why it was needed

Provider SDK errors can echo credential-like values. Before this change, Kitaru took the raw provider exception text and put it directly into a Kitaru error message. That meant a fake or real key value supplied by Kitaru could end up in terminal output, logs, or persisted error fields.

## Key implementation decisions

- The redaction helper lives privately in `src/kitaru/llm.py`, matching the existing private auth-error redaction precedent without broadening scope into a shared helper yet.
- Redaction uses credential-like overlay keys, explicit provider credential env names, and explicit SDK credential arguments. It skips unrelated overlay values and very short values so harmless provider diagnostics are not over-redacted.
- Secrets are sorted longest-first before replacement, so overlapping fake key strings are handled deterministically.
- Exception chaining is preserved deliberately: Kitaru's constructed message is safe, while debug tooling that prints `__cause__` can still show the original SDK exception.

## Reviewer Notes

The important behavior happens at the provider SDK boundary in `src/kitaru/llm.py`. Kitaru temporarily applies any credential overlay, constructs the provider client, performs the request, and catches exceptions from both steps. It converts only the exception text through `_redact_provider_error_text(...)`, then raises `KitaruBackendError` with the redacted text.

The highest-risk thing to inspect is the boundary between sanitized user-facing text and the preserved chained cause. If this implementation is wrong, either credentials can still appear in `str(KitaruBackendError)`, or Kitaru loses useful local debugging context by removing `raise ... from exc`.

### Reproduction

Run the focused regression suite:

```bash
just test tests/test_llm.py
```

The new tests create fake provider exceptions containing fake credential strings such as `sk-test-*` and `or-test-*`. The reviewer should see those fake values absent from `str(exc.value)`, replaced with `[redacted]`, while the original provider exception is still available through `exc.value.__cause__`.

Local checks run:

```bash
just check
just test
```

Both passed locally in the worktree after the latest follow-up commit.
