### PR TITLE
Push execution list filters to the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added count-based execution statistics through `KitaruClient().executions.statistics(...)`, `kitaru executions statistics`, and the `kitaru_executions_statistics` MCP tool, with grouping by status, flow, stack, tag, time bucket, and execution metadata.
 
 ### Fixed
+- `KitaruClient.executions.list()` now pushes flow and status filters to the server instead of scanning all project runs client-side.
 - Fixed a LangGraph adapter crash when running graphs without a LangGraph checkpointer under Kitaru's default durability policy. (#403)
 
 ## [0.15.0] - 2026-06-04

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import ValidationError
@@ -70,6 +71,20 @@ _RAW_STATUS_TO_PUBLIC_STATUS: dict[str, ExecutionStatus] = {
     for public_status, raw_statuses in _RAW_STATUSES_BY_PUBLIC_STATUS.items()
     for raw_status in raw_statuses
 }
+
+
+def _backend_filter_value(values: Sequence[str]) -> str:
+    """Format values for ZenML backend string-filter fields."""
+    if len(values) == 1:
+        return values[0]
+    return f"oneof:{json.dumps(list(values), separators=(',', ':'))}"
+
+
+def _status_filter_value(public_status: ExecutionStatus | None) -> str | None:
+    """Map a public status filter to the backend string-filter syntax."""
+    if public_status is None:
+        return None
+    return _backend_filter_value(_RAW_STATUSES_BY_PUBLIC_STATUS[public_status])
 
 
 def _to_plain_dict(values: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -525,6 +525,7 @@ def _map_execution(
     run: PipelineRunResponse,
     client: KitaruClient,
     include_details: bool,
+    resolve_wait_status: bool = False,
 ) -> Execution:
     """Map a ZenML pipeline run into a Kitaru execution model."""
     status = _to_public_status(run.status)
@@ -536,7 +537,9 @@ def _map_execution(
         active_wait = _get_active_wait_condition(run)
         if active_wait is not None:
             pending_wait = _map_pending_wait(active_wait)
-        elif include_details:
+        elif include_details or resolve_wait_status:
+            # Some ZenML responses only expose pending waits through
+            # list_run_wait_conditions(...), not through active_wait_condition.
             pending_wait = _first_pending_wait(run=run, client=client)
 
     if pending_wait is not None:

--- a/src/kitaru/_client/_statistics.py
+++ b/src/kitaru/_client/_statistics.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -10,8 +9,8 @@ from typing import TYPE_CHECKING, Any
 from pydantic import ValidationError
 
 from kitaru._client._mappers import (
-    _RAW_STATUSES_BY_PUBLIC_STATUS,
     _coerce_status_filter,
+    _status_filter_value,
     _to_public_status,
 )
 from kitaru._client._models import (
@@ -419,17 +418,6 @@ def normalize_execution_statistics_tags(
             raise KitaruUsageError("`tags` cannot contain empty strings.")
         normalized_tags.append(normalized_tag)
     return normalized_tags
-
-
-def _status_filter_value(public_status: ExecutionStatus | None) -> str | None:
-    """Map a public status filter to the backend string-filter syntax."""
-    if public_status is None:
-        return None
-
-    raw_statuses = _RAW_STATUSES_BY_PUBLIC_STATUS[public_status]
-    if len(raw_statuses) == 1:
-        return raw_statuses[0]
-    return f"oneof:{json.dumps(list(raw_statuses), separators=(',', ':'))}"
 
 
 def _status_grouping_name(

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -73,7 +73,9 @@ from kitaru._client._logs import (
 from kitaru._client._mappers import (
     _CHECKPOINT_SOURCE_ALIAS_PREFIX,
     _PIPELINE_SOURCE_ALIAS_PREFIX,
+    _RAW_STATUSES_BY_PUBLIC_STATUS,
     _WAIT_CONDITION_STATUS_PENDING,
+    _backend_filter_value,
     _checkpoint_lineage_key,
     _coerce_status_filter,
     _first_pending_wait,
@@ -89,6 +91,7 @@ from kitaru._client._mappers import (
     _map_pending_wait,
     _parse_frozen_execution_spec,
     _select_pending_wait_condition,
+    _status_filter_value,
     _to_plain_dict,
     _to_public_status,
 )
@@ -826,6 +829,25 @@ def _run_has_complete_step_list(run: Any) -> bool:
     return _to_public_status(run.status).is_finished
 
 
+def _pipeline_name_filter_value(flow: str) -> str:
+    """Return the backend filter value for both stored names of a Kitaru flow."""
+    candidates = [flow, f"{_PIPELINE_SOURCE_ALIAS_PREFIX}{flow}"]
+    return _backend_filter_value(candidates)
+
+
+def _list_status_filter_value(public_status: ExecutionStatus) -> str:
+    """Return the safest backend status filter for execution listing."""
+    if public_status in {ExecutionStatus.RUNNING, ExecutionStatus.WAITING}:
+        raw_statuses = (
+            *_RAW_STATUSES_BY_PUBLIC_STATUS[ExecutionStatus.RUNNING],
+            *_RAW_STATUSES_BY_PUBLIC_STATUS[ExecutionStatus.WAITING],
+        )
+        return _backend_filter_value(raw_statuses)
+    status_value = _status_filter_value(public_status)
+    assert status_value is not None
+    return status_value
+
+
 class _ExecutionsAPI:
     """Namespace for execution lifecycle and inspection operations."""
 
@@ -1353,6 +1375,12 @@ class _ExecutionsAPI:
         else:
             page_size = 50
 
+        server_filters: dict[str, Any] = {}
+        if flow is not None:
+            server_filters["pipeline_name"] = _pipeline_name_filter_value(flow)
+        if status_filter is not None:
+            server_filters["status"] = _list_status_filter_value(status_filter)
+
         while True:
             run_page = self._client_ref._client().list_pipeline_runs(
                 sort_by="desc:created",
@@ -1360,6 +1388,7 @@ class _ExecutionsAPI:
                 size=page_size,
                 project=self._client_ref._project,
                 hydrate=True,
+                **server_filters,
             )
             runs = list(run_page.items)
             if not runs:
@@ -1372,6 +1401,8 @@ class _ExecutionsAPI:
                     include_details=False,
                 )
 
+                # Server filters only reduce fetched runs; these public checks
+                # still decide the final result because flow/status can be derived.
                 if flow is not None and execution.flow_name != flow:
                     continue
                 if status_filter is not None and execution.status != status_filter:

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -1356,6 +1356,9 @@ class _ExecutionsAPI:
         if size is not None and page is None:
             page = 1
 
+        if flow is not None and _normalize_flow_name(flow) is None:
+            return []
+
         start_index = 0
         stop_index: int | None = None
         if limit is not None:
@@ -1380,6 +1383,10 @@ class _ExecutionsAPI:
             server_filters["pipeline_name"] = _pipeline_name_filter_value(flow)
         if status_filter is not None:
             server_filters["status"] = _list_status_filter_value(status_filter)
+        resolve_wait_status = status_filter in {
+            ExecutionStatus.RUNNING,
+            ExecutionStatus.WAITING,
+        }
 
         while True:
             run_page = self._client_ref._client().list_pipeline_runs(
@@ -1399,6 +1406,7 @@ class _ExecutionsAPI:
                     run=run,
                     client=self._client_ref,
                     include_details=False,
+                    resolve_wait_status=resolve_wait_status,
                 )
 
                 # Server filters only reduce fetched runs; these public checks

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,6 +20,8 @@ from zenml.enums import ExecutionStatus as ZenMLExecutionStatus
 from zenml.exceptions import EntityExistsError
 from zenml.models import PipelineRunResponse, StepRunResponse
 from zenml.models.v2.core.artifact_version import ArtifactVersionResponse
+from zenml.models.v2.core.pipeline_run import PipelineRunFilter
+from zenml.zen_stores.schemas import PipelineRunSchema
 
 from kitaru._client._deployments import (
     build_deployment_snapshot_name,
@@ -31,6 +33,7 @@ from kitaru._client._mappers import (
     _PIPELINE_SOURCE_ALIAS_PREFIX,
     _RAW_STATUS_TO_PUBLIC_STATUS,
     _RAW_STATUSES_BY_PUBLIC_STATUS,
+    _backend_filter_value,
     _to_public_status,
 )
 from kitaru._client._statistics import (
@@ -129,6 +132,12 @@ def _backend_filter_for_values(values: tuple[str, ...]) -> str:
     if len(values) == 1:
         return values[0]
     return f"oneof:{json.dumps(list(values), separators=(',', ':'))}"
+
+
+def _backend_filter_values(filter_value: str) -> tuple[str, ...]:
+    if filter_value.startswith("oneof:"):
+        return tuple(json.loads(filter_value.removeprefix("oneof:")))
+    return (filter_value,)
 
 
 class _DummyArtifact:
@@ -2427,6 +2436,86 @@ def test_list_filters_flow_status_and_limit() -> None:
     assert executions[0].exec_id == str(run_1.id)
 
 
+@pytest.mark.parametrize("blank_flow", ["", "   ", "\t\n"])
+def test_list_blank_flow_returns_empty_without_backend_call(blank_flow: str) -> None:
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+
+        client = KitaruClient()
+        executions = client.executions.list(flow=blank_flow)
+
+    assert executions == []
+    client_mock.list_pipeline_runs.assert_not_called()
+
+
+def test_backend_filter_value_round_trips_special_characters() -> None:
+    values = (
+        "plain_flow",
+        'flow with "quotes"',
+        r"flow\with\backslashes",
+    )
+
+    filter_value = _backend_filter_value(values)
+
+    assert filter_value.startswith("oneof:")
+    assert _backend_filter_values(filter_value) == values
+
+
+def test_list_backend_filters_match_zenml_pipeline_run_filter_contract() -> None:
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_pipeline_runs.return_value = SimpleNamespace(items=[])
+
+        client = KitaruClient()
+        client.executions.list(flow="contract_flow", status="waiting")
+
+    kwargs = client_mock.list_pipeline_runs.call_args.kwargs
+    filter_model = PipelineRunFilter(
+        pipeline_name=kwargs["pipeline_name"],
+        status=kwargs["status"],
+    )
+
+    assert filter_model.pipeline_name is not None
+    pipeline_names = _backend_filter_values(filter_model.pipeline_name)
+    assert set(pipeline_names) == {
+        "contract_flow",
+        f"{_PIPELINE_SOURCE_ALIAS_PREFIX}contract_flow",
+    }
+
+    custom_filters = filter_model.get_custom_filters(PipelineRunSchema)
+    assert len(custom_filters) == 1
+    pipeline_condition = str(
+        custom_filters[0].compile(compile_kwargs={"literal_binds": True})
+    )
+    assert "oneof:" not in pipeline_condition
+    assert "pipeline.name = 'contract_flow'" in pipeline_condition
+    assert (
+        f"pipeline.name = '{_PIPELINE_SOURCE_ALIAS_PREFIX}contract_flow'"
+        in pipeline_condition
+    )
+
+    status_filter = next(
+        item for item in filter_model.list_of_filters if item.column == "status"
+    )
+    assert status_filter.operation.value == "oneof"
+    assert status_filter.value == [
+        *_RAW_STATUSES_BY_PUBLIC_STATUS[ExecutionStatus.RUNNING],
+        *_RAW_STATUSES_BY_PUBLIC_STATUS[ExecutionStatus.WAITING],
+    ]
+
+
 def test_list_forwards_flow_filter_to_backend() -> None:
     run = _DummyRun(status=ZenMLExecutionStatus.COMPLETED, flow_name="my_flow")
 
@@ -2523,6 +2612,77 @@ def test_list_waiting_and_running_filters_fetch_shared_raw_statuses() -> None:
         client_mock.list_pipeline_runs.call_args_list[1].kwargs["status"]
         == shared_status_filter
     )
+
+
+def test_list_waiting_detects_pending_wait_from_wait_condition_listing() -> None:
+    wait_condition = _dummy_wait_condition(
+        name="approve_release",
+        question="Approve release?",
+    )
+    waiting_run = _DummyRun(
+        status=ZenMLExecutionStatus.RUNNING,
+        flow_name="flow_a",
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_pipeline_runs.return_value = SimpleNamespace(
+            items=[_as_pipeline_run(waiting_run)]
+        )
+        client_mock.list_run_wait_conditions.return_value = SimpleNamespace(
+            items=[wait_condition]
+        )
+
+        client = KitaruClient()
+        waiting_executions = client.executions.list(status="waiting")
+
+    assert len(waiting_executions) == 1
+    execution = waiting_executions[0]
+    assert execution.exec_id == str(waiting_run.id)
+    assert execution.status is ExecutionStatus.WAITING
+    assert execution.pending_wait is not None
+    assert execution.pending_wait.name == "approve_release"
+    client_mock.list_run_wait_conditions.assert_called_once_with(
+        pipeline_run=waiting_run.id,
+        project=None,
+        status="pending",
+        hydrate=True,
+        sort_by="asc:created",
+        size=200,
+    )
+
+
+def test_unfiltered_list_keeps_raw_running_shallow_when_wait_is_not_active() -> None:
+    running_run = _DummyRun(
+        status=ZenMLExecutionStatus.RUNNING,
+        flow_name="flow_a",
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_pipeline_runs.return_value = SimpleNamespace(
+            items=[_as_pipeline_run(running_run)]
+        )
+
+        client = KitaruClient()
+        executions = client.executions.list()
+
+    assert len(executions) == 1
+    assert executions[0].exec_id == str(running_run.id)
+    assert executions[0].status is ExecutionStatus.RUNNING
+    client_mock.list_run_wait_conditions.assert_not_called()
 
 
 def test_list_without_filters_does_not_forward_filter_kwargs() -> None:
@@ -3250,12 +3410,6 @@ def test_statistics_fetches_metrics_from_zen_store() -> None:
         ],
         truncated=False,
     )
-
-
-def _backend_filter_values(filter_value: str) -> tuple[str, ...]:
-    if filter_value.startswith("oneof:"):
-        return tuple(json.loads(filter_value.removeprefix("oneof:")))
-    return (filter_value,)
 
 
 def test_status_grouping_skips_global_zero_placeholders_before_max_groups() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,6 +28,7 @@ from kitaru._client._deployments import (
     parse_deployment_snapshot_name,
 )
 from kitaru._client._mappers import (
+    _PIPELINE_SOURCE_ALIAS_PREFIX,
     _RAW_STATUS_TO_PUBLIC_STATUS,
     _RAW_STATUSES_BY_PUBLIC_STATUS,
     _to_public_status,
@@ -122,6 +123,12 @@ def _as_step_run(step: _DummyStep) -> StepRunResponse:
 
 def _as_artifact(artifact: _DummyArtifact) -> ArtifactVersionResponse:
     return cast(ArtifactVersionResponse, artifact)
+
+
+def _backend_filter_for_values(values: tuple[str, ...]) -> str:
+    if len(values) == 1:
+        return values[0]
+    return f"oneof:{json.dumps(list(values), separators=(',', ':'))}"
 
 
 class _DummyArtifact:
@@ -2420,6 +2427,154 @@ def test_list_filters_flow_status_and_limit() -> None:
     assert executions[0].exec_id == str(run_1.id)
 
 
+def test_list_forwards_flow_filter_to_backend() -> None:
+    run = _DummyRun(status=ZenMLExecutionStatus.COMPLETED, flow_name="my_flow")
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_pipeline_runs.return_value = SimpleNamespace(
+            items=[_as_pipeline_run(run)]
+        )
+
+        client = KitaruClient()
+        client.executions.list(flow="my_flow")
+
+    pipeline_name = client_mock.list_pipeline_runs.call_args.kwargs["pipeline_name"]
+    pipeline_names = _backend_filter_values(pipeline_name)
+    assert set(pipeline_names) == {
+        "my_flow",
+        f"{_PIPELINE_SOURCE_ALIAS_PREFIX}my_flow",
+    }
+    assert len(pipeline_names) == 2
+
+
+def test_list_forwards_terminal_status_filter_to_backend() -> None:
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_pipeline_runs.return_value = SimpleNamespace(items=[])
+
+        client = KitaruClient()
+        client.executions.list(status="completed")
+
+    status_filter = client_mock.list_pipeline_runs.call_args.kwargs["status"]
+    assert status_filter == _backend_filter_for_values(
+        _RAW_STATUSES_BY_PUBLIC_STATUS[ExecutionStatus.COMPLETED]
+    )
+
+
+def test_list_waiting_and_running_filters_fetch_shared_raw_statuses() -> None:
+    wait_condition = _dummy_wait_condition(
+        name="approve_release",
+        question="Approve release?",
+    )
+    waiting_run = _DummyRun(
+        status=ZenMLExecutionStatus.RUNNING,
+        flow_name="flow_a",
+        active_wait_condition=wait_condition,
+    )
+    running_run = _DummyRun(status=ZenMLExecutionStatus.RUNNING, flow_name="flow_a")
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_pipeline_runs.return_value = SimpleNamespace(
+            items=[_as_pipeline_run(waiting_run), _as_pipeline_run(running_run)]
+        )
+        client_mock.list_run_wait_conditions.return_value = SimpleNamespace(items=[])
+
+        client = KitaruClient()
+        waiting_executions = client.executions.list(status="waiting")
+        running_executions = client.executions.list(status="running")
+
+    assert [execution.exec_id for execution in waiting_executions] == [
+        str(waiting_run.id)
+    ]
+    assert [execution.exec_id for execution in running_executions] == [
+        str(running_run.id)
+    ]
+    shared_status_filter = _backend_filter_for_values(
+        (
+            *_RAW_STATUSES_BY_PUBLIC_STATUS[ExecutionStatus.RUNNING],
+            *_RAW_STATUSES_BY_PUBLIC_STATUS[ExecutionStatus.WAITING],
+        )
+    )
+    assert (
+        client_mock.list_pipeline_runs.call_args_list[0].kwargs["status"]
+        == shared_status_filter
+    )
+    assert (
+        client_mock.list_pipeline_runs.call_args_list[1].kwargs["status"]
+        == shared_status_filter
+    )
+
+
+def test_list_without_filters_does_not_forward_filter_kwargs() -> None:
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_pipeline_runs.return_value = SimpleNamespace(items=[])
+
+        client = KitaruClient()
+        client.executions.list()
+
+    kwargs = client_mock.list_pipeline_runs.call_args.kwargs
+    assert "pipeline_name" not in kwargs
+    assert "status" not in kwargs
+
+
+def test_list_keeps_client_side_flow_filter_as_backstop() -> None:
+    non_matching_run = _DummyRun(
+        status=ZenMLExecutionStatus.COMPLETED,
+        flow_name="flow_b",
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_pipeline_runs.return_value = SimpleNamespace(
+            items=[_as_pipeline_run(non_matching_run)]
+        )
+
+        client = KitaruClient()
+        executions = client.executions.list(flow="flow_a")
+
+    assert executions == []
+    pipeline_name = client_mock.list_pipeline_runs.call_args.kwargs["pipeline_name"]
+    pipeline_names = _backend_filter_values(pipeline_name)
+    assert set(pipeline_names) == {
+        "flow_a",
+        f"{_PIPELINE_SOURCE_ALIAS_PREFIX}flow_a",
+    }
+    assert len(pipeline_names) == 2
+
+
 def test_list_paginates_after_client_side_filters() -> None:
     """Execution pagination should apply after Kitaru flow/status filters."""
     run_1 = _DummyRun(
@@ -2502,6 +2657,12 @@ def test_list_pagination_finds_matches_across_backend_pages() -> None:
 
     assert len(executions) == 1
     assert executions[0].exec_id == str(matching_run.id)
+    expected_pipeline_filter = _backend_filter_for_values(
+        ("flow_a", f"{_PIPELINE_SOURCE_ALIAS_PREFIX}flow_a")
+    )
+    expected_status_filter = _backend_filter_for_values(
+        _RAW_STATUSES_BY_PUBLIC_STATUS[ExecutionStatus.COMPLETED]
+    )
     client_mock.list_pipeline_runs.assert_has_calls(
         [
             call(
@@ -2510,6 +2671,8 @@ def test_list_pagination_finds_matches_across_backend_pages() -> None:
                 size=50,
                 project=None,
                 hydrate=True,
+                pipeline_name=expected_pipeline_filter,
+                status=expected_status_filter,
             ),
             call(
                 sort_by="desc:created",
@@ -2517,6 +2680,8 @@ def test_list_pagination_finds_matches_across_backend_pages() -> None:
                 size=50,
                 project=None,
                 hydrate=True,
+                pipeline_name=expected_pipeline_filter,
+                status=expected_status_filter,
             ),
         ]
     )
@@ -3087,7 +3252,7 @@ def test_statistics_fetches_metrics_from_zen_store() -> None:
     )
 
 
-def _raw_statuses_from_backend_filter(filter_value: str) -> tuple[str, ...]:
+def _backend_filter_values(filter_value: str) -> tuple[str, ...]:
     if filter_value.startswith("oneof:"):
         return tuple(json.loads(filter_value.removeprefix("oneof:")))
     return (filter_value,)
@@ -3182,8 +3347,7 @@ def test_status_grouping_without_status_filter_splits_by_public_status() -> None
     ]
     assert len(requests) == len(ExecutionStatus)
     assert {
-        frozenset(_raw_statuses_from_backend_filter(request.filter.status))
-        for request in requests
+        frozenset(_backend_filter_values(request.filter.status)) for request in requests
     } == {
         frozenset(_RAW_STATUSES_BY_PUBLIC_STATUS[public_status])
         for public_status in ExecutionStatus


### PR DESCRIPTION
## Reviewer Notes

This change makes `KitaruClient().executions.list(flow=..., status=...)` ask ZenML for a narrower page of pipeline runs before Kitaru maps them into public execution objects.

Previously, the client asked ZenML for every hydrated pipeline run in the project, then threw away non-matching runs in Python. On a large project, asking for `flow="my_flow"` could still walk through thousands of unrelated runs before finding the few matching ones.

Now the list call sends backend filters when it can:

- `flow="my_flow"` becomes a ZenML `pipeline_name` filter containing both stored pipeline-name candidates: `my_flow` and the alias-prefixed name Kitaru may have registered.
- terminal public statuses such as `completed` use the existing public-status-to-raw-ZenML-status mapping.
- `waiting` and `running` intentionally send the same broader raw-status filter. A raw ZenML `running` run can become public Kitaru `waiting` after Kitaru sees a pending wait condition, so the server only narrows the candidate set. Kitaru still maps each run and then applies the existing Python `flow_name` and `status` checks before returning anything to the caller.

The first review pass raised four edge cases, and the branch now covers them:

- Blank or whitespace-only `flow` returns `[]` without calling ZenML. That preserves the old effective result while avoiding a surprising backend filter such as an empty `pipeline_name` candidate.
- A contract test feeds Kitaru-generated filter strings into ZenML's real `PipelineRunFilter`, including the custom `pipeline_name` filter path and the parsed status `oneof` filter.
- A raw ZenML `RUNNING` run with no `active_wait_condition`, but with a pending wait discoverable through `list_run_wait_conditions(...)`, is classified as public `WAITING` when the caller asks for `status="waiting"`. Unfiltered shallow listing stays cheap and does not do one wait lookup per running execution.
- `_backend_filter_value(...)` has direct coverage for quote and backslash escaping through the `oneof:` JSON payload.

The risky bit is preserving the final client-side checks. If the server returns a run that is too broad, Kitaru should still remove it before the user sees it. The tests cover both the forwarded backend filters and those Python backstops.

### Reproduction

Run the focused regression tests:

```bash
just test tests/test_client.py::test_list_blank_flow_returns_empty_without_backend_call \
  tests/test_client.py::test_backend_filter_value_round_trips_special_characters \
  tests/test_client.py::test_list_backend_filters_match_zenml_pipeline_run_filter_contract \
  tests/test_client.py::test_list_waiting_and_running_filters_fetch_shared_raw_statuses \
  tests/test_client.py::test_list_waiting_detects_pending_wait_from_wait_condition_listing \
  tests/test_client.py::test_unfiltered_list_keeps_raw_running_shallow_when_wait_is_not_active
```

Useful reviewer checkpoints:

1. `test_list_backend_filters_match_zenml_pipeline_run_filter_contract` proves the exact filter strings Kitaru generates are accepted by ZenML's filter model.
2. `test_list_waiting_detects_pending_wait_from_wait_condition_listing` proves `status="waiting"` can find a raw `RUNNING` run whose pending wait is only available from `list_run_wait_conditions(...)`.
3. `test_unfiltered_list_keeps_raw_running_shallow_when_wait_is_not_active` documents the performance trade-off: unfiltered shallow listing does not perform an N+1 wait-condition lookup for every running run.
4. `test_list_keeps_client_side_flow_filter_as_backstop` simulates an over-broad server response and proves the public result is still filtered in Python.

Local checks run:

```bash
just check
just test tests/test_client.py::test_list_blank_flow_returns_empty_without_backend_call tests/test_client.py::test_list_waiting_and_running_filters_fetch_shared_raw_statuses tests/test_client.py::test_list_waiting_detects_pending_wait_from_wait_condition_listing tests/test_client.py::test_unfiltered_list_keeps_raw_running_shallow_when_wait_is_not_active tests/test_client.py::test_list_backend_filters_match_zenml_pipeline_run_filter_contract
just test
```
