### PR TITLE
Fix execution retry resume state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added count-based execution statistics through `KitaruClient().executions.statistics(...)`, `kitaru executions statistics`, and the `kitaru_executions_statistics` MCP tool, with grouping by status, flow, stack, tag, time bucket, and execution metadata.
 
 ### Fixed
+- Fixed `kitaru executions retry` and `kitaru executions resume` so failed or paused executions are reopened correctly before continuation is submitted, preventing local no-ops and server-token failures.
 - Fixed a LangGraph adapter crash when running graphs without a LangGraph checkpointer under Kitaru's default durability policy. (#403)
 
 ## [0.15.0] - 2026-06-04

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -33,7 +33,7 @@ from zenml.config.pipeline_run_configuration import PipelineRunConfiguration
 from zenml.enums import ExecutionStatus as ZenMLExecutionStatus
 from zenml.exceptions import EntityExistsError
 from zenml.login.credentials_store import get_credentials_store
-from zenml.models import PipelineRunResponse
+from zenml.models import PipelineRunResponse, PipelineRunUpdate
 from zenml.models.v2.core.artifact_version import ArtifactVersionResponse
 from zenml.utils.run_utils import stop_run
 from zenml.zen_stores.rest_zen_store import RestZenStore
@@ -162,6 +162,10 @@ logger = logging.getLogger(__name__)
 
 _WAIT_CONDITION_RESOLUTION_CONTINUE = "continue"
 _WAIT_CONDITION_RESOLUTION_ABORT = "abort"
+_RETRY_RESUMING_REASON = "Manual retry requested by user."
+_RETRY_ROLLBACK_REASON = "Retry submission failed."
+_RESUME_RESUMING_REASON = "Manual resume requested by user."
+_RESUME_ROLLBACK_REASON = "Manual resume failed."
 _REPLAY_IMPORT_LOCK = threading.RLock()
 
 
@@ -736,11 +740,84 @@ def _resolve_pipeline_for_replay(run: PipelineRunResponse) -> Any:
     return pipeline_obj
 
 
+def _run_status_value(run: PipelineRunResponse) -> str:
+    """Return a pipeline run status as a plain string."""
+    return str(getattr(run.status, "value", run.status))
+
+
+def _rollback_reopened_run(
+    *,
+    run: PipelineRunResponse,
+    client: KitaruClient,
+    operation_name: str,
+    original_error: Exception,
+    rollback_status: ZenMLExecutionStatus,
+    rollback_reason: str,
+) -> None:
+    """Try to restore a run status after reopening it failed."""
+    try:
+        client._client().zen_store.update_run(
+            run_id=run.id,
+            run_update=PipelineRunUpdate(
+                status=rollback_status,
+                status_reason=rollback_reason,
+            ),
+        )
+    except Exception as rollback_error:
+        raise KitaruBackendError(
+            f"Failed to {operation_name} execution '{run.id}': {original_error}. "
+            "Additionally failed to roll back execution status to "
+            f"'{rollback_status.value}': {rollback_error}. "
+            "The execution may remain RESUMING."
+        ) from original_error
+
+    raise KitaruBackendError(
+        f"Failed to {operation_name} execution '{run.id}': {original_error}"
+    ) from original_error
+
+
+def _repair_reopened_run_after_resume_failure(
+    *,
+    run: PipelineRunResponse,
+    client: KitaruClient,
+    operation_name: str,
+    original_error: Exception,
+    rollback_status: ZenMLExecutionStatus,
+    rollback_reason: str,
+) -> None:
+    """Repair a reopened run if ZenML did not move it out of RESUMING."""
+    try:
+        latest_run = client._get_pipeline_run(str(run.id), hydrate=False)
+    except Exception as refresh_error:
+        raise KitaruBackendError(
+            f"Failed to {operation_name} execution '{run.id}': {original_error}. "
+            "Could not verify whether the execution is still RESUMING: "
+            f"{refresh_error}. The execution may remain RESUMING."
+        ) from original_error
+
+    if _run_status_value(latest_run) != ZenMLExecutionStatus.RESUMING.value:
+        raise KitaruBackendError(
+            f"Failed to {operation_name} execution '{run.id}': {original_error}"
+        ) from original_error
+
+    _rollback_reopened_run(
+        run=run,
+        client=client,
+        operation_name=operation_name,
+        original_error=original_error,
+        rollback_status=rollback_status,
+        rollback_reason=rollback_reason,
+    )
+
+
 def _restart_run_from_snapshot(
     *,
     run: PipelineRunResponse,
     client: KitaruClient,
     operation_name: str,
+    resuming_reason: str,
+    rollback_status: ZenMLExecutionStatus,
+    rollback_reason: str,
 ) -> None:
     """Restart an execution from its stored snapshot metadata."""
     snapshot = run.snapshot
@@ -756,18 +833,56 @@ def _restart_run_from_snapshot(
         )
 
     try:
+        reopened_run = client._client().zen_store.update_run(
+            run_id=run.id,
+            run_update=PipelineRunUpdate(
+                status=ZenMLExecutionStatus.RESUMING,
+                status_reason=resuming_reason,
+            ),
+        )
+    except Exception as exc:
+        raise KitaruBackendError(
+            f"Failed to reopen execution '{run.id}' for {operation_name}: {exc}"
+        ) from exc
+
+    resume_started = False
+    resume_returned = False
+    try:
         with _temporary_active_stack(str(snapshot.stack.id)):
             active_stack = client._client().active_stack
             orchestrator = cast(Any, active_stack.orchestrator)
+            resume_started = True
             orchestrator.resume_run(
                 snapshot=snapshot,
-                run=run,
+                run=reopened_run,
                 stack=active_stack,
             )
+            resume_returned = True
     except Exception as exc:
-        raise KitaruBackendError(
-            f"Failed to {operation_name} execution '{run.id}': {exc}"
-        ) from exc
+        if resume_returned:
+            raise KitaruBackendError(
+                f"The {operation_name} request for execution '{run.id}' was submitted, "
+                "but restoring the previous active Kitaru stack failed: "
+                f"{exc}. The execution may continue; inspect its latest status "
+                "before retrying."
+            ) from exc
+        if resume_started:
+            _repair_reopened_run_after_resume_failure(
+                run=reopened_run,
+                client=client,
+                operation_name=operation_name,
+                original_error=exc,
+                rollback_status=rollback_status,
+                rollback_reason=rollback_reason,
+            )
+        _rollback_reopened_run(
+            run=reopened_run,
+            client=client,
+            operation_name=operation_name,
+            original_error=exc,
+            rollback_status=rollback_status,
+            rollback_reason=rollback_reason,
+        )
 
 
 def _validate_event_filter_values(
@@ -1151,7 +1266,7 @@ class _ExecutionsAPI:
     def retry(self, exec_id: str) -> Execution:
         """Retry a failed execution as same-execution recovery."""
         run = self._client_ref._get_pipeline_run(exec_id, hydrate=True)
-        run_status_value = str(getattr(run.status, "value", run.status))
+        run_status_value = _run_status_value(run)
         if run_status_value != ZenMLExecutionStatus.FAILED.value:
             raise KitaruStateError(
                 "Only failed executions can be retried. "
@@ -1162,6 +1277,9 @@ class _ExecutionsAPI:
             run=run,
             client=self._client_ref,
             operation_name="retry",
+            resuming_reason=_RETRY_RESUMING_REASON,
+            rollback_status=ZenMLExecutionStatus.FAILED,
+            rollback_reason=_RETRY_ROLLBACK_REASON,
         )
         track(AnalyticsEvent.EXECUTION_RETRIED, {})
         return self.get(exec_id)
@@ -1178,8 +1296,8 @@ class _ExecutionsAPI:
                 f"Resolve pending wait input before resuming execution '{exec_id}'."
             )
 
-        run_status_value = str(getattr(run.status, "value", run.status))
-        if run_status_value != "paused":
+        run_status_value = _run_status_value(run)
+        if run_status_value != ZenMLExecutionStatus.PAUSED.value:
             raise KitaruStateError(
                 "Only paused executions can be resumed. "
                 f"Execution '{exec_id}' is currently '{run_status_value}'."
@@ -1189,6 +1307,9 @@ class _ExecutionsAPI:
             run=run,
             client=self._client_ref,
             operation_name="resume",
+            resuming_reason=_RESUME_RESUMING_REASON,
+            rollback_status=ZenMLExecutionStatus.PAUSED,
+            rollback_reason=_RESUME_ROLLBACK_REASON,
         )
         track(AnalyticsEvent.EXECUTION_RESUMED, {})
         return self.get(exec_id)
@@ -1204,7 +1325,7 @@ class _ExecutionsAPI:
         """Replay an execution from a checkpoint boundary."""
         source_run = self._client_ref._get_pipeline_run(exec_id, hydrate=True)
 
-        run_status_value = str(getattr(source_run.status, "value", source_run.status))
+        run_status_value = _run_status_value(source_run)
         if run_status_value in {
             "initializing",
             "provisioning",

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -25,7 +25,8 @@ from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Protocol, cast, runtime_checkable
+from typing import Any, Literal, NoReturn, Protocol, cast, runtime_checkable
+from uuid import UUID
 
 from pydantic import ValidationError
 from zenml.client import Client
@@ -476,22 +477,6 @@ class _ReplayFlowLike(Protocol):
     ) -> Any: ...
 
 
-@contextmanager
-def _temporary_active_stack(stack_name_or_id: str | None) -> Iterator[None]:
-    """Temporarily activate a stack while running an operation."""
-    if not stack_name_or_id:
-        yield
-        return
-
-    client = Client()
-    old_stack_id = client.active_stack_model.id
-    client.activate_stack(stack_name_or_id)
-    try:
-        yield
-    finally:
-        client.activate_stack(old_stack_id)
-
-
 def _snapshot_source_parts(run: PipelineRunResponse) -> tuple[str, str | None]:
     """Return `(module, attribute)` from a run snapshot source."""
     snapshot = run.snapshot
@@ -753,7 +738,7 @@ def _rollback_reopened_run(
     original_error: Exception,
     rollback_status: ZenMLExecutionStatus,
     rollback_reason: str,
-) -> None:
+) -> NoReturn:
     """Try to restore a run status after reopening it failed."""
     try:
         client._client().zen_store.update_run(
@@ -784,7 +769,7 @@ def _repair_reopened_run_after_resume_failure(
     original_error: Exception,
     rollback_status: ZenMLExecutionStatus,
     rollback_reason: str,
-) -> None:
+) -> NoReturn:
     """Repair a reopened run if ZenML did not move it out of RESUMING."""
     try:
         latest_run = client._get_pipeline_run(str(run.id), hydrate=False)
@@ -810,6 +795,34 @@ def _repair_reopened_run_after_resume_failure(
     )
 
 
+def _restore_previous_active_stack(
+    *,
+    client: Client,
+    old_stack_id: str | UUID,
+) -> Exception | None:
+    """Restore the active Kitaru stack and return the error if it fails."""
+    try:
+        client.activate_stack(old_stack_id)
+    except Exception as exc:
+        return exc
+    return None
+
+
+def _raise_with_restore_failure_context(
+    *,
+    error: KitaruBackendError,
+    original_error: Exception,
+    restoration_error: Exception | None,
+) -> NoReturn:
+    """Raise an operation failure, adding Kitaru stack restore context if needed."""
+    if restoration_error is None:
+        raise error
+    raise KitaruBackendError(
+        f"{error}. Additionally failed to restore the previous active Kitaru "
+        f"stack: {restoration_error}."
+    ) from original_error
+
+
 def _restart_run_from_snapshot(
     *,
     run: PipelineRunResponse,
@@ -831,6 +844,12 @@ def _restart_run_from_snapshot(
             f"Unable to {operation_name} execution because snapshot stack "
             "metadata is missing."
         )
+    snapshot_stack_id = getattr(snapshot.stack, "id", None)
+    if not snapshot_stack_id:
+        raise KitaruRuntimeError(
+            f"Unable to {operation_name} execution because snapshot stack "
+            "id is missing."
+        )
 
     try:
         reopened_run = client._client().zen_store.update_run(
@@ -845,36 +864,10 @@ def _restart_run_from_snapshot(
             f"Failed to reopen execution '{run.id}' for {operation_name}: {exc}"
         ) from exc
 
-    resume_started = False
-    resume_returned = False
     try:
-        with _temporary_active_stack(str(snapshot.stack.id)):
-            active_stack = client._client().active_stack
-            orchestrator = cast(Any, active_stack.orchestrator)
-            resume_started = True
-            orchestrator.resume_run(
-                snapshot=snapshot,
-                run=reopened_run,
-                stack=active_stack,
-            )
-            resume_returned = True
+        stack_client = Client()
+        old_stack_id = cast(str | UUID, stack_client.active_stack_model.id)
     except Exception as exc:
-        if resume_returned:
-            raise KitaruBackendError(
-                f"The {operation_name} request for execution '{run.id}' was submitted, "
-                "but restoring the previous active Kitaru stack failed: "
-                f"{exc}. The execution may continue; inspect its latest status "
-                "before retrying."
-            ) from exc
-        if resume_started:
-            _repair_reopened_run_after_resume_failure(
-                run=reopened_run,
-                client=client,
-                operation_name=operation_name,
-                original_error=exc,
-                rollback_status=rollback_status,
-                rollback_reason=rollback_reason,
-            )
         _rollback_reopened_run(
             run=reopened_run,
             client=client,
@@ -883,6 +876,81 @@ def _restart_run_from_snapshot(
             rollback_status=rollback_status,
             rollback_reason=rollback_reason,
         )
+
+    try:
+        stack_client.activate_stack(str(snapshot_stack_id))
+    except Exception as exc:
+        _rollback_reopened_run(
+            run=reopened_run,
+            client=client,
+            operation_name=operation_name,
+            original_error=exc,
+            rollback_status=rollback_status,
+            rollback_reason=rollback_reason,
+        )
+
+    try:
+        active_stack = stack_client.active_stack
+        orchestrator = cast(Any, active_stack.orchestrator)
+    except Exception as exc:
+        restoration_error = _restore_previous_active_stack(
+            client=stack_client,
+            old_stack_id=old_stack_id,
+        )
+        try:
+            _rollback_reopened_run(
+                run=reopened_run,
+                client=client,
+                operation_name=operation_name,
+                original_error=exc,
+                rollback_status=rollback_status,
+                rollback_reason=rollback_reason,
+            )
+        except KitaruBackendError as operation_error:
+            _raise_with_restore_failure_context(
+                error=operation_error,
+                original_error=exc,
+                restoration_error=restoration_error,
+            )
+
+    try:
+        orchestrator.resume_run(
+            snapshot=snapshot,
+            run=reopened_run,
+            stack=active_stack,
+        )
+    except Exception as exc:
+        restoration_error = _restore_previous_active_stack(
+            client=stack_client,
+            old_stack_id=old_stack_id,
+        )
+        try:
+            _repair_reopened_run_after_resume_failure(
+                run=reopened_run,
+                client=client,
+                operation_name=operation_name,
+                original_error=exc,
+                rollback_status=rollback_status,
+                rollback_reason=rollback_reason,
+            )
+        except KitaruBackendError as operation_error:
+            _raise_with_restore_failure_context(
+                error=operation_error,
+                original_error=exc,
+                restoration_error=restoration_error,
+            )
+
+    restoration_error = _restore_previous_active_stack(
+        client=stack_client,
+        old_stack_id=old_stack_id,
+    )
+    if restoration_error is not None:
+        raise KitaruBackendError(
+            f"The {operation_name} request for execution '{run.id}' was submitted, "
+            "but restoring the previous active Kitaru stack failed: "
+            f"{restoration_error}. The execution may continue; inspect its latest "
+            "status before retrying."
+        ) from restoration_error
 
 
 def _validate_event_filter_values(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,7 @@ from importlib.machinery import ModuleSpec
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any, cast
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -3569,6 +3569,35 @@ def test_retry_rejects_non_failed_execution() -> None:
             client.executions.retry(str(run.id))
 
 
+def test_retry_rejects_missing_snapshot_stack_id_before_reopening() -> None:
+    run_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace()),
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(failed)
+
+        client = KitaruClient()
+        with pytest.raises(KitaruRuntimeError, match="snapshot stack id is missing"):
+            client.executions.retry(str(run_id))
+
+    client_mock.zen_store.update_run.assert_not_called()
+    client_mock.activate_stack.assert_not_called()
+    track_mock.assert_not_called()
+
+
 def test_retry_rolls_back_when_stack_activation_fails_after_reopening() -> None:
     run_id = uuid4()
     snapshot_stack_id = uuid4()
@@ -3606,6 +3635,65 @@ def test_retry_rolls_back_when_stack_activation_fails_after_reopening() -> None:
         with pytest.raises(KitaruBackendError, match="stack unavailable"):
             client.executions.retry(str(run_id))
 
+    assert client_mock.zen_store.update_run.call_count == 2
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args_list[0],
+        run_id=run_id,
+        status=ZenMLExecutionStatus.RESUMING,
+        reason=_RETRY_RESUMING_REASON,
+    )
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args_list[1],
+        run_id=run_id,
+        status=ZenMLExecutionStatus.FAILED,
+        reason=_RETRY_ROLLBACK_REASON,
+    )
+    track_mock.assert_not_called()
+
+
+def test_retry_rolls_back_when_loading_active_stack_model_fails_after_reopening() -> (
+    None
+):
+    run_id = uuid4()
+    snapshot_stack_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    failed_run = _as_pipeline_run(failed)
+    resuming_run = _as_pipeline_run(resuming)
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.zen_store.update_run.side_effect = [resuming_run, failed_run]
+        client_mock.get_pipeline_run.return_value = failed_run
+
+        with patch.object(
+            type(client_mock),
+            "active_stack_model",
+            PropertyMock(side_effect=RuntimeError("active stack unavailable")),
+            create=True,
+        ):
+            client = KitaruClient()
+            with pytest.raises(KitaruBackendError, match="active stack unavailable"):
+                client.executions.retry(str(run_id))
+
+    client_mock.activate_stack.assert_not_called()
     assert client_mock.zen_store.update_run.call_count == 2
     _assert_run_update(
         client_mock.zen_store.update_run.call_args_list[0],
@@ -3737,6 +3825,88 @@ def test_retry_rolls_back_when_resume_submission_leaves_run_resuming() -> None:
         status=ZenMLExecutionStatus.FAILED,
         reason=_RETRY_ROLLBACK_REASON,
     )
+    track_mock.assert_not_called()
+
+
+def test_retry_reports_submission_and_restore_failures_after_rollback() -> None:
+    run_id = uuid4()
+    snapshot_stack_id = uuid4()
+    old_stack_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    failed_run = _as_pipeline_run(failed)
+    resuming_run = _as_pipeline_run(resuming)
+    active_stack = SimpleNamespace(
+        orchestrator=SimpleNamespace(
+            resume_run=MagicMock(side_effect=RuntimeError("submit offline"))
+        )
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
+        client_mock.active_stack = active_stack
+        client_mock.activate_stack.side_effect = [
+            None,
+            RuntimeError("restore offline"),
+        ]
+        client_mock.zen_store.update_run.side_effect = [
+            resuming_run,
+            failed_run,
+        ]
+        client_mock.get_pipeline_run.side_effect = [
+            failed_run,
+            resuming_run,
+        ]
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError) as exc_info:
+            client.executions.retry(str(run_id))
+
+    message = str(exc_info.value)
+    assert "submit offline" in message
+    assert "restore offline" in message
+    assert "previous active Kitaru stack" in message
+    active_stack.orchestrator.resume_run.assert_called_once_with(
+        snapshot=failed.snapshot,
+        run=resuming_run,
+        stack=active_stack,
+    )
+    assert client_mock.activate_stack.call_args_list == [
+        call(str(snapshot_stack_id)),
+        call(old_stack_id),
+    ]
+    assert client_mock.zen_store.update_run.call_count == 2
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args_list[0],
+        run_id=run_id,
+        status=ZenMLExecutionStatus.RESUMING,
+        reason=_RETRY_RESUMING_REASON,
+    )
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args_list[1],
+        run_id=run_id,
+        status=ZenMLExecutionStatus.FAILED,
+        reason=_RETRY_ROLLBACK_REASON,
+    )
+    assert client_mock.get_pipeline_run.call_count == 2
     track_mock.assert_not_called()
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,6 +41,10 @@ from kitaru._client._statistics import (
 from kitaru._interface_deployments import Deployment
 from kitaru.analytics import AnalyticsEvent
 from kitaru.client import (
+    _RESUME_RESUMING_REASON,
+    _RESUME_ROLLBACK_REASON,
+    _RETRY_RESUMING_REASON,
+    _RETRY_ROLLBACK_REASON,
     AuthAPIKey,
     AuthAPIKeyWithValue,
     AuthServiceAccount,
@@ -342,6 +346,19 @@ def _dummy_wait_condition(
 
 def _paused_status() -> Any:
     return SimpleNamespace(value="paused")
+
+
+def _assert_run_update(
+    update_call: Any,
+    *,
+    run_id: UUID,
+    status: ZenMLExecutionStatus,
+    reason: str,
+) -> None:
+    assert update_call.kwargs["run_id"] == run_id
+    run_update = update_call.kwargs["run_update"]
+    assert run_update.status == status
+    assert run_update.status_reason == reason
 
 
 def _snapshot_source(module: str, attribute: str) -> Any:
@@ -3460,15 +3477,37 @@ def test_retry_restarts_failed_execution() -> None:
         run_id=run_id,
         snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
     )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
     retried = _DummyRun(
         status=ZenMLExecutionStatus.RUNNING,
         flow_name="flow_a",
         run_id=run_id,
         snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
     )
+    failed_run = _as_pipeline_run(failed)
+    resuming_run = _as_pipeline_run(resuming)
+    retried_run = _as_pipeline_run(retried)
 
     old_stack_id = uuid4()
-    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+    order: list[str] = []
+
+    def record_resume_run(**_: Any) -> None:
+        order.append("resume_run")
+
+    def record_update_run(**_: Any) -> PipelineRunResponse:
+        order.append("update_run")
+        return resuming_run
+
+    active_stack = SimpleNamespace(
+        orchestrator=SimpleNamespace(
+            resume_run=MagicMock(side_effect=record_resume_run)
+        )
+    )
 
     with (
         patch(
@@ -3480,19 +3519,28 @@ def test_retry_restarts_failed_execution() -> None:
         client_mock = client_cls.return_value
         client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
         client_mock.active_stack = active_stack
-        client_mock.get_pipeline_run.side_effect = [
-            _as_pipeline_run(failed),
-            _as_pipeline_run(retried),
-        ]
+        client_mock.zen_store.update_run.side_effect = record_update_run
+        client_mock.get_pipeline_run.side_effect = [failed_run, retried_run]
 
         client = KitaruClient()
         execution = client.executions.retry(str(run_id))
 
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args,
+        run_id=run_id,
+        status=ZenMLExecutionStatus.RESUMING,
+        reason=_RETRY_RESUMING_REASON,
+    )
     active_stack.orchestrator.resume_run.assert_called_once_with(
         snapshot=failed.snapshot,
-        run=_as_pipeline_run(failed),
+        run=resuming_run,
         stack=active_stack,
     )
+    assert active_stack.orchestrator.resume_run.call_args.kwargs["run"] is resuming_run
+    assert (
+        active_stack.orchestrator.resume_run.call_args.kwargs["run"] is not failed_run
+    )
+    assert order == ["update_run", "resume_run"]
     assert client_mock.activate_stack.call_args_list == [
         call(str(snapshot_stack_id)),
         call(old_stack_id),
@@ -3519,6 +3567,408 @@ def test_retry_rejects_non_failed_execution() -> None:
         client = KitaruClient()
         with pytest.raises(RuntimeError, match="Only failed executions can be retried"):
             client.executions.retry(str(run.id))
+
+
+def test_retry_rolls_back_when_stack_activation_fails_after_reopening() -> None:
+    run_id = uuid4()
+    snapshot_stack_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.activate_stack.side_effect = RuntimeError("stack unavailable")
+        client_mock.zen_store.update_run.side_effect = [
+            _as_pipeline_run(resuming),
+            _as_pipeline_run(failed),
+        ]
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(failed)
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="stack unavailable"):
+            client.executions.retry(str(run_id))
+
+    assert client_mock.zen_store.update_run.call_count == 2
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args_list[0],
+        run_id=run_id,
+        status=ZenMLExecutionStatus.RESUMING,
+        reason=_RETRY_RESUMING_REASON,
+    )
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args_list[1],
+        run_id=run_id,
+        status=ZenMLExecutionStatus.FAILED,
+        reason=_RETRY_ROLLBACK_REASON,
+    )
+    track_mock.assert_not_called()
+
+
+def test_retry_does_not_roll_back_when_stack_restore_fails_after_submission() -> None:
+    run_id = uuid4()
+    snapshot_stack_id = uuid4()
+    old_stack_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    failed_run = _as_pipeline_run(failed)
+    resuming_run = _as_pipeline_run(resuming)
+    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
+        client_mock.active_stack = active_stack
+        client_mock.activate_stack.side_effect = [None, RuntimeError("restore offline")]
+        client_mock.zen_store.update_run.return_value = resuming_run
+        client_mock.get_pipeline_run.side_effect = [failed_run, resuming_run]
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError) as exc_info:
+            client.executions.retry(str(run_id))
+
+    message = str(exc_info.value)
+    assert "was submitted" in message
+    assert "restoring the previous active Kitaru stack failed" in message
+    assert "inspect its latest status" in message
+    active_stack.orchestrator.resume_run.assert_called_once_with(
+        snapshot=failed.snapshot,
+        run=resuming_run,
+        stack=active_stack,
+    )
+    assert client_mock.activate_stack.call_args_list == [
+        call(str(snapshot_stack_id)),
+        call(old_stack_id),
+    ]
+    client_mock.zen_store.update_run.assert_called_once()
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args,
+        run_id=run_id,
+        status=ZenMLExecutionStatus.RESUMING,
+        reason=_RETRY_RESUMING_REASON,
+    )
+    assert client_mock.get_pipeline_run.call_count == 1
+    track_mock.assert_not_called()
+
+
+def test_retry_rolls_back_when_resume_submission_leaves_run_resuming() -> None:
+    run_id = uuid4()
+    snapshot_stack_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    active_stack = SimpleNamespace(
+        orchestrator=SimpleNamespace(
+            resume_run=MagicMock(side_effect=RuntimeError("submit offline"))
+        )
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.zen_store.update_run.side_effect = [
+            _as_pipeline_run(resuming),
+            _as_pipeline_run(failed),
+        ]
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(failed),
+            _as_pipeline_run(resuming),
+        ]
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="submit offline"):
+            client.executions.retry(str(run_id))
+
+    assert client_mock.zen_store.update_run.call_count == 2
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args_list[1],
+        run_id=run_id,
+        status=ZenMLExecutionStatus.FAILED,
+        reason=_RETRY_ROLLBACK_REASON,
+    )
+    track_mock.assert_not_called()
+
+
+def test_resume_rolls_back_when_resume_submission_leaves_run_resuming() -> None:
+    run_id = uuid4()
+    snapshot_stack_id = uuid4()
+    paused = _DummyRun(
+        status=ZenMLExecutionStatus.PAUSED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=paused.snapshot,
+    )
+    active_stack = SimpleNamespace(
+        orchestrator=SimpleNamespace(
+            resume_run=MagicMock(side_effect=RuntimeError("submit offline"))
+        )
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.zen_store.update_run.side_effect = [
+            _as_pipeline_run(resuming),
+            _as_pipeline_run(paused),
+        ]
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(paused),
+            _as_pipeline_run(resuming),
+        ]
+        client_mock.list_run_wait_conditions.return_value = SimpleNamespace(items=[])
+        client_mock.list_run_steps.return_value = SimpleNamespace(items=[])
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="submit offline"):
+            client.executions.resume(str(run_id))
+
+    assert client_mock.zen_store.update_run.call_count == 2
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args_list[1],
+        run_id=run_id,
+        status=ZenMLExecutionStatus.PAUSED,
+        reason=_RESUME_ROLLBACK_REASON,
+    )
+    track_mock.assert_not_called()
+
+
+def test_retry_reports_rollback_failure_and_skips_success_analytics() -> None:
+    run_id = uuid4()
+    snapshot_stack_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    active_stack = SimpleNamespace(
+        orchestrator=SimpleNamespace(
+            resume_run=MagicMock(side_effect=RuntimeError("submit offline"))
+        )
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.zen_store.update_run.side_effect = [
+            _as_pipeline_run(resuming),
+            RuntimeError("rollback store offline"),
+        ]
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(failed),
+            _as_pipeline_run(resuming),
+        ]
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError) as exc_info:
+            client.executions.retry(str(run_id))
+
+    message = str(exc_info.value)
+    assert "submit offline" in message
+    assert "rollback store offline" in message
+    assert "may remain RESUMING" in message
+    track_mock.assert_not_called()
+
+
+def test_retry_preserves_runner_status_when_resume_failure_changed_run_status() -> None:
+    run_id = uuid4()
+    snapshot_stack_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    runner_failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+        status_reason="Runner wrote a real failure status.",
+    )
+    active_stack = SimpleNamespace(
+        orchestrator=SimpleNamespace(
+            resume_run=MagicMock(side_effect=RuntimeError("worker crashed"))
+        )
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.zen_store.update_run.return_value = _as_pipeline_run(resuming)
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(failed),
+            _as_pipeline_run(runner_failed),
+        ]
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="worker crashed"):
+            client.executions.retry(str(run_id))
+
+    client_mock.zen_store.update_run.assert_called_once()
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args,
+        run_id=run_id,
+        status=ZenMLExecutionStatus.RESUMING,
+        reason=_RETRY_RESUMING_REASON,
+    )
+    track_mock.assert_not_called()
+
+
+def test_resume_preserves_runner_status_when_resume_failure_changed_run_status() -> (
+    None
+):
+    run_id = uuid4()
+    snapshot_stack_id = uuid4()
+    paused = _DummyRun(
+        status=ZenMLExecutionStatus.PAUSED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=paused.snapshot,
+    )
+    runner_failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=paused.snapshot,
+        status_reason="Runner wrote a real failure status.",
+    )
+    active_stack = SimpleNamespace(
+        orchestrator=SimpleNamespace(
+            resume_run=MagicMock(side_effect=RuntimeError("worker crashed"))
+        )
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.zen_store.update_run.return_value = _as_pipeline_run(resuming)
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(paused),
+            _as_pipeline_run(runner_failed),
+        ]
+        client_mock.list_run_wait_conditions.return_value = SimpleNamespace(items=[])
+        client_mock.list_run_steps.return_value = SimpleNamespace(items=[])
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="worker crashed"):
+            client.executions.resume(str(run_id))
+
+    client_mock.zen_store.update_run.assert_called_once()
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args,
+        run_id=run_id,
+        status=ZenMLExecutionStatus.RESUMING,
+        reason=_RESUME_RESUMING_REASON,
+    )
+    track_mock.assert_not_called()
 
 
 def test_input_resolves_pending_wait_condition() -> None:
@@ -3858,15 +4308,37 @@ def test_resume_restarts_paused_execution() -> None:
         run_id=run_id,
         snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
     )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
     resumed = _DummyRun(
         status=ZenMLExecutionStatus.RUNNING,
         flow_name="flow_a",
         run_id=run_id,
         snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
     )
+    paused_run = _as_pipeline_run(paused)
+    resuming_run = _as_pipeline_run(resuming)
+    resumed_run = _as_pipeline_run(resumed)
 
     old_stack_id = uuid4()
-    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+    order: list[str] = []
+
+    def record_resume_run(**_: Any) -> None:
+        order.append("resume_run")
+
+    def record_update_run(**_: Any) -> PipelineRunResponse:
+        order.append("update_run")
+        return resuming_run
+
+    active_stack = SimpleNamespace(
+        orchestrator=SimpleNamespace(
+            resume_run=MagicMock(side_effect=record_resume_run)
+        )
+    )
 
     with (
         patch(
@@ -3878,21 +4350,30 @@ def test_resume_restarts_paused_execution() -> None:
         client_mock = client_cls.return_value
         client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
         client_mock.active_stack = active_stack
-        client_mock.get_pipeline_run.side_effect = [
-            _as_pipeline_run(paused),
-            _as_pipeline_run(resumed),
-        ]
+        client_mock.zen_store.update_run.side_effect = record_update_run
+        client_mock.get_pipeline_run.side_effect = [paused_run, resumed_run]
         client_mock.list_run_wait_conditions.return_value = SimpleNamespace(items=[])
         client_mock.list_run_steps.return_value = SimpleNamespace(items=[])
 
         client = KitaruClient()
         execution = client.executions.resume(str(run_id))
 
+    _assert_run_update(
+        client_mock.zen_store.update_run.call_args,
+        run_id=run_id,
+        status=ZenMLExecutionStatus.RESUMING,
+        reason=_RESUME_RESUMING_REASON,
+    )
     active_stack.orchestrator.resume_run.assert_called_once_with(
         snapshot=paused.snapshot,
-        run=_as_pipeline_run(paused),
+        run=resuming_run,
         stack=active_stack,
     )
+    assert active_stack.orchestrator.resume_run.call_args.kwargs["run"] is resuming_run
+    assert (
+        active_stack.orchestrator.resume_run.call_args.kwargs["run"] is not paused_run
+    )
+    assert order == ["update_run", "resume_run"]
     assert client_mock.activate_stack.call_args_list == [
         call(str(snapshot_stack_id)),
         call(old_stack_id),
@@ -5125,6 +5606,12 @@ def test_retry_emits_execution_retried_event() -> None:
         run_id=run_id,
         snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
     )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
     retried = _DummyRun(
         status=ZenMLExecutionStatus.RUNNING,
         flow_name="flow_a",
@@ -5146,6 +5633,7 @@ def test_retry_emits_execution_retried_event() -> None:
         client_mock = client_cls.return_value
         client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
         client_mock.active_stack = active_stack
+        client_mock.zen_store.update_run.return_value = _as_pipeline_run(resuming)
         client_mock.get_pipeline_run.side_effect = [
             _as_pipeline_run(failed),
             _as_pipeline_run(retried),
@@ -5172,6 +5660,12 @@ def test_resume_emits_execution_resumed_event() -> None:
         run_id=run_id,
         snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
     )
+    resuming = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
     resumed = _DummyRun(
         status=ZenMLExecutionStatus.RUNNING,
         flow_name="flow_a",
@@ -5193,6 +5687,7 @@ def test_resume_emits_execution_resumed_event() -> None:
         client_mock = client_cls.return_value
         client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
         client_mock.active_stack = active_stack
+        client_mock.zen_store.update_run.return_value = _as_pipeline_run(resuming)
         client_mock.get_pipeline_run.side_effect = [
             _as_pipeline_run(paused),
             _as_pipeline_run(resumed),


### PR DESCRIPTION
## What changed

- Reopens failed/paused executions to `RESUMING` before calling ZenML's `orchestrator.resume_run(...)` internals.
- Passes the updated `PipelineRunResponse` returned by `zen_store.update_run(...)` into `resume_run(...)`, instead of passing the stale failed/paused run object.
- Adds cautious repair behavior when reopening succeeds but submission fails:
  - rolls back only when the run still appears stuck in `RESUMING`;
  - preserves runner-written statuses such as a real `FAILED` after local inline execution;
  - validates the snapshot Kitaru stack id before reopening the run;
  - rolls back if local active Kitaru stack lookup fails after reopening;
  - reports both the submission error and the previous active Kitaru stack restoration error when both fail;
  - avoids rollback if submission returned successfully but restoring the previous active Kitaru stack failed.
- Adds regression tests for stale-object usage, call ordering, rollback, rollback failure, runner-written status preservation, stack-restore-after-success, missing stack-id preflight validation, active-stack lookup failure rollback, submission-plus-restore failure reporting, and analytics suppression.
- Adds an `[Unreleased]` changelog entry.

## Why

`kitaru executions retry` could call ZenML's resume machinery while the run still said `FAILED`. ZenML treats `FAILED` as a finished status, so local dynamic retry could no-op with an "already finished" path. On server-backed runs, the same stale terminal state could prevent workload-token generation because the run was still concluded.

## Reviewer Notes

The important behavior now lives in `src/kitaru/client.py` around `_restart_run_from_snapshot(...)`.

The old story was:

1. Kitaru fetched a failed run.
2. Kitaru checked that it was `failed`.
3. Kitaru handed that same failed run object back to ZenML.
4. ZenML saw a finished run and stopped, or refused to generate run-scoped workload tokens.

The new story is:

1. Kitaru fetches the failed/paused run and validates the requested operation.
2. Kitaru verifies the snapshot includes a stack id before reopening.
3. Kitaru updates the existing run to `RESUMING`.
4. Kitaru keeps the updated run object returned by `update_run(...)`.
5. Kitaru activates the Kitaru stack recorded on the run snapshot.
6. Kitaru rolls back if it cannot load the local active Kitaru stack after reopening.
7. Kitaru passes the updated run object into `resume_run(...)`.
8. Kitaru restores the previously active Kitaru stack as a separate step, so a restore failure does not hide the original submission error.
9. If submission fails before ZenML writes a more meaningful status, Kitaru rolls back to the original status.
10. If local execution already wrote a real failure status, Kitaru preserves it instead of overwriting it with a generic rollback reason.

The riskiest review area is the exception handling in `_restart_run_from_snapshot(...)`: especially the distinction between a failed submission, an inline runner failure that already changed run status, a local active-stack lookup failure after reopening, a failed submission plus failed previous-stack restoration, and a successful submission followed by failure restoring the previous active Kitaru stack.

### Reproduction

Before this change, a failed dynamic execution retried through Kitaru could be handed to ZenML while it was still `FAILED`, so the local runner would treat it as already finished and return without doing useful retry work. Server-backed runs could fail earlier while generating a run-scoped workload token because the run remained concluded.

To inspect the fixed behavior without needing a live server:

1. Run the focused regression tests:
   ```bash
   uv run pytest tests/test_client.py -k "retry or resume"
   ```
2. In `tests/test_client.py`, inspect `test_retry_restarts_failed_execution` and `test_resume_restarts_paused_execution`:
   - both set up an original failed/paused run;
   - both configure `zen_store.update_run(...)` to return a distinct `RESUMING` run;
   - both assert `orchestrator.resume_run(...)` receives the updated `RESUMING` object, not the stale original object.
3. Inspect the rollback tests around the same section to see the failure cases:
   - missing snapshot stack id fails before reopening;
   - stack activation failure rolls back;
   - local active-stack lookup failure after reopening rolls back;
   - submission failure rolls back only if latest status is still `RESUMING`;
   - submission failure plus previous active Kitaru stack restore failure reports both errors after rollback;
   - runner-written `FAILED` status is preserved;
   - successful submission followed by stack restore failure does not roll back.

### Local checks run

- `uv run ruff format src/kitaru/client.py tests/test_client.py`
- `uv run ruff check src/kitaru/client.py tests/test_client.py`
- `uv run pytest tests/test_client.py -k "retry or resume"` — 18 passed
- `just check`
- `just test` — 2421 passed, 13 skipped

### Review assistance

- `/simplify` review pass completed; the actionable cleanup was folded in.
- Oracle review loop reported no blocking correctness issues after the final type-check fix.

