### PR TITLE
Add contract tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added count-based execution statistics through `KitaruClient().executions.statistics(...)`, `kitaru executions statistics`, and the `kitaru_executions_statistics` MCP tool, with grouping by status, flow, stack, tag, time bucket, and execution metadata.
 
 ### Fixed
+- Fixed `kitaru executions retry` and resume-style execution restarts so failed or paused runs reopen to `RESUMING` before submission, avoiding local no-op retries and server token failures while guarding rollback with a Kitaru ownership marker.
 - Fixed a LangGraph adapter crash when running graphs without a LangGraph checkpointer under Kitaru's default durability policy. (#403)
 
 ## [0.15.0] - 2026-06-04

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -26,6 +26,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, Protocol, cast, runtime_checkable
+from uuid import uuid4
 
 from pydantic import ValidationError
 from zenml.client import Client
@@ -33,7 +34,7 @@ from zenml.config.pipeline_run_configuration import PipelineRunConfiguration
 from zenml.enums import ExecutionStatus as ZenMLExecutionStatus
 from zenml.exceptions import EntityExistsError
 from zenml.login.credentials_store import get_credentials_store
-from zenml.models import PipelineRunResponse
+from zenml.models import PipelineRunResponse, PipelineRunUpdate
 from zenml.models.v2.core.artifact_version import ArtifactVersionResponse
 from zenml.utils.run_utils import stop_run
 from zenml.zen_stores.rest_zen_store import RestZenStore
@@ -162,6 +163,11 @@ logger = logging.getLogger(__name__)
 
 _WAIT_CONDITION_RESOLUTION_CONTINUE = "continue"
 _WAIT_CONDITION_RESOLUTION_ABORT = "abort"
+_RETRY_RESUMING_REASON = "Manual retry requested by user."
+_RESUME_RESUMING_REASON = "Manual resume requested by user."
+_RETRY_ROLLBACK_REASON = "Retry submission failed."
+_RESUME_ROLLBACK_REASON = "Manual resume failed."
+_RESTART_OWNER_REASON_PREFIX = " Kitaru restart owner: "
 _REPLAY_IMPORT_LOCK = threading.RLock()
 
 
@@ -736,11 +742,166 @@ def _resolve_pipeline_for_replay(run: PipelineRunResponse) -> Any:
     return pipeline_obj
 
 
+class _RestartOwnershipError(KitaruBackendError):
+    """Restart ownership could not be verified, so submission must stop."""
+
+
+def _raw_status_value(status: Any) -> str:
+    """Return the string value of a ZenML status-like object."""
+    return str(getattr(status, "value", status))
+
+
+def _restart_status_reason(base_reason: str, owner_id: str) -> str:
+    """Return a transient RESUMING reason tied to this process."""
+    return f"{base_reason}{_RESTART_OWNER_REASON_PREFIX}{owner_id}"
+
+
+def _run_has_restart_owner(run: PipelineRunResponse, status_reason: str) -> bool:
+    """Return whether a run is still the RESUMING run this process reopened."""
+    return (
+        _raw_status_value(run.status) == ZenMLExecutionStatus.RESUMING.value
+        and getattr(run, "status_reason", None) == status_reason
+    )
+
+
+def _load_latest_restart_run(
+    *,
+    run_id: Any,
+    client: KitaruClient,
+    operation_name: str,
+    original_error: Exception | None = None,
+) -> PipelineRunResponse:
+    """Load latest run state for restart ownership checks."""
+    try:
+        return client._get_pipeline_run(str(run_id), hydrate=True)
+    except Exception as refresh_error:
+        message = (
+            f"Kitaru could not verify the latest run status for execution "
+            f"'{run_id}', so it did not attempt rollback or submission: "
+            f"{refresh_error}"
+        )
+        if original_error is not None:
+            message = (
+                f"Failed to {operation_name} execution '{run_id}': "
+                f"{original_error}. {message}"
+            )
+        raise _RestartOwnershipError(message) from (original_error or refresh_error)
+
+
+def _ensure_restart_owner(
+    *,
+    run_id: Any,
+    client: KitaruClient,
+    operation_name: str,
+    status_reason: str,
+) -> PipelineRunResponse:
+    """Confirm that this process still owns the reopened RESUMING run."""
+    latest_run = _load_latest_restart_run(
+        run_id=run_id,
+        client=client,
+        operation_name=operation_name,
+    )
+    if _run_has_restart_owner(latest_run, status_reason):
+        return latest_run
+
+    raise _RestartOwnershipError(
+        f"Unable to {operation_name} execution '{run_id}' because another "
+        "retry/resume attempt or the runner changed the run after Kitaru "
+        "reopened it. No rollback was attempted."
+    )
+
+
+def _update_run_status(
+    *,
+    client: KitaruClient,
+    run_id: Any,
+    status: ZenMLExecutionStatus,
+    status_reason: str,
+) -> PipelineRunResponse:
+    """Update one ZenML run status through the active store."""
+    return client._client().zen_store.update_run(
+        run_id=run_id,
+        run_update=PipelineRunUpdate(
+            status=status,
+            status_reason=status_reason,
+        ),
+    )
+
+
+def _raise_restart_failure(
+    *,
+    run_id: Any,
+    operation_name: str,
+    original_error: Exception,
+    rollback_error: Exception | None = None,
+) -> None:
+    """Raise the public restart error, optionally including rollback failure."""
+    if rollback_error is None:
+        raise KitaruBackendError(
+            f"Failed to {operation_name} execution '{run_id}': {original_error}"
+        ) from original_error
+
+    raise KitaruBackendError(
+        f"Failed to {operation_name} execution '{run_id}': {original_error}. "
+        "Kitaru also failed to roll the run back from RESUMING: "
+        f"{rollback_error}. The run may remain RESUMING."
+    ) from original_error
+
+
+def _rollback_reopened_run(
+    *,
+    run_id: Any,
+    client: KitaruClient,
+    operation_name: str,
+    rollback_status: ZenMLExecutionStatus,
+    rollback_reason: str,
+    original_error: Exception,
+    expected_resuming_reason: str,
+) -> None:
+    """Roll back a reopened run only while this process still owns it."""
+    latest_run = _load_latest_restart_run(
+        run_id=run_id,
+        client=client,
+        operation_name=operation_name,
+        original_error=original_error,
+    )
+    if not _run_has_restart_owner(latest_run, expected_resuming_reason):
+        raise KitaruBackendError(
+            f"Failed to {operation_name} execution '{run_id}': {original_error}. "
+            "Kitaru did not roll the run back because another retry/resume "
+            "attempt or the runner changed it after this process reopened it."
+        ) from original_error
+
+    try:
+        _update_run_status(
+            client=client,
+            run_id=run_id,
+            status=rollback_status,
+            status_reason=rollback_reason,
+        )
+    except Exception as rollback_error:
+        _raise_restart_failure(
+            run_id=run_id,
+            operation_name=operation_name,
+            original_error=original_error,
+            rollback_error=rollback_error,
+        )
+
+    _raise_restart_failure(
+        run_id=run_id,
+        operation_name=operation_name,
+        original_error=original_error,
+    )
+
+
 def _restart_run_from_snapshot(
     *,
     run: PipelineRunResponse,
     client: KitaruClient,
     operation_name: str,
+    resuming_reason: str,
+    rollback_status: ZenMLExecutionStatus,
+    rollback_reason: str,
 ) -> None:
     """Restart an execution from its stored snapshot metadata."""
     snapshot = run.snapshot
@@ -754,20 +915,61 @@ def _restart_run_from_snapshot(
             f"Unable to {operation_name} execution because snapshot stack "
             "metadata is missing."
         )
+    snapshot_stack_id = getattr(snapshot.stack, "id", None)
+    if not snapshot_stack_id:
+        raise KitaruRuntimeError(
+            f"Unable to {operation_name} execution because snapshot stack "
+            "ID is missing."
+        )
 
+    restart_owner = uuid4().hex
+    owned_resuming_reason = _restart_status_reason(resuming_reason, restart_owner)
     try:
-        with _temporary_active_stack(str(snapshot.stack.id)):
-            active_stack = client._client().active_stack
-            orchestrator = cast(Any, active_stack.orchestrator)
-            orchestrator.resume_run(
-                snapshot=snapshot,
-                run=run,
-                stack=active_stack,
-            )
+        reopened_run = _update_run_status(
+            client=client,
+            run_id=run.id,
+            status=ZenMLExecutionStatus.RESUMING,
+            status_reason=owned_resuming_reason,
+        )
     except Exception as exc:
         raise KitaruBackendError(
-            f"Failed to {operation_name} execution '{run.id}': {exc}"
+            f"Failed to reopen execution '{run.id}' for {operation_name}: {exc}"
         ) from exc
+
+    submission_completed = False
+    try:
+        with _temporary_active_stack(str(snapshot_stack_id)):
+            active_stack = client._client().active_stack
+            orchestrator = cast(Any, active_stack.orchestrator)
+            reopened_run = _ensure_restart_owner(
+                run_id=reopened_run.id,
+                client=client,
+                operation_name=operation_name,
+                status_reason=owned_resuming_reason,
+            )
+            orchestrator.resume_run(
+                snapshot=snapshot,
+                run=reopened_run,
+                stack=active_stack,
+            )
+            submission_completed = True
+    except _RestartOwnershipError:
+        raise
+    except Exception as exc:
+        if submission_completed:
+            raise KitaruBackendError(
+                f"Submitted {operation_name} execution '{run.id}', but failed "
+                f"to restore the previous active stack: {exc}"
+            ) from exc
+        _rollback_reopened_run(
+            run_id=reopened_run.id,
+            client=client,
+            operation_name=operation_name,
+            rollback_status=rollback_status,
+            rollback_reason=rollback_reason,
+            original_error=exc,
+            expected_resuming_reason=owned_resuming_reason,
+        )
 
 
 def _validate_event_filter_values(
@@ -1151,7 +1353,7 @@ class _ExecutionsAPI:
     def retry(self, exec_id: str) -> Execution:
         """Retry a failed execution as same-execution recovery."""
         run = self._client_ref._get_pipeline_run(exec_id, hydrate=True)
-        run_status_value = str(getattr(run.status, "value", run.status))
+        run_status_value = _raw_status_value(run.status)
         if run_status_value != ZenMLExecutionStatus.FAILED.value:
             raise KitaruStateError(
                 "Only failed executions can be retried. "
@@ -1162,6 +1364,9 @@ class _ExecutionsAPI:
             run=run,
             client=self._client_ref,
             operation_name="retry",
+            resuming_reason=_RETRY_RESUMING_REASON,
+            rollback_status=ZenMLExecutionStatus.FAILED,
+            rollback_reason=_RETRY_ROLLBACK_REASON,
         )
         track(AnalyticsEvent.EXECUTION_RETRIED, {})
         return self.get(exec_id)
@@ -1178,8 +1383,8 @@ class _ExecutionsAPI:
                 f"Resolve pending wait input before resuming execution '{exec_id}'."
             )
 
-        run_status_value = str(getattr(run.status, "value", run.status))
-        if run_status_value != "paused":
+        run_status_value = _raw_status_value(run.status)
+        if run_status_value != ZenMLExecutionStatus.PAUSED.value:
             raise KitaruStateError(
                 "Only paused executions can be resumed. "
                 f"Execution '{exec_id}' is currently '{run_status_value}'."
@@ -1189,6 +1394,9 @@ class _ExecutionsAPI:
             run=run,
             client=self._client_ref,
             operation_name="resume",
+            resuming_reason=_RESUME_RESUMING_REASON,
+            rollback_status=ZenMLExecutionStatus.PAUSED,
+            rollback_reason=_RESUME_ROLLBACK_REASON,
         )
         track(AnalyticsEvent.EXECUTION_RESUMED, {})
         return self.get(exec_id)
@@ -1204,13 +1412,13 @@ class _ExecutionsAPI:
         """Replay an execution from a checkpoint boundary."""
         source_run = self._client_ref._get_pipeline_run(exec_id, hydrate=True)
 
-        run_status_value = str(getattr(source_run.status, "value", source_run.status))
+        run_status_value = _raw_status_value(source_run.status)
         if run_status_value in {
-            "initializing",
-            "provisioning",
-            "running",
-            "retrying",
-            "stopping",
+            ZenMLExecutionStatus.INITIALIZING.value,
+            ZenMLExecutionStatus.PROVISIONING.value,
+            ZenMLExecutionStatus.RUNNING.value,
+            ZenMLExecutionStatus.RETRYING.value,
+            ZenMLExecutionStatus.STOPPING.value,
         }:
             raise KitaruStateError(
                 "Replay requires a non-running source execution. "

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -56,9 +57,40 @@ from kitaru.mcp.server import (
     kitaru_status,
     kitaru_stop_local_server,
     manage_stack,
+    mcp,
     tracked_mcp_tool,
 )
 from kitaru.secrets import SecretSummary
+
+_REGISTERED_MCP_TOOL_FUNCTIONS = (
+    kitaru_executions_list,
+    kitaru_executions_statistics,
+    kitaru_executions_get,
+    kitaru_executions_latest,
+    get_execution_logs,
+    kitaru_executions_run,
+    kitaru_deployments_deploy,
+    kitaru_deployments_invoke,
+    kitaru_deployments_list,
+    kitaru_deployments_get,
+    kitaru_deployments_delete,
+    kitaru_deployments_tag,
+    kitaru_deployments_untag,
+    kitaru_executions_cancel,
+    kitaru_executions_input,
+    kitaru_executions_retry,
+    kitaru_executions_replay,
+    kitaru_secrets_create,
+    kitaru_artifacts_list,
+    kitaru_artifacts_get,
+    kitaru_start_local_server,
+    kitaru_stop_local_server,
+    kitaru_status,
+    kitaru_stacks_list,
+    manage_stack,
+    kitaru_info,
+    kitaru_clean_preview,
+)
 
 
 def _write_flow_target_module(path: Path, *, marker: str) -> None:
@@ -79,6 +111,48 @@ def _load_mcp_flow_target(target: str) -> Any:
         target,
         module_name_prefix="_kitaru_mcp_run_target_",
     )
+
+
+def _mcp_tool_schemas_by_name() -> dict[str, dict[str, Any]]:
+    """Return FastMCP input schemas from the in-process registry."""
+    tools = asyncio.run(mcp.list_tools())
+    return {tool.name: tool.inputSchema for tool in tools}
+
+
+def test_fastmcp_registers_public_tools_with_expected_input_schemas() -> None:
+    tool_schemas = _mcp_tool_schemas_by_name()
+    expected_names = {func.__name__ for func in _REGISTERED_MCP_TOOL_FUNCTIONS}
+
+    assert set(tool_schemas) == expected_names
+    assert "_wrapper" not in tool_schemas
+
+    input_schema = tool_schemas["kitaru_executions_input"]
+    assert set(input_schema["properties"]) == {"exec_id", "wait", "value"}
+    assert input_schema["required"] == ["exec_id", "wait", "value"]
+
+    invoke_schema = tool_schemas["kitaru_deployments_invoke"]
+    assert set(invoke_schema["properties"]) == {
+        "flow",
+        "version",
+        "tag",
+        "inputs",
+    }
+    assert invoke_schema["required"] == ["flow"]
+    assert invoke_schema["properties"]["version"]["default"] is None
+    assert invoke_schema["properties"]["tag"]["default"] is None
+    assert invoke_schema["properties"]["inputs"]["default"] is None
+
+    stack_schema = tool_schemas["manage_stack"]
+    assert {"action", "name"}.issubset(stack_schema["properties"])
+    assert stack_schema["required"] == ["action", "name"]
+    assert stack_schema["properties"]["action"]["enum"] == ["create", "delete"]
+    assert stack_schema["properties"]["stack_type"]["default"] == "local"
+    assert stack_schema["properties"]["activate"]["default"] is True
+    assert stack_schema["properties"]["recursive"]["default"] is False
+    assert stack_schema["properties"]["force"]["default"] is False
+    assert stack_schema["properties"]["async_mode"]["default"] is False
+    assert stack_schema["properties"]["verify"]["default"] is True
+    assert "extra" in stack_schema["properties"]
 
 
 def test_load_flow_target_supports_module_paths(

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
 from zenml.enums import ArtifactSaveType, ArtifactType
 
+from kitaru._client._mappers import _map_artifact_ref
 from kitaru.artifacts import _parse_scope_uuid, load, save
 from kitaru.errors import (
     KitaruContextError,
@@ -18,15 +21,90 @@ from kitaru.errors import (
 )
 from kitaru.runtime import _checkpoint_scope, _flow_scope
 
+if TYPE_CHECKING:
+    from zenml.models.v2.core.artifact_version import ArtifactVersionResponse
+
+    from kitaru.client import KitaruClient
+
+
+@dataclass(slots=True)
+class _StrictArtifactVersion:
+    """Minimal ZenML artifact-version shape read by artifact contracts."""
+
+    id: UUID
+    name: str
+    save_type: ArtifactSaveType
+    run_metadata: dict[str, Any] = field(default_factory=dict)
+    producer_step_run_id: UUID | None = None
+
+
+@dataclass(slots=True)
+class _StrictHydratedArtifactVersion:
+    """Hydrated artifact-version shape returned before materialization."""
+
+    value: Any
+    load_call_count: int = 0
+
+    def load(self) -> Any:
+        """Materialize the stored artifact value."""
+        self.load_call_count += 1
+        return self.value
+
+
+@dataclass(slots=True)
+class _StrictStepRun:
+    """Minimal hydrated step-run shape used by `kitaru.load()`."""
+
+    outputs: dict[str, list[_StrictArtifactVersion]]
+
+
+@dataclass(slots=True)
+class _StrictHydratedRun:
+    """Minimal hydrated run shape used by `kitaru.load()`."""
+
+    id: UUID
+    steps: dict[str, _StrictStepRun]
+
+
+@dataclass(slots=True)
+class _StrictRunResponse:
+    """Pipeline-run response that proves hydration is explicitly requested."""
+
+    hydrated_run: _StrictHydratedRun
+    hydration_count: int = 0
+
+    def get_hydrated_version(self) -> _StrictHydratedRun:
+        """Return the hydrated run and record that Kitaru required it."""
+        self.hydration_count += 1
+        return self.hydrated_run
+
+
+@dataclass(slots=True)
+class _StrictKitaruClient:
+    """Minimal Kitaru client shape used by `ArtifactRef.load()`."""
+
+    hydrated_artifact: _StrictHydratedArtifactVersion
+    artifact_version_calls: list[tuple[str, bool]] = field(default_factory=list)
+
+    def _get_artifact_version(
+        self,
+        artifact_id: str,
+        *,
+        hydrate: bool,
+    ) -> _StrictHydratedArtifactVersion:
+        """Record artifact-version fetches and return a hydrated artifact."""
+        self.artifact_version_calls.append((artifact_id, hydrate))
+        return self.hydrated_artifact
+
 
 def _artifact(
     *,
     name: str,
     save_type: ArtifactSaveType,
     artifact_id: UUID | None = None,
-) -> SimpleNamespace:
-    """Create a lightweight artifact-like object for tests."""
-    return SimpleNamespace(
+) -> _StrictArtifactVersion:
+    """Create a strict artifact-like object for tests."""
+    return _StrictArtifactVersion(
         id=artifact_id or uuid4(),
         name=name,
         save_type=save_type,
@@ -35,13 +113,13 @@ def _artifact(
 
 def _hydrated_run(
     *,
-    step_outputs: dict[str, dict[str, list[SimpleNamespace]]],
-) -> SimpleNamespace:
-    """Create a lightweight hydrated run-like object for tests."""
-    return SimpleNamespace(
+    step_outputs: dict[str, dict[str, list[_StrictArtifactVersion]]],
+) -> _StrictHydratedRun:
+    """Create a strict hydrated run-like object for tests."""
+    return _StrictHydratedRun(
         id=uuid4(),
         steps={
-            step_name: SimpleNamespace(outputs=outputs)
+            step_name: _StrictStepRun(outputs=outputs)
             for step_name, outputs in step_outputs.items()
         },
     )
@@ -236,11 +314,8 @@ def test_load_resolves_manual_saved_artifact_by_name() -> None:
         }
     )
 
-    run_response = MagicMock()
-    run_response.get_hydrated_version.return_value = hydrated_run
-
-    loaded_artifact = MagicMock()
-    loaded_artifact.load.return_value = {"topic": "kitaru"}
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value={"topic": "kitaru"})
 
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = run_response
@@ -267,6 +342,8 @@ def test_load_resolves_manual_saved_artifact_by_name() -> None:
         manual_artifact.id,
         hydrate=True,
     )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
 
 
 def test_load_resolves_checkpoint_output_by_checkpoint_name() -> None:
@@ -284,11 +361,8 @@ def test_load_resolves_checkpoint_output_by_checkpoint_name() -> None:
         }
     )
 
-    run_response = MagicMock()
-    run_response.get_hydrated_version.return_value = hydrated_run
-
-    loaded_artifact = MagicMock()
-    loaded_artifact.load.return_value = "notes"
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value="notes")
 
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = run_response
@@ -311,9 +385,54 @@ def test_load_resolves_checkpoint_output_by_checkpoint_name() -> None:
         step_output_artifact.id,
         hydrate=True,
     )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
 
 
-def test_load_resolves_checkpoint_output_by_step_name() -> None:
+def test_load_resolves_checkpoint_output_by_artifact_name() -> None:
+    execution_id, checkpoint_id = _scope_ids()
+
+    step_output_artifact = _artifact(
+        name="research_summary",
+        save_type=ArtifactSaveType.STEP_OUTPUT,
+    )
+    hydrated_run = _hydrated_run(
+        step_outputs={
+            "research": {
+                "output": [step_output_artifact],
+            }
+        }
+    )
+
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value="named notes")
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = run_response
+    client_mock.get_artifact_version.return_value = loaded_artifact
+
+    with (
+        _flow_scope(name="flow", execution_id=execution_id),
+        _checkpoint_scope(
+            name="reader",
+            checkpoint_type=None,
+            execution_id=execution_id,
+            checkpoint_id=checkpoint_id,
+        ),
+        patch("kitaru.artifacts.Client", return_value=client_mock),
+    ):
+        value = load(str(uuid4()), "research_summary")
+
+    assert value == "named notes"
+    client_mock.get_artifact_version.assert_called_once_with(
+        step_output_artifact.id,
+        hydrate=True,
+    )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
+
+
+def test_load_resolves_checkpoint_output_by_raw_step_name() -> None:
     execution_id, checkpoint_id = _scope_ids()
 
     step_output_artifact = _artifact(
@@ -328,11 +447,8 @@ def test_load_resolves_checkpoint_output_by_step_name() -> None:
         }
     )
 
-    run_response = MagicMock()
-    run_response.get_hydrated_version.return_value = hydrated_run
-
-    loaded_artifact = MagicMock()
-    loaded_artifact.load.return_value = "notes"
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value="notes")
 
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = run_response
@@ -351,6 +467,106 @@ def test_load_resolves_checkpoint_output_by_step_name() -> None:
         value = load(str(uuid4()), "research")
 
     assert value == "notes"
+    client_mock.get_artifact_version.assert_called_once_with(
+        step_output_artifact.id,
+        hydrate=True,
+    )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
+
+
+def test_load_resolves_checkpoint_output_by_normalized_checkpoint_name() -> None:
+    execution_id, checkpoint_id = _scope_ids()
+
+    step_output_artifact = _artifact(
+        name="output",
+        save_type=ArtifactSaveType.STEP_OUTPUT,
+    )
+    hydrated_run = _hydrated_run(
+        step_outputs={
+            "__kitaru_checkpoint_source_research": {
+                "output": [step_output_artifact],
+            }
+        }
+    )
+
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value="notes")
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = run_response
+    client_mock.get_artifact_version.return_value = loaded_artifact
+
+    with (
+        _flow_scope(name="flow", execution_id=execution_id),
+        _checkpoint_scope(
+            name="reader",
+            checkpoint_type=None,
+            execution_id=execution_id,
+            checkpoint_id=checkpoint_id,
+        ),
+        patch("kitaru.artifacts.Client", return_value=client_mock),
+    ):
+        value = load(str(uuid4()), "research")
+
+    assert value == "notes"
+    client_mock.get_artifact_version.assert_called_once_with(
+        step_output_artifact.id,
+        hydrate=True,
+    )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
+
+
+def test_load_deduplicates_repeated_artifact_ids() -> None:
+    execution_id, checkpoint_id = _scope_ids()
+    repeated_artifact_id = uuid4()
+
+    first_reference = _artifact(
+        name="shared",
+        save_type=ArtifactSaveType.MANUAL,
+        artifact_id=repeated_artifact_id,
+    )
+    second_reference = _artifact(
+        name="shared",
+        save_type=ArtifactSaveType.MANUAL,
+        artifact_id=repeated_artifact_id,
+    )
+    hydrated_run = _hydrated_run(
+        step_outputs={
+            "research": {
+                "first": [first_reference],
+                "second": [second_reference],
+            },
+        }
+    )
+
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value={"shared": True})
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = run_response
+    client_mock.get_artifact_version.return_value = loaded_artifact
+
+    with (
+        _flow_scope(name="flow", execution_id=execution_id),
+        _checkpoint_scope(
+            name="reader",
+            checkpoint_type=None,
+            execution_id=execution_id,
+            checkpoint_id=checkpoint_id,
+        ),
+        patch("kitaru.artifacts.Client", return_value=client_mock),
+    ):
+        value = load(str(uuid4()), "shared")
+
+    assert value == {"shared": True}
+    client_mock.get_artifact_version.assert_called_once_with(
+        repeated_artifact_id,
+        hydrate=True,
+    )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
 
 
 def test_load_raises_when_name_is_not_found() -> None:
@@ -369,8 +585,7 @@ def test_load_raises_when_name_is_not_found() -> None:
         }
     )
 
-    run_response = MagicMock()
-    run_response.get_hydrated_version.return_value = hydrated_run
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
 
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = run_response
@@ -387,6 +602,9 @@ def test_load_raises_when_name_is_not_found() -> None:
         pytest.raises(KitaruRuntimeError, match="No artifact named"),
     ):
         load(str(uuid4()), "research_context")
+
+    assert run_response.hydration_count == 1
+    client_mock.get_artifact_version.assert_not_called()
 
 
 def test_load_raises_on_ambiguous_matches() -> None:
@@ -414,8 +632,7 @@ def test_load_raises_on_ambiguous_matches() -> None:
         }
     )
 
-    run_response = MagicMock()
-    run_response.get_hydrated_version.return_value = hydrated_run
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
 
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = run_response
@@ -432,3 +649,111 @@ def test_load_raises_on_ambiguous_matches() -> None:
         pytest.raises(KitaruRuntimeError, match="Multiple artifacts named"),
     ):
         load(str(uuid4()), duplicate_name)
+
+    assert run_response.hydration_count == 1
+    client_mock.get_artifact_version.assert_not_called()
+
+
+def test_map_artifact_ref_and_ref_load_use_strict_artifact_contract() -> None:
+    artifact_id = uuid4()
+    producer_step_run_id = uuid4()
+    artifact = _StrictArtifactVersion(
+        id=artifact_id,
+        name="research_context",
+        save_type=ArtifactSaveType.MANUAL,
+        run_metadata={
+            "kitaru_artifact_type": "context",
+            "reviewed": True,
+        },
+        producer_step_run_id=producer_step_run_id,
+    )
+    hydrated_artifact = _StrictHydratedArtifactVersion(
+        value={"topic": "kitaru"},
+    )
+    client = _StrictKitaruClient(hydrated_artifact=hydrated_artifact)
+
+    artifact_ref = _map_artifact_ref(
+        artifact=cast("ArtifactVersionResponse", artifact),
+        client=cast("KitaruClient", client),
+        producing_call="research",
+    )
+
+    assert artifact_ref.artifact_id == str(artifact_id)
+    assert artifact_ref.name == "research_context"
+    assert artifact_ref.kind == "context"
+    assert artifact_ref.save_type == ArtifactSaveType.MANUAL.value
+    assert artifact_ref.producing_call == "research"
+    assert artifact_ref.metadata == {
+        "kitaru_artifact_type": "context",
+        "reviewed": True,
+    }
+
+    assert artifact_ref.load() == {"topic": "kitaru"}
+    assert client.artifact_version_calls == [(str(artifact_id), True)]
+    assert hydrated_artifact.load_call_count == 1
+
+
+def test_flow_with_artifacts_example_checkpoint_bodies_are_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from examples.features.basic_flow import flow_with_artifacts
+
+    save_calls: list[dict[str, Any]] = []
+    load_calls: list[tuple[str, str]] = []
+
+    def fake_save(
+        name: str,
+        value: Any,
+        *,
+        type: str = "output",
+        tags: list[str] | None = None,
+    ) -> None:
+        save_calls.append(
+            {
+                "name": name,
+                "value": value,
+                "type": type,
+                "tags": tags,
+            }
+        )
+
+    def fake_load(exec_id: str, name: str) -> Any:
+        load_calls.append((exec_id, name))
+        if name == "research":
+            return "Research notes about kitaru."
+        if name == "research_context":
+            return {"topic": "kitaru"}
+        raise AssertionError(f"Unexpected artifact load: {name}")
+
+    monkeypatch.setattr(flow_with_artifacts.kitaru, "save", fake_save)
+    monkeypatch.setattr(flow_with_artifacts.kitaru, "load", fake_load)
+
+    research_body = cast(
+        Callable[[str], str],
+        cast(Any, flow_with_artifacts.research).__wrapped__,
+    )
+    follow_up_body = cast(
+        Callable[[str], str],
+        cast(Any, flow_with_artifacts.follow_up_from_previous).__wrapped__,
+    )
+
+    assert research_body("kitaru") == "Research notes about kitaru."
+    assert save_calls == [
+        {
+            "name": "research_context",
+            "value": {
+                "topic": "kitaru",
+                "notes": "Research notes about kitaru.",
+            },
+            "type": "context",
+            "tags": None,
+        }
+    ]
+
+    assert follow_up_body("previous-exec-id") == (
+        "Research notes about kitaru. [topic=kitaru]"
+    )
+    assert load_calls == [
+        ("previous-exec-id", "research"),
+        ("previous-exec-id", "research_context"),
+    ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from importlib.machinery import ModuleSpec
 from pathlib import Path
@@ -15,10 +17,11 @@ from unittest.mock import MagicMock, Mock, call, patch
 from uuid import UUID, uuid4
 
 import pytest
-from zenml.enums import ArtifactSaveType, StackComponentType
+from zenml.client import Client as ZenMLClient
+from zenml.enums import ArtifactSaveType, RunWaitConditionResolution, StackComponentType
 from zenml.enums import ExecutionStatus as ZenMLExecutionStatus
 from zenml.exceptions import EntityExistsError
-from zenml.models import PipelineRunResponse, StepRunResponse
+from zenml.models import PipelineRunResponse, PipelineRunUpdate, StepRunResponse
 from zenml.models.v2.core.artifact_version import ArtifactVersionResponse
 
 from kitaru._client._deployments import (
@@ -41,6 +44,9 @@ from kitaru._client._statistics import (
 from kitaru._interface_deployments import Deployment
 from kitaru.analytics import AnalyticsEvent
 from kitaru.client import (
+    _RESUME_RESUMING_REASON,
+    _RETRY_RESUMING_REASON,
+    _RETRY_ROLLBACK_REASON,
     AuthAPIKey,
     AuthAPIKeyWithValue,
     AuthServiceAccount,
@@ -274,6 +280,64 @@ class _DummySnapshot:
         self.kitaru_deployment = metadata or {}
 
 
+@dataclass(slots=True)
+class _StrictTag:
+    name: str
+
+
+@dataclass(slots=True)
+class _StrictStack:
+    name: str | None = None
+    id: str | None = None
+
+
+@dataclass(slots=True)
+class _StrictSnapshotResources:
+    tags: list[Any]
+    stack: Any | None = None
+
+
+@dataclass(slots=True)
+class _StrictSnapshot:
+    id: UUID
+    name: str
+    tags: list[Any] | None = None
+    resources: _StrictSnapshotResources | None = None
+    metadata: dict[str, Any] | None = None
+    run_metadata: dict[str, Any] | None = None
+    stack: Any | None = None
+    build: Any | None = None
+    body: Any | None = None
+    kitaru_deployment: dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class _StrictWaitCondition:
+    id: UUID
+    name: str
+    question: str | None = None
+    data_schema: dict[str, Any] | None = None
+    run_metadata: dict[str, Any] | None = None
+    created: datetime | None = None
+
+
+def _strict_wait_condition(
+    *,
+    name: str,
+    wait_id: UUID | None = None,
+    question: str | None = None,
+    data_schema: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> _StrictWaitCondition:
+    return _StrictWaitCondition(
+        id=wait_id or uuid4(),
+        name=name,
+        question=question,
+        data_schema=data_schema,
+        run_metadata=metadata or {},
+    )
+
+
 def _resolved_connection(project: str | None = None) -> ResolvedConnectionConfig:
     return ResolvedConnectionConfig(
         server_url=None,
@@ -349,6 +413,64 @@ def _snapshot_source(module: str, attribute: str) -> Any:
         module=module,
         attribute=attribute,
         import_path=f"{module}.{attribute}",
+    )
+
+
+def _assert_pipeline_run_update(
+    update: Any,
+    *,
+    status: ZenMLExecutionStatus,
+    status_reason: str,
+    allow_owner_suffix: bool = False,
+) -> None:
+    assert isinstance(update, PipelineRunUpdate)
+    assert update.status == status
+    if allow_owner_suffix:
+        assert update.status_reason is not None
+        assert update.status_reason.startswith(status_reason)
+        assert "Kitaru restart owner:" in update.status_reason
+    else:
+        assert update.status_reason == status_reason
+
+
+def _updated_run_response(run: _DummyRun) -> Any:
+    def _update_run(**kwargs: Any) -> PipelineRunResponse:
+        run_update = kwargs["run_update"]
+        run.status = run_update.status
+        run.status_reason = run_update.status_reason
+        return _as_pipeline_run(run)
+
+    return _update_run
+
+
+def _updated_run_responses(*runs: _DummyRun) -> Any:
+    remaining_runs = iter(runs)
+
+    def _update_run(**kwargs: Any) -> PipelineRunResponse:
+        run = next(remaining_runs)
+        run_update = kwargs["run_update"]
+        run.status = run_update.status
+        run.status_reason = run_update.status_reason
+        return _as_pipeline_run(run)
+
+    return _update_run
+
+
+def _assert_update_run_call(
+    update_call: Any,
+    *,
+    run_id: UUID,
+    status: ZenMLExecutionStatus,
+    status_reason: str,
+    allow_owner_suffix: bool = False,
+) -> None:
+    kwargs = update_call.kwargs
+    assert kwargs["run_id"] == run_id
+    _assert_pipeline_run_update(
+        kwargs["run_update"],
+        status=status,
+        status_reason=status_reason,
+        allow_owner_suffix=allow_owner_suffix,
     )
 
 
@@ -1152,6 +1274,117 @@ def test_map_deployment_snapshot_extracts_public_model_fields() -> None:
     assert deployment.stack == "serverless-prod"
 
 
+def test_deployment_snapshot_mapping_contract_sources() -> None:
+    direct_tags_snapshot = _StrictSnapshot(
+        id=uuid4(),
+        name="kitaru::direct_tags::v1",
+        tags=[
+            deployment_public_tag("stable", exclusive=True),
+            _StrictTag(deployment_public_tag("canary", exclusive=False)),
+        ],
+        resources=_StrictSnapshotResources(tags=[], stack=None),
+        metadata={
+            "kitaru_deployment": {
+                "commit_sha": "abc123",
+                "commit_dirty": "true",
+            },
+            "config_schema": {"type": "object", "properties": {"x": {}}},
+        },
+        stack=_StrictStack(name="direct-stack"),
+    )
+    direct_tags = map_deployment_snapshot(direct_tags_snapshot)
+
+    assert direct_tags is not None
+    assert direct_tags.tags == {"stable": True, "canary": False}
+    assert direct_tags.commit_sha == "abc123"
+    assert direct_tags.commit_dirty is True
+    assert direct_tags.schema == {"type": "object", "properties": {"x": {}}}
+    assert direct_tags.stack == "direct-stack"
+
+    resources_snapshot = _StrictSnapshot(
+        id=uuid4(),
+        name="kitaru::resources_tags::v2",
+        resources=_StrictSnapshotResources(
+            tags=[_StrictTag(deployment_public_tag("blue", exclusive=False))],
+            stack=_StrictStack(id="resource-stack-id"),
+        ),
+    )
+    resources_deployment = map_deployment_snapshot(resources_snapshot)
+
+    assert resources_deployment is not None
+    assert resources_deployment.tags == {"blue": False}
+    assert resources_deployment.stack == "resource-stack-id"
+
+    run_metadata_snapshot = _StrictSnapshot(
+        id=uuid4(),
+        name="kitaru::run_metadata::v3",
+        resources=_StrictSnapshotResources(tags=[], stack=None),
+        run_metadata={
+            "kitaru_deployment": {
+                "image_digest": "sha256:feed",
+                "stack": "metadata-stack",
+            }
+        },
+    )
+    run_metadata_deployment = map_deployment_snapshot(run_metadata_snapshot)
+
+    assert run_metadata_deployment is not None
+    assert run_metadata_deployment.image_digest == "sha256:feed"
+    assert run_metadata_deployment.stack == "metadata-stack"
+
+
+def test_deployments_list_snapshots_contract_and_pagination() -> None:
+    first_page = [
+        _StrictSnapshot(id=uuid4(), name=f"kitaru::flow::v{i}") for i in range(100)
+    ]
+    second_page = [_StrictSnapshot(id=uuid4(), name="kitaru::flow::v101")]
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(project="proj"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_snapshots.side_effect = [
+            SimpleNamespace(items=first_page),
+            SimpleNamespace(items=second_page),
+        ]
+
+        client = KitaruClient()
+        snapshots = client.deployments._list_snapshots()
+
+    assert snapshots == [*first_page, *second_page]
+    assert client_mock.list_snapshots.call_args_list == [
+        call(
+            sort_by="asc:created",
+            page=1,
+            size=100,
+            project="proj",
+            named_only=True,
+            hydrate=True,
+        ),
+        call(
+            sort_by="asc:created",
+            page=2,
+            size=100,
+            project="proj",
+            named_only=True,
+            hydrate=True,
+        ),
+    ]
+
+
+def test_zenml_trigger_pipeline_signature_accepts_kitaru_kwargs() -> None:
+    parameters = inspect.signature(ZenMLClient.trigger_pipeline).parameters
+
+    assert "snapshot_name_or_id" in parameters
+    assert "run_configuration" in parameters
+    assert "project" in parameters
+    assert "synchronous" in parameters
+
+
 def test_deployments_list_requires_flow_filters_and_sorts_versions() -> None:
     snapshots = [
         _DummySnapshot(name="kitaru::research_flow::v3"),
@@ -1795,7 +2028,66 @@ def test_deployment_facade_invoke_returns_flow_handle_with_parameters() -> None:
     invoke_kwargs = client_mock.trigger_pipeline.call_args.kwargs
     assert invoke_kwargs["snapshot_name_or_id"] == deployment.deployment_id
     assert invoke_kwargs["project"] == "proj"
+    assert invoke_kwargs["synchronous"] is False
     assert invoke_kwargs["run_configuration"].parameters == {"question": "hello"}
+
+
+def test_deployments_invoke_without_inputs_sends_no_run_configuration() -> None:
+    run = _as_pipeline_run(
+        _DummyRun(status=ZenMLExecutionStatus.RUNNING, flow_name="research_flow")
+    )
+    snapshot = _DummySnapshot(
+        name="kitaru::research_flow::v1",
+        tags=[deployment_public_tag("default", exclusive=True)],
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(project="proj"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch("kitaru.client.ensure_stack_is_server_runnable"),
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_snapshots.return_value = SimpleNamespace(items=[snapshot])
+        client_mock.get_snapshot.return_value = snapshot
+        client_mock.trigger_pipeline.return_value = run
+
+        client = KitaruClient()
+        handle = client.deployments.invoke(flow="research_flow", version=1)
+
+    assert handle.exec_id == str(run.id)
+    client_mock.trigger_pipeline.assert_called_once_with(
+        snapshot_name_or_id=str(snapshot.id),
+        run_configuration=None,
+        project="proj",
+        synchronous=False,
+    )
+
+
+def test_deployments_invoke_rejects_missing_pipeline_run_response() -> None:
+    snapshot = _DummySnapshot(
+        name="kitaru::research_flow::v1",
+        tags=[deployment_public_tag("default", exclusive=True)],
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(project="proj"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch("kitaru.client.ensure_stack_is_server_runnable"),
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_snapshots.return_value = SimpleNamespace(items=[snapshot])
+        client_mock.get_snapshot.return_value = snapshot
+        client_mock.trigger_pipeline.return_value = None
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="did not produce"):
+            client.deployments.invoke(flow="research_flow", version=1)
 
 
 def test_deployments_invoke_completed_run_emits_immediate_terminal_event() -> None:
@@ -3460,15 +3752,34 @@ def test_retry_restarts_failed_execution() -> None:
         run_id=run_id,
         snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
     )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
     retried = _DummyRun(
         status=ZenMLExecutionStatus.RUNNING,
         flow_name="flow_a",
         run_id=run_id,
-        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+        snapshot=failed.snapshot,
     )
 
+    events: list[str] = []
     old_stack_id = uuid4()
     active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+
+    def _update_run(**kwargs: Any) -> PipelineRunResponse:
+        events.append("update_run")
+        run_update = kwargs["run_update"]
+        reopening.status = run_update.status
+        reopening.status_reason = run_update.status_reason
+        return _as_pipeline_run(reopening)
+
+    def _resume_run(**kwargs: Any) -> None:
+        events.append("resume_run")
+
+    active_stack.orchestrator.resume_run.side_effect = _resume_run
 
     with (
         patch(
@@ -3480,19 +3791,31 @@ def test_retry_restarts_failed_execution() -> None:
         client_mock = client_cls.return_value
         client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
         client_mock.active_stack = active_stack
+        client_mock.zen_store.update_run.side_effect = _update_run
         client_mock.get_pipeline_run.side_effect = [
             _as_pipeline_run(failed),
+            _as_pipeline_run(reopening),
             _as_pipeline_run(retried),
         ]
 
         client = KitaruClient()
         execution = client.executions.retry(str(run_id))
 
+    client_mock.zen_store.update_run.assert_called_once()
+    update_kwargs = client_mock.zen_store.update_run.call_args.kwargs
+    assert update_kwargs["run_id"] == run_id
+    _assert_pipeline_run_update(
+        update_kwargs["run_update"],
+        status=ZenMLExecutionStatus.RESUMING,
+        status_reason=_RETRY_RESUMING_REASON,
+        allow_owner_suffix=True,
+    )
     active_stack.orchestrator.resume_run.assert_called_once_with(
         snapshot=failed.snapshot,
-        run=_as_pipeline_run(failed),
+        run=_as_pipeline_run(reopening),
         stack=active_stack,
     )
+    assert events == ["update_run", "resume_run"]
     assert client_mock.activate_stack.call_args_list == [
         call(str(snapshot_stack_id)),
         call(old_stack_id),
@@ -3567,10 +3890,103 @@ def test_input_resolves_pending_wait_condition() -> None:
 
     client_mock.resolve_run_wait_condition.assert_called_once_with(
         run_wait_condition_id=wait_condition.id,
-        resolution="continue",
+        resolution=RunWaitConditionResolution.CONTINUE.value,
         result=True,
     )
+    assert client_mock.get_pipeline_run.call_args_list[0] == call(
+        name_id_or_prefix=str(run_id),
+        allow_name_prefix_match=False,
+        project=None,
+        hydrate=True,
+    )
     assert execution.status == ExecutionStatus.RUNNING
+
+
+def test_input_selects_pending_wait_by_id() -> None:
+    run_id = uuid4()
+    wait_condition = _strict_wait_condition(name="approve_deploy")
+    waiting_run = _DummyRun(
+        status=_paused_status(),
+        flow_name="flow_a",
+        run_id=run_id,
+        active_wait_condition=None,
+    )
+    resumed_run = _DummyRun(
+        status=ZenMLExecutionStatus.RUNNING,
+        flow_name="flow_a",
+        run_id=run_id,
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(waiting_run),
+            _as_pipeline_run(resumed_run),
+        ]
+        client_mock.list_run_wait_conditions.side_effect = [
+            SimpleNamespace(items=[wait_condition]),
+            SimpleNamespace(items=[]),
+        ]
+        client_mock.list_run_steps.return_value = SimpleNamespace(items=[])
+
+        client = KitaruClient()
+        execution = client.executions.input(
+            str(run_id),
+            wait=str(wait_condition.id),
+            value={"approved": True},
+        )
+
+    client_mock.resolve_run_wait_condition.assert_called_once_with(
+        run_wait_condition_id=wait_condition.id,
+        resolution=RunWaitConditionResolution.CONTINUE.value,
+        result={"approved": True},
+    )
+    assert execution.status == ExecutionStatus.RUNNING
+
+
+def test_input_rejects_duplicate_pending_wait_names() -> None:
+    wait_one = _strict_wait_condition(name="approve")
+    wait_two = _strict_wait_condition(name="approve")
+    run = _DummyRun(
+        status=_paused_status(),
+        flow_name="flow_a",
+        active_wait_condition=None,
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
+        client_mock.list_run_wait_conditions.return_value = SimpleNamespace(
+            items=[wait_one, wait_two]
+        )
+
+        client = KitaruClient()
+        with pytest.raises(KitaruStateError, match="Multiple pending waits"):
+            client.executions.input(str(run.id), wait="approve", value=True)
+
+    client_mock.resolve_run_wait_condition.assert_not_called()
+
+
+def test_zenml_wait_resolution_signature_accepts_kitaru_kwargs() -> None:
+    parameters = inspect.signature(ZenMLClient.resolve_run_wait_condition).parameters
+
+    assert "run_wait_condition_id" in parameters
+    assert "resolution" in parameters
+    assert "result" in parameters
+    assert RunWaitConditionResolution.CONTINUE.value == "continue"
+    assert RunWaitConditionResolution.ABORT.value == "abort"
 
 
 def test_get_surfaces_waiting_status_for_running_wait_condition() -> None:
@@ -3821,10 +4237,85 @@ def test_abort_wait_resolves_with_abort_resolution() -> None:
 
     client_mock.resolve_run_wait_condition.assert_called_once_with(
         run_wait_condition_id=wait_condition.id,
-        resolution="abort",
+        resolution=RunWaitConditionResolution.ABORT.value,
         result=None,
     )
     assert execution.status == ExecutionStatus.FAILED
+
+
+def test_abort_wait_selects_pending_wait_by_id() -> None:
+    run_id = uuid4()
+    wait_condition = _strict_wait_condition(name="approve_deploy")
+    waiting_run = _DummyRun(
+        status=_paused_status(),
+        flow_name="flow_a",
+        run_id=run_id,
+    )
+    aborted_run = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(waiting_run),
+            _as_pipeline_run(aborted_run),
+        ]
+        client_mock.list_run_wait_conditions.side_effect = [
+            SimpleNamespace(items=[wait_condition]),
+            SimpleNamespace(items=[]),
+        ]
+        client_mock.list_run_steps.return_value = SimpleNamespace(items=[])
+
+        client = KitaruClient()
+        execution = client.executions.abort_wait(
+            str(run_id),
+            wait=str(wait_condition.id),
+        )
+
+    client_mock.resolve_run_wait_condition.assert_called_once_with(
+        run_wait_condition_id=wait_condition.id,
+        resolution=RunWaitConditionResolution.ABORT.value,
+        result=None,
+    )
+    assert execution.status == ExecutionStatus.FAILED
+
+
+def test_abort_wait_rejects_duplicate_pending_wait_names() -> None:
+    wait_one = _strict_wait_condition(name="approve")
+    wait_two = _strict_wait_condition(name="approve")
+    run = _DummyRun(
+        status=_paused_status(),
+        flow_name="flow_a",
+        active_wait_condition=None,
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
+        client_mock.list_run_wait_conditions.return_value = SimpleNamespace(
+            items=[wait_one, wait_two]
+        )
+
+        client = KitaruClient()
+        with pytest.raises(KitaruStateError, match="Multiple pending waits"):
+            client.executions.abort_wait(str(run.id), wait="approve")
+
+    client_mock.resolve_run_wait_condition.assert_not_called()
 
 
 def test_abort_wait_rejects_when_no_pending_waits() -> None:
@@ -3858,11 +4349,17 @@ def test_resume_restarts_paused_execution() -> None:
         run_id=run_id,
         snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
     )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=paused.snapshot,
+    )
     resumed = _DummyRun(
         status=ZenMLExecutionStatus.RUNNING,
         flow_name="flow_a",
         run_id=run_id,
-        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+        snapshot=paused.snapshot,
     )
 
     old_stack_id = uuid4()
@@ -3878,8 +4375,10 @@ def test_resume_restarts_paused_execution() -> None:
         client_mock = client_cls.return_value
         client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
         client_mock.active_stack = active_stack
+        client_mock.zen_store.update_run.side_effect = _updated_run_response(reopening)
         client_mock.get_pipeline_run.side_effect = [
             _as_pipeline_run(paused),
+            _as_pipeline_run(reopening),
             _as_pipeline_run(resumed),
         ]
         client_mock.list_run_wait_conditions.return_value = SimpleNamespace(items=[])
@@ -3888,9 +4387,18 @@ def test_resume_restarts_paused_execution() -> None:
         client = KitaruClient()
         execution = client.executions.resume(str(run_id))
 
+    client_mock.zen_store.update_run.assert_called_once()
+    update_kwargs = client_mock.zen_store.update_run.call_args.kwargs
+    assert update_kwargs["run_id"] == run_id
+    _assert_pipeline_run_update(
+        update_kwargs["run_update"],
+        status=ZenMLExecutionStatus.RESUMING,
+        status_reason=_RESUME_RESUMING_REASON,
+        allow_owner_suffix=True,
+    )
     active_stack.orchestrator.resume_run.assert_called_once_with(
         snapshot=paused.snapshot,
-        run=_as_pipeline_run(paused),
+        run=_as_pipeline_run(reopening),
         stack=active_stack,
     )
     assert client_mock.activate_stack.call_args_list == [
@@ -3946,6 +4454,522 @@ def test_resume_rejects_non_paused_execution() -> None:
         client = KitaruClient()
         with pytest.raises(KitaruStateError, match="Only paused executions"):
             client.executions.resume(str(run.id))
+
+
+def test_retry_rejects_snapshot_stack_without_id_before_reopen() -> None:
+    run_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace()),
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(failed)
+
+        client = KitaruClient()
+        with pytest.raises(KitaruRuntimeError, match="snapshot stack ID is missing"):
+            client.executions.retry(str(run_id))
+
+    client_mock.zen_store.update_run.assert_not_called()
+
+
+def test_retry_reopen_failure_does_not_attempt_rollback() -> None:
+    run_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=uuid4())),
+    )
+    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(failed)
+        client_mock.zen_store.update_run.side_effect = RuntimeError("store offline")
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="Failed to reopen"):
+            client.executions.retry(str(run_id))
+
+    assert client_mock.zen_store.update_run.call_count == 1
+    active_stack.orchestrator.resume_run.assert_not_called()
+    track_mock.assert_not_called()
+
+
+def test_retry_rolls_back_when_stack_activation_fails_after_reopen() -> None:
+    run_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=uuid4())),
+    )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    rolled_back = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(failed),
+            _as_pipeline_run(reopening),
+        ]
+        client_mock.zen_store.update_run.side_effect = _updated_run_responses(
+            reopening,
+            rolled_back,
+        )
+        client_mock.activate_stack.side_effect = RuntimeError("stack offline")
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="stack offline"):
+            client.executions.retry(str(run_id))
+
+    assert client_mock.zen_store.update_run.call_count == 2
+    _assert_update_run_call(
+        client_mock.zen_store.update_run.call_args_list[0],
+        run_id=run_id,
+        status=ZenMLExecutionStatus.RESUMING,
+        status_reason=_RETRY_RESUMING_REASON,
+        allow_owner_suffix=True,
+    )
+    _assert_update_run_call(
+        client_mock.zen_store.update_run.call_args_list[1],
+        run_id=run_id,
+        status=ZenMLExecutionStatus.FAILED,
+        status_reason=_RETRY_ROLLBACK_REASON,
+    )
+    active_stack.orchestrator.resume_run.assert_not_called()
+    track_mock.assert_not_called()
+
+
+def test_retry_rolls_back_when_resume_run_raises_and_run_is_still_owned() -> None:
+    run_id = uuid4()
+    snapshot_stack_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    rolled_back = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(failed),
+            _as_pipeline_run(reopening),
+            _as_pipeline_run(reopening),
+        ]
+        client_mock.zen_store.update_run.side_effect = _updated_run_responses(
+            reopening,
+            rolled_back,
+        )
+        active_stack.orchestrator.resume_run.side_effect = RuntimeError("submit failed")
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="submit failed"):
+            client.executions.retry(str(run_id))
+
+    assert client_mock.zen_store.update_run.call_count == 2
+    _assert_update_run_call(
+        client_mock.zen_store.update_run.call_args_list[1],
+        run_id=run_id,
+        status=ZenMLExecutionStatus.FAILED,
+        status_reason=_RETRY_ROLLBACK_REASON,
+    )
+    active_stack.orchestrator.resume_run.assert_called_once_with(
+        snapshot=failed.snapshot,
+        run=_as_pipeline_run(reopening),
+        stack=active_stack,
+    )
+    track_mock.assert_not_called()
+
+
+def test_resume_does_not_rollback_after_submission_starts() -> None:
+    run_id = uuid4()
+    paused = _DummyRun(
+        status=_paused_status(),
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=uuid4())),
+    )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=paused.snapshot,
+    )
+    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        stolen = _DummyRun(
+            status=ZenMLExecutionStatus.RESUMING,
+            flow_name="flow_a",
+            run_id=run_id,
+            snapshot=paused.snapshot,
+            status_reason=(
+                "Manual resume requested by user. Kitaru restart owner: other"
+            ),
+        )
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(paused),
+            _as_pipeline_run(reopening),
+            _as_pipeline_run(stolen),
+        ]
+        client_mock.list_run_wait_conditions.return_value = SimpleNamespace(items=[])
+        client_mock.zen_store.update_run.side_effect = _updated_run_response(reopening)
+        active_stack.orchestrator.resume_run.side_effect = RuntimeError("submit failed")
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="did not roll the run back"):
+            client.executions.resume(str(run_id))
+
+    client_mock.zen_store.update_run.assert_called_once()
+    active_stack.orchestrator.resume_run.assert_called_once_with(
+        snapshot=paused.snapshot,
+        run=_as_pipeline_run(reopening),
+        stack=active_stack,
+    )
+    track_mock.assert_not_called()
+
+
+def test_retry_stops_before_submission_if_latest_resuming_has_different_owner() -> None:
+    run_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=uuid4())),
+    )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    stolen = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+        status_reason="Retry requested by user. Kitaru restart owner: other",
+    )
+    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(failed),
+            _as_pipeline_run(stolen),
+        ]
+        client_mock.zen_store.update_run.side_effect = _updated_run_response(reopening)
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="runner changed the run"):
+            client.executions.retry(str(run_id))
+
+    client_mock.zen_store.update_run.assert_called_once()
+    active_stack.orchestrator.resume_run.assert_not_called()
+    track_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "latest_status",
+    [
+        ZenMLExecutionStatus.FAILED,
+        ZenMLExecutionStatus.RUNNING,
+        ZenMLExecutionStatus.COMPLETED,
+    ],
+)
+def test_retry_stops_before_submission_if_reopened_run_changes(
+    latest_status: ZenMLExecutionStatus,
+) -> None:
+    run_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=uuid4())),
+    )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    latest = _DummyRun(
+        status=latest_status,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(failed),
+            _as_pipeline_run(latest),
+        ]
+        client_mock.zen_store.update_run.side_effect = _updated_run_response(reopening)
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="runner changed the run"):
+            client.executions.retry(str(run_id))
+
+    client_mock.zen_store.update_run.assert_called_once()
+    active_stack.orchestrator.resume_run.assert_not_called()
+    track_mock.assert_not_called()
+
+
+def test_retry_does_not_rollback_if_latest_run_refresh_fails() -> None:
+    run_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=uuid4())),
+    )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(failed),
+            RuntimeError("refresh offline"),
+        ]
+        client_mock.zen_store.update_run.side_effect = _updated_run_response(reopening)
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError) as exc_info:
+            client.executions.retry(str(run_id))
+
+    message = str(exc_info.value)
+    assert "could not verify the latest run status" in message
+    assert "refresh offline" in message
+    client_mock.zen_store.update_run.assert_called_once()
+    active_stack.orchestrator.resume_run.assert_not_called()
+    track_mock.assert_not_called()
+
+
+def test_retry_does_not_rollback_if_stack_restore_fails_after_submission() -> None:
+    run_id = uuid4()
+    snapshot_stack_id = uuid4()
+    old_stack_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+    )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
+        client_mock.active_stack = active_stack
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(failed),
+            _as_pipeline_run(reopening),
+        ]
+        client_mock.zen_store.update_run.side_effect = _updated_run_response(reopening)
+        client_mock.activate_stack.side_effect = [
+            None,
+            RuntimeError("restore failed"),
+        ]
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="Submitted retry execution"):
+            client.executions.retry(str(run_id))
+
+    active_stack.orchestrator.resume_run.assert_called_once_with(
+        snapshot=failed.snapshot,
+        run=_as_pipeline_run(reopening),
+        stack=active_stack,
+    )
+    client_mock.zen_store.update_run.assert_called_once()
+    assert client_mock.activate_stack.call_args_list == [
+        call(str(snapshot_stack_id)),
+        call(old_stack_id),
+    ]
+    track_mock.assert_not_called()
+
+
+def test_retry_reports_original_and_rollback_errors_when_rollback_fails() -> None:
+    run_id = uuid4()
+    failed = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=SimpleNamespace(stack=SimpleNamespace(id=uuid4())),
+    )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
+    active_stack = SimpleNamespace(orchestrator=SimpleNamespace(resume_run=MagicMock()))
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.track") as track_mock,
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.active_stack_model = SimpleNamespace(id=uuid4())
+        client_mock.active_stack = active_stack
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(failed),
+            _as_pipeline_run(reopening),
+        ]
+        updates: list[ZenMLExecutionStatus] = []
+
+        def _update_run(**kwargs: Any) -> PipelineRunResponse:
+            run_update = kwargs["run_update"]
+            updates.append(run_update.status)
+            if len(updates) == 1:
+                reopening.status = run_update.status
+                reopening.status_reason = run_update.status_reason
+                return _as_pipeline_run(reopening)
+            raise RuntimeError("rollback offline")
+
+        client_mock.zen_store.update_run.side_effect = _update_run
+        client_mock.activate_stack.side_effect = RuntimeError("stack offline")
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError) as exc_info:
+            client.executions.retry(str(run_id))
+
+    message = str(exc_info.value)
+    assert "stack offline" in message
+    assert "rollback offline" in message
+    assert "may remain RESUMING" in message
+    assert client_mock.zen_store.update_run.call_count == 2
+    track_mock.assert_not_called()
+
+
+def test_zenml_status_finished_contract_for_retry_resume() -> None:
+    assert ZenMLExecutionStatus.FAILED.is_finished is True
+    assert ZenMLExecutionStatus.RESUMING.is_finished is False
 
 
 def test_replay_delegates_to_flow_wrapper_when_available() -> None:
@@ -5125,11 +6149,17 @@ def test_retry_emits_execution_retried_event() -> None:
         run_id=run_id,
         snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
     )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=failed.snapshot,
+    )
     retried = _DummyRun(
         status=ZenMLExecutionStatus.RUNNING,
         flow_name="flow_a",
         run_id=run_id,
-        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+        snapshot=failed.snapshot,
     )
 
     old_stack_id = uuid4()
@@ -5146,8 +6176,10 @@ def test_retry_emits_execution_retried_event() -> None:
         client_mock = client_cls.return_value
         client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
         client_mock.active_stack = active_stack
+        client_mock.zen_store.update_run.side_effect = _updated_run_response(reopening)
         client_mock.get_pipeline_run.side_effect = [
             _as_pipeline_run(failed),
+            _as_pipeline_run(reopening),
             _as_pipeline_run(retried),
         ]
         client_mock.list_run_steps.return_value = SimpleNamespace(items=[])
@@ -5172,11 +6204,17 @@ def test_resume_emits_execution_resumed_event() -> None:
         run_id=run_id,
         snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
     )
+    reopening = _DummyRun(
+        status=ZenMLExecutionStatus.RESUMING,
+        flow_name="flow_a",
+        run_id=run_id,
+        snapshot=paused.snapshot,
+    )
     resumed = _DummyRun(
         status=ZenMLExecutionStatus.RUNNING,
         flow_name="flow_a",
         run_id=run_id,
-        snapshot=SimpleNamespace(stack=SimpleNamespace(id=snapshot_stack_id)),
+        snapshot=paused.snapshot,
     )
 
     old_stack_id = uuid4()
@@ -5193,8 +6231,10 @@ def test_resume_emits_execution_resumed_event() -> None:
         client_mock = client_cls.return_value
         client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
         client_mock.active_stack = active_stack
+        client_mock.zen_store.update_run.side_effect = _updated_run_response(reopening)
         client_mock.get_pipeline_run.side_effect = [
             _as_pipeline_run(paused),
+            _as_pipeline_run(reopening),
             _as_pipeline_run(resumed),
         ]
         client_mock.list_run_wait_conditions.return_value = SimpleNamespace(items=[])


### PR DESCRIPTION
## What changed

- Fixed execution retry/resume restart handling so Kitaru reopens failed or paused runs to `RESUMING` before calling ZenML `orchestrator.resume_run(...)`.
- Added ownership-aware restart markers so Kitaru only submits or rolls back a `RESUMING` run if the latest run still belongs to the same Kitaru restart attempt.
- Added deterministic contract coverage for:
  - retry/resume lifecycle transitions and rollback behavior;
  - wait-condition resolution signatures and enum values;
  - deployment discovery/invocation ZenML call shapes;
  - artifact load/reference behavior against strict ZenML-shaped objects;
  - FastMCP registry-visible tool names and representative input schemas.
- Added an `[Unreleased]` changelog entry for the retry/resume fix.

## Why it was needed

`kitaru executions retry` could validate that a run was failed and then ask ZenML to resume that still-failed run. ZenML treats `FAILED` as terminal, so local retries could no-op and server-backed retries could fail during run-scoped token generation. The tests around this path were too mock-heavy: they proved Kitaru called a mocked orchestrator, but not that the run had been moved into the state ZenML expects.

## Key implementation decisions

- Kitaru now writes `RESUMING` via `PipelineRunUpdate` and passes the returned reopened run object to `resume_run(...)`.
- The temporary `status_reason` includes a Kitaru restart owner marker. Before submission or rollback, Kitaru reloads the latest run and checks that the marker is still present. If another process has taken over, Kitaru stops rather than submitting duplicate work or rolling back someone else's restart.
- Contract tests use strict local test objects, installed dependency signature checks, and FastMCP's in-process registry instead of live/server-backed tests.

## Reviewer Notes

The central story is in `src/kitaru/client.py`: retry/resume used to hand ZenML a failed or paused run and trust the orchestrator mock in tests. Now Kitaru changes the run to `RESUMING`, confirms the latest run still carries this Kitaru call's owner marker, and only then submits. If submission preparation fails and the marker still belongs to this call, Kitaru rolls the run back; if the marker changed, Kitaru leaves it alone to avoid corrupting a concurrent restart.

The trickiest part to inspect is the ownership-aware rollback logic around `_restart_run_from_snapshot(...)`. Please check the tests in `tests/test_client.py` that cover: owned rollback after `resume_run(...)` raises, different-owner `RESUMING` no-submit/no-rollback, missing stack ID before mutation, and rollback failure messaging.

The rest of the PR is mostly confidence-building tests. `tests/test_artifacts.py` uses stricter ZenML-shaped objects so missing fields fail loudly. `tests/mcp/test_server.py` checks FastMCP's registered tool names/schemas through `mcp.list_tools()` instead of only calling Python wrappers directly.

### Reproduction

To see the original bug mechanically, read the retry/resume tests around `test_retry_restarts_failed_execution`: the important assertion is that `zen_store.update_run(... status=RESUMING ...)` happens before `orchestrator.resume_run(...)`, and that `resume_run(...)` receives the reopened run object rather than the original failed object.

A reviewer can reproduce the confidence checks locally with:

```bash
just test tests/test_client.py -k "retry or resume"
just test tests/test_artifacts.py
just test tests/mcp/test_server.py
```

Those focused tests should show the concrete behavior this PR protects without needing a live ZenML server or MCP transport process.

### Local checks run

```bash
just check
just test
```

Final full suite result: `2440 passed, 13 skipped`.
