### PR TITLE
Add tests for ZenML and MCP behavior mocks missed

### DIFF
--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -56,9 +57,40 @@ from kitaru.mcp.server import (
     kitaru_status,
     kitaru_stop_local_server,
     manage_stack,
+    mcp,
     tracked_mcp_tool,
 )
 from kitaru.secrets import SecretSummary
+
+_REGISTERED_MCP_TOOL_FUNCTIONS = (
+    kitaru_executions_list,
+    kitaru_executions_statistics,
+    kitaru_executions_get,
+    kitaru_executions_latest,
+    get_execution_logs,
+    kitaru_executions_run,
+    kitaru_deployments_deploy,
+    kitaru_deployments_invoke,
+    kitaru_deployments_list,
+    kitaru_deployments_get,
+    kitaru_deployments_delete,
+    kitaru_deployments_tag,
+    kitaru_deployments_untag,
+    kitaru_executions_cancel,
+    kitaru_executions_input,
+    kitaru_executions_retry,
+    kitaru_executions_replay,
+    kitaru_secrets_create,
+    kitaru_artifacts_list,
+    kitaru_artifacts_get,
+    kitaru_start_local_server,
+    kitaru_stop_local_server,
+    kitaru_status,
+    kitaru_stacks_list,
+    manage_stack,
+    kitaru_info,
+    kitaru_clean_preview,
+)
 
 
 def _write_flow_target_module(path: Path, *, marker: str) -> None:
@@ -79,6 +111,48 @@ def _load_mcp_flow_target(target: str) -> Any:
         target,
         module_name_prefix="_kitaru_mcp_run_target_",
     )
+
+
+def _mcp_tool_schemas_by_name() -> dict[str, dict[str, Any]]:
+    """Return FastMCP input schemas from the in-process registry."""
+    tools = asyncio.run(mcp.list_tools())
+    return {tool.name: tool.inputSchema for tool in tools}
+
+
+def test_fastmcp_registers_public_tools_with_expected_input_schemas() -> None:
+    tool_schemas = _mcp_tool_schemas_by_name()
+    expected_names = {func.__name__ for func in _REGISTERED_MCP_TOOL_FUNCTIONS}
+
+    assert expected_names <= set(tool_schemas)
+    assert "_wrapper" not in tool_schemas
+
+    input_schema = tool_schemas["kitaru_executions_input"]
+    assert set(input_schema["properties"]) == {"exec_id", "wait", "value"}
+    assert input_schema["required"] == ["exec_id", "wait", "value"]
+
+    invoke_schema = tool_schemas["kitaru_deployments_invoke"]
+    assert set(invoke_schema["properties"]) == {
+        "flow",
+        "version",
+        "tag",
+        "inputs",
+    }
+    assert invoke_schema["required"] == ["flow"]
+    assert invoke_schema["properties"]["version"]["default"] is None
+    assert invoke_schema["properties"]["tag"]["default"] is None
+    assert invoke_schema["properties"]["inputs"]["default"] is None
+
+    stack_schema = tool_schemas["manage_stack"]
+    assert {"action", "name"}.issubset(stack_schema["properties"])
+    assert stack_schema["required"] == ["action", "name"]
+    assert stack_schema["properties"]["action"]["enum"] == ["create", "delete"]
+    assert stack_schema["properties"]["stack_type"]["default"] == "local"
+    assert stack_schema["properties"]["activate"]["default"] is True
+    assert stack_schema["properties"]["recursive"]["default"] is False
+    assert stack_schema["properties"]["force"]["default"] is False
+    assert stack_schema["properties"]["async_mode"]["default"] is False
+    assert stack_schema["properties"]["verify"]["default"] is True
+    assert "extra" in stack_schema["properties"]
 
 
 def test_load_flow_target_supports_module_paths(

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
 from zenml.enums import ArtifactSaveType, ArtifactType
 
+from kitaru._client._mappers import _map_artifact_ref
 from kitaru.artifacts import _parse_scope_uuid, load, save
 from kitaru.errors import (
     KitaruContextError,
@@ -18,15 +21,90 @@ from kitaru.errors import (
 )
 from kitaru.runtime import _checkpoint_scope, _flow_scope
 
+if TYPE_CHECKING:
+    from zenml.models.v2.core.artifact_version import ArtifactVersionResponse
+
+    from kitaru.client import KitaruClient
+
+
+@dataclass(slots=True)
+class _StrictArtifactVersion:
+    """Minimal ZenML artifact-version shape read by artifact contracts."""
+
+    id: UUID
+    name: str
+    save_type: ArtifactSaveType
+    run_metadata: dict[str, Any] = field(default_factory=dict)
+    producer_step_run_id: UUID | None = None
+
+
+@dataclass(slots=True)
+class _StrictHydratedArtifactVersion:
+    """Hydrated artifact-version shape returned before materialization."""
+
+    value: Any
+    load_call_count: int = 0
+
+    def load(self) -> Any:
+        """Materialize the stored artifact value."""
+        self.load_call_count += 1
+        return self.value
+
+
+@dataclass(slots=True)
+class _StrictStepRun:
+    """Minimal hydrated step-run shape used by `kitaru.load()`."""
+
+    outputs: dict[str, list[_StrictArtifactVersion]]
+
+
+@dataclass(slots=True)
+class _StrictHydratedRun:
+    """Minimal hydrated run shape used by `kitaru.load()`."""
+
+    id: UUID
+    steps: dict[str, _StrictStepRun]
+
+
+@dataclass(slots=True)
+class _StrictRunResponse:
+    """Pipeline-run response that proves hydration is explicitly requested."""
+
+    hydrated_run: _StrictHydratedRun
+    hydration_count: int = 0
+
+    def get_hydrated_version(self) -> _StrictHydratedRun:
+        """Return the hydrated run and record that Kitaru required it."""
+        self.hydration_count += 1
+        return self.hydrated_run
+
+
+@dataclass(slots=True)
+class _StrictKitaruClient:
+    """Minimal Kitaru client shape used by `ArtifactRef.load()`."""
+
+    hydrated_artifact: _StrictHydratedArtifactVersion
+    artifact_version_calls: list[tuple[str, bool]] = field(default_factory=list)
+
+    def _get_artifact_version(
+        self,
+        artifact_id: str,
+        *,
+        hydrate: bool,
+    ) -> _StrictHydratedArtifactVersion:
+        """Record artifact-version fetches and return a hydrated artifact."""
+        self.artifact_version_calls.append((artifact_id, hydrate))
+        return self.hydrated_artifact
+
 
 def _artifact(
     *,
     name: str,
     save_type: ArtifactSaveType,
     artifact_id: UUID | None = None,
-) -> SimpleNamespace:
-    """Create a lightweight artifact-like object for tests."""
-    return SimpleNamespace(
+) -> _StrictArtifactVersion:
+    """Create a strict artifact-like object for tests."""
+    return _StrictArtifactVersion(
         id=artifact_id or uuid4(),
         name=name,
         save_type=save_type,
@@ -35,13 +113,13 @@ def _artifact(
 
 def _hydrated_run(
     *,
-    step_outputs: dict[str, dict[str, list[SimpleNamespace]]],
-) -> SimpleNamespace:
-    """Create a lightweight hydrated run-like object for tests."""
-    return SimpleNamespace(
+    step_outputs: dict[str, dict[str, list[_StrictArtifactVersion]]],
+) -> _StrictHydratedRun:
+    """Create a strict hydrated run-like object for tests."""
+    return _StrictHydratedRun(
         id=uuid4(),
         steps={
-            step_name: SimpleNamespace(outputs=outputs)
+            step_name: _StrictStepRun(outputs=outputs)
             for step_name, outputs in step_outputs.items()
         },
     )
@@ -236,11 +314,8 @@ def test_load_resolves_manual_saved_artifact_by_name() -> None:
         }
     )
 
-    run_response = MagicMock()
-    run_response.get_hydrated_version.return_value = hydrated_run
-
-    loaded_artifact = MagicMock()
-    loaded_artifact.load.return_value = {"topic": "kitaru"}
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value={"topic": "kitaru"})
 
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = run_response
@@ -267,6 +342,8 @@ def test_load_resolves_manual_saved_artifact_by_name() -> None:
         manual_artifact.id,
         hydrate=True,
     )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
 
 
 def test_load_resolves_checkpoint_output_by_checkpoint_name() -> None:
@@ -284,11 +361,8 @@ def test_load_resolves_checkpoint_output_by_checkpoint_name() -> None:
         }
     )
 
-    run_response = MagicMock()
-    run_response.get_hydrated_version.return_value = hydrated_run
-
-    loaded_artifact = MagicMock()
-    loaded_artifact.load.return_value = "notes"
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value="notes")
 
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = run_response
@@ -311,9 +385,54 @@ def test_load_resolves_checkpoint_output_by_checkpoint_name() -> None:
         step_output_artifact.id,
         hydrate=True,
     )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
 
 
-def test_load_resolves_checkpoint_output_by_step_name() -> None:
+def test_load_resolves_checkpoint_output_by_artifact_name() -> None:
+    execution_id, checkpoint_id = _scope_ids()
+
+    step_output_artifact = _artifact(
+        name="research_summary",
+        save_type=ArtifactSaveType.STEP_OUTPUT,
+    )
+    hydrated_run = _hydrated_run(
+        step_outputs={
+            "research": {
+                "output": [step_output_artifact],
+            }
+        }
+    )
+
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value="named notes")
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = run_response
+    client_mock.get_artifact_version.return_value = loaded_artifact
+
+    with (
+        _flow_scope(name="flow", execution_id=execution_id),
+        _checkpoint_scope(
+            name="reader",
+            checkpoint_type=None,
+            execution_id=execution_id,
+            checkpoint_id=checkpoint_id,
+        ),
+        patch("kitaru.artifacts.Client", return_value=client_mock),
+    ):
+        value = load(str(uuid4()), "research_summary")
+
+    assert value == "named notes"
+    client_mock.get_artifact_version.assert_called_once_with(
+        step_output_artifact.id,
+        hydrate=True,
+    )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
+
+
+def test_load_resolves_checkpoint_output_by_raw_step_name() -> None:
     execution_id, checkpoint_id = _scope_ids()
 
     step_output_artifact = _artifact(
@@ -328,11 +447,8 @@ def test_load_resolves_checkpoint_output_by_step_name() -> None:
         }
     )
 
-    run_response = MagicMock()
-    run_response.get_hydrated_version.return_value = hydrated_run
-
-    loaded_artifact = MagicMock()
-    loaded_artifact.load.return_value = "notes"
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value="notes")
 
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = run_response
@@ -351,6 +467,106 @@ def test_load_resolves_checkpoint_output_by_step_name() -> None:
         value = load(str(uuid4()), "research")
 
     assert value == "notes"
+    client_mock.get_artifact_version.assert_called_once_with(
+        step_output_artifact.id,
+        hydrate=True,
+    )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
+
+
+def test_load_resolves_checkpoint_output_by_normalized_checkpoint_name() -> None:
+    execution_id, checkpoint_id = _scope_ids()
+
+    step_output_artifact = _artifact(
+        name="output",
+        save_type=ArtifactSaveType.STEP_OUTPUT,
+    )
+    hydrated_run = _hydrated_run(
+        step_outputs={
+            "__kitaru_checkpoint_source_research": {
+                "output": [step_output_artifact],
+            }
+        }
+    )
+
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value="notes")
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = run_response
+    client_mock.get_artifact_version.return_value = loaded_artifact
+
+    with (
+        _flow_scope(name="flow", execution_id=execution_id),
+        _checkpoint_scope(
+            name="reader",
+            checkpoint_type=None,
+            execution_id=execution_id,
+            checkpoint_id=checkpoint_id,
+        ),
+        patch("kitaru.artifacts.Client", return_value=client_mock),
+    ):
+        value = load(str(uuid4()), "research")
+
+    assert value == "notes"
+    client_mock.get_artifact_version.assert_called_once_with(
+        step_output_artifact.id,
+        hydrate=True,
+    )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
+
+
+def test_load_deduplicates_repeated_artifact_ids() -> None:
+    execution_id, checkpoint_id = _scope_ids()
+    repeated_artifact_id = uuid4()
+
+    first_reference = _artifact(
+        name="shared",
+        save_type=ArtifactSaveType.MANUAL,
+        artifact_id=repeated_artifact_id,
+    )
+    second_reference = _artifact(
+        name="shared",
+        save_type=ArtifactSaveType.MANUAL,
+        artifact_id=repeated_artifact_id,
+    )
+    hydrated_run = _hydrated_run(
+        step_outputs={
+            "research": {
+                "first": [first_reference],
+                "second": [second_reference],
+            },
+        }
+    )
+
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
+    loaded_artifact = _StrictHydratedArtifactVersion(value={"shared": True})
+
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = run_response
+    client_mock.get_artifact_version.return_value = loaded_artifact
+
+    with (
+        _flow_scope(name="flow", execution_id=execution_id),
+        _checkpoint_scope(
+            name="reader",
+            checkpoint_type=None,
+            execution_id=execution_id,
+            checkpoint_id=checkpoint_id,
+        ),
+        patch("kitaru.artifacts.Client", return_value=client_mock),
+    ):
+        value = load(str(uuid4()), "shared")
+
+    assert value == {"shared": True}
+    client_mock.get_artifact_version.assert_called_once_with(
+        repeated_artifact_id,
+        hydrate=True,
+    )
+    assert run_response.hydration_count == 1
+    assert loaded_artifact.load_call_count == 1
 
 
 def test_load_raises_when_name_is_not_found() -> None:
@@ -369,8 +585,7 @@ def test_load_raises_when_name_is_not_found() -> None:
         }
     )
 
-    run_response = MagicMock()
-    run_response.get_hydrated_version.return_value = hydrated_run
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
 
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = run_response
@@ -387,6 +602,9 @@ def test_load_raises_when_name_is_not_found() -> None:
         pytest.raises(KitaruRuntimeError, match="No artifact named"),
     ):
         load(str(uuid4()), "research_context")
+
+    assert run_response.hydration_count == 1
+    client_mock.get_artifact_version.assert_not_called()
 
 
 def test_load_raises_on_ambiguous_matches() -> None:
@@ -414,8 +632,7 @@ def test_load_raises_on_ambiguous_matches() -> None:
         }
     )
 
-    run_response = MagicMock()
-    run_response.get_hydrated_version.return_value = hydrated_run
+    run_response = _StrictRunResponse(hydrated_run=hydrated_run)
 
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = run_response
@@ -432,3 +649,111 @@ def test_load_raises_on_ambiguous_matches() -> None:
         pytest.raises(KitaruRuntimeError, match="Multiple artifacts named"),
     ):
         load(str(uuid4()), duplicate_name)
+
+    assert run_response.hydration_count == 1
+    client_mock.get_artifact_version.assert_not_called()
+
+
+def test_map_artifact_ref_and_ref_load_use_strict_artifact_contract() -> None:
+    artifact_id = uuid4()
+    producer_step_run_id = uuid4()
+    artifact = _StrictArtifactVersion(
+        id=artifact_id,
+        name="research_context",
+        save_type=ArtifactSaveType.MANUAL,
+        run_metadata={
+            "kitaru_artifact_type": "context",
+            "reviewed": True,
+        },
+        producer_step_run_id=producer_step_run_id,
+    )
+    hydrated_artifact = _StrictHydratedArtifactVersion(
+        value={"topic": "kitaru"},
+    )
+    client = _StrictKitaruClient(hydrated_artifact=hydrated_artifact)
+
+    artifact_ref = _map_artifact_ref(
+        artifact=cast("ArtifactVersionResponse", artifact),
+        client=cast("KitaruClient", client),
+        producing_call="research",
+    )
+
+    assert artifact_ref.artifact_id == str(artifact_id)
+    assert artifact_ref.name == "research_context"
+    assert artifact_ref.kind == "context"
+    assert artifact_ref.save_type == ArtifactSaveType.MANUAL.value
+    assert artifact_ref.producing_call == "research"
+    assert artifact_ref.metadata == {
+        "kitaru_artifact_type": "context",
+        "reviewed": True,
+    }
+
+    assert artifact_ref.load() == {"topic": "kitaru"}
+    assert client.artifact_version_calls == [(str(artifact_id), True)]
+    assert hydrated_artifact.load_call_count == 1
+
+
+def test_flow_with_artifacts_example_checkpoint_bodies_are_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from examples.features.basic_flow import flow_with_artifacts
+
+    save_calls: list[dict[str, Any]] = []
+    load_calls: list[tuple[str, str]] = []
+
+    def fake_save(
+        name: str,
+        value: Any,
+        *,
+        type: str = "output",
+        tags: list[str] | None = None,
+    ) -> None:
+        save_calls.append(
+            {
+                "name": name,
+                "value": value,
+                "type": type,
+                "tags": tags,
+            }
+        )
+
+    def fake_load(exec_id: str, name: str) -> Any:
+        load_calls.append((exec_id, name))
+        if name == "research":
+            return "Research notes about kitaru."
+        if name == "research_context":
+            return {"topic": "kitaru"}
+        raise AssertionError(f"Unexpected artifact load: {name}")
+
+    monkeypatch.setattr(flow_with_artifacts.kitaru, "save", fake_save)
+    monkeypatch.setattr(flow_with_artifacts.kitaru, "load", fake_load)
+
+    research_body = cast(
+        Callable[[str], str],
+        cast(Any, flow_with_artifacts.research).__wrapped__,
+    )
+    follow_up_body = cast(
+        Callable[[str], str],
+        cast(Any, flow_with_artifacts.follow_up_from_previous).__wrapped__,
+    )
+
+    assert research_body("kitaru") == "Research notes about kitaru."
+    assert save_calls == [
+        {
+            "name": "research_context",
+            "value": {
+                "topic": "kitaru",
+                "notes": "Research notes about kitaru.",
+            },
+            "type": "context",
+            "tags": None,
+        }
+    ]
+
+    assert follow_up_body("previous-exec-id") == (
+        "Research notes about kitaru. [topic=kitaru]"
+    )
+    assert load_calls == [
+        ("previous-exec-id", "research"),
+        ("previous-exec-id", "research_context"),
+    ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from importlib.machinery import ModuleSpec
 from pathlib import Path
@@ -15,7 +17,8 @@ from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
 from uuid import UUID, uuid4
 
 import pytest
-from zenml.enums import ArtifactSaveType, StackComponentType
+from zenml.client import Client as ZenMLClient
+from zenml.enums import ArtifactSaveType, RunWaitConditionResolution, StackComponentType
 from zenml.enums import ExecutionStatus as ZenMLExecutionStatus
 from zenml.exceptions import EntityExistsError
 from zenml.models import PipelineRunResponse, StepRunResponse
@@ -6333,3 +6336,399 @@ def test_abort_wait_emits_wait_resolved_event() -> None:
             "resolution": "abort",
         },
     )
+
+
+# Contract-test strict objects kept separate from the looser dummy helpers above.
+# They intentionally expose only the fields Kitaru reads from ZenML-shaped objects.
+@dataclass(slots=True)
+class _StrictTag:
+    name: str
+
+
+@dataclass(slots=True)
+class _StrictStack:
+    name: str | None = None
+    id: str | None = None
+
+
+@dataclass(slots=True)
+class _StrictSnapshotResources:
+    tags: list[Any]
+    stack: Any | None = None
+
+
+@dataclass(slots=True)
+class _StrictSnapshot:
+    id: UUID
+    name: str
+    tags: list[Any] | None = None
+    resources: _StrictSnapshotResources | None = None
+    metadata: dict[str, Any] | None = None
+    run_metadata: dict[str, Any] | None = None
+    stack: Any | None = None
+    build: Any | None = None
+    body: Any | None = None
+    kitaru_deployment: dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class _StrictWaitCondition:
+    id: UUID
+    name: str
+    question: str | None = None
+    data_schema: dict[str, Any] | None = None
+    run_metadata: dict[str, Any] | None = None
+    created: datetime | None = None
+
+
+def _strict_wait_condition(
+    *,
+    name: str,
+    wait_id: UUID | None = None,
+    question: str | None = None,
+    data_schema: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> _StrictWaitCondition:
+    return _StrictWaitCondition(
+        id=wait_id or uuid4(),
+        name=name,
+        question=question,
+        data_schema=data_schema,
+        run_metadata=metadata or {},
+    )
+
+
+def test_deployment_snapshot_mapping_contract_sources() -> None:
+    direct_tags_snapshot = _StrictSnapshot(
+        id=uuid4(),
+        name="kitaru::direct_tags::v1",
+        tags=[
+            deployment_public_tag("stable", exclusive=True),
+            _StrictTag(deployment_public_tag("canary", exclusive=False)),
+        ],
+        resources=_StrictSnapshotResources(tags=[], stack=None),
+        metadata={
+            "kitaru_deployment": {
+                "commit_sha": "abc123",
+                "commit_dirty": "true",
+            },
+            "config_schema": {"type": "object", "properties": {"x": {}}},
+        },
+        stack=_StrictStack(name="direct-stack"),
+    )
+    direct_tags = map_deployment_snapshot(direct_tags_snapshot)
+
+    assert direct_tags is not None
+    assert direct_tags.tags == {"stable": True, "canary": False}
+    assert direct_tags.commit_sha == "abc123"
+    assert direct_tags.commit_dirty is True
+    assert direct_tags.schema == {"type": "object", "properties": {"x": {}}}
+    assert direct_tags.stack == "direct-stack"
+
+    resources_snapshot = _StrictSnapshot(
+        id=uuid4(),
+        name="kitaru::resources_tags::v2",
+        resources=_StrictSnapshotResources(
+            tags=[_StrictTag(deployment_public_tag("blue", exclusive=False))],
+            stack=_StrictStack(id="resource-stack-id"),
+        ),
+    )
+    resources_deployment = map_deployment_snapshot(resources_snapshot)
+
+    assert resources_deployment is not None
+    assert resources_deployment.tags == {"blue": False}
+    assert resources_deployment.stack == "resource-stack-id"
+
+    run_metadata_snapshot = _StrictSnapshot(
+        id=uuid4(),
+        name="kitaru::run_metadata::v3",
+        resources=_StrictSnapshotResources(tags=[], stack=None),
+        run_metadata={
+            "kitaru_deployment": {
+                "image_digest": "sha256:feed",
+                "stack": "metadata-stack",
+            }
+        },
+    )
+    run_metadata_deployment = map_deployment_snapshot(run_metadata_snapshot)
+
+    assert run_metadata_deployment is not None
+    assert run_metadata_deployment.image_digest == "sha256:feed"
+    assert run_metadata_deployment.stack == "metadata-stack"
+
+
+def test_deployments_list_snapshots_contract_and_pagination() -> None:
+    first_page = [
+        _StrictSnapshot(id=uuid4(), name=f"kitaru::flow::v{i}") for i in range(100)
+    ]
+    second_page = [_StrictSnapshot(id=uuid4(), name="kitaru::flow::v101")]
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(project="proj"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_snapshots.side_effect = [
+            SimpleNamespace(items=first_page),
+            SimpleNamespace(items=second_page),
+        ]
+
+        client = KitaruClient()
+        snapshots = client.deployments._list_snapshots()
+
+    assert snapshots == [*first_page, *second_page]
+    assert client_mock.list_snapshots.call_args_list == [
+        call(
+            sort_by="asc:created",
+            page=1,
+            size=100,
+            project="proj",
+            named_only=True,
+            hydrate=True,
+        ),
+        call(
+            sort_by="asc:created",
+            page=2,
+            size=100,
+            project="proj",
+            named_only=True,
+            hydrate=True,
+        ),
+    ]
+
+
+def test_zenml_trigger_pipeline_signature_accepts_kitaru_kwargs() -> None:
+    parameters = inspect.signature(ZenMLClient.trigger_pipeline).parameters
+
+    assert "snapshot_name_or_id" in parameters
+    assert "run_configuration" in parameters
+    assert "project" in parameters
+    assert "synchronous" in parameters
+
+
+def test_deployments_invoke_without_inputs_sends_no_run_configuration() -> None:
+    run = _as_pipeline_run(
+        _DummyRun(status=ZenMLExecutionStatus.RUNNING, flow_name="research_flow")
+    )
+    snapshot = _DummySnapshot(
+        name="kitaru::research_flow::v1",
+        tags=[deployment_public_tag("default", exclusive=True)],
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(project="proj"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch("kitaru.client.ensure_stack_is_server_runnable"),
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_snapshots.return_value = SimpleNamespace(items=[snapshot])
+        client_mock.get_snapshot.return_value = snapshot
+        client_mock.trigger_pipeline.return_value = run
+
+        client = KitaruClient()
+        handle = client.deployments.invoke(flow="research_flow", version=1)
+
+    assert handle.exec_id == str(run.id)
+    client_mock.trigger_pipeline.assert_called_once_with(
+        snapshot_name_or_id=str(snapshot.id),
+        run_configuration=None,
+        project="proj",
+        synchronous=False,
+    )
+
+
+def test_deployments_invoke_rejects_missing_pipeline_run_response() -> None:
+    snapshot = _DummySnapshot(
+        name="kitaru::research_flow::v1",
+        tags=[deployment_public_tag("default", exclusive=True)],
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(project="proj"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch("kitaru.client.ensure_stack_is_server_runnable"),
+    ):
+        client_mock = client_cls.return_value
+        client_mock.list_snapshots.return_value = SimpleNamespace(items=[snapshot])
+        client_mock.get_snapshot.return_value = snapshot
+        client_mock.trigger_pipeline.return_value = None
+
+        client = KitaruClient()
+        with pytest.raises(KitaruBackendError, match="did not produce"):
+            client.deployments.invoke(flow="research_flow", version=1)
+
+
+def test_input_selects_pending_wait_by_id() -> None:
+    run_id = uuid4()
+    wait_condition = _strict_wait_condition(name="approve_deploy")
+    waiting_run = _DummyRun(
+        status=_paused_status(),
+        flow_name="flow_a",
+        run_id=run_id,
+        active_wait_condition=None,
+    )
+    resumed_run = _DummyRun(
+        status=ZenMLExecutionStatus.RUNNING,
+        flow_name="flow_a",
+        run_id=run_id,
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(waiting_run),
+            _as_pipeline_run(resumed_run),
+        ]
+        client_mock.list_run_wait_conditions.side_effect = [
+            SimpleNamespace(items=[wait_condition]),
+            SimpleNamespace(items=[]),
+        ]
+        client_mock.list_run_steps.return_value = SimpleNamespace(items=[])
+
+        client = KitaruClient()
+        execution = client.executions.input(
+            str(run_id),
+            wait=str(wait_condition.id),
+            value={"approved": True},
+        )
+
+    client_mock.resolve_run_wait_condition.assert_called_once_with(
+        run_wait_condition_id=wait_condition.id,
+        resolution=RunWaitConditionResolution.CONTINUE.value,
+        result={"approved": True},
+    )
+    assert execution.status == ExecutionStatus.RUNNING
+
+
+def test_input_rejects_duplicate_pending_wait_names() -> None:
+    wait_one = _strict_wait_condition(name="approve")
+    wait_two = _strict_wait_condition(name="approve")
+    run = _DummyRun(
+        status=_paused_status(),
+        flow_name="flow_a",
+        active_wait_condition=None,
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
+        client_mock.list_run_wait_conditions.return_value = SimpleNamespace(
+            items=[wait_one, wait_two]
+        )
+
+        client = KitaruClient()
+        with pytest.raises(KitaruStateError, match="Multiple pending waits"):
+            client.executions.input(str(run.id), wait="approve", value=True)
+
+    client_mock.resolve_run_wait_condition.assert_not_called()
+
+
+def test_zenml_wait_resolution_signature_accepts_kitaru_kwargs() -> None:
+    parameters = inspect.signature(ZenMLClient.resolve_run_wait_condition).parameters
+
+    assert "run_wait_condition_id" in parameters
+    assert "resolution" in parameters
+    assert "result" in parameters
+    assert RunWaitConditionResolution.CONTINUE.value == "continue"
+    assert RunWaitConditionResolution.ABORT.value == "abort"
+
+
+def test_abort_wait_selects_pending_wait_by_id() -> None:
+    run_id = uuid4()
+    wait_condition = _strict_wait_condition(name="approve_deploy")
+    waiting_run = _DummyRun(
+        status=_paused_status(),
+        flow_name="flow_a",
+        run_id=run_id,
+    )
+    aborted_run = _DummyRun(
+        status=ZenMLExecutionStatus.FAILED,
+        flow_name="flow_a",
+        run_id=run_id,
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.side_effect = [
+            _as_pipeline_run(waiting_run),
+            _as_pipeline_run(aborted_run),
+        ]
+        client_mock.list_run_wait_conditions.side_effect = [
+            SimpleNamespace(items=[wait_condition]),
+            SimpleNamespace(items=[]),
+        ]
+        client_mock.list_run_steps.return_value = SimpleNamespace(items=[])
+
+        client = KitaruClient()
+        execution = client.executions.abort_wait(
+            str(run_id),
+            wait=str(wait_condition.id),
+        )
+
+    client_mock.resolve_run_wait_condition.assert_called_once_with(
+        run_wait_condition_id=wait_condition.id,
+        resolution=RunWaitConditionResolution.ABORT.value,
+        result=None,
+    )
+    assert execution.status == ExecutionStatus.FAILED
+
+
+def test_abort_wait_rejects_duplicate_pending_wait_names() -> None:
+    wait_one = _strict_wait_condition(name="approve")
+    wait_two = _strict_wait_condition(name="approve")
+    run = _DummyRun(
+        status=_paused_status(),
+        flow_name="flow_a",
+        active_wait_condition=None,
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
+        client_mock.list_run_wait_conditions.return_value = SimpleNamespace(
+            items=[wait_one, wait_two]
+        )
+
+        client = KitaruClient()
+        with pytest.raises(KitaruStateError, match="Multiple pending waits"):
+            client.executions.abort_wait(str(run.id), wait="approve")
+
+    client_mock.resolve_run_wait_condition.assert_not_called()
+
+
+def test_zenml_status_finished_contract_for_retry_resume() -> None:
+    assert ZenMLExecutionStatus.FAILED.is_finished is True
+    assert ZenMLExecutionStatus.RESUMING.is_finished is False


### PR DESCRIPTION
## What changed

This PR adds tests for places where our current tests could look green while real Kitaru behavior is broken.

The retry/resume bug in #442 showed the problem clearly: the test mocked ZenML, Kitaru called the mock, and the mock returned a happy-looking run. But real ZenML needed the run to be moved from `FAILED` or `PAUSED` to `RESUMING` first. The test was checking that we called something, not that we satisfied ZenML's actual contract.

This PR adds that kind of protection around a few similar areas:

- artifact loading and artifact references;
- deployment listing, mapping, and invocation;
- wait-condition input/abort calls;
- MCP tool registration and input schemas.

No production code changes are included here. #442 owns the retry/resume fix itself.

## Why it was needed

The main risk is false confidence.

A permissive mock can accidentally say, "yes, this works," even when the real dependency would say, "no, this object is missing a field," "that keyword changed," or "that tool was never registered under that name."

These tests try to catch those mistakes earlier by using stricter fake objects, real installed dependency signatures/enums, and FastMCP's in-process tool registry.

## Key implementation decisions

- Keep this PR tests-only.
- Use small strict dataclasses in artifact tests so Kitaru only gets the fields it actually reads.
- Add ZenML signature/value checks where Kitaru depends on specific kwargs or enum values.
- Use `mcp.list_tools()` to check FastMCP registration instead of starting a subprocess or adding live transport tests.

## Reviewer Notes

The most important thing to review is whether these tests protect real contracts without becoming fake ZenML implementations.

A concrete example: in `tests/test_artifacts.py`, the strict objects intentionally expose only the fields Kitaru reads. If Kitaru starts reading a new field, the test should fail loudly. But those objects should not grow into full copies of ZenML models.

In `tests/test_client.py`, the new tests check deployment and wait-condition calls against the shapes and keyword names Kitaru depends on. They should complement #442's retry/resume tests, not replace them.

In `tests/mcp/test_server.py`, the new test checks that FastMCP actually sees the registered tool names and representative input schemas. This catches the case where direct Python wrapper tests pass, but the MCP server would expose the wrong thing to clients.

### Reproduction

Focused checks:

```bash
just test tests/test_artifacts.py
just test tests/test_client.py -k "deployment_snapshot_mapping_contract_sources or deployments_list_snapshots_contract_and_pagination or zenml_trigger_pipeline_signature_accepts_kitaru_kwargs or deployments_invoke_without_inputs_sends_no_run_configuration or deployments_invoke_rejects_missing_pipeline_run_response or input_selects_pending_wait_by_id or input_rejects_duplicate_pending_wait_names or zenml_wait_resolution_signature_accepts_kitaru_kwargs or abort_wait_selects_pending_wait_by_id or abort_wait_rejects_duplicate_pending_wait_names or zenml_status_finished_contract_for_retry_resume"
just test tests/mcp/test_server.py
```

Those focused tests show the behavior this PR protects without needing a live ZenML server or MCP transport process.

### Local checks run

```bash
just check
just test
```

Final full suite result: `2473 passed, 13 skipped`.
