### PR TITLE
Preserve LangGraph tool calls after checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - Added a LangGraph runner convenience API so fresh `invoke`, `ainvoke`, `stream`, and `astream` calls can pass raw graph input with `thread_id=...` instead of manually building `LangGraphRunRequest.start(...)`, while keeping request objects as the resume and advanced path. (#455)
 
+### Fixed
+- Fixed LangGraph calls-mode checkpoints so tool calls survive model-call materialization and LangGraph routes to tools correctly. (#458)
+
 ### Security
 - Bumped audited dependency locks (`langsmith`, `msgpack`, `pydantic-settings`) to clear advisories flagged against the earlier pinned versions. (#455)
 

--- a/src/kitaru/adapters/langgraph/langchain.py
+++ b/src/kitaru/adapters/langgraph/langchain.py
@@ -20,6 +20,11 @@ except ModuleNotFoundError as exc:  # pragma: no cover - import guard only
 
 try:
     from langchain.agents.middleware import AgentMiddleware
+    from langchain_core.messages import (
+        BaseMessage,
+        messages_from_dict,
+        messages_to_dict,
+    )
 except ImportError as exc:  # pragma: no cover - exercised via import-guard tests
     raise ImportError(
         "LangChain is installed, but Kitaru could not import "
@@ -63,6 +68,18 @@ from ._utils import (
 )
 
 CheckpointMode = Literal["true", "metadata_only"]
+
+_MODEL_RESPONSE_CHECKPOINT_ENVELOPE_SCHEMA = (
+    "kitaru.langgraph.langchain.model_response_checkpoint.v1"
+)
+_MODEL_RESPONSE_CHECKPOINT_SCHEMA_KEY = "schema"
+_MODEL_RESPONSE_CHECKPOINT_RESPONSE_KEY = "response"
+_MODEL_RESPONSE_CHECKPOINT_MESSAGES_KEY = "messages"
+_MODEL_RESPONSE_CHECKPOINT_TARGET_KEY = "target"
+_MODEL_RESPONSE_CHECKPOINT_RESULT_IS_SEQUENCE_KEY = "result_is_sequence"
+_MODEL_RESPONSE_CHECKPOINT_RESULT_TARGET = "result"
+_MODEL_RESPONSE_CHECKPOINT_RESPONSE_TARGET = "response"
+ModelResponseCheckpointTarget = Literal["result", "response"]
 
 
 class KitaruLangGraphMiddleware(AgentMiddleware):
@@ -133,7 +150,7 @@ class KitaruLangGraphMiddleware(AgentMiddleware):
                     input_artifacts=input_artifacts,
                     output_artifacts=output_artifacts,
                 ):
-                    return self._tracked_model_call(
+                    response = self._tracked_model_call(
                         request,
                         handler,
                         capture=capture,
@@ -144,8 +161,9 @@ class KitaruLangGraphMiddleware(AgentMiddleware):
                         checkpoint_name=checkpoint_name,
                         model_input=model_input,
                     )
+                    return _model_response_checkpoint_envelope(response)
 
-            return run_sync_in_checkpoint(
+            checkpoint_output = run_sync_in_checkpoint(
                 config=effective_config,
                 step_name=checkpoint_name,
                 body=_in_checkpoint,
@@ -155,6 +173,7 @@ class KitaruLangGraphMiddleware(AgentMiddleware):
                 ),
                 checkpoint_inputs=checkpoint_inputs,
             )
+            return _restore_model_response_checkpoint_output(checkpoint_output)
 
         return self._tracked_model_call(
             request,
@@ -592,6 +611,9 @@ def _model_cache_key(request: Any, *, enabled: bool) -> str | None:
             "adapter": "langgraph",
             "integration": "langchain",
             "kind": "model_call",
+            "model_response_checkpoint_schema": (
+                _MODEL_RESPONSE_CHECKPOINT_ENVELOPE_SCHEMA
+            ),
             "model": _model_identity(request),
             "input": _model_cache_identity_envelope(request),
         }
@@ -1027,13 +1049,197 @@ def _tool_call_ids_from_messages(messages: list[Any]) -> list[str]:
     return ids
 
 
-def _model_response_messages(response: Any) -> list[Any]:
+def _model_response_checkpoint_envelope(response: Any) -> dict[str, Any]:
+    """Return a checkpoint-safe wrapper for LangChain model responses."""
+    payload: dict[str, Any] = {
+        _MODEL_RESPONSE_CHECKPOINT_SCHEMA_KEY: (
+            _MODEL_RESPONSE_CHECKPOINT_ENVELOPE_SCHEMA
+        ),
+        _MODEL_RESPONSE_CHECKPOINT_RESPONSE_KEY: response,
+    }
+    message_payload = _model_response_message_payload(response)
+    if message_payload is not None:
+        payload[_MODEL_RESPONSE_CHECKPOINT_MESSAGES_KEY] = message_payload
+    return payload
+
+
+def _model_response_message_payload(response: Any) -> dict[str, Any] | None:
+    result_ref = _model_response_result_ref(response)
+    if result_ref is not None:
+        _owner, result = result_ref
+        if isinstance(result, list | tuple) and _all_langchain_messages(result):
+            return _model_response_messages_payload(
+                target=_MODEL_RESPONSE_CHECKPOINT_RESULT_TARGET,
+                result_is_sequence=True,
+                messages=list(result),
+            )
+        if isinstance(result, BaseMessage):
+            return _model_response_messages_payload(
+                target=_MODEL_RESPONSE_CHECKPOINT_RESULT_TARGET,
+                result_is_sequence=False,
+                messages=[result],
+            )
+    if isinstance(response, list | tuple) and _all_langchain_messages(response):
+        return _model_response_messages_payload(
+            target=_MODEL_RESPONSE_CHECKPOINT_RESPONSE_TARGET,
+            result_is_sequence=True,
+            messages=list(response),
+        )
+    return None
+
+
+def _model_response_messages_payload(
+    *,
+    target: ModelResponseCheckpointTarget,
+    result_is_sequence: bool,
+    messages: list[BaseMessage],
+) -> dict[str, Any]:
+    return {
+        _MODEL_RESPONSE_CHECKPOINT_TARGET_KEY: target,
+        _MODEL_RESPONSE_CHECKPOINT_RESULT_IS_SEQUENCE_KEY: result_is_sequence,
+        _MODEL_RESPONSE_CHECKPOINT_MESSAGES_KEY: messages_to_dict(messages),
+    }
+
+
+def _restore_model_response_checkpoint_output(output: Any) -> Any:
+    if not _is_model_response_checkpoint_envelope(output):
+        return output
+    response = output.get(_MODEL_RESPONSE_CHECKPOINT_RESPONSE_KEY)
+    message_payload = output.get(_MODEL_RESPONSE_CHECKPOINT_MESSAGES_KEY)
+    if message_payload is None:
+        return response
+    if not isinstance(message_payload, Mapping):
+        raise RuntimeError("Invalid LangGraph model checkpoint envelope: messages.")
+    message_dicts = message_payload.get(_MODEL_RESPONSE_CHECKPOINT_MESSAGES_KEY)
+    if not isinstance(message_dicts, list):
+        raise RuntimeError("Invalid LangGraph model checkpoint envelope: message list.")
+    restored_messages = messages_from_dict(message_dicts)
+    target = message_payload.get(_MODEL_RESPONSE_CHECKPOINT_TARGET_KEY)
+    result_is_sequence = (
+        message_payload.get(_MODEL_RESPONSE_CHECKPOINT_RESULT_IS_SEQUENCE_KEY)
+        is not False
+    )
+    if target == _MODEL_RESPONSE_CHECKPOINT_RESPONSE_TARGET:
+        return (
+            restored_messages
+            if result_is_sequence
+            else _single_restored_message(restored_messages)
+        )
+    if target == _MODEL_RESPONSE_CHECKPOINT_RESULT_TARGET:
+        return _restore_model_response_result(
+            response,
+            restored_messages,
+            result_is_sequence=result_is_sequence,
+        )
+    raise RuntimeError("Invalid LangGraph model checkpoint envelope: target.")
+
+
+def _is_model_response_checkpoint_envelope(output: Any) -> bool:
+    return (
+        isinstance(output, Mapping)
+        and output.get(_MODEL_RESPONSE_CHECKPOINT_SCHEMA_KEY)
+        == _MODEL_RESPONSE_CHECKPOINT_ENVELOPE_SCHEMA
+    )
+
+
+def _restore_model_response_result(
+    response: Any,
+    restored_messages: list[BaseMessage],
+    *,
+    result_is_sequence: bool,
+) -> Any:
+    result_ref = _model_response_result_ref(response)
+    if result_ref is None:
+        raise RuntimeError(
+            "LangGraph model checkpoint response no longer has a result field."
+        )
+    owner, _original_result = result_ref
+    result_value: Any = (
+        restored_messages
+        if result_is_sequence
+        else _single_restored_message(restored_messages)
+    )
+    try:
+        owner.result = result_value
+        return response
+    except Exception as assign_error:
+        copied_owner, copy_error = _copy_with_result(owner, result_value)
+        if copied_owner is None:
+            raise RuntimeError(
+                "LangGraph model checkpoint response could not restore "
+                "LangChain message subclasses."
+            ) from (copy_error or assign_error)
+        if owner is response:
+            return copied_owner
+        try:
+            response.model_response = copied_owner
+            return response
+        except Exception as nested_assign_error:
+            copied_response, nested_copy_error = _copy_with_model_response(
+                response, copied_owner
+            )
+            if copied_response is not None:
+                return copied_response
+            raise RuntimeError(
+                "LangGraph model checkpoint response could not restore nested "
+                "LangChain message subclasses."
+            ) from (nested_copy_error or nested_assign_error)
+
+
+def _single_restored_message(
+    restored_messages: list[BaseMessage],
+) -> BaseMessage | None:
+    return restored_messages[0] if restored_messages else None
+
+
+def _copy_with_result(
+    owner: Any,
+    result: Any,
+) -> tuple[Any | None, Exception | None]:
+    return _copy_with_update(owner, {"result": result})
+
+
+def _copy_with_model_response(
+    response: Any,
+    model_response: Any,
+) -> tuple[Any | None, Exception | None]:
+    return _copy_with_update(response, {"model_response": model_response})
+
+
+def _copy_with_update(
+    value: Any,
+    update: dict[str, Any],
+) -> tuple[Any | None, Exception | None]:
+    last_error: Exception | None = None
+    for method_name in ("model_copy", "copy"):
+        copy_method = getattr(value, method_name, None)
+        if not callable(copy_method):
+            continue
+        try:
+            return copy_method(update=update), None
+        except Exception as error:
+            last_error = error
+    return None, last_error
+
+
+def _model_response_result_ref(response: Any) -> tuple[Any, Any] | None:
     inner = getattr(response, "model_response", response)
-    result = getattr(inner, "result", None)
-    if isinstance(result, list | tuple):
-        return list(result)
-    if result is not None:
-        return [result]
+    return (inner, getattr(inner, "result", None)) if hasattr(inner, "result") else None
+
+
+def _all_langchain_messages(messages: list[Any] | tuple[Any, ...]) -> bool:
+    return all(isinstance(message, BaseMessage) for message in messages)
+
+
+def _model_response_messages(response: Any) -> list[Any]:
+    result_ref = _model_response_result_ref(response)
+    if result_ref is not None:
+        _owner, result = result_ref
+        if isinstance(result, list | tuple):
+            return list(result)
+        if result is not None:
+            return [result]
+    inner = getattr(response, "model_response", response)
     if isinstance(inner, list | tuple):
         return list(inner)
     return [inner]

--- a/tests/test_langgraph_calls_strategy.py
+++ b/tests/test_langgraph_calls_strategy.py
@@ -1,16 +1,16 @@
 """Deterministic tests for LangGraph calls-mode LangChain middleware."""
 
-from __future__ import annotations
-
 import asyncio
 import importlib
 import json
+import time
 from collections.abc import Callable
 from contextlib import suppress
 from types import SimpleNamespace
 from typing import Any, cast
 
-from kitaru import SandboxCommandResult
+from kitaru import SandboxCommandResult, checkpoint, flow
+from kitaru._client._models import ExecutionStatus
 from kitaru.adapters.langgraph import (
     KitaruGraphRunner,
     LangGraphCallCheckpointPolicy,
@@ -19,6 +19,7 @@ from kitaru.adapters.langgraph import (
     create_sandbox_command_tool,
 )
 from kitaru.adapters.langgraph.langchain import KitaruLangGraphMiddleware
+from kitaru.client import KitaruClient
 
 
 def _patch_runner_summary_runtime(monkeypatch) -> tuple[Any, dict[str, object]]:
@@ -128,6 +129,128 @@ def _logged_events(logged: dict[str, object]) -> list[dict[str, object]]:
         logged[constants.LANGGRAPH_EVENTS_METADATA_KEY],
     )
     return next(iter(event_payload.values()))
+
+
+def add_one_for_checkpoint_materialization(value: int) -> str:
+    """Add one to the provided value."""
+    return str(value + 1)
+
+
+def _model_checkpoint_output_contains_tool_call(
+    output: Any,
+    tool_call_id: str,
+) -> bool:
+    if not isinstance(output, dict):
+        return False
+    if (
+        output.get("schema")
+        != "kitaru.langgraph.langchain.model_response_checkpoint.v1"
+    ):
+        return False
+    message_payload = output.get("messages")
+    if not isinstance(message_payload, dict):
+        return False
+    messages = message_payload.get("messages")
+    if not isinstance(messages, list):
+        return False
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        data = message.get("data")
+        if not isinstance(data, dict):
+            continue
+        tool_calls = data.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for tool_call in tool_calls:
+            if isinstance(tool_call, dict) and tool_call.get("id") == tool_call_id:
+                return True
+    return False
+
+
+@checkpoint
+def persist_langgraph_materialization_summary(
+    summary: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the flow summary through one final result checkpoint."""
+    return summary
+
+
+@flow
+def langgraph_calls_materialization_regression() -> dict[str, Any]:
+    """Run a calls-mode LangGraph agent through real checkpoint materialization."""
+    from langchain.agents import create_agent
+    from langchain_core.language_models.fake_chat_models import (
+        FakeMessagesListChatModel,
+    )
+    from langchain_core.messages import AIMessage
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    class BindableFakeMessagesListChatModel(FakeMessagesListChatModel):
+        def bind_tools(
+            self,
+            tools: Any,
+            *,
+            tool_choice: str | None = None,
+            **kwargs: Any,
+        ) -> Any:
+            return self
+
+    model = BindableFakeMessagesListChatModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "add_one_for_checkpoint_materialization",
+                        "args": {"value": 1},
+                        "id": "call-materialized",
+                    }
+                ],
+            ),
+            AIMessage(content="done"),
+        ]
+    )
+    graph = create_agent(
+        model,
+        tools=[add_one_for_checkpoint_materialization],
+        middleware=[KitaruLangGraphMiddleware()],
+        checkpointer=InMemorySaver(),
+        name="materialized_langchain_agent",
+    )
+    runner = KitaruGraphRunner(
+        graph,
+        name="materialized_langchain_agent",
+        checkpoint_strategy="calls",
+        capture=LangGraphCapturePolicy(save_state_snapshot=False),
+    )
+
+    result = runner.invoke(
+        {"messages": [{"role": "user", "content": "use the tool"}]},
+        thread_id="materialized-langchain-thread",
+    )
+    output = cast(dict[str, Any], result.output)
+    messages = cast(list[Any], output["messages"])
+    summary = {
+        "status": result.status,
+        "message_types": [type(message).__name__ for message in messages],
+        "contents": [str(getattr(message, "content", "")) for message in messages],
+        "tool_call_counts": [
+            len(getattr(message, "tool_calls", None) or []) for message in messages
+        ],
+        "tool_call_ids": [
+            [
+                str(tool_call["id"])
+                for tool_call in cast(
+                    list[dict[str, Any]],
+                    getattr(message, "tool_calls", None) or [],
+                )
+                if "id" in tool_call
+            ]
+            for message in messages
+        ],
+    }
+    return persist_langgraph_materialization_summary(summary)
 
 
 def test_runner_calls_mode_uses_middleware_without_outer_graph_checkpoint(
@@ -384,6 +507,68 @@ def test_real_langchain_create_agent_calls_mode_reaches_middleware_contextvars(
     ] == ["true", "true", "true"]
     assert events[2]["tool_name"] == "add_one"
     assert events[2]["tool_call_id"] == "call-1"
+
+
+def test_real_materialized_model_checkpoint_preserves_tool_calls(
+    primed_zenml: None,
+) -> None:
+    del primed_zenml
+    handle = langgraph_calls_materialization_regression.run()
+    deadline = time.monotonic() + 15
+    while not handle.status.is_finished:
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"Execution {handle.exec_id} did not finish within 15 seconds."
+            )
+        time.sleep(0.25)
+
+    assert handle.status.is_successful
+    execution = KitaruClient().executions.get(handle.exec_id)
+    assert execution.status == ExecutionStatus.COMPLETED
+    summary_checkpoints = [
+        checkpoint
+        for checkpoint in execution.checkpoints
+        if checkpoint.name == "persist_langgraph_materialization_summary"
+    ]
+    assert len(summary_checkpoints) == 1
+    summary_outputs = [
+        artifact
+        for artifact in summary_checkpoints[0].artifacts
+        if artifact.direction == "output"
+    ]
+    assert len(summary_outputs) == 1
+    summary = cast(dict[str, Any], summary_outputs[0].load())
+    assert summary["status"] == "completed"
+    assert summary["message_types"] == [
+        "HumanMessage",
+        "AIMessage",
+        "ToolMessage",
+        "AIMessage",
+    ]
+    assert summary["tool_call_counts"] == [0, 1, 0, 0]
+    assert summary["tool_call_ids"] == [[], ["call-materialized"], [], []]
+    assert summary["contents"][-2:] == ["2", "done"]
+
+    checkpoint_names = [checkpoint.name for checkpoint in execution.checkpoints]
+    assert any(name.startswith("model_call__") for name in checkpoint_names)
+    assert any(
+        name.startswith(
+            "tool_call__add_one_for_checkpoint_materialization_call_materialized_"
+        )
+        for name in checkpoint_names
+    )
+
+    model_outputs = (
+        artifact.load()
+        for checkpoint in execution.checkpoints
+        if checkpoint.name.startswith("model_call__")
+        for artifact in checkpoint.artifacts
+        if artifact.direction == "output"
+    )
+    assert any(
+        _model_checkpoint_output_contains_tool_call(output, "call-materialized")
+        for output in model_outputs
+    )
 
 
 def test_sandbox_command_tool_uses_calls_mode_true_tool_checkpoint(


### PR DESCRIPTION
Closes #458

## Reviewer Notes

This fixes the LangGraph `checkpoint_strategy="calls"` path where model-call checkpoint materialization could erase the concrete LangChain message subtype that LangGraph needs for tool routing.

The concrete failure looked like this: the model returned an `AIMessage` that asked for a tool. Kitaru stored the synthetic model-call checkpoint output, then materialized it back before returning to LangGraph. During that checkpoint round-trip, the response still looked like a LangChain model response, but the inner message could come back as a plainer `BaseMessage`. LangGraph then looked for `.tool_calls`, found none, and skipped the tool node. The run appeared successful, but the expected `tool_call__...` checkpoint never happened.

The adapter now returns a private checkpoint envelope for sync LangChain model-call checkpoints. That envelope stores the materialized response plus LangChain-native `messages_to_dict(...)` data for the response messages. After `run_sync_in_checkpoint(...)` returns, the adapter restores those messages with `messages_from_dict(...)`, patches them back onto the materialized response, and only then returns the response to LangGraph. That keeps the full response object available while preserving `AIMessage.tool_calls` for LangGraph's routing decision.

The model-call cache key also includes the private envelope schema marker so old cached model-call artifacts from the lossy shape are not reused. Tool-call cache keys are unchanged.

### Reproduction

Offline regression test with a fake LangChain model:

```bash
uv run pytest tests/test_langgraph_calls_strategy.py::test_real_materialized_model_checkpoint_preserves_tool_calls
```

That test runs through a real Kitaru flow/materialization path, verifies the private envelope artifact survives, and asserts that the `tool_call__add_one_for_checkpoint_materialization...` checkpoint appears.

User-facing example command:

```bash
uv run python examples/integrations/langgraph_agent/langgraph_adapter.py --strategy calls --ticket demo-1
```

With the fix, a model request for a tool should lead to the corresponding tool checkpoint instead of silently completing after only model-call checkpoints.

Local checks run:

- `just check`
- `just test`
- `uv run pytest tests/test_langgraph_calls_strategy.py`
- `uv run pytest tests/test_langgraph_adapter_foundation.py tests/test_langgraph_sandbox_example.py`
