### PR TITLE
Add execution statistics pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added `--page` and `--size` pagination options to `kitaru executions statistics`.
+
 ### Fixed
 - Fixed direct `kitaru.llm()` OpenAI calls so public `max_tokens` is sent as OpenAI's `max_completion_tokens` for newer reasoning/GPT-5-style models, while older OpenAI, OpenRouter, and Ollama calls keep using `max_tokens`.
 

--- a/docs/book/guides/execution-management.md
+++ b/docs/book/guides/execution-management.md
@@ -133,7 +133,11 @@ kitaru executions statistics --group-by status
 kitaru executions statistics --group-by status --metric duration_avg:duration:avg
 
 # Daily execution health, script-friendly JSON
-kitaru executions statistics --group-by time:day --group-by status -o json
+kitaru executions statistics --group-by time:day --group-by status --output json
+kitaru executions statistics --group-by status -o json
+
+# Second page of grouped status results
+kitaru executions statistics --group-by status --page 2 --size 20
 
 # Sum a numeric execution metadata key by flow
 kitaru executions statistics \
@@ -167,6 +171,12 @@ completed   12           43.2
 failed      2            18.7
 running     1
 ```
+
+Statistics JSON output uses the shared `--output json` / `-o json` option.
+When `--page` or `--size` is used, `group_count` is the number of groups in the
+current response page. Like other Kitaru CLI JSON outputs, statistics JSON does
+not include separate pagination metadata. `--max-groups` limits the total groups
+returned by the statistics query before CLI pagination is applied.
 
 Supported groupings are:
 

--- a/src/kitaru/_cli/_executions.py
+++ b/src/kitaru/_cli/_executions.py
@@ -53,6 +53,7 @@ from ._helpers import (
     _format_timestamp,
     _is_input_interactive,
     _is_interactive,
+    _paginate_items,
     _print_success,
     _resolve_output_format,
     _validate_pagination,
@@ -753,11 +754,27 @@ def statistics(
         int,
         Parameter(help="Maximum number of public statistics groups to return."),
     ] = 1000,
+    page: Annotated[
+        int | None, Parameter(help="1-based page number to return.")
+    ] = None,
+    size: Annotated[
+        int | None, Parameter(help="Number of groups to return per page.")
+    ] = None,
     output: OutputFormatOption = "text",
 ) -> None:
     """Show grouped execution statistics."""
     command = "executions.statistics"
     output_format = _resolve_output_format(output)
+    pagination_requested = page is not None or size is not None
+    resolved_page = DEFAULT_LIST_PAGE if page is None else page
+    resolved_size = DEFAULT_LIST_SIZE if size is None else size
+    if pagination_requested:
+        resolved_page, resolved_size = _validate_pagination(
+            page=resolved_page,
+            size=resolved_size,
+            command=command,
+            output=output_format,
+        )
     try:
         validate_statistics_max_groups(max_groups, label="--max-groups")
     except KitaruUsageError as exc:
@@ -782,10 +799,21 @@ def statistics(
         exit_with_error=_exit_with_error,
     )
 
+    display_statistics = statistics_result
+    if pagination_requested:
+        display_statistics = ExecutionStatistics(
+            groups=_paginate_items(
+                statistics_result.groups,
+                page=resolved_page,
+                size=resolved_size,
+            ),
+            truncated=statistics_result.truncated,
+        )
+
     if output_format == CLIOutputFormat.JSON:
         _emit_json_item(
             command,
-            serialize_execution_statistics(statistics_result),
+            serialize_execution_statistics(display_statistics),
             output=output_format,
         )
         return
@@ -794,11 +822,19 @@ def statistics(
         metric.name for metric in normalize_execution_statistics_metrics(metric or [])
     ]
     columns, rows = _execution_statistics_table(
-        statistics_result,
+        display_statistics,
         requested_metric_names=requested_metric_names,
     )
     _emit_table("Kitaru execution statistics", columns, rows)
-    if statistics_result.truncated:
+    if pagination_requested:
+        _emit_pagination_note(
+            page=resolved_page,
+            size=resolved_size,
+            returned_count=len(display_statistics.groups),
+            total_count=len(statistics_result.groups),
+            output=output_format,
+        )
+    if display_statistics.truncated:
         print(
             f"Results truncated at --max-groups {max_groups}. "
             "Narrow filters or increase --max-groups."

--- a/src/kitaru/_cli/_helpers.py
+++ b/src/kitaru/_cli/_helpers.py
@@ -296,7 +296,8 @@ def _paginate_items(items: Sequence[_T], *, page: int, size: int) -> list[_T]:
     """Return one 1-based page from an already materialized item sequence."""
     start = (page - 1) * size
     end = start + size
-    return list(items[start:end])
+    page_items = items[start:end]
+    return page_items if isinstance(page_items, list) else list(page_items)
 
 
 def _emit_pagination_note(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2487,6 +2487,20 @@ def test_executions_list_accepts_page_and_size() -> None:
     )
 
 
+def _statistics_with_status_groups(
+    *groups: tuple[str, int],
+    truncated: bool = False,
+) -> ExecutionStatistics:
+    """Build execution statistics grouped by status for CLI tests."""
+    return ExecutionStatistics(
+        groups=[
+            ExecutionStatisticsGroup(keys={"status": status}, execution_count=count)
+            for status, count in groups
+        ],
+        truncated=truncated,
+    )
+
+
 def test_executions_statistics_forwards_filters_and_repeatable_options() -> None:
     """`kitaru executions statistics` should delegate to the SDK surface."""
     fake_client = Mock()
@@ -2540,6 +2554,80 @@ def test_executions_statistics_forwards_filters_and_repeatable_options() -> None
         tags=["nightly", "customer-facing"],
         max_groups=25,
     )
+
+
+def test_executions_statistics_accepts_pagination_without_forwarding_it() -> None:
+    """Statistics pagination should page CLI output, not SDK queries."""
+    fake_client = Mock()
+    fake_client.executions.statistics.return_value = _statistics_with_status_groups(
+        ("completed", 12),
+        ("failed", 2),
+        ("running", 1),
+    )
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(
+            [
+                "executions",
+                "statistics",
+                "--group-by",
+                "status",
+                "--page",
+                "2",
+                "--size",
+                "1",
+            ]
+        )
+
+    assert exc_info.value.code == 0
+    fake_client.executions.statistics.assert_called_once_with(
+        group_by=["status"],
+        metrics=[],
+        flow=None,
+        status=None,
+        stack=None,
+        tags=None,
+        max_groups=1000,
+    )
+
+
+def test_executions_statistics_pages_text_output(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Statistics text output should contain only the requested group page."""
+    fake_client = Mock()
+    fake_client.executions.statistics.return_value = _statistics_with_status_groups(
+        ("completed", 12),
+        ("failed", 2),
+        ("running", 1),
+    )
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(
+            [
+                "executions",
+                "statistics",
+                "--group-by",
+                "status",
+                "--page",
+                "2",
+                "--size",
+                "1",
+            ]
+        )
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "completed" not in output
+    assert "failed" in output
+    assert "running" not in output
+    assert "Page 2 (size 1, showing 1 of 3)" in output
 
 
 def test_executions_statistics_renders_grouped_text(
@@ -2650,8 +2738,13 @@ def test_executions_statistics_renders_global_text(
     assert "18" in output
 
 
+@pytest.mark.parametrize(
+    "output_args",
+    (["-o", "json"], ["--output", "json"]),
+)
 def test_executions_statistics_emits_json(
     capsys: pytest.CaptureFixture[str],
+    output_args: list[str],
 ) -> None:
     """JSON statistics output should use the standard single-item envelope."""
     fake_client = Mock()
@@ -2661,7 +2754,12 @@ def test_executions_statistics_emits_json(
                 keys={"status": "completed", "day": "2026-05-30"},
                 execution_count=7,
                 metrics={"duration_avg": 9.5},
-            )
+            ),
+            ExecutionStatisticsGroup(
+                keys={"status": "failed", "day": "2026-05-30"},
+                execution_count=2,
+                metrics={"duration_avg": 3.0},
+            ),
         ],
         truncated=True,
     )
@@ -2678,8 +2776,7 @@ def test_executions_statistics_emits_json(
                 "time:day",
                 "--group-by",
                 "status",
-                "-o",
-                "json",
+                *output_args,
             ]
         )
 
@@ -2693,12 +2790,168 @@ def test_executions_statistics_emits_json(
                     "keys": {"status": "completed", "day": "2026-05-30"},
                     "execution_count": 7,
                     "metrics": {"duration_avg": 9.5},
-                }
+                },
+                {
+                    "keys": {"status": "failed", "day": "2026-05-30"},
+                    "execution_count": 2,
+                    "metrics": {"duration_avg": 3.0},
+                },
             ],
             "truncated": True,
-            "group_count": 1,
+            "group_count": 2,
         },
     }
+
+
+def test_executions_statistics_pages_json_without_pagination_metadata(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Paged JSON statistics should keep the single-item command envelope."""
+    fake_client = Mock()
+    fake_client.executions.statistics.return_value = _statistics_with_status_groups(
+        ("completed", 12),
+        ("failed", 2),
+        ("running", 1),
+        truncated=True,
+    )
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(
+            [
+                "executions",
+                "statistics",
+                "--group-by",
+                "status",
+                "--page",
+                "2",
+                "--size",
+                "1",
+                "--output",
+                "json",
+            ]
+        )
+
+    assert exc_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == {"command", "item"}
+    assert "items" not in payload
+    item = payload["item"]
+    assert "page" not in item
+    assert "size" not in item
+    assert "total_count" not in item
+    assert item == {
+        "groups": [
+            {
+                "keys": {"status": "failed"},
+                "execution_count": 2,
+                "metrics": {},
+            }
+        ],
+        "truncated": True,
+        "group_count": 1,
+    }
+
+
+def test_executions_statistics_uses_default_size_for_partial_pagination(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Providing only --page should use the shared default page size."""
+    fake_client = Mock()
+    fake_client.executions.statistics.return_value = ExecutionStatistics(
+        groups=[
+            ExecutionStatisticsGroup(keys={"status": f"status-{i}"}, execution_count=i)
+            for i in range(25)
+        ],
+        truncated=False,
+    )
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "statistics", "--page", "2"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "status-19" not in output
+    assert "status-20" in output
+    assert "status-24" in output
+    assert "Page 2 (size 20, showing 5 of 25)" in output
+
+
+def test_executions_statistics_uses_default_page_for_partial_pagination(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Providing only --size should use the first page."""
+    fake_client = Mock()
+    fake_client.executions.statistics.return_value = _statistics_with_status_groups(
+        ("completed", 12),
+        ("failed", 2),
+    )
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "statistics", "--size", "1"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "completed" in output
+    assert "failed" not in output
+    assert "Page 1 (size 1, showing 1 of 2)" in output
+
+
+@pytest.mark.parametrize(
+    ("pagination_args", "expected_message"),
+    [
+        (["--page", "0"], "`--page` must be >= 1."),
+        (["--size", "0"], "`--size` must be >= 1."),
+    ],
+)
+def test_executions_statistics_pagination_validation_json_error(
+    capsys: pytest.CaptureFixture[str],
+    pagination_args: list[str],
+    expected_message: str,
+) -> None:
+    """Invalid statistics pagination should respect JSON error output."""
+    with pytest.raises(SystemExit) as exc_info:
+        app(["executions", "statistics", *pagination_args, "--output", "json"])
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload == {
+        "command": "executions.statistics",
+        "error": {"message": expected_message},
+    }
+
+
+def test_executions_statistics_out_of_range_page_is_empty(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Out-of-range statistics pages should be successful empty responses."""
+    fake_client = Mock()
+    fake_client.executions.statistics.return_value = _statistics_with_status_groups(
+        ("completed", 12),
+        ("failed", 2),
+        ("running", 1),
+    )
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "statistics", "--page", "99", "--size", "20"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "none found" in output
+    assert "Page 99 (size 20, showing 0 of 3)" in output
 
 
 def test_executions_statistics_rejects_invalid_max_groups(


### PR DESCRIPTION
## Summary

- Add explicit `--page` / `--size` options to `kitaru executions statistics`.
- Page statistics groups in the CLI after the SDK returns its `--max-groups`-limited result.
- Preserve the existing `{command, item}` JSON envelope and avoid pagination metadata in statistics JSON.
- Document the pagination behavior in the execution-management guide.

## Reviewer Notes

The important behavior now happens inside `src/kitaru/_cli/_executions.py` after `client.executions.statistics(...)` returns. The command still asks the SDK the same aggregate question as before: groupings, metrics, filters, and `max_groups`. If the user did not pass `--page` or `--size`, the CLI renders exactly that returned `ExecutionStatistics` object, so existing text and JSON output keep their old payload behavior.

When the user does pass `--page` or `--size`, the CLI resolves the missing value with the shared defaults (`page=1`, `size=20`), validates those values with the existing pagination helper, then replaces only the `groups` list on the object used for output. JSON still goes through `_emit_json_item`, so scripts still receive `{ "command": "executions.statistics", "item": ... }`. The `item.groups` array is the requested page, and `item.group_count` is the number of groups in that response page. There is deliberately no `page`, `size`, or `total_count` field in the JSON because other Kitaru CLI JSON output does not expose that metadata.

The highest-risk area to inspect is the boundary between `--max-groups` and `--page` / `--size`: `--max-groups` still limits what the statistics query can return, and CLI pagination only pages those already-returned groups. The tests in `tests/test_cli.py` pin that `page` and `size` are not forwarded to the SDK call.

### Reproduction

For a deterministic check without needing runtime data:

```bash
uv run pytest tests/test_cli.py -k "executions_statistics or executions_list"
```

For a manual CLI check in a project with enough grouped executions:

```bash
kitaru executions statistics --group-by status --page 2 --size 20
kitaru executions statistics --group-by status --page 2 --size 1 --output json
```

Expected behavior: text output shows only the requested page and prints a note like `Page 2 (size 1, showing 1 of 3)`. JSON output remains a single-item envelope with `command` and `item`; `item.groups` contains only the requested page, `item.group_count` matches that page length, and there is no separate pagination metadata.

### Local checks run

- `uv run pytest tests/test_cli.py -k "executions_statistics or executions_list"` — passed
- `just check` — passed
- `just test` — passed (`2819 passed, 13 skipped`)
- `just generate-docs` — generated CLI reference, then stopped at SDK docs because local `fumapy` / `griffe` dependency was missing
- `just docs-build` — initially blocked because `docs/node_modules` was missing; attempted `pnpm install --frozen-lockfile`, but npm registry fetches failed with `ECONNRESET` while fetching `fumadocs-core`
