### PR TITLE
Add LLM statistics shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added named LLM cost/token metric shortcuts for execution statistics across SDK, CLI, and MCP.
+
 ## [0.18.0] - 2026-06-25
 
 ### Added

--- a/docs/book/agent-native/mcp-server.md
+++ b/docs/book/agent-native/mcp-server.md
@@ -248,6 +248,14 @@ Example payloads:
 
 ```json
 {
+  "group_by": ["flow"],
+  "metrics": ["llm_display_cost", "llm_total_tokens"],
+  "max_groups": 20
+}
+```
+
+```json
+{
   "group_by": ["metadata:customer_tier", "status"],
   "tags": ["customer-facing"],
   "max_groups": 100
@@ -278,7 +286,9 @@ The result shape is:
 Supported groupings are `status`, `flow`, `stack`, `tag`, `time:hour`,
 `time:day`, `time:week`, `time:month`, and `metadata:<key>`. `flow` and
 `stack` groupings return IDs as `flow_id` and `stack_id`; filters can still use
-names. Optional metrics use the same string format as the CLI:
+names. Optional metrics use the same strings as the CLI and SDK. For common LLM
+totals, use shortcuts such as `llm_display_cost`, `llm_estimated_cost`,
+`llm_total_tokens`, and `llm_incurred_tokens`. For other metrics, use
 `<name>:<source>:<avg|sum|min|max>` for built-in numeric sources such as
 `duration`, or `<name>:metadata:<metadata_key>:<avg|sum|min|max>` for numeric
 execution metadata. The tool does not yet filter by time range or metadata

--- a/docs/book/guides/execution-management.md
+++ b/docs/book/guides/execution-management.md
@@ -231,10 +231,11 @@ writes two execution-level views:
   happened in one execution. Its `usage_record_count`,
   `incurred_usage_record_count`, and `reused_usage_record_count` fields count
   Kitaru usage records, not raw provider API calls.
-- Flat numeric metadata keys such as `kitaru_llm_display_cost_usd_v1` and
-  `kitaru_llm_total_tokens_v1` are the statistics view. Kitaru execution
-  statistics can sum or average these because they are top-level numbers, not
-  nested objects.
+- Common LLM totals are available as execution-statistics shortcuts:
+  `llm_display_cost`, `llm_estimated_cost`, `llm_total_tokens`, and
+  `llm_incurred_tokens`. These shortcuts read the flat execution-level numeric
+  metadata that Kitaru writes for statistics, so users do not need to spell the
+  internal `_v1` metadata keys for common cost and token totals.
 
 Cost fields are intentionally split:
 
@@ -302,21 +303,28 @@ observability and trend analysis, not financial reconciliation.
 Useful statistics queries:
 
 ```bash
-# Sum display cost by flow. This is an observability number, not an invoice.
+# Sum display cost and total token volume for one flow.
+# Display cost is an observability number, not an invoice.
+kitaru executions statistics \
+  --flow content_pipeline \
+  --metric llm_display_cost \
+  --metric llm_total_tokens
+
+# Sum estimated cost by flow.
 kitaru executions statistics \
   --group-by flow \
-  --metric llm_display_cost_sum:metadata:kitaru_llm_display_cost_usd_v1:sum
+  --metric llm_estimated_cost
 
 # Sum incurred token volume by day.
 kitaru executions statistics \
   --group-by time:day \
-  --metric llm_tokens_sum:metadata:kitaru_llm_incurred_total_tokens_v1:sum
-
-# Count usage records that reused checkpoint metadata instead of incurring new usage.
-kitaru executions statistics \
-  --group-by flow \
-  --metric llm_reused_usage_records:metadata:kitaru_llm_reused_usage_record_count_v1:sum
+  --metric llm_incurred_tokens
 ```
+
+The shortcut names above mean "sum this common LLM total". The raw
+`<name>:metadata:<metadata_key>:<avg|sum|min|max>` form still exists for custom
+numeric execution metadata and for advanced internal debugging, but you should
+not need `kitaru_llm_*_v1` keys for common LLM cost and token totals.
 
 {% hint style="warning" %}
 In v1, terminal LLM summaries are written when the SDK observes completion via

--- a/docs/book/guides/llm-calls.md
+++ b/docs/book/guides/llm-calls.md
@@ -95,7 +95,9 @@ kitaru.configure(llm_estimated_costs="off")
 
 See [Execution Management → LLM usage and cost metadata](execution-management.md#llm-usage-and-cost-metadata)
 for how checkpoint-level records roll up into execution summaries and
-statistics.
+statistics. Common LLM totals can be queried through execution-statistics
+shortcuts such as `llm_display_cost`, `llm_estimated_cost`, `llm_total_tokens`,
+and `llm_incurred_tokens`.
 
 ## Credential resolution order
 

--- a/src/kitaru/_cli/_executions.py
+++ b/src/kitaru/_cli/_executions.py
@@ -13,6 +13,7 @@ from typing import Annotated, Any
 from cyclopts import Parameter
 
 from kitaru._client._statistics import (
+    LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS_DISPLAY,
     normalize_execution_statistics_metrics,
     validate_statistics_max_groups,
 )
@@ -725,7 +726,9 @@ def statistics(
                 "Metric to compute. Repeat for multiple metrics. Use "
                 "<name>:<source>:<avg|sum|min|max> for built-in sources "
                 "(duration, step_count, cached_step_count, output_artifact_count) "
-                "or <name>:metadata:<metadata_key>:<avg|sum|min|max>."
+                "or <name>:metadata:<metadata_key>:<avg|sum|min|max>. "
+                "Common LLM shortcuts: "
+                f"{LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS_DISPLAY}."
             ),
         ),
     ] = None,

--- a/src/kitaru/_client/_statistics.py
+++ b/src/kitaru/_client/_statistics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 from pydantic import ValidationError
@@ -24,6 +25,12 @@ from kitaru._client._models import (
     ExecutionStatisticsTimeGranularity,
     ExecutionStatus,
 )
+from kitaru._llm_usage import (
+    LLM_FLAT_DISPLAY_COST_USD_KEY,
+    LLM_FLAT_ESTIMATED_COST_USD_KEY,
+    LLM_FLAT_INCURRED_TOTAL_TOKENS_KEY,
+    LLM_FLAT_TOTAL_TOKENS_KEY,
+)
 from kitaru.errors import (
     KitaruBackendError,
     KitaruFeatureNotAvailableError,
@@ -36,6 +43,17 @@ if TYPE_CHECKING:
 JsonScalar = str | int | float | bool | None
 GroupMergeKey = tuple[tuple[str, JsonScalar], ...]
 GroupEntry = tuple[dict[str, Any], int, dict[str, float | None]]
+LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS = MappingProxyType(
+    {
+        "llm_display_cost": LLM_FLAT_DISPLAY_COST_USD_KEY,
+        "llm_estimated_cost": LLM_FLAT_ESTIMATED_COST_USD_KEY,
+        "llm_total_tokens": LLM_FLAT_TOTAL_TOKENS_KEY,
+        "llm_incurred_tokens": LLM_FLAT_INCURRED_TOTAL_TOKENS_KEY,
+    }
+)
+LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS_DISPLAY = ", ".join(
+    LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS
+)
 
 
 @dataclass(frozen=True)
@@ -346,6 +364,15 @@ def coerce_execution_statistics_metric(
     if not token:
         raise KitaruUsageError("Execution statistics metric tokens cannot be empty.")
 
+    shortcut_metadata_key = LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS.get(token)
+    if shortcut_metadata_key is not None:
+        return ExecutionStatisticsMetric(
+            name=token,
+            source=ExecutionStatisticsMetricSource.METADATA,
+            aggregation=ExecutionStatisticsMetricAggregation.SUM,
+            metadata_key=shortcut_metadata_key,
+        )
+
     parts = [part.strip() for part in token.split(":")]
     if len(parts) == 3:
         name, source, aggregation = parts
@@ -365,8 +392,10 @@ def coerce_execution_statistics_metric(
 
     raise KitaruUsageError(
         f"Unsupported execution statistics metric {metric!r}. Expected "
-        "<name>:<source>:<avg|sum|min|max> for built-in sources or "
-        "<name>:metadata:<metadata_key>:<avg|sum|min|max> for metadata."
+        "<name>:<source>:<avg|sum|min|max> for built-in sources, "
+        "<name>:metadata:<metadata_key>:<avg|sum|min|max> for metadata, "
+        "or one of these LLM shortcuts: "
+        f"{LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS_DISPLAY}."
     )
 
 

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -349,6 +349,51 @@ def test_executions_statistics_calls_client_and_serializes(
     }
 
 
+def test_executions_statistics_forwards_llm_shortcuts_and_serializes(
+    mock_kitaru_client: MagicMock,
+) -> None:
+    """MCP statistics should pass LLM shortcut metric strings to the SDK."""
+    statistics = ExecutionStatistics(
+        groups=[
+            ExecutionStatisticsGroup(
+                keys={"flow_id": "flow-123"},
+                execution_count=3,
+                metrics={"llm_display_cost": 0.42, "llm_total_tokens": 128.0},
+            )
+        ],
+        truncated=False,
+    )
+    mock_kitaru_client.executions.statistics.return_value = statistics
+
+    with patch("kitaru.client.KitaruClient", return_value=mock_kitaru_client):
+        payload = kitaru_executions_statistics(
+            group_by=["flow"],
+            metrics=["llm_display_cost", "llm_total_tokens"],
+            max_groups=20,
+        )
+
+    mock_kitaru_client.executions.statistics.assert_called_once_with(
+        group_by=["flow"],
+        metrics=["llm_display_cost", "llm_total_tokens"],
+        flow=None,
+        status=None,
+        stack=None,
+        tags=None,
+        max_groups=20,
+    )
+    assert payload == {
+        "groups": [
+            {
+                "keys": {"flow_id": "flow-123"},
+                "execution_count": 3,
+                "metrics": {"llm_display_cost": 0.42, "llm_total_tokens": 128.0},
+            }
+        ],
+        "truncated": False,
+        "group_count": 1,
+    }
+
+
 def test_executions_statistics_delegates_to_inspection_serializer(
     mock_kitaru_client: MagicMock,
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,10 @@ from zenml.zen_stores.rest_zen_store import RestZenStore
 
 from kitaru._cli._executions import _execution_statistics_table
 from kitaru._client._models import AuthAPIKey, AuthAPIKeyWithValue, AuthServiceAccount
+from kitaru._client._statistics import (
+    LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS_DISPLAY,
+    normalize_execution_statistics_metrics,
+)
 from kitaru.analytics import AnalyticsEvent
 from kitaru.cli import (
     ActiveConfigSelectionProvenance,
@@ -2554,6 +2558,143 @@ def test_executions_statistics_forwards_filters_and_repeatable_options() -> None
         tags=["nightly", "customer-facing"],
         max_groups=25,
     )
+
+
+def test_executions_statistics_forwards_llm_shortcuts_and_emits_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """LLM shortcut metric strings should pass through to the SDK unchanged."""
+    fake_client = Mock()
+    fake_client.executions.statistics.return_value = ExecutionStatistics(
+        groups=[
+            ExecutionStatisticsGroup(
+                keys={"flow_id": "flow-123"},
+                execution_count=3,
+                metrics={"llm_display_cost": 0.42, "llm_total_tokens": 128.0},
+            )
+        ],
+        truncated=False,
+    )
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(
+            [
+                "executions",
+                "statistics",
+                "--flow",
+                "my_flow",
+                "--group-by",
+                "flow",
+                "--metric",
+                "llm_display_cost",
+                "--metric",
+                "llm_total_tokens",
+                "-o",
+                "json",
+            ]
+        )
+
+    assert exc_info.value.code == 0
+    fake_client.executions.statistics.assert_called_once_with(
+        group_by=["flow"],
+        metrics=["llm_display_cost", "llm_total_tokens"],
+        flow="my_flow",
+        status=None,
+        stack=None,
+        tags=None,
+        max_groups=1000,
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["item"]["groups"] == [
+        {
+            "keys": {"flow_id": "flow-123"},
+            "execution_count": 3,
+            "metrics": {"llm_display_cost": 0.42, "llm_total_tokens": 128.0},
+        }
+    ]
+
+
+def test_executions_statistics_text_orders_llm_shortcut_columns(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Text metric columns should follow requested shortcut order."""
+    fake_client = Mock()
+    fake_client.executions.statistics.return_value = ExecutionStatistics(
+        groups=[
+            ExecutionStatisticsGroup(
+                keys={"status": "completed"},
+                execution_count=3,
+                metrics={"llm_total_tokens": 128.0, "llm_display_cost": 0.42},
+            )
+        ],
+        truncated=False,
+    )
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(
+            [
+                "executions",
+                "statistics",
+                "--group-by",
+                "status",
+                "--metric",
+                "llm_display_cost",
+                "--metric",
+                "llm_total_tokens",
+            ]
+        )
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert output.index("Llm Display Cost") < output.index("Llm Total Tokens")
+    assert "0.42" in output
+    assert "128.0" in output
+
+
+def test_executions_statistics_rejects_invalid_llm_shortcut_like_metric(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Invalid shortcut-like metrics should use the normal CLI error path."""
+    fake_client = Mock()
+
+    def _statistics(**kwargs: Any) -> ExecutionStatistics:
+        normalize_execution_statistics_metrics(kwargs["metrics"])
+        raise AssertionError("invalid metric should fail before statistics return")
+
+    fake_client.executions.statistics.side_effect = _statistics
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "statistics", "--metric", "llm_not_a_real_shortcut"])
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert (
+        "Unsupported execution statistics metric 'llm_not_a_real_shortcut'"
+        in captured.err
+    )
+
+
+def test_executions_statistics_metric_help_lists_llm_shortcuts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The metric help text should advertise the common LLM shortcuts."""
+    with pytest.raises(SystemExit) as exc_info:
+        app(["executions", "statistics", "--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    for shortcut in LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS_DISPLAY.split(", "):
+        assert shortcut in output
 
 
 def test_executions_statistics_accepts_pagination_without_forwarding_it() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -40,12 +40,20 @@ from kitaru._client._mappers import (
     _to_public_status,
 )
 from kitaru._client._statistics import (
+    LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS_DISPLAY,
     build_run_statistics_request,
+    coerce_execution_statistics_metric,
     map_run_statistics_response,
     normalize_execution_statistics_groupings,
     normalize_execution_statistics_metrics,
 )
 from kitaru._interface_deployments import Deployment
+from kitaru._llm_usage import (
+    LLM_FLAT_DISPLAY_COST_USD_KEY,
+    LLM_FLAT_ESTIMATED_COST_USD_KEY,
+    LLM_FLAT_INCURRED_TOTAL_TOKENS_KEY,
+    LLM_FLAT_TOTAL_TOKENS_KEY,
+)
 from kitaru.analytics import AnalyticsEvent
 from kitaru.client import (
     _RESUME_RESUMING_REASON,
@@ -555,6 +563,65 @@ def test_execution_statistics_metric_parser_rejects_duplicates() -> None:
         normalize_execution_statistics_metrics(
             ["duration_avg:duration:avg", "duration_avg:step_count:sum"]
         )
+
+
+@pytest.mark.parametrize(
+    ("shortcut", "metadata_key"),
+    [
+        ("llm_display_cost", LLM_FLAT_DISPLAY_COST_USD_KEY),
+        ("llm_estimated_cost", LLM_FLAT_ESTIMATED_COST_USD_KEY),
+        ("llm_total_tokens", LLM_FLAT_TOTAL_TOKENS_KEY),
+        ("llm_incurred_tokens", LLM_FLAT_INCURRED_TOTAL_TOKENS_KEY),
+    ],
+)
+def test_execution_statistics_metric_parser_normalizes_llm_shortcuts(
+    shortcut: str,
+    metadata_key: str,
+) -> None:
+    metric = coerce_execution_statistics_metric(shortcut)
+
+    assert metric == ExecutionStatisticsMetric(
+        name=shortcut,
+        source=ExecutionStatisticsMetricSource.METADATA,
+        aggregation=ExecutionStatisticsMetricAggregation.SUM,
+        metadata_key=metadata_key,
+    )
+
+
+def test_execution_statistics_metric_parser_keeps_llm_shortcuts_sum_only() -> None:
+    metric = coerce_execution_statistics_metric(" llm_display_cost ")
+
+    assert metric.name == "llm_display_cost"
+    assert metric.source is ExecutionStatisticsMetricSource.METADATA
+    assert metric.aggregation is ExecutionStatisticsMetricAggregation.SUM
+    assert metric.metadata_key == LLM_FLAT_DISPLAY_COST_USD_KEY
+
+
+@pytest.mark.parametrize(
+    "metrics",
+    [
+        ["llm_total_tokens", "llm_total_tokens"],
+        [
+            "llm_total_tokens",
+            f"llm_total_tokens:metadata:{LLM_FLAT_TOTAL_TOKENS_KEY}:sum",
+        ],
+    ],
+)
+def test_execution_statistics_metric_parser_rejects_duplicate_llm_shortcut_names(
+    metrics: list[str],
+) -> None:
+    with pytest.raises(KitaruUsageError, match="Duplicate"):
+        normalize_execution_statistics_metrics(metrics)
+
+
+def test_execution_statistics_metric_parser_rejects_unknown_plain_strings() -> None:
+    with pytest.raises(KitaruUsageError) as exc_info:
+        coerce_execution_statistics_metric("llm_not_a_real_shortcut")
+
+    message = str(exc_info.value)
+    assert "Unsupported execution statistics metric" in message
+    assert "or one of these LLM shortcuts" in message
+    assert LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS_DISPLAY in message
 
 
 def test_execution_status_mapping_covers_zenml_execution_status_values() -> None:
@@ -3326,6 +3393,30 @@ def test_statistics_delegates_to_internal_helper_and_tracks_safe_payload() -> No
     assert "private_key" not in repr(metadata)
 
 
+def test_statistics_tracks_llm_shortcut_metrics_without_metric_names() -> None:
+    result = ExecutionStatistics(groups=[], truncated=False)
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection("project-a"),
+        ),
+        patch("kitaru.client.get_execution_statistics", return_value=result),
+        patch("kitaru.client.track") as track_mock,
+    ):
+        client = KitaruClient()
+        statistics = client.executions.statistics(metrics=["llm_display_cost"])
+
+    assert statistics is result
+    track_mock.assert_called_once()
+    event, metadata = track_mock.call_args.args
+    assert event is AnalyticsEvent.EXECUTION_STATISTICS_QUERIED
+    assert metadata["metric_count"] == 1
+    assert metadata["has_metadata_metric"] is True
+    assert "llm_display_cost" not in repr(metadata)
+    assert LLM_FLAT_DISPLAY_COST_USD_KEY not in repr(metadata)
+
+
 def test_statistics_fetches_global_count_from_zen_store() -> None:
     response = SimpleNamespace(
         groups=[SimpleNamespace(group_keys={}, run_count=18)],
@@ -3428,6 +3519,53 @@ def test_statistics_fetches_metrics_from_zen_store() -> None:
                 keys={"flow_id": "flow-a"},
                 execution_count=2,
                 metrics={"duration_avg": 11.0, "cost_sum": 0.42},
+            )
+        ],
+        truncated=False,
+    )
+
+
+def test_statistics_maps_llm_shortcuts_to_metadata_metrics() -> None:
+    response = SimpleNamespace(
+        groups=[
+            SimpleNamespace(
+                group_keys={"flow_id": "flow-a"},
+                run_count=2,
+                metrics={"llm_display_cost": 0.42, "llm_total_tokens": 128.0},
+            )
+        ],
+        truncated=False,
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection("project-a"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch("kitaru.client.track"),
+    ):
+        zen_store = SimpleNamespace(get_run_statistics=Mock(return_value=response))
+        client_cls.return_value.zen_store = zen_store
+
+        client = KitaruClient()
+        statistics = client.executions.statistics(
+            group_by=["flow"],
+            metrics=["llm_display_cost", "llm_total_tokens"],
+        )
+
+    request = zen_store.get_run_statistics.call_args.args[0]
+    assert [(metric.name, metric.metadata_key) for metric in request.metrics] == [
+        ("llm_display_cost", LLM_FLAT_DISPLAY_COST_USD_KEY),
+        ("llm_total_tokens", LLM_FLAT_TOTAL_TOKENS_KEY),
+    ]
+    assert [metric.aggregation.value for metric in request.metrics] == ["sum", "sum"]
+    assert statistics == ExecutionStatistics(
+        groups=[
+            ExecutionStatisticsGroup(
+                keys={"flow_id": "flow-a"},
+                execution_count=2,
+                metrics={"llm_display_cost": 0.42, "llm_total_tokens": 128.0},
             )
         ],
         truncated=False,


### PR DESCRIPTION
## What changed

Added named LLM cost/token metric shortcuts for execution statistics across the shared SDK parser, CLI help/output path, and MCP forwarding path.

The MVP shortcuts are:

- `llm_display_cost`
- `llm_estimated_cost`
- `llm_total_tokens`
- `llm_incurred_tokens`

Each shortcut expands to a `sum` metadata metric over the existing flat `kitaru_llm_*_v1` execution metadata key. Bare `kitaru executions statistics` remains count-only.

Closes #468.

## Why it was needed

Issue #468 found that v0.18.0 already records the right LLM usage/cost metadata, but users had to know internal `_v1` metadata key names to aggregate it. This makes the obvious statistics query discoverable without changing how LLM usage metadata is recorded.

## Key implementation decisions

- Keep shortcut parsing in `src/kitaru/_client/_statistics.py`, so SDK, CLI, and MCP all share the same behavior.
- Keep MCP thin: `kitaru_executions_statistics` still forwards metrics to `KitaruClient().executions.statistics(...)`.
- Keep shortcuts sum-only. Advanced callers can still use explicit metadata metric syntax for `avg`, `min`, or `max`.
- Do not auto-add LLM metrics to bare statistics output, so existing scripts keep a predictable count-only response shape.

## Reviewer Notes

The important behavior happens in the statistics metric parser. A user passes `llm_display_cost`; Kitaru turns that into the same metadata metric they used to have to type manually: sum the existing flat display-cost metadata key. From there, the normal statistics request builder sends a metadata metric to the backend. Nothing new is added to LLM usage recording itself.

The highest-risk areas to inspect are:

- `src/kitaru/_client/_statistics.py`: shortcut registry, parser expansion, and error text.
- `tests/test_client.py`: proves shortcuts normalize to metadata metrics, preserve analytics privacy, and map into backend requests.
- `tests/test_cli.py` and `tests/mcp/test_server.py`: prove CLI and MCP use the shared behavior rather than custom per-surface parsing.

### Reproduction

SDK:

```python
from kitaru import KitaruClient

stats = KitaruClient().executions.statistics(
    flow="content_pipeline",
    metrics=["llm_display_cost", "llm_total_tokens"],
)
print(stats.groups[0].metrics)
```

CLI:

```bash
kitaru executions statistics \
  --flow content_pipeline \
  --metric llm_display_cost \
  --metric llm_total_tokens \
  -o json
```

MCP payload:

```json
{
  "group_by": ["flow"],
  "metrics": ["llm_display_cost", "llm_total_tokens"],
  "max_groups": 20
}
```

For an execution set that has terminal LLM summary metadata, those metrics should appear under the shortcut names. If no matching LLM metadata exists, the statistics response remains structurally valid and behaves like any other missing numeric metadata aggregate.

### Local checks run

- `just check`
- `just test` → `2915 passed, 13 skipped`
- `uv run pytest tests/test_client.py -k 'statistics and (metric or llm)'`
- `uv run pytest tests/test_cli.py -k 'statistics'`
- `uv run pytest tests/mcp/test_server.py -k 'statistics'`
- `just links`
- `/simplify` review pass with reuse, quality, and efficiency reviewers
- Oracle review: clear/no blockers
