### PR TITLE
Fix FlowHandle run output extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added named LLM cost/token metric shortcuts for execution statistics across SDK, CLI, and MCP.
 
 ### Fixed
-- Fixed `FlowHandle.wait()` and `.get()` to return persisted flow run outputs before falling back to terminal-checkpoint inference, so granular adapter flows with explicit return values no longer raise ambiguous-result errors.
-- Moved terminal LLM usage summary aggregation to a Kitaru run-end hook, with `FlowHandle.wait()` and `.get()` kept as fallback aggregation paths.
+- Fixed `FlowHandle.wait()` and `.get()` to return persisted flow outputs for flows with explicit return values, so granular adapter flows no longer raise ambiguous-result errors in that common case.
+- Updated LLM usage summaries so Kitaru normally writes them when executions finish, while `FlowHandle.wait()` and `.get()` can populate missing summaries for older executions or executions where the finish-time summary was not written.
 
 ## [0.18.0] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - Added named LLM cost/token metric shortcuts for execution statistics across SDK, CLI, and MCP.
 
+### Fixed
+- Fixed `FlowHandle.wait()` and `.get()` to return persisted flow run outputs before falling back to terminal-checkpoint inference, so granular adapter flows with explicit return values no longer raise ambiguous-result errors.
+- Moved terminal LLM usage summary aggregation to a Kitaru run-end hook, with `FlowHandle.wait()` and `.get()` kept as fallback aggregation paths.
+
 ## [0.18.0] - 2026-06-25
 
 ### Added

--- a/docs/book/adapters/claude-agent-sdk.md
+++ b/docs/book/adapters/claude-agent-sdk.md
@@ -488,7 +488,7 @@ Some Claude SDK results expose `model_usage` instead of the top-level `usage` pa
 
 The canonical record is independent of the durable adapter event log. Turning `emit_events=False` suppresses the invocation event and run summary artifacts, but it does not stop the lightweight LLM usage metadata record. Set `save_usage=False` when you do not want Claude usage persisted; that disables both the separate usage artifact and the canonical invocation record used for execution-level LLM summaries.
 
-These records normally roll up from Kitaru's run-end hook; `FlowHandle.wait()` and `FlowHandle.get()` keep the same aggregation as a fallback. If Claude reports usage but not cost, the usage record keeps token counts and leaves cost fields empty unless you pass a calculator.
+Kitaru normally rolls these records into the execution-level usage summary when the execution finishes. `FlowHandle.wait()` and `FlowHandle.get()` can populate missing summaries for older executions or executions where the finish-time summary was not written. If Claude reports usage but not cost, the usage record keeps token counts and leaves cost fields empty unless you pass a calculator.
 
 You can reduce what is stored with `ClaudeCapturePolicy`:
 

--- a/docs/book/adapters/claude-agent-sdk.md
+++ b/docs/book/adapters/claude-agent-sdk.md
@@ -488,7 +488,7 @@ Some Claude SDK results expose `model_usage` instead of the top-level `usage` pa
 
 The canonical record is independent of the durable adapter event log. Turning `emit_events=False` suppresses the invocation event and run summary artifacts, but it does not stop the lightweight LLM usage metadata record. Set `save_usage=False` when you do not want Claude usage persisted; that disables both the separate usage artifact and the canonical invocation record used for execution-level LLM summaries.
 
-These records roll up after your code observes the terminal execution with `FlowHandle.wait()` or `FlowHandle.get()`. If Claude reports usage but not cost, the summary can still count tokens while marking that record as missing a dollar-cost value.
+These records normally roll up from Kitaru's run-end hook; `FlowHandle.wait()` and `FlowHandle.get()` keep the same aggregation as a fallback. If Claude reports usage but not cost, the usage record keeps token counts and leaves cost fields empty unless you pass a calculator.
 
 You can reduce what is stored with `ClaudeCapturePolicy`:
 

--- a/docs/book/adapters/gemini-interactions.md
+++ b/docs/book/adapters/gemini-interactions.md
@@ -135,9 +135,10 @@ That canonical statistics record uses Gemini token fields such as
 `prompt_token_count` / `promptTokenCount`, `candidates_token_count` /
 `candidatesTokenCount`, `cached_content_token_count` /
 `cachedContentTokenCount`, and `thoughts_token_count` / `thoughtsTokenCount` when
-Google reports them. The token counts then roll up into execution-level LLM usage
-summary fields and flat statistics keys after your code observes the terminal
-execution with `FlowHandle.wait()` or `FlowHandle.get()`.
+Google reports them. The token counts then normally roll up into
+execution-level LLM usage summary fields and flat statistics keys from Kitaru's
+run-end hook. `FlowHandle.wait()` and `FlowHandle.get()` keep the same
+aggregation as a fallback.
 
 The canonical usage record's `status` describes the provider call, not the next
 thing your application must do. So a Gemini interaction that returns

--- a/docs/book/adapters/gemini-interactions.md
+++ b/docs/book/adapters/gemini-interactions.md
@@ -135,10 +135,10 @@ That canonical statistics record uses Gemini token fields such as
 `prompt_token_count` / `promptTokenCount`, `candidates_token_count` /
 `candidatesTokenCount`, `cached_content_token_count` /
 `cachedContentTokenCount`, and `thoughts_token_count` / `thoughtsTokenCount` when
-Google reports them. The token counts then normally roll up into
-execution-level LLM usage summary fields and flat statistics keys from Kitaru's
-run-end hook. `FlowHandle.wait()` and `FlowHandle.get()` keep the same
-aggregation as a fallback.
+Google reports them. Kitaru normally rolls those token counts into
+execution-level LLM usage summary fields and flat statistics keys when the
+execution finishes. `FlowHandle.wait()` and `FlowHandle.get()` can populate
+missing summaries for older executions or executions where the finish-time summary was not written.
 
 The canonical usage record's `status` describes the provider call, not the next
 thing your application must do. So a Gemini interaction that returns

--- a/docs/book/adapters/openai-agents.md
+++ b/docs/book/adapters/openai-agents.md
@@ -179,11 +179,11 @@ The per-call checkpoints are siblings under the flow, but a flow that explicitly
 returns a value still has one persisted run output. In that common shape,
 `flow.run(...).wait()` returns the flow's output after completion while the
 per-checkpoint artifacts remain visible in the Kitaru UI and retrievable via
-`KitaruClient`. Ambiguity remains only for legacy or no-output runs where Kitaru
-has to infer a result from terminal checkpoint artifacts. Wrapping the
-`runner.run_sync()` call in your own `@checkpoint` is **not** a workaround for
-changing per-call placement — the adapter guards against it and will raise,
-because per-call checkpoints cannot be nested inside another Kitaru checkpoint.
+`KitaruClient`. If your flow does not return a value, inspect those artifacts
+instead. Wrapping the `runner.run_sync()` call in your own `@checkpoint` is
+**not** a workaround for changing per-call placement — the adapter guards against
+it and will raise, because per-call checkpoints cannot be nested inside another
+Kitaru checkpoint.
 
 ## Sandbox command tool
 
@@ -542,7 +542,7 @@ When `save_usage=True` (the default), each completed or interrupted runner call 
 
 If you pass a `cost_calculator=` to `KitaruRunner`, Kitaru stores the returned value as `estimated_cost_usd`. Calculator failures are non-fatal: the runner still returns the OpenAI result, adds a warning, and leaves the estimated cost empty. Without a user calculator, Kitaru estimates with `genai-prices` when the SDK usage summary names a single OpenAI model and includes priceable token counts. If the run does not expose a reliable model name, Kitaru records tokens only rather than pricing a multi-model or handoff run with the wrong model. OpenAI Agents records do not store provider-reported actual cost in this adapter path, so `actual_cost_usd` is normally empty.
 
-These records normally roll up into the execution-level LLM usage summary from Kitaru's run-end hook. `FlowHandle.wait()` and `FlowHandle.get()` keep the same aggregation as a fallback when they observe a terminal run that does not already have a complete summary. Set `save_usage=False` when you do not want the adapter to persist canonical usage metadata for that runner call.
+Kitaru normally rolls these records into the execution-level LLM usage summary when the execution finishes. `FlowHandle.wait()` and `FlowHandle.get()` can populate missing summaries for older executions or executions where the finish-time summary was not written. Set `save_usage=False` when you do not want the adapter to persist canonical usage metadata for that runner call.
 
 Two privacy switches are worth calling out:
 

--- a/docs/book/adapters/openai-agents.md
+++ b/docs/book/adapters/openai-agents.md
@@ -20,8 +20,10 @@ runner = KitaruRunner(agent, checkpoint_strategy="runner_call")
 ```
 
 The runtime default is `checkpoint_strategy="calls"` (per-call checkpoints —
-see below); pass `"runner_call"` whenever you want a single terminal
-checkpoint so `flow.run(...).wait()` returns the run result directly.
+see below). If your flow returns the runner result or a value derived from it,
+`flow.run(...).wait()` returns that persisted run output after completion. Pass
+`"runner_call"` when you want the OpenAI runner call itself to be one coarse
+checkpoint.
 
 You run the agent through `runner.run(...)` or `runner.run_sync(...)` with an
 `OpenAIRunRequest`.
@@ -155,7 +157,7 @@ you need Kitaru checkpoints there too.
 
 You choose how Kitaru places checkpoints with `checkpoint_strategy=`.
 
-### `checkpoint_strategy="runner_call"` (recommended for `.wait()`)
+### `checkpoint_strategy="runner_call"`
 
 Kitaru places one checkpoint around the outer OpenAI `Runner.run(...)` call. That
 single checkpoint becomes the flow's terminal artifact, so
@@ -163,8 +165,7 @@ single checkpoint becomes the flow's terminal artifact, so
 `"runner_call"` is deliberately specific: it means Kitaru is wrapping the outer
 OpenAI runner call, not claiming to own every SDK-internal step.
 
-Use this when you want one coarse replay boundary for the whole agent run, or
-whenever you want a clean Python value back from `.wait()`.
+Use this when you want one coarse replay unit for the whole agent run.
 
 ### `checkpoint_strategy="calls"` (default)
 
@@ -174,15 +175,15 @@ checkpoints under the flow.
 Use this when you want finer replay units: if call 6 fails, calls 1–5 can come
 from cache, and you can replay from any individual call's checkpoint.
 
-Because the per-call checkpoints are siblings under the flow with no single
-sink, `flow.run(...).wait()` cannot pick one as "the" return value and raises
-`KitaruAmbiguousFlowResultError`. The per-checkpoint artifacts are still
-fully visible in the Kitaru UI and retrievable via `KitaruClient` — the
-error message points at them. If you need a clean `.wait()` return value,
-switch to `checkpoint_strategy="runner_call"`. Wrapping the `runner.run_sync()`
-call in your own `@checkpoint` is **not** a workaround here — the adapter
-guards against it and will raise, because per-call checkpoints cannot be
-nested inside another Kitaru checkpoint.
+The per-call checkpoints are siblings under the flow, but a flow that explicitly
+returns a value still has one persisted run output. In that common shape,
+`flow.run(...).wait()` returns the flow's output after completion while the
+per-checkpoint artifacts remain visible in the Kitaru UI and retrievable via
+`KitaruClient`. Ambiguity remains only for legacy or no-output runs where Kitaru
+has to infer a result from terminal checkpoint artifacts. Wrapping the
+`runner.run_sync()` call in your own `@checkpoint` is **not** a workaround for
+changing per-call placement — the adapter guards against it and will raise,
+because per-call checkpoints cannot be nested inside another Kitaru checkpoint.
 
 ## Sandbox command tool
 
@@ -434,8 +435,8 @@ OpenAI Agents SDK structured outputs work through the adapter. If your agent is
 created with `Agent(output_type=...)`, Kitaru preserves the SDK result object and
 its typed `final_output` in both supported strategies:
 
-- `checkpoint_strategy="runner_call"` records the outer runner call and returns
-  the structured result from `.wait()` cleanly.
+- `checkpoint_strategy="runner_call"` records the outer runner call as one
+  checkpoint.
 - `checkpoint_strategy="calls"` records supported model and tool calls
   individually, while the SDK still produces the typed final output for your
   Python code.
@@ -541,7 +542,7 @@ When `save_usage=True` (the default), each completed or interrupted runner call 
 
 If you pass a `cost_calculator=` to `KitaruRunner`, Kitaru stores the returned value as `estimated_cost_usd`. Calculator failures are non-fatal: the runner still returns the OpenAI result, adds a warning, and leaves the estimated cost empty. Without a user calculator, Kitaru estimates with `genai-prices` when the SDK usage summary names a single OpenAI model and includes priceable token counts. If the run does not expose a reliable model name, Kitaru records tokens only rather than pricing a multi-model or handoff run with the wrong model. OpenAI Agents records do not store provider-reported actual cost in this adapter path, so `actual_cost_usd` is normally empty.
 
-These records roll up into the execution-level LLM usage summary after your code observes the terminal execution with `FlowHandle.wait()` or `FlowHandle.get()`. Set `save_usage=False` when you do not want the adapter to persist canonical usage metadata for that runner call.
+These records normally roll up into the execution-level LLM usage summary from Kitaru's run-end hook. `FlowHandle.wait()` and `FlowHandle.get()` keep the same aggregation as a fallback when they observe a terminal run that does not already have a complete summary. Set `save_usage=False` when you do not want the adapter to persist canonical usage metadata for that runner call.
 
 Two privacy switches are worth calling out:
 

--- a/docs/book/adapters/pydantic-ai.md
+++ b/docs/book/adapters/pydantic-ai.md
@@ -292,7 +292,7 @@ def visible_tool_calls() -> str:
     return publish_final_answer(result.output)
 ```
 
-Here the agent runs directly in the flow body, so `checkpoint_strategy="calls"` can create rows such as `researcher_model_request` and `run_sandbox_command_tool`. Because the flow explicitly returns `publish_final_answer(...)`, `FlowHandle.wait()` returns that persisted run output after the execution completes. Ambiguity remains only for legacy or no-output runs where Kitaru has to infer a result from terminal checkpoint artifacts.
+Here the agent runs directly in the flow body, so `checkpoint_strategy="calls"` can create rows such as `researcher_model_request` and `run_sandbox_command_tool`. Because the flow explicitly returns `publish_final_answer(...)`, `FlowHandle.wait()` returns that persisted run output after the execution completes. If your flow does not return a value, inspect the persisted artifacts instead.
 
 ```python
 @kitaru.checkpoint
@@ -496,7 +496,7 @@ durable_agent = KitaruAgent(agent, cost_calculator=calculate_agent_cost)
 
 If Kitaru cannot identify the provider/model for a model event, or `genai-prices` cannot price it, the usage record keeps the tokens and leaves cost empty. Disable automatic estimates with `KITARU_LLM_ESTIMATED_COSTS=off` when you want token-only adapter records unless a user calculator is configured.
 
-In `checkpoint_strategy="calls"`, cached model checkpoint results are recorded as `reused_not_incurred`, so replay and cache hits do not look like fresh spend in the execution summary. The canonical records normally roll up from Kitaru's run-end hook; `FlowHandle.wait()` and `FlowHandle.get()` keep the same aggregation as a fallback. Setting `emit_child_events=False` disables the model/tool event tracking that produces these per-model usage records.
+In `checkpoint_strategy="calls"`, cached model checkpoint results are recorded as `reused_not_incurred`, so replay and cache hits do not look like fresh spend when Kitaru builds execution-level usage summaries. Kitaru normally writes those summaries when executions finish; `FlowHandle.wait()` and `FlowHandle.get()` can populate missing summaries for older executions or executions where the finish-time summary was not written. Setting `emit_child_events=False` disables the model/tool event tracking that produces these per-model usage records.
 
 ## Message history
 

--- a/docs/book/adapters/pydantic-ai.md
+++ b/docs/book/adapters/pydantic-ai.md
@@ -292,7 +292,7 @@ def visible_tool_calls() -> str:
     return publish_final_answer(result.output)
 ```
 
-Here the agent runs directly in the flow body, so `checkpoint_strategy="calls"` can create rows such as `researcher_model_request` and `run_sandbox_command_tool`. In current file-based flows, those adapter-created model/tool checkpoints can still be terminal graph steps. If your flow keeps this per-tool shape, do not rely on `FlowHandle.wait()` to return the final answer; it may refuse to choose between several terminal checkpoint outputs. Poll `handle.status` until completion, then inspect the execution in the UI/CLI and read the final-answer checkpoint artifact.
+Here the agent runs directly in the flow body, so `checkpoint_strategy="calls"` can create rows such as `researcher_model_request` and `run_sandbox_command_tool`. Because the flow explicitly returns `publish_final_answer(...)`, `FlowHandle.wait()` returns that persisted run output after the execution completes. Ambiguity remains only for legacy or no-output runs where Kitaru has to infer a result from terminal checkpoint artifacts.
 
 ```python
 @kitaru.checkpoint
@@ -496,7 +496,7 @@ durable_agent = KitaruAgent(agent, cost_calculator=calculate_agent_cost)
 
 If Kitaru cannot identify the provider/model for a model event, or `genai-prices` cannot price it, the usage record keeps the tokens and leaves cost empty. Disable automatic estimates with `KITARU_LLM_ESTIMATED_COSTS=off` when you want token-only adapter records unless a user calculator is configured.
 
-In `checkpoint_strategy="calls"`, cached model checkpoint results are recorded as `reused_not_incurred`, so replay and cache hits do not look like fresh spend in the execution summary. The canonical records roll up after `FlowHandle.wait()` or `FlowHandle.get()` observes the terminal execution. Setting `emit_child_events=False` disables the model/tool event tracking that produces these per-model usage records.
+In `checkpoint_strategy="calls"`, cached model checkpoint results are recorded as `reused_not_incurred`, so replay and cache hits do not look like fresh spend in the execution summary. The canonical records normally roll up from Kitaru's run-end hook; `FlowHandle.wait()` and `FlowHandle.get()` keep the same aggregation as a fallback. Setting `emit_child_events=False` disables the model/tool event tracking that produces these per-model usage records.
 
 ## Message history
 
@@ -609,9 +609,7 @@ Set `PYDANTIC_AI_MODEL` if you want to use a model other than the default
 `openai:gpt-5-nano`. The example runs the agent directly in the flow body so
 `run_sandbox_command_tool` is visible as its own checkpoint, then passes the
 answer into a small `publish_sandbox_answer` checkpoint for inspection. The
-script polls execution status instead of calling `.wait()`, because `.wait()`
-would try to pick one result from several terminal model/tool checkpoints in
-this per-tool demo shape.
+script calls `.wait()` and prints the persisted final run output.
 
 For the broader catalog, see [Examples](../getting-started/examples.md).
 

--- a/docs/book/concepts/flows.md
+++ b/docs/book/concepts/flows.md
@@ -136,9 +136,9 @@ execution:
 
 {% hint style="info" %}
 `handle.get()` does **not** wait. If the execution is still running, it raises a
-`KitaruStateError`. Use `handle.wait()` when you want to block. For current runs
-that return a value, both methods read the saved run output; Kitaru only falls
-back to terminal-checkpoint result inference for older or no-output runs.
+`KitaruStateError`. Use `handle.wait()` when you want to block. For flows
+that explicitly return a value, both methods return the saved run output. For
+flows that do not return a value, inspect the persisted artifacts instead.
 {% endhint %}
 
 ### How errors surface

--- a/docs/book/concepts/flows.md
+++ b/docs/book/concepts/flows.md
@@ -59,7 +59,8 @@ result = handle.wait()   # block until finished
 
 `.run()` submits the execution and immediately returns a `FlowHandle`. The flow
 runs in the background while your code continues. Call `handle.wait()` when you
-need the result.
+need the result: it waits for the execution to finish, then returns the persisted
+run output from the flow's `return` statement.
 
 For a synchronous one-liner, chain `.wait()`:
 
@@ -80,7 +81,8 @@ from a checkpoint with `flow.replay(...)`. Keep the `exec_id` a run returns —
 that's the handle into replay.
 
 ```python
-handle = my_agent.run(url="https://example.com").wait()
+handle = my_agent.run(url="https://example.com")
+result = handle.wait()
 exec_id = handle.exec_id
 
 # Faithful rerun with no change = the control/baseline.
@@ -129,12 +131,14 @@ execution:
 |---|---|
 | `handle.exec_id` | The unique execution identifier (a string you can store or log) |
 | `handle.status` | Current execution status (refreshed on each access) |
-| `handle.wait()` | Block until the execution finishes, then return the result |
-| `handle.get()` | Return the result immediately if finished, otherwise raise an error |
+| `handle.wait()` | Block until the execution finishes, then return the persisted run output |
+| `handle.get()` | Return the persisted run output immediately if finished, otherwise raise an error |
 
 {% hint style="info" %}
 `handle.get()` does **not** wait. If the execution is still running, it raises a
-`KitaruStateError`. Use `handle.wait()` when you want to block.
+`KitaruStateError`. Use `handle.wait()` when you want to block. For current runs
+that return a value, both methods read the saved run output; Kitaru only falls
+back to terminal-checkpoint result inference for older or no-output runs.
 {% endhint %}
 
 ### How errors surface

--- a/docs/book/guides/execution-management.md
+++ b/docs/book/guides/execution-management.md
@@ -226,9 +226,9 @@ When an execution makes LLM calls through `kitaru.llm()` or the supported agent
 adapters, Kitaru records canonical `llm_usage_v1` metadata on the checkpoint
 that made or reused the provider work. One usage record usually means one
 provider interaction or one adapter-level graph/agent invocation, depending on
-which adapter produced it. At run end, Kitaru reads those checkpoint records and
-writes two execution-level views. `FlowHandle.wait()` and `FlowHandle.get()` keep
-the same aggregation as a fallback for older runs or unexpected hook failures:
+which adapter produced it. When the execution finishes, Kitaru reads those
+checkpoint records and writes two execution-level views. `FlowHandle.wait()` and
+`FlowHandle.get()` can populate missing summaries for older executions or executions where the finish-time summary was not written:
 
 - `llm_usage_summary_v1` is the inspection view. `kitaru executions get` and the
   Python client parse it into `execution.llm_usage_summary`. It tells you what
@@ -331,11 +331,10 @@ numeric execution metadata and for advanced internal debugging, but you should
 not need `kitaru_llm_*_v1` keys for common LLM cost and token totals.
 
 {% hint style="info" %}
-Terminal LLM summaries are normally written by the Kitaru run-end hook, so a
+Kitaru normally writes terminal LLM summaries when executions finish, so a
 remote execution can get `llm_usage_summary_v1` and the flat `kitaru_llm_*_v1`
 statistics keys even if no local SDK process calls `.wait()` or `.get()`. Those
-methods still perform the same aggregation as an idempotent fallback when they
-observe a terminal run that does not already have a complete summary.
+methods can still populate missing summaries for older executions or terminal executions where the finish-time summary was not written.
 {% endhint %}
 
 Supported filters are `flow`, `status`, `stack`, `tags`, and `max_groups`.

--- a/docs/book/guides/execution-management.md
+++ b/docs/book/guides/execution-management.md
@@ -226,9 +226,9 @@ When an execution makes LLM calls through `kitaru.llm()` or the supported agent
 adapters, Kitaru records canonical `llm_usage_v1` metadata on the checkpoint
 that made or reused the provider work. One usage record usually means one
 provider interaction or one adapter-level graph/agent invocation, depending on
-which adapter produced it. When `FlowHandle.wait()` or `FlowHandle.get()`
-observes the execution finishing, Kitaru reads those checkpoint records and
-writes two execution-level views:
+which adapter produced it. At run end, Kitaru reads those checkpoint records and
+writes two execution-level views. `FlowHandle.wait()` and `FlowHandle.get()` keep
+the same aggregation as a fallback for older runs or unexpected hook failures:
 
 - `llm_usage_summary_v1` is the inspection view. `kitaru executions get` and the
   Python client parse it into `execution.llm_usage_summary`. It tells you what
@@ -330,13 +330,12 @@ The shortcut names above mean "sum this common LLM total". The raw
 numeric execution metadata and for advanced internal debugging, but you should
 not need `kitaru_llm_*_v1` keys for common LLM cost and token totals.
 
-{% hint style="warning" %}
-In v1, terminal LLM summaries are written when the SDK observes completion via
-`FlowHandle.wait()` or `FlowHandle.get()`. A remote execution that finishes but
-is never observed through those paths can still have per-checkpoint
-`llm_usage_v1` records, but it may not have `llm_usage_summary_v1` or the flat
-`kitaru_llm_*_v1` statistics keys yet. `executions.get` stays read-only and does
-not backfill missing summaries.
+{% hint style="info" %}
+Terminal LLM summaries are normally written by the Kitaru run-end hook, so a
+remote execution can get `llm_usage_summary_v1` and the flat `kitaru_llm_*_v1`
+statistics keys even if no local SDK process calls `.wait()` or `.get()`. Those
+methods still perform the same aggregation as an idempotent fallback when they
+observe a terminal run that does not already have a complete summary.
 {% endhint %}
 
 Supported filters are `flow`, `status`, `stack`, `tags`, and `max_groups`.

--- a/examples/end_to_end/openai_research_bot/research_bot.py
+++ b/examples/end_to_end/openai_research_bot/research_bot.py
@@ -21,9 +21,7 @@ from pydantic import BaseModel
 import kitaru
 from kitaru import ImageSettings, checkpoint, flow
 from kitaru.adapters.openai_agents import KitaruRunner, OpenAIRunRequest
-from kitaru.client import KitaruClient
 from kitaru.config import classify_stack_deployment_type
-from kitaru.errors import KitaruAmbiguousFlowResultError
 
 try:  # Package import path used by tests.
     from .bot_agents import (
@@ -501,17 +499,7 @@ def _run_once(
         run_kwargs["image"] = image_override
 
     handle = openai_research_bot.run(**run_kwargs)
-    try:
-        return str(handle.wait())
-    except KitaruAmbiguousFlowResultError:
-        artifacts = KitaruClient().artifacts.list(
-            handle.exec_id,
-            name="final_report",
-            limit=1,
-        )
-        if not artifacts:
-            raise
-        return str(artifacts[0].load())
+    return str(handle.wait())
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/examples/integrations/openai_agents_agent/README.md
+++ b/examples/integrations/openai_agents_agent/README.md
@@ -104,24 +104,23 @@ adapter's `OpenAIRunResult` becomes the flow's terminal artifact and
 ## `calls` vs `runner_call` (plain-language version)
 
 - `runner_call`: Kitaru places one bigger checkpoint around the entire
-  `Runner.run(...)` call. Single terminal artifact, clean `.wait()` return.
+  `Runner.run(...)` call. This is useful when you want one coarse replay unit.
 - `calls`: Kitaru places smaller checkpoints around each supported model/tool
-  call. Finer replay units, but each call becomes a peer checkpoint with no
-  single sink — `.wait()` raises `KitaruAmbiguousFlowResultError` because
-  there is no "the" return value. The per-checkpoint artifacts are still
-  visible in the Kitaru UI.
+  call. You get finer replay units, and `.wait()` still returns the flow's
+  persisted final output when the flow has an explicit `return` value. The
+  per-checkpoint artifacts are still visible in the Kitaru UI.
 
 To see both side-by-side (the default `runner_call` run, then the `calls`
-run with the expected ambiguity error printed), use:
+run with the same final output plus finer checkpoint detail), use:
 
 ```bash
 OPENAI_AGENTS_COMPARE_CALLS=1 uv run python openai_agents_adapter.py
 ```
 
 In that mode you'll see the `runner_call` model output first, then a
-`=== calls strategy output ===` section showing the new actionable error
-that names the terminal checkpoints, gives the execution ID, and points at
-the Kitaru UI / `KitaruClient` for per-checkpoint artifact retrieval.
+`=== calls strategy output ===` section that prints the final answer from the
+persisted flow output. The `calls` run also produces finer-grained model/tool
+checkpoints that are visible in the Kitaru UI.
 
 ## Passing OpenAI Agents context
 

--- a/examples/integrations/openai_agents_agent/openai_agents_adapter.py
+++ b/examples/integrations/openai_agents_agent/openai_agents_adapter.py
@@ -26,7 +26,6 @@ from kitaru.adapters.openai_agents import (
     OpenAIRunRequest,
     OpenAIRunResult,
 )
-from kitaru.errors import KitaruAmbiguousFlowResultError
 
 ORDERS: dict[str, dict[str, str]] = {
     "ORD-1007": {
@@ -199,21 +198,11 @@ def main() -> None:
         "true",
         "yes",
     }:
-        # `calls` strategy creates per-tool/per-model peer checkpoints with no
-        # single sink, so `.wait()` raises `KitaruAmbiguousFlowResultError`
-        # when it can't pick a single terminal artifact. The raised message
-        # points at the per-checkpoint artifacts in the Kitaru UI /
-        # `KitaruClient`, which is the right surface for `calls` flows.
-        # Real execution failures (model error, tool failure, etc.) will not
-        # match this specific subclass and will propagate normally.
-        try:
-            calls_output = _run_once("calls")
-        except KitaruAmbiguousFlowResultError as error:
-            print("\n=== calls strategy output ===")
-            print(f"(per-checkpoint artifacts only; .wait() raised: {error})")
-        else:
-            print("\n=== calls strategy output ===")
-            print(calls_output)
+        # `calls` strategy still creates separate per-tool/per-model checkpoints,
+        # while `.wait()` returns the flow's persisted final output.
+        calls_output = _run_once("calls")
+        print("\n=== calls strategy output ===")
+        print(calls_output)
 
 
 if __name__ == "__main__":

--- a/examples/integrations/openai_agents_agent/openai_agents_sandbox_tool.py
+++ b/examples/integrations/openai_agents_agent/openai_agents_sandbox_tool.py
@@ -25,7 +25,6 @@ from kitaru.adapters.openai_agents import (
     OpenAIRunRequest,
     sandbox_command_tool,
 )
-from kitaru.errors import KitaruAmbiguousFlowResultError
 
 SAFE_INSPECTION_COMMAND = (
     'python -c "import os, platform; '
@@ -104,14 +103,9 @@ def main() -> None:
         "true",
         "yes",
     }:
-        try:
-            calls_output = _run_once("calls")
-        except KitaruAmbiguousFlowResultError as error:
-            print("\n=== sandbox tool calls output ===")
-            print(f"(per-checkpoint artifacts only; .wait() raised: {error})")
-        else:
-            print("\n=== sandbox tool calls output ===")
-            print(calls_output)
+        calls_output = _run_once("calls")
+        print("\n=== sandbox tool calls output ===")
+        print(calls_output)
 
 
 if __name__ == "__main__":

--- a/examples/integrations/pydantic_ai_agent/README.md
+++ b/examples/integrations/pydantic_ai_agent/README.md
@@ -57,11 +57,9 @@ agent with `KitaruAgent(checkpoint_strategy="calls")`. The model is asked to cal
 `run_sandbox_command` for `python --version`. The agent runs directly in the flow
 body, so the dashboard can show the model request checkpoint and the
 `run_sandbox_command_tool` checkpoint separately. The example then passes the
-answer into a tiny `publish_sandbox_answer` checkpoint for UI/CLI inspection.
-It does not call `.wait()` for the final answer, because the visible
-model/tool checkpoints are also terminal graph steps in this demo shape.
-Instead, the script polls execution status and prints the execution ID to open
-in the UI or inspect with `kitaru executions get`.
+answer into a tiny `publish_sandbox_answer` checkpoint for UI/CLI inspection,
+returns that answer from the flow, and prints the persisted final output from
+`.wait()` after completion.
 
 The example uses the adapter's 20,000-character output limit and disables cache
 for the sandbox command checkpoint. Your active stack must have exactly one

--- a/examples/integrations/pydantic_ai_agent/pydantic_ai_sandbox_toolset.py
+++ b/examples/integrations/pydantic_ai_agent/pydantic_ai_sandbox_toolset.py
@@ -159,13 +159,11 @@ def wait_for_completion(
     poll_seconds: float = 1.0,
     timeout_seconds: float = 300.0,
 ) -> ExecutionStatus:
-    """Wait for terminal execution status without extracting a flow result.
+    """Poll until the example flow reaches a terminal status.
 
-    This demo intentionally keeps per-call adapter checkpoints visible. In that
-    shape, ``FlowHandle.wait()`` is not the right API because result extraction
-    sees several terminal model/tool checkpoints and refuses to guess. Polling
-    ``handle.status`` waits for completion without asking Kitaru to choose one
-    output value.
+    The script's main path uses ``handle.wait()`` so it can print the persisted
+    run output. This helper remains available for tests and for callers that
+    only want terminal status without loading the result.
     """
     start = time.monotonic()
     last_status = handle.status
@@ -184,7 +182,7 @@ def wait_for_completion(
 
 
 def _raise_failed_execution_details(handle: Any, status: ExecutionStatus) -> None:
-    """Raise the execution failure while avoiding successful result extraction."""
+    """Raise the execution failure details for a terminal failed status."""
     try:
         handle.get()
     except KitaruExecutionError:
@@ -206,9 +204,7 @@ def main() -> None:
     try:
         handle = submit_sandbox_toolset_flow(model=model)
         print(f"Submitted sandbox toolset flow execution: {handle.exec_id}")
-        status = wait_for_completion(handle)
-        if status is not ExecutionStatus.COMPLETED:
-            _raise_failed_execution_details(handle, status)
+        final_answer = handle.wait()
     except (KitaruFeatureNotAvailableError, KitaruStateError) as error:
         raise SystemExit(
             "This example needs an active Kitaru stack with exactly one sandbox "
@@ -221,8 +217,6 @@ def main() -> None:
         ) from error
     except KitaruExecutionError as error:
         raise SystemExit(str(error)) from error
-    except TimeoutError as error:
-        raise SystemExit(str(error)) from error
 
     print("=== sandbox command checkpoints ===")
     print(f"Execution: {handle.exec_id}")
@@ -233,10 +227,10 @@ def main() -> None:
     print("  - run_sandbox_command_tool")
     print("  - publish_sandbox_answer")
     print(
-        "The final text is stored on the publish_sandbox_answer checkpoint. "
-        "This per-tool checkpoint demo does not use `.wait()` for the final answer "
-        "because adapter-created model/tool checkpoints are also terminal graph steps."
+        "The final text is stored on the publish_sandbox_answer checkpoint "
+        "and returned by `.wait()`:"
     )
+    print(final_answer)
 
 
 if __name__ == "__main__":

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -187,24 +187,25 @@ def _checkpoint_lineage_key(step: StepRunResponse) -> str:
     return str(step.id)
 
 
-def _list_checkpoint_attempts_for_run(
+def _list_checkpoint_attempts_for_run_with_zenml_client(
     *,
     run: PipelineRunResponse,
-    client: KitaruClient,
+    zenml_client: Any,
+    project: Any | None = None,
 ) -> dict[str, list[StepRunResponse]]:
-    """Fetch all step attempts for one execution, including retried runs."""
+    """Fetch all step attempts for one execution with a ZenML client."""
     grouped_attempts: defaultdict[str, list[StepRunResponse]] = defaultdict(list)
     page = 1
     page_size = 200
 
     try:
         while True:
-            step_page = client._client().list_run_steps(
+            step_page = zenml_client.list_run_steps(
                 sort_by="asc:created",
                 page=page,
                 size=page_size,
                 pipeline_run_id=run.id,
-                project=client._project,
+                project=project,
                 exclude_retried=False,
                 hydrate=True,
             )
@@ -224,6 +225,19 @@ def _list_checkpoint_attempts_for_run(
         ) from exc
 
     return dict(grouped_attempts)
+
+
+def _list_checkpoint_attempts_for_run(
+    *,
+    run: PipelineRunResponse,
+    client: KitaruClient,
+) -> dict[str, list[StepRunResponse]]:
+    """Fetch all step attempts for one execution, including retried runs."""
+    return _list_checkpoint_attempts_for_run_with_zenml_client(
+        run=run,
+        zenml_client=client._client(),
+        project=client._project,
+    )
 
 
 def _map_checkpoint_attempt(step: StepRunResponse) -> CheckpointAttempt:

--- a/src/kitaru/_llm_usage.py
+++ b/src/kitaru/_llm_usage.py
@@ -1211,6 +1211,39 @@ def _valid_summary_number(value: Any, *, is_float: bool) -> bool:
     return number is not None and number >= 0
 
 
+def metadata_matches_usage_metadata(
+    metadata: Mapping[str, Any],
+    expected_metadata: Mapping[str, Any],
+) -> bool:
+    """Return whether stored usage metadata matches freshly generated metadata."""
+    if not metadata_has_complete_usage_summary(metadata):
+        return False
+
+    summary = parse_usage_summary(metadata.get(LLM_USAGE_SUMMARY_METADATA_KEY))
+    expected_summary = parse_usage_summary(
+        expected_metadata.get(LLM_USAGE_SUMMARY_METADATA_KEY)
+    )
+    if summary is None or expected_summary is None or summary != expected_summary:
+        return False
+
+    for metadata_key, summary_key, _coerce in _FLAT_METADATA_FIELDS:
+        is_float = summary_key in _SUMMARY_FLOAT_FIELDS
+        current = (
+            _float_or_none(metadata.get(metadata_key))
+            if is_float
+            else _int_or_none(metadata.get(metadata_key))
+        )
+        expected = (
+            _float_or_none(expected_metadata.get(metadata_key))
+            if is_float
+            else _int_or_none(expected_metadata.get(metadata_key))
+        )
+        if current is None or expected is None or current != expected:
+            return False
+
+    return True
+
+
 def metadata_has_complete_usage_summary(metadata: Mapping[str, Any]) -> bool:
     """Return whether terminal LLM aggregation metadata is complete enough to trust."""
     summary = parse_usage_summary(metadata.get(LLM_USAGE_SUMMARY_METADATA_KEY))

--- a/src/kitaru/_terminal_hooks.py
+++ b/src/kitaru/_terminal_hooks.py
@@ -1,0 +1,74 @@
+"""Importable ZenML lifecycle hooks used by Kitaru flows."""
+
+from __future__ import annotations
+
+import logging
+
+from zenml.client import Client
+from zenml.config.source import DistributionPackageSource, SourceType
+from zenml.execution.pipeline.dynamic.run_context import DynamicPipelineRunContext
+from zenml.utils.source_utils import ZENML_SOURCE_ATTRIBUTE_NAME
+
+from kitaru._terminal_usage import _safe_persist_terminal_llm_usage_metadata
+
+logger = logging.getLogger(__name__)
+
+
+def _current_dynamic_run_id() -> str | None:
+    """Return the active dynamic pipeline run ID, if lifecycle context exists."""
+    try:
+        context = DynamicPipelineRunContext.get()
+    except Exception:
+        logger.debug(
+            "Skipping terminal LLM usage aggregation because no dynamic run "
+            "context is available.",
+            exc_info=True,
+        )
+        return None
+
+    run = getattr(context, "run", None)
+    run_id = getattr(run, "id", None)
+    if run_id is None:
+        logger.debug(
+            "Skipping terminal LLM usage aggregation because the dynamic run "
+            "context has no run ID."
+        )
+        return None
+    return str(run_id)
+
+
+def aggregate_llm_usage_on_run_end(
+    exception: BaseException | None = None,
+) -> None:
+    """Aggregate terminal LLM usage metadata at ZenML run end.
+
+    The hook is deliberately best-effort. A cost-summary failure should be
+    visible in debug logs, but it must never change the user's run outcome.
+    """
+    del exception
+    try:
+        run_id = _current_dynamic_run_id()
+        if run_id is None:
+            return
+        run = Client().get_pipeline_run(
+            run_id,
+            allow_name_prefix_match=False,
+        )
+        _safe_persist_terminal_llm_usage_metadata(run)
+    except Exception:
+        logger.debug(
+            "Failed to aggregate terminal LLM usage metadata from run-end hook.",
+            exc_info=True,
+        )
+
+
+setattr(
+    aggregate_llm_usage_on_run_end,
+    ZENML_SOURCE_ATTRIBUTE_NAME,
+    DistributionPackageSource(
+        module="kitaru._terminal_hooks",
+        attribute="aggregate_llm_usage_on_run_end",
+        package_name="kitaru",
+        type=SourceType.DISTRIBUTION_PACKAGE,
+    ),
+)

--- a/src/kitaru/_terminal_hooks.py
+++ b/src/kitaru/_terminal_hooks.py
@@ -50,11 +50,12 @@ def aggregate_llm_usage_on_run_end(
         run_id = _current_dynamic_run_id()
         if run_id is None:
             return
-        run = Client().get_pipeline_run(
+        client = Client()
+        run = client.get_pipeline_run(
             run_id,
             allow_name_prefix_match=False,
         )
-        _safe_persist_terminal_llm_usage_metadata(run)
+        _safe_persist_terminal_llm_usage_metadata(run, zenml_client=client)
     except Exception:
         logger.debug(
             "Failed to aggregate terminal LLM usage metadata from run-end hook.",

--- a/src/kitaru/_terminal_usage.py
+++ b/src/kitaru/_terminal_usage.py
@@ -8,11 +8,15 @@ from typing import Any
 
 from zenml.models import PipelineRunResponse
 
-from kitaru._client._mappers import _list_checkpoint_attempts_for_run, _to_plain_dict
+from kitaru._client._mappers import (
+    _list_checkpoint_attempts_for_run_with_zenml_client,
+    _to_plain_dict,
+)
 from kitaru._llm_usage import (
     cache_status_for_checkpoint_status,
     execution_metadata_from_records,
     metadata_has_complete_usage_summary,
+    metadata_matches_usage_metadata,
     usage_records_from_metadata,
 )
 from kitaru._source_aliases import (
@@ -34,15 +38,30 @@ def _run_has_llm_usage_summary(run: PipelineRunResponse) -> bool:
     return metadata_has_complete_usage_summary(metadata)
 
 
-def _persist_terminal_llm_usage_metadata(run: PipelineRunResponse) -> bool:
+def _list_checkpoint_attempts_for_run(
+    *,
+    run: PipelineRunResponse,
+    client: Any,
+) -> dict[str, list[Any]]:
+    """Fetch checkpoint attempts with the ZenML client valid in this context."""
+    return _list_checkpoint_attempts_for_run_with_zenml_client(
+        run=run,
+        zenml_client=client,
+    )
+
+
+def _persist_terminal_llm_usage_metadata(
+    run: PipelineRunResponse,
+    *,
+    zenml_client: Any | None = None,
+) -> bool:
     """Aggregate LLM usage records and write execution-level metadata."""
-    from kitaru.client import KitaruClient
+    from zenml.client import Client
+
     from kitaru.logging import log_to_execution
 
-    if _run_has_llm_usage_summary(run):
-        return True
-
-    client = KitaruClient()
+    run_metadata = _metadata_mapping(getattr(run, "run_metadata", None))
+    client = zenml_client or Client()
     try:
         attempts_by_lineage = _list_checkpoint_attempts_for_run(run=run, client=client)
     except KitaruBackendError:
@@ -57,7 +76,7 @@ def _persist_terminal_llm_usage_metadata(run: PipelineRunResponse) -> bool:
     execution_id = str(run.id)
     records.extend(
         usage_records_from_metadata(
-            _metadata_mapping(getattr(run, "run_metadata", None)),
+            run_metadata,
             source_attempt_id=f"run:{execution_id}",
         )
     )
@@ -80,14 +99,20 @@ def _persist_terminal_llm_usage_metadata(run: PipelineRunResponse) -> bool:
     metadata = execution_metadata_from_records(records)
     if not metadata:
         return True
+    if metadata_matches_usage_metadata(run_metadata, metadata):
+        return True
     log_to_execution(str(run.id), **metadata)
     return True
 
 
-def _safe_persist_terminal_llm_usage_metadata(run: PipelineRunResponse) -> bool:
+def _safe_persist_terminal_llm_usage_metadata(
+    run: PipelineRunResponse,
+    *,
+    zenml_client: Any | None = None,
+) -> bool:
     """Best-effort terminal LLM usage aggregation."""
     try:
-        return _persist_terminal_llm_usage_metadata(run)
+        return _persist_terminal_llm_usage_metadata(run, zenml_client=zenml_client)
     except Exception:
         logger.debug(
             "Failed to persist terminal LLM usage metadata.",

--- a/src/kitaru/_terminal_usage.py
+++ b/src/kitaru/_terminal_usage.py
@@ -1,0 +1,96 @@
+"""Terminal execution metadata aggregation helpers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from zenml.models import PipelineRunResponse
+
+from kitaru._client._mappers import _list_checkpoint_attempts_for_run, _to_plain_dict
+from kitaru._llm_usage import (
+    cache_status_for_checkpoint_status,
+    execution_metadata_from_records,
+    metadata_has_complete_usage_summary,
+    usage_records_from_metadata,
+)
+from kitaru._source_aliases import (
+    normalize_checkpoint_name as _normalize_checkpoint_name,
+)
+from kitaru.errors import KitaruBackendError
+
+logger = logging.getLogger(__name__)
+
+
+def _metadata_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return _to_plain_dict(value)
+    return {}
+
+
+def _run_has_llm_usage_summary(run: PipelineRunResponse) -> bool:
+    metadata = _metadata_mapping(getattr(run, "run_metadata", None))
+    return metadata_has_complete_usage_summary(metadata)
+
+
+def _persist_terminal_llm_usage_metadata(run: PipelineRunResponse) -> bool:
+    """Aggregate LLM usage records and write execution-level metadata."""
+    from kitaru.client import KitaruClient
+    from kitaru.logging import log_to_execution
+
+    if _run_has_llm_usage_summary(run):
+        return True
+
+    client = KitaruClient()
+    try:
+        attempts_by_lineage = _list_checkpoint_attempts_for_run(run=run, client=client)
+    except KitaruBackendError:
+        logger.debug(
+            "Skipping terminal LLM usage aggregation because all checkpoint "
+            "attempts could not be fetched.",
+            exc_info=True,
+        )
+        return False
+
+    records: list[dict[str, Any]] = []
+    execution_id = str(run.id)
+    records.extend(
+        usage_records_from_metadata(
+            _metadata_mapping(getattr(run, "run_metadata", None)),
+            source_attempt_id=f"run:{execution_id}",
+        )
+    )
+    for attempts in attempts_by_lineage.values():
+        for step in attempts:
+            cache_status = cache_status_for_checkpoint_status(
+                getattr(step, "status", None)
+            )
+            records.extend(
+                usage_records_from_metadata(
+                    _metadata_mapping(getattr(step, "run_metadata", None)),
+                    source_attempt_id=str(step.id),
+                    default_checkpoint_name=_normalize_checkpoint_name(
+                        str(getattr(step, "name", ""))
+                    ),
+                    reused=cache_status is not None,
+                    reused_cache_status=cache_status or "checkpoint_cache_hit",
+                )
+            )
+    metadata = execution_metadata_from_records(records)
+    if not metadata:
+        return True
+    log_to_execution(str(run.id), **metadata)
+    return True
+
+
+def _safe_persist_terminal_llm_usage_metadata(run: PipelineRunResponse) -> bool:
+    """Best-effort terminal LLM usage aggregation."""
+    try:
+        return _persist_terminal_llm_usage_metadata(run)
+    except Exception:
+        logger.debug(
+            "Failed to persist terminal LLM usage metadata.",
+            exc_info=True,
+        )
+        return False

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -63,10 +63,7 @@ from kitaru._terminal_hooks import aggregate_llm_usage_on_run_end
 from kitaru._terminal_usage import (
     _persist_terminal_llm_usage_metadata as _shared_persist_terminal_llm_usage_metadata,
 )
-from kitaru._terminal_usage import (
-    _run_has_llm_usage_summary,
-    _safe_persist_terminal_llm_usage_metadata,
-)
+from kitaru._terminal_usage import _safe_persist_terminal_llm_usage_metadata
 from kitaru.analytics import AnalyticsEvent, track
 from kitaru.config import (
     KITARU_MODEL_REGISTRY_ENV,
@@ -1170,9 +1167,16 @@ def _raise_for_unsuccessful_run(
     )
 
 
-def _persist_terminal_llm_usage_metadata(run: PipelineRunResponse) -> bool:
+def _persist_terminal_llm_usage_metadata(
+    run: PipelineRunResponse,
+    *,
+    zenml_client: Any | None = None,
+) -> bool:
     """Compatibility wrapper for terminal LLM usage aggregation."""
-    return _shared_persist_terminal_llm_usage_metadata(run)
+    return _shared_persist_terminal_llm_usage_metadata(
+        run,
+        zenml_client=zenml_client,
+    )
 
 
 class FlowHandle:
@@ -1261,13 +1265,12 @@ class FlowHandle:
     def _persist_terminal_llm_usage_once(self, run: PipelineRunResponse) -> None:
         if self._terminal_llm_usage_metadata_persisted:
             return
-        if _run_has_llm_usage_summary(run):
-            self._terminal_llm_usage_metadata_persisted = True
-            return
 
         aggregation_run = run
+        zenml_client: Client | None = None
         try:
-            aggregation_run = Client().get_pipeline_run(
+            zenml_client = Client()
+            aggregation_run = zenml_client.get_pipeline_run(
                 run.id,
                 allow_name_prefix_match=False,
             )
@@ -1279,11 +1282,11 @@ class FlowHandle:
             )
         else:
             self._run = aggregation_run
-            if _run_has_llm_usage_summary(aggregation_run):
-                self._terminal_llm_usage_metadata_persisted = True
-                return
 
-        if _safe_persist_terminal_llm_usage_metadata(aggregation_run):
+        if _safe_persist_terminal_llm_usage_metadata(
+            aggregation_run,
+            zenml_client=zenml_client,
+        ):
             self._terminal_llm_usage_metadata_persisted = True
 
     def wait(self) -> Any:

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -323,11 +323,16 @@ def _flow_result_tuple_metadata(length: int) -> dict[str, Any]:
 
 def _is_flow_result_tuple_metadata(value: Any) -> bool:
     """Return whether a loaded output value is Kitaru tuple metadata."""
+    if not isinstance(value, Mapping):
+        return False
+
+    length = value.get("length")
     return (
-        isinstance(value, Mapping)
-        and value.get("kitaru_artifact_type") == _FLOW_RESULT_TUPLE_METADATA_MARKER
+        value.get("kitaru_artifact_type") == _FLOW_RESULT_TUPLE_METADATA_MARKER
         and value.get("version") == 1
-        and isinstance(value.get("length"), int)
+        and isinstance(length, int)
+        and not isinstance(length, bool)
+        and length > 0
     )
 
 
@@ -772,6 +777,8 @@ def _extract_outputs_from_run_outputs(
         return []
 
     outputs: list[_FlowResultOutput] = []
+    # ZenML hydrates PipelineRunResponse.outputs in output_index order, so the
+    # mapping iteration order is the persisted flow return order.
     for output_name, artifact in run_outputs.items():
         if artifact is None:
             raise KitaruRuntimeError(

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -17,7 +17,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime
 from functools import update_wrapper, wraps
-from typing import Any, cast, overload
+from typing import Any, Literal, cast, overload
 from urllib.parse import quote
 from uuid import uuid4
 
@@ -37,7 +37,7 @@ from zenml.pipelines.pipeline_decorator import pipeline
 from zenml.pipelines.pipeline_definition import Pipeline
 
 from kitaru._client._deployments import DEFAULT_DEPLOYMENT_TAG
-from kitaru._client._mappers import _list_checkpoint_attempts_for_run, _to_public_status
+from kitaru._client._mappers import _to_public_status
 from kitaru._client._models import ExecutionStatus
 from kitaru._config._active_context import (
     ActiveConfigSelectionProvenance,
@@ -51,22 +51,21 @@ from kitaru._interface_deployments import (
     resolve_deployment_selector,
     validate_deployment_selector,
 )
-from kitaru._llm_usage import (
-    cache_status_for_checkpoint_status,
-    execution_metadata_from_records,
-    metadata_has_complete_usage_summary,
-    usage_records_from_metadata,
-)
 from kitaru._source_aliases import (
     build_pipeline_registration_name,
     build_pipeline_source_alias,
     callable_name,
 )
-from kitaru._source_aliases import (
-    normalize_checkpoint_name as _normalize_checkpoint_name,
-)
 from kitaru._telemetry import (
     deployment_metadata_for_stack as _deployment_metadata_for_stack,
+)
+from kitaru._terminal_hooks import aggregate_llm_usage_on_run_end
+from kitaru._terminal_usage import (
+    _persist_terminal_llm_usage_metadata as _shared_persist_terminal_llm_usage_metadata,
+)
+from kitaru._terminal_usage import (
+    _run_has_llm_usage_summary,
+    _safe_persist_terminal_llm_usage_metadata,
 )
 from kitaru.analytics import AnalyticsEvent, track
 from kitaru.config import (
@@ -697,10 +696,28 @@ def _emit_kitaru_execution_url(
 class _FlowResultOutput:
     """Loaded flow-output value plus the artifact identity it came from."""
 
-    step_name: str
+    provenance: Literal["run_output", "step_output"]
+    step_name: str | None
     output_name: str
     artifact: Any
     value: Any
+
+
+def _loaded_flow_result_output(
+    *,
+    provenance: Literal["run_output", "step_output"],
+    step_name: str | None,
+    output_name: str,
+    artifact: Any,
+) -> _FlowResultOutput:
+    """Load one artifact and wrap it with result-extraction metadata."""
+    return _FlowResultOutput(
+        provenance=provenance,
+        step_name=step_name,
+        output_name=output_name,
+        artifact=artifact,
+        value=artifact.load(),
+    )
 
 
 def _extract_outputs_from_output_specs(
@@ -733,14 +750,41 @@ def _extract_outputs_from_output_specs(
             )
 
         outputs.append(
-            _FlowResultOutput(
+            _loaded_flow_result_output(
+                provenance="step_output",
                 step_name=output_spec.step_name,
                 output_name=output_spec.output_name,
                 artifact=artifact,
-                value=artifact.load(),
             )
         )
 
+    return outputs
+
+
+def _extract_outputs_from_run_outputs(
+    run: PipelineRunResponse,
+) -> list[_FlowResultOutput]:
+    """Extract return outputs from persisted run-level output artifacts."""
+    run_outputs = getattr(run, "outputs", None)
+    if not run_outputs:
+        return []
+    if not isinstance(run_outputs, Mapping):
+        return []
+
+    outputs: list[_FlowResultOutput] = []
+    for output_name, artifact in run_outputs.items():
+        if artifact is None:
+            raise KitaruRuntimeError(
+                f"Execution {run.id} is missing run output artifact '{output_name}'."
+            )
+        outputs.append(
+            _loaded_flow_result_output(
+                provenance="run_output",
+                step_name=None,
+                output_name=str(output_name),
+                artifact=artifact,
+            )
+        )
     return outputs
 
 
@@ -890,11 +934,11 @@ def _extract_outputs_from_terminal_steps(
     output_name = next(iter(terminal_step.regular_outputs))
     artifact = terminal_step.regular_outputs[output_name]
     return [
-        _FlowResultOutput(
+        _loaded_flow_result_output(
+            provenance="step_output",
             step_name=terminal_step_name,
             output_name=output_name,
             artifact=artifact,
-            value=artifact.load(),
         )
     ]
 
@@ -969,7 +1013,9 @@ def _extract_flow_result(run: PipelineRunResponse) -> Any:
     Returns:
         The flow result (`None`, a single value, or a tuple of values).
     """
-    outputs = _extract_outputs_from_output_specs(run)
+    outputs = _extract_outputs_from_run_outputs(run)
+    if not outputs:
+        outputs = _extract_outputs_from_output_specs(run)
     if not outputs:
         outputs = _extract_outputs_from_terminal_steps(run)
 
@@ -1085,79 +1131,6 @@ def _checkpoint_count_from_run(run: PipelineRunResponse) -> int | None:
     return None
 
 
-def _metadata_mapping(value: Any) -> dict[str, Any]:
-    if isinstance(value, Mapping):
-        return {str(key): item for key, item in value.items()}
-    return {}
-
-
-def _run_has_llm_usage_summary(run: PipelineRunResponse) -> bool:
-    metadata = _metadata_mapping(getattr(run, "run_metadata", None))
-    return metadata_has_complete_usage_summary(metadata)
-
-
-def _persist_terminal_llm_usage_metadata(run: PipelineRunResponse) -> bool:
-    """Aggregate LLM usage records and write execution-level metadata."""
-    from kitaru.client import KitaruClient
-    from kitaru.logging import log_to_execution
-
-    if _run_has_llm_usage_summary(run):
-        return True
-
-    client = KitaruClient()
-    try:
-        attempts_by_lineage = _list_checkpoint_attempts_for_run(run=run, client=client)
-    except KitaruBackendError:
-        logger.debug(
-            "Skipping terminal LLM usage aggregation because all checkpoint "
-            "attempts could not be fetched.",
-            exc_info=True,
-        )
-        return False
-
-    records: list[dict[str, Any]] = []
-    execution_id = str(run.id)
-    records.extend(
-        usage_records_from_metadata(
-            _metadata_mapping(getattr(run, "run_metadata", None)),
-            source_attempt_id=f"run:{execution_id}",
-        )
-    )
-    for attempts in attempts_by_lineage.values():
-        for step in attempts:
-            cache_status = cache_status_for_checkpoint_status(
-                getattr(step, "status", None)
-            )
-            records.extend(
-                usage_records_from_metadata(
-                    _metadata_mapping(getattr(step, "run_metadata", None)),
-                    source_attempt_id=str(step.id),
-                    default_checkpoint_name=_normalize_checkpoint_name(
-                        str(getattr(step, "name", ""))
-                    ),
-                    reused=cache_status is not None,
-                    reused_cache_status=cache_status or "checkpoint_cache_hit",
-                )
-            )
-    metadata = execution_metadata_from_records(records)
-    if not metadata:
-        return True
-    log_to_execution(str(run.id), **metadata)
-    return True
-
-
-def _safe_persist_terminal_llm_usage_metadata(run: PipelineRunResponse) -> bool:
-    """Best-effort terminal LLM usage aggregation."""
-    try:
-        return _persist_terminal_llm_usage_metadata(run)
-    except Exception:
-        logger.debug(
-            "Failed to persist terminal LLM usage metadata.",
-            exc_info=True,
-        )
-        return False
-
-
 def _raise_for_unsuccessful_run(
     run: PipelineRunResponse,
     *,
@@ -1188,6 +1161,11 @@ def _raise_for_unsuccessful_run(
         status=_to_public_status(run.status),
         origin=failure_origin,
     )
+
+
+def _persist_terminal_llm_usage_metadata(run: PipelineRunResponse) -> bool:
+    """Compatibility wrapper for terminal LLM usage aggregation."""
+    return _shared_persist_terminal_llm_usage_metadata(run)
 
 
 class FlowHandle:
@@ -1276,7 +1254,29 @@ class FlowHandle:
     def _persist_terminal_llm_usage_once(self, run: PipelineRunResponse) -> None:
         if self._terminal_llm_usage_metadata_persisted:
             return
-        if _safe_persist_terminal_llm_usage_metadata(run):
+        if _run_has_llm_usage_summary(run):
+            self._terminal_llm_usage_metadata_persisted = True
+            return
+
+        aggregation_run = run
+        try:
+            aggregation_run = Client().get_pipeline_run(
+                run.id,
+                allow_name_prefix_match=False,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to refresh execution metadata before terminal LLM "
+                "usage aggregation.",
+                exc_info=True,
+            )
+        else:
+            self._run = aggregation_run
+            if _run_has_llm_usage_summary(aggregation_run):
+                self._terminal_llm_usage_metadata_persisted = True
+                return
+
+        if _safe_persist_terminal_llm_usage_metadata(aggregation_run):
             self._terminal_llm_usage_metadata_persisted = True
 
     def wait(self) -> Any:
@@ -1381,6 +1381,7 @@ class _FlowDefinition:
         self._pipeline: Pipeline = pipeline(
             dynamic=True,
             name=registration_name,
+            on_end=aggregate_llm_usage_on_run_end,
         )(wrapped_entrypoint)
         _register_pipeline_source_alias(
             func=func,

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1593,7 +1593,7 @@ def test_terminal_hook_fetches_current_run_and_aggregates(monkeypatch) -> None:
     from kitaru import _terminal_hooks
 
     fetched_run = SimpleNamespace(id="fresh-run")
-    aggregated: list[object] = []
+    aggregation_calls: list[tuple[object, object]] = []
     client = SimpleNamespace(
         get_pipeline_run=MagicMock(return_value=fetched_run),
     )
@@ -1607,7 +1607,9 @@ def test_terminal_hook_fetches_current_run_and_aggregates(monkeypatch) -> None:
     monkeypatch.setattr(
         _terminal_hooks,
         "_safe_persist_terminal_llm_usage_metadata",
-        lambda run: aggregated.append(run) or True,
+        lambda run, **kwargs: (
+            aggregation_calls.append((run, kwargs.get("zenml_client"))) or True
+        ),
     )
 
     _terminal_hooks.aggregate_llm_usage_on_run_end()
@@ -1616,7 +1618,7 @@ def test_terminal_hook_fetches_current_run_and_aggregates(monkeypatch) -> None:
         "run-1",
         allow_name_prefix_match=False,
     )
-    assert aggregated == [fetched_run]
+    assert aggregation_calls == [(fetched_run, client)]
 
 
 def test_terminal_hook_returns_silently_without_run_context(monkeypatch) -> None:
@@ -1659,7 +1661,9 @@ def test_terminal_hook_catches_aggregation_failures(monkeypatch) -> None:
     monkeypatch.setattr(
         _terminal_hooks,
         "_safe_persist_terminal_llm_usage_metadata",
-        lambda _run: (_ for _ in ()).throw(RuntimeError("aggregation failed")),
+        lambda _run, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("aggregation failed")
+        ),
     )
 
     _terminal_hooks.aggregate_llm_usage_on_run_end()
@@ -1694,7 +1698,7 @@ def test_flow_handle_persists_terminal_llm_usage_once(monkeypatch) -> None:
     flow_module = sys.modules["kitaru.flow"]
     calls: list[str] = []
 
-    def fake_safe(run: PipelineRunResponse) -> bool:
+    def fake_safe(run: PipelineRunResponse, **_kwargs: object) -> bool:
         calls.append(str(run.id))
         return True
 
@@ -1718,10 +1722,10 @@ def test_flow_handle_persists_terminal_llm_usage_once(monkeypatch) -> None:
     )
 
 
-def test_flow_handle_skips_terminal_llm_usage_when_fresh_run_has_summary(
+def test_flow_handle_aggregates_fresh_run_even_when_summary_exists(
     monkeypatch,
 ) -> None:
-    """The wait/get fallback should not list attempts after the hook wrote a summary."""
+    """A stale summary should not permanently block recomputation."""
     from kitaru._llm_usage import (
         LLM_USAGE_SUMMARY_METADATA_KEY,
         empty_usage_summary,
@@ -1748,12 +1752,16 @@ def test_flow_handle_skips_terminal_llm_usage_when_fresh_run_has_summary(
     client_mock = MagicMock()
     client_mock.get_pipeline_run.return_value = fresh_run
     monkeypatch.setattr(flow_module, "Client", lambda: client_mock)
+    aggregation_calls: list[tuple[PipelineRunResponse, object]] = []
+
+    def fake_safe(run: PipelineRunResponse, **kwargs: object) -> bool:
+        aggregation_calls.append((run, kwargs.get("zenml_client")))
+        return True
+
     monkeypatch.setattr(
         flow_module,
         "_safe_persist_terminal_llm_usage_metadata",
-        lambda _run: (_ for _ in ()).throw(
-            AssertionError("attempt aggregation should not run")
-        ),
+        fake_safe,
     )
 
     handle = FlowHandle(_as_pipeline_run(_DummyRun(status=ExecutionStatus.COMPLETED)))
@@ -1765,12 +1773,13 @@ def test_flow_handle_skips_terminal_llm_usage_when_fresh_run_has_summary(
         allow_name_prefix_match=False,
     )
     assert handle._run is fresh_run
+    assert aggregation_calls == [(fresh_run, client_mock)]
 
 
-def test_terminal_llm_usage_metadata_skips_attempt_fetch_when_summary_exists(
+def test_terminal_llm_usage_metadata_skips_write_when_summary_count_matches(
     monkeypatch,
 ) -> None:
-    """A terminal run that already has a summary should not fetch attempts."""
+    """A matching existing summary should suppress only the metadata write."""
     from kitaru._llm_usage import (
         LLM_USAGE_SUMMARY_METADATA_KEY,
         empty_usage_summary,
@@ -1781,11 +1790,15 @@ def test_terminal_llm_usage_metadata_skips_attempt_fetch_when_summary_exists(
 
     terminal_usage_module = sys.modules["kitaru._terminal_usage"]
 
-    def fail_fetch(*, run: PipelineRunResponse, client: object) -> object:
-        raise AssertionError("attempt fetch should not run")
+    fetch_calls = 0
+
+    def fake_fetch(*, run: PipelineRunResponse, client: object) -> object:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return {}
 
     monkeypatch.setattr(
-        terminal_usage_module, "_list_checkpoint_attempts_for_run", fail_fetch
+        terminal_usage_module, "_list_checkpoint_attempts_for_run", fake_fetch
     )
     monkeypatch.setattr("kitaru.client.KitaruClient", lambda: SimpleNamespace())
     monkeypatch.setattr(
@@ -1812,6 +1825,205 @@ def test_terminal_llm_usage_metadata_skips_attempt_fetch_when_summary_exists(
     )
 
     assert persisted is True
+    assert fetch_calls == 1
+
+
+def test_terminal_llm_usage_metadata_uses_zenml_client_without_kitaru_auth(
+    monkeypatch,
+) -> None:
+    """Run-end aggregation must not construct the strict user-facing client."""
+    from kitaru._llm_usage import (
+        LLM_USAGE_METADATA_KEY,
+        LLM_USAGE_SUMMARY_METADATA_KEY,
+        build_usage_record,
+        parse_usage_summary,
+    )
+    from kitaru.flow import _persist_terminal_llm_usage_metadata
+
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
+    record = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="remote-env-call",
+        total_tokens=11,
+    )
+    written: dict[str, Any] = {}
+
+    monkeypatch.setenv("KITARU_SERVER_URL", "https://kitaru.example.test")
+    monkeypatch.delenv("KITARU_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(
+        "kitaru.client.KitaruClient",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("terminal aggregation must not construct KitaruClient")
+        ),
+    )
+    monkeypatch.setattr(
+        terminal_usage_module,
+        "_list_checkpoint_attempts_for_run",
+        lambda *, run, client: {},
+    )
+
+    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+        written.update(metadata)
+
+    monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
+
+    persisted = _persist_terminal_llm_usage_metadata(
+        cast(
+            PipelineRunResponse,
+            SimpleNamespace(
+                id="run-1",
+                run_metadata={LLM_USAGE_METADATA_KEY: {"call": record}},
+            ),
+        ),
+        zenml_client=SimpleNamespace(),
+    )
+
+    summary = parse_usage_summary(written[LLM_USAGE_SUMMARY_METADATA_KEY])
+    assert persisted is True
+    assert summary is not None
+    assert summary["usage_record_count"] == 1
+    assert summary["total_tokens"] == 11
+
+
+def test_terminal_llm_usage_metadata_rewrites_stale_complete_summary(
+    monkeypatch,
+) -> None:
+    """Visible attempt records should beat an old complete undercount."""
+    from kitaru._llm_usage import (
+        LLM_FLAT_USAGE_RECORD_COUNT_KEY,
+        LLM_USAGE_METADATA_KEY,
+        LLM_USAGE_SUMMARY_METADATA_KEY,
+        build_usage_record,
+        execution_metadata_from_records,
+        parse_usage_summary,
+    )
+    from kitaru.flow import _persist_terminal_llm_usage_metadata
+
+    first = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="visible-call-1",
+        total_tokens=10,
+    )
+    second = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="visible-call-2",
+        total_tokens=15,
+    )
+    stale_metadata = execution_metadata_from_records([first])
+    attempts_by_lineage = {
+        "checkpoint": [
+            SimpleNamespace(
+                id="attempt-1",
+                name="checkpoint",
+                status="completed",
+                run_metadata={LLM_USAGE_METADATA_KEY: {"first": first}},
+            ),
+            SimpleNamespace(
+                id="attempt-2",
+                name="checkpoint",
+                status="completed",
+                run_metadata={LLM_USAGE_METADATA_KEY: {"second": second}},
+            ),
+        ]
+    }
+    written: dict[str, Any] = {}
+
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
+    monkeypatch.setattr(
+        terminal_usage_module,
+        "_list_checkpoint_attempts_for_run",
+        lambda *, run, client: attempts_by_lineage,
+    )
+
+    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+        written.update(metadata)
+
+    monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
+
+    persisted = _persist_terminal_llm_usage_metadata(
+        cast(
+            PipelineRunResponse,
+            SimpleNamespace(id="run-1", run_metadata=stale_metadata),
+        ),
+        zenml_client=SimpleNamespace(),
+    )
+
+    summary = parse_usage_summary(written[LLM_USAGE_SUMMARY_METADATA_KEY])
+    assert persisted is True
+    assert summary is not None
+    assert summary["usage_record_count"] == 2
+    assert summary["total_tokens"] == 25
+    assert written[LLM_FLAT_USAGE_RECORD_COUNT_KEY] == 2
+
+
+def test_terminal_llm_usage_metadata_rewrites_same_count_stale_summary(
+    monkeypatch,
+) -> None:
+    """A matching record count is not enough if totals changed."""
+    from kitaru._llm_usage import (
+        LLM_FLAT_TOTAL_TOKENS_KEY,
+        LLM_USAGE_METADATA_KEY,
+        LLM_USAGE_SUMMARY_METADATA_KEY,
+        build_usage_record,
+        execution_metadata_from_records,
+        parse_usage_summary,
+    )
+    from kitaru.flow import _persist_terminal_llm_usage_metadata
+
+    stale_record = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="same-count-call",
+        total_tokens=10,
+    )
+    fresh_record = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="same-count-call",
+        total_tokens=2000,
+    )
+    stale_metadata = execution_metadata_from_records([stale_record])
+    attempts_by_lineage = {
+        "checkpoint": [
+            SimpleNamespace(
+                id="attempt-1",
+                name="checkpoint",
+                status="completed",
+                run_metadata={LLM_USAGE_METADATA_KEY: {"fresh": fresh_record}},
+            )
+        ]
+    }
+    written: dict[str, Any] = {}
+
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
+    monkeypatch.setattr(
+        terminal_usage_module,
+        "_list_checkpoint_attempts_for_run",
+        lambda *, run, client: attempts_by_lineage,
+    )
+
+    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+        written.update(metadata)
+
+    monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
+
+    persisted = _persist_terminal_llm_usage_metadata(
+        cast(
+            PipelineRunResponse,
+            SimpleNamespace(id="run-1", run_metadata=stale_metadata),
+        ),
+        zenml_client=SimpleNamespace(),
+    )
+
+    summary = parse_usage_summary(written[LLM_USAGE_SUMMARY_METADATA_KEY])
+    assert persisted is True
+    assert summary is not None
+    assert summary["usage_record_count"] == 1
+    assert summary["total_tokens"] == 2000
+    assert written[LLM_FLAT_TOTAL_TOKENS_KEY] == 2000
 
 
 def test_terminal_llm_usage_metadata_does_not_skip_partial_summary(

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1505,22 +1505,48 @@ def test_flow_result_extraction_rejects_unexpected_tuple_metadata_role() -> None
         _extract_flow_result(_as_pipeline_run(run))
 
 
-def test_flow_result_extraction_rejects_malformed_tuple_metadata() -> None:
-    """Reserved tuple metadata artifacts must contain valid marker payloads."""
-    run = _DummyRun(
+def _run_with_reserved_tuple_metadata_artifact(
+    metadata_value: Mapping[str, object],
+) -> _DummyRun:
+    """Build a run whose final output is Kitaru's reserved tuple metadata artifact."""
+    return _DummyRun(
         status=ExecutionStatus.COMPLETED,
         outputs=[
             ("step", "output_0", "value"),
             _DummyOutput(
                 step_name="step",
                 output_name="output_1",
-                value={"kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER},
+                value=metadata_value,
                 artifact_name=_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
                 run_metadata={
                     _FLOW_RESULT_ROLE_METADATA_KEY: _FLOW_RESULT_TUPLE_METADATA_ROLE
                 },
             ),
         ],
+    )
+
+
+def test_flow_result_extraction_rejects_malformed_tuple_metadata() -> None:
+    """Reserved tuple metadata artifacts must contain valid marker payloads."""
+    run = _run_with_reserved_tuple_metadata_artifact(
+        {"kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER}
+    )
+
+    with pytest.raises(KitaruRuntimeError, match="valid Kitaru tuple metadata"):
+        _extract_flow_result(_as_pipeline_run(run))
+
+
+@pytest.mark.parametrize("length", [True, 0, -1])
+def test_flow_result_extraction_rejects_invalid_tuple_metadata_lengths(
+    length: object,
+) -> None:
+    """Reserved tuple metadata artifacts must contain a positive integer length."""
+    run = _run_with_reserved_tuple_metadata_artifact(
+        {
+            "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+            "version": 1,
+            "length": length,
+        }
     )
 
     with pytest.raises(KitaruRuntimeError, match="valid Kitaru tuple metadata"):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -140,6 +140,14 @@ class _DummyOutput:
     upstream_steps: list[str] | None = None
 
 
+@dataclass(frozen=True)
+class _DummyRunOutput:
+    output_name: str
+    value: object
+    artifact_name: str | None = None
+    run_metadata: Mapping[str, object] | None = None
+
+
 class _DummyArtifact:
     def __init__(
         self,
@@ -162,6 +170,7 @@ class _DummyRun:
         *,
         status: ExecutionStatus,
         outputs: list[tuple[str, str, object] | _DummyOutput] | None = None,
+        run_outputs: list[tuple[str, object] | _DummyRunOutput] | None = None,
         run_id: object | None = None,
         pipeline_id: object | None = None,
         pipeline: object | None = None,
@@ -183,6 +192,24 @@ class _DummyRun:
         self.exception_info = (
             SimpleNamespace(traceback=traceback) if traceback else None
         )
+
+        self.outputs: dict[str, _DummyArtifact] = {}
+        for output in run_outputs or []:
+            if isinstance(output, _DummyRunOutput):
+                output_name = output.output_name
+                value = output.value
+                artifact_name = output.artifact_name or output_name
+                run_metadata = dict(output.run_metadata or {})
+            else:
+                output_name, value = output
+                artifact_name = output_name
+                run_metadata = None
+
+            self.outputs[output_name] = _DummyArtifact(
+                value,
+                name=artifact_name,
+                run_metadata=run_metadata,
+            )
 
         outputs = outputs or []
         output_specs: list[SimpleNamespace] = []
@@ -382,6 +409,8 @@ def test_inject_model_registry_env_rejects_invalid_override() -> None:
 
 
 def test_flow_decorator_creates_wrapper_with_run() -> None:
+    from kitaru._terminal_hooks import aggregate_llm_usage_on_run_end
+
     run = _DummyRun(status=ExecutionStatus.RUNNING)
     configured_pipeline = MagicMock(return_value=run)
     base_pipeline = MagicMock()
@@ -401,7 +430,11 @@ def test_flow_decorator_creates_wrapper_with_run() -> None:
         wrapped = flow(lambda x: x)
         handle = wrapped.run(123)
 
-    pipeline_mock.assert_called_once_with(dynamic=True, name="_lambda_")
+    pipeline_mock.assert_called_once_with(
+        dynamic=True,
+        name="_lambda_",
+        on_end=aggregate_llm_usage_on_run_end,
+    )
     assert hasattr(wrapped, "run")
     assert hasattr(wrapped, "deploy")
     assert hasattr(wrapped, "invoke")
@@ -1285,6 +1318,111 @@ def test_flow_result_extraction_restores_singleton_tuple_outputs() -> None:
     assert _extract_flow_result(_as_pipeline_run(run)) == ("value",)
 
 
+def test_flow_result_extraction_prefers_run_outputs_over_ambiguous_terminal_steps() -> (
+    None
+):
+    """Persisted run outputs are authoritative when terminal checkpoints fan out."""
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[
+            _DummyOutput(step_name="model_call", output_name="output", value="model"),
+            _DummyOutput(step_name="tool_call", output_name="output", value="tool"),
+        ],
+        run_outputs=[("final_output", "final answer")],
+    )
+    run.snapshot.pipeline_spec.outputs = []
+
+    assert _extract_flow_result(_as_pipeline_run(run)) == "final answer"
+
+
+def test_flow_result_extraction_returns_multiple_run_outputs_in_persisted_order() -> (
+    None
+):
+    """Multiple run outputs follow ZenML's persisted output order."""
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        run_outputs=[
+            ("second_declared_output", "second"),
+            ("first_declared_output", "first"),
+        ],
+    )
+
+    assert _extract_flow_result(_as_pipeline_run(run)) == ("second", "first")
+
+
+def test_flow_result_extraction_restores_tuple_metadata_from_run_outputs() -> None:
+    """Run-level output artifacts use the same tuple metadata reconstruction."""
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        run_outputs=[
+            ("output_0", "left"),
+            ("output_1", "right"),
+            _DummyRunOutput(
+                output_name="output_2",
+                value={
+                    "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+                    "version": 1,
+                    "length": 2,
+                },
+                artifact_name=_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
+                run_metadata={
+                    _FLOW_RESULT_ROLE_METADATA_KEY: _FLOW_RESULT_TUPLE_METADATA_ROLE
+                },
+            ),
+        ],
+    )
+
+    assert _extract_flow_result(_as_pipeline_run(run)) == ("left", "right")
+
+
+def test_flow_result_extraction_restores_singleton_tuple_from_run_outputs() -> None:
+    """A single user output plus tuple metadata stays tuple-shaped."""
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        run_outputs=[
+            ("output_0", "only"),
+            _DummyRunOutput(
+                output_name="output_1",
+                value={
+                    "kitaru_artifact_type": _FLOW_RESULT_TUPLE_METADATA_MARKER,
+                    "version": 1,
+                    "length": 1,
+                },
+                artifact_name=_FLOW_RESULT_TUPLE_METADATA_ARTIFACT_NAME,
+                run_metadata={
+                    _FLOW_RESULT_ROLE_METADATA_KEY: _FLOW_RESULT_TUPLE_METADATA_ROLE
+                },
+            ),
+        ],
+    )
+
+    assert _extract_flow_result(_as_pipeline_run(run)) == ("only",)
+
+
+def test_flow_result_extraction_empty_run_outputs_fall_back_to_output_specs() -> None:
+    """Empty run outputs preserve the previous output-spec extraction path."""
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[("declared_step", "output", "declared result")],
+        run_outputs=[],
+    )
+
+    assert _extract_flow_result(_as_pipeline_run(run)) == "declared result"
+
+
+def test_flow_result_extraction_missing_run_outputs_falls_back_to_output_specs() -> (
+    None
+):
+    """Old run records without an outputs field still use output specs."""
+    run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        outputs=[("declared_step", "output", "declared result")],
+    )
+    delattr(run, "outputs")
+
+    assert _extract_flow_result(_as_pipeline_run(run)) == "declared result"
+
+
 def test_flow_result_extraction_preserves_marker_shaped_single_output() -> None:
     """A user value shaped like tuple metadata should still round-trip as data."""
     value = {
@@ -1424,6 +1562,94 @@ def test_flow_result_extraction_rejects_multiple_tuple_metadata_artifacts() -> N
         _extract_flow_result(_as_pipeline_run(run))
 
 
+def test_terminal_hook_fetches_current_run_and_aggregates(monkeypatch) -> None:
+    """The run-end hook should fetch a fresh run model before aggregation."""
+    from kitaru import _terminal_hooks
+
+    fetched_run = SimpleNamespace(id="fresh-run")
+    aggregated: list[object] = []
+    client = SimpleNamespace(
+        get_pipeline_run=MagicMock(return_value=fetched_run),
+    )
+
+    monkeypatch.setattr(
+        _terminal_hooks.DynamicPipelineRunContext,
+        "get",
+        lambda: SimpleNamespace(run=SimpleNamespace(id="run-1")),
+    )
+    monkeypatch.setattr(_terminal_hooks, "Client", lambda: client)
+    monkeypatch.setattr(
+        _terminal_hooks,
+        "_safe_persist_terminal_llm_usage_metadata",
+        lambda run: aggregated.append(run) or True,
+    )
+
+    _terminal_hooks.aggregate_llm_usage_on_run_end()
+
+    client.get_pipeline_run.assert_called_once_with(
+        "run-1",
+        allow_name_prefix_match=False,
+    )
+    assert aggregated == [fetched_run]
+
+
+def test_terminal_hook_returns_silently_without_run_context(monkeypatch) -> None:
+    """The run-end hook should be safe to import and call outside ZenML hooks."""
+    from kitaru import _terminal_hooks
+
+    def missing_context() -> object:
+        raise RuntimeError("no active dynamic run")
+
+    monkeypatch.setattr(
+        _terminal_hooks.DynamicPipelineRunContext,
+        "get",
+        missing_context,
+    )
+    monkeypatch.setattr(
+        _terminal_hooks,
+        "Client",
+        lambda: (_ for _ in ()).throw(AssertionError("client should not run")),
+    )
+
+    _terminal_hooks.aggregate_llm_usage_on_run_end()
+
+
+def test_terminal_hook_catches_aggregation_failures(monkeypatch) -> None:
+    """A cost-summary failure must not change the user run outcome."""
+    from kitaru import _terminal_hooks
+
+    monkeypatch.setattr(
+        _terminal_hooks.DynamicPipelineRunContext,
+        "get",
+        lambda: SimpleNamespace(run=SimpleNamespace(id="run-1")),
+    )
+    monkeypatch.setattr(
+        _terminal_hooks,
+        "Client",
+        lambda: SimpleNamespace(
+            get_pipeline_run=lambda *_args, **_kwargs: SimpleNamespace(id="run-1")
+        ),
+    )
+    monkeypatch.setattr(
+        _terminal_hooks,
+        "_safe_persist_terminal_llm_usage_metadata",
+        lambda _run: (_ for _ in ()).throw(RuntimeError("aggregation failed")),
+    )
+
+    _terminal_hooks.aggregate_llm_usage_on_run_end()
+
+
+def test_terminal_hook_imports_do_not_create_flow_cycle() -> None:
+    """The hook module and flow module should be importable in either order."""
+    import importlib
+
+    terminal_hooks = importlib.import_module("kitaru._terminal_hooks")
+    flow_module = importlib.import_module("kitaru.flow")
+
+    assert terminal_hooks.aggregate_llm_usage_on_run_end is not None
+    assert flow_module.FlowHandle is FlowHandle
+
+
 def test_flow_return_coercion_rejects_mixed_tuple_subclasses() -> None:
     """Tuple subclasses with handles would otherwise lose their field semantics."""
     Pair = namedtuple("Pair", ["left", "right"])
@@ -1452,11 +1678,67 @@ def test_flow_handle_persists_terminal_llm_usage_once(monkeypatch) -> None:
 
     handle = FlowHandle(_as_pipeline_run(_DummyRun(status=ExecutionStatus.COMPLETED)))
     run = _as_pipeline_run(_DummyRun(status=ExecutionStatus.COMPLETED, run_id="run-1"))
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = run
+    monkeypatch.setattr(flow_module, "Client", lambda: client_mock)
 
     handle._persist_terminal_llm_usage_once(run)
     handle._persist_terminal_llm_usage_once(run)
 
     assert calls == ["run-1"]
+    client_mock.get_pipeline_run.assert_called_once_with(
+        run.id,
+        allow_name_prefix_match=False,
+    )
+
+
+def test_flow_handle_skips_terminal_llm_usage_when_fresh_run_has_summary(
+    monkeypatch,
+) -> None:
+    """The wait/get fallback should not list attempts after the hook wrote a summary."""
+    from kitaru._llm_usage import (
+        LLM_USAGE_SUMMARY_METADATA_KEY,
+        empty_usage_summary,
+        serialize_summary_for_metadata,
+        summary_to_flat_metadata,
+    )
+
+    flow_module = sys.modules["kitaru.flow"]
+    summary = empty_usage_summary()
+    fresh_run = cast(
+        PipelineRunResponse,
+        SimpleNamespace(
+            id="run-1",
+            run_metadata={
+                LLM_USAGE_SUMMARY_METADATA_KEY: serialize_summary_for_metadata(summary),
+                **summary_to_flat_metadata(summary),
+            },
+        ),
+    )
+    stale_run = cast(
+        PipelineRunResponse,
+        SimpleNamespace(id="run-1", run_metadata={}),
+    )
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = fresh_run
+    monkeypatch.setattr(flow_module, "Client", lambda: client_mock)
+    monkeypatch.setattr(
+        flow_module,
+        "_safe_persist_terminal_llm_usage_metadata",
+        lambda _run: (_ for _ in ()).throw(
+            AssertionError("attempt aggregation should not run")
+        ),
+    )
+
+    handle = FlowHandle(_as_pipeline_run(_DummyRun(status=ExecutionStatus.COMPLETED)))
+    handle._persist_terminal_llm_usage_once(stale_run)
+    handle._persist_terminal_llm_usage_once(stale_run)
+
+    client_mock.get_pipeline_run.assert_called_once_with(
+        "run-1",
+        allow_name_prefix_match=False,
+    )
+    assert handle._run is fresh_run
 
 
 def test_terminal_llm_usage_metadata_skips_attempt_fetch_when_summary_exists(
@@ -1471,12 +1753,14 @@ def test_terminal_llm_usage_metadata_skips_attempt_fetch_when_summary_exists(
     )
     from kitaru.flow import _persist_terminal_llm_usage_metadata
 
-    flow_module = sys.modules["kitaru.flow"]
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
 
     def fail_fetch(*, run: PipelineRunResponse, client: object) -> object:
         raise AssertionError("attempt fetch should not run")
 
-    monkeypatch.setattr(flow_module, "_list_checkpoint_attempts_for_run", fail_fetch)
+    monkeypatch.setattr(
+        terminal_usage_module, "_list_checkpoint_attempts_for_run", fail_fetch
+    )
     monkeypatch.setattr("kitaru.client.KitaruClient", lambda: SimpleNamespace())
     monkeypatch.setattr(
         "kitaru.logging.log_to_execution",
@@ -1517,7 +1801,7 @@ def test_terminal_llm_usage_metadata_does_not_skip_partial_summary(
     )
     from kitaru.flow import _persist_terminal_llm_usage_metadata
 
-    flow_module = sys.modules["kitaru.flow"]
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
     record = build_usage_record(
         adapter="kitaru.llm",
         surface="direct_llm",
@@ -1536,7 +1820,9 @@ def test_terminal_llm_usage_metadata_does_not_skip_partial_summary(
         written.update(metadata)
 
     monkeypatch.setattr("kitaru.client.KitaruClient", lambda: SimpleNamespace())
-    monkeypatch.setattr(flow_module, "_list_checkpoint_attempts_for_run", fake_fetch)
+    monkeypatch.setattr(
+        terminal_usage_module, "_list_checkpoint_attempts_for_run", fake_fetch
+    )
     monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
 
     persisted = _persist_terminal_llm_usage_metadata(
@@ -1568,7 +1854,7 @@ def test_terminal_llm_usage_metadata_marks_empty_successful_fetch_done(
     """A no-LLM run should not be retried forever by the same handle."""
     from kitaru.flow import _persist_terminal_llm_usage_metadata
 
-    flow_module = sys.modules["kitaru.flow"]
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
     fetch_calls = 0
 
     def fake_fetch(*, run: PipelineRunResponse, client: object) -> object:
@@ -1577,7 +1863,9 @@ def test_terminal_llm_usage_metadata_marks_empty_successful_fetch_done(
         return {}
 
     monkeypatch.setattr("kitaru.client.KitaruClient", lambda: SimpleNamespace())
-    monkeypatch.setattr(flow_module, "_list_checkpoint_attempts_for_run", fake_fetch)
+    monkeypatch.setattr(
+        terminal_usage_module, "_list_checkpoint_attempts_for_run", fake_fetch
+    )
     monkeypatch.setattr(
         "kitaru.logging.log_to_execution",
         lambda run_id, **metadata: (_ for _ in ()).throw(
@@ -1587,11 +1875,18 @@ def test_terminal_llm_usage_metadata_marks_empty_successful_fetch_done(
 
     handle = FlowHandle(_as_pipeline_run(_DummyRun(status=ExecutionStatus.COMPLETED)))
     run = cast(PipelineRunResponse, SimpleNamespace(id="run-1", run_metadata={}))
+    client_mock = MagicMock()
+    client_mock.get_pipeline_run.return_value = run
+    monkeypatch.setattr(sys.modules["kitaru.flow"], "Client", lambda: client_mock)
 
     handle._persist_terminal_llm_usage_once(run)
     handle._persist_terminal_llm_usage_once(run)
 
     assert fetch_calls == 1
+    client_mock.get_pipeline_run.assert_called_once_with(
+        "run-1",
+        allow_name_prefix_match=False,
+    )
     assert _persist_terminal_llm_usage_metadata(run) is True
 
 
@@ -1637,10 +1932,10 @@ def test_terminal_llm_usage_metadata_counts_retry_attempts(monkeypatch) -> None:
     }
     written: dict[str, Any] = {}
 
-    flow_module = sys.modules["kitaru.flow"]
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
     monkeypatch.setattr("kitaru.client.KitaruClient", lambda: SimpleNamespace())
     monkeypatch.setattr(
-        flow_module,
+        terminal_usage_module,
         "_list_checkpoint_attempts_for_run",
         lambda *, run, client: attempts_by_lineage,
     )
@@ -1682,10 +1977,10 @@ def test_terminal_llm_usage_metadata_includes_execution_metadata(monkeypatch) ->
     )
     written: dict[str, Any] = {}
 
-    flow_module = sys.modules["kitaru.flow"]
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
     monkeypatch.setattr("kitaru.client.KitaruClient", lambda: SimpleNamespace())
     monkeypatch.setattr(
-        flow_module,
+        terminal_usage_module,
         "_list_checkpoint_attempts_for_run",
         lambda *, run, client: {},
     )
@@ -1733,10 +2028,10 @@ def test_terminal_llm_usage_metadata_is_idempotent(monkeypatch) -> None:
     )
     written: list[dict[str, Any]] = []
 
-    flow_module = sys.modules["kitaru.flow"]
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
     monkeypatch.setattr("kitaru.client.KitaruClient", lambda: SimpleNamespace())
     monkeypatch.setattr(
-        flow_module,
+        terminal_usage_module,
         "_list_checkpoint_attempts_for_run",
         lambda *, run, client: {},
     )
@@ -1799,10 +2094,10 @@ def test_terminal_llm_usage_metadata_marks_cached_attempts_reused(monkeypatch) -
     }
     written: dict[str, Any] = {}
 
-    flow_module = sys.modules["kitaru.flow"]
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
     monkeypatch.setattr("kitaru.client.KitaruClient", lambda: SimpleNamespace())
     monkeypatch.setattr(
-        flow_module,
+        terminal_usage_module,
         "_list_checkpoint_attempts_for_run",
         lambda *, run, client: attempts_by_lineage,
     )
@@ -1847,8 +2142,10 @@ def test_terminal_llm_usage_metadata_skips_when_attempt_fetch_fails(
     def fail_fetch(*, run: PipelineRunResponse, client: object) -> object:
         raise KitaruBackendError("attempt fetch failed")
 
-    flow_module = sys.modules["kitaru.flow"]
-    monkeypatch.setattr(flow_module, "_list_checkpoint_attempts_for_run", fail_fetch)
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
+    monkeypatch.setattr(
+        terminal_usage_module, "_list_checkpoint_attempts_for_run", fail_fetch
+    )
 
     def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
         written.update(metadata)

--- a/tests/test_openai_research_bot_example.py
+++ b/tests/test_openai_research_bot_example.py
@@ -28,7 +28,6 @@ from examples.end_to_end.openai_research_bot.tools import _safe_error_message
 from pydantic import BaseModel
 
 from kitaru.client import KitaruClient
-from kitaru.errors import KitaruAmbiguousFlowResultError
 
 
 def test_example_imports_without_openai_api_key(monkeypatch) -> None:
@@ -279,8 +278,7 @@ def test_flow_keeps_final_report_artifact_available(
         search_tool_model="gpt-5-nano",
         fail_on_search_error=True,
     )
-    with pytest.raises(KitaruAmbiguousFlowResultError):
-        handle.wait()
+    assert handle.wait() == "# Durable agents\n\nReplay saves completed work."
 
     artifacts = KitaruClient().artifacts.list(
         handle.exec_id,

--- a/tests/test_phase17_pydantic_ai_adapter.py
+++ b/tests/test_phase17_pydantic_ai_adapter.py
@@ -749,7 +749,7 @@ def test_phase17_hitl_tool_still_reaches_wait(primed_zenml) -> None:
 
 
 def test_phase17_default_granular_mode_tracks_at_flow_scope(primed_zenml) -> None:
-    """Default granular mode should flush run metadata at flow scope."""
+    """Default granular mode should return final output and flush run metadata."""
     durable_agent = KitaruAgent(_make_test_agent(name_prefix="granular_agent"))
 
     @flow
@@ -757,8 +757,11 @@ def test_phase17_default_granular_mode_tracks_at_flow_scope(primed_zenml) -> Non
         return durable_agent.run_sync(prompt).output
 
     handle = granular_flow.run("use the add tool")
+    result = handle.wait()
     hydrated_run = _wait_for_hydrated_run(handle.exec_id)
 
+    assert isinstance(result, str)
+    assert result
     assert "pydantic_ai_run_summaries" in hydrated_run.run_metadata
     assert "pydantic_ai_events" in hydrated_run.run_metadata
 

--- a/uv.lock
+++ b/uv.lock
@@ -1511,15 +1511,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.0"
+version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/b4/6005c5dd88ad484fe6235d4c43a0d2cee7e91b08ad85a180985c2662df87/langgraph_checkpoint-4.1.0.tar.gz", hash = "sha256:e5bb304e30fc1363ac8fcb5f7dee5ca2185d77fe475b0d01de2c5f91324c2c21", size = 181942, upload-time = "2026-05-12T03:33:49.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/74/d3be2b41955e20ccd624dba5f6fe9d38dcee385ba470a6e13ed86732fc86/langgraph_checkpoint-4.1.0-py3-none-any.whl", hash = "sha256:8bc2a0466a20c38b865ce6671b42093fd5c041133f32351cae4222e0eeaf7fb5", size = 56047, upload-time = "2026-05-12T03:33:48.548Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

This PR fixes `FlowHandle.wait()` / `.get()` for flows that have explicit return values.

Previously, a granular adapter flow could finish successfully but still fail at `.wait()` because Kitaru tried to infer one final result from several model/tool checkpoints. Now, when the flow returns a value, `.wait()` / `.get()` return that saved flow output. If a flow does not return a value, users should inspect its checkpoint artifacts instead of expecting Kitaru to choose one automatically.

This also improves LLM usage summaries: Kitaru now normally writes execution-level LLM summaries when executions finish, including remote executions that no local SDK process observes. `FlowHandle.wait()` / `.get()` can still populate a missing summary for older executions or executions where the finish-time summary was not written.

Closes #476.

## Why it was needed

The broken concrete story was:

1. A wrapped agent creates several granular model/tool checkpoints.
2. The flow itself returns one final answer.
3. The execution finishes successfully.
4. `.wait()` asks checkpoint artifacts, “which one of you is the answer?”
5. Several checkpoints look plausible, so Kitaru refuses to guess and raises.

That was the wrong source of truth for flows with explicit returns. Kitaru should ask the finished run what the flow returned.

## Key implementation decisions

- `src/kitaru/flow.py` now reads persisted run outputs before the older output-spec and terminal-step result paths.
- Hidden tuple metadata validation now rejects boolean, zero, and negative tuple lengths.
- A code comment documents the ordering dependency: ZenML hydrates `PipelineRunResponse.outputs` in persisted `output_index` order.
- `src/kitaru/_terminal_usage.py` holds shared terminal LLM usage aggregation logic that used to live inside `flow.py`.
- `src/kitaru/_terminal_hooks.py` provides the importable ZenML lifecycle hook used to write summaries when executions finish.
- `.wait()` / `.get()` still retain the same aggregation capability for older/missing-summary cases, but first refresh the run once so they can skip duplicate work if the summary is already present.

## Reviewer Notes

The important behavior now happens in two places.

First, result extraction in `src/kitaru/flow.py` checks persisted run outputs before doing any graph inference. The thing to inspect is the order of the result-source chain: saved flow output first, older compatibility paths second. If that order is wrong, issue #476 comes back because granular adapter runs can still look ambiguous at the checkpoint graph level.

Second, usage aggregation now has two ways to succeed: the execution itself normally writes the summary when it finishes, and SDK observation through `FlowHandle` can fill it in when needed. The intended safety property is: remote runs get summaries without a local `.wait()`, while older or unusual records still have a best-effort repair path.

The docs/examples changed because the old guidance told users to avoid `.wait()` for granular adapter flows. That guidance is now too pessimistic when the flow has an explicit `return` value. Adapter docs now keep the simple authoring rule: return the value you want `.wait()` to produce; inspect artifacts for flows that do not return a value.

### Reproduction

For the issue shape, run the deterministic granular PydanticAI regression:

```bash
uv run pytest tests/test_phase17_pydantic_ai_adapter.py::test_phase17_default_granular_mode_tracks_at_flow_scope -n 0
```

Before this change, that shape could complete the execution but fail at `.wait()` with an ambiguous result. With this PR, `handle.wait()` returns the flow's final output while the granular checkpoints and run metadata remain available.

For the unit-level behavior, run:

```bash
uv run pytest tests/test_flow.py -k "flow_result or terminal_llm_usage or terminal_hook or flow_decorator_creates_wrapper_with_run" -n 0
```

That covers run-output precedence, tuple metadata reconstruction/validation, hook attachment, hook best-effort behavior, and terminal usage summary behavior.

Local checks run:

```bash
just check
just test
```

Latest `just test` result after review-feedback follow-up: `2929 passed, 13 skipped`.

cc @AlexejPenner
