### PR TITLE
Fix named pipeline completion logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Breaking:** Redesigned replay API around explicit override groups: `flow_overrides`, `checkpoint_overrides`, and `invocation_overrides`. `flow.replay(...)`, `KitaruClient().executions.replay(...)`, CLI `kitaru executions replay`, and MCP `kitaru_executions_replay` now use the same `ReplaySubmission` result model. Batch replay now uses multi-ID replay instead of the removed prototype `replay_many` / `executions replay-many` paths, and diff cohorts were renamed to `diff_matrix`, `kitaru executions diff-matrix`, and `kitaru_executions_diff_matrix`.
 
 ### Fixed
+- Kitaru terminal logs now rewrite ZenML's named pipeline completion message to ``Flow `...` completed successfully.``, so ``Pipeline `...` completed successfully.`` no longer leaks into flow output.
 - Replay checkpoint overrides now fan out across repeated adapter-generated model and tool calls, while suffixed selectors still target exactly one recorded call.
 - Replay output overrides on terminal checkpoints now fail with a clearer error explaining that output replacement requires a downstream consumer.
 - MCP replay now lets omitted `on_error` use the shared SDK default (`fail` for one parent, `collect` for batches), and `kitaru.diff()` now scans up to 10,000 same-flow executions when auto-discovering replays before warning that older replays may require explicit IDs.
@@ -35,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `kitaru.diff()` and `kitaru executions diff` now emit one multi-execution compare URL when auto-discovering replays, not one pairwise URL per replay.
 - Replay planning now re-executes the full live tail after `at` for linear adapter call sequences that lack explicit DAG upstream edges (for example PydanticAI `calls` checkpoints after `lookup_policy_tool`).
 - `FlowHandle.wait()` / `.get()` now recover a flow's plain return value when an adapter produced several non-result model/tool checkpoints (the common `checkpoint_strategy="calls"` shape). Previously such flows raised an ambiguous-terminal error even though they completed successfully; the returned value is now linked via execution metadata and read back.
+
+### Security
+- Raised the `pydantic-ai-slim` lower bound and lockfile version to clear CVE-2026-48782.
 
 ### Fixed
 - Fixed `FlowHandle.wait()` and `.get()` to return persisted flow outputs for flows with explicit return values, so granular adapter flows no longer raise ambiguous-result errors in that common case.

--- a/examples/end_to_end/news_scout/scout.py
+++ b/examples/end_to_end/news_scout/scout.py
@@ -112,7 +112,7 @@ def new_scout_agent() -> KitaruAgent:
 # inside the container; the `-slim` variant keeps the image small.
 SCOUT_IMAGE = ImageSettings(
     requirements=[
-        "pydantic-ai-slim[anthropic,openai]>=1.89,<1.104",
+        "pydantic-ai-slim[anthropic,openai]>=1.102.0,<1.104",
     ],
     environment=_collect_non_secret_env(),
 )

--- a/examples/end_to_end/prospect_scout/README.md
+++ b/examples/end_to_end/prospect_scout/README.md
@@ -101,7 +101,7 @@ uv run kitaru secrets set prospect-scout-keys --OPENAI_API_KEY=sk-... --EXA_API_
 
 ```python
 PROSPECTOR_IMAGE = ImageSettings(
-    requirements=["pydantic-ai-slim[openai]>=1.89,<1.104"],
+    requirements=["pydantic-ai-slim[openai]>=1.102.0,<1.104"],
     secret_environment_from=["prospect-scout-keys"],
 )
 ```

--- a/examples/end_to_end/prospect_scout/prospector.py
+++ b/examples/end_to_end/prospect_scout/prospector.py
@@ -65,7 +65,7 @@ EXA_SEARCH_ENDPOINT = "https://api.exa.ai/search"
 # older pin builds a remote image whose agent import fails. The `-slim` variant
 # with an explicit provider extra keeps remote images small.
 PROSPECTOR_IMAGE = ImageSettings(
-    requirements=["pydantic-ai-slim[openai]>=1.89,<1.104"],
+    requirements=["pydantic-ai-slim[openai]>=1.102.0,<1.104"],
 )
 
 # ---------------------------------------------------------------------------

--- a/examples/end_to_end/replay_overrides_demo/support_agent.py
+++ b/examples/end_to_end/replay_overrides_demo/support_agent.py
@@ -177,7 +177,7 @@ def publish_support_decision(decision: dict) -> Annotated[dict, "support_decisio
 @flow(
     cache=False,
     image=ImageSettings(
-        requirements=["pydantic-ai-slim[openai]>=1.96.0,<1.104.0"],
+        requirements=["pydantic-ai-slim[openai]>=1.102.0,<1.104.0"],
         secret_environment_from=["openai-creds"],
     ),
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ local = [
     "zenml[server]>=0.95.1",
 ]
 pydantic-ai = [
-    "pydantic-ai-slim>=1.89.0,<1.104.0",
+    "pydantic-ai-slim>=1.102.0,<1.104.0",
     "typing_extensions>=4.12",
 ]
 openai-agents = [
@@ -131,7 +131,7 @@ dev = [
     "pytest-xdist[psutil]",
     "griffe>=1.13.0,<2.0.0",
     "griffe-typingdoc>=0.2.8,<1.0.0",
-    "pydantic-ai-slim>=1.89.0,<1.104.0",
+    "pydantic-ai-slim>=1.102.0,<1.104.0",
     "openai-agents>=0.15.0,<0.18.0",
     "langchain>=1.0,<2",
     "langchain-openai>=1.0,<2",

--- a/src/kitaru/_terminal_logging.py
+++ b/src/kitaru/_terminal_logging.py
@@ -111,6 +111,11 @@ _REWRITE_RULES: list[tuple[re.Pattern[str], _TerminalKind | None, str]] = [
         "Starting flow `{0}`.",
     ),
     (
+        re.compile(r"^Pipeline `(.+?)` completed successfully\.$"),
+        "success",
+        "Flow `{0}` completed successfully.",
+    ),
+    (
         re.compile(r"^Pipeline completed successfully\.$"),
         "success",
         "Flow completed.",

--- a/tests/test_news_scout_example.py
+++ b/tests/test_news_scout_example.py
@@ -210,9 +210,8 @@ def test_image_settings_carries_non_secret_env_and_pinned_requirements(
     assert scout_module._image_override_for_active_stack() is None
 
     requirements = scout_module.SCOUT_IMAGE.requirements or []
-    # The pin must overlap Kitaru's own pydantic-ai range (>=1.89,<1.104) so the
-    # bundled adapter's imports resolve in the container; a lower floor crashes
-    # the pod at import. Provider extras are kept so the slim package ships the
-    # Anthropic + OpenAI clients.
+    # The pin must overlap Kitaru's own pydantic-ai range and stay above the
+    # CVE-2026-48782 fix floor. Provider extras are kept so the slim package
+    # ships the Anthropic + OpenAI clients.
     assert any("pydantic-ai-slim[anthropic,openai]" in req for req in requirements)
-    assert any(">=1.89" in req for req in requirements)
+    assert any(">=1.102.0" in req for req in requirements)

--- a/tests/test_prospect_scout_example.py
+++ b/tests/test_prospect_scout_example.py
@@ -108,12 +108,13 @@ def test_qualifier_actually_calls_search_web(
 def test_image_pins_adapter_compatible_pydantic_ai(prospector_module: Any) -> None:
     """PROSPECTOR_IMAGE pins a pydantic-ai the Kitaru adapter can import.
 
-    The adapter imports names that only exist in pydantic-ai >=1.89, so a
-    too-old pin (e.g. <1.80) builds a remote image whose agent import fails.
+    The adapter needs a recent pydantic-ai and the image pin must stay above
+    the CVE-2026-48782 fix floor, otherwise remote images can build with a
+    vulnerable installed version.
     """
     requirements = prospector_module.PROSPECTOR_IMAGE.requirements or []
     assert any("pydantic-ai-slim" in req for req in requirements)
-    assert any(">=1.89" in req for req in requirements)
+    assert any(">=1.102.0" in req for req in requirements)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_replay_overrides_demo.py
+++ b/tests/test_replay_overrides_demo.py
@@ -175,17 +175,25 @@ def test_env_example_documents_openai_key() -> None:
 
 
 def test_load_support_decision_prefers_flow_result_ref() -> None:
-    import importlib
+    import importlib.util
     import sys
     from types import SimpleNamespace
 
+    spec = importlib.util.spec_from_file_location(
+        "replay_overrides_load_decision_under_test",
+        DEMO_ROOT / "utils" / "load_decision.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
     sys.path.insert(0, str(DEMO_ROOT.resolve()))
+    sys.modules[spec.name] = module
     try:
-        load_support_decision = importlib.import_module(
-            "utils.load_decision"
-        ).load_support_decision
+        spec.loader.exec_module(module)
     finally:
         sys.path.pop(0)
+        sys.modules.pop(spec.name, None)
+    load_support_decision = module.load_support_decision
 
     decision = {
         "policy_label": "restricted_account_change",

--- a/tests/test_terminal_logging.py
+++ b/tests/test_terminal_logging.py
@@ -202,6 +202,16 @@ class TestDecidePipelineLifecycle:
         assert decision.text == "Flow completed."
         assert decision.kind == "success"
 
+    def test_named_pipeline_completed(self) -> None:
+        record = _make_record(
+            "zenml.execution.pipeline.dynamic.runner",
+            "Pipeline `google_adk_workflow` completed successfully.",
+        )
+        decision = terminal_logging._decide(record)
+        assert decision is not None
+        assert decision.text == "Flow `google_adk_workflow` completed successfully."
+        assert decision.kind == "success"
+
     def test_pausing_pipeline_run(self) -> None:
         record = _make_record(
             "zenml.execution.pipeline.dynamic.runner",

--- a/uv.lock
+++ b/uv.lock
@@ -1387,7 +1387,7 @@ requires-dist = [
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0,<3" },
     { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.15.0,<0.18.0" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=1.89.0,<1.104.0" },
+    { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=1.102.0,<1.104.0" },
     { name = "rich", specifier = ">=12.0.0" },
     { name = "typing-extensions", marker = "extra == 'pydantic-ai'", specifier = ">=4.12" },
     { name = "zenml", extras = ["local"], specifier = ">=0.95.1" },
@@ -1408,7 +1408,7 @@ dev = [
     { name = "openai", specifier = ">=1.0.0,<3" },
     { name = "openai-agents", specifier = ">=0.15.0,<0.18.0" },
     { name = "pip-audit", specifier = ">=2.9.0" },
-    { name = "pydantic-ai-slim", specifier = ">=1.89.0,<1.104.0" },
+    { name = "pydantic-ai-slim", specifier = ">=1.102.0,<1.104.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-clarity" },
     { name = "pytest-randomly" },
@@ -2440,7 +2440,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.96.0"
+version = "1.103.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -2451,9 +2451,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/b0/26299238be57ddbc1ce5b4fc019338dc4856a549d5b636276bf3743a1008/pydantic_ai_slim-1.96.0.tar.gz", hash = "sha256:44ff8bb5cf81023076e82174de1d6a089515277ce508906263d17880e3fcb2f4", size = 699284, upload-time = "2026-05-14T01:09:07.519Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/ce/ae3cd88af67e418e8d68749b1014d52aa84188acee438241ec819918a31a/pydantic_ai_slim-1.103.0.tar.gz", hash = "sha256:b0fda8eea125440b74c1de9cb5c8ed4fa6cfae72586b7de03581adf263903b8a", size = 748460, upload-time = "2026-05-27T02:49:04.141Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/a0/4ceb29871244a398fed43009b8d6577ee60b8562437e47027e371ef2d22c/pydantic_ai_slim-1.96.0-py3-none-any.whl", hash = "sha256:58044dee3e5429499938a5ef1a44ef44d5e179f3f68e80600bbddea1f6081967", size = 870756, upload-time = "2026-05-14T01:08:58.945Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/36/261c0891cc0925a59f0f3741ef2057ff3074c9a7940220ea39f83e9dd434/pydantic_ai_slim-1.103.0-py3-none-any.whl", hash = "sha256:866d5a6376f113bcb7e20749b87640db919efd9a44fdbb73574b77f06bc83c3d", size = 927993, upload-time = "2026-05-27T02:48:56.067Z" },
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.96.0"
+version = "1.103.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2563,9 +2563,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/b3/7e279ee3e8d1db7ff29fb4c6cf21c2b30a002e0900eae94bcc829a66f0e2/pydantic_graph-1.96.0.tar.gz", hash = "sha256:299a2b1e47e232a78b8038779c1ff5b387d6f02d79aebae217806c5d53607f9e", size = 59294, upload-time = "2026-05-14T01:09:10.11Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/f9/301c8477cc2309d827ef0e99e73c36581bd9d8811bd85a2a8bdd58a17a74/pydantic_graph-1.103.0.tar.gz", hash = "sha256:174ce80e3a67e393a227c70f5c9531497a15ce064fae8aef4635c1a5d9507c68", size = 62589, upload-time = "2026-05-27T02:49:06.61Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/58/918e641e1d94b95315a174bf318a78c0c127191333ffe021a92d417f6159/pydantic_graph-1.96.0-py3-none-any.whl", hash = "sha256:5904661751c4f19cba726e4e16a878f2f83722432236c231c88dba2bd887b43d", size = 73047, upload-time = "2026-05-14T01:09:02.476Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fb/60037718a0219933ae4fd2c393c69529260593a49f3fd334b3e7f9e3a912/pydantic_graph-1.103.0-py3-none-any.whl", hash = "sha256:98687e53811db9e324fabbf5f4692b5dd6af458591461ab6255230d8bc4bebf3", size = 80100, upload-time = "2026-05-27T02:48:59.756Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

Kitaru's terminal log rewrite now recognizes ZenML's named pipeline completion message:

```text
Pipeline `google_adk_workflow` completed successfully.
```

and renders it with Kitaru vocabulary while preserving the flow name:

```text
Flow `google_adk_workflow` completed successfully.
```

The older nameless ZenML message still renders as:

```text
Flow completed.
```

This branch also raises the declared `pydantic-ai-slim` lower bound from `1.89.0` to `1.102.0` in `pyproject.toml`, updates remote/example `ImageSettings(requirements=...)` floors to the same fixed version, and updates `uv.lock` to `pydantic-ai-slim==1.103.0`, clearing CVE-2026-48782 reported by `pip-audit`. `pydantic-graph` moved with it to the matching `1.103.0` version as part of the targeted resolver update. The tests that assert those image pins now check the new security floor too.

Finally, it makes `test_load_support_decision_prefers_flow_result_ref` independent of test worker import order. The replay-fork demo test can leave a top-level `utils.py` module/path around; the replay-overrides test now loads `utils/load_decision.py` by file path so it no longer accidentally asks the wrong `utils` module for `load_decision`.

## Why it was needed

ZenML now emits the dynamic runner completion message with the pipeline name included. Kitaru already had a rewrite rule for the older nameless message, `Pipeline completed successfully.`, but the named form missed the regex and fell through to the generic passthrough path. Because the passthrough still uses the Kitaru terminal renderer, the result looked like a Kitaru message but kept ZenML vocabulary.

The dependency bump is needed because CI's audit job reports `pydantic-ai-slim==1.96.0` as vulnerable and lists `1.102.0` or newer as the fixed release line. Raising the lower bound matters because released consumers installing `kitaru[pydantic-ai]` should not be allowed to satisfy Kitaru's metadata with a vulnerable `pydantic-ai-slim` version already present in their environment. The example image requirements need the same floor because remote/base images can satisfy `ImageSettings(requirements=...)` independently of the local Kitaru extra.

The test isolation fix is needed because the Python 3.13 CI lane can run replay-fork demo tests and replay-overrides demo tests in the same worker. Replay-fork imports `examples/end_to_end/replay_fork_demo/utils.py` as top-level `utils`; replay-overrides previously imported `utils.load_decision`, which can then resolve against the wrong `utils` module.

## Key implementation decisions

The terminal logging fix keeps separate rewrite rules for the named and nameless message shapes. The named form captures the pipeline name and reprints it as a Kitaru flow name. The nameless form keeps the previous `Flow completed.` output. The original log record is still left unchanged for stored execution logs.

The security fix raises the public lower bound and remote image floors to the first fixed stable version, `pydantic-ai-slim>=1.102.0`, while the lockfile resolves to `1.103.0` under the existing `<1.104.0` cap. The lock update used `uv lock --upgrade-package pydantic-ai-slim`, rather than a broad lock refresh. The resulting package-version diff is limited to `pydantic-ai-slim` and the resolver-required matching `pydantic-graph` bump.

The test fix avoids the shared top-level module name instead of relying on global cleanup. It loads `examples/end_to_end/replay_overrides_demo/utils/load_decision.py` with `importlib.util.spec_from_file_location(...)`, while temporarily adding the demo root so that `support_agent` still resolves the same way it would for the example.

## Reviewer Notes

The important logging path is `src/kitaru/_terminal_logging.py`. When a ZenML log record arrives, Kitaru checks the rewrite rules before falling back to printing the original message. Previously, the named completion message missed the completion rule, so the fallback printed `Pipeline ... completed successfully.` with a Kitaru prefix. Now that message matches the named completion rule and renders as `Flow ... completed successfully.`.

If this is wrong, the user-facing symptom is easy to spot: after a flow completes, the terminal would still show ZenML's `Pipeline` wording instead of Kitaru's `Flow` wording, or it would drop the flow name even though ZenML provided it.

For the audit fix, review `pyproject.toml`, `uv.lock`, and the end-to-end examples using `ImageSettings(requirements=...)`: current install surfaces should require `pydantic-ai-slim>=1.102.0,<1.104.0`, and `uv.lock` should resolve `pydantic-ai-slim`/`pydantic-graph` to `1.103.0`.

For the CI import-order fix, the useful review target is `tests/test_replay_overrides_demo.py`. The failure only appears when another test has already imported a top-level `utils` module from a different example.

### Reproduction

You can reproduce the exact terminal-log parser behavior without making a live provider call:

```bash
uv run --python 3.12 pytest tests/test_terminal_logging.py::TestDecidePipelineLifecycle::test_named_pipeline_completed
```

That test feeds this ZenML message into the terminal decision logic:

```text
Pipeline `google_adk_workflow` completed successfully.
```

and asserts that Kitaru renders it as:

```text
Flow `google_adk_workflow` completed successfully.
```

For an end-to-end manual check, run a Kitaru flow using a ZenML version that emits named pipeline completion logs. The terminal should now show this shape:

```text
Kitaru ✓ Flow `...` completed successfully.
```

instead of this shape:

```text
Kitaru › Pipeline `...` completed successfully.
```

For the audit fix, run:

```bash
just audit
```

It should report:

```text
No known vulnerabilities found, 9 ignored
```

For the Python 3.13 CI import-order failure, this command reproduced the failure before the test change and now passes:

```bash
uv run --python 3.13 pytest -n0 -p no:randomly \
  tests/adapters/langgraph/replay/test_replay_fork_demo.py::test_demo_jsonl_loader_requires_trace_id_for_multiple_traces \
  tests/test_replay_overrides_demo.py::test_load_support_decision_prefers_flow_result_ref -vv
```

Local checks run:

```bash
git diff --check
uv run pip-audit --timeout 60 ... # same ignores as just audit; just audit hit transient local PyPI TLS timeouts
uv run --python 3.13 pytest tests/test_news_scout_example.py::test_image_settings_carries_non_secret_env_and_pinned_requirements tests/test_prospect_scout_example.py::test_image_pins_adapter_compatible_pydantic_ai -vv
uv run --python 3.13 pytest tests/test_news_scout_example.py tests/test_prospect_scout_example.py
uv run --python 3.13 pytest tests/test_replay_overrides_demo.py
uv run --python 3.13 pytest -n0 -p no:randomly \
  tests/adapters/langgraph/replay/test_replay_fork_demo.py::test_demo_jsonl_loader_requires_trace_id_for_multiple_traces \
  tests/test_replay_overrides_demo.py::test_load_support_decision_prefers_flow_result_ref -vv
uv run --python 3.12 pytest tests/test_terminal_logging.py
```
