### PR TITLE
Bump ZenML to 0.96.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
-      ZENML_SERVER_TAG: 0.95.1
+      ZENML_SERVER_TAG: 0.96.0
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
-      ZENML_SERVER_TAG: 0.96.0
+      ZENML_SERVER_TAG: 0.96.1
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -550,7 +550,7 @@ jobs:
           target: server
           push: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
           build-args: |
-            ZENML_SERVER_TAG=0.96.0
+            ZENML_SERVER_TAG=0.96.1
             ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') && format('KITARU_VERSION={0}', env.VERSION) || '' }}
           tags: |
             zenmldocker/kitaru:${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -550,7 +550,7 @@ jobs:
           target: server
           push: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
           build-args: |
-            ZENML_SERVER_TAG=0.95.1
+            ZENML_SERVER_TAG=0.96.0
             ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') && format('KITARU_VERSION={0}', env.VERSION) || '' }}
           tags: |
             zenmldocker/kitaru:${{ env.VERSION }}

--- a/.github/workflows/ui-prerelease-smoke.yml
+++ b/.github/workflows/ui-prerelease-smoke.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   KITARU_ANALYTICS_OPT_IN: false
   ZENML_ANALYTICS_OPT_IN: false
-  ZENML_SERVER_TAG: 0.95.1
+  ZENML_SERVER_TAG: 0.96.0
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/ui-prerelease-smoke.yml
+++ b/.github/workflows/ui-prerelease-smoke.yml
@@ -25,7 +25,7 @@ concurrency:
 env:
   KITARU_ANALYTICS_OPT_IN: false
   ZENML_ANALYTICS_OPT_IN: false
-  ZENML_SERVER_TAG: 0.96.0
+  ZENML_SERVER_TAG: 0.96.1
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
-- Bumped the minimum ZenML dependency, server image tag, and Helm subchart version to `0.96.0`.
+- Bumped the minimum ZenML dependency, server image tag, and Helm subchart version to `0.96.1`.
 
 ## [0.19.0] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Bumped the minimum ZenML dependency, server image tag, and Helm subchart version to `0.96.0`.
+
 ## [0.19.0] - 2026-06-30
 
 ### Added

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 # Pinned ZenML server image version — bump here when upgrading.
 # Must match pyproject.toml, uv.lock, the server Dockerfiles, CI/release
 # workflow pins, and helm/Chart.yaml; contract tests enforce alignment.
-ZENML_SERVER_TAG := "0.96.0"
+ZENML_SERVER_TAG := "0.96.1"
 DOCKER_REPO := "zenmldocker/kitaru"
 DOCKER_TAG := "latest"
 UI_TAG := "latest"

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 # Pinned ZenML server image version — bump here when upgrading.
 # Must match pyproject.toml, uv.lock, the server Dockerfiles, CI/release
 # workflow pins, and helm/Chart.yaml; contract tests enforce alignment.
-ZENML_SERVER_TAG := "0.95.1"
+ZENML_SERVER_TAG := "0.96.0"
 DOCKER_REPO := "zenmldocker/kitaru"
 DOCKER_TAG := "latest"
 UI_TAG := "latest"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 # Published to: zenmldocker/kitaru
 
-ARG ZENML_SERVER_TAG=0.96.0
+ARG ZENML_SERVER_TAG=0.96.1
 
 FROM zenmldocker/zenml-server:${ZENML_SERVER_TAG} AS server
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 #
 # Published to: zenmldocker/kitaru
 
-ARG ZENML_SERVER_TAG=0.95.1
+ARG ZENML_SERVER_TAG=0.96.0
 
 FROM zenmldocker/zenml-server:${ZENML_SERVER_TAG} AS server
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -19,10 +19,10 @@ COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /uvx /bin/
 ENV UV_SYSTEM_PYTHON=1
 
 # Install kitaru from local source. Its pyproject.toml pulls
-# zenml[local]>=0.95.1 from PyPI automatically.
+# zenml[local]>=0.96.0 from PyPI automatically.
 COPY . /tmp/kitaru
 RUN cd /tmp/kitaru && uv pip install . && rm -rf /tmp/kitaru
 
 # Layer on cloud extras for remote artifact stores and connectors.
 RUN uv pip install \
-    "zenml[s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure]>=0.95.1"
+    "zenml[s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure]>=0.96.0"

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -19,10 +19,10 @@ COPY --from=ghcr.io/astral-sh/uv:0.10 /uv /uvx /bin/
 ENV UV_SYSTEM_PYTHON=1
 
 # Install kitaru from local source. Its pyproject.toml pulls
-# zenml[local]>=0.96.0 from PyPI automatically.
+# zenml[local]>=0.96.1 from PyPI automatically.
 COPY . /tmp/kitaru
 RUN cd /tmp/kitaru && uv pip install . && rm -rf /tmp/kitaru
 
 # Layer on cloud extras for remote artifact stores and connectors.
 RUN uv pip install \
-    "zenml[s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure]>=0.96.0"
+    "zenml[s3fs,gcsfs,adlfs,connectors-aws,connectors-gcp,connectors-azure]>=0.96.1"

--- a/docker/Dockerfile.server-dev
+++ b/docker/Dockerfile.server-dev
@@ -13,7 +13,7 @@
 #   4. Run:
 #        docker run -p 8080:8080 kitaru-server-dev
 
-ARG ZENML_SERVER_TAG=0.96.0
+ARG ZENML_SERVER_TAG=0.96.1
 
 FROM zenmldocker/zenml-server:${ZENML_SERVER_TAG} AS server
 

--- a/docker/Dockerfile.server-dev
+++ b/docker/Dockerfile.server-dev
@@ -13,7 +13,7 @@
 #   4. Run:
 #        docker run -p 8080:8080 kitaru-server-dev
 
-ARG ZENML_SERVER_TAG=0.95.1
+ARG ZENML_SERVER_TAG=0.96.0
 
 FROM zenmldocker/zenml-server:${ZENML_SERVER_TAG} AS server
 

--- a/docs/book/adapters/google-adk.md
+++ b/docs/book/adapters/google-adk.md
@@ -20,7 +20,7 @@ There are two useful paths today. Both persist checkpoints when the wrapped ADK 
 
 ## Install in an isolated ADK environment
 
-Use a no-dev ADK environment for adapter checks. As of 2026-06-29, `google-adk` resolves FastAPI `0.138.0` / Starlette `1.3.1`. A direct resolver probe with `google-adk>=2.3,<3` plus `zenml[server]>=0.95.1` succeeds, but this project still intentionally blocks `google-adk` with the local/dev extras until the full local server path is certified with that newer stack.
+Use a no-dev ADK environment for adapter checks. As of 2026-07-02, `google-adk` resolves FastAPI `0.138.0` / Starlette `1.3.1`. A direct resolver probe with `google-adk>=2.3,<3` plus `zenml[server]>=0.96.0` succeeds, but this project still intentionally blocks `google-adk` with the local/dev extras until the full local server path is certified with that newer stack.
 
 ```bash
 UV_PROJECT_ENVIRONMENT=.venv-google-adk \

--- a/docs/book/adapters/google-adk.md
+++ b/docs/book/adapters/google-adk.md
@@ -20,7 +20,7 @@ There are two useful paths today. Both persist checkpoints when the wrapped ADK 
 
 ## Install in an isolated ADK environment
 
-Use a no-dev ADK environment for adapter checks. As of 2026-07-02, `google-adk` resolves FastAPI `0.138.0` / Starlette `1.3.1`. A direct resolver probe with `google-adk>=2.3,<3` plus `zenml[server]>=0.96.0` succeeds, but this project still intentionally blocks `google-adk` with the local/dev extras until the full local server path is certified with that newer stack.
+Use a no-dev ADK environment for adapter checks. As of 2026-07-02, `google-adk` resolves FastAPI `0.138.0` / Starlette `1.3.1`. A direct resolver probe with `google-adk>=2.3,<3` plus `zenml[server]>=0.96.1` succeeds, but this project still intentionally blocks `google-adk` with the local/dev extras until the full local server path is certified with that newer stack.
 
 ```bash
 UV_PROJECT_ENVIRONMENT=.venv-google-adk \

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://kitaru.ai/kitaru-logo.svg
 
 dependencies:
   - name: zenml
-    version: "0.96.0"
+    version: "0.96.1"
     repository: "oci://public.ecr.aws/zenml"
     alias: kitaru

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -15,6 +15,6 @@ icon: https://kitaru.ai/kitaru-logo.svg
 
 dependencies:
   - name: zenml
-    version: "0.95.1"
+    version: "0.96.0"
     repository: "oci://public.ecr.aws/zenml"
     alias: kitaru

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "genai-prices>=0.0.66,<0.1",
     "pydantic>=2.0",
     "rich>=12.0.0",
-    "zenml[local]>=0.96.0",
+    "zenml[local]>=0.96.1",
 ]
 
 [project.optional-dependencies]
@@ -58,7 +58,7 @@ llm = [
     "kitaru[anthropic]",
 ]
 local = [
-    "zenml[server]>=0.96.0",
+    "zenml[server]>=0.96.1",
 ]
 pydantic-ai = [
     "pydantic-ai-slim>=1.102.0,<1.104.0",
@@ -123,7 +123,7 @@ exclude-newer = "3 days"
 exclude-newer-package = { zenml = false, aiohttp = false, langsmith = false, pydantic-settings = false }
 # google-adk 2.3.x currently resolves FastAPI 0.138 / Starlette 1.3.
 # A direct no-project resolver probe with google-adk>=2.3,<3 plus
-# zenml[server]>=0.96.0 succeeded on 2026-07-02, including a
+# zenml[server]>=0.96.1 succeeded on 2026-07-02, including a
 # zenml.zen_server.zen_server_api import. Keep ADK out of the normal dev/local
 # project environment until the full Kitaru local-server path is certified with
 # that newer FastAPI/Starlette stack.
@@ -147,7 +147,7 @@ dev = [
     "ruff>=0.11",
     "ty>=0.0.1a7",
     "yamlfix",
-    "zenml[server]>=0.96.0",
+    "zenml[server]>=0.96.1",
     "pytest>=8.0",
     "pytest-randomly",
     "pytest-clarity",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "genai-prices>=0.0.66,<0.1",
     "pydantic>=2.0",
     "rich>=12.0.0",
-    "zenml[local]>=0.95.1",
+    "zenml[local]>=0.96.0",
 ]
 
 [project.optional-dependencies]
@@ -58,7 +58,7 @@ llm = [
     "kitaru[anthropic]",
 ]
 local = [
-    "zenml[server]>=0.95.1",
+    "zenml[server]>=0.96.0",
 ]
 pydantic-ai = [
     "pydantic-ai-slim>=1.102.0,<1.104.0",
@@ -123,11 +123,11 @@ exclude-newer = "3 days"
 exclude-newer-package = { zenml = false, aiohttp = false, langsmith = false, pydantic-settings = false }
 # google-adk 2.3.x currently resolves FastAPI 0.138 / Starlette 1.3.
 # A direct no-project resolver probe with google-adk>=2.3,<3 plus
-# zenml[server]>=0.95.1 succeeded on 2026-06-29, including a
+# zenml[server]>=0.96.0 succeeded on 2026-07-02, including a
 # zenml.zen_server.zen_server_api import. Keep ADK out of the normal dev/local
 # project environment until the full Kitaru local-server path is certified with
 # that newer FastAPI/Starlette stack.
-# Verified isolated contract command (2026-06-29):
+# Verified isolated contract command (2026-07-02):
 # UV_PROJECT_ENVIRONMENT=<tmp-env> KITARU_REQUIRE_GOOGLE_ADK_CONTRACT=1 \
 #   uv run --python 3.12 --no-dev --extra google-adk --with pytest \
 #   pytest -o addopts='-vv' tests/test_google_adk_installed_contract.py tests/test_google_adk_example.py
@@ -147,7 +147,7 @@ dev = [
     "ruff>=0.11",
     "ty>=0.0.1a7",
     "yamlfix",
-    "zenml[server]>=0.95.1",
+    "zenml[server]>=0.96.0",
     "pytest>=8.0",
     "pytest-randomly",
     "pytest-clarity",

--- a/tests/test_ui_release_contract.py
+++ b/tests/test_ui_release_contract.py
@@ -36,7 +36,7 @@ def test_release_workflow_uses_stable_monorepo_ui_bundling() -> None:
     docker_step = _workflow_step_block(workflow, "Build and push Docker image")
     assert "KITARU_UI_TAG=" not in docker_step
     assert "KITARU_VERSION=" in docker_step
-    assert "ZENML_SERVER_TAG=0.96.0" in docker_step
+    assert "ZENML_SERVER_TAG=0.96.1" in docker_step
 
 
 def test_ci_bundles_ui_before_source_docker_smoke() -> None:

--- a/tests/test_ui_release_contract.py
+++ b/tests/test_ui_release_contract.py
@@ -36,7 +36,7 @@ def test_release_workflow_uses_stable_monorepo_ui_bundling() -> None:
     docker_step = _workflow_step_block(workflow, "Build and push Docker image")
     assert "KITARU_UI_TAG=" not in docker_step
     assert "KITARU_VERSION=" in docker_step
-    assert "ZENML_SERVER_TAG=0.95.1" in docker_step
+    assert "ZENML_SERVER_TAG=0.96.0" in docker_step
 
 
 def test_ci_bundles_ui_before_source_docker_smoke() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1508,8 +1508,8 @@ requires-dist = [
     { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=1.102.0,<1.104.0" },
     { name = "rich", specifier = ">=12.0.0" },
     { name = "typing-extensions", marker = "extra == 'pydantic-ai'", specifier = ">=4.12" },
-    { name = "zenml", extras = ["local"], specifier = ">=0.96.0" },
-    { name = "zenml", extras = ["server"], marker = "extra == 'local'", specifier = ">=0.96.0" },
+    { name = "zenml", extras = ["local"], specifier = ">=0.96.1" },
+    { name = "zenml", extras = ["server"], marker = "extra == 'local'", specifier = ">=0.96.1" },
 ]
 provides-extras = ["openai", "anthropic", "llm", "local", "pydantic-ai", "openai-agents", "langgraph", "langgraph-openai", "langgraph-anthropic", "claude-agent-sdk", "gemini", "google-adk", "mcp"]
 
@@ -1535,7 +1535,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11" },
     { name = "ty", specifier = ">=0.0.1a7" },
     { name = "yamlfix" },
-    { name = "zenml", extras = ["server"], specifier = ">=0.96.0" },
+    { name = "zenml", extras = ["server"], specifier = ">=0.96.1" },
 ]
 
 [[package]]
@@ -4361,7 +4361,7 @@ wheels = [
 
 [[package]]
 name = "zenml"
-version = "0.96.0"
+version = "0.96.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
@@ -4382,9 +4382,9 @@ dependencies = [
     { name = "setuptools" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/af/e777abb31c9b770a5902efeebdd138e06fe606eda47ab6ad01e8f9375d39/zenml-0.96.0.tar.gz", hash = "sha256:1eb4e9f3f8719ff8a21e8c553bc439fa8e3747ed57c9341c8497072faed755f8", size = 7253846, upload-time = "2026-07-02T12:39:45.515Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/6d/aefaf52ac8e8ed741b3b76be45aae91df7db0da58173c0646e87fd263a16/zenml-0.96.1.tar.gz", hash = "sha256:726ad2f73d063e19790d210cc698154a15621c92c88a9ac4e37aa8ab4e6fb32e", size = 7268674, upload-time = "2026-07-02T20:21:06.188Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/9a/403fd0c38bd388778b5f95991725df2ae89de1e11b2befb83748614dd175/zenml-0.96.0-py3-none-any.whl", hash = "sha256:5b71bbeaad446bd255c936e1c76cb1d1da0042dde4c74d119a4e2a73d9ce5bdc", size = 8505352, upload-time = "2026-07-02T12:39:43.066Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4a/26b0707d65f30ec85a559ea0082405cb8d67876a962bb1fdd4ddddedd7a1/zenml-0.96.1-py3-none-any.whl", hash = "sha256:3775d6fd76ba06bce12837dd797510b110098c24dd2057b8681452e35fe04692", size = 8531373, upload-time = "2026-07-02T20:21:03.284Z" },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1508,8 +1508,8 @@ requires-dist = [
     { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=1.102.0,<1.104.0" },
     { name = "rich", specifier = ">=12.0.0" },
     { name = "typing-extensions", marker = "extra == 'pydantic-ai'", specifier = ">=4.12" },
-    { name = "zenml", extras = ["local"], specifier = ">=0.95.1" },
-    { name = "zenml", extras = ["server"], marker = "extra == 'local'", specifier = ">=0.95.1" },
+    { name = "zenml", extras = ["local"], specifier = ">=0.96.0" },
+    { name = "zenml", extras = ["server"], marker = "extra == 'local'", specifier = ">=0.96.0" },
 ]
 provides-extras = ["openai", "anthropic", "llm", "local", "pydantic-ai", "openai-agents", "langgraph", "langgraph-openai", "langgraph-anthropic", "claude-agent-sdk", "gemini", "google-adk", "mcp"]
 
@@ -1535,7 +1535,7 @@ dev = [
     { name = "ruff", specifier = ">=0.11" },
     { name = "ty", specifier = ">=0.0.1a7" },
     { name = "yamlfix" },
-    { name = "zenml", extras = ["server"], specifier = ">=0.95.1" },
+    { name = "zenml", extras = ["server"], specifier = ">=0.96.0" },
 ]
 
 [[package]]
@@ -4361,7 +4361,7 @@ wheels = [
 
 [[package]]
 name = "zenml"
-version = "0.95.1"
+version = "0.96.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
@@ -4382,9 +4382,9 @@ dependencies = [
     { name = "setuptools" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/56/9d8e8e6b17af7b5a7f0342edc05b950de2224dfa74c633d3aca631c1adab/zenml-0.95.1.tar.gz", hash = "sha256:b8034f2b46e9c6feb4bb880d4df8c86b112f4b12952b08e9f9a2009cbd229afd", size = 7228227, upload-time = "2026-06-18T12:21:31.672Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/af/e777abb31c9b770a5902efeebdd138e06fe606eda47ab6ad01e8f9375d39/zenml-0.96.0.tar.gz", hash = "sha256:1eb4e9f3f8719ff8a21e8c553bc439fa8e3747ed57c9341c8497072faed755f8", size = 7253846, upload-time = "2026-07-02T12:39:45.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/07/261fb8413f26494aa8fa45ff186a0532d3679314d46b81bb9b8207779dfd/zenml-0.95.1-py3-none-any.whl", hash = "sha256:63e8299aa62de2a818a18c3d6359a891550cbcebefe5faaeb59c133bed1b28a4", size = 8459753, upload-time = "2026-06-18T12:21:29.392Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/403fd0c38bd388778b5f95991725df2ae89de1e11b2befb83748614dd175/zenml-0.96.0-py3-none-any.whl", hash = "sha256:5b71bbeaad446bd255c936e1c76cb1d1da0042dde4c74d119a4e2a73d9ce5bdc", size = 8505352, upload-time = "2026-07-02T12:39:43.066Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Bumped Kitaru's ZenML Python dependency floor and generated lock metadata from `0.96.0` to `0.96.1`.
- Aligned the ZenML server image tag and Helm subchart version to `0.96.1` across Dockerfiles, CI/release workflows, the Justfile, and the Helm chart.
- Refreshed the Google ADK isolated resolver note and the Unreleased changelog entry for the version bump.

## Reviewer Notes

`pyproject.toml` is the source of truth for the supported ZenML Python lower bound. The Docker contract test reads that lower bound, then checks the lockfile metadata, resolved ZenML package version, server Dockerfiles, CI/release pins, Justfile assignment, and Helm chart dependency all match it.

The main thing to review is that every live surface now points at `0.96.1`: the Python requirements, `uv.lock` package block and hashes, `ZENML_SERVER_TAG` values, and Helm dependency. If one of those values drifts, `tests/test_dockerfile_contract.py` should fail.

No live `0.96.0` content references remain. One `0.95.1` reference remains intentionally in `CHANGELOG.md` under the released `0.19.0` section because it describes that historical release.

### Reproduction

Local checks run:

```bash
uv lock --upgrade-package zenml
uv sync --frozen
uv run pytest tests/test_dockerfile_contract.py tests/test_ui_release_contract.py
uv run ruff check tests/test_ui_release_contract.py tests/test_dockerfile_contract.py
just yaml-check
docker manifest inspect zenmldocker/zenml-server:0.96.1
helm dependency update helm
helm lint helm
UV_PROJECT_ENVIRONMENT=/private/tmp/kitaru-google-adk-0.96.1-env KITARU_REQUIRE_GOOGLE_ADK_CONTRACT=1 uv run --python 3.12 --no-dev --extra google-adk --with pytest pytest -o addopts='-vv' tests/test_google_adk_installed_contract.py tests/test_google_adk_example.py
git diff HEAD~1..HEAD --check
rg --line-number "0\\.96\\.0|0\\.95\\.1"
```

Checks skipped: none.
