### PR TITLE
Speed up pytest provider guard setup

### DIFF
--- a/scripts/summarize_pytest_speed.py
+++ b/scripts/summarize_pytest_speed.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import json
+import math
 import statistics
 import sys
 from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
+
+_SOURCE_KEY = "_source"
 
 
 def _read_events(report_dir: Path) -> list[dict[str, Any]]:
@@ -20,13 +23,95 @@ def _read_events(report_dir: Path) -> list[dict[str, Any]]:
                 line = line.strip()
                 if not line:
                     continue
+                source = f"{path}:{line_number}"
                 try:
-                    events.append(json.loads(line))
+                    event = json.loads(line)
                 except json.JSONDecodeError as exc:
+                    raise SystemExit(f"Invalid JSON in {source}: {exc}") from exc
+                if not isinstance(event, dict):
+                    type_name = type(event).__name__
                     raise SystemExit(
-                        f"Invalid JSON in {path}:{line_number}: {exc}"
-                    ) from exc
+                        f"Invalid probe event in {source}: expected JSON object, "
+                        f"got {type_name}"
+                    )
+                event[_SOURCE_KEY] = source
+                events.append(event)
     return events
+
+
+def _validate_single_session(events: list[dict[str, Any]]) -> None:
+    sources_by_session: dict[str, str] = {}
+    for event in events:
+        session_id = event.get("session_id")
+        source = str(event.get(_SOURCE_KEY, "<unknown>"))
+        if not isinstance(session_id, str) or not session_id:
+            raise SystemExit(
+                f"Invalid probe event in {source}: expected non-empty string "
+                "field 'session_id'. Remove stale event files or rerun the "
+                "speed probe."
+            )
+        sources_by_session.setdefault(session_id, source)
+
+    if len(sources_by_session) <= 1:
+        return
+
+    session_sources = "; ".join(
+        f"{session_id} at {sources_by_session[session_id]}"
+        for session_id in sorted(sources_by_session)
+    )
+    raise SystemExit(
+        "Probe report contains events from multiple pytest speed-probe "
+        f"sessions: {session_sources}. Summarize one session or remove "
+        "stale event files."
+    )
+
+
+def _event_context(event: dict[str, Any]) -> str:
+    context_parts: list[str] = []
+    for field in ("kind", "nodeid", "fixture", "phase", "worker"):
+        value = event.get(field)
+        if value:
+            context_parts.append(f"{field}={value}")
+    return ", ".join(context_parts) or "unknown event"
+
+
+def _invalid_numeric_message(
+    event: dict[str, Any], field: str, problem: str, value: Any
+) -> str:
+    source = str(event.get(_SOURCE_KEY, "<unknown>"))
+    return (
+        f"Invalid numeric field {field!r} in {source} ({_event_context(event)}): "
+        f"{problem}, got {value!r}"
+    )
+
+
+def _event_float(event: dict[str, Any], field: str) -> float:
+    if field not in event:
+        raise SystemExit(
+            _invalid_numeric_message(
+                event, field, "expected a finite number", "missing"
+            )
+        )
+
+    value = event[field]
+    if isinstance(value, bool):
+        raise SystemExit(
+            _invalid_numeric_message(event, field, "expected a finite number", value)
+        )
+
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as exc:
+        raise SystemExit(
+            _invalid_numeric_message(event, field, "expected a finite number", value)
+        ) from exc
+
+    if not math.isfinite(parsed):
+        raise SystemExit(
+            _invalid_numeric_message(event, field, "expected a finite number", value)
+        )
+
+    return parsed
 
 
 def _percentile(values: list[float], percentile: float) -> float:
@@ -52,11 +137,10 @@ def _print_fixture_totals(events: Iterable[dict[str, Any]]) -> None:
         kind = event.get("kind")
         fixture = event.get("fixture")
         if kind in {"fixture_setup", "fixture_teardown"} and fixture:
-            durations[f"{fixture} {kind.removeprefix('fixture_')}"].append(
-                float(event.get("seconds", 0.0))
-            )
+            phase_name = f"{fixture} {kind.removeprefix('fixture_')}"
+            durations[phase_name].append(_event_float(event, "seconds"))
         elif kind == "primed_zenml_setup":
-            durations["primed_zenml setup"].append(float(event.get("seconds", 0.0)))
+            durations["primed_zenml setup"].append(_event_float(event, "seconds"))
 
     print("## Fixture totals")
     print()
@@ -82,7 +166,7 @@ def _print_top_tests(events: Iterable[dict[str, Any]]) -> None:
             continue
         nodeid = str(event.get("nodeid", ""))
         phase = str(event.get("phase", ""))
-        phase_seconds[nodeid][phase] += float(event.get("seconds", 0.0))
+        phase_seconds[nodeid][phase] += _event_float(event, "seconds")
 
     print("## Top call durations")
     print()
@@ -113,14 +197,14 @@ def _print_worker_tail(events: Iterable[dict[str, Any]]) -> None:
     for event in events:
         worker = str(event.get("worker", "unknown"))
         if event.get("kind") == "test_phase":
-            worker_phase_totals[worker] += float(event.get("seconds", 0.0))
+            worker_phase_totals[worker] += _event_float(event, "seconds")
             nodeid = str(event.get("nodeid", ""))
-            timestamp = float(event.get("timestamp", 0.0))
+            timestamp = _event_float(event, "timestamp")
             if nodeid and timestamp >= last_test_by_worker.get(worker, (0.0, ""))[0]:
                 last_test_by_worker[worker] = (timestamp, nodeid)
         elif event.get("kind") == "primed_zenml_setup":
             primed_count_by_worker[worker] += 1
-            primed_seconds_by_worker[worker] += float(event.get("seconds", 0.0))
+            primed_seconds_by_worker[worker] += _event_float(event, "seconds")
 
     print("## Worker tail")
     print()
@@ -149,6 +233,7 @@ def main(argv: list[str]) -> int:
     if not events:
         print(f"No probe events found in {report_dir}", file=sys.stderr)
         return 1
+    _validate_single_session(events)
 
     print(f"# Pytest speed probe summary: `{report_dir}`")
     print()

--- a/scripts/summarize_pytest_speed.py
+++ b/scripts/summarize_pytest_speed.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Summarize Kitaru pytest speed probe JSONL output."""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+
+def _read_events(report_dir: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for path in sorted(report_dir.glob("events-*.jsonl")):
+        with path.open(encoding="utf-8") as file:
+            for line_number, line in enumerate(file, start=1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError as exc:
+                    raise SystemExit(
+                        f"Invalid JSON in {path}:{line_number}: {exc}"
+                    ) from exc
+    return events
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = (len(ordered) - 1) * percentile
+    lower = int(index)
+    upper = min(lower + 1, len(ordered) - 1)
+    if lower == upper:
+        return ordered[lower]
+    fraction = index - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def _fmt_seconds(value: float) -> str:
+    return f"{value:.3f}"
+
+
+def _print_fixture_totals(events: Iterable[dict[str, Any]]) -> None:
+    durations: dict[str, list[float]] = defaultdict(list)
+    for event in events:
+        kind = event.get("kind")
+        fixture = event.get("fixture")
+        if kind in {"fixture_setup", "fixture_teardown"} and fixture:
+            durations[f"{fixture} {kind.removeprefix('fixture_')}"].append(
+                float(event.get("seconds", 0.0))
+            )
+        elif kind == "primed_zenml_setup":
+            durations["primed_zenml setup"].append(float(event.get("seconds", 0.0)))
+
+    print("## Fixture totals")
+    print()
+    print("| Fixture/phase | Count | Total seconds | Mean | p50 | p95 |")
+    print("|---|---:|---:|---:|---:|---:|")
+    for name in sorted(durations):
+        values = durations[name]
+        total = sum(values)
+        mean = statistics.mean(values)
+        p50 = statistics.median(values)
+        p95 = _percentile(values, 0.95)
+        print(
+            f"| {name} | {len(values)} | {_fmt_seconds(total)} | "
+            f"{_fmt_seconds(mean)} | {_fmt_seconds(p50)} | {_fmt_seconds(p95)} |"
+        )
+    print()
+
+
+def _print_top_tests(events: Iterable[dict[str, Any]]) -> None:
+    phase_seconds: dict[str, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    for event in events:
+        if event.get("kind") != "test_phase":
+            continue
+        nodeid = str(event.get("nodeid", ""))
+        phase = str(event.get("phase", ""))
+        phase_seconds[nodeid][phase] += float(event.get("seconds", 0.0))
+
+    print("## Top call durations")
+    print()
+    for nodeid, phases in sorted(
+        phase_seconds.items(), key=lambda item: item[1].get("call", 0.0), reverse=True
+    )[:20]:
+        print(f"- {_fmt_seconds(phases.get('call', 0.0))}s call — {nodeid}")
+    print()
+
+    print("## Top setup + teardown durations")
+    print()
+    for nodeid, phases in sorted(
+        phase_seconds.items(),
+        key=lambda item: item[1].get("setup", 0.0) + item[1].get("teardown", 0.0),
+        reverse=True,
+    )[:20]:
+        setup_teardown = phases.get("setup", 0.0) + phases.get("teardown", 0.0)
+        print(f"- {_fmt_seconds(setup_teardown)}s setup+teardown — {nodeid}")
+    print()
+
+
+def _print_worker_tail(events: Iterable[dict[str, Any]]) -> None:
+    worker_phase_totals: dict[str, float] = defaultdict(float)
+    last_test_by_worker: dict[str, tuple[float, str]] = {}
+    primed_count_by_worker: dict[str, int] = defaultdict(int)
+    primed_seconds_by_worker: dict[str, float] = defaultdict(float)
+
+    for event in events:
+        worker = str(event.get("worker", "unknown"))
+        if event.get("kind") == "test_phase":
+            worker_phase_totals[worker] += float(event.get("seconds", 0.0))
+            nodeid = str(event.get("nodeid", ""))
+            timestamp = float(event.get("timestamp", 0.0))
+            if nodeid and timestamp >= last_test_by_worker.get(worker, (0.0, ""))[0]:
+                last_test_by_worker[worker] = (timestamp, nodeid)
+        elif event.get("kind") == "primed_zenml_setup":
+            primed_count_by_worker[worker] += 1
+            primed_seconds_by_worker[worker] += float(event.get("seconds", 0.0))
+
+    print("## Worker tail")
+    print()
+    print(
+        "| Worker | Total reported test-phase seconds | Last test | "
+        "Primed count | Primed seconds |"
+    )
+    print("|---|---:|---|---:|---:|")
+    for worker in sorted(worker_phase_totals):
+        _, last_test = last_test_by_worker.get(worker, (0.0, ""))
+        print(
+            f"| {worker} | {_fmt_seconds(worker_phase_totals[worker])} | "
+            f"{last_test} | {primed_count_by_worker[worker]} | "
+            f"{_fmt_seconds(primed_seconds_by_worker[worker])} |"
+        )
+    print()
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("Usage: summarize_pytest_speed.py REPORT_DIR", file=sys.stderr)
+        return 2
+
+    report_dir = Path(argv[1])
+    events = _read_events(report_dir)
+    if not events:
+        print(f"No probe events found in {report_dir}", file=sys.stderr)
+        return 1
+
+    print(f"# Pytest speed probe summary: `{report_dir}`")
+    print()
+    print(f"Events: {len(events)}")
+    print()
+    _print_fixture_totals(events)
+    _print_top_tests(events)
+    _print_worker_tail(events)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import json
 import os
 import sys
 import time
+import uuid
 from collections.abc import Generator, Iterable
 from pathlib import Path
 from typing import Any
@@ -43,6 +44,8 @@ _LIVE_PROVIDER_MARKERS = (
 )
 _PROVIDER_CALL_GUARD_ACTIVE = False
 _PROVIDER_CALL_GUARD_NODEID: str | None = None
+_SPEED_PROBE_SESSION_ID_ENV = "KITARU_TEST_SPEED_SESSION_ID"
+_SPEED_PROBE_SESSION_ID: str | None = None
 _EARLY_TEST_ENV_VARS = (
     "KITARU_SERVER_URL",
     "KITARU_AUTH_TOKEN",
@@ -130,6 +133,31 @@ def _speed_worker_id() -> str:
     return os.environ.get("PYTEST_XDIST_WORKER", "master")
 
 
+def _speed_probe_session_id() -> str:
+    global _SPEED_PROBE_SESSION_ID
+    if _SPEED_PROBE_SESSION_ID is not None:
+        return _SPEED_PROBE_SESSION_ID
+
+    session_id = os.environ.get(_SPEED_PROBE_SESSION_ID_ENV)
+    if not session_id:
+        session_id = os.environ.get("PYTEST_XDIST_TESTRUNUID")
+    if not session_id:
+        session_id = (
+            f"{int(time.time() * 1_000_000)}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+        )
+
+    _SPEED_PROBE_SESSION_ID = session_id
+    os.environ[_SPEED_PROBE_SESSION_ID_ENV] = session_id
+    return session_id
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config) -> None:
+    del config
+    if _speed_probe_enabled():
+        _speed_probe_session_id()
+
+
 def _record_speed_event(kind: str, payload: dict[str, Any]) -> None:
     if not _speed_probe_enabled():
         return
@@ -140,6 +168,7 @@ def _record_speed_event(kind: str, payload: dict[str, Any]) -> None:
     pid = os.getpid()
     event = {
         "kind": kind,
+        "session_id": _speed_probe_session_id(),
         "worker": worker,
         "pid": pid,
         "timestamp": time.time(),
@@ -430,6 +459,28 @@ def _provider_name_for_url(url: Any) -> str | None:
     return _provider_name_for_host(parsed.hostname)
 
 
+def _provider_name_for_possibly_relative_url(
+    url: Any,
+    base_url: Any | None = None,
+    *,
+    fallback: str | None = None,
+) -> str | None:
+    raw_url = str(url)
+    parsed = urlparse(raw_url)
+    if parsed.hostname is not None:
+        return _provider_name_for_host(parsed.hostname)
+    if base_url is not None:
+        return _provider_name_for_url(urljoin(str(base_url), raw_url))
+    return fallback
+
+
+def _provider_name_for_httpx_request(client: Any, url: Any) -> str | None:
+    return _provider_name_for_possibly_relative_url(
+        url,
+        getattr(client, "base_url", None),
+    )
+
+
 def _fail_provider_call(provider_name: str) -> None:
     nodeid = _PROVIDER_CALL_GUARD_NODEID
     location = f" in {nodeid}" if nodeid else ""
@@ -475,11 +526,11 @@ def _provider_name_for_sdk_request(
     base_url = getattr(client, "base_url", None)
 
     if raw_url is not None:
-        raw_url_string = str(raw_url)
-        if urlparse(raw_url_string).hostname is not None:
-            return _provider_name_for_url(raw_url_string)
-        if base_url is not None:
-            return _provider_name_for_url(urljoin(str(base_url), raw_url_string))
+        return _provider_name_for_possibly_relative_url(
+            raw_url,
+            base_url,
+            fallback=default_provider,
+        )
 
     if base_url is not None:
         return _provider_name_for_url(base_url)
@@ -549,14 +600,14 @@ def _install_provider_call_guard(monkeypatch: pytest.MonkeyPatch) -> None:
         def guarded_httpx_request(
             self: Any, method: str, url: Any, **kwargs: Any
         ) -> Any:
-            provider_name = _provider_name_for_url(url)
+            provider_name = _provider_name_for_httpx_request(self, url)
             _guard_provider_call_if_active(provider_name)
             return original_client_request(self, method, url, **kwargs)
 
         async def guarded_httpx_request_async(
             self: Any, method: str, url: Any, **kwargs: Any
         ) -> Any:
-            provider_name = _provider_name_for_url(url)
+            provider_name = _provider_name_for_httpx_request(self, url)
             _guard_provider_call_if_active(provider_name)
             return await original_async_client_request(self, method, url, **kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import sys
+import time
 from collections.abc import Generator, Iterable
 from pathlib import Path
 from typing import Any
@@ -39,6 +41,8 @@ _LIVE_PROVIDER_MARKERS = (
     "live_anthropic",
     "live_gemini",
 )
+_PROVIDER_CALL_GUARD_ACTIVE = False
+_PROVIDER_CALL_GUARD_NODEID: str | None = None
 _EARLY_TEST_ENV_VARS = (
     "KITARU_SERVER_URL",
     "KITARU_AUTH_TOKEN",
@@ -109,15 +113,56 @@ from kitaru.config import (
 )
 
 
+def _speed_probe_enabled() -> bool:
+    return os.environ.get("KITARU_TEST_SPEED_PROBE") == "1"
+
+
+def _speed_report_dir() -> Path:
+    return Path(
+        os.environ.get(
+            "KITARU_TEST_SPEED_REPORT_DIR",
+            "prompt-exports/test-speed/probe",
+        )
+    )
+
+
+def _speed_worker_id() -> str:
+    return os.environ.get("PYTEST_XDIST_WORKER", "master")
+
+
+def _record_speed_event(kind: str, payload: dict[str, Any]) -> None:
+    if not _speed_probe_enabled():
+        return
+
+    report_dir = _speed_report_dir()
+    report_dir.mkdir(parents=True, exist_ok=True)
+    worker = _speed_worker_id()
+    pid = os.getpid()
+    event = {
+        "kind": kind,
+        "worker": worker,
+        "pid": pid,
+        "timestamp": time.time(),
+        **payload,
+    }
+    event_path = report_dir / f"events-{worker}-{pid}.jsonl"
+    with event_path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(event, sort_keys=True) + "\n")
+
+
 @pytest.fixture(autouse=True)
 def isolated_zenml_global_config(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> Generator[Path]:
     """Isolate ZenML and Kitaru config so tests never touch real user state.
 
     Mirrors the production init hook: both Kitaru and ZenML share a single
     unified config directory.
     """
+    speed_probe = _speed_probe_enabled()
+    setup_started = time.perf_counter() if speed_probe else 0.0
     config_dir = tmp_path / "kitaru-config"
     config_dir.mkdir(parents=True)
 
@@ -182,13 +227,43 @@ def isolated_zenml_global_config(
     GlobalConfiguration._reset_instance()
     Client._reset_instance()
 
+    if speed_probe:
+        _record_speed_event(
+            "fixture_setup",
+            {
+                "fixture": "isolated_zenml_global_config",
+                "nodeid": request.node.nodeid,
+                "seconds": time.perf_counter() - setup_started,
+            },
+        )
+
     yield config_dir
 
+    teardown_started = time.perf_counter() if speed_probe else 0.0
     Client._reset_instance()
     GlobalConfiguration._reset_instance()
     set_custom_source_root(None)
     _reset_runtime_configuration()
     _reset_env_applied()
+    if speed_probe:
+        _record_speed_event(
+            "fixture_teardown",
+            {
+                "fixture": "isolated_zenml_global_config",
+                "nodeid": request.node.nodeid,
+                "seconds": time.perf_counter() - teardown_started,
+            },
+        )
+
+
+def _set_provider_call_guard_state(*, active: bool, nodeid: str | None) -> None:
+    global _PROVIDER_CALL_GUARD_ACTIVE, _PROVIDER_CALL_GUARD_NODEID
+    _PROVIDER_CALL_GUARD_ACTIVE = active
+    _PROVIDER_CALL_GUARD_NODEID = nodeid
+
+
+def _clear_provider_call_guard_state() -> None:
+    _set_provider_call_guard_state(active=False, nodeid=None)
 
 
 def _is_live_provider_test(item: pytest.Item) -> bool:
@@ -289,6 +364,39 @@ def pytest_collection_modifyitems(
     errors = _validate_live_marker_contract(marker_items)
     if errors:
         raise pytest.UsageError("\n\n".join(errors))
+    _record_speed_event(
+        "collection_finished",
+        {"item_count": len(items)},
+    )
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    if not _speed_probe_enabled():
+        return
+    if _speed_worker_id() == "master" and hasattr(report, "worker_id"):
+        return
+    _record_speed_event(
+        "test_phase",
+        {
+            "nodeid": report.nodeid,
+            "phase": report.when,
+            "outcome": report.outcome,
+            "seconds": report.duration,
+        },
+    )
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    if not _speed_probe_enabled():
+        return
+    _record_speed_event(
+        "session_finished",
+        {
+            "exitstatus": exitstatus,
+            "testsfailed": session.testsfailed,
+            "testscollected": session.testscollected,
+        },
+    )
 
 
 def _is_azure_openai_host(normalized: str) -> bool:
@@ -323,11 +431,19 @@ def _provider_name_for_url(url: Any) -> str | None:
 
 
 def _fail_provider_call(provider_name: str) -> None:
+    nodeid = _PROVIDER_CALL_GUARD_NODEID
+    location = f" in {nodeid}" if nodeid else ""
     raise AssertionError(
-        f"Blocked {provider_name} provider call from an unmarked deterministic "
-        "pytest test. Mark paid/provider tests with @pytest.mark.live_llm and "
-        "the provider-specific marker, for example @pytest.mark.live_openai."
+        f"Blocked {provider_name} provider call{location} from an unmarked "
+        "deterministic pytest test. Mark paid/provider tests with "
+        "@pytest.mark.live_llm and the provider-specific marker, for example "
+        "@pytest.mark.live_openai."
     )
+
+
+def _guard_provider_call_if_active(provider_name: str | None) -> None:
+    if _PROVIDER_CALL_GUARD_ACTIVE and provider_name is not None:
+        _fail_provider_call(provider_name)
 
 
 def _resolve_attr_target(dotted_path: str) -> tuple[Any, str] | None:
@@ -392,8 +508,7 @@ def _patch_sdk_request_if_available(
             provider_name = _provider_name_for_sdk_request(
                 self, args, kwargs, default_provider=default_provider
             )
-            if provider_name is not None:
-                _fail_provider_call(provider_name)
+            _guard_provider_call_if_active(provider_name)
             return await original(self, *args, **kwargs)
 
         monkeypatch.setattr(target, attr_name, guarded_async_request, raising=False)
@@ -403,8 +518,7 @@ def _patch_sdk_request_if_available(
         provider_name = _provider_name_for_sdk_request(
             self, args, kwargs, default_provider=default_provider
         )
-        if provider_name is not None:
-            _fail_provider_call(provider_name)
+        _guard_provider_call_if_active(provider_name)
         return original(self, *args, **kwargs)
 
     monkeypatch.setattr(target, attr_name, guarded_request, raising=False)
@@ -436,16 +550,14 @@ def _install_provider_call_guard(monkeypatch: pytest.MonkeyPatch) -> None:
             self: Any, method: str, url: Any, **kwargs: Any
         ) -> Any:
             provider_name = _provider_name_for_url(url)
-            if provider_name is not None:
-                _fail_provider_call(provider_name)
+            _guard_provider_call_if_active(provider_name)
             return original_client_request(self, method, url, **kwargs)
 
         async def guarded_httpx_request_async(
             self: Any, method: str, url: Any, **kwargs: Any
         ) -> Any:
             provider_name = _provider_name_for_url(url)
-            if provider_name is not None:
-                _fail_provider_call(provider_name)
+            _guard_provider_call_if_active(provider_name)
             return await original_async_client_request(self, method, url, **kwargs)
 
         monkeypatch.setattr(httpx.Client, "request", guarded_httpx_request)
@@ -462,8 +574,7 @@ def _install_provider_call_guard(monkeypatch: pytest.MonkeyPatch) -> None:
             self: Any, method: str, url: Any, **kwargs: Any
         ) -> Any:
             provider_name = _provider_name_for_url(url)
-            if provider_name is not None:
-                _fail_provider_call(provider_name)
+            _guard_provider_call_if_active(provider_name)
             return original_requests_request(self, method, url, **kwargs)
 
         monkeypatch.setattr(
@@ -481,8 +592,7 @@ def _install_provider_call_guard(monkeypatch: pytest.MonkeyPatch) -> None:
 
         def guarded_urllib3_urlopen(self: Any, *args: Any, **kwargs: Any) -> Any:
             provider_name = _provider_name_for_host(getattr(self, "host", None))
-            if provider_name is not None:
-                _fail_provider_call(provider_name)
+            _guard_provider_call_if_active(provider_name)
             return original_urlopen(self, *args, **kwargs)
 
         monkeypatch.setattr(
@@ -492,20 +602,64 @@ def _install_provider_call_guard(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
 
+@pytest.fixture(scope="session", autouse=True)
+def provider_call_guard_installation() -> Generator[None]:
+    """Install provider-call wrappers once in each pytest worker process."""
+    speed_probe = _speed_probe_enabled()
+    started = time.perf_counter() if speed_probe else 0.0
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        _install_provider_call_guard(monkeypatch)
+    finally:
+        if speed_probe:
+            _record_speed_event(
+                "fixture_setup",
+                {
+                    "fixture": "provider_call_guard_installation",
+                    "seconds": time.perf_counter() - started,
+                },
+            )
+
+    try:
+        yield
+    finally:
+        _clear_provider_call_guard_state()
+        monkeypatch.undo()
+
+
 @pytest.fixture(autouse=True)
-def provider_spend_guard(
-    request: pytest.FixtureRequest,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def provider_spend_guard(request: pytest.FixtureRequest) -> Generator[None]:
     """Block accidental provider calls unless a test is explicitly live-marked."""
-    if _is_live_provider_test(request.node):
-        _skip_if_live_provider_keys_are_missing(request.node)
-        return
-    _install_provider_call_guard(monkeypatch)
+    speed_probe = _speed_probe_enabled()
+    started = time.perf_counter() if speed_probe else 0.0
+    is_live = _is_live_provider_test(request.node)
+    _clear_provider_call_guard_state()
+    try:
+        if is_live:
+            _skip_if_live_provider_keys_are_missing(request.node)
+            _set_provider_call_guard_state(active=False, nodeid=request.node.nodeid)
+        else:
+            _set_provider_call_guard_state(active=True, nodeid=request.node.nodeid)
+    finally:
+        if speed_probe:
+            _record_speed_event(
+                "fixture_setup",
+                {
+                    "fixture": "provider_spend_guard",
+                    "is_live_provider_test": is_live,
+                    "nodeid": request.node.nodeid,
+                    "seconds": time.perf_counter() - started,
+                },
+            )
+
+    try:
+        yield
+    finally:
+        _clear_provider_call_guard_state()
 
 
 @pytest.fixture()
-def primed_zenml() -> None:
+def primed_zenml(request: pytest.FixtureRequest) -> None:
     """Eagerly initialize ZenML's store so flow-running tests avoid lazy-init races.
 
     Only request this fixture in tests that actually execute flows, use
@@ -513,4 +667,14 @@ def primed_zenml() -> None:
     runtime.  Lightweight unit/mock tests should NOT use this fixture —
     keeping them free of ZenML bootstrap is what makes xdist parallelism fast.
     """
+    speed_probe = _speed_probe_enabled()
+    started = time.perf_counter() if speed_probe else 0.0
     _ = Client().zen_store
+    if speed_probe:
+        _record_speed_event(
+            "primed_zenml_setup",
+            {
+                "nodeid": request.node.nodeid,
+                "seconds": time.perf_counter() - started,
+            },
+        )

--- a/tests/test_provider_spend_guard.py
+++ b/tests/test_provider_spend_guard.py
@@ -2,7 +2,32 @@
 
 from __future__ import annotations
 
-from tests.conftest import _provider_name_for_host, _validate_live_marker_contract
+import threading
+from typing import cast
+
+import pytest
+
+from tests.conftest import (
+    _guard_provider_call_if_active,
+    _missing_live_provider_auth_messages,
+    _provider_name_for_host,
+    _set_provider_call_guard_state,
+    _validate_live_marker_contract,
+)
+
+
+class _FakePytestItem:
+    def __init__(self, marker_names: set[str]) -> None:
+        self._marker_names = marker_names
+
+    def get_closest_marker(self, marker_name: str) -> object | None:
+        if marker_name in self._marker_names:
+            return object()
+        return None
+
+
+def _fake_pytest_item(marker_names: set[str]) -> pytest.Item:
+    return cast(pytest.Item, _FakePytestItem(marker_names))
 
 
 def _assert_marker_contract_accepts(*items: tuple[str, set[str]]) -> None:
@@ -15,6 +40,88 @@ def _assert_marker_contract_rejects(
 ) -> None:
     errors = _validate_live_marker_contract(items)
     assert any(match in error for error in errors)
+
+
+def test_provider_spend_guard_fixture_activates_for_non_live_tests() -> None:
+    with pytest.raises(AssertionError, match="Blocked OpenAI provider call"):
+        _guard_provider_call_if_active("OpenAI")
+
+
+def test_provider_spend_guard_inactive_state_allows_provider_calls() -> None:
+    _set_provider_call_guard_state(active=False, nodeid="tests/live/test_example.py")
+    _guard_provider_call_if_active("OpenAI")
+
+
+def test_provider_spend_guard_state_is_visible_to_background_threads() -> None:
+    errors: list[BaseException] = []
+
+    def attempt_provider_call() -> None:
+        try:
+            _guard_provider_call_if_active("Anthropic")
+        except BaseException as exc:
+            errors.append(exc)
+
+    _set_provider_call_guard_state(active=True, nodeid="tests/test_example.py")
+    thread = threading.Thread(target=attempt_provider_call)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], AssertionError)
+    assert "Blocked Anthropic provider call" in str(errors[0])
+
+
+def test_live_openai_auth_message_reports_missing_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    missing = _missing_live_provider_auth_messages(_fake_pytest_item({"live_openai"}))
+
+    assert missing == ["OPENAI_API_KEY"]
+
+
+def test_live_openai_auth_message_accepts_present_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    missing = _missing_live_provider_auth_messages(_fake_pytest_item({"live_openai"}))
+
+    assert missing == []
+
+
+def test_provider_spend_guard_blocks_httpx_provider_request_before_transport() -> None:
+    httpx = pytest.importorskip("httpx")
+    requests_seen: list[object] = []
+
+    def handler(request: object) -> object:
+        requests_seen.append(request)
+        return httpx.Response(200)
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(handler)) as client,
+        pytest.raises(AssertionError, match="Blocked OpenAI provider call"),
+    ):
+        client.get("https://api.openai.com/v1/models")
+
+    assert requests_seen == []
+
+
+def test_provider_spend_guard_allows_httpx_localhost_request() -> None:
+    httpx = pytest.importorskip("httpx")
+    requests_seen: list[object] = []
+
+    def handler(request: object) -> object:
+        requests_seen.append(request)
+        return httpx.Response(200)
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        response = client.get("http://127.0.0.1:9999/health")
+
+    assert response.status_code == 200
+    assert len(requests_seen) == 1
 
 
 def test_provider_spend_guard_matches_vertex_global_and_regional_hosts() -> None:

--- a/tests/test_provider_spend_guard.py
+++ b/tests/test_provider_spend_guard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from typing import cast
 
@@ -119,6 +120,65 @@ def test_provider_spend_guard_allows_httpx_localhost_request() -> None:
 
     with httpx.Client(transport=httpx.MockTransport(handler)) as client:
         response = client.get("http://127.0.0.1:9999/health")
+
+    assert response.status_code == 200
+    assert len(requests_seen) == 1
+
+
+def test_provider_spend_guard_blocks_httpx_provider_base_url_before_transport() -> None:
+    httpx = pytest.importorskip("httpx")
+    requests_seen: list[object] = []
+
+    def handler(request: object) -> object:
+        requests_seen.append(request)
+        return httpx.Response(200)
+
+    with (
+        httpx.Client(
+            base_url="https://api.openai.com",
+            transport=httpx.MockTransport(handler),
+        ) as client,
+        pytest.raises(AssertionError, match="Blocked OpenAI provider call"),
+    ):
+        client.get("/v1/models")
+
+    assert requests_seen == []
+
+
+def test_provider_spend_guard_blocks_async_httpx_base_url_before_transport() -> None:
+    httpx = pytest.importorskip("httpx")
+    requests_seen: list[object] = []
+
+    async def handler(request: object) -> object:
+        requests_seen.append(request)
+        return httpx.Response(200)
+
+    async def request_models() -> None:
+        async with httpx.AsyncClient(
+            base_url="https://api.openai.com",
+            transport=httpx.MockTransport(handler),
+        ) as client:
+            await client.get("/v1/models")
+
+    with pytest.raises(AssertionError, match="Blocked OpenAI provider call"):
+        asyncio.run(request_models())
+
+    assert requests_seen == []
+
+
+def test_provider_spend_guard_allows_httpx_localhost_base_url_request() -> None:
+    httpx = pytest.importorskip("httpx")
+    requests_seen: list[object] = []
+
+    def handler(request: object) -> object:
+        requests_seen.append(request)
+        return httpx.Response(200)
+
+    with httpx.Client(
+        base_url="http://127.0.0.1:9999",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        response = client.get("/health")
 
     assert response.status_code == 200
     assert len(requests_seen) == 1

--- a/tests/test_summarize_pytest_speed.py
+++ b/tests/test_summarize_pytest_speed.py
@@ -1,0 +1,105 @@
+"""Tests for pytest speed probe summarization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import summarize_pytest_speed
+
+
+def _write_events(path: Path, events: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "".join(f"{json.dumps(event, sort_keys=True)}\n" for event in events),
+        encoding="utf-8",
+    )
+
+
+def test_summarizer_reports_malformed_numeric_field_with_source(
+    tmp_path: Path,
+) -> None:
+    event_path = tmp_path / "events-master-1.jsonl"
+    _write_events(
+        event_path,
+        [
+            {
+                "kind": "test_phase",
+                "nodeid": "tests/test_example.py::test_example",
+                "phase": "call",
+                "pid": 123,
+                "seconds": "slow",
+                "session_id": "run-a",
+                "timestamp": 1.0,
+                "worker": "master",
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        summarize_pytest_speed.main(["summarize_pytest_speed.py", str(tmp_path)])
+
+    message = str(exc_info.value)
+    assert "Invalid numeric field 'seconds'" in message
+    assert "events-master-1.jsonl:1" in message
+    assert "tests/test_example.py::test_example" in message
+
+
+def test_summarizer_rejects_multiple_sessions(tmp_path: Path) -> None:
+    _write_events(
+        tmp_path / "events-master-1.jsonl",
+        [
+            {
+                "kind": "session_finished",
+                "pid": 123,
+                "session_id": "run-a",
+                "timestamp": 1.0,
+                "worker": "master",
+            }
+        ],
+    )
+    _write_events(
+        tmp_path / "events-master-2.jsonl",
+        [
+            {
+                "kind": "session_finished",
+                "pid": 456,
+                "session_id": "run-b",
+                "timestamp": 2.0,
+                "worker": "master",
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        summarize_pytest_speed.main(["summarize_pytest_speed.py", str(tmp_path)])
+
+    message = str(exc_info.value)
+    assert "multiple pytest speed-probe sessions" in message
+    assert "run-a" in message
+    assert "run-b" in message
+    assert "events-master-1.jsonl:1" in message
+    assert "events-master-2.jsonl:1" in message
+
+
+def test_summarizer_rejects_missing_session_id(tmp_path: Path) -> None:
+    _write_events(
+        tmp_path / "events-master-1.jsonl",
+        [
+            {
+                "kind": "session_finished",
+                "pid": 123,
+                "timestamp": 1.0,
+                "worker": "master",
+            }
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        summarize_pytest_speed.main(["summarize_pytest_speed.py", str(tmp_path)])
+
+    message = str(exc_info.value)
+    assert "session_id" in message
+    assert "events-master-1.jsonl:1" in message


### PR DESCRIPTION
## Summary

- Install provider-call wrappers once per pytest worker, then toggle the guard state per test instead of reinstalling the same wrappers for every test.
- Keep deterministic tests protected from accidental OpenAI/Anthropic/Gemini/Vertex/Azure OpenAI calls, including `httpx` clients that use `base_url` plus relative request paths.
- Add a pytest speed-probe JSONL summarizer and regression tests so future speed investigations can reject stale or mixed probe output instead of reporting misleading numbers.

## Reviewer Notes

The old path made every test pay for the same provider-spend guard setup. Imagine 3,000+ tests walking through the same front door and each one rebuilding the door lock before it enters. The branch changes that to: each pytest worker installs the network-call wrappers once; before each individual test, `provider_spend_guard` writes the current test's state into module-level guard state; when a wrapped provider request is attempted, the wrapper checks that state and either blocks the call with the current test node id or allows it because the test is explicitly marked live.

The important behavior to inspect is in `tests/conftest.py`. If this is wrong, two things could break: a deterministic test could accidentally spend provider money, or a live provider test could be blocked/checked in the wrong state. The follow-up hardening adds tests for background-thread visibility, live marker validation, relative `httpx` URLs, Azure OpenAI resource hosts, Vertex regional/global hosts, and lookalike domains that should not be treated as provider calls.

The speed-probe helper writes one JSONL stream per worker when `KITARU_PYTEST_SPEED_PROBE=1` is enabled. `scripts/summarize_pytest_speed.py` then reads those files and produces fixture totals, slow call durations, setup/teardown costs, and worker tail information. It now requires exactly one probe session and reports malformed numeric fields with the source file/line, so stale probe files do not quietly produce a false summary.

### Reproduction

To reproduce the reviewed behavior locally:

1. Run the targeted serial guard tests:
   ```bash
   just test -n 0 tests/test_provider_spend_guard.py tests/test_summarize_pytest_speed.py tests/test_checkpoint.py::test_checkpoint_rejects_negative_retries
   ```
   You should see 21 passing tests. This proves the guard state works without xdist and that the summarizer rejects bad probe data clearly.

2. Run the targeted xdist tests:
   ```bash
   just test tests/test_provider_spend_guard.py tests/test_summarize_pytest_speed.py
   ```
   You should see 20 passing tests across workers. This proves each worker can install the wrappers once while each test still gets the right active/live state.

3. Run the full suite with durations:
   ```bash
   /usr/bin/time -p just test --durations=30
   ```
   In this validation run it completed with `3232 passed, 27 skipped` in pytest's `58.21s`; `/usr/bin/time` reported `real 59.47`.

Local checks run:

- `uv run ruff format --check tests/conftest.py tests/test_provider_spend_guard.py scripts/summarize_pytest_speed.py tests/test_summarize_pytest_speed.py`
- `uv run ruff check tests/conftest.py tests/test_provider_spend_guard.py scripts/summarize_pytest_speed.py tests/test_summarize_pytest_speed.py`
- `just test -n 0 tests/test_provider_spend_guard.py tests/test_summarize_pytest_speed.py tests/test_checkpoint.py::test_checkpoint_rejects_negative_retries`
- `just test tests/test_provider_spend_guard.py tests/test_summarize_pytest_speed.py`
- `/usr/bin/time -p just test --durations=30`
- `just check`
