### PR TITLE
Preserve replay flow parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Bumped the minimum ZenML dependency, server image tag, and Helm subchart version to `0.96.1`.
 
 ### Fixed
+- Replay now preserves recorded flow parameters when submitting a replay, so overriding one flow argument no longer lets defaulted arguments such as `model=None` silently replace recorded values.
 - `FlowHandle.wait()` now distinguishes paused executions with pending wait input from paused executions that need `kitaru executions resume`, and `kitaru executions resume` accepts `--exec-id` while preserving clearer wait-condition resume diagnostics.
 - PydanticAI edited tool-argument replay now reruns the tool's own argument validator, so JSON override values are coerced back into richer Python types such as `date` before the tool body runs.
 - Checkpoint metadata now keeps Kitaru's reserved `boundary`, `type`, and `flow_result_candidate` keys authoritative when user metadata contains the same names.

--- a/src/kitaru/replay.py
+++ b/src/kitaru/replay.py
@@ -927,6 +927,29 @@ def _coerce_flow_overrides(flow_overrides: Mapping[str, Any] | None) -> dict[str
     return {str(key): value for key, value in flow_overrides.items()}
 
 
+def _recorded_flow_parameters(run: PipelineRunResponse) -> dict[str, Any]:
+    """Return flow parameters recorded on the source run.
+
+    Missing ``config`` or ``config.parameters`` means the source run did not
+    expose recorded flow parameters, so replay planning treats that as an empty
+    mapping. A present non-mapping ``parameters`` value is corrupt recorded
+    state and fails loudly. Recorded parameter keys are stringified to match the
+    public ``flow_overrides`` key normalization.
+    """
+    config = getattr(run, "config", None)
+    if config is None:
+        return {}
+
+    parameters = getattr(config, "parameters", None)
+    if parameters is None:
+        return {}
+    if not isinstance(parameters, Mapping):
+        raise KitaruStateError(
+            f"Recorded flow parameters for execution '{run.id}' must be a mapping."
+        )
+    return {str(key): value for key, value in parameters.items()}
+
+
 def build_replay_request_document(
     *,
     flow_overrides: Mapping[str, Any] | None = None,
@@ -1230,6 +1253,8 @@ def build_replay_plan(
     )
 
     normalized_flow_overrides = _coerce_flow_overrides(flow_overrides)
+    input_overrides = _recorded_flow_parameters(run)
+    input_overrides.update(normalized_flow_overrides)
     resolved_document = ReplayPlanDocument(
         flow_overrides=normalized_flow_overrides,
         checkpoint_overrides=document.checkpoint_overrides,
@@ -1241,7 +1266,7 @@ def build_replay_plan(
     return ReplayPlan(
         original_run_id=str(run.id),
         steps_to_skip=steps_to_skip,
-        input_overrides=normalized_flow_overrides,
+        input_overrides=input_overrides,
         step_input_overrides=step_input_overrides,
         runtime_context=runtime_context,
         document=resolved_document,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,7 @@ import inspect
 import json
 import os
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -231,6 +231,7 @@ class _DummyRun:
         status_reason: str | None = None,
         exception_traceback: str | None = None,
         active_wait_condition: Any = None,
+        parameters: Mapping[str, Any] | None = None,
     ) -> None:
         self.id = run_id or uuid4()
         self.status = status
@@ -238,6 +239,8 @@ class _DummyRun:
         self.start_time = None
         self.end_time = None
         self.run_metadata = run_metadata or {}
+        if parameters is not None:
+            self.config = SimpleNamespace(parameters=dict(parameters))
         self.pipeline = SimpleNamespace(name=flow_name, id=flow_id or uuid4())
         self.stack = SimpleNamespace(name=stack_name) if stack_name else None
         self.snapshot = snapshot
@@ -5949,6 +5952,7 @@ def test_replay_falls_back_to_pipeline_source_when_flow_missing() -> None:
 def _replay_fallback_source_and_pipeline(
     *,
     replayed_status: ZenMLExecutionStatus,
+    parameters: Mapping[str, Any] | None = None,
 ) -> tuple[_DummyRun, _DummyRun, SimpleNamespace, SimpleNamespace]:
     fetch_step = _DummyStep(
         name="fetch",
@@ -5982,6 +5986,7 @@ def _replay_fallback_source_and_pipeline(
                 )
             )
         ),
+        parameters=parameters,
     )
     replayed_run = _DummyRun(
         status=replayed_status,
@@ -5994,6 +5999,48 @@ def _replay_fallback_source_and_pipeline(
         __kitaru_pipeline_source_sample_flow=replay_pipeline,
     )
     return source_run, replayed_run, replay_pipeline, replay_module
+
+
+def test_replay_fallback_preserves_unoverridden_recorded_flow_parameters() -> None:
+    source_run, _replayed_run, replay_pipeline, replay_module = (
+        _replay_fallback_source_and_pipeline(
+            replayed_status=ZenMLExecutionStatus.RUNNING,
+            parameters={"topic": "recorded topic", "model": "model-a"},
+        )
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch(
+            "kitaru.client._resolve_flow_for_replay",
+            side_effect=KitaruRuntimeError("no replay flow"),
+        ),
+        patch("kitaru.client.safe_persist_replay_submission_metadata"),
+        patch("kitaru.client.importlib.import_module", return_value=replay_module),
+    ):
+        client_cls.return_value.get_pipeline_run.return_value = _as_pipeline_run(
+            source_run
+        )
+
+        KitaruClient().executions.replay(
+            str(source_run.id),
+            at="write",
+            flow_overrides={"topic": "new topic"},
+            wait=False,
+        )
+
+    replay_pipeline.replay.assert_called_once()
+    replay_kwargs = replay_pipeline.replay.call_args.kwargs
+    assert replay_kwargs["pipeline_run"] == source_run.id
+    assert replay_kwargs["skip"] == {"fetch"}
+    assert replay_kwargs["input_overrides"] == {
+        "topic": "new topic",
+        "model": "model-a",
+    }
 
 
 def test_replay_fallback_wait_persists_metadata_before_wait_aggregation() -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -226,6 +226,7 @@ class _DummyRun:
         traceback: str | None = None,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
+        parameters: Mapping[str, object] | None = None,
     ) -> None:
         self.id = run_id or uuid4()
         self.pipeline_id = pipeline_id
@@ -237,6 +238,8 @@ class _DummyRun:
         self.end_time = end_time
         self.status_reason = status_reason
         self.run_metadata: dict[str, object] = {}
+        if parameters is not None:
+            self.config = SimpleNamespace(parameters=dict(parameters))
         self.exception_info = (
             SimpleNamespace(traceback=traceback) if traceback else None
         )
@@ -3801,6 +3804,62 @@ def test_replay_submits_pipeline_replay_and_persists_frozen_spec() -> None:
         == _empty_registry_payload()
     )
     assert "KITARU_REPLAY_CONTEXT" in docker_settings.environment
+
+
+def test_replay_preserves_unoverridden_recorded_flow_parameters() -> None:
+    source_run = _DummyRun(
+        status=ExecutionStatus.COMPLETED,
+        parameters={"topic": "recorded topic", "model": "model-a"},
+    )
+    replayed_run = _DummyRun(status=ExecutionStatus.RUNNING)
+
+    configured_pipeline = MagicMock()
+    configured_pipeline.replay.return_value = replayed_run
+
+    base_pipeline = MagicMock()
+    base_pipeline.with_options.return_value = configured_pipeline
+    zenml_decorator = MagicMock(return_value=base_pipeline)
+
+    replay_plan = ReplayPlan(
+        original_run_id=str(source_run.id),
+        steps_to_skip=set(),
+        input_overrides={"topic": "new topic", "model": "model-a"},
+        step_input_overrides={},
+        runtime_context=ReplayRuntimeContext(at="write"),
+    )
+
+    with (
+        patch("kitaru.flow.pipeline", return_value=zenml_decorator),
+        patch("kitaru.flow.Client") as client_cls,
+        patch(
+            "kitaru.flow.resolve_execution_config",
+            return_value=_resolved_execution(stack="prod"),
+        ),
+        patch("kitaru.flow.resolve_connection_config", return_value=object()),
+        patch("kitaru.flow.build_frozen_execution_spec", return_value=object()),
+        patch("kitaru.flow.persist_frozen_execution_spec"),
+        patch("kitaru.flow.safe_persist_replay_submission_metadata"),
+        patch("kitaru.flow.build_replay_plan", return_value=replay_plan),
+    ):
+        client_instance = client_cls.return_value
+        client_instance.active_stack_model.id = "old-stack-id"
+        client_instance.get_pipeline_run.return_value = source_run
+
+        wrapped = flow(lambda topic, model=None: (topic, model))
+        wrapped.replay(
+            str(source_run.id),
+            at="write",
+            flow_overrides={"topic": "new topic"},
+            wait=False,
+        )
+
+    configured_pipeline.replay.assert_called_once_with(
+        pipeline_run=source_run.id,
+        skip=set(),
+        skip_successful_steps=False,
+        input_overrides={"topic": "new topic", "model": "model-a"},
+        step_input_overrides=None,
+    )
 
 
 def test_replay_uses_resolved_project_for_source_lookup_and_replay_write() -> None:

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any, cast
@@ -64,14 +65,17 @@ def _step(
     )
 
 
-def _run(*steps: Any) -> PipelineRunResponse:
-    return cast(
-        PipelineRunResponse,
-        SimpleNamespace(
-            id=uuid4(),
-            steps={step.name: step for step in steps},
-        ),
-    )
+def _run(
+    *steps: Any,
+    parameters: Mapping[str, Any] | None = None,
+) -> PipelineRunResponse:
+    kwargs: dict[str, Any] = {
+        "id": uuid4(),
+        "steps": {step.name: step for step in steps},
+    }
+    if parameters is not None:
+        kwargs["config"] = SimpleNamespace(parameters=parameters)
+    return cast(PipelineRunResponse, SimpleNamespace(**kwargs))
 
 
 def _adapter_metadata(
@@ -154,6 +158,51 @@ def test_build_replay_plan_skips_steps_before_at_selector() -> None:
     assert plan.steps_to_skip == {"fetch"}
     assert plan.input_overrides == {}
     assert plan.step_input_overrides == {}
+
+
+def test_replay_plan_preserves_recorded_flow_parameters_without_overrides() -> None:
+    t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
+    write = _step(name="write", invocation_id="write", started_at=t0)
+
+    plan = build_replay_plan(
+        run=_run(write, parameters={"topic": "recorded topic", "model": None}),
+        at="write",
+    )
+
+    assert plan.input_overrides == {"topic": "recorded topic", "model": None}
+    assert plan.document.flow_overrides == {}
+
+
+def test_replay_plan_layers_flow_overrides_over_recorded_parameters() -> None:
+    t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
+    write = _step(name="write", invocation_id="write", started_at=t0)
+
+    plan = build_replay_plan(
+        run=_run(write, parameters={"topic": "recorded topic", "model": "model-a"}),
+        at="write",
+        flow_overrides={"temperature": 0.2},
+    )
+
+    assert plan.input_overrides == {
+        "topic": "recorded topic",
+        "model": "model-a",
+        "temperature": 0.2,
+    }
+    assert plan.document.flow_overrides == {"temperature": 0.2}
+
+
+def test_replay_plan_flow_overrides_win_on_same_key() -> None:
+    t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
+    write = _step(name="write", invocation_id="write", started_at=t0)
+
+    plan = build_replay_plan(
+        run=_run(write, parameters={"topic": "recorded topic", "model": "model-a"}),
+        at="write",
+        flow_overrides={"topic": "new topic"},
+    )
+
+    assert plan.input_overrides == {"topic": "new topic", "model": "model-a"}
+    assert plan.document.flow_overrides == {"topic": "new topic"}
 
 
 def test_leaf_output_override_explains_no_downstream_consumer() -> None:

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -67,7 +67,7 @@ def _step(
 
 def _run(
     *steps: Any,
-    parameters: Mapping[str, Any] | None = None,
+    parameters: Mapping[Any, Any] | None = None,
 ) -> PipelineRunResponse:
     kwargs: dict[str, Any] = {
         "id": uuid4(),
@@ -203,6 +203,65 @@ def test_replay_plan_flow_overrides_win_on_same_key() -> None:
 
     assert plan.input_overrides == {"topic": "new topic", "model": "model-a"}
     assert plan.document.flow_overrides == {"topic": "new topic"}
+
+
+def test_replay_plan_missing_config_parameters_are_empty() -> None:
+    t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
+    write = _step(name="write", invocation_id="write", started_at=t0)
+    run = cast(
+        PipelineRunResponse,
+        SimpleNamespace(
+            id=uuid4(), steps={write.name: write}, config=SimpleNamespace()
+        ),
+    )
+
+    plan = build_replay_plan(run=run, at="write")
+
+    assert plan.input_overrides == {}
+    assert plan.document.flow_overrides == {}
+
+
+def test_replay_plan_rejects_malformed_recorded_flow_parameters() -> None:
+    t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
+    write = _step(name="write", invocation_id="write", started_at=t0)
+    run = cast(
+        PipelineRunResponse,
+        SimpleNamespace(
+            id=uuid4(),
+            steps={write.name: write},
+            config=SimpleNamespace(parameters=["not", "a", "mapping"]),
+        ),
+    )
+
+    with pytest.raises(KitaruStateError, match="must be a mapping"):
+        build_replay_plan(run=run, at="write")
+
+
+def test_replay_plan_stringifies_recorded_flow_parameter_keys() -> None:
+    t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
+    write = _step(name="write", invocation_id="write", started_at=t0)
+
+    plan = build_replay_plan(
+        run=_run(write, parameters={1: "recorded value"}),
+        at="write",
+    )
+
+    assert plan.input_overrides == {"1": "recorded value"}
+    assert plan.document.flow_overrides == {}
+
+
+def test_replay_plan_none_flow_override_wins_over_recorded_parameter() -> None:
+    t0 = datetime(2026, 3, 9, 10, 0, tzinfo=UTC)
+    write = _step(name="write", invocation_id="write", started_at=t0)
+
+    plan = build_replay_plan(
+        run=_run(write, parameters={"model": "model-a"}),
+        at="write",
+        flow_overrides={"model": None},
+    )
+
+    assert plan.input_overrides == {"model": None}
+    assert plan.document.flow_overrides == {"model": None}
 
 
 def test_leaf_output_override_explains_no_downstream_consumer() -> None:


### PR DESCRIPTION
## Reviewer Notes

This fixes replay input drift when a user overrides only one flow parameter. The concrete bad story was: the source run recorded `topic="recorded topic"` and `model="model-a"`; replay only changed `topic`; Kitaru sent only `{"topic": "new topic"}` into ZenML replay; ZenML then had room to use the current Python default for `model` instead of the recorded value.

The important behavior now happens in `src/kitaru/replay.py`: `build_replay_plan(...)` starts from the source run's recorded `run.config.parameters`, then overlays explicit `flow_overrides`. That means both replay paths receive the same effective ZenML input map: the normal flow-wrapper path and the client pipeline-fallback path. The public replay document still records only explicit `flow_overrides`, so submission metadata does not start echoing every recorded source parameter.

Risk areas to inspect:

- `src/kitaru/replay.py`: recorded parameter extraction and merge order; explicit `flow_overrides` must win.
- `tests/test_replay.py`: planner-level semantics, especially keeping `plan.document.flow_overrides` explicit-only, handling missing/malformed recorded parameter state, stringifying recorded keys, and preserving explicit `None` overrides.
- `tests/test_client.py`: fallback path coverage, because this was the path not covered by the earlier branch fix.

### Reproduction

Run the targeted regression checks:

```bash
uv run pytest -q tests/test_replay.py -k "replay_plan_preserves_recorded_flow_parameters or replay_plan_layers_flow_overrides or replay_plan_flow_overrides_win or replay_plan_missing_config_parameters_are_empty or replay_plan_rejects_malformed_recorded_flow_parameters or replay_plan_stringifies_recorded_flow_parameter_keys or replay_plan_none_flow_override_wins"
uv run pytest -q tests/test_flow.py -k "replay_submits_pipeline_replay_and_persists_frozen_spec or replay_preserves_unoverridden_recorded_flow_parameters"
uv run pytest -q tests/test_client.py -k "replay_falls_back_to_pipeline_source_when_flow_missing or replay_fallback_preserves_unoverridden_recorded_flow_parameters or replay_fallback_rejects_runtime_only_overrides_before_submit"
```

The thing to verify end to end in the tests is that replay with `flow_overrides={"topic": "new topic"}` sends ZenML `input_overrides={"topic": "new topic", "model": "model-a"}` when the source run recorded both values.

### Local checks run

Passed:

```bash
uv run pytest -q tests/test_replay.py
uv run pytest -q tests/test_replay.py tests/test_flow.py tests/test_client.py
just check
uv run pytest -q tests/test_smoke_test_script.py::test_remote_flow_image_is_only_passed_to_kubernetes_lane --randomly-seed=4089129355
```

Also ran `/simplify` review and Oracle review; neither found blockers.

Full `just test` note: one rerun of the full suite failed in unrelated smoke-test coverage, `tests/test_smoke_test_script.py::test_remote_flow_image_is_only_passed_to_kubernetes_lane`, with `scripts/smoke-test.sh: line 900: image_arg[@]: unbound variable`. The same test passed when rerun alone with the same random seed. The replay-specific and broad replay/client/flow suites above pass.

