### PR TITLE
Restrict project mutations to Pro servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Project create/use/delete operations now stop before changing server state unless Kitaru can verify a ZenML Pro/Cloud server. Read-only project inspection (`list`, `current`, and `show`) remains available on local/OSS servers for diagnostics.
+
 ## [0.20.0] - 2026-07-08
 
 ### Added

--- a/docs/book/guides/projects.md
+++ b/docs/book/guides/projects.md
@@ -1,5 +1,5 @@
 ---
-description: List, inspect, create, switch, and delete Kitaru projects from the CLI, SDK, and MCP server
+description: List and inspect Kitaru projects, and manage them on ZenML Pro/Cloud from the CLI, SDK, and MCP server
 icon: folder-tree
 ---
 
@@ -14,7 +14,20 @@ A concrete example helps: imagine one server used by the same team for
 production deployments. If you switch to `staging`, the same commands look at
 staging instead. The server did not change; the selected project changed.
 
-There are two normal ways to choose a project:
+## Availability
+
+Read-only project inspection works everywhere Kitaru can connect. You can run
+`kitaru project list`, `kitaru project current`, and `kitaru project show ...`
+against local/OSS servers as diagnostics. That lets you answer questions such as
+"what project does this process think it is using?" without changing server
+state.
+
+Creating, switching, and deleting projects require a verified ZenML Pro/Cloud
+server. On a local/OSS server, Kitaru stops before it sends the create, switch,
+or delete request and tells you that project management needs ZenML Pro/Cloud.
+Local/OSS users should stay on the default project.
+
+On ZenML Pro/Cloud, there are two normal ways to choose a project:
 
 1. **Persist it for your local shell:** run `kitaru project use production`.
    Kitaru remembers that choice for later CLI and SDK calls.
@@ -53,7 +66,13 @@ The serialized project shape is the same across CLI and MCP:
 
 `display_name` and `description` may be `null` when they are not set.
 
-## Create and switch projects
+## Create and switch projects on ZenML Pro/Cloud
+
+{% hint style="info" %}
+`kitaru project create` and `kitaru project use` require ZenML Pro/Cloud. On
+local/OSS servers, inspect projects with `list`, `current`, and `show`, and keep
+using the default project.
+{% endhint %}
 
 Create a project:
 
@@ -82,9 +101,9 @@ persists the choice in the same place the backend already uses for active
 project state. In practice, that means you do not get two competing answers to
 "which project am I using?" — Kitaru reads the same active project that it writes.
 
-## Delete projects
+## Delete projects on ZenML Pro/Cloud
 
-Project deletion is deliberately explicit:
+Project deletion also requires ZenML Pro/Cloud and is deliberately explicit:
 
 ```bash
 kitaru project delete staging --yes
@@ -113,9 +132,14 @@ kitaru project list
 kitaru project use production
 ```
 
+The `project use` command requires ZenML Pro/Cloud. On local/OSS servers, use
+`project list` and `project current` for diagnostics and leave the active project
+as the default.
+
 ## Headless, Docker, and CI
 
-For non-interactive processes, set the connection and project explicitly:
+For non-interactive processes on ZenML Pro/Cloud, set the connection and project
+explicitly:
 
 ```bash
 export KITARU_SERVER_URL=https://kitaru.example.com
@@ -125,7 +149,8 @@ export KITARU_PROJECT=production
 
 This is safer than relying on persisted local state. The job starts, reads the
 three variables, and there is no ambiguity about which server and project it
-will use.
+will use. `KITARU_PROJECT` is for explicit project selection; local/OSS users
+should keep using the default project instead of setting a non-default project.
 
 If `KITARU_SERVER_URL` and `KITARU_AUTH_TOKEN` come from environment variables,
 Kitaru requires `KITARU_PROJECT` before project-scoped operations such as
@@ -145,17 +170,25 @@ current = client.projects.current()
 print(current.name)
 ```
 
-Project operations live under `client.projects`:
+Read-only project operations live under `client.projects` and work on local/OSS
+and ZenML Pro/Cloud connections:
 
 ```python
 projects = client.projects.list()
 staging = client.projects.get("staging")
-created = client.projects.create("experiment", activate=False)
-active = client.projects.use("production")
 ```
 
-Use `KitaruClient.for_project_management()` when the process needs to list,
-create, or select projects before a project-scoped client can exist:
+Project mutations through the SDK require ZenML Pro/Cloud:
+
+```python
+created = client.projects.create("experiment", activate=False)
+active = client.projects.use("production")
+client.projects.delete("experiment")
+```
+
+Use `KitaruClient.for_project_management()` when the process needs to inspect
+projects before a project-scoped client can exist, or when a ZenML Pro/Cloud
+process needs to create or select a project first:
 
 ```python
 from kitaru import KitaruClient
@@ -164,20 +197,21 @@ client = KitaruClient.for_project_management()
 for project in client.projects.list():
     print(project.name)
 
-client.projects.use("production")
+client.projects.use("production")  # ZenML Pro/Cloud only
 ```
 
 The distinction is simple:
 
 - `KitaruClient()` is for project-scoped work: executions, artifacts,
   deployments, and normal runtime operations.
-- `KitaruClient.for_project_management()` is for choosing the project itself.
-  It still validates the server/auth pairing, but it does not require a project
-  to already be selected.
+- `KitaruClient.for_project_management()` is for project inspection everywhere
+  and project creation/selection on ZenML Pro/Cloud. It still validates the
+  server/auth pairing, but it does not require a project to already be selected.
 
 ## MCP tools
 
-The MCP server exposes read/switch project tools for automation agents:
+The MCP server exposes read project tools everywhere, plus a switch tool for
+ZenML Pro/Cloud automation agents:
 
 - `kitaru_projects_list`
 - `kitaru_projects_current`
@@ -185,10 +219,11 @@ The MCP server exposes read/switch project tools for automation agents:
 - `kitaru_projects_use`
 
 It does **not** expose project create/delete tools in this first pass. Agents can
-inspect the current project and switch to a named project, but durable project
+inspect the current project on any Kitaru connection. Switching to a named
+project with `kitaru_projects_use` requires ZenML Pro/Cloud; durable project
 creation and deletion stay in the CLI and SDK.
 
-A useful agent instruction is:
+On ZenML Pro/Cloud, a useful agent instruction is:
 
 ```text
 Check the current Kitaru project. If it is not production, switch to production before listing deployments.
@@ -205,9 +240,10 @@ priority like this:
 3. Public `KITARU_PROJECT` environment variable
 4. Process-local `kitaru.configure(project=...)`
 
-For normal usage, prefer the first and third entries: `kitaru project use` for
-interactive local work, and `KITARU_PROJECT` for CI, Docker, and other headless
-execution.
+For normal ZenML Pro/Cloud usage, prefer the first and third entries: `kitaru
+project use` for interactive work, and `KITARU_PROJECT` for CI, Docker, and
+other headless execution. On local/OSS servers, keep the default project and use
+the read-only commands when you need diagnostics.
 
 ## Related pages
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -35,6 +35,14 @@
 #                        Timeout for remote log readback (default: 60)
 #   --remote-run-prefix PREFIX
 #                        Non-secret prefix for generated remote smoke markers
+#   --pro-project-smoke
+#                        Opt into ZenML Pro/Cloud project mutation smoke
+#   --pro-project-server-url URL
+#                        ZenML Pro/Cloud server URL for project smoke
+#   --pro-project-login-timeout SECONDS
+#                        Timeout for Pro/Cloud project smoke login (default: 60)
+#   --pro-project-run-prefix PREFIX
+#                        Non-secret prefix for generated Pro/Cloud project names
 #   -h, --help           Show this help message
 
 # No -e: we deliberately continue past failures to collect all results.
@@ -94,6 +102,20 @@ Options:
   --remote-run-prefix PREFIX
                        Non-secret prefix for generated remote smoke markers.
                        Also settable with KITARU_REMOTE_SMOKE_RUN_PREFIX.
+  --pro-project-smoke
+                       Opt into ZenML Pro/Cloud project mutation smoke. Also
+                       settable with KITARU_PRO_PROJECT_SMOKE=1. This is off by
+                       default; local smoke still proves mutations are blocked.
+  --pro-project-server-url URL
+                       ZenML Pro/Cloud server URL for project smoke. Also
+                       settable with KITARU_PRO_PROJECT_SMOKE_SERVER_URL. Falls
+                       back to KITARU_REMOTE_SMOKE_SERVER_URL when set.
+  --pro-project-login-timeout SECONDS
+                       Timeout for Pro/Cloud project smoke login. Also settable
+                       with KITARU_PRO_PROJECT_SMOKE_LOGIN_TIMEOUT. Default: 60.
+  --pro-project-run-prefix PREFIX
+                       Non-secret prefix for generated Pro/Cloud project names.
+                       Also settable with KITARU_PRO_PROJECT_SMOKE_RUN_PREFIX.
   -h, --help           Show this help message
 EOF
 }
@@ -117,6 +139,10 @@ REMOTE_SMOKE_LOGIN_TIMEOUT="${KITARU_REMOTE_SMOKE_LOGIN_TIMEOUT:-60}"
 REMOTE_SMOKE_EXECUTION_TIMEOUT="${KITARU_REMOTE_SMOKE_EXECUTION_TIMEOUT:-900}"
 REMOTE_SMOKE_LOG_TIMEOUT="${KITARU_REMOTE_SMOKE_LOG_TIMEOUT:-60}"
 REMOTE_SMOKE_RUN_PREFIX="${KITARU_REMOTE_SMOKE_RUN_PREFIX:-kitaru-remote-smoke}"
+PRO_PROJECT_SMOKE=false
+PRO_PROJECT_SMOKE_SERVER_URL="${KITARU_PRO_PROJECT_SMOKE_SERVER_URL:-${KITARU_REMOTE_SMOKE_SERVER_URL:-}}"
+PRO_PROJECT_SMOKE_LOGIN_TIMEOUT="${KITARU_PRO_PROJECT_SMOKE_LOGIN_TIMEOUT:-60}"
+PRO_PROJECT_SMOKE_RUN_PREFIX="${KITARU_PRO_PROJECT_SMOKE_RUN_PREFIX:-kitaru-pro-project-smoke}"
 
 is_truthy_env_value() {
     local value
@@ -129,6 +155,9 @@ is_truthy_env_value() {
 
 if is_truthy_env_value "${KITARU_REMOTE_SMOKE:-}"; then
     REMOTE_STACK_SMOKE=true
+fi
+if is_truthy_env_value "${KITARU_PRO_PROJECT_SMOKE:-}"; then
+    PRO_PROJECT_SMOKE=true
 fi
 
 find_json_out_arg() {
@@ -304,6 +333,37 @@ while [[ $# -gt 0 ]]; do
             REMOTE_SMOKE_RUN_PREFIX="$2"
             shift 2
             ;;
+        --pro-project-smoke)
+            PRO_PROJECT_SMOKE=true
+            shift
+            ;;
+        --pro-project-server-url)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --pro-project-server-url requires a URL" >&2
+                write_early_json_result "${JSON_OUT:-$DISCOVERED_JSON_OUT}" "smoke option parsing" "--pro-project-server-url requires a value" "$RELEASE_MODE" || true
+                exit 1
+            fi
+            PRO_PROJECT_SMOKE_SERVER_URL="$2"
+            shift 2
+            ;;
+        --pro-project-login-timeout)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --pro-project-login-timeout requires seconds" >&2
+                write_early_json_result "${JSON_OUT:-$DISCOVERED_JSON_OUT}" "smoke option parsing" "--pro-project-login-timeout requires a value" "$RELEASE_MODE" || true
+                exit 1
+            fi
+            PRO_PROJECT_SMOKE_LOGIN_TIMEOUT="$2"
+            shift 2
+            ;;
+        --pro-project-run-prefix)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --pro-project-run-prefix requires a prefix" >&2
+                write_early_json_result "${JSON_OUT:-$DISCOVERED_JSON_OUT}" "smoke option parsing" "--pro-project-run-prefix requires a value" "$RELEASE_MODE" || true
+                exit 1
+            fi
+            PRO_PROJECT_SMOKE_RUN_PREFIX="$2"
+            shift 2
+            ;;
         --required-provider-area)
             if [[ $# -lt 2 ]]; then
                 echo "Error: --required-provider-area requires one of: openai, anthropic, gemini-model, gemini-sandbox-function, gemini-antigravity, google-adk, research-bot" >&2
@@ -356,6 +416,8 @@ RESULT_RECORDS_FILE=$(mktemp "${TMPDIR:-/tmp}/kitaru-smoke-results.XXXXXX")
 RECORDING_FAILED=false
 GEMINI_SANDBOX_FUNCTION_SMOKE_STACK=""
 GOOGLE_ADK_SMOKE_ENV=""
+PRO_PROJECT_SMOKE_CREATED_PROJECT=""
+PRO_PROJECT_SMOKE_LOGGED_IN=false
 # Track whether this script started the server (vs. attaching to an existing one).
 SCRIPT_OWNS_SERVER=false
 
@@ -759,8 +821,57 @@ run_expected_failure() {
     return 0
 }
 
+run_sdk_project_guard_checks() {
+    local project_name="$1"
+    run_test "SDK: local/OSS blocks project create/use/delete" env \
+        KITARU_SMOKE_PROJECT_NAME="$project_name" \
+        $UV_RUN python -c '
+from collections.abc import Callable
+import os
+
+from kitaru import KitaruClient
+from kitaru.errors import KitaruFeatureNotAvailableError
+
+project_name = os.environ["KITARU_SMOKE_PROJECT_NAME"]
+client = KitaruClient.for_project_management()
+operations: dict[str, Callable[[], object]] = {
+    "create": lambda: client.projects.create(project_name, activate=False),
+    "use": lambda: client.projects.use(project_name),
+    "delete": lambda: client.projects.delete(project_name),
+}
+
+for operation, call in operations.items():
+    try:
+        call()
+    except KitaruFeatureNotAvailableError as exc:
+        message = str(exc)
+        if "requires a ZenML Pro/Cloud server" not in message:
+            raise AssertionError(f"unexpected guard message: {message}") from exc
+    else:
+        raise AssertionError(f"project {operation} unexpectedly succeeded")
+'
+}
+
 remote_required_env_names() {
     printf '%s' "KITARU_REMOTE_SMOKE_SERVER_URL,KITARU_REMOTE_SMOKE_KUBERNETES_STACK,KITARU_REMOTE_SMOKE_LOCAL_REMOTE_ARTIFACT_STACK"
+}
+
+pro_project_required_env_names() {
+    printf '%s' "KITARU_PRO_PROJECT_SMOKE_SERVER_URL,KITARU_REMOTE_SMOKE_SERVER_URL"
+}
+
+project_current_name_from_json() {
+    python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+item = payload.get("item") if isinstance(payload, dict) else None
+name = item.get("name") if isinstance(item, dict) else None
+if not name:
+    raise SystemExit("current project response did not include item.name")
+print(name)
+'
 }
 
 redact_remote_output() {
@@ -776,7 +887,8 @@ sys.stdout.write(text)
         "$REMOTE_SMOKE_SERVER_URL" \
         "$REMOTE_SMOKE_KUBERNETES_STACK" \
         "$REMOTE_SMOKE_LOCAL_REMOTE_ARTIFACT_STACK" \
-        "$REMOTE_SMOKE_FLOW_IMAGE"
+        "$REMOTE_SMOKE_FLOW_IMAGE" \
+        "$PRO_PROJECT_SMOKE_SERVER_URL"
 }
 
 remote_evidence_field() {
@@ -935,6 +1047,146 @@ run_remote_flow_smoke() {
     return 1
 }
 
+run_pro_project_smoke_section() {
+    section_header "Pro/Cloud project smoke"
+
+    if [[ "$PRO_PROJECT_SMOKE" != true ]]; then
+        skip_test "Pro/Cloud project smoke" "not opted in; set KITARU_PRO_PROJECT_SMOKE=1 or pass --pro-project-smoke for Pro/Cloud project release evidence"
+        return 0
+    fi
+
+    if [[ -z "$PRO_PROJECT_SMOKE_SERVER_URL" ]]; then
+        local reason="missing required Pro/Cloud project smoke config: KITARU_PRO_PROJECT_SMOKE_SERVER_URL or KITARU_REMOTE_SMOKE_SERVER_URL"
+        printf "  ${RED}✗${RESET} Pro/Cloud project smoke configuration\n"
+        printf "    %s\n" "$reason"
+        record_failure "Pro/Cloud project smoke configuration" "$reason" "none" "$(pro_project_required_env_names)" 0
+        return 0
+    fi
+
+    if ! is_positive_integer "$PRO_PROJECT_SMOKE_LOGIN_TIMEOUT"; then
+        local reason="Pro/Cloud project smoke login timeout must be a positive integer: KITARU_PRO_PROJECT_SMOKE_LOGIN_TIMEOUT"
+        printf "  ${RED}✗${RESET} Pro/Cloud project smoke timeout configuration\n"
+        printf "    %s\n" "$reason"
+        record_failure "Pro/Cloud project smoke timeout configuration" "$reason" "none" "KITARU_PRO_PROJECT_SMOKE_LOGIN_TIMEOUT" 0
+        return 0
+    fi
+
+    local login_output
+    local login_start=$SECONDS
+    login_output=$(timed "$PRO_PROJECT_SMOKE_LOGIN_TIMEOUT" \
+        $UV_RUN kitaru login "$PRO_PROJECT_SMOKE_SERVER_URL" --timeout "$PRO_PROJECT_SMOKE_LOGIN_TIMEOUT" 2>&1)
+    local login_rc=$?
+    local login_duration=$((SECONDS - login_start))
+    if [[ $login_rc -eq 0 ]]; then
+        printf "  ${GREEN}✓${RESET} Pro/Cloud project smoke login\n"
+        record_pass_evidence "Pro/Cloud project smoke login" \
+            '{"pro_project_server_configured":true}' "$login_duration"
+        PRO_PROJECT_SMOKE_LOGGED_IN=true
+        if [[ "$VERBOSE" == true ]]; then
+            echo "$login_output" | redact_remote_output | sed 's/^/    /'
+        fi
+    else
+        printf "  ${RED}✗${RESET} Pro/Cloud project smoke login\n"
+        echo "$login_output" | redact_remote_output | tail -30 | sed 's/^/    /'
+        record_failure "Pro/Cloud project smoke login" "exit status $login_rc" "none" "KITARU_PRO_PROJECT_SMOKE_SERVER_URL" "$login_duration"
+        return 0
+    fi
+
+    local current_output
+    local current_name
+    local current_start=$SECONDS
+    current_output=$(timed 60 $UV_RUN kitaru project current -o json 2>&1)
+    local current_rc=$?
+    local current_duration=$((SECONDS - current_start))
+    if [[ $current_rc -ne 0 ]]; then
+        printf "  ${RED}✗${RESET} Pro/Cloud project current inspection\n"
+        echo "$current_output" | redact_remote_output | tail -30 | sed 's/^/    /'
+        record_failure "Pro/Cloud project current inspection" "exit status $current_rc" "none" "" "$current_duration"
+        return 0
+    fi
+    current_name=$(printf '%s' "$current_output" | project_current_name_from_json 2>/dev/null) || current_name=""
+    if [[ -z "$current_name" ]]; then
+        printf "  ${RED}✗${RESET} Pro/Cloud project current inspection\n"
+        echo "$current_output" | redact_remote_output | tail -30 | sed 's/^/    /'
+        record_failure "Pro/Cloud project current inspection" "current project response did not include item.name" "none" "" "$current_duration"
+        return 0
+    fi
+    printf "  ${GREEN}✓${RESET} Pro/Cloud project current inspection\n"
+    record_pass_evidence "Pro/Cloud project current inspection" \
+        '{"active_project_detected":true}' "$current_duration"
+    if [[ "$VERBOSE" == true ]]; then
+        echo "$current_output" | redact_remote_output | sed 's/^/    /'
+    fi
+    run_test "Pro/Cloud project use current project" \
+        timed 60 $UV_RUN kitaru project use "$current_name"
+
+    local project_name
+    project_name="${PRO_PROJECT_SMOKE_RUN_PREFIX}-$(date +%Y%m%d%H%M%S)-$$"
+    local created=false
+    local active_project_changed=false
+
+    PRO_PROJECT_SMOKE_CREATED_PROJECT="$project_name"
+    if run_test "Pro/Cloud project create --no-activate" \
+        timed 60 $UV_RUN kitaru project create "$project_name" --no-activate; then
+        created=true
+    fi
+
+    if [[ "$created" == true ]]; then
+        local after_create_output
+        local after_create_name
+        local after_create_start=$SECONDS
+        after_create_output=$(timed 60 $UV_RUN kitaru project current -o json 2>&1)
+        local after_create_rc=$?
+        local after_create_duration=$((SECONDS - after_create_start))
+        if [[ $after_create_rc -eq 0 ]]; then
+            after_create_name=$(printf '%s' "$after_create_output" | project_current_name_from_json 2>/dev/null) || after_create_name=""
+        else
+            after_create_name=""
+        fi
+
+        if [[ $after_create_rc -eq 0 && -n "$after_create_name" ]]; then
+            if [[ "$after_create_name" == "$current_name" ]]; then
+                printf "  ${GREEN}✓${RESET} Pro/Cloud project create kept active project\n"
+                record_pass_evidence "Pro/Cloud project create kept active project" \
+                    '{"create_no_activate_preserved_active_project":true}' "$after_create_duration"
+            else
+                printf "  ${RED}✗${RESET} Pro/Cloud project create kept active project\n"
+                record_failure "Pro/Cloud project create kept active project" \
+                    "active project changed after create --no-activate" "none" "" "$after_create_duration"
+                active_project_changed=true
+            fi
+        else
+            printf "  ${RED}✗${RESET} Pro/Cloud project active project recheck\n"
+            echo "$after_create_output" | redact_remote_output | tail -30 | sed 's/^/    /'
+            record_failure "Pro/Cloud project active project recheck" \
+                "current project response did not include item.name" "none" "" "$after_create_duration"
+            active_project_changed=true
+        fi
+
+        if [[ "$active_project_changed" == true ]]; then
+            run_test "Pro/Cloud project restore previous active project" \
+                timed 60 $UV_RUN kitaru project use "$current_name" || true
+        else
+            printf "  ${GREEN}✓${RESET} Pro/Cloud project restore not needed\n"
+            record_pass_evidence "Pro/Cloud project restore not needed" \
+                '{"active_project_already_restored":true}' 0
+        fi
+
+        run_test "Pro/Cloud project show created project" \
+            timed 60 $UV_RUN kitaru project show "$project_name" || true
+        if run_test "Pro/Cloud project delete created project" \
+            timed 60 $UV_RUN kitaru project delete "$project_name" --yes; then
+            PRO_PROJECT_SMOKE_CREATED_PROJECT=""
+        fi
+    else
+        if timed 60 $UV_RUN kitaru project delete "$project_name" --yes &>/dev/null; then
+            PRO_PROJECT_SMOKE_CREATED_PROJECT=""
+        fi
+        skip_test "Pro/Cloud project show created project" "project create did not pass"
+        skip_test "Pro/Cloud project delete created project" "project create did not pass"
+    fi
+}
+
 run_remote_stack_smoke_section() {
     section_header "Remote stack smoke"
 
@@ -1040,6 +1292,16 @@ cleanup() {
     # before its own restore ran, then drop the backup file.
     restore_repo_active_stack
 
+    if [[ -n "${PRO_PROJECT_SMOKE_CREATED_PROJECT:-}" ]] && [[ "${PRO_PROJECT_SMOKE_LOGGED_IN:-false}" == true ]]; then
+        timed 60 $UV_RUN kitaru project delete \
+            "$PRO_PROJECT_SMOKE_CREATED_PROJECT" --yes &>/dev/null || true
+        PRO_PROJECT_SMOKE_CREATED_PROJECT=""
+    fi
+    if [[ "${PRO_PROJECT_SMOKE_LOGGED_IN:-false}" == true ]]; then
+        timed 10 $UV_RUN kitaru logout &>/dev/null || true
+        PRO_PROJECT_SMOKE_LOGGED_IN=false
+    fi
+
     if [[ -n "${SMOKE_AUTH_SA:-}" ]]; then
         timed 10 $UV_RUN kitaru auth api-keys delete \
             "$SMOKE_AUTH_SA" "${SMOKE_AUTH_KEY:-smoke-key}" --yes &>/dev/null || true
@@ -1133,6 +1395,9 @@ fi
 
 if [[ "$REMOTE_STACK_SMOKE" == true ]]; then
     printf "  Remote stack smoke: enabled (operator-provided config)\n"
+fi
+if [[ "$PRO_PROJECT_SMOKE" == true ]]; then
+    printf "  Pro/Cloud project smoke: enabled (operator-provided config)\n"
 fi
 
 # Internal test hook: exercise the remote section without running local install/server smoke.
@@ -1229,8 +1494,19 @@ run_remote_stack_smoke_section
 section_header "Clear state"
 
 # Logout may exit non-zero if no session is active — that's fine.
-$UV_RUN kitaru logout &>/dev/null || true
-printf "  ${GREEN}✓${RESET} kitaru logout (clear state)\n"
+if [[ -n "${PRO_PROJECT_SMOKE_CREATED_PROJECT:-}" ]] && [[ "${PRO_PROJECT_SMOKE_LOGGED_IN:-false}" == true ]]; then
+    if timed 60 $UV_RUN kitaru project delete \
+        "$PRO_PROJECT_SMOKE_CREATED_PROJECT" --yes &>/dev/null; then
+        PRO_PROJECT_SMOKE_CREATED_PROJECT=""
+    fi
+fi
+if [[ -z "${PRO_PROJECT_SMOKE_CREATED_PROJECT:-}" ]]; then
+    $UV_RUN kitaru logout &>/dev/null || true
+    PRO_PROJECT_SMOKE_LOGGED_IN=false
+    printf "  ${GREEN}✓${RESET} kitaru logout (clear state)\n"
+else
+    printf "  ${YELLOW}!${RESET} skipped kitaru logout so exit cleanup can retry project deletion\n"
+fi
 
 # ---------------------------------------------------------------------------
 # Start local server
@@ -1294,6 +1570,18 @@ run_test "kitaru project list"           $UV_RUN kitaru project list
 run_test "kitaru project list -o json"   $UV_RUN kitaru project list -o json
 run_test "kitaru project current"        $UV_RUN kitaru project current
 run_test "SDK project-management API"    $UV_RUN python -c 'from kitaru import KitaruClient; client = KitaruClient.for_project_management(); projects = client.projects.list(); current = client.projects.current(); assert isinstance(projects, list); assert current.name'
+PROJECT_GUARD_MESSAGE="requires a ZenML Pro/Cloud server"
+SMOKE_LOCAL_PROJECT="kitaru-smoke-local-project-$$"
+run_expected_failure "local/OSS blocks kitaru project create" \
+    "$PROJECT_GUARD_MESSAGE" \
+    $UV_RUN kitaru project create "$SMOKE_LOCAL_PROJECT" --no-activate
+run_expected_failure "local/OSS blocks kitaru project use" \
+    "$PROJECT_GUARD_MESSAGE" \
+    $UV_RUN kitaru project use "$SMOKE_LOCAL_PROJECT"
+run_expected_failure "local/OSS blocks kitaru project delete" \
+    "$PROJECT_GUARD_MESSAGE" \
+    $UV_RUN kitaru project delete "$SMOKE_LOCAL_PROJECT" --yes
+run_sdk_project_guard_checks "$SMOKE_LOCAL_PROJECT"
 run_test "kitaru stack list"             $UV_RUN kitaru stack list
 run_test "kitaru stack current"          $UV_RUN kitaru stack current
 run_test "kitaru stack create help mentions modal" \
@@ -1728,6 +2016,11 @@ run_test "MCP: kitaru_projects_list" \
 run_test "MCP: kitaru_projects_current" \
     $FASTMCP call --command "$MCP_SERVER" --target kitaru_projects_current --json
 
+run_expected_failure "MCP: local/OSS blocks kitaru_projects_use" \
+    "$PROJECT_GUARD_MESSAGE" \
+    $FASTMCP call --command "$MCP_SERVER" --target kitaru_projects_use \
+        --input-json "{\"name_or_id\":\"$SMOKE_LOCAL_PROJECT\"}" --json
+
 run_test "MCP: kitaru_executions_list" \
     $FASTMCP call --command "$MCP_SERVER" --target kitaru_executions_list \
         --input-json '{"limit": 3}' --json
@@ -1740,6 +2033,20 @@ run_test "MCP query snapshot (example)" \
     timed 30 $UV_RUN examples/features/mcp/mcp_query_tools.py
 
 fi  # LOGIN_RC == 0
+
+# ---------------------------------------------------------------------------
+# Pro/Cloud project smoke
+# ---------------------------------------------------------------------------
+if [[ "$SCRIPT_OWNS_SERVER" == true ]] && [[ "$KEEP_SERVER" != true ]]; then
+    printf "\n${CYAN}Stopping local server before Pro/Cloud project smoke...${RESET}\n"
+    if timed 10 $UV_RUN kitaru logout &>/dev/null; then
+        printf "${GREEN}Server stopped.${RESET}\n"
+    else
+        printf "${RED}Warning: server stop may have failed. Check port 8383.${RESET}\n"
+    fi
+    SCRIPT_OWNS_SERVER=false
+fi
+run_pro_project_smoke_section
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/src/kitaru/_cli/__init__.py
+++ b/src/kitaru/_cli/__init__.py
@@ -30,7 +30,7 @@ stack_app = cyclopts.App(
 )
 project_app = cyclopts.App(
     name="project",
-    help="Inspect, create, delete, and switch Kitaru projects.",
+    help="Inspect projects; create, delete, and switch them on ZenML Pro/Cloud.",
 )
 secrets_app = cyclopts.App(
     name="secrets",

--- a/src/kitaru/_cli/_projects.py
+++ b/src/kitaru/_cli/_projects.py
@@ -165,7 +165,7 @@ def create(
     ] = None,
     output: OutputFormatOption = "text",
 ) -> None:
-    """Create a Kitaru project, activating it by default."""
+    """Create a Kitaru project on ZenML Pro/Cloud, activating it by default."""
     command = "project.create"
     output_format = _resolve_output_format(output)
     result = run_with_cli_error_boundary(
@@ -209,7 +209,7 @@ def use(
     ],
     output: OutputFormatOption = "text",
 ) -> None:
-    """Use a Kitaru project as the active default by name or ID."""
+    """Use a Kitaru project on ZenML Pro/Cloud as the active default."""
     command = "project.use"
     output_format = _resolve_output_format(output)
     project = run_with_cli_error_boundary(
@@ -242,13 +242,14 @@ def delete(
     ] = False,
     output: OutputFormatOption = "text",
 ) -> None:
-    """Delete a Kitaru project by name or ID."""
+    """Delete a Kitaru project on ZenML Pro/Cloud by name or ID."""
     command = "project.delete"
     output_format = _resolve_output_format(output)
     if not yes:
         _exit_with_error(
             command,
-            "Refusing to delete project without --yes.",
+            f"Kitaru will not delete project '{name_or_id}' without explicit "
+            "confirmation. Re-run with --yes if you want to delete it.",
             output=output_format,
         )
 

--- a/src/kitaru/_config/_projects.py
+++ b/src/kitaru/_config/_projects.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Literal
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict
 from zenml.client import Client
@@ -16,7 +17,12 @@ from kitaru._env import (
     _normalized_kitaru_env,
 )
 from kitaru.analytics import AnalyticsEvent, track
-from kitaru.errors import KitaruBackendError, KitaruStateError, KitaruUsageError
+from kitaru.errors import (
+    KitaruBackendError,
+    KitaruFeatureNotAvailableError,
+    KitaruStateError,
+    KitaruUsageError,
+)
 
 
 class ProjectInfo(BaseModel):
@@ -49,12 +55,85 @@ class ProjectDeleteResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+_ProjectManagementOperation = Literal["create", "use", "delete"]
+
+
 def _normalize_project_selector(value: str, *, field_name: str = "name_or_id") -> str:
     """Return a non-empty project selector."""
     normalized = value.strip()
     if not normalized:
         raise KitaruUsageError(f"Project {field_name} cannot be empty.")
     return normalized
+
+
+def _is_known_pro_cloud_backend_url(value: Any) -> bool:
+    """Return whether a store URL points at a known ZenML Pro/Cloud backend."""
+    if not isinstance(value, str):
+        return False
+
+    candidate = value.strip()
+    if not candidate:
+        return False
+
+    parsed = urlsplit(candidate if "://" in candidate else f"//{candidate}")
+    hostname = parsed.hostname
+    if hostname is None:
+        return False
+
+    normalized = hostname.lower()
+    return normalized == "cloudinfra.zenml.io" or normalized.endswith(
+        ".cloudinfra.zenml.io"
+    )
+
+
+def _connected_store_url_is_known_pro_cloud(client: Any) -> bool:
+    """Return whether the connected store URL is a known Pro/Cloud backend."""
+    try:
+        store_url = client.zen_store.url
+    except Exception:
+        return False
+    return _is_known_pro_cloud_backend_url(store_url)
+
+
+def _require_pro_cloud_project_management(
+    client: Any,
+    *,
+    operation: _ProjectManagementOperation,
+) -> None:
+    """Require ZenML Pro/Cloud before project-changing operations."""
+
+    def unknown_server_type_error() -> KitaruBackendError:
+        return KitaruBackendError(
+            "Kitaru could not verify whether the connected ZenML server is "
+            f"Pro/Cloud before project {operation}. Project {operation} was "
+            "not attempted. Check your server connection and authentication, "
+            "then retry."
+        )
+
+    try:
+        server_info = client.zen_store.get_store_info()
+        is_pro_server = server_info.is_pro_server
+    except Exception as exc:
+        raise unknown_server_type_error() from exc
+
+    if not callable(is_pro_server):
+        raise unknown_server_type_error()
+
+    try:
+        is_pro = is_pro_server()
+    except Exception as exc:
+        raise unknown_server_type_error() from exc
+
+    if not isinstance(is_pro, bool):
+        raise unknown_server_type_error()
+
+    if not is_pro and not _connected_store_url_is_known_pro_cloud(client):
+        raise KitaruFeatureNotAvailableError(
+            f"Kitaru project {operation} requires a ZenML Pro/Cloud server. "
+            "You are connected to a non-Pro ZenML server. Use the default "
+            "project on local/OSS ZenML, or connect to a ZenML Pro/Cloud "
+            "workspace to manage Kitaru projects."
+        )
 
 
 def _safe_optional_project_string(
@@ -341,6 +420,7 @@ def create_project(
     project_description = _normalize_optional_project_string(description) or ""
     project_display_name = _normalize_optional_project_string(display_name)
     client = client_factory()
+    _require_pro_cloud_project_management(client, operation="create")
     env_selector = _active_project_selector_from_env()
     active_project_read_failed = False
     try:
@@ -405,6 +485,7 @@ def use_project(
     """Set the active Kitaru project and return the resulting project info."""
     selector = _normalize_project_selector(name_or_id)
     client = client_factory()
+    _require_pro_cloud_project_management(client, operation="use")
     try:
         project = client.get_project(
             selector,
@@ -432,6 +513,7 @@ def delete_project(
     """Delete a Kitaru project and return structured operation details."""
     selector = _normalize_project_selector(name_or_id)
     client = client_factory()
+    _require_pro_cloud_project_management(client, operation="delete")
     try:
         project = client.get_project(
             selector,

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -3089,7 +3089,7 @@ class _ProjectsAPI:
         display_name: str | None = None,
         activate: bool = True,
     ) -> ProjectCreateResult:
-        """Create a Kitaru project and optionally activate it."""
+        """Create a Kitaru project on ZenML Pro/Cloud and optionally activate it."""
         return _create_project(
             name,
             description=description,
@@ -3099,11 +3099,11 @@ class _ProjectsAPI:
         )
 
     def use(self, name_or_id: str) -> ProjectInfo:
-        """Set the active Kitaru project."""
+        """Set the active Kitaru project on ZenML Pro/Cloud."""
         return _use_project(name_or_id, client_factory=self._client_ref._client)
 
     def delete(self, name_or_id: str) -> ProjectDeleteResult:
-        """Delete a Kitaru project."""
+        """Delete a Kitaru project on ZenML Pro/Cloud."""
         return _delete_project(name_or_id, client_factory=self._client_ref._client)
 
 
@@ -3179,9 +3179,10 @@ class KitaruClient:
     def for_project_management(cls) -> KitaruClient:
         """Create a client for project-management operations.
 
-        Listing, creating, or choosing projects happens before a project-scoped
-        operation can run, so this constructor validates server/auth pairing
-        while intentionally skipping the active-project requirement.
+        Reading projects happens before a project-scoped operation can run.
+        Project create/use/delete additionally require ZenML Pro/Cloud through
+        the shared project helpers. This constructor validates server/auth
+        pairing while intentionally skipping the active-project requirement.
         """
         return cls(_require_project=False)
 

--- a/src/kitaru/mcp/server.py
+++ b/src/kitaru/mcp/server.py
@@ -673,7 +673,7 @@ def kitaru_projects_show(name_or_id: str) -> dict[str, Any]:
 
 @tracked_mcp_tool
 def kitaru_projects_use(name_or_id: str) -> dict[str, Any]:
-    """Use a Kitaru project as the active default by name or ID."""
+    """Use a Kitaru project on ZenML Pro/Cloud as the active default."""
     return run_with_mcp_error_boundary(
         lambda: inspection.serialize_project(project_ops.use_project(name_or_id))
     )

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -29,7 +29,12 @@ from kitaru.config import (
     StackType,
     VertexStackSpec,
 )
-from kitaru.errors import KitaruRuntimeError, KitaruStateError, KitaruUsageError
+from kitaru.errors import (
+    KitaruFeatureNotAvailableError,
+    KitaruRuntimeError,
+    KitaruStateError,
+    KitaruUsageError,
+)
 from kitaru.inspection import RuntimeSnapshot
 from kitaru.mcp.server import (
     get_execution_logs,
@@ -1685,6 +1690,20 @@ def test_projects_use_delegates_to_shared_helpers() -> None:
     mock_use.assert_called_once_with("production")
     assert payload["name"] == "production"
     assert payload["is_active"] is True
+
+
+def test_projects_use_preserves_pro_cloud_feature_error() -> None:
+    """MCP project use should preserve the shared Pro/Cloud guard error."""
+    with (
+        patch(
+            "kitaru._config._projects.use_project",
+            side_effect=KitaruFeatureNotAvailableError(
+                "Kitaru project use requires a ZenML Pro/Cloud server."
+            ),
+        ),
+        pytest.raises(KitaruFeatureNotAvailableError, match="Pro/Cloud"),
+    ):
+        kitaru_projects_use("staging")
 
 
 def test_manage_stack_create_returns_structured_result() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,6 +57,7 @@ from kitaru.config import (
 )
 from kitaru.errors import (
     KitaruDeploymentInputValuesError,
+    KitaruFeatureNotAvailableError,
     KitaruStackNotRemoteExecutableUsageError,
     KitaruStateError,
     KitaruUsageError,
@@ -5817,6 +5818,80 @@ def test_project_show_renders_snapshot(
     assert "Active: yes" in output
 
 
+def test_project_help_mentions_pro_cloud_for_mutations(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Project mutation help should explain the ZenML Pro/Cloud requirement."""
+    with pytest.raises(SystemExit) as exc_info:
+        app(["project", "--help"])
+    assert exc_info.value.code == 0
+    assert "pro/cloud" in capsys.readouterr().out.lower()
+
+    for command in ("create", "use", "delete"):
+        with pytest.raises(SystemExit) as command_exc_info:
+            app(["project", command, "--help"])
+        assert command_exc_info.value.code == 0
+        assert "pro/cloud" in capsys.readouterr().out.lower()
+
+
+@pytest.mark.parametrize(
+    ("command", "patch_target", "args"),
+    [
+        (
+            "project.create",
+            "kitaru.cli.create_project",
+            ["project", "create", "staging"],
+        ),
+        ("project.use", "kitaru.cli.use_project", ["project", "use", "staging"]),
+        (
+            "project.delete",
+            "kitaru.cli.delete_project",
+            ["project", "delete", "staging", "--yes"],
+        ),
+    ],
+)
+def test_project_mutation_text_errors_preserve_feature_error(
+    capsys: pytest.CaptureFixture[str],
+    command: str,
+    patch_target: str,
+    args: list[str],
+) -> None:
+    message = f"Kitaru {command} requires a ZenML Pro/Cloud server."
+    with (
+        patch(patch_target, side_effect=KitaruFeatureNotAvailableError(message)),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(args)
+
+    assert exc_info.value.code == 1
+    assert message in capsys.readouterr().err
+
+
+def test_project_create_json_error_preserves_feature_error_type(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    message = "Kitaru project create requires a ZenML Pro/Cloud server."
+    with (
+        patch(
+            "kitaru.cli.create_project",
+            side_effect=KitaruFeatureNotAvailableError(message),
+        ),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["project", "create", "staging", "--output", "json"])
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err) == {
+        "command": "project.create",
+        "error": {
+            "message": message,
+            "type": "KitaruFeatureNotAvailableError",
+        },
+    }
+
+
 def test_project_use_delegates_to_config(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -5908,7 +5983,9 @@ def test_project_delete_requires_yes(
 
     assert exc_info.value.code == 1
     mock_delete_project.assert_not_called()
-    assert "Refusing to delete project without --yes." in capsys.readouterr().err
+    error_output = capsys.readouterr().err
+    assert "Kitaru will not delete project 'staging'" in error_output
+    assert "Re-run with --yes if you want to delete it." in error_output
 
 
 def test_project_delete_reports_success(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -843,6 +843,36 @@ def test_projects_api_delegates_to_shared_helpers() -> None:
     delete.assert_called_once_with("staging", client_factory=client._client)
 
 
+@pytest.mark.parametrize(
+    ("method", "patch_target", "expected_args"),
+    [
+        ("create", "kitaru.client._create_project", ("staging",)),
+        ("use", "kitaru.client._use_project", ("staging",)),
+        ("delete", "kitaru.client._delete_project", ("staging",)),
+    ],
+)
+def test_projects_api_propagates_project_management_feature_error(
+    method: str,
+    patch_target: str,
+    expected_args: tuple[str, ...],
+) -> None:
+    error = KitaruFeatureNotAvailableError(
+        "Kitaru project management requires a ZenML Pro/Cloud server."
+    )
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch(patch_target, side_effect=error) as helper,
+    ):
+        client = KitaruClient()
+        with pytest.raises(KitaruFeatureNotAvailableError, match="Pro/Cloud"):
+            getattr(client.projects, method)(*expected_args)
+
+    helper.assert_called_once()
+
+
 def test_auth_service_accounts_delegate_to_zenml_client() -> None:
     service_account = _service_account_response()
 

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -20,7 +20,12 @@ from kitaru._config._projects import (
 )
 from kitaru._env import KITARU_PROJECT_ENV, ZENML_ACTIVE_PROJECT_ID_ENV
 from kitaru.analytics import AnalyticsEvent
-from kitaru.errors import KitaruBackendError, KitaruStateError, KitaruUsageError
+from kitaru.errors import (
+    KitaruBackendError,
+    KitaruFeatureNotAvailableError,
+    KitaruStateError,
+    KitaruUsageError,
+)
 from kitaru.inspection import serialize_project
 
 
@@ -57,6 +62,25 @@ def _project_model(
         display_name=display_name,
         description=description,
     )
+
+
+class _ServerInfo:
+    def __init__(self, *, is_pro: bool) -> None:
+        self._is_pro = is_pro
+
+    def is_pro_server(self) -> bool:
+        return self._is_pro
+
+
+def _with_project_management_server(
+    client: Any,
+    *,
+    is_pro: bool = True,
+) -> Any:
+    zen_store_mock = Mock()
+    zen_store_mock.get_store_info.return_value = _ServerInfo(is_pro=is_pro)
+    client.zen_store = zen_store_mock
+    return client
 
 
 class _EnvSelectedProjectClient:
@@ -99,6 +123,7 @@ class _DeleteProjectClient:
         self.persisted_active_project_name = persisted_active_project_name
         self.get_project_calls: list[tuple[str, bool, bool]] = []
         self.zen_store = Mock()
+        self.zen_store.get_store_info.return_value = _ServerInfo(is_pro=True)
         self.delete_project = Mock(
             side_effect=AssertionError("Kitaru should bypass Client.delete_project")
         )
@@ -265,8 +290,75 @@ def test_get_project_rejects_empty_selector() -> None:
         get_project("  ", client_factory=Mock)
 
 
-def test_use_project_resolves_exact_selector_and_activates_by_id() -> None:
+@pytest.mark.parametrize("operation", ["create", "use", "delete"])
+def test_project_mutations_require_pro_cloud_before_backend_calls(
+    operation: str,
+) -> None:
+    fake_client = _with_project_management_server(Mock(), is_pro=False)
+
+    with (
+        patch("kitaru._config._projects.track", return_value=True) as track_mock,
+        pytest.raises(
+            KitaruFeatureNotAvailableError,
+            match=f"project {operation} requires a ZenML Pro/Cloud server",
+        ),
+    ):
+        if operation == "create":
+            create_project("staging", client_factory=lambda: fake_client)
+        elif operation == "use":
+            use_project("staging", client_factory=lambda: fake_client)
+        else:
+            delete_project("staging", client_factory=lambda: fake_client)
+
+    fake_client.create_project.assert_not_called()
+    fake_client.get_project.assert_not_called()
+    fake_client.set_active_project.assert_not_called()
+    fake_client.zen_store.delete_project.assert_not_called()
+    track_mock.assert_not_called()
+
+
+def test_create_project_allows_cloudinfra_url_when_metadata_says_not_pro() -> None:
+    created = _project_model("new-id", "hamster")
+    fake_client = _with_project_management_server(Mock(), is_pro=False)
+    fake_client.zen_store.url = "https://161e5333-zenml.staging.cloudinfra.zenml.io"
+    fake_client.create_project.return_value = created
+    fake_client.set_active_project.return_value = created
+
+    with patch("kitaru._config._projects.track", return_value=True) as track_mock:
+        result = create_project("hamster", client_factory=lambda: fake_client)
+
+    assert result.project.name == "hamster"
+    assert result.activated is True
+    fake_client.create_project.assert_called_once_with(
+        name="hamster",
+        description="",
+        display_name=None,
+    )
+    fake_client.set_active_project.assert_called_once_with("new-id")
+    track_mock.assert_called_once_with(
+        AnalyticsEvent.PROJECT_CREATED,
+        {"activated": True},
+    )
+
+
+def test_project_mutation_blocks_when_server_type_cannot_be_verified() -> None:
     fake_client = Mock()
+    fake_client.zen_store.get_store_info.return_value = SimpleNamespace(
+        is_pro_server=lambda: "yes"
+    )
+
+    with (
+        patch("kitaru._config._projects.track", return_value=True) as track_mock,
+        pytest.raises(KitaruBackendError, match="could not verify"),
+    ):
+        create_project("staging", client_factory=lambda: fake_client)
+
+    fake_client.create_project.assert_not_called()
+    track_mock.assert_not_called()
+
+
+def test_use_project_resolves_exact_selector_and_activates_by_id() -> None:
+    fake_client = _with_project_management_server(Mock())
     fake_client.get_project.return_value = _project_model("prod-id", "production")
     fake_client.set_active_project.return_value = _project_model(
         "prod-id", "production"
@@ -289,7 +381,7 @@ def test_use_project_resolves_exact_selector_and_activates_by_id() -> None:
 def test_create_project_activates_by_default_and_tracks_safe_metadata() -> None:
     previous = _project_model("old-id", "default")
     created = _project_model("new-id", "production")
-    fake_client = Mock()
+    fake_client = _with_project_management_server(Mock())
     fake_client.active_project = previous
     fake_client.create_project.return_value = created
     fake_client.set_active_project.return_value = created
@@ -315,7 +407,7 @@ def test_create_project_activates_by_default_and_tracks_safe_metadata() -> None:
 def test_create_project_without_activation_leaves_active_project_unchanged() -> None:
     previous = _project_model("old-id", "default")
     created = _project_model("new-id", "staging")
-    fake_client = Mock()
+    fake_client = _with_project_management_server(Mock())
     fake_client.active_project = previous
     fake_client.create_project.return_value = created
 
@@ -342,6 +434,9 @@ def test_create_project_handles_no_previous_active_project() -> None:
     created = _project_model("new-id", "first-project")
 
     class _FakeClient:
+        def __init__(self) -> None:
+            _with_project_management_server(self)
+
         @property
         def active_project(self) -> Any:
             raise RuntimeError("no active project")
@@ -369,6 +464,7 @@ def test_create_project_creates_missing_kitaru_project_env_selection(
 
     class _CreateEnvSelectedProjectClient:
         def __init__(self) -> None:
+            _with_project_management_server(self)
             self.get_project_calls: list[str] = []
             self.create_project = Mock(return_value=created)
             self.set_active_project = Mock(return_value=created)
@@ -414,6 +510,7 @@ def test_create_project_without_activation_handles_missing_kitaru_project_env(
 
     class _CreateEnvSelectedProjectClient:
         def __init__(self) -> None:
+            _with_project_management_server(self)
             self.create_project = Mock(return_value=created)
             self.set_active_project = Mock()
 
@@ -466,6 +563,7 @@ def test_create_project_ignores_stale_unrelated_kitaru_project_env(
 
     class _CreateWithStaleEnvClient:
         def __init__(self) -> None:
+            _with_project_management_server(self)
             self.get_project_calls: list[str] = []
             self.create_project = Mock(return_value=created)
             self.set_active_project = Mock(return_value=created)
@@ -507,6 +605,7 @@ def test_create_project_without_activation_ignores_stale_unrelated_env(
 
     class _CreateWithoutActivationWithStaleEnvClient:
         def __init__(self) -> None:
+            _with_project_management_server(self)
             self.get_project_calls: list[str] = []
             self.create_project = Mock(return_value=created)
             self.set_active_project = Mock()
@@ -546,7 +645,7 @@ def test_create_project_without_activation_ignores_stale_unrelated_env(
 
 def test_delete_project_returns_deleted_project_and_tracks() -> None:
     target = _project_model("stage-id", "staging")
-    fake_client = Mock()
+    fake_client = _with_project_management_server(Mock())
     fake_client.active_project = _project_model("prod-id", "production")
     fake_client.get_project.return_value = target
 
@@ -637,7 +736,7 @@ def test_current_project_preserves_backend_failure_diagnosis() -> None:
 
 
 def test_project_backend_errors_are_kitaru_worded() -> None:
-    fake_client = Mock()
+    fake_client = _with_project_management_server(Mock())
     fake_client.set_active_project.side_effect = RuntimeError("backend exploded")
 
     with pytest.raises(KitaruBackendError, match="Failed to activate project"):

--- a/tests/test_smoke_test_script.py
+++ b/tests/test_smoke_test_script.py
@@ -68,6 +68,14 @@ def test_help_documents_remote_stack_smoke_contract() -> None:
     assert "KITARU_REMOTE_SMOKE_LOCAL_REMOTE_ARTIFACT_STACK" in help_text
     assert "KITARU_REMOTE_SMOKE_FLOW_IMAGE" in help_text
     assert "just dev-image REPO=<operator-image-repo>" in help_text
+    assert "--pro-project-smoke" in help_text
+    assert "--pro-project-server-url URL" in help_text
+    assert "--pro-project-login-timeout SECONDS" in help_text
+    assert "--pro-project-run-prefix PREFIX" in help_text
+    assert "KITARU_PRO_PROJECT_SMOKE" in help_text
+    assert "KITARU_PRO_PROJECT_SMOKE_SERVER_URL" in help_text
+    assert "KITARU_PRO_PROJECT_SMOKE_LOGIN_TIMEOUT" in help_text
+    assert "KITARU_PRO_PROJECT_SMOKE_RUN_PREFIX" in help_text
 
 
 def test_default_remote_smoke_is_opt_in_and_records_no_remote_checks(


### PR DESCRIPTION
## What changed

- Added a shared Kitaru-side Pro/Cloud guard for project-changing operations: `create_project`, `use_project`, and `delete_project` now fail before backend mutation unless the connected ZenML server is recognized as Pro/Cloud.
- Recognition primarily uses `server_info.is_pro_server()`, with a narrow fallback for known ZenML Cloud backend hostnames such as `*.cloudinfra.zenml.io`. This covers staging/pro workspaces whose older server metadata can report non-Pro even though the connected backend is Cloud.
- Kept read-only project inspection available on local/OSS servers: list/current/show remain usable for diagnostics.
- Updated CLI, SDK, and MCP wording/tests so the Pro/Cloud rule is visible and consistently enforced.
- Updated the project guide, changelog, and smoke test coverage for the patch behavior.

## Why it was needed

Projects were shipped as a Kitaru feature, but project management is a ZenML Pro/Cloud workflow. Without a Kitaru-side guard, a local/OSS user could run `kitaru project create staging` and think Kitaru supports project management there. This patch makes Kitaru fail early with a clear feature-availability error instead of letting users build around unsupported behavior.

A follow-up regression from manual staging testing showed the first version of the guard was too literal: it trusted only `is_pro_server()`. In a staging Cloud workspace with a client/server version mismatch, that metadata answer was false even though the connected store URL was a ZenML Cloud backend. The guard now accepts either signal, while local/OSS URLs still fail.

## Key implementation decisions

- The guard lives in `src/kitaru/_config/_projects.py`, because CLI, top-level SDK helpers, `KitaruClient.projects`, and MCP all delegate there.
- The guard raises `KitaruFeatureNotAvailableError` for verified non-Pro servers and `KitaruBackendError` when Kitaru cannot verify server type safely.
- Known Cloud-backend URL fallback is limited to `cloudinfra.zenml.io` and subdomains after hostname parsing, so arbitrary URLs containing that text in a path/query do not pass.
- The guard runs outside the existing broad backend-error wrappers so the feature error is not rewritten as a generic backend error.
- The smoke script now proves local/OSS mutation blocking by default, and adds opt-in Pro/Cloud project smoke for release evidence when credentials are available.

## Reviewer Notes

The main behavior to inspect is the order of events in `src/kitaru/_config/_projects.py`: Kitaru creates a client, asks the ZenML store whether the server is Pro/Cloud, checks the connected store hostname if the metadata answer is false, and only then lets project create/use/delete continue. If that order is wrong, a local/OSS user could still mutate project state, a staging Cloud workspace could be blocked incorrectly, or the clear Pro/Cloud error could be hidden behind `KitaruBackendError`.

The second area worth reviewing is `scripts/smoke-test.sh`. The default smoke now checks that local/OSS project mutations fail, while the optional Pro/Cloud path runs near the end so its login/logout state does not interfere with local-server cleanup. The Pro/Cloud path also tracks any created temporary project and retries cleanup on exit.

### Reproduction

Local/OSS behavior:

```bash
uv sync
uv run kitaru login
uv run kitaru project list
uv run kitaru project current
uv run kitaru project create smoke-project --no-activate
```

Expected result: list/current work, while create fails with a message containing `requires a ZenML Pro/Cloud server`.

Staging/Cloud metadata fallback:

```bash
uv run kitaru login https://161e5333-zenml.staging.cloudinfra.zenml.io
uv run kitaru project create hamster
```

Expected result: project creation is allowed even if the server metadata reports non-Pro, because the connected store hostname is a known ZenML Cloud backend.

Smoke proof:

```bash
./scripts/smoke-test.sh -s --json-out /tmp/kitaru-project-pro-guards-smoke.json
```

Expected result: default local smoke passes and includes successful checks for:

- `local/OSS blocks kitaru project create`
- `local/OSS blocks kitaru project use`
- `local/OSS blocks kitaru project delete`
- `SDK: local/OSS blocks project create/use/delete`
- `MCP: local/OSS blocks kitaru_projects_use`

Optional Pro/Cloud release evidence:

```bash
./scripts/smoke-test.sh -s \
  --pro-project-smoke \
  --pro-project-server-url <ZENML_PRO_SERVER_URL> \
  --json-out /tmp/kitaru-project-pro-guards-pro-smoke.json
```

Expected result: Pro/Cloud create/use/show/delete checks pass and the temporary project is deleted.

## Local checks run

- `just fix`
- `just format-check && just lint && just typecheck`
- `uvx typos CHANGELOG.md docs/book/guides/projects.md scripts/smoke-test.sh src/kitaru/_cli/__init__.py src/kitaru/_cli/_projects.py src/kitaru/_config/_projects.py src/kitaru/client.py src/kitaru/mcp/server.py tests/mcp/test_server.py tests/test_cli.py tests/test_client.py tests/test_projects.py tests/test_smoke_test_script.py`
- `just yaml-check && just actions-lint && just links`
- `uv run pytest tests/test_projects.py tests/test_cli.py -k 'project_create or project_use or project_delete or projects_api or projects' tests/mcp/test_server.py -k projects` → `35 passed`
- `uv run pytest tests/test_cli.py::test_project_delete_requires_yes` + touched-file Ruff format/check after the delete-confirmation wording follow-up.
- `just test` → `3487 passed, 29 skipped`
- `./scripts/smoke-test.sh -s --json-out /tmp/kitaru-project-pro-guards-smoke.json` → `Passed: 111`, `Failed: 0`, `Skipped: 7`
- `/simplify` review pass completed and actionable findings were applied.
- Oracle review loop completed with verdict: `HAPPY`.
- Follow-up Oracle review of the staging Cloud URL fallback completed with verdict: `HAPPY`.

Note: running the literal aggregate `just check` command in this local checkout was blocked by pre-existing untracked `docs/strategy/` files containing British spelling typos. Those files are not part of this branch or PR; the component checks relevant to tracked PR files are listed above.

