### PR TITLE
Skip signature assets in release-asset reconcile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,9 +491,12 @@ jobs:
 
       # --- GitHub Release (skip on dry-run) ---
       # If the release already exists, verify it's attached to v$VERSION, then
-      # check each expected dist/* asset. Present assets are SHA256-compared
-      # against the local build; matching assets are skipped, mismatched assets
-      # fail loudly (never silently overwrite), and missing assets get uploaded.
+      # check each expected dist/* asset. Reproducible assets (wheel, sdist) are
+      # SHA256-compared against the local build; matching assets are skipped,
+      # mismatched assets fail loudly (never silently overwrite), and missing
+      # assets get uploaded. Signature/attestation assets are regenerated on
+      # every publish run and are never byte-identical, so they are uploaded when
+      # missing and left as-is otherwise rather than SHA256-compared.
       - name: Create GitHub Release
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
         env:
@@ -516,6 +519,22 @@ jobs:
           existing_assets=$(echo "$release_json" | jq -r '.assets[].name')
           for f in dist/*; do
             name=$(basename "$f")
+            case "$name" in
+              *.attestation|*.sigstore|*.sig|*.asc)
+                # Signatures/attestations are regenerated on every publish run and
+                # are never byte-identical, so they cannot be SHA256-reconciled.
+                # Upload if the release is missing one; otherwise keep the existing
+                # signature. A signature is verified by validating it against the
+                # artifact, never by expecting two signatures to match byte-for-byte.
+                if echo "$existing_assets" | grep -Fxq "$name"; then
+                  echo "  keeping existing signature asset (not reproducible): $name"
+                else
+                  echo "  uploading missing signature asset: $name"
+                  gh release upload "v$VERSION" "$f"
+                fi
+                continue
+                ;;
+            esac
             if echo "$existing_assets" | grep -Fxq "$name"; then
               gh release download "v$VERSION" --pattern "$name" --dir existing-assets --clobber
               local_hash=$(sha256sum "$f" | awk '{print $1}')


### PR DESCRIPTION
## What this changes

The `Create GitHub Release` step in `release.yml` reconciles each freshly built `dist/*` file against the assets already attached to an existing release by comparing SHA-256 hashes. This runs on a **recovery dispatch** (when the version tag already exists). PyPI `*.publish.attestation` files are cryptographic signatures regenerated fresh on every publish run, so their bytes are never identical to a previous run's. The reconcile treated that mismatch as `The existing asset was built from a different commit. Manual intervention required.` and `exit 1`, which blocked every downstream step (Docker image, Helm chart, cloud-plugins Pro-trigger tag), even though the wheel and sdist were byte-identical and already on PyPI.

This change exempts signature/attestation assets (`*.attestation`, `*.sigstore`, `*.sig`, `*.asc`) from byte-comparison: they are uploaded when the release is missing one and left as-is otherwise. Only the reproducible wheel and sdist are still SHA-256 verified (mismatch there still fails loudly, as before).

## Reviewer Notes

The whole change is inside one Bash step, `Create GitHub Release`, in `.github/workflows/release.yml`. The risk lives entirely in that reconcile loop:

- The new `case` matches signature suffixes and `continue`s the enclosing `for` loop before the hash-compare branch. A `case` is not a loop, so `continue` correctly targets the `for` (verified against the step's `bash -e` shell).
- The reproducible-artifact path (wheel/sdist) is unchanged: matching assets are skipped, a genuine mismatch still `exit 1`s, and missing assets are uploaded. So the "never silently overwrite a real artifact built from a different commit" guarantee is preserved.
- If the suffix list were wrong (e.g. it accidentally matched the wheel), the wheel would stop being hash-verified. It does not: `*.attestation` etc. cannot match `kitaru-<v>-py3-none-any.whl` or `kitaru-<v>.tar.gz`.

What would break if this were wrong: a recovery dispatch would either keep hard-failing on attestations (no worse than today) or, in the bad case, skip verifying a real artifact. The suffix patterns are specific to signature files, so the wheel/sdist stay verified.

`actionlint` (`just actions-lint`) and `zizmor` (`just zizmor`) both pass locally with no findings.

## Reproduction

This was hit for real while cutting **0.20.1**. To reproduce the original failure without a fix:

1. Cut a release so a GitHub Release exists with `kitaru-<v>-py3-none-any.whl.publish.attestation` and `kitaru-<v>.tar.gz.publish.attestation` attached.
2. Re-dispatch `release.yml` for the same version (a recovery dispatch, e.g. after a transient Docker/PyPI failure).
3. Before this fix: the `Create GitHub Release` step fails with `Release asset kitaru-<v>-py3-none-any.whl.publish.attestation hash mismatch ... built from a different commit. Manual intervention required.`, and Docker/Helm/cloud-plugins never run.

With this fix, step 2's re-dispatch keeps the existing attestation, re-verifies the wheel/sdist by hash, and proceeds to the downstream publish steps.

### Local checks run

`just actions-lint` and `just zizmor` both pass with no findings.