### PR TITLE
Trim always-loaded AGENTS guidance

### DIFF
--- a/.agents/skills/kitaru-dev/SKILL.md
+++ b/.agents/skills/kitaru-dev/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: kitaru-dev
+description: Use for Kitaru commands, CLI, analytics, PRs.
+---
+
+# Kitaru Development, CLI, and PR Workflow
+
+Use this when you need the command catalog beyond the daily loop in the root
+`AGENTS.md`, or when adding CLI commands, analytics events, or PR descriptions.
+
+## Python Workflows
+
+- `uv sync`: install and sync dependencies
+- `uv sync --extra local`: install with local ZenML runtime components
+- `uv run kitaru init`: required in a fresh `git worktree`; it creates the
+  `.kitaru/` project marker that ZenML's dynamic pipeline resolver needs to
+  re-import example modules by dotted path
+- `just check`: all checks: format, lint, typecheck, typos, YAML, actions lint, links
+- `just fix`: auto-fix formatting, lint issues, and YAML
+- `just test`: full pytest suite
+- `just test tests/test_file.py::test_name`: one targeted test
+- `just lint`: lint only
+- `just typecheck`: type check only
+- `just typos`: typo check only
+- `just format-check`: check formatting without modifying files
+- `just yaml-check`: check YAML formatting
+- `just actions-lint`: lint GitHub Actions workflows; requires `actionlint`
+- `just zizmor`: audit GitHub Actions workflow security with `zizmor`
+- `just audit`: audit Python dependencies with `pip-audit` and the documented ignore list
+- `just links`: check markdown links offline; requires `lychee`
+- `just links-external`: check links including external URLs; slow
+- `just example-coverage-audit`: validate `examples/example-coverage.yaml`
+  against public example docs, referenced tests/smoke/provider metadata, and
+  explicit waivers for `missing`, `planned`, or `manual_only` coverage
+- `just build`: build wheel and sdist locally
+
+When merging `develop` into a feature branch and resolving `pyproject.toml` or
+`uv.lock`, do not assume a broad `uv lock` preserves recent dependency-security
+fixes. Check recent commits touching `uv.lock` or `.github/pip-audit-ignored.txt`,
+use targeted commands such as `uv lock --upgrade-package <package>` when a
+package was intentionally bumped, and run `just audit` before pushing.
+
+## Docs Workflows
+
+These require Node 22+ and pnpm.
+
+- `just generate-docs`: generate CLI reference, changelog, and SDK reference docs
+- `just docs`: preview docs locally at `localhost:3000`
+- `just docs-build`: build docs static export
+- `just docs-validate`: validate the static export as served under `/docs`
+
+## CLI Structure
+
+The `kitaru` console script is defined in `pyproject.toml` under
+`[project.scripts]`. `src/kitaru/cli.py` is the thin facade / entrypoint.
+Command implementations live in `src/kitaru/_cli/`.
+
+Add new subcommands in the appropriate `src/kitaru/_cli/_*.py` module and
+register them on the shared Cyclopts app there. When testing CLI commands,
+always pass an explicit arg list, such as `app(["--help"])`, not bare `app()`.
+Successful invocations raise `SystemExit(0)`.
+
+## JSON Output Contract
+
+Agent-facing commands should keep the shared `--output json` / `-o json`
+contract consistent:
+
+- single-item commands emit `{command, item}`
+- list commands emit `{command, items, count}`
+- `kitaru executions logs --follow --output json` emits JSONL event objects
+  instead of one final document
+
+Document login consistently: bare `kitaru login` starts the local server, while
+`kitaru login <server>` is the remote-login path. Local server support requires
+the `kitaru[local]` extra.
+
+## Diagnostics and Cleanup
+
+`kitaru info` shows a multi-section diagnostic overview: connection, config
+provenance, connection sources, and system info. Use `--all` for a full dump
+including installed packages and environment type. Use `--file debug.json` or
+`.yaml` to export diagnostics to a file. Environment variable secrets are masked.
+
+`kitaru clean project|global|all` resets Kitaru state. `project` removes
+`.kitaru/`, `global` removes the global config directory with auto-backup and
+local server teardown, and `all` does both. Use `--dry-run` to preview and
+`--force` when model registry aliases exist for `global` or `all`. The `clean`
+command is bootstrap-safe: it works even when the store is broken.
+
+## Analytics
+
+Kitaru collects anonymous usage analytics for opted-in users. When adding new
+features, discuss analytics coverage with the core team to decide what should
+be tracked.
+
+- Add every event name to the `AnalyticsEvent` enum in `src/kitaru/analytics.py`.
+- Track only non-sensitive metadata: event names, boolean flags, enum values,
+  and counts.
+- Never include user content, file paths, prompts, or secret values.
+- CLI feature events use `track()` in subcommand handlers under `src/kitaru/_cli/`.
+- MCP feature events use `@tracked_mcp_tool` in `src/kitaru/mcp/server.py`.
+- Core SDK lifecycle events use `track(AnalyticsEvent.X, {...})` in the relevant module.
+- All `track()` calls must fail silently.
+
+If a CLI command is multi-word, such as `clean project`, add it to
+`_MULTI_TOKEN_COMMANDS` in `cli.py`.
+
+## Pull Requests
+
+Use a clear human-readable title. Never include a `[Codex] ` prefix. Include:
+
+- what changed
+- why it was needed
+- key implementation decisions
+- reviewer focus areas
+
+Link related issues when applicable.
+
+Every PR description should include a `Reviewer Notes` H2 or H3 section. Treat
+that section as a narrative guide for a human reviewer, not a file-by-file
+checklist:
+
+- Start with the story of the change: where important behavior now happens,
+  what used to go wrong, and what would break if the implementation is wrong.
+- Point reviewers toward genuinely tricky or high-risk areas. Mention files
+  only when the file name helps the story, and explain what to inspect there.
+- Include a concrete `Reproduction` subsection either inside Reviewer Notes or
+  immediately after it.
+- Prefer an example, CLI flow, or UI path that proves the behavior end to end.
+- Do not use a standalone `Verification` section as a substitute for
+  reproduction when it only says `just check`, `just test`, or `/simplify`.
+  Those commands are useful local hygiene, but they do not show the reviewer
+  how to see the feature or bug fix.
+- If local hygiene commands are worth mentioning, keep them as a short `Local
+  checks run` note after the reproduction steps.

--- a/.agents/skills/kitaru-docs/SKILL.md
+++ b/.agents/skills/kitaru-docs/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: kitaru-docs
+description: Use for Kitaru docs.
+---
+
+# Kitaru Documentation Workflow
+
+Use this when editing or reviewing Kitaru documentation, examples, generated
+reference docs, docs redirects, or docs CI behavior.
+
+## Documentation Surfaces
+
+Kitaru docs live on three surfaces:
+
+1. Hand-written docs are plain Markdown in `docs/book/`, published to
+   `docs.zenml.io/kitaru` via GitBook Git Sync. Edit these `.md` files directly.
+   Navigation is `docs/book/toc.md`, config is `docs/book/.gitbook.yaml`, and
+   authoring conventions live in `docs/book/AGENTS.md`.
+2. Generated SDK + CLI reference docs live in the FumaDocs app under `docs/`.
+   Generated output is `docs/content/docs/cli/` and
+   `docs/content/docs/reference/python/`, served from `sdkdocs.kitaru.ai`.
+3. `kitaru.ai/docs/*` redirects are handled by `docs/worker/redirect.mjs` and
+   `wrangler.redirect.toml`.
+
+Do not add hand-written pages to the FumaDocs app under `docs/content/docs/`.
+The public changelog is owned by the changelog repo at `docs.zenml.io/changelog`.
+This repo may generate a gitignored `docs/content/docs/changelog.mdx` for local
+reference builds, but agents should not hand-edit or commit it.
+
+The public marketing/runtime site for Kitaru lives in `zenml-io-v2`. If a task
+involves Astro pages, public site assets, marketing Cloudflare Pages deployment,
+or runtime web APIs such as waitlist/get-started/newsletter endpoints, switch
+to that repository instead of adding that code here.
+
+## Docs Content Rules
+
+- Only document shipped features; do not add "Coming Soon" sections.
+- Keep ZenML invisible to users. Use Kitaru terminology such as workflow,
+  checkpoint, stack, deployment, and storage. Avoid ZenML terms such as
+  orchestrator, artifact store, pipeline, and step in user docs.
+- Inside `docs/book/`, link to sibling pages with relative `.md` paths, such as
+  `../concepts/checkpoints.md` or `flows.md#runtime-options`.
+- Link to SDK/CLI reference with `https://sdkdocs.kitaru.ai`.
+- Link to other ZenML docs with absolute `https://docs.zenml.io/...` URLs.
+- Link to diagrams with
+  `https://assets.kitaru.ai/docs/diagrams/<slug>.png`.
+- Do not commit temporary planning/review files such as `docs/plans/*`,
+  `docs/reviews/*`, or prompt exports unless the user explicitly asks for a
+  durable tracked document.
+- Only `kitaru.llm()` auto-resolves alias-linked secrets today. If documenting
+  non-LLM secret access, label it as the current low-level pattern instead of
+  implying there is a dedicated Kitaru secret getter.
+- If generated CLI reference syntax is wrong, fix `scripts/generate_cli_docs.py`
+  and/or the relevant `src/kitaru/_cli/_*.py` module. Use `src/kitaru/cli.py`
+  only for facade/bootstrap issues.
+- Current shipped stack-create types on CLI/MCP are `local`, `kubernetes`,
+  `vertex`, `sagemaker`, and `azureml`.
+- Advanced CLI/MCP stack creation supports `--extra` / structured `extra` plus
+  the remote-only `--async` / `async_mode` convenience flag.
+- Public Python SDK `kitaru.create_stack(...)` remains local-only; keep that
+  distinction explicit.
+- Document `KITARU_*` env vars as the public surface. Mention `ZENML_*` only as
+  a compatibility note when necessary for migration or interop.
+- `kitaru model register` still writes aliases to local config, but
+  submitted/replayed runs automatically receive a transported registry snapshot
+  via `KITARU_MODEL_REGISTRY`.
+- Describe `kitaru model list` as listing aliases available in the current
+  environment, not only aliases stored locally.
+- Every `.mdx` page needs `title` and `description` frontmatter.
+
+## Example READMEs
+
+Example READMEs are user-facing. They should teach new users what Kitaru does
+and walk them through the specific example.
+
+Do not add maintainer-oriented sections such as "Testing", CI-only credential
+setup, or notes about stubbed/mocked test runs. If a section would not help a
+first-time user understand Kitaru, it belongs in tests, contributor docs, or PR
+descriptions instead.

--- a/.agents/skills/kitaru-tests-release/SKILL.md
+++ b/.agents/skills/kitaru-tests-release/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: kitaru-tests-release
+description: Use for Kitaru tests, CI, releases.
+---
+
+# Kitaru Tests, CI, and Release Workflow
+
+Use this when adding, moving, or debugging tests beyond the basic commands and
+safety rules in `tests/AGENTS.md`, or when changing CI/release behavior.
+
+## `primed_zenml`
+
+`primed_zenml` eagerly initializes the ZenML store. Use it only when the test:
+
+- actually runs a flow
+- uses `KitaruClient` against real local state
+- spawns threads or code paths that touch the ZenML runtime lazily
+
+Do not add `primed_zenml` to lightweight unit tests, parser tests, serializer
+tests, or simple CLI rendering tests.
+
+## Unit and Contract Tests
+
+- Build small stubs or `SimpleNamespace` objects instead of booting full runtime state.
+- Assert on one behavior or contract at a time.
+- Include regression coverage for bug fixes.
+
+## CLI Tests
+
+- Always call the Cyclopts app with an explicit arg list, such as `app(["--help"])`.
+- Successful invocations raise `SystemExit(0)`; assert on that explicitly.
+- Use `capsys` and assert on stable plain-text substrings.
+- Prefer lightweight stubs/mocks for execution objects instead of full backend setup.
+
+Keep CLI tests focused on argument parsing, command dispatch, and rendered
+output, not unrelated runtime bootstrapping.
+
+## Example-Driven Tests
+
+`tests/test_phase*.py` tests are close to executable documentation. They prove
+that examples in `examples/` still work end to end.
+
+When adding or updating one:
+
+- import and call the example entrypoint directly
+- use `monkeypatch` to provide fake credentials or mock-response env vars
+- request `primed_zenml` when the flow genuinely executes
+- assert on persisted execution state, metadata, checkpoints, or artifacts, not
+  only a return value
+
+Good pattern: `tests/test_phase12_llm_example.py` registers a model alias,
+injects fake API credentials, runs the example flow, and inspects recorded
+metadata in ZenML.
+
+## Live Provider Tests
+
+Live provider tests live under `tests/live/` and are off by default. They are
+for trusted manual or scheduled runs, not normal PR CI.
+
+- Mark every live provider test with `@pytest.mark.live_llm` plus the provider
+  marker: `live_openai`, `live_anthropic`, or `live_gemini`.
+- `live_llm` by itself is invalid because it bypasses the deterministic
+  provider-call guard but is not selected by provider workflows.
+- Put slower or higher-cost checks under `@pytest.mark.provider_extended`.
+- Skip cleanly when the required key is absent.
+- The shared guard skips `live_openai` without `OPENAI_API_KEY`,
+  `live_anthropic` without `ANTHROPIC_API_KEY`, and `live_gemini` without
+  `GEMINI_API_KEY` or `GOOGLE_API_KEY`.
+- Keep prompts tiny and bounded.
+- Set max-turns or equivalent limits explicitly.
+- Do not add live provider tests to fork PR workflows.
+- Do not bypass the provider guard in deterministic tests; fake the provider or
+  patch Kitaru's local call point instead.
+
+## MCP Tests
+
+- Keep MCP-only fixtures in `tests/mcp/conftest.py`.
+- Use mocked `KitaruClient` namespaces unless the test truly needs deeper integration.
+- Verify both delegation and serialized payload shape.
+- Cover file/module loading behavior with `tmp_path` and
+  `monkeypatch.syspath_prepend(...)` rather than real project files.
+
+## Parallel Safety and Fixtures
+
+- no hidden dependence on cwd unless the test sets it up itself
+- no shared mutable module-level state
+- no assumptions about another test having already created config, stores, or env vars
+- no reliance on wall-clock ordering between tests
+
+Put fixtures in `tests/conftest.py` when many files need them, in
+`tests/mcp/conftest.py` when only MCP tests need them, and locally when only one
+file needs them.
+
+## Bug Fix Workflow
+
+Every bug fix should come with a regression test that would have caught the
+original problem:
+
+1. Write or update the test so it captures the broken behavior.
+2. Make the code change.
+3. Rerun the targeted test.
+4. Rerun the broader relevant suite.
+
+If you change code after running tests, run the tests again. Do not assume the
+earlier green run still counts.
+
+## Feature Completion Checklist
+
+When adding a new CLI command, MCP tool, or SDK feature:
+
+- Add a non-destructive invocation to `scripts/smoke-test.sh`, such as
+  `kitaru <command> --dry-run` or `kitaru <command> --help`.
+- When adding, removing, renaming, or publicly documenting an example under
+  `examples/`, update `examples/example-coverage.yaml` and run
+  `just example-coverage-audit`.
+- Check whether analytics coverage is needed. Add the event to
+  `AnalyticsEvent` and wire it into the appropriate surface.
+- If the CLI command is multi-word, add it to `_MULTI_TOKEN_COMMANDS` in `cli.py`.
+
+## Python CI
+
+`.github/workflows/ci.yml` runs on push/PR to `develop`. PR jobs run lint,
+format check, YAML check, typos, type check, dependency audit, link check, base
+tests on Python 3.11/3.12/3.13, and additional test lanes with `kitaru[mcp]`
+installed on Python 3.11/3.12.
+
+Push jobs also run Docker server smoke and wheel-packaging checks because those
+paths may need trusted UI release credentials.
+
+When changing Kitaru UI bundling, frontend smoke testing, Docker dashboard
+packaging, or release UI selection, read `FRONTEND-TESTING.md` first.
+
+## Docs CI
+
+`.github/workflows/docs.yml` runs on manual dispatch, `main` pushes, and PRs
+touching docs/reference-related inputs such as `docs/**`, docs generation
+scripts, SDK source, `CHANGELOG.md`, `pyproject.toml`, `uv.lock`, or Wrangler
+config.
+
+It regenerates CLI/SDK reference docs and builds the FumaDocs static export on
+all runs. It deploys `sdkdocs.kitaru.ai` and the `kitaru.ai/docs` redirect
+worker only on `main` push or manual dispatch. PRs build only and do not create
+preview Workers. Hand-written docs publish separately through GitBook Git Sync.
+Marketing site deployment is handled from `zenml-io-v2`.
+
+## Other Workflows
+
+- `release.yml`: release automation for version bump, PyPI publish, Docker
+  image publish, and GitHub Release. Do not add live provider calls here.
+- `llm-integration.yml`: trusted weekly/manual live OpenAI/Anthropic provider
+  checks. It has only `schedule` and `workflow_dispatch` triggers, runs paid
+  tests outside PR CI, can target an exact ref/SHA, uploads logs/results only,
+  and sends compact Discord failure alerts via `DISCORD_WEBHOOK_SRE`.
+- `spellcheck.yml`: typo/spell checking on `develop` pushes and non-draft PRs.
+- `image-optimiser.yml`: PR-only compression for changed JPG/JPEG/PNG/WebP
+  files in same-repo non-draft PRs.
+- `zizmor.yml`: GitHub Actions security analysis for workflow/dependabot changes,
+  plus weekly and manual runs.
+
+## Branching and Releases
+
+- Default branch is `develop`.
+- All PRs target `develop`.
+- `main` tracks the latest released version only; do not push directly.
+- Releases are cut via the Release workflow: `workflow_dispatch` on `develop`
+  or `v*` tag push.
+- Release branches (`release/X.Y.Z`) and tags (`vX.Y.Z`) are created automatically.
+- Version is maintained in `pyproject.toml` and bumped by the release workflow.
+  Never hardcode it; use `importlib.metadata.version("kitaru")`.
+- Update `CHANGELOG.md` under `[Unreleased]` when making user-facing changes.
+
+Before release dispatch, check `.github/workflows/llm-integration.yml`. A weekly
+green run on `develop` is a canary, not exact release evidence. If OpenAI or
+Anthropic adapter/example behavior changed, trigger a manual
+`llm-integration.yml` run for the exact release ref or SHA and require it to
+pass, or record an explicit waiver in the release conversation. Gemini remains
+local release-smoke evidence or waiver for v1.
+
+## Release Smoke
+
+Before releasing, run release-grade smoke with structured output:
+
+```bash
+./scripts/smoke-test.sh --release --json-out smoke-results.json
+```
+
+Add repeatable `--required-provider-area <area>` flags for changed
+provider-backed behavior: `openai`, `anthropic`, `gemini-model`,
+`gemini-antigravity`, `google-adk`, or `research-bot`.
+
+For normal runtime releases, also opt into remote-stack smoke with
+operator-provided private config: `--remote-stack-smoke` or
+`KITARU_REMOTE_SMOKE=1`. Docs-only or no-runtime releases may record an explicit
+waiver instead.
+
+Bare `./scripts/smoke-test.sh` remains useful for local development, but it is
+not enough release evidence for provider- or remote-stack-relevant changes.
+Use `-s` to skip reinstall and `-k` to keep the server running afterward.

--- a/.gitignore
+++ b/.gitignore
@@ -258,6 +258,12 @@ src/kitaru/_ui/bundle_manifest.json
 !.codex/skills/
 AGENTS.override.md
 .agents/skills/*
+!.agents/skills/kitaru-dev/
+!.agents/skills/kitaru-dev/**
+!.agents/skills/kitaru-docs/
+!.agents/skills/kitaru-docs/**
+!.agents/skills/kitaru-tests-release/
+!.agents/skills/kitaru-tests-release/**
 
 # Agent Skills
 .pi/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,209 +1,174 @@
 # Repository Guidelines
 
-## Project Structure
+Kitaru is a mixed Python + docs repo. It produces the Python SDK package and
+the SDK/CLI reference docs app. The public marketing site and `kitaru.ai`
+runtime live in the sibling `zenml-io-v2` repository, not here.
 
-Kitaru is a **mixed Python + docs repo** that produces two things: a Python SDK package and the Kitaru documentation app. The marketing landing page and public `kitaru.ai` runtime now live in the sibling `zenml-io-v2` repository.
+## Project Map
 
-```
-src/kitaru/           # Python SDK package (src layout)
-  cli.py              # CLI facade / console entrypoint (cyclopts)
-  _cli/               # Internal command modules + shared CLI helpers
-  adapters/           # Framework adapters (includes PydanticAI and OpenAI Agents)
-  mcp/                # MCP server tools (optional `kitaru[mcp]` extra)
-tests/                # pytest tests
-tests/mcp/            # MCP-specific tests (runs in `[mcp]` CI path)
-examples/             # Runnable SDK examples
-docs/                 # Two docs surfaces — see "Documentation surfaces" below
-  book/               # GitBook source for docs.zenml.io/kitaru (hand-written .md)
-  content/docs/       # FumaDocs SDK+CLI reference content (generated cli/ + reference/)
-  scripts/            # Node-side doc generation (convert-sdk-docs.mjs)
-  app/                # Next.js app routes for the sdkdocs.kitaru.ai reference site
-  worker/             # Cloudflare worker: redirect.mjs (kitaru.ai/docs) + routing maps
-scripts/              # Doc generation, smoke test, and UI bundle scripts
-FRONTEND-TESTING.md   # Internal runbook for Kitaru UI bundle/frontend testing
-                         and stable/prerelease release validation
-docker/               # Dockerfiles (production server, server-dev, and dev flow images)
-design/               # Design docs, meeting notes (gitignored, never commit)
-```
+- `src/kitaru/`: Python SDK package (`src` layout)
+- `src/kitaru/cli.py`: thin CLI facade / console entrypoint
+- `src/kitaru/_cli/`: Cyclopts command implementations and shared helpers
+- `src/kitaru/adapters/`: framework adapters
+- `src/kitaru/mcp/`: optional MCP server tools
+- `tests/`: pytest suite; see `tests/AGENTS.md` when working there
+- `examples/`: runnable SDK examples
+- `docs/book/`: hand-written GitBook docs; see `docs/book/AGENTS.md`
+- `docs/content/docs/`: generated SDK + CLI reference content
+- `docs/app/`, `docs/scripts/`, `docs/worker/`: reference app, generation, and redirect worker code
+- `scripts/`: doc generation, smoke tests, and UI bundle scripts
+- `docker/`: production, server-dev, and dev-flow Dockerfiles
+- `design/`: gitignored design notes; never commit anything from this directory
 
-### Documentation surfaces
+For the full project map, docs routing, command catalog, CI/release details, and
+task-specific runbooks, load the Kitaru repo skills under `.agents/skills/`.
 
-Kitaru docs live on three surfaces — know which one a task touches:
+## Core Commands
 
-1. **Hand-written docs → GitBook.** Concepts, guides, adapters, getting-started, etc. are plain Markdown in **`docs/book/`**, published to **`docs.zenml.io/kitaru`** via GitBook Git Sync. Edit those `.md` directly; nav is `docs/book/toc.md`, config is `docs/book/.gitbook.yaml`, authoring conventions are in `docs/book/AGENTS.md`.
-2. **Generated SDK + CLI reference → `sdkdocs.kitaru.ai`.** The FumaDocs app in `docs/` is now reference-only (generated `content/docs/cli/` + `content/docs/reference/python/` + a landing). Built/deployed to the `kitaru-sdkdocs` worker (root `wrangler.toml`). See `docs/CLAUDE.md`.
-3. **`kitaru.ai/docs` → redirects.** The `kitaru-site` worker (`docs/worker/redirect.mjs`, `wrangler.redirect.toml`) 301-redirects old `kitaru.ai/docs/*` URLs to GitBook / `sdkdocs.kitaru.ai` / the changelog.
-
-Do not add hand-written pages to the FumaDocs app (`docs/content/docs/`) — they belong in `docs/book/`. The public changelog is owned by the changelog repo (`docs.zenml.io/changelog`); this repo may still generate a gitignored `docs/content/docs/changelog.mdx` for local/reference builds, but agents should not hand-edit or commit it.
-
-The public marketing/runtime site for Kitaru now lives in `zenml-io-v2`. If a task involves Astro pages, public site assets, marketing Cloudflare Pages deployment, or runtime web APIs such as waitlist/get-started/newsletter endpoints, switch to that repository instead of adding that code back here.
-
-## Build, Test, and Development Commands
-
-Use `uv` for Python dependency management and `just` as the command stack.
-
-### Python workflows
+Use `uv` for Python dependency management and `just` for the normal command
+stack.
 
 - `uv sync`: install and sync dependencies
-- `uv sync --extra local`: install with local ZenML runtime components
-- `uv run kitaru init`: **required in a fresh `git worktree`.** Creates the `.kitaru/` project marker that ZenML's dynamic pipeline resolver needs to re-import example modules by dotted path. Without it, ~14 `test_phase*_example::*_runs_end_to_end` tests fail with `RuntimeError: Unable to resolve dynamic pipeline source`. Worktrees do not inherit `.kitaru/` from the main checkout.
-- **Lockfile merge caution:** when merging `develop` into a feature branch and resolving `pyproject.toml` / `uv.lock`, do not assume a broad `uv lock` preserves recent dependency-security fixes. Check recent commits touching `uv.lock` / `.github/pip-audit-ignored.txt`, use targeted commands such as `uv lock --upgrade-package <package>` when a package was intentionally bumped, and run `just audit` before pushing.
-
-**Core dev loop — these three commands handle the vast majority of development needs:**
-
-| Command | What it does | When to run |
-|---|---|---|
-| **`just check`** | All checks: format, lint, typecheck, typos, yaml, actions lint, links | After every chunk of work, before commit/push |
-| **`just fix`** | Auto-fixes formatting, lint issues, yaml | When `just check` reports fixable issues — resolves most linting problems automatically |
-| **`just test`** | Full pytest suite | After code changes, before commit/push |
-
-**Typical loop:** write code → `just fix` → `just check` → `just test` → commit.
-
-- `just test tests/test_file.py::test_name`: run one test
-- **Agent tip:** the full suite takes ~4 minutes. When running it through a pager or any stream that may truncate output, pipe through grep so the failure names survive the truncation: `just test 2>&1 | grep -E "FAILED|ERROR|passed|failed" | tail -20`. This keeps the PASS/FAIL summary and every `FAILED` line without forcing a rerun just to recover the list.
-- `just lint`: lint only
-- `just typecheck`: type check only
-- `just typos`: typo check only
-- `just format-check`: check formatting without modifying
-- `just yaml-check`: check YAML formatting
-- `just actions-lint`: lint GitHub Actions workflows (requires `actionlint`: `brew install actionlint`)
-- `just zizmor`: audit GitHub Actions workflow security with `zizmor`
-- `just audit`: audit Python dependencies with `pip-audit` and the documented ignore list
-- `just links`: check markdown links offline (requires `lychee`: `brew install lychee`)
-- `just links-external`: check links including external URLs (slow)
-- `just example-coverage-audit`: validate `examples/example-coverage.yaml` against public example docs, referenced tests/smoke/provider metadata, and explicit waivers for `missing`, `planned`, or `manual_only` coverage. Audit-only: it does not run examples or call providers, so a pass means the metadata is honest and internally consistent, not that every example executed.
+- `uv sync --extra local`: install local ZenML runtime components
+- `uv run kitaru init`: required in a fresh `git worktree`; without `.kitaru/`,
+  example-driven flow tests can fail because the dynamic pipeline source cannot
+  be resolved
+- `just fix`: auto-fix formatting, lint, and YAML issues
+- `just check`: run format, lint, typecheck, typos, YAML, actions lint, and links
+- `just test`: run the full pytest suite
+- `just test tests/test_file.py::test_name`: run one targeted test
 - `just build`: build wheel and sdist locally
 
-### Docs workflows
+Typical loop: write code -> `just fix` -> `just check` -> `just test`.
 
-These require Node 22+ and pnpm.
+When running the full suite through output that may truncate, preserve the
+failure names:
 
-- `just generate-docs`: generate CLI reference + changelog + SDK reference docs
-- `just docs`: preview docs locally (dev server at localhost:3000)
-- `just docs-build`: build docs static export
-- `just docs-validate`: validate the static export as served under `/docs`
+```bash
+just test 2>&1 | grep -E "FAILED|ERROR|passed|failed" | tail -20
+```
 
-## Coding Style & Naming Conventions
+Docs commands, release smoke commands, and the full command catalog live in the
+`kitaru-dev` skill.
+
+## Coding Style
 
 - Follow US English spelling in code and docs (`initialize`, `serialize`, `color`).
-- Use type hints on all public functions and return values.
+- Use type hints on public functions and return values.
 - Prefer modern annotations (`list[str]`, `str | None`) over legacy `typing` aliases.
-- **Do not use `from __future__ import annotations` in files that define Kitaru `@flow`/`@checkpoint` functions or ZenML `@pipeline`/`@step` functions.** ZenML inspects step output annotations at runtime and currently rejects postponed/string annotations such as `"dict[str, Any]"`. Use real runtime annotations instead; Python 3.11+ supports `list[str]` / `str | None` without the future import.
+- Do not use `from __future__ import annotations` in files that define Kitaru
+  `@flow`/`@checkpoint` functions or ZenML `@pipeline`/`@step` functions. ZenML
+  inspects step output annotations at runtime and currently rejects postponed
+  string annotations such as `"dict[str, Any]"`.
 - Follow Google Python style for docstrings.
-- Keep comments focused on *why* (intent/trade-offs), not line-by-line narration.
-- Treat leading underscore names as private to module/class boundaries.
+- Keep comments focused on why the code exists or why a trade-off was chosen.
+- Treat leading underscore names as private to their module or class.
 - Prefer Protocols/ABCs or `isinstance` over `getattr`/`hasattr` for capability checks.
-- Put helpers on the class when tied to its behavior; use standalone utils only for generic cross-module functions.
+- Put helpers on the class when tied to its behavior; use standalone utilities
+  only for generic cross-module functions.
 - Prefer Pydantic models for data structures; checkpoint return values must be serializable.
 
 ## CLI
 
-The `kitaru` console script is defined in `pyproject.toml` under `[project.scripts]`. `src/kitaru/cli.py` is the thin facade / entrypoint, while command implementations live in `src/kitaru/_cli/`. Add new subcommands in the appropriate `src/kitaru/_cli/_*.py` module and register them on the shared Cyclopts app there. When testing CLI commands, always pass an explicit arg list (`app(["--help"])`, not bare `app()`). CLI invocations raise `SystemExit(0)` on success.
+The `kitaru` console script is defined in `pyproject.toml` under
+`[project.scripts]`. `src/kitaru/cli.py` is the facade; command implementations
+live in `src/kitaru/_cli/`.
 
-Agent-facing commands should keep the shared `--output json` / `-o json` contract consistent:
-- single-item commands emit `{command, item}`
-- list commands emit `{command, items, count}`
-- `kitaru executions logs --follow --output json` emits JSONL event objects instead of one final document
-- Document login consistently: bare `kitaru login` starts the local server, while `kitaru login <server>` is the remote-login path. Local server support requires the `kitaru[local]` extra.
+- Add new subcommands in the appropriate `src/kitaru/_cli/_*.py` module and
+  register them on the shared Cyclopts app there.
+- When testing CLI commands, always pass an explicit arg list such as
+  `app(["--help"])`; do not call bare `app()`.
+- CLI invocations raise `SystemExit(0)` on success.
+- Keep the shared `--output json` / `-o json` contract consistent.
 
-### Diagnostics and cleanup
+For detailed CLI output contracts, diagnostics commands, cleanup behavior, and
+analytics wiring, load the `kitaru-dev` skill.
 
-- `kitaru info` shows a multi-section diagnostic overview (connection, config provenance, connection sources, system info). Use `--all` for a full dump including all installed packages and environment type. Use `--file debug.json` (or `.yaml`) to export diagnostics to a file (environment variable secrets are masked).
-- `kitaru clean project|global|all` resets Kitaru state. The `project` subcommand removes `.kitaru/`, `global` removes the global config directory (with auto-backup and local server teardown), and `all` does both. Use `--dry-run` to preview, `--force` when model registry aliases exist (global/all only). The `clean` command is bootstrap-safe — it works even when the store is broken.
+## Testing
 
-## Testing Guidelines
+Use `pytest` for unit and integration tests. Name files `test_*.py` and test
+functions `test_*`. Mirror source paths where practical. Every bug fix should
+include a regression test that fails before the fix and passes after it.
 
-Use `pytest` for unit and integration tests. Name files `test_*.py` and test functions `test_*`. Mirror source paths (example: `src/kitaru/runtime.py` -> `tests/test_runtime.py`). Every bug fix should include a regression test that fails before the fix and passes after it.
+Default pytest runs exclude live provider checks via `-m 'not live_llm'`. Tests
+that call OpenAI, Anthropic/Claude, Gemini, or similar paid/external providers
+must live under `tests/live/`, carry `live_llm` plus the provider-specific
+marker, use short bounded prompts, and skip cleanly when credentials are absent.
+The shared provider-spend guard in `tests/conftest.py` blocks accidental
+provider calls from deterministic tests while allowing localhost/Kitaru/ZenML
+local traffic.
 
-Default pytest runs exclude live provider checks via `-m 'not live_llm'`. Tests that call OpenAI, Anthropic/Claude, Gemini, or similar paid/external providers must live under `tests/live/`, carry `live_llm` plus the provider-specific marker, use short bounded prompts, and skip cleanly when credentials are absent. The shared provider-spend guard in `tests/conftest.py` blocks accidental provider calls from deterministic tests while allowing localhost/Kitaru/ZenML local traffic.
+When you work under `tests/`, also read `tests/AGENTS.md`. For test design
+patterns, fixture guidance, CI, and release checks, load the
+`kitaru-tests-release` skill.
 
-## Analytics Instrumentation
+## Docs
 
-Kitaru collects anonymous usage analytics for opted-in users. When adding new features, discuss analytics coverage with the core team to decide what should be tracked.
+Kitaru docs live on three different surfaces:
 
-- All event names must be added to the `AnalyticsEvent` enum in `src/kitaru/analytics.py`.
-- Track only non-sensitive metadata (event names, boolean flags, enum values, counts). Never include user content, file paths, prompts, or secret values.
-- Follow the existing patterns for each surface:
-  - **CLI:** feature events via `track()` in subcommand handlers (`src/kitaru/_cli/`).
-  - **MCP:** `@tracked_mcp_tool` decorator in `src/kitaru/mcp/server.py`.
-  - **Core SDK:** `track(AnalyticsEvent.X, {...})` at lifecycle points in the relevant module.
-- All `track()` calls must fail silently — never break user-facing functionality for analytics.
+- Hand-written docs are GitBook Markdown in `docs/book/`, published to
+  `docs.zenml.io/kitaru`.
+- Generated SDK + CLI reference docs live under `docs/content/docs/` and are
+  served at `sdkdocs.kitaru.ai`.
+- `kitaru.ai/docs/*` is handled by the redirect worker under `docs/worker/`.
 
-## Commit & Pull Request Guidelines
+Do not add hand-written pages to the FumaDocs app under `docs/content/docs/`;
+they belong in `docs/book/`. Do not hand-edit generated CLI or SDK reference
+output. If generated CLI reference syntax is wrong, fix
+`scripts/generate_cli_docs.py` and/or the relevant `src/kitaru/_cli/_*.py`
+module.
 
-Use short, imperative subjects (for example: `Add ...`, `Update ...`, `Create ...`). Keep commit titles concise (about 50 chars), and explain any important or useful implementation details (esp those relating to 'why' choices were made) in the commit body message.
+Only document shipped features. Users should not need to know Kitaru is built
+on ZenML: use Kitaru terms such as workflow, checkpoint, and storage instead of
+ZenML terms such as orchestrator, artifact store, pipeline, or step.
 
-For pull requests, use a clear human-readable title and include:
-- what changed
-- why it was needed
-- key implementation decisions
-- reviewer focus areas
+For docs URLs, GitBook authoring, stack docs, environment variable docs, model
+registry docs, and example README rules, load the `kitaru-docs` skill.
 
-Link related issues (for example `Fixes #123`) when applicable.
+## Analytics
 
-Never include a "[Codex] " prefix to PR titles.
+Kitaru collects anonymous usage analytics for opted-in users. Track only
+non-sensitive metadata: event names, boolean flags, enum values, and counts.
+Never include user content, file paths, prompts, or secret values.
 
-Every PR description should include a "Reviewer Notes" H2 or H3 section. Treat that section as a narrative guide for a human reviewer, not a file-by-file checklist:
-- Start with the story of the change: where the important behavior now happens, what used to go wrong, and what would break if the implementation is wrong.
-- Point reviewers toward the genuinely tricky or high-risk areas. Mention files only when the file name helps the story, and explain what to inspect there.
-- Include a concrete "Reproduction" subsection either inside Reviewer Notes or immediately after it. Prefer an example, CLI flow, or UI path that proves the behavior end to end. For example: run a specific `examples/...` script, then open the UI or run `kitaru executions list` / `kitaru executions logs` and describe the exact thing the reviewer should see.
-- Do not use a standalone "Verification" section as a substitute for reproduction when it only says `just check`, `just test`, or `/simplify`. Those commands are useful local hygiene, but they do not tell the reviewer how to see the feature or bug fix. If they are worth mentioning, keep them as a short "Local checks run" note after the reproduction steps.
+All event names must be added to the `AnalyticsEvent` enum in
+`src/kitaru/analytics.py`. All `track()` calls must fail silently and must never
+break user-facing functionality. For wiring patterns by surface, load the
+`kitaru-dev` skill.
 
-### Feature completion checklist
+## Git, Commits, and PRs
 
-When adding a new CLI command, MCP tool, or SDK feature:
+- Default branch is `develop`; all PRs target `develop`.
+- `main` tracks the latest released version only; do not push directly.
+- Use short, imperative commit subjects such as `Add ...` or `Update ...`.
+- Keep commit titles concise, around 50 characters when practical.
+- Never include a `[Codex] ` prefix in PR titles.
+- Link related issues when applicable.
+- Every PR description should include a `Reviewer Notes` H2 or H3 section with
+  a concrete reproduction path for reviewers.
 
-- **Smoke test**: add a non-destructive invocation to `scripts/smoke-test.sh` (e.g. `kitaru <command> --dry-run` or `kitaru <command> --help`). The smoke test runs before every release, so new features should be exercised there to catch regressions.
-- **Example coverage manifest**: when adding, removing, renaming, or publicly documenting an example under `examples/`, update `examples/example-coverage.yaml` and run `just example-coverage-audit`. The manifest records coverage status and required waivers only; it is not an example runner, so manual-only or missing coverage remains a release-review item.
-- **Analytics**: check whether the feature needs a tracking event. Add the event to `AnalyticsEvent` in `src/kitaru/analytics.py` and wire it into the appropriate surface (CLI handler via `track()`, MCP tool via `@tracked_mcp_tool`, or SDK lifecycle point). If the CLI command is multi-word (e.g. `clean project`), add it to `_MULTI_TOKEN_COMMANDS` in `cli.py`.
+For the detailed PR-description format, feature completion checklist, release
+branch behavior, and release smoke requirements, load the `kitaru-tests-release`
+skill.
 
 ## CI/CD
 
-### Python CI (`ci.yml`)
+Python CI runs on push/PR to `develop`; docs CI runs for docs/reference-related
+changes. Do not add live provider calls to PR CI or `release.yml`; provider
+validation belongs in `.github/workflows/llm-integration.yml` or release smoke
+with explicit credentials and waivers.
 
-Runs on push/PR to `develop`. PR jobs run lint + format check + yaml check, typos, type check, dependency audit, link check, base tests (Python 3.11 + 3.12 + 3.13), and additional test lanes with `kitaru[mcp]` installed (3.11 + 3.12). Push jobs also run Docker server smoke and wheel-packaging checks, because those paths may need trusted UI release credentials.
+When changing Kitaru UI bundling, frontend smoke testing, Docker dashboard
+packaging, or release UI selection, read `FRONTEND-TESTING.md` first.
 
-When changing Kitaru UI bundling, frontend smoke testing, Docker dashboard packaging, or release UI selection, read `FRONTEND-TESTING.md` first. It is the runbook for stable vs prerelease `kitaru-ui-v*` bundle testing and the trusted-event/token boundaries.
+For workflow inventory and release evidence rules, load the `kitaru-tests-release`
+skill.
 
-### Docs CI (`docs.yml`)
+## Security and Generated Files
 
-Runs on manual dispatch, `main` pushes, and PRs touching `docs/**`, docs generation scripts, SDK source, `CHANGELOG.md`, `pyproject.toml`, `uv.lock`, or Wrangler config. It regenerates the CLI/SDK reference and builds the FumaDocs static export on all runs. It deploys the **SDK+CLI reference site to `sdkdocs.kitaru.ai`** (worker `kitaru-sdkdocs`) plus the **`kitaru.ai/docs` redirect worker** (`kitaru-site`, `wrangler.redirect.toml`) only on `main` push or manual dispatch; PRs build only and do not create preview Workers. Hand-written docs (`docs/book/`) publish separately to `docs.zenml.io/kitaru` via GitBook Git Sync (not this workflow). Marketing site deployment is handled from `zenml-io-v2`.
+Do not commit local secrets, `.env` files, or anything in `design/`. Use `uv`,
+not raw `pip`, for dependency management to keep environments reproducible.
 
-### Other workflows
-
-- `release.yml`: release automation (version bump, PyPI publish, Docker image publish, GitHub Release). Do not add live provider calls here; provider validation happens before release dispatch.
-- `llm-integration.yml`: trusted weekly/manual live OpenAI/Anthropic provider checks. It has only `schedule` and `workflow_dispatch` triggers, runs paid tests outside PR CI, can target an exact ref/SHA, uploads logs/results only, and sends a compact Discord failure alert via `DISCORD_WEBHOOK_SRE`. Its secret-bearing jobs use the GitHub Environment `live-provider-tests`; configure `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `DISCORD_WEBHOOK_SRE` as Environment secrets there, with `kitaru-admins` approval/restrictions.
-- `spellcheck.yml`: separate typo/spell checking on `develop` pushes and non-draft PRs
-- `image-optimiser.yml`: PR-only compression for changed JPG/JPEG/PNG/WebP files in same-repo non-draft PRs
-- `zizmor.yml`: GitHub Actions security analysis for workflow/dependabot changes, plus weekly and manual runs
-
-## Branching and Release Strategy
-
-- Default branch is `develop`. All PRs target `develop`.
-- `main` tracks the latest released version only; do not push directly.
-- Before releasing, run release-grade smoke with structured output: `./scripts/smoke-test.sh --release --json-out smoke-results.json` plus repeatable `--required-provider-area <area>` flags for any changed provider-backed behavior (`openai`, `anthropic`, `gemini-model`, `gemini-antigravity`, `google-adk`, `research-bot`). For normal runtime releases, also opt into remote-stack smoke with operator-provided private config (`--remote-stack-smoke` / `KITARU_REMOTE_SMOKE=1`) to prove one Kubernetes-backed stack and one local-runner stack with remote artifact storage; docs-only/no-runtime releases may record an explicit waiver instead. Bare `./scripts/smoke-test.sh` remains useful for local development, but it is not enough to prove a provider- or remote-stack-relevant release because skipped provider checks and remote smoke opt-in do not fail outside the release policy. Use `-s` to skip reinstall, `-k` to keep the server running afterward. Set the relevant provider credentials, remote stack config, and opt-in env vars before marking provider or remote-stack areas covered.
-- Also check `.github/workflows/llm-integration.yml` before release dispatch. A weekly green run on `develop` is a canary that provider paths are generally healthy; it is not exact release evidence. If OpenAI or Anthropic adapter/example behavior changed, trigger a manual `llm-integration.yml` run for the exact release ref or SHA and require it to pass, or record an explicit waiver in the release conversation. Gemini remains local release-smoke evidence or waiver for v1.
-- Releases are cut via the Release workflow (`workflow_dispatch` on `develop` or `v*` tag push).
-- Release branches (`release/X.Y.Z`) and tags (`vX.Y.Z`) are created automatically.
-- Version is maintained in `pyproject.toml` and bumped by the release workflow. Never hardcode it — use `importlib.metadata.version("kitaru")`.
-- Update `CHANGELOG.md` under `[Unreleased]` when making user-facing changes.
-## Docs Content Rules
-
-- **Only document shipped features.** No "Coming Soon" sections.
-- **ZenML invisibility:** users should never need to know Kitaru is built on ZenML. Use Kitaru terminology (workflow, checkpoint, storage), not ZenML terms (orchestrator, artifact store, pipeline).
-- **Where to edit:** hand-written docs are GitBook Markdown in **`docs/book/`** (see `docs/book/AGENTS.md`) — add new pages there and to `docs/book/toc.md`. The FumaDocs app under `docs/content/docs/` is reference-only and **fully generated** (CLI + SDK); do not hand-edit it. SDK reference still uses a two-step pipeline: `scripts/generate_sdk_docs.py` (Python → JSON) then `docs/scripts/convert-sdk-docs.mjs` (JSON → MDX via fumadocs-python).
-- **Docs URL references:** inside `docs/book/`, link to sibling pages with relative `.md` paths (e.g. `../concepts/checkpoints.md`, `flows.md#runtime-options`). Link to the SDK/CLI reference with `https://sdkdocs.kitaru.ai`, to other ZenML docs with absolute `https://docs.zenml.io/...`, and to diagrams with `https://assets.kitaru.ai/docs/diagrams/<slug>.png`.
-- **Planning artifacts stay untracked:** do not commit temporary agent planning/review files such as `docs/plans/*`, `docs/reviews/*`, or prompt exports unless the user explicitly asks for a durable tracked document. These are coordination scratchpads, not product docs.
-- **Secret docs accuracy:** only `kitaru.llm()` auto-resolves alias-linked secrets today. If you need to document non-LLM secret access, label it clearly as the current low-level pattern instead of implying there is already a dedicated Kitaru secret getter.
-- **CLI docs source of truth:** if generated CLI reference syntax is wrong, fix `scripts/generate_cli_docs.py` and/or the relevant `src/kitaru/_cli/_*.py` module (use `src/kitaru/cli.py` only for facade/bootstrap issues), never the generated `docs/content/docs/cli/*` output.
-- **Stack docs accuracy:** current shipped stack-create types on CLI/MCP are `local`, `kubernetes`, `vertex`, `sagemaker`, and `azureml`. Advanced CLI/MCP stack creation also supports `--extra` / structured `extra` plus the remote-only `--async` / `async_mode` convenience flag. The public Python SDK `kitaru.create_stack(...)` remains local-only, so docs should keep that distinction explicit.
-- **Environment-variable docs:** document `KITARU_*` env vars as the public surface. Mention `ZENML_*` only as a compatibility note when necessary to explain migration or interop.
-- **Model-registry docs:** `kitaru model register` still writes aliases to local config, but submitted/replayed runs automatically receive a transported registry snapshot via `KITARU_MODEL_REGISTRY`. `kitaru model list` should be described as listing aliases available in the current environment, not just aliases stored locally.
-- **Frontmatter required:** every `.mdx` page needs `title` and `description`.
-- **Example READMEs are user-facing, not contributor-facing:** `examples/**/README.md` files exist to teach new users what Kitaru does and walk them through the specific example. Keep them focused on concepts, the primitives used, and how to run the example. Do **not** add maintainer-oriented sections such as "Testing" (internal test commands), CI-only credential setup, or notes about how stubbed/mocked test runs work — those are implementation details for the Kitaru team and belong in `tests/`, contributor docs, or PR descriptions. If a section would not help a first-time user understand Kitaru, it does not belong in an example README.
-
-## Security & Configuration Notes
-
-Do not commit local secrets, `.env` files, or anything in `design/`. Use `uv` (not raw `pip`) for dependency management to keep environments reproducible.
-
-Do not commit RepoPrompt/orchestration scratch documents such as plans, reviews, handoffs, or prompt exports. In particular, do not add `docs/plans/*.md`, `docs/reviews/*.md`, `docs/investigations/*.md`, `prompt-exports/*.md`, or ad-hoc handoff Markdown files unless the user explicitly asks for that artifact to be part of the repository history.
+Do not commit RepoPrompt/orchestration scratch documents such as plans, reviews,
+handoffs, prompt exports, or ad-hoc coordination docs unless the user explicitly
+asks for that artifact to be part of repository history.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,59 +1,43 @@
 # Test Suite Guidelines
 
-This file applies to everything under `tests/`. It supplements the repo-root `AGENTS.md` with test-specific guidance. When there is no conflict, follow both documents.
+This file applies to everything under `tests/`. It supplements the repo-root
+`AGENTS.md`; when there is no conflict, follow both documents.
 
 ## What Lives Here
 
-The test suite mixes a few different layers of coverage:
-
-- `tests/test_*.py`: unit, contract, and integration tests for the Python SDK and CLI
-- `tests/test_phase*.py`: example-driven end-to-end tests that exercise the runnable flows in `examples/`
+- `tests/test_*.py`: unit, contract, and integration tests for the SDK and CLI
+- `tests/test_phase*.py`: example-driven end-to-end tests for runnable flows in `examples/`
 - `tests/mcp/test_*.py`: MCP-specific tests for the optional `kitaru[mcp]` surface
-- `tests/live/test_*.py`: paid/external provider checks, always marked `live_llm` plus a provider-specific marker and excluded from default pytest runs
-- `tests/conftest.py`: the shared isolation harness for Kitaru + ZenML state and provider-call guard
+- `tests/live/test_*.py`: paid/external provider checks, always marked
+  `live_llm` plus a provider-specific marker and excluded from default pytest runs
+- `tests/conftest.py`: shared isolation harness and provider-call guard
 - `tests/mcp/conftest.py`: MCP-only fixtures and sample objects
 
-When adding a new test file, mirror the source area it protects where possible. Examples:
-
-- `src/kitaru/runtime.py` -> `tests/test_runtime.py`
-- `src/kitaru/_cli/_stacks.py` -> `tests/test_cli.py` or a focused CLI test file if it grows too large
-- `src/kitaru/mcp/server.py` -> `tests/mcp/test_server.py`
+When adding a new test file, mirror the source area it protects where possible.
+For example, `src/kitaru/runtime.py` maps naturally to `tests/test_runtime.py`.
 
 ## Running Tests
 
-Use the repo-level commands from the project root:
+Run tests from the repo root:
 
-- `just test`: run the whole suite
-- `just test tests/test_runtime.py`: run one file
-- `just test tests/test_runtime.py::test_name`: run one test
-- `just check`: run the required formatting, lint, type, typo, YAML, actionlint, and link checks
+- `just test`: whole default suite
+- `just test tests/test_runtime.py`: one file
+- `just test tests/test_runtime.py::test_name`: one test
+- `just check`: formatting, lint, type, typo, YAML, actionlint, and link checks
 
-Important repo defaults:
+Default pytest uses `-vv -n auto -m 'not live_llm'`, so tests must be safe under
+parallel execution. If a failure looks timing- or isolation-related, rerun it
+serially with `just test -n 0 tests/...`.
 
-- `pytest` is configured with `-vv -n auto -m 'not live_llm'`, so default runs are deterministic and tests should be safe under `xdist`
-- `pythonpath = ["scripts"]`, so tests may import helpers from `scripts/` without ad hoc path hacks
-- live provider tests are selected explicitly, for example `uv run pytest -m live_openai`, `uv run pytest -m live_anthropic`, or `uv run pytest -m "live_llm and not provider_extended"`. In GitHub, those checks belong in `.github/workflows/llm-integration.yml` only; do not wire them into PR CI or `release.yml`.
-
-Useful debugging pattern:
-
-- If a failure looks timing- or isolation-related, rerun it serially with `just test -n 0 tests/...`
-
-Extra installation notes:
-
-- base suite: `uv sync`
-- tests that execute real local Kitaru/ZenML flows often assume `uv sync --extra local`
-- MCP tests assume `uv sync --extra mcp`
+Use `uv sync` for the base suite. Tests that execute real local Kitaru/ZenML
+flows often assume `uv sync --extra local`; MCP tests assume `uv sync --extra mcp`.
 
 ## Shared Isolation Rules
 
-`tests/conftest.py` is the heart of the safety story. It does four important things before tests run:
-
-1. clears Kitaru- and ZenML-related environment variables that could leak in from a developer machine
-2. redirects config and home-directory lookups into `tmp_path`
-3. resets global Kitaru and ZenML client/config singletons between tests
-4. blocks accidental provider calls from unmarked tests while still allowing localhost/Kitaru/ZenML local traffic
-
-That means the suite is designed to avoid touching a real local config directory, real user state, or paid provider APIs during default runs. Keep it that way. When you need exact fixture names, config paths, provider markers, or the environment-variable denylist, read `tests/conftest.py` and `tests/mcp/conftest.py`; this file intentionally keeps the rule at a higher level.
+`tests/conftest.py` protects local state before tests run. It clears Kitaru and
+ZenML environment variables, redirects config/home lookups into `tmp_path`,
+resets global clients/config singletons, and blocks accidental provider calls
+from unmarked deterministic tests.
 
 When writing new tests:
 
@@ -61,105 +45,24 @@ When writing new tests:
 - use `monkeypatch` for env vars and process-global state
 - prefer test-local fixtures or helpers over hidden module-level state
 - do not rely on execution order
+- do not bypass the provider guard in deterministic tests; fake the provider or
+  patch Kitaru's local call point instead
 
-## `primed_zenml` Fixture
+## Live Provider Tests
 
-`primed_zenml` eagerly initializes the ZenML store. Think of it like starting the engine before a road test: useful for tests that genuinely drive the system, but unnecessary overhead for tests that only inspect one component on the workbench.
+Live provider tests live under `tests/live/` and are off by default. They are
+for trusted manual or scheduled runs, not normal PR CI.
 
-Use `primed_zenml` only when the test:
+- Mark every live provider test with `@pytest.mark.live_llm` plus exactly the
+  provider marker it needs, such as `live_openai`, `live_anthropic`, or
+  `live_gemini`.
+- Use `@pytest.mark.provider_extended` for slower or higher-cost checks.
+- Skip cleanly when required credentials are absent.
+- Keep prompts tiny and set max-turns or equivalent limits explicitly.
+- Do not add live provider tests to fork PR workflows.
 
-- actually runs a flow
-- uses `KitaruClient` against real local state
-- spawns threads or code paths that touch the ZenML runtime lazily
+## More Test Guidance
 
-Do not add `primed_zenml` to lightweight unit tests, parser tests, serializer tests, or simple CLI rendering tests. Keeping those tests cheap is what makes `-n auto` practical.
-
-## Patterns To Copy
-
-### Unit and contract tests
-
-These should stay lightweight and explicit:
-
-- build small stubs or `SimpleNamespace` objects rather than booting full runtime state
-- assert on one behavior or contract at a time
-- include regression coverage for bug fixes
-
-This is the pattern used heavily in `tests/test_cli.py`, `tests/test_checkpoint.py`, and similar files.
-
-### CLI tests
-
-CLI tests in this repo follow a few important rules:
-
-- always call the Cyclopts app with an explicit arg list, for example `app(["--help"])`
-- successful invocations raise `SystemExit(0)`; assert on that explicitly
-- use `capsys` and assert on stable plain-text substrings
-- prefer lightweight stubs/mocks for execution objects rather than full backend setup
-
-The story here is simple: keep CLI tests focused on argument parsing, command dispatch, and rendered output, not on unrelated runtime bootstrapping.
-
-### Example-driven `test_phase*.py` tests
-
-These are closer to executable documentation than ordinary unit tests. Their job is to prove that the examples in `examples/` still work end to end.
-
-When adding or updating one:
-
-- import and call the example entrypoint directly
-- use `monkeypatch` to provide fake credentials or mock-response env vars
-- request `primed_zenml` when the flow genuinely executes
-- assert on persisted execution state, metadata, checkpoints, or artifacts, not just a return value
-
-Good example: `tests/test_phase12_llm_example.py` registers a model alias, injects fake API credentials, runs the example flow, and then inspects the recorded metadata in ZenML.
-
-### Live provider tests
-
-Live provider tests live under `tests/live/` and are off by default. They are for trusted manual or scheduled runs, not normal PR CI.
-
-Rules:
-
-- mark every live provider test with `@pytest.mark.live_llm` plus the provider marker: `live_openai`, `live_anthropic`, or `live_gemini`; `live_llm` by itself is invalid because it bypasses the deterministic provider-call guard but is not selected by provider workflows
-- put slower or higher-cost checks under `@pytest.mark.provider_extended` as well
-- skip cleanly when the required key is absent; the shared guard already skips `live_openai` without `OPENAI_API_KEY`, `live_anthropic` without `ANTHROPIC_API_KEY`, and `live_gemini` without `GEMINI_API_KEY` or `GOOGLE_API_KEY`
-- keep prompts tiny and bounded; set max-turns or equivalent limits explicitly
-- do not add live provider tests to fork PR workflows
-- do not bypass the provider guard in deterministic tests; fake the provider or patch Kitaru's local call point instead
-
-### MCP tests
-
-MCP tests live under `tests/mcp/` for a reason:
-
-- keep MCP-only fixtures in `tests/mcp/conftest.py`
-- use mocked `KitaruClient` namespaces unless the test truly needs deeper integration
-- verify both delegation and serialized payload shape
-- cover file/module loading behavior with `tmp_path` and `monkeypatch.syspath_prepend(...)` rather than real project files
-
-## Parallel-Safety Expectations
-
-Because the suite defaults to `-n auto`, tests should behave like good neighbors in a shared apartment:
-
-- no hidden dependence on cwd unless the test sets it up itself
-- no shared mutable module-level state
-- no assumptions about another test having already created config, stores, or env vars
-- no reliance on wall-clock ordering between tests
-
-If a test is flaky under parallelism, fix the isolation problem instead of silently depending on single-process execution.
-
-## Choosing Where Fixtures Live
-
-Use this rule of thumb:
-
-- if many test files across `tests/` need it, put it in `tests/conftest.py`
-- if only MCP tests need it, put it in `tests/mcp/conftest.py`
-- if only one file needs it, keep it local to that file unless duplication becomes painful
-
-Keep shared fixtures small and intention-revealing. A fixture should make setup easier to understand, not hide the whole story.
-
-## When Fixing Bugs
-
-Every bug fix should come with a regression test that would have caught the original problem. The best pattern is:
-
-1. write or update the test so it captures the broken behavior
-2. make the code change
-3. rerun the targeted test
-4. rerun the broader relevant suite
-
-If you change code after running tests, run the tests again. Do not assume the earlier green run still counts.
+For fixture placement, `primed_zenml`, CLI-test patterns, example-driven tests,
+MCP tests, and bug-fix regression-test workflow, load the
+`kitaru-tests-release` skill.


### PR DESCRIPTION
## Summary

Codex sessions in this repo were starting above the 32 KiB instruction cap, which means later repo guidance could silently disappear before the model ever saw it. This PR keeps the daily commands and hard safety rules in always-loaded files, then moves task-specific runbooks into three repo skills that load only when the work calls for them.

## Reviewer Notes

The important behavior now happens in the instruction layout rather than product code. Root `AGENTS.md` stays as the compact always-loaded entry point: project map, core `uv`/`just` commands, universal coding rules, CLI/test/docs/security prohibitions, and pointers to lazy skills. The longer command catalog, CLI/analytics details, PR guidance, docs rules, test patterns, CI inventory, and release smoke workflow now live in repo skills under `.agents/skills/`.

The high-risk part is whether any hard rule moved somewhere it might not load. I kept prohibitions such as not committing secrets, not using postponed annotations in flow/checkpoint definitions, not adding hand-written docs to generated FumaDocs output, not adding live provider calls to PR CI/release workflow, and not pushing to `main` in always-loaded guidance. `tests/AGENTS.md` is also shorter now, but still keeps the test-state isolation and live-provider safety rules resident when Codex starts inside `tests/`.

`.gitignore` now keeps `.agents/skills/*` ignored by default and unblocks only the three Kitaru repo skills added here. That means local agent scratch skills remain ignored, while the repo-owned instruction skills can travel with the branch.

### Reproduction

To reproduce the context-size check from a local checkout with the `trim-agents-md` skill installed:

```bash
git switch develop
bash "$HOME/.agents/skills/trim-agents-md/scripts/measure-context.sh" --save /tmp/kitaru-agents-baseline.txt
git switch trim-agents-md-kitaru
bash "$HOME/.agents/skills/trim-agents-md/scripts/measure-context.sh" --compare /tmp/kitaru-agents-baseline.txt
```

Expected result on this machine: root launch drops from `37,737` to `23,040` bytes, worst-case nested launch is `26,126` bytes, and the skill listing is `7,948` chars. That puts both instruction chains back under the 32 KiB cap and the skill listing just under the 8,000-char cap.

Local checks run:

```bash
git diff --check -- .gitignore AGENTS.md tests/AGENTS.md \
  .agents/skills/kitaru-dev/SKILL.md \
  .agents/skills/kitaru-docs/SKILL.md \
  .agents/skills/kitaru-tests-release/SKILL.md
```
