### PR TITLE
Add checkpoint cost metadata

### DIFF
--- a/src/kitaru/_checkpoint_steps.py
+++ b/src/kitaru/_checkpoint_steps.py
@@ -1,0 +1,36 @@
+"""Shared helpers for ZenML checkpoint step runs."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, TypeVar
+
+_RETRIED_STEP_STATUS = "retried"
+_TStep = TypeVar("_TStep")
+
+
+def _step_status_value(step: Any) -> str:
+    status = getattr(step, "status", "")
+    return str(getattr(status, "value", status)).strip().lower()
+
+
+def visible_checkpoint_step_for_lineage(
+    attempts: Sequence[_TStep],
+) -> _TStep | None:
+    """Return the checkpoint step run exposed by ZenML's run DAG.
+
+    Args:
+        attempts: Step-run attempts for one checkpoint lineage, sorted by
+            ascending creation time. The attempt fetcher that calls this helper
+            requests ``sort_by="asc:created"`` from ZenML before grouping steps.
+
+    Returns:
+        The newest non-retried attempt, or the newest attempt when every attempt
+        is marked retried.
+    """
+    for step in reversed(attempts):
+        if _step_status_value(step) != _RETRIED_STEP_STATUS:
+            return step
+    if attempts:
+        return attempts[-1]
+    return None

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -24,6 +24,7 @@ from kitaru._checkpoint_metadata import (
     checkpoint_metadata_slots,
     checkpoint_metadata_str,
 )
+from kitaru._checkpoint_steps import visible_checkpoint_step_for_lineage
 from kitaru._client._models import (
     ArtifactRef,
     CheckpointAttempt,
@@ -652,8 +653,9 @@ def _map_execution(
 
         latest_steps_by_lineage: dict[str, StepRunResponse] = {}
         for lineage_key, attempts in attempts_by_lineage.items():
-            if attempts:
-                latest_steps_by_lineage[lineage_key] = attempts[-1]
+            visible_step = visible_checkpoint_step_for_lineage(attempts)
+            if visible_step is not None:
+                latest_steps_by_lineage[lineage_key] = visible_step
 
         for step in run.steps.values():
             lineage_key = _checkpoint_lineage_key(step)

--- a/src/kitaru/_llm_usage.py
+++ b/src/kitaru/_llm_usage.py
@@ -189,7 +189,7 @@ def usage_reuse_classification(
     cache_status = cache_status_for_checkpoint_status(checkpoint_status)
     if cache_status is not None:
         return True, cache_status
-    return False, "checkpoint_cache_hit"
+    return False, "executed"
 
 
 def _int_or_none(value: Any) -> int | None:
@@ -1199,6 +1199,18 @@ def summary_to_flat_metadata(summary: Mapping[str, Any]) -> dict[str, int | floa
     }
 
 
+def flat_usage_metadata_from_records(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    include_empty_metadata: bool = False,
+) -> dict[str, int | float]:
+    """Build promoted flat LLM usage metadata from per-call records."""
+    summary = aggregate_usage_records(records)
+    if not include_empty_metadata and summary["usage_record_count"] == 0:
+        return {}
+    return summary_to_flat_metadata(summary)
+
+
 def serialize_summary_for_metadata(summary: Mapping[str, Any]) -> str:
     """Serialize the rich summary as last-write-wins metadata text."""
     return json.dumps(summary, sort_keys=True, separators=(",", ":"))
@@ -1227,21 +1239,11 @@ def _valid_summary_number(value: Any, *, is_float: bool) -> bool:
     return number is not None and number >= 0
 
 
-def metadata_matches_usage_metadata(
+def _flat_metadata_values_match(
     metadata: Mapping[str, Any],
     expected_metadata: Mapping[str, Any],
 ) -> bool:
-    """Return whether stored usage metadata matches freshly generated metadata."""
-    if not metadata_has_complete_usage_summary(metadata):
-        return False
-
-    summary = parse_usage_summary(metadata.get(LLM_USAGE_SUMMARY_METADATA_KEY))
-    expected_summary = parse_usage_summary(
-        expected_metadata.get(LLM_USAGE_SUMMARY_METADATA_KEY)
-    )
-    if summary is None or expected_summary is None or summary != expected_summary:
-        return False
-
+    """Return whether all promoted flat usage fields match expected values."""
     for metadata_key, summary_key, _coerce in _FLAT_METADATA_FIELDS:
         is_float = summary_key in _SUMMARY_FLOAT_FIELDS
         current = (
@@ -1258,6 +1260,34 @@ def metadata_matches_usage_metadata(
             return False
 
     return True
+
+
+def metadata_matches_flat_usage_metadata(
+    metadata: Mapping[str, Any],
+    expected_metadata: Mapping[str, Any],
+) -> bool:
+    """Return whether stored flat usage metadata already matches expected values."""
+    if not expected_metadata:
+        return False
+    return _flat_metadata_values_match(metadata, expected_metadata)
+
+
+def metadata_matches_usage_metadata(
+    metadata: Mapping[str, Any],
+    expected_metadata: Mapping[str, Any],
+) -> bool:
+    """Return whether stored usage metadata matches freshly generated metadata."""
+    if not metadata_has_complete_usage_summary(metadata):
+        return False
+
+    summary = parse_usage_summary(metadata.get(LLM_USAGE_SUMMARY_METADATA_KEY))
+    expected_summary = parse_usage_summary(
+        expected_metadata.get(LLM_USAGE_SUMMARY_METADATA_KEY)
+    )
+    if summary is None or expected_summary is None or summary != expected_summary:
+        return False
+
+    return _flat_metadata_values_match(metadata, expected_metadata)
 
 
 def metadata_has_complete_usage_summary(metadata: Mapping[str, Any]) -> bool:

--- a/src/kitaru/_terminal_usage.py
+++ b/src/kitaru/_terminal_usage.py
@@ -8,13 +8,16 @@ from typing import Any
 
 from zenml.models import PipelineRunResponse
 
+from kitaru._checkpoint_steps import visible_checkpoint_step_for_lineage
 from kitaru._client._mappers import (
     _list_checkpoint_attempts_for_run_with_zenml_client,
     _to_plain_dict,
 )
 from kitaru._llm_usage import (
     execution_metadata_from_records,
+    flat_usage_metadata_from_records,
     metadata_has_complete_usage_summary,
+    metadata_matches_flat_usage_metadata,
     metadata_matches_usage_metadata,
     usage_records_from_metadata,
     usage_reuse_classification,
@@ -59,10 +62,10 @@ def _persist_terminal_llm_usage_metadata(
     *,
     zenml_client: Any | None = None,
 ) -> bool:
-    """Aggregate LLM usage records and write execution-level metadata."""
+    """Aggregate LLM usage records and write terminal cost metadata."""
     from zenml.client import Client
 
-    from kitaru.logging import log_to_execution
+    from kitaru.logging import log_to_checkpoint, log_to_execution
 
     run_metadata = _metadata_mapping(getattr(run, "run_metadata", None))
     replay_skipped_steps = parse_replay_skipped_steps_metadata(run_metadata)
@@ -78,6 +81,7 @@ def _persist_terminal_llm_usage_metadata(
         return False
 
     records: list[dict[str, Any]] = []
+    checkpoint_metadata_writes: list[tuple[str, dict[str, int | float]]] = []
     execution_id = str(run.id)
     records.extend(
         usage_records_from_metadata(
@@ -86,29 +90,65 @@ def _persist_terminal_llm_usage_metadata(
         )
     )
     for attempts in attempts_by_lineage.values():
+        checkpoint_records: list[dict[str, Any]] = []
         for step in attempts:
             reused, reused_cache_status = usage_reuse_classification(
                 replay_reused=replay_step_invocation_id(step) in replay_skipped_steps,
                 checkpoint_status=getattr(step, "status", None),
             )
-            records.extend(
-                usage_records_from_metadata(
-                    _metadata_mapping(getattr(step, "run_metadata", None)),
-                    source_attempt_id=str(step.id),
-                    default_checkpoint_name=_normalize_checkpoint_name(
-                        str(getattr(step, "name", ""))
-                    ),
-                    reused=reused,
-                    reused_cache_status=reused_cache_status,
-                )
+            step_records = usage_records_from_metadata(
+                _metadata_mapping(getattr(step, "run_metadata", None)),
+                source_attempt_id=str(step.id),
+                default_checkpoint_name=_normalize_checkpoint_name(
+                    str(getattr(step, "name", ""))
+                ),
+                reused=reused,
+                reused_cache_status=reused_cache_status,
             )
+            checkpoint_records.extend(step_records)
+            records.extend(step_records)
+
+        checkpoint_metadata = flat_usage_metadata_from_records(checkpoint_records)
+        if not checkpoint_metadata:
+            continue
+        visible_step = visible_checkpoint_step_for_lineage(attempts)
+        if visible_step is None:
+            continue
+        visible_step_metadata = _metadata_mapping(
+            getattr(visible_step, "run_metadata", None)
+        )
+        if metadata_matches_flat_usage_metadata(
+            visible_step_metadata,
+            checkpoint_metadata,
+        ):
+            continue
+        checkpoint_metadata_writes.append((str(visible_step.id), checkpoint_metadata))
+
+    metadata_write_failed = False
     metadata = execution_metadata_from_records(records)
-    if not metadata:
-        return True
-    if metadata_matches_usage_metadata(run_metadata, metadata):
-        return True
-    log_to_execution(str(run.id), **metadata)
-    return True
+    if metadata and not metadata_matches_usage_metadata(run_metadata, metadata):
+        try:
+            log_to_execution(str(run.id), _client=client, **metadata)
+        except Exception:
+            metadata_write_failed = True
+            logger.debug(
+                "Failed to persist terminal LLM usage metadata on execution %s.",
+                run.id,
+                exc_info=True,
+            )
+
+    for checkpoint_id, checkpoint_metadata in checkpoint_metadata_writes:
+        try:
+            log_to_checkpoint(checkpoint_id, _client=client, **checkpoint_metadata)
+        except Exception:
+            metadata_write_failed = True
+            logger.debug(
+                "Failed to persist terminal LLM usage metadata on checkpoint %s.",
+                checkpoint_id,
+                exc_info=True,
+            )
+
+    return not metadata_write_failed
 
 
 def _safe_persist_terminal_llm_usage_metadata(

--- a/src/kitaru/logging.py
+++ b/src/kitaru/logging.py
@@ -54,31 +54,13 @@ def _resolve_log_target() -> tuple[RunMetadataResource, UUID | None]:
         checkpoint_id = _get_current_checkpoint_id()
         if checkpoint_id is None:
             raise KitaruStateError(_LOG_MISSING_CHECKPOINT_ID_ERROR)
-        checkpoint_uuid = _parse_scope_uuid(
-            checkpoint_id, scope_name="checkpoint", api_name="log"
-        )
-        return (
-            RunMetadataResource(
-                id=checkpoint_uuid,
-                type=MetadataResourceTypes.STEP_RUN,
-            ),
-            checkpoint_uuid,
-        )
+        return _checkpoint_run_resource(checkpoint_id)
 
     if _is_inside_flow():
         execution_id = _get_current_execution_id()
         if execution_id is None:
             raise KitaruStateError(_LOG_MISSING_EXECUTION_ID_ERROR)
-        execution_uuid = _parse_scope_uuid(
-            execution_id, scope_name="execution", api_name="log"
-        )
-        return (
-            RunMetadataResource(
-                id=execution_uuid,
-                type=MetadataResourceTypes.PIPELINE_RUN,
-            ),
-            None,
-        )
+        return (_pipeline_run_resource(execution_id), None)
 
     raise KitaruContextError(_LOG_OUTSIDE_FLOW_ERROR)
 
@@ -92,16 +74,58 @@ def _pipeline_run_resource(run_id: str) -> RunMetadataResource:
     )
 
 
-def log_to_execution(run_id: str, **kwargs: Any) -> None:
+def _checkpoint_run_resource(step_id: str) -> tuple[RunMetadataResource, UUID]:
+    """Build a step-run metadata resource for an explicit checkpoint ID."""
+    checkpoint_uuid = _parse_scope_uuid(
+        step_id,
+        scope_name="checkpoint",
+        api_name="log",
+    )
+    return (
+        RunMetadataResource(
+            id=checkpoint_uuid,
+            type=MetadataResourceTypes.STEP_RUN,
+        ),
+        checkpoint_uuid,
+    )
+
+
+def log_to_execution(
+    run_id: str,
+    *,
+    _client: Any | None = None,
+    **kwargs: Any,
+) -> None:
     """Attach structured metadata to a specific execution.
 
     This helper is for SDK observation paths such as ``FlowHandle.wait()`` that
     need to write pipeline-run metadata after user code has finished and there
     is no active flow context anymore.
     """
-    Client().create_run_metadata(
+    client = _client if _client is not None else Client()
+    client.create_run_metadata(
         metadata=kwargs,
         resources=[_pipeline_run_resource(run_id)],
+    )
+
+
+def log_to_checkpoint(
+    step_id: str,
+    *,
+    _client: Any | None = None,
+    **kwargs: Any,
+) -> None:
+    """Attach structured metadata to a specific checkpoint step run.
+
+    This helper is for code paths that need to publish metadata by checkpoint
+    step ID when there is no active checkpoint context.
+    """
+    client = _client if _client is not None else Client()
+    resource, checkpoint_uuid = _checkpoint_run_resource(step_id)
+    client.create_run_metadata(
+        metadata=kwargs,
+        resources=[resource],
+        publisher_step_id=checkpoint_uuid,
     )
 
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2416,6 +2416,8 @@ def test_terminal_llm_usage_metadata_uses_zenml_client_without_kitaru_auth(
         total_tokens=11,
     )
     written: dict[str, Any] = {}
+    terminal_client = SimpleNamespace(name="terminal-client")
+    execution_write_client: object | None = None
 
     monkeypatch.setenv("KITARU_SERVER_URL", "https://kitaru.example.test")
     monkeypatch.delenv("KITARU_AUTH_TOKEN", raising=False)
@@ -2425,13 +2427,25 @@ def test_terminal_llm_usage_metadata_uses_zenml_client_without_kitaru_auth(
             AssertionError("terminal aggregation must not construct KitaruClient")
         ),
     )
+
+    def fake_fetch(*, run: PipelineRunResponse, client: object) -> object:
+        assert client is terminal_client
+        return {}
+
     monkeypatch.setattr(
         terminal_usage_module,
         "_list_checkpoint_attempts_for_run",
-        lambda *, run, client: {},
+        fake_fetch,
     )
 
-    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+    def fake_log_to_execution(
+        run_id: str,
+        *,
+        _client: object | None = None,
+        **metadata: Any,
+    ) -> None:
+        nonlocal execution_write_client
+        execution_write_client = _client
         written.update(metadata)
 
     monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
@@ -2444,12 +2458,13 @@ def test_terminal_llm_usage_metadata_uses_zenml_client_without_kitaru_auth(
                 run_metadata={LLM_USAGE_METADATA_KEY: {"call": record}},
             ),
         ),
-        zenml_client=SimpleNamespace(),
+        zenml_client=terminal_client,
     )
 
     summary = parse_usage_summary(written[LLM_USAGE_SUMMARY_METADATA_KEY])
     assert persisted is True
     assert summary is not None
+    assert execution_write_client is terminal_client
     assert summary["usage_record_count"] == 1
     assert summary["total_tokens"] == 11
 
@@ -2506,10 +2521,19 @@ def test_terminal_llm_usage_metadata_rewrites_stale_complete_summary(
         lambda *, run, client: attempts_by_lineage,
     )
 
-    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+    def fake_log_to_execution(
+        run_id: str,
+        *,
+        _client: object | None = None,
+        **metadata: Any,
+    ) -> None:
         written.update(metadata)
 
     monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_checkpoint",
+        lambda checkpoint_id, **metadata: None,
+    )
 
     persisted = _persist_terminal_llm_usage_metadata(
         cast(
@@ -2573,10 +2597,19 @@ def test_terminal_llm_usage_metadata_rewrites_same_count_stale_summary(
         lambda *, run, client: attempts_by_lineage,
     )
 
-    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+    def fake_log_to_execution(
+        run_id: str,
+        *,
+        _client: object | None = None,
+        **metadata: Any,
+    ) -> None:
         written.update(metadata)
 
     monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_checkpoint",
+        lambda checkpoint_id, **metadata: None,
+    )
 
     persisted = _persist_terminal_llm_usage_metadata(
         cast(
@@ -2622,7 +2655,12 @@ def test_terminal_llm_usage_metadata_does_not_skip_partial_summary(
         fetch_calls += 1
         return {}
 
-    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+    def fake_log_to_execution(
+        run_id: str,
+        *,
+        _client: object | None = None,
+        **metadata: Any,
+    ) -> None:
         written.update(metadata)
 
     monkeypatch.setattr("kitaru.client.KitaruClient", lambda: SimpleNamespace())
@@ -2747,10 +2785,19 @@ def test_terminal_llm_usage_metadata_counts_retry_attempts(monkeypatch) -> None:
         lambda *, run, client: attempts_by_lineage,
     )
 
-    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+    def fake_log_to_execution(
+        run_id: str,
+        *,
+        _client: object | None = None,
+        **metadata: Any,
+    ) -> None:
         written.update(metadata)
 
     monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_checkpoint",
+        lambda checkpoint_id, **metadata: None,
+    )
 
     _persist_terminal_llm_usage_metadata(
         cast(PipelineRunResponse, SimpleNamespace(id="run-1", run_metadata={}))
@@ -2761,6 +2808,437 @@ def test_terminal_llm_usage_metadata_counts_retry_attempts(monkeypatch) -> None:
     assert summary["usage_record_count"] == 2
     assert written[LLM_FLAT_INCURRED_USAGE_RECORD_COUNT_KEY] == 2
     assert written[LLM_FLAT_INCURRED_TOTAL_TOKENS_KEY] == 25
+
+
+def test_terminal_llm_usage_metadata_writes_checkpoint_flat_metadata_to_visible_step(
+    monkeypatch,
+) -> None:
+    """Checkpoint flat metadata is written to the non-retried DAG step run."""
+    from kitaru._llm_usage import (
+        LLM_FLAT_DISPLAY_COST_USD_KEY,
+        LLM_FLAT_INCURRED_TOTAL_TOKENS_KEY,
+        LLM_FLAT_INCURRED_USAGE_RECORD_COUNT_KEY,
+        LLM_USAGE_METADATA_KEY,
+        LLM_USAGE_SUMMARY_METADATA_KEY,
+        build_usage_record,
+        parse_usage_summary,
+    )
+    from kitaru.flow import _persist_terminal_llm_usage_metadata
+
+    retried_id = str(uuid4())
+    visible_id = str(uuid4())
+    first = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="summary_call_first",
+        total_tokens=10,
+        actual_cost_usd=0.2,
+    )
+    second = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="summary_call_second",
+        total_tokens=15,
+        estimated_cost_usd=0.3,
+    )
+    attempts_by_lineage = {
+        "summary_call": [
+            SimpleNamespace(
+                id=retried_id,
+                name="summary_call",
+                status="retried",
+                run_metadata={LLM_USAGE_METADATA_KEY: {"call": first}},
+            ),
+            SimpleNamespace(
+                id=visible_id,
+                name="summary_call",
+                status="completed",
+                run_metadata={LLM_USAGE_METADATA_KEY: {"call": second}},
+            ),
+        ]
+    }
+    execution_metadata: dict[str, Any] = {}
+    terminal_client = SimpleNamespace(name="terminal-client")
+    checkpoint_writes: list[tuple[str, object | None, dict[str, Any]]] = []
+
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
+    monkeypatch.setattr(
+        terminal_usage_module,
+        "_list_checkpoint_attempts_for_run",
+        lambda *, run, client: attempts_by_lineage,
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_execution",
+        lambda run_id, _client=None, **metadata: execution_metadata.update(metadata),
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_checkpoint",
+        lambda checkpoint_id, _client=None, **metadata: checkpoint_writes.append(
+            (checkpoint_id, _client, dict(metadata))
+        ),
+    )
+
+    persisted = _persist_terminal_llm_usage_metadata(
+        cast(PipelineRunResponse, SimpleNamespace(id="run-1", run_metadata={})),
+        zenml_client=terminal_client,
+    )
+
+    summary = parse_usage_summary(execution_metadata[LLM_USAGE_SUMMARY_METADATA_KEY])
+    assert persisted is True
+    assert summary is not None
+    assert summary["usage_record_count"] == 2
+    assert len(checkpoint_writes) == 1
+    checkpoint_id, writer_client, checkpoint_metadata = checkpoint_writes[0]
+    assert checkpoint_id == visible_id
+    assert writer_client is terminal_client
+    assert LLM_USAGE_SUMMARY_METADATA_KEY not in checkpoint_metadata
+    assert checkpoint_metadata[LLM_FLAT_INCURRED_USAGE_RECORD_COUNT_KEY] == 2
+    assert checkpoint_metadata[LLM_FLAT_INCURRED_TOTAL_TOKENS_KEY] == 25
+    assert checkpoint_metadata[LLM_FLAT_DISPLAY_COST_USD_KEY] == 0.5
+
+
+def test_terminal_llm_usage_metadata_continues_after_checkpoint_write_failure(
+    monkeypatch,
+) -> None:
+    """One failed checkpoint metadata write should not stop later writes."""
+    from kitaru._llm_usage import LLM_USAGE_METADATA_KEY, build_usage_record
+    from kitaru.flow import _persist_terminal_llm_usage_metadata
+
+    failing_id = str(uuid4())
+    later_id = str(uuid4())
+    first = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="first-checkpoint-call",
+        total_tokens=10,
+    )
+    second = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="second-checkpoint-call",
+        total_tokens=20,
+    )
+    attempts_by_lineage = {
+        "first_checkpoint": [
+            SimpleNamespace(
+                id=failing_id,
+                name="first_checkpoint",
+                status="completed",
+                run_metadata={LLM_USAGE_METADATA_KEY: {"first": first}},
+            )
+        ],
+        "second_checkpoint": [
+            SimpleNamespace(
+                id=later_id,
+                name="second_checkpoint",
+                status="completed",
+                run_metadata={LLM_USAGE_METADATA_KEY: {"second": second}},
+            )
+        ],
+    }
+    terminal_client = SimpleNamespace(name="terminal-client")
+    checkpoint_writes: list[tuple[str, object | None, dict[str, Any]]] = []
+
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
+    monkeypatch.setattr(
+        terminal_usage_module,
+        "_list_checkpoint_attempts_for_run",
+        lambda *, run, client: attempts_by_lineage,
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_execution",
+        lambda run_id, _client=None, **metadata: None,
+    )
+
+    def fake_log_to_checkpoint(
+        checkpoint_id: str,
+        *,
+        _client: object | None = None,
+        **metadata: Any,
+    ) -> None:
+        checkpoint_writes.append((checkpoint_id, _client, dict(metadata)))
+        if checkpoint_id == failing_id:
+            raise RuntimeError("first checkpoint write failed")
+
+    monkeypatch.setattr("kitaru.logging.log_to_checkpoint", fake_log_to_checkpoint)
+
+    persisted = _persist_terminal_llm_usage_metadata(
+        cast(PipelineRunResponse, SimpleNamespace(id="run-1", run_metadata={})),
+        zenml_client=terminal_client,
+    )
+
+    assert persisted is False
+    checkpoint_write_ids = [
+        checkpoint_id for checkpoint_id, _client, _metadata in checkpoint_writes
+    ]
+    assert checkpoint_write_ids == [failing_id, later_id]
+    assert all(
+        _client is terminal_client
+        for _checkpoint_id, _client, _metadata in checkpoint_writes
+    )
+
+
+def test_terminal_llm_usage_metadata_writes_reused_checkpoint_zero_display_cost(
+    monkeypatch,
+) -> None:
+    """Replay-reused checkpoint details should show zero new spend."""
+    from kitaru._llm_usage import (
+        LLM_FLAT_ACTUAL_COST_USD_KEY,
+        LLM_FLAT_DISPLAY_COST_USD_KEY,
+        LLM_FLAT_REUSED_TOTAL_TOKENS_KEY,
+        LLM_FLAT_REUSED_USAGE_RECORD_COUNT_KEY,
+        LLM_USAGE_METADATA_KEY,
+        LLM_USAGE_SUMMARY_METADATA_KEY,
+        build_usage_record,
+    )
+    from kitaru.flow import _persist_terminal_llm_usage_metadata
+    from kitaru.replay import REPLAY_SKIPPED_STEPS_METADATA_KEY
+
+    visible_id = str(uuid4())
+    record = build_usage_record(
+        adapter="openai_agents",
+        surface="runner_call",
+        record_id="replayed-call",
+        total_tokens=37,
+        actual_cost_usd=1.25,
+        billing_effect="incurred",
+        cache_status="executed",
+    )
+    attempts_by_lineage = {
+        "fetch": [
+            SimpleNamespace(
+                id=visible_id,
+                name="fetch",
+                spec=SimpleNamespace(invocation_id="fetch"),
+                status="replay_reused",
+                run_metadata={LLM_USAGE_METADATA_KEY: {"replayed-call": record}},
+            )
+        ]
+    }
+    checkpoint_writes: list[tuple[str, dict[str, Any]]] = []
+
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
+    monkeypatch.setattr(
+        terminal_usage_module,
+        "_list_checkpoint_attempts_for_run",
+        lambda *, run, client: attempts_by_lineage,
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_execution", lambda run_id, _client=None, **metadata: None
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_checkpoint",
+        lambda checkpoint_id, _client=None, **metadata: checkpoint_writes.append(
+            (checkpoint_id, dict(metadata))
+        ),
+    )
+
+    _persist_terminal_llm_usage_metadata(
+        cast(
+            PipelineRunResponse,
+            SimpleNamespace(
+                id="run-1",
+                run_metadata={REPLAY_SKIPPED_STEPS_METADATA_KEY: ["fetch"]},
+            ),
+        )
+    )
+
+    assert len(checkpoint_writes) == 1
+    checkpoint_id, checkpoint_metadata = checkpoint_writes[0]
+    assert checkpoint_id == visible_id
+    assert LLM_USAGE_SUMMARY_METADATA_KEY not in checkpoint_metadata
+    assert checkpoint_metadata[LLM_FLAT_REUSED_USAGE_RECORD_COUNT_KEY] == 1
+    assert checkpoint_metadata[LLM_FLAT_REUSED_TOTAL_TOKENS_KEY] == 37
+    assert checkpoint_metadata[LLM_FLAT_ACTUAL_COST_USD_KEY] == 0.0
+    assert checkpoint_metadata[LLM_FLAT_DISPLAY_COST_USD_KEY] == 0.0
+
+
+def test_terminal_llm_usage_metadata_writes_cached_checkpoint_zero_display_cost(
+    monkeypatch,
+) -> None:
+    """Cached checkpoint details should show zero new spend."""
+    from kitaru._llm_usage import (
+        LLM_FLAT_ACTUAL_COST_USD_KEY,
+        LLM_FLAT_DISPLAY_COST_USD_KEY,
+        LLM_FLAT_REUSED_TOTAL_TOKENS_KEY,
+        LLM_FLAT_REUSED_USAGE_RECORD_COUNT_KEY,
+        LLM_USAGE_METADATA_KEY,
+        LLM_USAGE_SUMMARY_METADATA_KEY,
+        build_usage_record,
+    )
+    from kitaru.flow import _persist_terminal_llm_usage_metadata
+
+    visible_id = str(uuid4())
+    record = build_usage_record(
+        adapter="openai_agents",
+        surface="runner_call",
+        record_id="cached-call",
+        total_tokens=37,
+        actual_cost_usd=1.25,
+        billing_effect="incurred",
+        cache_status="executed",
+    )
+    attempts_by_lineage = {
+        "fetch": [
+            SimpleNamespace(
+                id=visible_id,
+                name="fetch",
+                status="cached",
+                run_metadata={LLM_USAGE_METADATA_KEY: {"cached-call": record}},
+            )
+        ]
+    }
+    checkpoint_writes: list[tuple[str, dict[str, Any]]] = []
+
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
+    monkeypatch.setattr(
+        terminal_usage_module,
+        "_list_checkpoint_attempts_for_run",
+        lambda *, run, client: attempts_by_lineage,
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_execution", lambda run_id, _client=None, **metadata: None
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_checkpoint",
+        lambda checkpoint_id, _client=None, **metadata: checkpoint_writes.append(
+            (checkpoint_id, dict(metadata))
+        ),
+    )
+
+    _persist_terminal_llm_usage_metadata(
+        cast(PipelineRunResponse, SimpleNamespace(id="run-1", run_metadata={}))
+    )
+
+    assert len(checkpoint_writes) == 1
+    checkpoint_id, checkpoint_metadata = checkpoint_writes[0]
+    assert checkpoint_id == visible_id
+    assert LLM_USAGE_SUMMARY_METADATA_KEY not in checkpoint_metadata
+    assert checkpoint_metadata[LLM_FLAT_REUSED_USAGE_RECORD_COUNT_KEY] == 1
+    assert checkpoint_metadata[LLM_FLAT_REUSED_TOTAL_TOKENS_KEY] == 37
+    assert checkpoint_metadata[LLM_FLAT_ACTUAL_COST_USD_KEY] == 0.0
+    assert checkpoint_metadata[LLM_FLAT_DISPLAY_COST_USD_KEY] == 0.0
+
+
+def test_terminal_llm_usage_metadata_skips_matching_checkpoint_flat_metadata(
+    monkeypatch,
+) -> None:
+    """Existing complete checkpoint flat metadata should not be rewritten."""
+    from kitaru._llm_usage import (
+        LLM_USAGE_METADATA_KEY,
+        build_usage_record,
+        flat_usage_metadata_from_records,
+    )
+    from kitaru.flow import _persist_terminal_llm_usage_metadata
+
+    visible_id = str(uuid4())
+    record = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="checkpoint-call",
+        total_tokens=12,
+        estimated_cost_usd=0.04,
+    )
+    existing_flat_metadata = flat_usage_metadata_from_records([record])
+    attempts_by_lineage = {
+        "checkpoint_call": [
+            SimpleNamespace(
+                id=visible_id,
+                name="checkpoint_call",
+                status="completed",
+                run_metadata={
+                    LLM_USAGE_METADATA_KEY: {"checkpoint-call": record},
+                    **existing_flat_metadata,
+                },
+            )
+        ]
+    }
+    checkpoint_writes: list[tuple[str, dict[str, Any]]] = []
+
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
+    monkeypatch.setattr(
+        terminal_usage_module,
+        "_list_checkpoint_attempts_for_run",
+        lambda *, run, client: attempts_by_lineage,
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_execution", lambda run_id, _client=None, **metadata: None
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_checkpoint",
+        lambda checkpoint_id, _client=None, **metadata: checkpoint_writes.append(
+            (checkpoint_id, dict(metadata))
+        ),
+    )
+
+    _persist_terminal_llm_usage_metadata(
+        cast(PipelineRunResponse, SimpleNamespace(id="run-1", run_metadata={}))
+    )
+
+    assert checkpoint_writes == []
+
+
+def test_terminal_llm_usage_metadata_rewrites_partial_checkpoint_flat_metadata(
+    monkeypatch,
+) -> None:
+    """Missing checkpoint flat fields should be republished as a full set."""
+    from kitaru._llm_usage import (
+        LLM_FLAT_DISPLAY_COST_USD_KEY,
+        LLM_USAGE_METADATA_KEY,
+        build_usage_record,
+        flat_usage_metadata_from_records,
+    )
+    from kitaru.flow import _persist_terminal_llm_usage_metadata
+
+    visible_id = str(uuid4())
+    record = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="checkpoint-call",
+        total_tokens=12,
+        estimated_cost_usd=0.04,
+    )
+    partial_flat_metadata = flat_usage_metadata_from_records([record])
+    partial_flat_metadata.pop(LLM_FLAT_DISPLAY_COST_USD_KEY)
+    attempts_by_lineage = {
+        "checkpoint_call": [
+            SimpleNamespace(
+                id=visible_id,
+                name="checkpoint_call",
+                status="completed",
+                run_metadata={
+                    LLM_USAGE_METADATA_KEY: {"checkpoint-call": record},
+                    **partial_flat_metadata,
+                },
+            )
+        ]
+    }
+    checkpoint_writes: list[tuple[str, dict[str, Any]]] = []
+
+    terminal_usage_module = sys.modules["kitaru._terminal_usage"]
+    monkeypatch.setattr(
+        terminal_usage_module,
+        "_list_checkpoint_attempts_for_run",
+        lambda *, run, client: attempts_by_lineage,
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_execution", lambda run_id, _client=None, **metadata: None
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_checkpoint",
+        lambda checkpoint_id, _client=None, **metadata: checkpoint_writes.append(
+            (checkpoint_id, dict(metadata))
+        ),
+    )
+
+    _persist_terminal_llm_usage_metadata(
+        cast(PipelineRunResponse, SimpleNamespace(id="run-1", run_metadata={}))
+    )
+
+    assert len(checkpoint_writes) == 1
+    checkpoint_id, checkpoint_metadata = checkpoint_writes[0]
+    assert checkpoint_id == visible_id
+    assert checkpoint_metadata[LLM_FLAT_DISPLAY_COST_USD_KEY] == 0.04
 
 
 def test_terminal_llm_usage_metadata_includes_execution_metadata(monkeypatch) -> None:
@@ -2792,7 +3270,12 @@ def test_terminal_llm_usage_metadata_includes_execution_metadata(monkeypatch) ->
         lambda *, run, client: {},
     )
 
-    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+    def fake_log_to_execution(
+        run_id: str,
+        *,
+        _client: object | None = None,
+        **metadata: Any,
+    ) -> None:
         written.update(metadata)
 
     monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
@@ -2843,7 +3326,12 @@ def test_terminal_llm_usage_metadata_is_idempotent(monkeypatch) -> None:
         lambda *, run, client: {},
     )
 
-    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+    def fake_log_to_execution(
+        run_id: str,
+        *,
+        _client: object | None = None,
+        **metadata: Any,
+    ) -> None:
         written.append(dict(metadata))
 
     monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
@@ -2909,10 +3397,19 @@ def test_terminal_llm_usage_metadata_marks_cached_attempts_reused(monkeypatch) -
         lambda *, run, client: attempts_by_lineage,
     )
 
-    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+    def fake_log_to_execution(
+        run_id: str,
+        *,
+        _client: object | None = None,
+        **metadata: Any,
+    ) -> None:
         written.update(metadata)
 
     monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_checkpoint",
+        lambda checkpoint_id, **metadata: None,
+    )
 
     _persist_terminal_llm_usage_metadata(
         cast(PipelineRunResponse, SimpleNamespace(id="run-1", run_metadata={}))
@@ -2972,7 +3469,11 @@ def test_terminal_llm_usage_metadata_preserves_replay_tail_incurred_record(
     )
     monkeypatch.setattr(
         "kitaru.logging.log_to_execution",
-        lambda run_id, **metadata: written.update(metadata),
+        lambda run_id, _client=None, **metadata: written.update(metadata),
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_checkpoint",
+        lambda checkpoint_id, **metadata: None,
     )
 
     _persist_terminal_llm_usage_metadata(
@@ -3036,7 +3537,11 @@ def test_terminal_llm_usage_metadata_marks_replay_skipped_attempt_reused(
     )
     monkeypatch.setattr(
         "kitaru.logging.log_to_execution",
-        lambda run_id, **metadata: written.update(metadata),
+        lambda run_id, _client=None, **metadata: written.update(metadata),
+    )
+    monkeypatch.setattr(
+        "kitaru.logging.log_to_checkpoint",
+        lambda checkpoint_id, **metadata: None,
     )
 
     _persist_terminal_llm_usage_metadata(
@@ -3082,7 +3587,12 @@ def test_terminal_llm_usage_metadata_skips_when_attempt_fetch_fails(
         terminal_usage_module, "_list_checkpoint_attempts_for_run", fail_fetch
     )
 
-    def fake_log_to_execution(run_id: str, **metadata: Any) -> None:
+    def fake_log_to_execution(
+        run_id: str,
+        *,
+        _client: object | None = None,
+        **metadata: Any,
+    ) -> None:
         written.update(metadata)
 
     monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -31,11 +31,21 @@ from kitaru._llm_usage import (
     calculated_or_genai_cost_metadata,
     estimate_genai_prices_cost,
     execution_metadata_from_records,
+    flat_usage_metadata_from_records,
     log_usage_record_best_effort,
+    metadata_matches_flat_usage_metadata,
     parse_usage_summary,
     usage_records_from_metadata,
+    usage_reuse_classification,
 )
 from tests._genai_prices_helpers import install_fake_genai_calc_price
+
+
+def test_usage_reuse_classification_marks_non_reused_records_executed() -> None:
+    reused, cache_status = usage_reuse_classification(checkpoint_status="completed")
+
+    assert reused is False
+    assert cache_status == "executed"
 
 
 def test_genai_prices_helper_estimates_gemini_with_normalized_usage(
@@ -956,6 +966,52 @@ def test_execution_metadata_uses_json_summary_and_flat_numeric_keys() -> None:
     assert metadata[LLM_FLAT_ACTUAL_COST_USD_KEY] == 0.0
     assert metadata[LLM_FLAT_ESTIMATED_COST_USD_KEY] == 0.123
     assert metadata[LLM_FLAT_DISPLAY_COST_USD_KEY] == 0.123
+
+
+def test_flat_usage_metadata_from_records_omits_summary_key() -> None:
+    record = build_usage_record(
+        adapter="openai_agents",
+        surface="runner_call",
+        record_id="checkpoint",
+        total_tokens=42,
+        estimated_cost_usd=0.123,
+    )
+
+    metadata = flat_usage_metadata_from_records([record])
+
+    assert LLM_USAGE_SUMMARY_METADATA_KEY not in metadata
+    assert metadata[LLM_FLAT_INCURRED_USAGE_RECORD_COUNT_KEY] == 1
+    assert metadata[LLM_FLAT_INCURRED_TOTAL_TOKENS_KEY] == 42
+    assert metadata[LLM_FLAT_DISPLAY_COST_USD_KEY] == 0.123
+
+
+def test_flat_usage_metadata_from_records_omits_empty_by_default() -> None:
+    assert flat_usage_metadata_from_records([]) == {}
+    assert (
+        flat_usage_metadata_from_records([], include_empty_metadata=True)[
+            LLM_FLAT_DISPLAY_COST_USD_KEY
+        ]
+        == 0.0
+    )
+
+
+def test_metadata_matches_flat_usage_metadata_requires_complete_matching_keys() -> None:
+    record = build_usage_record(
+        adapter="openai_agents",
+        surface="runner_call",
+        record_id="checkpoint",
+        total_tokens=42,
+        estimated_cost_usd=0.123,
+    )
+    metadata = flat_usage_metadata_from_records([record])
+    partial = dict(metadata)
+    partial.pop(LLM_FLAT_DISPLAY_COST_USD_KEY)
+    stale = dict(metadata)
+    stale[LLM_FLAT_DISPLAY_COST_USD_KEY] = 0.0
+
+    assert metadata_matches_flat_usage_metadata(metadata, metadata) is True
+    assert metadata_matches_flat_usage_metadata(partial, metadata) is False
+    assert metadata_matches_flat_usage_metadata(stale, metadata) is False
 
 
 def test_cached_checkpoint_attempt_public_records_are_marked_reused() -> None:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,7 +10,7 @@ from zenml.enums import MetadataResourceTypes
 from zenml.models.v2.misc.run_metadata import RunMetadataResource
 
 from kitaru.errors import KitaruContextError, KitaruStateError
-from kitaru.logging import _parse_scope_uuid, log
+from kitaru.logging import _parse_scope_uuid, log, log_to_checkpoint, log_to_execution
 from kitaru.runtime import _checkpoint_scope, _flow_scope
 
 
@@ -92,6 +92,54 @@ def test_log_attaches_to_checkpoint_inside_checkpoint() -> None:
     assert client.create_run_metadata.call_args.kwargs["publisher_step_id"] == UUID(
         checkpoint_id
     )
+
+
+def test_log_to_checkpoint_attaches_to_explicit_step_run() -> None:
+    checkpoint_id = str(uuid4())
+
+    with patch("kitaru.logging.Client") as client_cls:
+        log_to_checkpoint(checkpoint_id, cost=0.01, tokens=128)
+
+    client = client_cls.return_value
+    client.create_run_metadata.assert_called_once()
+    resource = _get_logged_resource(client)
+    assert resource.type == MetadataResourceTypes.STEP_RUN
+    assert resource.id == UUID(checkpoint_id)
+    assert client.create_run_metadata.call_args.kwargs["metadata"] == {
+        "cost": 0.01,
+        "tokens": 128,
+    }
+    assert client.create_run_metadata.call_args.kwargs["publisher_step_id"] == UUID(
+        checkpoint_id
+    )
+
+
+def test_log_to_checkpoint_reuses_explicit_client() -> None:
+    checkpoint_id = str(uuid4())
+    client = MagicMock()
+
+    with patch("kitaru.logging.Client") as client_cls:
+        log_to_checkpoint(checkpoint_id, _client=client, cost=0.01)
+
+    client_cls.assert_not_called()
+    client.create_run_metadata.assert_called_once()
+    resource = _get_logged_resource(client)
+    assert resource.type == MetadataResourceTypes.STEP_RUN
+    assert resource.id == UUID(checkpoint_id)
+
+
+def test_log_to_execution_reuses_explicit_client() -> None:
+    execution_id = str(uuid4())
+    client = MagicMock()
+
+    with patch("kitaru.logging.Client") as client_cls:
+        log_to_execution(execution_id, _client=client, cost=0.01)
+
+    client_cls.assert_not_called()
+    client.create_run_metadata.assert_called_once()
+    resource = _get_logged_resource(client)
+    assert resource.type == MetadataResourceTypes.PIPELINE_RUN
+    assert resource.id == UUID(execution_id)
 
 
 def test_log_prefers_checkpoint_target_when_both_scopes_are_active() -> None:


### PR DESCRIPTION
## Summary

- publish checkpoint-level flat `kitaru_llm_*_v1` metadata during terminal LLM usage aggregation
- preserve execution-level `llm_usage_summary_v1` behavior while keeping checkpoint metadata flat-only
- keep cost metadata best-effort: failed metadata writes are debug-logged, later checkpoint writes are still attempted, and aggregation reports incomplete persistence for retry
- add regression coverage for visible-step writes, retry accounting, cached/replay-reused zero display cost, stale metadata rewrites, checkpoint metadata logging, client reuse, and checkpoint-write failure continuation

## Reviewer Notes

To reproduce the verification locally:

```bash
just test tests/test_flow.py -k terminal_llm_usage_metadata
just test tests/test_logging.py tests/test_llm_usage.py
just check
git diff --check
```

Oracle review completed with no blocking backend correctness or maintainability findings after the best-effort metadata write handling was added.
