### PR TITLE
Increase Gemini model smoke timeout

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1774,7 +1774,7 @@ run_test "examples/integrations/gemini_interactions_agent/gemini_interactions_ad
 if [[ "$HAS_GEMINI_API_KEY" == true ]]; then
     run_provider_test "gemini-model" "GEMINI_API_KEY,GOOGLE_API_KEY" \
         "examples/integrations/gemini_interactions_agent/gemini_interactions_adapter.py --mode model" \
-        timed 120 $UV_RUN python examples/integrations/gemini_interactions_agent/gemini_interactions_adapter.py \
+        timed 180 $UV_RUN python examples/integrations/gemini_interactions_agent/gemini_interactions_adapter.py \
             --mode model \
             --prompt "Explain one Kitaru checkpoint in one short sentence."
 elif [[ "$HAS_GEMINI_VERTEX" == true ]]; then

--- a/tests/test_smoke_test_script.py
+++ b/tests/test_smoke_test_script.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -39,6 +40,17 @@ def _run_smoke_script(
             text=True,
             timeout=30,
         )
+
+
+def test_gemini_model_smoke_allows_for_variable_thinking_latency() -> None:
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+    match = re.search(
+        r'gemini_interactions_adapter\.py --mode model" \\\n\s+timed (\d+)',
+        script,
+    )
+
+    assert match is not None
+    assert int(match.group(1)) == 180
 
 
 def test_smoke_script_has_valid_bash_syntax() -> None:


### PR DESCRIPTION
## Summary

- increase the Gemini Interactions `--mode model` release-smoke timeout from 120 to 180 seconds
- add a regression test that protects the provider check's timeout budget
- keep timeout failures explicit instead of retrying a potentially accepted paid request

Closes #529.

## Reviewer Notes

The Gemini model smoke check could complete successfully in 22–61 seconds when run alone, yet exceed its 120-second limit during a full release smoke run because Gemini may spend much of the request on thinking tokens. The harness then reported a healthy provider path as failed.

This change gives only that command another 60 seconds. Successful checks still finish immediately; a genuinely stuck command remains bounded at 180 seconds. It does not retry, because the provider may already have accepted the first request before the local timeout kills the client process.

The regression test reads the real smoke command and verifies its declared timeout. Before the script change, it failed with `assert 120 == 180`.

### Reproduction

Run the deterministic regression coverage:

```bash
uv run pytest -q -n 0 tests/test_smoke_test_script.py
bash -n scripts/smoke-test.sh
```

For trusted release-smoke evidence with Gemini credentials available:

```bash
./scripts/smoke-test.sh --release \
  --required-provider-area gemini-model \
  --json-out smoke-results.json
```

The `examples/integrations/gemini_interactions_agent/gemini_interactions_adapter.py --mode model` check now has a 180-second budget and still records `TIMEOUT` distinctly if it exceeds that limit.

### Local checks run

- `uv run pytest -q -n 0 tests/test_smoke_test_script.py` — 7 passed
- `bash -n scripts/smoke-test.sh`
- `just check`
- Oracle review — no findings
