### PR TITLE
Fix checkpoint retry grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 - Terminal cost metadata writes are best-effort: a failed write is debug-logged, the remaining checkpoint writes are still attempted, and incomplete persistence is reported so aggregation can be retried. A metadata write failure never fails the flow run. (#528)
 
+### Fixed
+- Retried checkpoint invocations are now exposed as one checkpoint call with attempt history ordered by retry version. (#530)
+
 ### Infrastructure
 - The release workflow's GitHub Release asset reconcile step now skips signature and attestation assets, which are regenerated per dispatch and previously caused recovery re-dispatches to hard-fail on a non-reproducible asset mismatch. (#513)
 

--- a/src/kitaru/_checkpoint_steps.py
+++ b/src/kitaru/_checkpoint_steps.py
@@ -20,9 +20,9 @@ def visible_checkpoint_step_for_lineage(
     """Return the checkpoint step run exposed by ZenML's run DAG.
 
     Args:
-        attempts: Step-run attempts for one checkpoint lineage, sorted by
-            ascending creation time. The attempt fetcher that calls this helper
-            requests ``sort_by="asc:created"`` from ZenML before grouping steps.
+        attempts: All available step-run attempts for one exact run-local
+            checkpoint name, merged from available sources and sorted by
+            ascending ZenML retry version.
 
     Returns:
         The newest non-retried attempt, or the newest attempt when every attempt

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -207,10 +207,8 @@ def _map_failure_info(
 
 
 def _checkpoint_lineage_key(step: StepRunResponse) -> str:
-    """Return the stable lineage key for checkpoint retry grouping."""
-    if step.original_step_run_id is not None:
-        return str(step.original_step_run_id)
-    return str(step.id)
+    """Return the run-local invocation name used for retry grouping."""
+    return step.name
 
 
 def _list_checkpoint_attempts_for_run_with_zenml_client(
@@ -250,6 +248,8 @@ def _list_checkpoint_attempts_for_run_with_zenml_client(
             f"Failed to fetch checkpoint attempts for execution {run.id}: {exc}"
         ) from exc
 
+    for attempts in grouped_attempts.values():
+        attempts.sort(key=lambda step: step.version)
     return dict(grouped_attempts)
 
 
@@ -651,16 +651,25 @@ def _map_execution(
         except KitaruBackendError:
             attempts_by_lineage = {}
 
+        attempt_ids_by_lineage = {
+            lineage_key: {str(attempt.id) for attempt in attempts}
+            for lineage_key, attempts in attempts_by_lineage.items()
+        }
+        for step in run.steps.values():
+            lineage_key = _checkpoint_lineage_key(step)
+            attempts = attempts_by_lineage.setdefault(lineage_key, [])
+            attempt_ids = attempt_ids_by_lineage.setdefault(lineage_key, set())
+            step_id = str(step.id)
+            if step_id not in attempt_ids:
+                attempts.append(step)
+                attempt_ids.add(step_id)
+
         latest_steps_by_lineage: dict[str, StepRunResponse] = {}
         for lineage_key, attempts in attempts_by_lineage.items():
+            attempts.sort(key=lambda step: step.version)
             visible_step = visible_checkpoint_step_for_lineage(attempts)
             if visible_step is not None:
                 latest_steps_by_lineage[lineage_key] = visible_step
-
-        for step in run.steps.values():
-            lineage_key = _checkpoint_lineage_key(step)
-            latest_steps_by_lineage.setdefault(lineage_key, step)
-            attempts_by_lineage.setdefault(lineage_key, [step])
 
         for step in latest_steps_by_lineage.values():
             checkpoints.append(

--- a/tests/test_checkpoint_retry_grouping.py
+++ b/tests/test_checkpoint_retry_grouping.py
@@ -1,0 +1,90 @@
+"""Regression tests for checkpoint retry history grouping."""
+
+from zenml.client import Client as ZenMLClient
+
+from kitaru import KitaruClient, checkpoint, flow
+
+
+def test_real_zenml_retry_maps_to_one_checkpoint_call(
+    primed_zenml: None,
+) -> None:
+    calls = {"count": 0}
+
+    @checkpoint(retries=1, runtime="inline", cache=False)
+    def research() -> str:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise RuntimeError("fail once")
+        return "ok"
+
+    @flow(cache=False)
+    def retry_once() -> None:
+        research()
+
+    handle = retry_once.run()
+    handle.wait()
+
+    raw_attempts = list(
+        ZenMLClient()
+        .list_run_steps(
+            pipeline_run_id=handle.exec_id,
+            exclude_retried=False,
+            hydrate=True,
+            sort_by="asc:created",
+            size=20,
+        )
+        .items
+    )
+    diagnostics = [
+        {
+            "id": str(step.id),
+            "name": step.name,
+            "version": step.version,
+            "status": step.status.value,
+            "original_step_run_id": (
+                str(step.original_step_run_id)
+                if step.original_step_run_id is not None
+                else None
+            ),
+            "invocation_id": step.spec.invocation_id,
+            "created": step.created,
+            "start_time": step.start_time,
+            "end_time": step.end_time,
+        }
+        for step in raw_attempts
+    ]
+
+    assert calls["count"] == 2
+    assert len(raw_attempts) == 2, diagnostics
+    assert [step.version for step in raw_attempts] == [1, 2], diagnostics
+    assert len({step.name for step in raw_attempts}) == 1, diagnostics
+    assert [step.spec.invocation_id for step in raw_attempts] == [
+        step.name for step in raw_attempts
+    ], diagnostics
+    assert [step.original_step_run_id for step in raw_attempts] == [None, None], (
+        diagnostics
+    )
+    assert [step.status.value for step in raw_attempts] == [
+        "retried",
+        "completed",
+    ], diagnostics
+    assert all(
+        step.created is not None
+        and step.start_time is not None
+        and step.end_time is not None
+        for step in raw_attempts
+    ), diagnostics
+
+    execution = KitaruClient().executions.get(handle.exec_id)
+
+    assert len(execution.checkpoints) == 1
+    checkpoint_call = execution.checkpoints[0]
+    assert checkpoint_call.status.value == "completed"
+    assert [attempt.attempt_id for attempt in checkpoint_call.attempts] == [
+        str(step.id) for step in raw_attempts
+    ]
+    assert [attempt.status.value for attempt in checkpoint_call.attempts] == [
+        "failed",
+        "completed",
+    ]
+    assert checkpoint_call.failure is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -191,6 +191,7 @@ class _DummyStep:
         outputs: dict[str, list[_DummyArtifact]],
         inputs: dict[str, list[_DummyArtifact]] | None = None,
         step_id: UUID | None = None,
+        version: int = 1,
         original_step_run_id: UUID | None = None,
         run_metadata: dict[str, Any] | None = None,
         exception_traceback: str | None = None,
@@ -199,6 +200,7 @@ class _DummyStep:
     ) -> None:
         self.id = step_id or uuid4()
         self.name = name
+        self.version = version
         self.status = status
         self.start_time = None
         self.end_time = None
@@ -2523,17 +2525,17 @@ def test_get_prefers_output_artifact_ref_when_input_seen_first() -> None:
 def test_get_surfaces_checkpoint_attempt_history() -> None:
     attempt_one = _DummyStep(
         name="research",
+        version=1,
         status=ZenMLExecutionStatus.RETRIED,
         outputs={},
         exception_traceback="Traceback\nValueError: boom",
     )
     attempt_two = _DummyStep(
         name="research",
+        version=2,
         status=ZenMLExecutionStatus.COMPLETED,
         outputs={},
-        original_step_run_id=attempt_one.id,
     )
-
     run = _DummyRun(
         status=ZenMLExecutionStatus.COMPLETED,
         flow_name="flow_a",
@@ -2550,19 +2552,130 @@ def test_get_surfaces_checkpoint_attempt_history() -> None:
         client_mock = client_cls.return_value
         client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
         client_mock.list_run_steps.return_value = SimpleNamespace(
-            items=[_as_step_run(attempt_one), _as_step_run(attempt_two)]
+            items=[_as_step_run(attempt_two), _as_step_run(attempt_one)]
         )
 
         client = KitaruClient()
         execution = client.executions.get(str(run.id))
 
+    assert len(execution.checkpoints) == 1
     checkpoint = execution.checkpoints[0]
+    assert checkpoint.call_id == str(attempt_two.id)
+    assert checkpoint.status == ExecutionStatus.COMPLETED
+    assert checkpoint.original_call_id is None
+    assert [attempt.attempt_id for attempt in checkpoint.attempts] == [
+        str(attempt_one.id),
+        str(attempt_two.id),
+    ]
     assert len(checkpoint.attempts) == 2
     assert checkpoint.attempts[0].status == ExecutionStatus.FAILED
     assert checkpoint.attempts[0].failure is not None
     assert checkpoint.attempts[0].failure.origin == FailureOrigin.USER_CODE
     assert checkpoint.attempts[0].failure.exception_type == "ValueError"
+    assert checkpoint.attempts[1].status == ExecutionStatus.COMPLETED
+    assert checkpoint.attempts[1].failure is None
     assert checkpoint.failure is None
+
+
+def test_get_merges_run_step_into_partial_attempt_history() -> None:
+    attempt_one = _DummyStep(
+        name="research",
+        version=1,
+        status=ZenMLExecutionStatus.RETRIED,
+        outputs={},
+    )
+    attempt_two = _DummyStep(
+        name="research",
+        version=2,
+        status=ZenMLExecutionStatus.COMPLETED,
+        outputs={},
+    )
+    run = _DummyRun(
+        status=ZenMLExecutionStatus.COMPLETED,
+        flow_name="flow_a",
+        steps={attempt_two.name: attempt_two},
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
+        client_mock.list_run_steps.return_value = SimpleNamespace(
+            items=[_as_step_run(attempt_one)]
+        )
+
+        client = KitaruClient()
+        execution = client.executions.get(str(run.id))
+
+    assert len(execution.checkpoints) == 1
+    checkpoint = execution.checkpoints[0]
+    assert checkpoint.call_id == str(attempt_two.id)
+    assert checkpoint.status == ExecutionStatus.COMPLETED
+    assert [attempt.attempt_id for attempt in checkpoint.attempts] == [
+        str(attempt_one.id),
+        str(attempt_two.id),
+    ]
+
+
+def test_get_keeps_distinct_checkpoint_names_with_shared_original_step_separate() -> (
+    None
+):
+    original_step_run_id = uuid4()
+    first = _DummyStep(
+        name="research",
+        status=ZenMLExecutionStatus.COMPLETED,
+        outputs={},
+        original_step_run_id=original_step_run_id,
+    )
+    second = _DummyStep(
+        name="research_2",
+        status=ZenMLExecutionStatus.COMPLETED,
+        outputs={},
+        original_step_run_id=original_step_run_id,
+    )
+    run = _DummyRun(
+        status=ZenMLExecutionStatus.COMPLETED,
+        flow_name="flow_a",
+        steps={first.name: first, second.name: second},
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
+        client_mock.list_run_steps.return_value = SimpleNamespace(
+            items=[_as_step_run(first), _as_step_run(second)]
+        )
+
+        client = KitaruClient()
+        execution = client.executions.get(str(run.id))
+
+    assert [checkpoint.name for checkpoint in execution.checkpoints] == [
+        "research",
+        "research_2",
+    ]
+    checkpoints_by_name = {
+        checkpoint.name: checkpoint for checkpoint in execution.checkpoints
+    }
+    assert [
+        attempt.attempt_id for attempt in checkpoints_by_name["research"].attempts
+    ] == [str(first.id)]
+    assert [
+        attempt.attempt_id for attempt in checkpoints_by_name["research_2"].attempts
+    ] == [str(second.id)]
+    assert {checkpoint.original_call_id for checkpoint in execution.checkpoints} == {
+        str(original_step_run_id)
+    }
 
 
 def test_get_surfaces_execution_failure_origin() -> None:

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -1112,6 +1112,7 @@ def test_mapped_execution_uses_replay_skip_metadata_for_public_records(
     fetch_step = SimpleNamespace(
         id="fetch-attempt",
         name="fetch",
+        version=1,
         status="replay_reused",
         start_time=None,
         end_time=None,
@@ -1127,6 +1128,7 @@ def test_mapped_execution_uses_replay_skip_metadata_for_public_records(
     write_step = SimpleNamespace(
         id="write-attempt",
         name="write",
+        version=1,
         status="replay_reused",
         start_time=None,
         end_time=None,
@@ -1155,8 +1157,8 @@ def test_mapped_execution_uses_replay_skip_metadata_for_public_records(
     monkeypatch.setattr(
         "kitaru._client._mappers._list_checkpoint_attempts_for_run",
         lambda *, run, client: {
-            "fetch-attempt": [fetch_step],
-            "write-attempt": [write_step],
+            "fetch": [fetch_step],
+            "write": [write_step],
         },
     )
 


### PR DESCRIPTION
## Summary

- Group ZenML retry attempts by the run-local checkpoint step name. Real ZenML retry records keep the same name while `original_step_run_id` remains unset, so the previous ID-based key exposed each retry as a separate checkpoint call.
- Merge retry history returned by `list_run_steps` with the hydrated step in the run DAG, deduplicate attempts by step-run ID, and order them by ZenML retry version.
- Add unit coverage for ordered retries, partial history, and distinct checkpoint names, plus a regression test that executes a real ZenML retry.

## Verification

- `just fix`
- `just check`
- `just test` — 3,503 passed, 29 skipped
- `just test tests/test_checkpoint_retry_grouping.py` — 1 passed

## Reviewer Notes

A checkpoint that fails once and then succeeds produces two ZenML step-run records with the same step name and versions 1 and 2. Both records have no `original_step_run_id`. The mapper now groups those records by name, adds the current run-DAG step if the history response omitted it, removes duplicate IDs, sorts by version, and exposes the version-2 step as one completed checkpoint call containing both attempts.

The main review risk is accidentally combining two different checkpoint invocations or losing the successful attempt when ZenML returns only partial history. The focused unit tests cover both cases, while the real-ZenML test proves the actual retry record shape and public mapping end to end.

### Reproduction

```bash
git checkout fix/issue-530-checkpoint-retry-grouping
just test tests/test_checkpoint_retry_grouping.py
just test tests/test_client.py -k 'surfaces_checkpoint_attempt_history or merges_run_step_into_partial_attempt_history or keeps_distinct_checkpoint_names'
```

Closes #530
