### PR TITLE
Document `openai`, `anthropic`, `llm` extras before quickstart LLM call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Document the `openai`, `anthropic`, and `llm` provider extras on the installation page, and add the `kitaru[openai]` install step before the quickstart's first LLM call so a base-package user does not crash on the first `kitaru.llm()` invocation. (#522)
+
 ## [0.20.2] - 2026-07-10
 
 ### Added

--- a/docs/book/getting-started/installation.md
+++ b/docs/book/getting-started/installation.md
@@ -39,6 +39,9 @@ This gives you the full SDK, CLI, and everything you need to run flows locally.
 | `mcp` | MCP server for querying executions from AI assistants |
 | `modal` | Python dependencies needed to create and validate Modal-backed stacks |
 | `pydantic-ai` | PydanticAI adapter for wrapping agents in checkpoints |
+| `openai` | OpenAI SDK for `kitaru.llm()` calls to OpenAI models |
+| `anthropic` | Anthropic SDK for `kitaru.llm()` calls to Claude models |
+| `llm` | Both `openai` and `anthropic` provider packages in one install |
 
 ```bash
 uv add "kitaru[mcp,pydantic-ai,local]"
@@ -46,6 +49,9 @@ uv add "kitaru[mcp,pydantic-ai,local]"
 
 # Modal stacks: uv add "kitaru[modal]"
 # or: pip install "kitaru[modal]"
+
+# Provider extras: uv add "kitaru[openai]"
+# or: pip install "kitaru[openai]"
 ```
 
 The `modal` extra does not create Modal tokens, Docker registry logins, cloud

--- a/docs/book/getting-started/quickstart.md
+++ b/docs/book/getting-started/quickstart.md
@@ -21,6 +21,23 @@ kitaru init
 
 This creates a `.kitaru/` directory that marks your project root.
 
+The example calls an OpenAI model, so install Kitaru with the OpenAI
+provider package:
+
+{% tabs %}
+{% tab title="uv (recommended)" %}
+```bash
+uv add "kitaru[openai]"
+```
+{% endtab %}
+
+{% tab title="pip" %}
+```bash
+pip install "kitaru[openai]"
+```
+{% endtab %}
+{% endtabs %}
+
 `kitaru.llm()` reads its provider key and default model from the environment:
 
 ```bash


### PR DESCRIPTION
## Summary

The installation page listed four optional extras (`local`, `mcp`, `modal`, `pydantic-ai`) but omitted the `openai`, `anthropic`, and `llm` provider extras that `pyproject.toml` defines. The quickstart then asked the user to run an OpenAI-backed `kitaru.llm()` flow without first telling them to install `kitaru[openai]`.

A fresh user who installed the base package and followed both pages correctly would crash on the first `kitaru.llm()` call with `ModuleNotFoundError: openai`.

### What changed

- **`docs/book/getting-started/installation.md`** — Added `openai`, `anthropic`, and `llm` rows to the optional-extras table, plus a uv/pip example line in the existing comment-block style.
- **`docs/book/getting-started/quickstart.md`** — Inserted a `{% tabs %}` install step for `kitaru[openai]` immediately before the `export OPENAI_API_KEY=...` environment-variable block, so dependency setup, credentials, and the production model-alias hint remain three clearly separate concerns.
- **`CHANGELOG.md`** — Added a `### Fixed` entry under `[Unreleased]`.

### Scope

Only the three files above are touched. No code, no `pyproject.toml` change — the extras already exist; they were just undocumented. The other extras (`openai-agents`, `langgraph`, `claude-agent-sdk`, `gemini`, `google-adk`) are out of scope for this issue.

## Reviewer Notes

The story of this change: a new user opens the installation page, sees four extras, runs `uv add kitaru`, and thinks they are done. They click into the Quickstart, which sets `OPENAI_API_KEY` and runs a flow whose default model is `openai/gpt-5-nano`. The first `kitaru.llm()` call tries `import openai` — but `openai` was never installed, because the `openai` extra was never mentioned on the install page and never re-mentioned in the Quickstart before the call that needs it.

The fix lives in two files:
- The **installation page** now has three new rows in the extras table and a matching example line, so every extra in `pyproject.toml` that a user might need to install is listed there.
- The **quickstart** now has a one-line install step (using the same `{% tabs %}` uv/pip pattern the page already uses) placed between `kitaru init` and the `export OPENAI_API_KEY=...` block. The `{% hint %}` block for production model-alias/secret guidance is untouched — dependency installation, credentials, and production setup stay as separate steps.

If the implementation is wrong, the user would still hit `ModuleNotFoundError` on the first LLM call, or the three concerns (dependencies, credentials, aliases) would be muddled together instead of cleanly separated.

### Reproduction

1. Start from a clean environment with only `kitaru` (the base package) installed.
2. Follow `docs/book/getting-started/installation.md` — you should see `openai`, `anthropic`, and `llm` in the extras table.
3. Follow `docs/book/getting-started/quickstart.md` from the top. Before the `export OPENAI_API_KEY=sk-...` block, you should see the install instruction for `kitaru[openai]`.
4. Run `uv add "kitaru[openai]"` (or `pip install "kitaru[openai]"`), then continue the quickstart. The `kitaru.llm()` call should succeed instead of crashing.

### Local checks run

```bash
just typos   # passed
just links   # passed
just check   # passed (two pre-existing PydanticAI deprecation warnings, no errors)
```

Closes #522