### PR TITLE
Expose resume and abort-wait through MCP

### DIFF
--- a/docs/book/agent-native/mcp-server.md
+++ b/docs/book/agent-native/mcp-server.md
@@ -134,7 +134,9 @@ Execution tools:
 - `get_execution_logs`
 - `kitaru_executions_run`
 - `kitaru_executions_cancel`
+- `kitaru_executions_abort_wait`
 - `kitaru_executions_input`
+- `kitaru_executions_resume`
 - `kitaru_executions_retry`
 - `kitaru_executions_replay`
 - `kitaru_executions_cohort`
@@ -468,9 +470,15 @@ serverless routing, and auth context, see [Deployments](../concepts/deployments.
 
 1. Call `kitaru_executions_statistics(group_by=["status"])` to get the execution health overview
 2. Call `kitaru_executions_list(status="waiting")` if the overview shows waiting executions
-3. Ask the user to confirm an action for a pending wait
-4. Call `kitaru_executions_input(exec_id=..., wait=..., value=...)` (MCP requires explicit `wait`; CLI auto-detects)
-5. Re-check state via `kitaru_executions_get(exec_id)`
+3. Use the pending-wait name or ID shown by the execution, or already known by the workflow
+4. Ask the user whether to provide input or explicitly abort that wait
+5. Call `kitaru_executions_input(exec_id=..., wait=..., value=...)` or `kitaru_executions_abort_wait(exec_id=..., wait=...)` (MCP requires explicit `wait`; CLI auto-detects)
+6. Inspect the returned execution's `status` and singular `pending_wait`
+7. If `pending_wait` is absent but the execution does not continue, call `kitaru_executions_resume(exec_id=...)` (for example, because the original runner exited)
+
+Aborting a wait resolves only that selected wait; it does not cancel the whole
+execution. The input and abort-wait tools do not call resume themselves, though
+an existing runner may continue after the wait is resolved.
 
 To provision or clean up a local stack, use `manage_stack(action="create", name="local-dev")`
 or `manage_stack(action="delete", name="local-dev", force=True)`.
@@ -521,6 +529,8 @@ For diffs, use:
 Replay does not support `wait.*` overrides. If the replayed execution reaches a
 wait, resolve it through the normal input flow afterward.
 
-MCP currently exposes `kitaru_executions_input` but not a separate resume tool.
-If your backend requires an explicit resume step after input resolution, use the
-CLI or SDK `resume(...)` surface.
+After resolving the wait with `kitaru_executions_input` or
+`kitaru_executions_abort_wait`, inspect the returned execution. If
+`pending_wait` is absent but the execution does not continue, call
+`kitaru_executions_resume` (for example, because the original runner exited).
+The input and abort-wait tools do not call resume themselves.

--- a/docs/book/guides/execution-management.md
+++ b/docs/book/guides/execution-management.md
@@ -529,13 +529,22 @@ Then use tool calls like:
 - `kitaru_executions_list(status="waiting")`
 - `kitaru_executions_statistics(group_by=["status"])`
 - `kitaru_executions_input(exec_id=..., wait=..., value=...)` (MCP requires explicit `wait`)
+- `kitaru_executions_abort_wait(exec_id=..., wait=...)`
+- `kitaru_executions_resume(exec_id=...)`
 - `get_execution_logs(exec_id=...)`
 - `kitaru_artifacts_get(artifact_id=...)`
 - `kitaru_status()`
 
-If the execution does not continue automatically after wait input is resolved
-(e.g. the original runner already exited), use the CLI or SDK `resume(...)` call.
-MCP does not currently expose a separate resume tool.
+Use the pending-wait name or ID shown by the execution, or already known by the
+workflow. Resolve that wait with `kitaru_executions_input` or explicitly abort
+it with `kitaru_executions_abort_wait`, then inspect the returned execution's
+`status` and singular `pending_wait`. If `pending_wait` is absent but the
+execution does not continue, call `kitaru_executions_resume` (for example,
+because the original runner exited).
+
+Aborting a wait resolves only that selected wait; it does not cancel the whole
+execution. The input and abort-wait tools do not call resume themselves, though
+an existing runner may continue after the wait is resolved.
 
 See the full setup guide at [MCP Server](../agent-native/mcp-server.md).
 

--- a/src/kitaru/mcp/server.py
+++ b/src/kitaru/mcp/server.py
@@ -407,6 +407,16 @@ def kitaru_executions_cancel(exec_id: str) -> dict[str, Any]:
 
 
 @tracked_mcp_tool
+def kitaru_executions_abort_wait(exec_id: str, wait: str) -> dict[str, Any]:
+    """Abort one pending wait without cancelling its execution."""
+    return run_with_mcp_error_boundary(
+        lambda: inspection.serialize_execution(
+            client_api.KitaruClient().executions.abort_wait(exec_id, wait=wait)
+        )
+    )
+
+
+@tracked_mcp_tool
 def kitaru_executions_input(exec_id: str, wait: str, value: Any) -> dict[str, Any]:
     """Provide input to a waiting execution and return updated details."""
 
@@ -423,6 +433,16 @@ def kitaru_executions_input(exec_id: str, wait: str, value: Any) -> dict[str, An
         return inspection.serialize_execution(updated_execution)
 
     return run_with_mcp_error_boundary(_provide_input)
+
+
+@tracked_mcp_tool
+def kitaru_executions_resume(exec_id: str) -> dict[str, Any]:
+    """Resume one execution after its pending waits are resolved."""
+    return run_with_mcp_error_boundary(
+        lambda: inspection.serialize_execution(
+            client_api.KitaruClient().executions.resume(exec_id)
+        )
+    )
 
 
 @tracked_mcp_tool

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -48,6 +48,7 @@ from kitaru.mcp.server import (
     kitaru_deployments_list,
     kitaru_deployments_tag,
     kitaru_deployments_untag,
+    kitaru_executions_abort_wait,
     kitaru_executions_cancel,
     kitaru_executions_diff_matrix,
     kitaru_executions_get,
@@ -55,6 +56,7 @@ from kitaru.mcp.server import (
     kitaru_executions_latest,
     kitaru_executions_list,
     kitaru_executions_replay,
+    kitaru_executions_resume,
     kitaru_executions_retry,
     kitaru_executions_run,
     kitaru_executions_statistics,
@@ -88,8 +90,10 @@ _REGISTERED_MCP_TOOL_FUNCTIONS = (
     kitaru_deployments_delete,
     kitaru_deployments_tag,
     kitaru_deployments_untag,
+    kitaru_executions_abort_wait,
     kitaru_executions_cancel,
     kitaru_executions_input,
+    kitaru_executions_resume,
     kitaru_executions_retry,
     kitaru_executions_replay,
     kitaru_executions_diff_matrix,
@@ -146,6 +150,14 @@ def test_fastmcp_registers_public_tools_with_expected_input_schemas() -> None:
     input_schema = tool_schemas["kitaru_executions_input"]
     assert set(input_schema["properties"]) == {"exec_id", "wait", "value"}
     assert input_schema["required"] == ["exec_id", "wait", "value"]
+
+    resume_schema = tool_schemas["kitaru_executions_resume"]
+    assert set(resume_schema["properties"]) == {"exec_id"}
+    assert resume_schema["required"] == ["exec_id"]
+
+    abort_wait_schema = tool_schemas["kitaru_executions_abort_wait"]
+    assert set(abort_wait_schema["properties"]) == {"exec_id", "wait"}
+    assert abort_wait_schema["required"] == ["exec_id", "wait"]
 
     invoke_schema = tool_schemas["kitaru_deployments_invoke"]
     assert set(invoke_schema["properties"]) == {
@@ -1317,6 +1329,90 @@ def test_execution_mutation_tools_return_serialized_execution(
 
     assert cancel_payload["exec_id"] == sample_execution.exec_id
     assert retry_payload["exec_id"] == sample_execution.exec_id
+
+
+def test_executions_resume_delegates_and_serializes_execution(
+    mock_kitaru_client: MagicMock,
+    sample_execution,
+) -> None:
+    """Resume should delegate once and return the full normalized payload."""
+    mock_kitaru_client.executions.resume.return_value = sample_execution
+    normalized = {"exec_id": sample_execution.exec_id, "status": "running"}
+
+    with (
+        patch("kitaru.client.KitaruClient", return_value=mock_kitaru_client),
+        patch(
+            "kitaru.inspection.serialize_execution",
+            return_value=normalized,
+        ) as mock_serialize,
+    ):
+        payload = kitaru_executions_resume(sample_execution.exec_id)
+
+    mock_kitaru_client.executions.resume.assert_called_once_with(
+        sample_execution.exec_id
+    )
+    mock_serialize.assert_called_once_with(sample_execution)
+    assert payload == normalized
+
+
+def test_executions_abort_wait_delegates_and_serializes_execution(
+    mock_kitaru_client: MagicMock,
+    sample_execution,
+) -> None:
+    """Abort-wait should pass the selector by keyword and normalize the result."""
+    mock_kitaru_client.executions.abort_wait.return_value = sample_execution
+    normalized = {"exec_id": sample_execution.exec_id, "status": "waiting"}
+
+    with (
+        patch("kitaru.client.KitaruClient", return_value=mock_kitaru_client),
+        patch(
+            "kitaru.inspection.serialize_execution",
+            return_value=normalized,
+        ) as mock_serialize,
+    ):
+        payload = kitaru_executions_abort_wait(
+            sample_execution.exec_id,
+            wait="approve_draft",
+        )
+
+    mock_kitaru_client.executions.abort_wait.assert_called_once_with(
+        sample_execution.exec_id,
+        wait="approve_draft",
+    )
+    mock_serialize.assert_called_once_with(sample_execution)
+    assert payload == normalized
+
+
+@pytest.mark.parametrize(
+    ("tool", "client_method", "kwargs"),
+    [
+        (kitaru_executions_resume, "resume", {}),
+        (
+            kitaru_executions_abort_wait,
+            "abort_wait",
+            {"wait": "approve_draft"},
+        ),
+    ],
+)
+def test_execution_wait_mutations_preserve_client_state_errors(
+    mock_kitaru_client: MagicMock,
+    tool,
+    client_method: str,
+    kwargs: dict[str, str],
+) -> None:
+    """Wait mutation tools should re-raise SDK state errors without serializing."""
+    error = KitaruStateError("execution cannot make this transition")
+    getattr(mock_kitaru_client.executions, client_method).side_effect = error
+
+    with (
+        patch("kitaru.client.KitaruClient", return_value=mock_kitaru_client),
+        patch("kitaru.inspection.serialize_execution") as mock_serialize,
+        pytest.raises(KitaruStateError) as exc_info,
+    ):
+        tool("kr-a8f3c2", **kwargs)
+
+    assert exc_info.value is error
+    mock_serialize.assert_not_called()
 
 
 def test_artifact_tools_call_client_and_serialize(


### PR DESCRIPTION
## Summary

- expose  and  through the MCP server
- reuse the existing SDK validation, MCP error boundary, execution serializer, and analytics decorator
- add MCP registration, schema, exact delegation, serialization, and error-preservation contract tests
- document explicit wait resolution and resume behavior on both hand-written MCP pages

## Reviewer Notes

The new MCP functions are intentionally thin: each delegates once to the existing executions client and serializes the returned execution. In particular, abort-wait resolves only the selected wait, and neither input nor abort-wait calls resume itself. A live runner may continue after resolution; callers should inspect the returned execution and call resume if it does not continue.

The focused cases verify the registered argument schemas, exact SDK calls including keyword-only , full execution serialization, and unchanged SDK state errors.

Closes #521