### PR TITLE
Add metadata-only `kitaru_secrets_list` MCP tool

### DIFF
--- a/docs/book/agent-native/mcp-server.md
+++ b/docs/book/agent-native/mcp-server.md
@@ -166,6 +166,10 @@ returns only metadata for each secret: `id`, `name`, `visibility`, `keys`, and
 `has_missing_values`. It never returns secret values. Pages beyond the available
 results return `[]`.
 
+When listing secrets, `keys` and `has_missing_values` may be unpopulated because
+the backend does not include key names in list responses. These fields are
+meaningful in `kitaru_secrets_create` responses and the CLI `secrets show` path.
+
 `kitaru_secrets_create` also returns metadata only. The MCP server intentionally
 does not expose `kitaru_secrets_delete`; use the CLI or Python SDK for deletion.
 

--- a/docs/book/agent-native/mcp-server.md
+++ b/docs/book/agent-native/mcp-server.md
@@ -159,10 +159,15 @@ Artifact tools:
 Secret tools:
 
 - `kitaru_secrets_create`
+- `kitaru_secrets_list`
 
-`kitaru_secrets_create` returns metadata only: secret ID, name, visibility, key
-names, and missing-value status. The MCP server intentionally does not expose a
-secret delete tool; use the CLI or Python SDK for deletion.
+`kitaru_secrets_list` accepts `page` and `size` (defaults: `1` and `20`) and
+returns only metadata for each secret: `id`, `name`, `visibility`, `keys`, and
+`has_missing_values`. It never returns secret values. Pages beyond the available
+results return `[]`.
+
+`kitaru_secrets_create` also returns metadata only. The MCP server intentionally
+does not expose `kitaru_secrets_delete`; use the CLI or Python SDK for deletion.
 
 Project tools:
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1841,6 +1841,8 @@ run_expected_failure "kitaru build rejects local stack deployments" \
 # ---------------------------------------------------------------------------
 section_header "Secret API"
 
+run_test "kitaru secrets list --help" $UV_RUN kitaru secrets list --help
+
 SMOKE_SECRET_NAME="kitaru-smoke-creds"
 run_test "kitaru secrets set smoke secret" \
     $UV_RUN kitaru secrets set "$SMOKE_SECRET_NAME" --SMOKE_TOKEN=smoke-value
@@ -2015,6 +2017,9 @@ run_test "MCP: kitaru_projects_list" \
 
 run_test "MCP: kitaru_projects_current" \
     $FASTMCP call --command "$MCP_SERVER" --target kitaru_projects_current --json
+
+run_test "MCP: kitaru_secrets_list" \
+    $FASTMCP call --command "$MCP_SERVER" --target kitaru_secrets_list --json
 
 run_expected_failure "MCP: local/OSS blocks kitaru_projects_use" \
     "$PROJECT_GUARD_MESSAGE" \

--- a/src/kitaru/__init__.py
+++ b/src/kitaru/__init__.py
@@ -25,7 +25,7 @@ Current status:
 - Implemented: ``@flow``, ``@checkpoint``, ``kitaru.log()``,
   ``kitaru.progress()``, ``kitaru.events.publish()``,
   ``save()``, ``load()``, ``wait()``, ``llm()``, ``get_secret()``,
-  ``create_secret()``, ``delete_secret()``, ``connect()``,
+  ``list_secrets()``, ``create_secret()``, ``delete_secret()``, ``connect()``,
   ``configure()``, stack lifecycle helpers (``list_stacks()``,
   ``current_stack()``, ``use_stack()``, ``create_stack()``,
   ``delete_stack()``), model alias helpers via CLI
@@ -147,6 +147,7 @@ from kitaru.secrets import (
     create_secret,
     delete_secret,
     get_secret,
+    list_secrets,
 )
 from kitaru.wait import wait
 
@@ -225,6 +226,7 @@ __all__ = [
     "get_secret",
     "is_replay",
     "list_projects",
+    "list_secrets",
     "list_stacks",
     "llm",
     "load",

--- a/src/kitaru/_cli/_secrets.py
+++ b/src/kitaru/_cli/_secrets.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated
 
 from cyclopts import Parameter
 from zenml.exceptions import EntityExistsError
 from zenml.models import SecretResponse
 
+import kitaru.secrets as secrets_api
 from kitaru._interface_errors import run_with_cli_error_boundary
 from kitaru.cli_output import CLIOutputFormat
 from kitaru.inspection import serialize_secret_detail, serialize_secret_summary
-from kitaru.secrets import _SECRET_KEY_PATTERN
+from kitaru.secrets import _SECRET_KEY_PATTERN, SecretSummary
 
 from . import secrets_app
 from ._dependencies import cli_dependencies
@@ -31,8 +32,6 @@ from ._helpers import (
     _resolve_output_format,
     _validate_pagination,
 )
-
-_SECRETS_BACKEND_SCAN_SIZE = 50
 
 
 def _parse_secret_assignments(raw_assignments: list[str]) -> dict[str, str]:
@@ -101,21 +100,6 @@ def _parse_secret_assignments(raw_assignments: list[str]) -> dict[str, str]:
     return parsed
 
 
-def _list_accessible_secrets(client: Any) -> list[SecretResponse]:
-    """List all accessible secrets across all backend pages."""
-    first_page = client.list_secrets(page=1, size=_SECRETS_BACKEND_SCAN_SIZE)
-    secrets = list(first_page.items)
-
-    for page_number in range(2, first_page.total_pages + 1):
-        page = client.list_secrets(
-            page=page_number,
-            size=_SECRETS_BACKEND_SCAN_SIZE,
-        )
-        secrets.extend(page.items)
-
-    return secrets
-
-
 def _secret_show_rows(
     secret: SecretResponse,
     *,
@@ -139,12 +123,7 @@ def _secret_show_rows(
     return rows
 
 
-def _order_secrets(secrets: list[SecretResponse]) -> list[SecretResponse]:
-    """Return secrets in deterministic CLI display order."""
-    return sorted(secrets, key=lambda secret: (secret.name.lower(), str(secret.id)))
-
-
-def _secret_list_rows(secrets: list[SecretResponse]) -> list[tuple[str, str]]:
+def _secret_list_rows(secrets: list[SecretSummary]) -> list[tuple[str, str]]:
     """Build label/value rows for `kitaru secrets list`."""
     if not secrets:
         return [("Secrets", "none found")]
@@ -285,14 +264,13 @@ def list__(
         output=output_format,
     )
     secrets = run_with_cli_error_boundary(
-        lambda: _list_accessible_secrets(cli_dependencies().zenml_client()),
+        secrets_api.list_secrets,
         command=command,
         output=output_format,
         exit_with_error=_exit_with_error,
     )
 
-    ordered = _order_secrets(secrets)
-    visible_secrets = _paginate_items(ordered, page=page, size=size)
+    visible_secrets = _paginate_items(secrets, page=page, size=size)
 
     if output_format == CLIOutputFormat.JSON:
         _emit_json_items(
@@ -302,7 +280,7 @@ def list__(
         )
         return
 
-    if ordered and not visible_secrets:
+    if secrets and not visible_secrets:
         rows: list[tuple[str, str]] = [("Secrets", f"no items on page {page}")]
     else:
         rows = _secret_list_rows(visible_secrets)
@@ -311,7 +289,7 @@ def list__(
         page=page,
         size=size,
         returned_count=len(visible_secrets),
-        total_count=len(ordered),
+        total_count=len(secrets),
         output=output_format,
     )
 

--- a/src/kitaru/cli.py
+++ b/src/kitaru/cli.py
@@ -173,7 +173,6 @@ from kitaru._cli._projects import (
 )
 from kitaru._cli._secrets import (
     _SECRET_KEY_PATTERN,
-    _list_accessible_secrets,
     _parse_secret_assignments,
     _secret_list_rows,
     _secret_show_rows,
@@ -439,7 +438,6 @@ __all__ = [
     "_info_rows",
     "_is_input_interactive",
     "_is_interactive",
-    "_list_accessible_secrets",
     "_list_stack_entries",
     "_load_stack_create_file",
     "_log_entry_dedup_key",

--- a/src/kitaru/mcp/server.py
+++ b/src/kitaru/mcp/server.py
@@ -37,6 +37,7 @@ from kitaru._local_server import (
     stop_registered_local_server,
 )
 from kitaru.analytics import AnalyticsEvent, set_source, track
+from kitaru.errors import KitaruUsageError
 
 _MCP_INSTALL_ERROR = (
     "MCP server dependencies are not installed. Install with: pip install kitaru[mcp]"
@@ -561,6 +562,28 @@ def kitaru_secrets_create(
             secrets_api.create_secret(name, values, private=private)
         )
     )
+
+
+@tracked_mcp_tool
+def kitaru_secrets_list(
+    page: int = 1,
+    size: int = 20,
+) -> list[dict[str, Any]]:
+    """List paginated secret metadata without raw values."""
+
+    def _list_secrets() -> list[dict[str, Any]]:
+        if isinstance(page, bool) or not isinstance(page, int) or page < 1:
+            raise KitaruUsageError("`page` must be an integer >= 1.")
+        if isinstance(size, bool) or not isinstance(size, int) or size < 1:
+            raise KitaruUsageError("`size` must be an integer >= 1.")
+
+        all_summaries = secrets_api.list_secrets()
+        start = (page - 1) * size
+        end = start + size
+        page_items = all_summaries[start:end]
+        return [inspection.serialize_secret_summary(summary) for summary in page_items]
+
+    return run_with_mcp_error_boundary(_list_secrets)
 
 
 @tracked_mcp_tool

--- a/src/kitaru/mcp/server.py
+++ b/src/kitaru/mcp/server.py
@@ -577,11 +577,10 @@ def kitaru_secrets_list(
         if isinstance(size, bool) or not isinstance(size, int) or size < 1:
             raise KitaruUsageError("`size` must be an integer >= 1.")
 
-        all_summaries = secrets_api.list_secrets()
-        start = (page - 1) * size
-        end = start + size
-        page_items = all_summaries[start:end]
-        return [inspection.serialize_secret_summary(summary) for summary in page_items]
+        return [
+            inspection.serialize_secret_summary(summary)
+            for summary in secrets_api.list_secrets()[(page - 1) * size : page * size]
+        ]
 
     return run_with_mcp_error_boundary(_list_secrets)
 

--- a/src/kitaru/secrets.py
+++ b/src/kitaru/secrets.py
@@ -15,6 +15,7 @@ from kitaru.analytics import AnalyticsEvent, track
 from kitaru.errors import KitaruBackendError, KitaruRuntimeError, KitaruUsageError
 
 _SECRET_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SECRETS_BACKEND_SCAN_SIZE = 50
 
 
 class Secret(BaseModel):
@@ -223,6 +224,40 @@ def _read_secret_values(secret_name: str) -> dict[str, str]:
     return values
 
 
+def list_secrets() -> list[SecretSummary]:
+    """List all accessible secrets as metadata-only summaries.
+
+    Returns:
+        All accessible secrets, ordered case-insensitively by name and then by
+        ID.
+
+    Raises:
+        KitaruBackendError: If client creation, a backend request, or response
+            conversion fails.
+    """
+    try:
+        client = _ZenMLClient()
+        first_page = client.list_secrets(page=1, size=_SECRETS_BACKEND_SCAN_SIZE)
+        summaries = [
+            _secret_summary_from_response(secret_response)
+            for secret_response in first_page.items
+        ]
+
+        for page_number in range(2, first_page.total_pages + 1):
+            page = client.list_secrets(
+                page=page_number,
+                size=_SECRETS_BACKEND_SCAN_SIZE,
+            )
+            summaries.extend(
+                _secret_summary_from_response(secret_response)
+                for secret_response in page.items
+            )
+
+        return sorted(summaries, key=lambda summary: (summary.name.lower(), summary.id))
+    except Exception as exc:
+        raise KitaruBackendError(f"Failed to list secrets: {exc}") from exc
+
+
 def get_secret(name_or_id: str) -> Secret:
     """Read a stored secret by exact name or ID.
 
@@ -303,4 +338,11 @@ def delete_secret(name_or_id: str) -> SecretSummary:
     return summary
 
 
-__all__ = ["Secret", "SecretSummary", "create_secret", "delete_secret", "get_secret"]
+__all__ = [
+    "Secret",
+    "SecretSummary",
+    "create_secret",
+    "delete_secret",
+    "get_secret",
+    "list_secrets",
+]

--- a/src/kitaru/secrets.py
+++ b/src/kitaru/secrets.py
@@ -244,13 +244,12 @@ def list_secrets() -> list[SecretSummary]:
         ]
 
         for page_number in range(2, first_page.total_pages + 1):
-            page = client.list_secrets(
-                page=page_number,
-                size=_SECRETS_BACKEND_SCAN_SIZE,
-            )
             summaries.extend(
                 _secret_summary_from_response(secret_response)
-                for secret_response in page.items
+                for secret_response in client.list_secrets(
+                    page=page_number,
+                    size=_SECRETS_BACKEND_SCAN_SIZE,
+                ).items
             )
 
         return sorted(summaries, key=lambda summary: (summary.name.lower(), summary.id))

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -30,6 +30,7 @@ from kitaru.config import (
     VertexStackSpec,
 )
 from kitaru.errors import (
+    KitaruBackendError,
     KitaruFeatureNotAvailableError,
     KitaruRuntimeError,
     KitaruStateError,
@@ -64,6 +65,7 @@ from kitaru.mcp.server import (
     kitaru_projects_show,
     kitaru_projects_use,
     kitaru_secrets_create,
+    kitaru_secrets_list,
     kitaru_stacks_list,
     kitaru_start_local_server,
     kitaru_status,
@@ -94,6 +96,7 @@ _REGISTERED_MCP_TOOL_FUNCTIONS = (
     kitaru_executions_replay,
     kitaru_executions_diff_matrix,
     kitaru_secrets_create,
+    kitaru_secrets_list,
     kitaru_artifacts_list,
     kitaru_artifacts_get,
     kitaru_start_local_server,
@@ -220,6 +223,17 @@ def test_fastmcp_registers_public_tools_with_expected_input_schemas() -> None:
     assert "kitaru_projects_delete" not in tool_schemas
     assert "kitaru_executions_diff_matrix" in tool_schemas
     assert "kitaru_executions_diff_cohort" not in tool_schemas
+
+
+def test_secrets_list_schema_has_optional_pagination_parameters() -> None:
+    schema = _mcp_tool_schemas_by_name()["kitaru_secrets_list"]
+
+    assert set(schema["properties"]) == {"page", "size"}
+    assert schema["properties"]["page"]["type"] == "integer"
+    assert schema["properties"]["page"]["default"] == 1
+    assert schema["properties"]["size"]["type"] == "integer"
+    assert schema["properties"]["size"]["default"] == 20
+    assert schema.get("required", []) == []
 
 
 def test_load_flow_target_supports_module_paths(
@@ -1379,6 +1393,196 @@ def test_artifact_get_delegates_value_serialization_to_inspection(
     assert payload["value_type"] == "custom.Type"
 
 
+def test_secrets_list_uses_default_pagination() -> None:
+    summaries = [
+        SecretSummary(
+            name=f"secret-{index:02d}",
+            id=f"secret-id-{index:02d}",
+            private=False,
+            keys=["API_KEY"],
+        )
+        for index in range(25)
+    ]
+
+    with patch(
+        "kitaru.mcp.server.secrets_api.list_secrets",
+        return_value=summaries,
+    ) as mock_list:
+        payload = kitaru_secrets_list()
+
+    mock_list.assert_called_once_with()
+    assert len(payload) == 20
+    assert [item["id"] for item in payload] == [
+        summary.id for summary in summaries[:20]
+    ]
+
+
+def test_secrets_list_applies_non_default_pagination_without_resorting() -> None:
+    summaries = [
+        SecretSummary(
+            name=name,
+            id=f"secret-id-{index}",
+            private=False,
+            keys=["API_KEY"],
+        )
+        for index, name in enumerate(["zeta", "alpha", "gamma", "beta", "delta"])
+    ]
+
+    with patch(
+        "kitaru.mcp.server.secrets_api.list_secrets",
+        return_value=summaries,
+    ) as mock_list:
+        payload = kitaru_secrets_list(page=2, size=2)
+
+    mock_list.assert_called_once_with()
+    assert [item["id"] for item in payload] == [
+        summaries[2].id,
+        summaries[3].id,
+    ]
+
+
+def test_secrets_list_returns_empty_for_out_of_range_page() -> None:
+    summaries = [
+        SecretSummary(
+            name="openai-creds",
+            id="secret-id",
+            private=False,
+            keys=["OPENAI_API_KEY"],
+        )
+    ]
+
+    with (
+        patch(
+            "kitaru.mcp.server.secrets_api.list_secrets",
+            return_value=summaries,
+        ),
+        patch(
+            "kitaru.mcp.server.inspection.serialize_secret_summary",
+        ) as mock_serialize,
+    ):
+        payload = kitaru_secrets_list(page=2, size=20)
+
+    assert payload == []
+    mock_serialize.assert_not_called()
+
+
+def test_secrets_list_delegates_in_page_items_to_serializer_in_order() -> None:
+    summaries = [
+        SecretSummary(
+            name=f"secret-{index}",
+            id=f"secret-id-{index}",
+            private=False,
+            keys=["API_KEY"],
+        )
+        for index in range(4)
+    ]
+    serialized = [{"id": summaries[2].id}, {"id": summaries[3].id}]
+
+    with (
+        patch(
+            "kitaru.mcp.server.secrets_api.list_secrets",
+            return_value=summaries,
+        ),
+        patch(
+            "kitaru.mcp.server.inspection.serialize_secret_summary",
+            side_effect=serialized,
+        ) as mock_serialize,
+    ):
+        payload = kitaru_secrets_list(page=2, size=2)
+
+    assert payload == serialized
+    assert mock_serialize.call_args_list == [
+        call(summaries[2]),
+        call(summaries[3]),
+    ]
+
+
+def test_secrets_list_returns_metadata_only_for_public_and_private_secrets() -> None:
+    summaries = [
+        SecretSummary(
+            name="shared-creds",
+            id="public-id",
+            private=False,
+            keys=["OPENAI_API_KEY"],
+            has_missing_values=True,
+        ),
+        SecretSummary(
+            name="personal-creds",
+            id="private-id",
+            private=True,
+            keys=["ANTHROPIC_API_KEY"],
+        ),
+    ]
+
+    with patch(
+        "kitaru.mcp.server.secrets_api.list_secrets",
+        return_value=summaries,
+    ):
+        payload = kitaru_secrets_list()
+
+    assert payload == [
+        {
+            "id": "public-id",
+            "name": "shared-creds",
+            "visibility": "public",
+            "keys": ["OPENAI_API_KEY"],
+            "has_missing_values": True,
+        },
+        {
+            "id": "private-id",
+            "name": "personal-creds",
+            "visibility": "private",
+            "keys": ["ANTHROPIC_API_KEY"],
+            "has_missing_values": False,
+        },
+    ]
+    for item in payload:
+        assert set(item) == {
+            "id",
+            "name",
+            "visibility",
+            "keys",
+            "has_missing_values",
+        }
+        assert "values" not in item
+        assert "secret_values" not in item
+
+
+@pytest.mark.parametrize("page", [True, 0, -1])
+def test_secrets_list_rejects_invalid_page(page: Any) -> None:
+    with (
+        patch("kitaru.mcp.server.secrets_api.list_secrets") as mock_list,
+        pytest.raises(KitaruUsageError) as exc_info,
+    ):
+        kitaru_secrets_list(page=page)
+
+    assert str(exc_info.value) == "`page` must be an integer >= 1."
+    mock_list.assert_not_called()
+
+
+@pytest.mark.parametrize("size", [True, 0, -1])
+def test_secrets_list_rejects_invalid_size(size: Any) -> None:
+    with (
+        patch("kitaru.mcp.server.secrets_api.list_secrets") as mock_list,
+        pytest.raises(KitaruUsageError) as exc_info,
+    ):
+        kitaru_secrets_list(size=size)
+
+    assert str(exc_info.value) == "`size` must be an integer >= 1."
+    mock_list.assert_not_called()
+
+
+def test_secrets_list_propagates_sdk_backend_errors() -> None:
+    with (
+        patch(
+            "kitaru.mcp.server.secrets_api.list_secrets",
+            side_effect=KitaruBackendError("backend unavailable"),
+        ),
+        pytest.raises(KitaruBackendError, match="backend unavailable"),
+    ):
+        kitaru_secrets_list()
+
+
 def test_secrets_create_returns_metadata_without_values() -> None:
     """MCP secret creation should delegate to SDK creation safely."""
     summary = SecretSummary(
@@ -1456,6 +1660,7 @@ def test_mcp_does_not_expose_secret_delete_tool() -> None:
     import kitaru.mcp.server as server
 
     assert not hasattr(server, "kitaru_secrets_delete")
+    assert "kitaru_secrets_delete" not in _mcp_tool_schemas_by_name()
 
 
 def test_start_local_server_returns_structured_payload() -> None:

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1500,6 +1500,33 @@ def test_secrets_list_returns_metadata_only_for_public_and_private_secrets() -> 
     ]
 
 
+def test_secrets_list_returns_empty_keys_when_backend_omits_value_metadata() -> None:
+    """MCP listing should serialize the metadata available in real list responses."""
+    summary = SecretSummary(
+        name="provider-creds",
+        id="secret-id",
+        private=False,
+        keys=[],
+        has_missing_values=False,
+    )
+
+    with patch(
+        "kitaru.mcp.server.secrets_api.list_secrets",
+        return_value=[summary],
+    ):
+        payload = kitaru_secrets_list()
+
+    assert payload == [
+        {
+            "id": "secret-id",
+            "name": "provider-creds",
+            "visibility": "public",
+            "keys": [],
+            "has_missing_values": False,
+        }
+    ]
+
+
 @pytest.mark.parametrize("page", [True, 0, -1])
 def test_secrets_list_rejects_invalid_page(page: Any) -> None:
     with (

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -30,7 +30,6 @@ from kitaru.config import (
     VertexStackSpec,
 )
 from kitaru.errors import (
-    KitaruBackendError,
     KitaruFeatureNotAvailableError,
     KitaruRuntimeError,
     KitaruStateError,
@@ -1451,50 +1450,13 @@ def test_secrets_list_returns_empty_for_out_of_range_page() -> None:
         )
     ]
 
-    with (
-        patch(
-            "kitaru.mcp.server.secrets_api.list_secrets",
-            return_value=summaries,
-        ),
-        patch(
-            "kitaru.mcp.server.inspection.serialize_secret_summary",
-        ) as mock_serialize,
+    with patch(
+        "kitaru.mcp.server.secrets_api.list_secrets",
+        return_value=summaries,
     ):
         payload = kitaru_secrets_list(page=2, size=20)
 
     assert payload == []
-    mock_serialize.assert_not_called()
-
-
-def test_secrets_list_delegates_in_page_items_to_serializer_in_order() -> None:
-    summaries = [
-        SecretSummary(
-            name=f"secret-{index}",
-            id=f"secret-id-{index}",
-            private=False,
-            keys=["API_KEY"],
-        )
-        for index in range(4)
-    ]
-    serialized = [{"id": summaries[2].id}, {"id": summaries[3].id}]
-
-    with (
-        patch(
-            "kitaru.mcp.server.secrets_api.list_secrets",
-            return_value=summaries,
-        ),
-        patch(
-            "kitaru.mcp.server.inspection.serialize_secret_summary",
-            side_effect=serialized,
-        ) as mock_serialize,
-    ):
-        payload = kitaru_secrets_list(page=2, size=2)
-
-    assert payload == serialized
-    assert mock_serialize.call_args_list == [
-        call(summaries[2]),
-        call(summaries[3]),
-    ]
 
 
 def test_secrets_list_returns_metadata_only_for_public_and_private_secrets() -> None:
@@ -1536,16 +1498,6 @@ def test_secrets_list_returns_metadata_only_for_public_and_private_secrets() -> 
             "has_missing_values": False,
         },
     ]
-    for item in payload:
-        assert set(item) == {
-            "id",
-            "name",
-            "visibility",
-            "keys",
-            "has_missing_values",
-        }
-        assert "values" not in item
-        assert "secret_values" not in item
 
 
 @pytest.mark.parametrize("page", [True, 0, -1])
@@ -1570,17 +1522,6 @@ def test_secrets_list_rejects_invalid_size(size: Any) -> None:
 
     assert str(exc_info.value) == "`size` must be an integer >= 1."
     mock_list.assert_not_called()
-
-
-def test_secrets_list_propagates_sdk_backend_errors() -> None:
-    with (
-        patch(
-            "kitaru.mcp.server.secrets_api.list_secrets",
-            side_effect=KitaruBackendError("backend unavailable"),
-        ),
-        pytest.raises(KitaruBackendError, match="backend unavailable"),
-    ):
-        kitaru_secrets_list()
 
 
 def test_secrets_create_returns_metadata_without_values() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5645,8 +5645,6 @@ def test_secrets_list_json_contains_metadata_without_values(
         ],
         "count": 1,
     }
-    assert "values" not in payload["items"][0]
-    assert "secret_values" not in payload["items"][0]
 
 
 def test_secrets_list_paginates_after_shared_ordering(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from zenml.constants import ENV_ZENML_ACTIVE_STACK_ID
@@ -56,6 +56,7 @@ from kitaru.config import (
     VertexStackSpec,
 )
 from kitaru.errors import (
+    KitaruBackendError,
     KitaruDeploymentInputValuesError,
     KitaruFeatureNotAvailableError,
     KitaruStackNotRemoteExecutableUsageError,
@@ -63,6 +64,7 @@ from kitaru.errors import (
     KitaruUsageError,
 )
 from kitaru.replay import ReplayPlanDocument, ReplayResultRow, ReplaySubmission
+from kitaru.secrets import SecretSummary
 
 
 class _BrokenGlobalConfig:
@@ -3300,17 +3302,13 @@ def test_secrets_list_past_end_does_not_claim_none_found(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Paging past the end of a non-empty secret list must not say 'none found'."""
-    secret_a = SimpleNamespace(name="alpha", id="secret-a", private=False)
-    secret_b = SimpleNamespace(name="beta", id="secret-b", private=False)
-    fake_client = Mock()
-    fake_client.list_secrets.return_value = SimpleNamespace(
-        items=[secret_a, secret_b],
-        total_pages=1,
-        max_size=2,
-    )
+    secrets = [
+        SecretSummary(name="alpha", id="secret-a", private=False, keys=[]),
+        SecretSummary(name="beta", id="secret-b", private=False, keys=[]),
+    ]
 
     with (
-        patch("kitaru.cli.Client", return_value=fake_client),
+        patch("kitaru.secrets.list_secrets", return_value=secrets),
         pytest.raises(SystemExit) as exc_info,
     ):
         app(["secrets", "list", "--page", "9", "--size", "1"])
@@ -5588,32 +5586,23 @@ def test_secrets_show_displays_values_when_requested(
     assert "Value (OPENAI_API_KEY): sk-123" in output
 
 
-def test_secrets_list_renders_all_pages_sorted(
+def test_secrets_list_renders_shared_order(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """`kitaru secrets list` should merge all pages and sort by secret name."""
-    secret_z = SimpleNamespace(name="zeta", id="secret-z", private=False)
-    secret_a = SimpleNamespace(name="alpha", id="secret-a", private=True)
-    fake_client = Mock()
-    fake_client.list_secrets.side_effect = [
-        SimpleNamespace(items=[secret_z], total_pages=2, max_size=1),
-        SimpleNamespace(items=[secret_a], total_pages=2, max_size=1),
+    """`kitaru secrets list` should render the SDK's deterministic order."""
+    secrets = [
+        SecretSummary(name="alpha", id="secret-a", private=True, keys=[]),
+        SecretSummary(name="zeta", id="secret-z", private=False, keys=[]),
     ]
 
     with (
-        patch("kitaru.cli.Client", return_value=fake_client),
+        patch("kitaru.secrets.list_secrets", return_value=secrets) as mock_list_secrets,
         pytest.raises(SystemExit) as exc_info,
     ):
         app(["secrets", "list"])
 
     assert exc_info.value.code == 0
-    calls = fake_client.list_secrets.call_args_list
-    assert len(calls) == 2
-    backend_scan_size = calls[0].kwargs["size"]
-    assert calls == [
-        call(page=1, size=backend_scan_size),
-        call(page=2, size=backend_scan_size),
-    ]
+    mock_list_secrets.assert_called_once_with()
     output = capsys.readouterr().out
     assert "Kitaru secrets" in output
     assert "alpha: secret-a (private)" in output
@@ -5623,61 +5612,55 @@ def test_secrets_list_renders_all_pages_sorted(
     )
 
 
-def test_secrets_list_uses_stable_backend_page_size(
+def test_secrets_list_json_contains_metadata_without_values(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Backend scan pagination should not switch sizes after the first page."""
-    secret_z = SimpleNamespace(name="zeta", id="secret-z", private=False)
-    secret_a = SimpleNamespace(name="alpha", id="secret-a", private=True)
-    observed_sizes: list[int] = []
-
-    def list_secrets(*, page: int, size: int | None = None) -> SimpleNamespace:
-        if size is None:
-            raise AssertionError("backend scan calls must pass an explicit size")
-        observed_sizes.append(size)
-        if page == 1:
-            return SimpleNamespace(
-                items=[secret_z],
-                total_pages=2,
-                max_size=size + 100,
-            )
-        if page == 2 and size == observed_sizes[0]:
-            return SimpleNamespace(items=[secret_a], total_pages=2, max_size=size + 100)
-        return SimpleNamespace(items=[], total_pages=2, max_size=size + 100)
-
-    fake_client = Mock()
-    fake_client.list_secrets.side_effect = list_secrets
-
-    with (
-        patch("kitaru.cli.Client", return_value=fake_client),
-        pytest.raises(SystemExit) as exc_info,
-    ):
-        app(["secrets", "list"])
-
-    assert exc_info.value.code == 0
-    assert len(observed_sizes) == 2
-    assert observed_sizes[0] == observed_sizes[1]
-    output = capsys.readouterr().out
-    assert "alpha: secret-a (private)" in output
-    assert "zeta: secret-z (public)" in output
-
-
-def test_secrets_list_paginates_after_sorting(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """`secrets list` should slice after deterministic name/id ordering."""
-    secret_z = SimpleNamespace(name="zeta", id="secret-z", private=False)
-    secret_b = SimpleNamespace(name="beta", id="secret-b", private=False)
-    secret_a = SimpleNamespace(name="alpha", id="secret-a", private=True)
-    fake_client = Mock()
-    fake_client.list_secrets.return_value = SimpleNamespace(
-        items=[secret_z, secret_b, secret_a],
-        total_pages=1,
-        max_size=3,
+    """JSON list output should include key names but never secret values."""
+    secret = SecretSummary(
+        name="openai-creds",
+        id="secret-id",
+        private=True,
+        keys=["OPENAI_API_KEY"],
+        has_missing_values=False,
     )
 
     with (
-        patch("kitaru.cli.Client", return_value=fake_client),
+        patch("kitaru.secrets.list_secrets", return_value=[secret]),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["secrets", "list", "--output", "json"])
+
+    assert exc_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "command": "secrets.list",
+        "items": [
+            {
+                "id": "secret-id",
+                "name": "openai-creds",
+                "visibility": "private",
+                "keys": ["OPENAI_API_KEY"],
+                "has_missing_values": False,
+            }
+        ],
+        "count": 1,
+    }
+    assert "values" not in payload["items"][0]
+    assert "secret_values" not in payload["items"][0]
+
+
+def test_secrets_list_paginates_after_shared_ordering(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The CLI should slice the complete list after the SDK has ordered it."""
+    secrets = [
+        SecretSummary(name="alpha", id="secret-a", private=True, keys=[]),
+        SecretSummary(name="beta", id="secret-b", private=False, keys=[]),
+        SecretSummary(name="zeta", id="secret-z", private=False, keys=[]),
+    ]
+
+    with (
+        patch("kitaru.secrets.list_secrets", return_value=secrets),
         pytest.raises(SystemExit) as exc_info,
     ):
         app(["secrets", "list", "--page", "1", "--size", "2"])
@@ -5690,12 +5673,15 @@ def test_secrets_list_paginates_after_sorting(
     assert "Page 1 (size 2, showing 2 of 3)" in output
 
 
-def test_secrets_list_surfaces_client_errors(
+def test_secrets_list_surfaces_sdk_errors(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """`kitaru secrets list` should surface backend errors as CLI errors."""
+    """`kitaru secrets list` should surface SDK errors as CLI errors."""
     with (
-        patch("kitaru.cli.Client", side_effect=RuntimeError("offline")),
+        patch(
+            "kitaru.secrets.list_secrets",
+            side_effect=KitaruBackendError("Failed to list secrets: offline"),
+        ),
         pytest.raises(SystemExit) as exc_info,
     ):
         app(["secrets", "list"])

--- a/tests/test_kitaru.py
+++ b/tests/test_kitaru.py
@@ -155,6 +155,7 @@ class TestPublicExports:
             "get_secret",
             "is_replay",
             "list_projects",
+            "list_secrets",
             "list_stacks",
             "llm",
             "load",

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -98,6 +98,35 @@ def test_list_secrets_returns_metadata_without_raw_values() -> None:
     }
 
 
+def test_list_secrets_returns_empty_keys_when_backend_does_not_populate_values() -> None:
+    """SDK listing should reflect backend responses that omit value metadata."""
+    client = Mock()
+    client.list_secrets.return_value = SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                name="provider-creds",
+                id="secret-id",
+                private=False,
+                values={},
+            )
+        ],
+        total_pages=1,
+    )
+
+    with patch("kitaru.secrets._ZenMLClient", return_value=client):
+        summaries = list_secrets()
+
+    assert summaries == [
+        SecretSummary(
+            name="provider-creds",
+            id="secret-id",
+            private=False,
+            keys=[],
+            has_missing_values=False,
+        )
+    ]
+
+
 def test_list_secrets_orders_by_case_insensitive_name_then_id() -> None:
     """SDK listing should return deterministic global ordering."""
     client = Mock()

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, call, patch
 import pytest
 from zenml.exceptions import EntityExistsError
 
+import kitaru
 from kitaru.analytics import AnalyticsEvent
 from kitaru.errors import KitaruBackendError, KitaruRuntimeError, KitaruUsageError
 from kitaru.secrets import (
@@ -19,6 +20,11 @@ from kitaru.secrets import (
     get_secret,
     list_secrets,
 )
+
+
+def test_list_secrets_is_exported_from_package_root() -> None:
+    """The listing helper should follow the existing top-level import pattern."""
+    assert kitaru.list_secrets is list_secrets
 
 
 def test_list_secrets_scans_all_backend_pages_at_fixed_size() -> None:
@@ -98,7 +104,7 @@ def test_list_secrets_returns_metadata_without_raw_values() -> None:
     }
 
 
-def test_list_secrets_returns_empty_keys_when_backend_does_not_populate_values() -> None:
+def test_list_secrets_returns_empty_keys_without_backend_values() -> None:
     """SDK listing should reflect backend responses that omit value metadata."""
     client = Mock()
     client.list_secrets.return_value = SimpleNamespace(

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytest
 from zenml.exceptions import EntityExistsError
@@ -17,7 +17,211 @@ from kitaru.secrets import (
     create_secret,
     delete_secret,
     get_secret,
+    list_secrets,
 )
+
+
+def test_list_secrets_scans_one_backend_page() -> None:
+    """SDK listing should request the first backend page at the fixed size."""
+    client = Mock()
+    client.list_secrets.return_value = SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                name="openai-creds",
+                id="secret-id",
+                private=False,
+                values={"OPENAI_API_KEY": object()},
+                has_missing_values=False,
+            )
+        ],
+        total_pages=1,
+    )
+
+    with patch("kitaru.secrets._ZenMLClient", return_value=client):
+        summaries = list_secrets()
+
+    client.list_secrets.assert_called_once_with(page=1, size=50)
+    assert summaries == [
+        SecretSummary(
+            name="openai-creds",
+            id="secret-id",
+            private=False,
+            keys=["OPENAI_API_KEY"],
+        )
+    ]
+
+
+def test_list_secrets_scans_all_backend_pages_at_fixed_size() -> None:
+    """SDK listing should fetch every reported page with the same scan size."""
+    client = Mock()
+    client.list_secrets.side_effect = [
+        SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    name="charlie",
+                    id="3",
+                    private=False,
+                    values={},
+                )
+            ],
+            total_pages=3,
+        ),
+        SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    name="alpha",
+                    id="1",
+                    private=False,
+                    values={},
+                )
+            ]
+        ),
+        SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    name="bravo",
+                    id="2",
+                    private=False,
+                    values={},
+                )
+            ]
+        ),
+    ]
+
+    with patch("kitaru.secrets._ZenMLClient", return_value=client):
+        summaries = list_secrets()
+
+    assert client.list_secrets.call_args_list == [
+        call(page=1, size=50),
+        call(page=2, size=50),
+        call(page=3, size=50),
+    ]
+    assert [summary.name for summary in summaries] == ["alpha", "bravo", "charlie"]
+
+
+def test_list_secrets_returns_metadata_without_raw_values() -> None:
+    """SDK listing should normalize IDs and expose key names, not values."""
+    client = Mock()
+    client.list_secrets.return_value = SimpleNamespace(
+        items=[
+            SimpleNamespace(
+                name="provider-creds",
+                id=123,
+                private=True,
+                values={"Z_TOKEN": object(), "A_KEY": object()},
+                secret_values={"Z_TOKEN": "secret-z", "A_KEY": "secret-a"},
+                has_missing_values=True,
+            )
+        ],
+        total_pages=1,
+    )
+
+    with patch("kitaru.secrets._ZenMLClient", return_value=client):
+        summary = list_secrets()[0]
+
+    assert summary == SecretSummary(
+        name="provider-creds",
+        id="123",
+        private=True,
+        keys=["A_KEY", "Z_TOKEN"],
+        has_missing_values=True,
+    )
+    payload = summary.model_dump()
+    assert "values" not in payload
+    assert "secret_values" not in payload
+    assert "secret-a" not in str(payload)
+    assert "secret-z" not in str(payload)
+
+
+def test_list_secrets_orders_by_case_insensitive_name_then_id() -> None:
+    """SDK listing should return deterministic global ordering."""
+    client = Mock()
+    client.list_secrets.return_value = SimpleNamespace(
+        items=[
+            SimpleNamespace(name="bravo", id="3", private=False, values={}),
+            SimpleNamespace(name="alpha", id="2", private=False, values={}),
+            SimpleNamespace(name="Alpha", id="1", private=False, values={}),
+        ],
+        total_pages=1,
+    )
+
+    with patch("kitaru.secrets._ZenMLClient", return_value=client):
+        summaries = list_secrets()
+
+    assert [(summary.name, summary.id) for summary in summaries] == [
+        ("Alpha", "1"),
+        ("alpha", "2"),
+        ("bravo", "3"),
+    ]
+
+
+def test_list_secrets_returns_empty_list_for_empty_backend() -> None:
+    """An accessible backend with no secrets should return an empty list."""
+    client = Mock()
+    client.list_secrets.return_value = SimpleNamespace(items=[], total_pages=1)
+
+    with patch("kitaru.secrets._ZenMLClient", return_value=client):
+        assert list_secrets() == []
+
+
+def test_list_secrets_maps_client_initialization_failure_to_backend_error() -> None:
+    """Client construction failures should become Kitaru backend errors."""
+    with (
+        patch("kitaru.secrets._ZenMLClient", side_effect=RuntimeError("offline")),
+        pytest.raises(KitaruBackendError, match="Failed to list secrets: offline"),
+    ):
+        list_secrets()
+
+
+def test_list_secrets_discards_partial_results_after_request_failure() -> None:
+    """A later page failure should raise instead of returning earlier items."""
+    client = Mock()
+    client.list_secrets.side_effect = [
+        SimpleNamespace(
+            items=[
+                SimpleNamespace(
+                    name="first-page-secret",
+                    id="1",
+                    private=False,
+                    values={},
+                )
+            ],
+            total_pages=2,
+        ),
+        RuntimeError("offline"),
+    ]
+
+    with (
+        patch("kitaru.secrets._ZenMLClient", return_value=client),
+        pytest.raises(KitaruBackendError, match="Failed to list secrets: offline"),
+    ):
+        list_secrets()
+
+    assert client.list_secrets.call_args_list == [
+        call(page=1, size=50),
+        call(page=2, size=50),
+    ]
+
+
+def test_list_secrets_maps_malformed_response_to_backend_error() -> None:
+    """Malformed backend items should not escape as public summaries."""
+    client = Mock()
+    client.list_secrets.return_value = SimpleNamespace(
+        items=[SimpleNamespace(id="missing-name", private=False, values={})],
+        total_pages=1,
+    )
+
+    with (
+        patch("kitaru.secrets._ZenMLClient", return_value=client),
+        pytest.raises(
+            KitaruBackendError,
+            match=(
+                "Failed to list secrets: Backend returned a secret "
+                "without a readable name"
+            ),
+        ),
+    ):
+        list_secrets()
 
 
 def test_get_secret_fetches_exact_secret_and_normalizes_values() -> None:

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -21,36 +21,6 @@ from kitaru.secrets import (
 )
 
 
-def test_list_secrets_scans_one_backend_page() -> None:
-    """SDK listing should request the first backend page at the fixed size."""
-    client = Mock()
-    client.list_secrets.return_value = SimpleNamespace(
-        items=[
-            SimpleNamespace(
-                name="openai-creds",
-                id="secret-id",
-                private=False,
-                values={"OPENAI_API_KEY": object()},
-                has_missing_values=False,
-            )
-        ],
-        total_pages=1,
-    )
-
-    with patch("kitaru.secrets._ZenMLClient", return_value=client):
-        summaries = list_secrets()
-
-    client.list_secrets.assert_called_once_with(page=1, size=50)
-    assert summaries == [
-        SecretSummary(
-            name="openai-creds",
-            id="secret-id",
-            private=False,
-            keys=["OPENAI_API_KEY"],
-        )
-    ]
-
-
 def test_list_secrets_scans_all_backend_pages_at_fixed_size() -> None:
     """SDK listing should fetch every reported page with the same scan size."""
     client = Mock()
@@ -119,18 +89,13 @@ def test_list_secrets_returns_metadata_without_raw_values() -> None:
     with patch("kitaru.secrets._ZenMLClient", return_value=client):
         summary = list_secrets()[0]
 
-    assert summary == SecretSummary(
-        name="provider-creds",
-        id="123",
-        private=True,
-        keys=["A_KEY", "Z_TOKEN"],
-        has_missing_values=True,
-    )
-    payload = summary.model_dump()
-    assert "values" not in payload
-    assert "secret_values" not in payload
-    assert "secret-a" not in str(payload)
-    assert "secret-z" not in str(payload)
+    assert summary.model_dump() == {
+        "name": "provider-creds",
+        "id": "123",
+        "private": True,
+        "keys": ["A_KEY", "Z_TOKEN"],
+        "has_missing_values": True,
+    }
 
 
 def test_list_secrets_orders_by_case_insensitive_name_then_id() -> None:
@@ -164,17 +129,8 @@ def test_list_secrets_returns_empty_list_for_empty_backend() -> None:
         assert list_secrets() == []
 
 
-def test_list_secrets_maps_client_initialization_failure_to_backend_error() -> None:
-    """Client construction failures should become Kitaru backend errors."""
-    with (
-        patch("kitaru.secrets._ZenMLClient", side_effect=RuntimeError("offline")),
-        pytest.raises(KitaruBackendError, match="Failed to list secrets: offline"),
-    ):
-        list_secrets()
-
-
-def test_list_secrets_discards_partial_results_after_request_failure() -> None:
-    """A later page failure should raise instead of returning earlier items."""
+def test_list_secrets_maps_later_page_failure_to_backend_error() -> None:
+    """Later page failures should become Kitaru backend errors."""
     client = Mock()
     client.list_secrets.side_effect = [
         SimpleNamespace(


### PR DESCRIPTION
## Summary

Adds a `kitaru_secrets_list(page, size)` MCP tool that returns secret metadata visible to the current user context — ID, name, visibility, key names, and whether values are missing/unreadable — without ever exposing secret values. A coding agent configuring a stack or model alias can now check whether a required secret already exists before attempting creation.

Closes #527.

## What changed

### Shared SDK listing helper (`src/kitaru/secrets.py`)
- Added public `list_secrets() -> list[SecretSummary]` that scans all backend pages (size 50), converts each response to metadata-only `SecretSummary` immediately, sorts by `(name.lower(), id)`, and returns the full ordered list.
- Failures become `KitaruBackendError("Failed to list secrets: ...")` — no partial results.
- Added `"list_secrets"` to `__all__`.

### CLI refactor (`src/kitaru/_cli/_secrets.py`, `src/kitaru/cli.py`)
- `kitaru secrets list` now delegates to `secrets_api.list_secrets()` instead of its own backend scan.
- Removed `_list_accessible_secrets`, `_order_secrets`, and `_SECRETS_BACKEND_SCAN_SIZE` from the CLI (the SDK owns them now).
- Removed the `_list_accessible_secrets` import and `__all__` re-export from `src/kitaru/cli.py`.
- `_secret_list_rows()` now accepts `list[SecretSummary]`.
- All CLI output behavior preserved: pagination, JSON safety, text rows, pagination notes.

### MCP tool (`src/kitaru/mcp/server.py`)
- Added `kitaru_secrets_list(page=1, size=20)` beside `kitaru_secrets_create`.
- Validates `page`/`size` as non-boolean positive integers (rejects `True`/`False` since `bool` subclasses `int`), raises `KitaruUsageError` with argument-specific messages.
- Calls `secrets_api.list_secrets()`, slices the already-ordered result locally, serializes via `inspection.serialize_secret_summary()`, returns a bare list.
- Out-of-range page returns `[]`.
- No `kitaru_secrets_delete` tool added — the existing test asserting its absence is preserved and strengthened (now also checks FastMCP registry).

### Documentation (`docs/book/agent-native/mcp-server.md`)
- Documented `kitaru_secrets_list` in the Secret tools section: page/size defaults, metadata-only response, out-of-range behavior, no-delete policy.
- Noted that `keys` and `has_missing_values` may not be populated in listing responses (the ZenML backend does not include key names in list responses).

### Smoke test (`scripts/smoke-test.sh`)
- Added `kitaru_secrets_list` to the MCP tools section.
- Added `kitaru secrets list --help` to the Secret API section.

## Reviewer Notes

The story of this change starts at the SDK level. The listing logic (`_list_accessible_secrets`, `_order_secrets`, `_SECRETS_BACKEND_SCAN_SIZE`) was previously private to the CLI module. We moved it into the public SDK (`kitaru.secrets.list_secrets()`) so that both the CLI and MCP share one implementation — a later fix to scanning or ordering can't affect one surface but not the other.

The MCP tool follows the same pattern as `kitaru_secrets_create`: call the SDK helper, serialize through `inspection.serialize_secret_summary()`, and wrap in `run_with_mcp_error_boundary`. The validation rejects booleans (`bool` subclasses `int`, so `True` would pass as `1` without the explicit check) and runs before the backend call.

**Critical refactor detail**: `src/kitaru/cli.py:176` imported and `:442` re-exported `_list_accessible_secrets`. Removing the function from `_cli/_secrets.py` without updating `cli.py` would have broken `import kitaru.cli` — the design critique caught this before implementation.

**Known limitation (documented)**: ZenML's `Client.list_secrets()` returns `SecretResponse` objects with `.values` as an empty dict — so `keys` is always `[]` and `has_missing_values` is always `False` when listing. These fields are part of the shared serializer contract (populated correctly on the create/get path) and are retained for schema consistency, but the MCP guide now documents this limitation.

**Where the risky behavior lives**: The boolean-rejection check in `kitaru_secrets_list` (`src/kitaru/mcp/server.py`) — if this check were removed, `True`/`False` would pass as valid page/size values. The test `test_secrets_list_rejects_invalid_page` parametrically covers this.

**What would break if the implementation is wrong**: If `_list_accessible_secrets` had been removed from `_cli/_secrets.py` without updating `cli.py`, every CLI test and the console entrypoint would die on `ImportError` before any assertion runs.

## Reproduction

```bash
# Start a local ZenML server
just local-server-start &

# Create a secret
kitaru secrets set my-api-key --API_KEY=sk-test-value

# List secrets via CLI (metadata only — no values shown)
kitaru secrets list --output json

# List via MCP
fastmcp call --command "kitaru-mcp" --target kitaru_secrets_list --json

# Verify: output contains id, name, visibility, keys, has_missing_values
# Verify: output does NOT contain any secret values
# Verify: kitaru_secrets_delete is not available as an MCP tool
fastmcp list --command "kitaru-mcp" | grep delete || echo "No delete tool (correct)"
```

## Local checks run

```bash
just test tests/test_secrets.py
just test tests/test_cli.py -k secrets
just test tests/mcp/test_server.py -k secret
just test tests/test_inspection.py -k secret
just fix
just check
```