### PR TITLE
Clarify missing stack dependency guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Missing stack integration dependencies now fail before deploy, run, or replay with a concise Kitaru explanation followed by ZenML's exact integration and whole-stack installation guidance. (#506)
+
 ## [0.20.2] - 2026-07-10
 
 ### Added

--- a/docs/book/getting-started/quickstart.md
+++ b/docs/book/getting-started/quickstart.md
@@ -215,6 +215,9 @@ def research_agent(topic: str, model: str = "openai/gpt-5-nano") -> str:
 `research_agent.run(...)` now executes on that stack. Agents run on the same
 stacks, server, and dashboard as ZenML pipelines.
 
+ZenML supplies optional stack-integration dependencies; install them in the
+Python environment that submits the flow, not in its remote execution image.
+
 This example lists `kitaru[pydantic-ai,openai]` explicitly because setting
 `base_image` means you control the image contents — Kitaru auto-adds plain
 `kitaru` but does not guess optional extras such as the PydanticAI/OpenAI

--- a/examples/end_to_end/compliance_review/README.md
+++ b/examples/end_to_end/compliance_review/README.md
@@ -44,7 +44,7 @@ Each stage's `run_workflow()` defaults to `cache=False`. That means every invoca
 
 ### Running against a remote stack
 
-The local default stack works out of the box. If you want to run against a remote stack (S3 artifact store, Kubernetes orchestrator, Vertex, etc.), install that stack's ZenML integration into the same venv after syncing.
+The local default stack works out of the box. ZenML supplies optional dependencies for remote stack components, so install that stack's ZenML integration in the same environment after syncing.
 
 A remote runner does not automatically inherit your laptop's shell `ANTHROPIC_API_KEY`. The safest path is to expose that credential at step runtime from a centralized `anthropic` secret:
 

--- a/examples/features/basic_flow/README.md
+++ b/examples/features/basic_flow/README.md
@@ -16,6 +16,9 @@ These examples use your current Kitaru connection context. If you want them to
 run against a deployed Kitaru server, connect first with `kitaru login
 <server>` and verify with `kitaru status`.
 
+ZenML supplies optional integration dependencies for remote stacks; if Kitaru
+reports one missing, follow the ZenML commands in the error.
+
 For the full catalog, see [../../README.md](../../README.md).
 
 ## Examples

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -268,10 +268,10 @@ def _preflight_active_stack_implementation_hydration(
     except ImportError as exc:
         zenml_guidance = str(exc).strip()
         message = (
-            "Cannot submit this Kitaru flow because the active stack could not "
-            "be loaded in this Python environment.\n\n"
-            "A stack integration dependency appears to be missing. Install the "
-            "missing ZenML integration or stack requirements, then retry."
+            "Cannot submit this Kitaru flow because this Python environment could not "
+            "load the active stack's integration dependencies.\n\n"
+            "ZenML supplies these dependencies. Install the missing integration or the "
+            "active stack requirements, then retry."
         )
         if zenml_guidance:
             message = f"{message}\n\nZenML guidance:\n\n{zenml_guidance}"

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sys
 import threading
+import traceback
 from collections import namedtuple
 from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager, nullcontext
@@ -72,6 +73,7 @@ from kitaru.flow import (
     _inject_model_registry_env,
     _is_flow_result_candidate_step,
     _is_multiple_terminal_steps_output_error,
+    _preflight_active_stack_implementation_hydration,
     _suspend_flow_return_coercion,
     _temporary_active_project,
     _temporary_active_stack,
@@ -114,6 +116,23 @@ def _empty_registry_payload() -> str:
     return ModelRegistryConfig().model_dump_json(exclude_none=True)
 
 
+_MISSING_STACK_DEPENDENCY_GUIDANCE = (
+    "Install the missing integration with `zenml integration install s3`.\n"
+    "Export stack requirements with `zenml stack export-requirements 'prod' "
+    "-o stack-requirements.txt`."
+)
+_MISSING_STACK_DEPENDENCY_INTRO = (
+    "Cannot submit this Kitaru flow because this Python environment could not "
+    "load the active stack's integration dependencies.\n\n"
+    "ZenML supplies these dependencies. Install the missing integration or the "
+    "active stack requirements, then retry."
+)
+_MISSING_STACK_DEPENDENCY_MESSAGE = (
+    f"{_MISSING_STACK_DEPENDENCY_INTRO}\n\n"
+    f"ZenML guidance:\n\n{_MISSING_STACK_DEPENDENCY_GUIDANCE}"
+)
+
+
 class _ClientWithMissingStackDependency:
     def __init__(self, *, old_stack_id: object, stack_name: str = "prod") -> None:
         self.old_stack_model = SimpleNamespace(id=old_stack_id, name="old")
@@ -133,13 +152,27 @@ class _ClientWithMissingStackDependency:
     def active_stack(self) -> object:
         if self.active_stack_model is not self.selected_stack_model:
             raise AssertionError("active stack must be selected before hydration")
-        raise ImportError(
-            "Install the missing integration with "
-            "`zenml integration install s3`.\n"
-            "Export stack requirements with "
-            "`zenml stack export-requirements 'prod' "
-            "-o stack-requirements.txt`."
-        )
+        raise ImportError(_MISSING_STACK_DEPENDENCY_GUIDANCE)
+
+
+def _assert_missing_stack_dependency_error(
+    exception: KitaruStackIntegrationDependencyError,
+    *,
+    expected_outer_frame: str,
+) -> None:
+    assert str(exception) == _MISSING_STACK_DEPENDENCY_MESSAGE
+    assert "zenml integration install s3" in str(exception)
+    assert "zenml stack export-requirements" in str(exception)
+    assert exception.__cause__ is None
+    assert isinstance(exception.__context__, ImportError)
+    assert str(exception.__context__) == _MISSING_STACK_DEPENDENCY_GUIDANCE
+    assert exception.__suppress_context__ is True
+    assert exception.__traceback__ is not None
+    frame_names = [
+        frame.name for frame in traceback.extract_tb(exception.__traceback__)
+    ]
+    assert "_preflight_active_stack_implementation_hydration" in frame_names
+    assert expected_outer_frame in frame_names
 
 
 class _EnvPoisonedActiveStackClient:
@@ -1245,13 +1278,11 @@ def test_deploy_translates_active_stack_hydration_import_error_before_prepare() 
         wrapped = flow(lambda x: x)
         wrapped.deploy(1, stack="prod")
 
-    message = str(exc_info.value)
-    assert "Cannot submit this Kitaru flow" in message
-    assert "stack integration dependency appears to be missing" in message
-    assert "zenml integration install s3" in message
-    assert "zenml stack export-requirements" in message
-    assert exc_info.value.__cause__ is None
-    assert exc_info.value.__suppress_context__ is True
+    _assert_missing_stack_dependency_error(
+        exc_info.value,
+        expected_outer_frame="deploy",
+    )
+    base_pipeline.with_options.assert_not_called()
     configured_pipeline.prepare.assert_not_called()
     configured_pipeline._create_snapshot.assert_not_called()
     deployments_api.create.assert_not_called()
@@ -1265,6 +1296,25 @@ def test_deploy_translates_active_stack_hydration_import_error_before_prepare() 
         call("prod"),
         call(old_stack_id),
     ]
+
+
+def test_preflight_omits_empty_zenml_guidance() -> None:
+    class _ClientWithEmptyMissingDependencyMessage:
+        @property
+        def active_stack(self) -> object:
+            raise ImportError
+
+    with pytest.raises(KitaruStackIntegrationDependencyError) as exc_info:
+        _preflight_active_stack_implementation_hydration(
+            client_factory=_ClientWithEmptyMissingDependencyMessage
+        )
+
+    assert str(exc_info.value) == _MISSING_STACK_DEPENDENCY_INTRO
+    assert "ZenML guidance:" not in str(exc_info.value)
+    assert exc_info.value.__cause__ is None
+    assert isinstance(exc_info.value.__context__, ImportError)
+    assert exc_info.value.__suppress_context__ is True
+    assert exc_info.value.__traceback__ is not None
 
 
 def test_flow_deploy_rewords_input_defaults_error() -> None:
@@ -3939,25 +3989,8 @@ def test_run_translates_active_stack_hydration_import_error() -> None:
     base_pipeline.with_options.return_value = configured_pipeline
     zenml_decorator = MagicMock(return_value=base_pipeline)
 
-    class _ClientWithMissingStackDependency:
-        def __init__(self) -> None:
-            self.active_stack_model = SimpleNamespace(id=old_stack_id)
-            self.activate_stack = MagicMock()
-
-        @property
-        def active_stack(self) -> object:
-            raise ImportError(
-                "Install the missing integration with "
-                "`zenml integration install s3`.\n"
-                "Export stack requirements with "
-                "`zenml stack export-requirements 'prod' "
-                "-o stack-requirements.txt`."
-            )
-
     old_stack_id = uuid4()
-    client_mock = _ClientWithMissingStackDependency()
-    client_mock.active_stack_model = SimpleNamespace(id=old_stack_id)
-    client_mock.activate_stack = MagicMock()
+    client_mock = _ClientWithMissingStackDependency(old_stack_id=old_stack_id)
 
     with (
         patch("kitaru.flow.pipeline", return_value=zenml_decorator),
@@ -3974,13 +4007,11 @@ def test_run_translates_active_stack_hydration_import_error() -> None:
         wrapped = flow(lambda: None)
         wrapped.run(stack="prod")
 
-    message = str(exc_info.value)
-    assert "Cannot submit this Kitaru flow" in message
-    assert "stack integration dependency appears to be missing" in message
-    assert "zenml integration install s3" in message
-    assert "zenml stack export-requirements" in message
-    assert exc_info.value.__cause__ is None
-    assert exc_info.value.__suppress_context__ is True
+    _assert_missing_stack_dependency_error(
+        exc_info.value,
+        expected_outer_frame="_submit",
+    )
+    base_pipeline.with_options.assert_not_called()
     configured_pipeline.assert_not_called()
     persist_mock.assert_not_called()
     assert client_mock.activate_stack.call_args_list == [
@@ -4290,13 +4321,11 @@ def test_replay_translates_active_stack_hydration_import_error_before_replay() -
         wrapped = flow(lambda topic: topic)
         wrapped.replay(str(source_run.id), at="write", stack="prod", wait=False)
 
-    message = str(exc_info.value)
-    assert "Cannot submit this Kitaru flow" in message
-    assert "stack integration dependency appears to be missing" in message
-    assert "zenml integration install s3" in message
-    assert "zenml stack export-requirements" in message
-    assert exc_info.value.__cause__ is None
-    assert exc_info.value.__suppress_context__ is True
+    _assert_missing_stack_dependency_error(
+        exc_info.value,
+        expected_outer_frame="_replay_one_handle",
+    )
+    base_pipeline.with_options.assert_not_called()
     configured_pipeline.replay.assert_not_called()
     persist_mock.assert_not_called()
     track_mock.assert_not_called()


### PR DESCRIPTION
## Summary

- Clarify that ZenML supplies the active stack's integration dependencies while preserving ZenML's exact installation guidance.
- Keep translation limited to active-stack hydration so user-code `ImportError` exceptions remain unchanged.
- Strengthen deploy, run, and replay regression coverage for traceback behavior, stack restoration, and prevention of submission side effects.
- Add concise guidance to the quickstart and existing examples, plus an Unreleased changelog entry.

## Reviewer Notes

Kitaru now checks whether the selected stack can be loaded before it configures or submits a flow. If a stack integration package is absent, the caller receives a short Kitaru explanation followed by ZenML's original integration and whole-stack commands. The narrow catch matters: an `ImportError` raised later by user code must remain an ordinary `ImportError`.

### Reproduction

1. Select a stack whose integration package is not installed in the Python environment submitting the flow.
2. Invoke a minimal flow through run, deploy, or replay.
3. Confirm the error starts with the concise Kitaru explanation and retains the ZenML integration-install and stack-requirements commands.
4. Confirm the previously active stack is restored and no run, deployment snapshot, or replay child is created.
5. Run the neighboring user-code `ImportError` regression and confirm it is not translated.

### Local checks run

- ✅ `uv run pytest -n 0 tests/test_flow.py -k "active_stack_hydration_import_error or does_not_translate_user_import_error_from_submission or preflight_omits_empty_zenml_guidance" -q` — 5 passed.
- ✅ `just test tests/test_flow.py` — 237 passed before the simplify cleanup; the affected five tests passed again afterward.
- ✅ `just check` — passed after the final Oracle fix.
- ⚠️ Full suite attempted with `cd /Users/strickvl/coding/zenml/repos/kitaru/.worktrees/issue-506-investigation && set -o pipefail; just test 2>&1 | grep -E "FAILED|ERROR|passed|failed" | tail -20`. It stalled without a final pytest summary under the execution environment's process isolation and was stopped rather than repeatedly rerun.

Closes #506
