### PR TITLE
Refresh `pip-audit` ignore list and suppress the `click` advisory

### DIFF
--- a/.github/pip-audit-ignored.txt
+++ b/.github/pip-audit-ignored.txt
@@ -24,11 +24,19 @@
 # Tracked upstream: https://github.com/zenml-io/zenml/issues/5077
 PYSEC-2026-2132  # click 8.2.1 -> 8.3.3 (CVE-2026-7246, `click.edit()` injection)
 
-# --- Waiting on a lockfile refresh, not on upstream. -----------------------
-# zenml has since relaxed the `pyjwt` pin that used to block this (it now
-# requires `pyjwt[crypto]>=2.13.0`), so `mcp` is free to move. Our lock simply
-# still resolves 1.19.0. Delete this entry once a bump past 1.23.0 lands.
-CVE-2025-66416  # mcp 1.19 -> 1.23 (no longer upstream-blocked; lock is stale)
+# --- Blocked by our own cap in the shipped `kitaru[mcp]` extra. ------------
+# `pyproject.toml` declares `mcp>=1.19.0,<1.20.0`, so this is not merely a
+# stale lock: every `pip install kitaru[mcp]` resolves to a vulnerable 1.19.x,
+# and no version of the extra gets a user to the 1.23.0 fix.
+#
+# The cap was correct when written (`mcp>=1.20` needs `pyjwt>=2.10.1`, and
+# zenml used to hard-pin `pyjwt==2.7.*`), but that reason is gone: zenml now
+# requires `pyjwt[crypto]>=2.13.0`. Only our ceiling remains. Widening it
+# changes a published extra and needs the MCP server re-verified against the
+# newer SDK, so it is tracked separately rather than bundled into a bump.
+# Delete this entry once that lands.
+# Tracked: https://github.com/zenml-io/kitaru/issues/546
+CVE-2025-66416  # mcp 1.19 -> 1.23; blocked by our `mcp<1.20.0` pin, not upstream
 
 # --- Blocked by the fastapi pin in zenml's [server] extra. -----------------
 # zenml pins `fastapi>=0.120.1,<0.121.0`, and fastapi 0.120.x in turn requires

--- a/.github/pip-audit-ignored.txt
+++ b/.github/pip-audit-ignored.txt
@@ -6,25 +6,44 @@
 # Format: one vulnerability ID per line, using a pip-audit-supported prefix
 # such as CVE-, GHSA-, or PYSEC-. Lines starting with `#` and blank lines are
 # ignored. Inline `#` comments after the ID are allowed and encouraged.
+#
+# To re-verify this list, run `uv run pip-audit` with no ignore flags and
+# compare the reported IDs against the entries below. Anything listed here
+# that pip-audit no longer reports is stale and should be deleted.
 
-# --- Blocked by zenml's `pyjwt==2.7.*` pin in the [server] extra. -----------
-# Tracked upstream: https://github.com/zenml-io/zenml/issues/4782
-CVE-2026-32597  # pyjwt 2.7 -> 2.12 (auth library; zenml hard-pins 2.7.*)
-PYSEC-2025-183  # pyjwt 2.7 disputed weak-key advisory; blocked by the same zenml pin
-PYSEC-2026-175  # pyjwt 2.7 -> 2.13.0; blocked by the same zenml pin
-PYSEC-2026-177  # pyjwt 2.7 -> 2.13.0; blocked by the same zenml pin
-PYSEC-2026-179  # pyjwt 2.7 -> 2.13.0; blocked by the same zenml pin
-CVE-2025-66416  # mcp 1.19 -> 1.23 (transitively blocked: mcp >=1.20 needs pyjwt >=2.10.1)
+# --- Blocked by zenml's `click<=8.2.1` cap. --------------------------------
+# zenml declares `click>=8.0.1,<=8.2.1`. The ceiling is inclusive and sits on
+# the vulnerable version itself, so no lockfile refresh can reach the 8.3.3
+# fix while we depend on zenml.
+#
+# Not exploitable here: the advisory is a command injection in `click.edit()`,
+# the helper that shells out to `$EDITOR`. Kitaru never calls it (our only
+# click usage is `click.get_app_dir()` and catching `click.ClickException`),
+# and neither does zenml. The CVSS vector is local-only and already requires
+# high privileges (AV:L/AC:H/PR:H/UI:R).
+# Tracked upstream: https://github.com/zenml-io/zenml/issues/5077
+PYSEC-2026-2132  # click 8.2.1 -> 8.3.3 (CVE-2026-7246, `click.edit()` injection)
 
-# --- Transitive deps in zenml's FastAPI/Starlette server stack. ------------
-# Forcing newer versions risks breaking zenml's request-handling and JSON
-# serialization paths. Will refresh when zenml widens its server-stack
-# constraints (see zenml-io/zenml#4782 for the keystone pin).
-CVE-2025-67221  # orjson 3.10 -> 3.11
-CVE-2025-54121  # starlette 0.45 -> 0.47
-CVE-2025-62727  # starlette 0.45 -> 0.49
-PYSEC-2026-161  # starlette 0.45 -> 1.0.1 (blocked by zenml server stack)
-CVE-2026-48817  # starlette 0.45 -> 1.1.0 (blocked by zenml server stack)
-CVE-2026-48818  # starlette 0.45 -> 1.1.0 (blocked by zenml server stack)
-CVE-2026-54282  # starlette 0.45 -> 1.3.0 (blocked by zenml server stack)
-CVE-2026-54283  # starlette 0.45 -> 1.3.1 (blocked by zenml server stack)
+# --- Waiting on a lockfile refresh, not on upstream. -----------------------
+# zenml has since relaxed the `pyjwt` pin that used to block this (it now
+# requires `pyjwt[crypto]>=2.13.0`), so `mcp` is free to move. Our lock simply
+# still resolves 1.19.0. Delete this entry once a bump past 1.23.0 lands.
+CVE-2025-66416  # mcp 1.19 -> 1.23 (no longer upstream-blocked; lock is stale)
+
+# --- Blocked by the fastapi pin in zenml's [server] extra. -----------------
+# zenml pins `fastapi>=0.120.1,<0.121.0`, and fastapi 0.120.x in turn requires
+# `starlette<0.50.0`. The fixes below all land in starlette 1.x, so they are
+# unreachable until zenml widens its server-stack constraints.
+PYSEC-2026-161  # starlette -> 1.0.1 (above fastapi's <0.50.0 ceiling)
+CVE-2026-48817  # starlette -> 1.1.0 (above fastapi's <0.50.0 ceiling)
+CVE-2026-48818  # starlette -> 1.1.0 (above fastapi's <0.50.0 ceiling)
+CVE-2026-54282  # starlette -> 1.3.0 (above fastapi's <0.50.0 ceiling)
+CVE-2026-54283  # starlette -> 1.3.1 (above fastapi's <0.50.0 ceiling)
+
+# --- Reachable today; suppressed only until the starlette bump lands. ------
+# Unlike the five above, these two are fixed *below* fastapi's <0.50.0 ceiling,
+# so nothing upstream is blocking them: our lock is just stale at starlette
+# 0.45.3. `uv lock --upgrade-package starlette` resolves to 0.49.3 and clears
+# both. Delete these two entries as part of that bump.
+CVE-2025-54121  # starlette 0.45 -> 0.47.2 (reachable; pending lock refresh)
+CVE-2025-62727  # starlette 0.45 -> 0.49.1 (reachable; pending lock refresh)


### PR DESCRIPTION
## What this does

Makes the `audit` CI job green again, and removes six suppressions that had silently gone stale.

A new advisory landed against `click` in the last few days: [`PYSEC-2026-2132`](https://osv.dev/vulnerability/PYSEC-2026-2132) / [`CVE-2026-7246`](https://nvd.nist.gov/vuln/detail/CVE-2026-7246), a command injection in `click.edit()`. It turned `audit` red on **every** open branch, including PR #543, which only edits GitHub Actions YAML and cannot affect Python packages at all. `develop`'s last CI run (2026-07-10) was fully green, so this is new and environmental rather than anything a PR introduced.

`click` cannot be upgraded. `zenml` declares `click>=8.0.1,<=8.2.1` — an *inclusive* ceiling that lands on exactly the vulnerable version, while the fix is in 8.3.3. `uv lock --upgrade-package click` will not move, and the latest `zenml` on PyPI (0.96.1, the one we are already on) still carries the cap. So the only honest option is an accepted-risk entry, which this PR adds along with a justification and an upstream tracking issue.

## The part that is more than a one-liner

While verifying the new entry I ran `pip-audit` with the ignore flags **off**, to see what it actually reports rather than trusting the file's comments. Six of the fourteen entries were suppressing advisories that no longer exist:

| Entries | Package | Why they are dead |
|---|---|---|
| `CVE-2026-32597`, `PYSEC-2025-183`, `PYSEC-2026-175`, `PYSEC-2026-177`, `PYSEC-2026-179` | `pyjwt` | zenml relaxed the pin (zenml-io/zenml#4782 is closed). It now requires `pyjwt[crypto]>=2.13.0`, and we resolve to 2.13.0. `pip-audit` reports **zero** pyjwt vulnerabilities. |
| `CVE-2025-67221` | `orjson` | zenml now requires `orjson>=3.11.6`. Nothing reported. |

The file's own header says to remove entries once the upstream cause is resolved, so this is following its stated contract — but nothing *fails* when a suppression becomes unnecessary, which is exactly why they sat there unnoticed.

The surviving comments were also blaming the wrong constraint. They attributed the `starlette` entries to the `pyjwt==2.7.*` pin. The real blocker is the `fastapi>=0.120.1,<0.121.0` pin in zenml's `[server]` extra: fastapi 0.120.x requires `starlette<0.50.0`, and five of those fixes only land in starlette 1.x. Those comments are corrected.

## Risk

Low, and specifically so. The `click` advisory is a command injection in `click.edit()`, the helper that shells out to `$EDITOR`. Kitaru never calls it — our entire click surface is three `click.get_app_dir()` calls and one `except click.ClickException`. `zenml` does not call it either (`grep -rn "click\.edit" site-packages/zenml` is empty). The CVSS vector is `AV:L/AC:H/PR:H/UI:R`: local only, high complexity, attacker already needs high privileges, and needs user interaction.

Tracked upstream at zenml-io/zenml#5077, asking for the cap to be widened.

## Reviewer Notes

The whole diff is one file, `.github/pip-audit-ignored.txt`, and it contains no code. So the thing worth your attention is not the mechanics but the **claim**: that six suppressions are genuinely dead and that removing them does not quietly un-suppress a real vulnerability.

That is the risky direction of error here. If I got it wrong, the failure mode is not a red build — it is a **green** build that is no longer checking something it used to. So the review question is "did deleting those six entries hide anything?", and the arithmetic below is designed to answer exactly that.

The other thing to sanity-check is the honesty of the comments. Two `starlette` entries (`CVE-2025-54121`, `CVE-2025-62727`) are deliberately kept even though they are **not** upstream-blocked — their fixes (0.47.2 and 0.49.1) sit below fastapi's `<0.50.0` ceiling and are reachable today. They are suppressed purely because our lock is stale at starlette 0.45.3. I have flagged them as such in their own section rather than filing them under "blocked", because calling them blocked would be false. See the follow-up below.

### Reproduction

Run the audit gate exactly as CI does (`.github/workflows/ci.yml`, `audit` job):

```bash
awk '/^(CVE|GHSA|PYSEC)-/ {printf "--ignore-vuln %s ", $1}' \
  .github/pip-audit-ignored.txt | xargs uv run pip-audit
```

On `develop` today this prints `Found 1 known vulnerability, ignored 9` and exits 123. On this branch it prints:

```
No known vulnerabilities found, 10 ignored
```

**The number to look at is the ignore count, not the pass/fail.** Now confirm the six deletions hid nothing, by checking the arithmetic lines up:

```bash
uv run pip-audit          # no ignore flags: ground truth
# -> Found 10 known vulnerabilities in 3 packages (click, mcp, starlette x8)
```

There are 10 vulnerability instances in total. The old 14-entry list matched **9** of them and let `click` through (`9 ignored` + `1 found` = 10). The new 9-entry list matches **all 10** (`10 ignored` + `0 found` = 10).

So six entries were deleted and the number of *matched* suppressions went **up** by one — the one being `click`. That is only possible if all six deleted entries were matching nothing. Had any of them been live, the count would have dropped and a real advisory would have surfaced in the report.

You can confirm the upstream story directly from package metadata, independently of the scanner:

```bash
uv run python -c "
from importlib.metadata import requires
print([r for r in requires('zenml') if r.lower().startswith(('click','pyjwt','orjson','fastapi'))])"
# click>=8.0.1,<=8.2.1              <- the hard cap, no path to 8.3.3
# pyjwt[crypto]>=2.13.0,<2.14.0     <- relaxed; the 5 pyjwt entries are dead
# orjson>=3.11.6,<3.12.0            <- relaxed; the orjson entry is dead
# fastapi>=0.120.1,<0.121.0         <- the real starlette blocker
```

And that `click.edit()` is never reachable:

```bash
grep -rn "click\." src/ --include="*.py" | grep -v _ui/dist
# only click.get_app_dir() x3 and click.ClickException x1 — no click.edit()
```

Local checks run: `just check` and `just test` (3545 passed, 29 skipped) both green.

## Follow-ups (not in this PR)

- **`starlette` 0.45.3 -> 0.49.3.** Nothing blocks it — `uv lock --upgrade-package starlette` resolves cleanly, and it fixes two *real* advisories (`CVE-2025-54121`, `CVE-2025-62727`), letting us delete those two entries. Kept out of this PR because it touches `uv.lock`, which PR #544 also rewrites.
- **`mcp` 1.19.0 -> 1.23+ (#546).** Raised by review on this PR: this one is **not** a stale lock. `pyproject.toml` caps the shipped `kitaru[mcp]` extra at `mcp>=1.19.0,<1.20.0`, so every `pip install kitaru[mcp]` resolves to a vulnerable 1.19.x and no version of the extra reaches the 1.23.0 fix. The cap existed because `mcp>=1.20` needs `pyjwt>=2.10.1` while zenml hard-pinned `pyjwt==2.7.*`; zenml has since relaxed that, but our ceiling outlived the reason for it. The entry here now names that pin as the blocker. Widening it changes a published extra and needs the MCP server re-verified against the newer SDK, so it is tracked separately in #546. Delete the `CVE-2025-66416` entry once it lands.

