### PR TITLE
Group `uv` dependency bumps by blast radius instead of semver magnitude

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,8 +32,23 @@ updates:
       # different places produces a PR that inherits the strictest verification
       # requirement while offering the weakest reviewability, so nothing moves.
       #
-      # Dependabot assigns each dependency to the FIRST group it matches, so the
-      # catch-all must stay last.
+      # ORDER DOES NOT DECIDE THE WINNER. Dependabot scores every candidate
+      # group and takes the highest, it does not take the first match
+      # (updater/lib/dependabot/updater/pattern_specificity_calculator.rb):
+      #
+      #   exact name .................... 1000
+      #   no patterns (a catch-all) ...... 500
+      #   wildcard ....................... 100 - 10*wildcards + max(len-5, 0)
+      #   universal '*' .................... 1
+      #
+      # So a wildcard like `langchain*` scores 95 and LOSES to the bare
+      # `minor-and-patch` catch-all at 500, which silently drags the dependency
+      # back into the mixed PR. Exact names score 1000 and win, so both are
+      # listed: the exact name pins today's packages, the wildcard catches
+      # future family members. `exclude-patterns` on the catch-all is what makes
+      # the wildcards viable at all, since an excluded dependency scores the
+      # catch-all at 0. Removing those excludes silently un-splits the groups.
+      # See dependabot/dependabot-core#14902.
 
       # Failures surface in CI and nowhere else, so a green pipeline is the
       # complete verification. Safe to merge on green.
@@ -42,10 +57,16 @@ updates:
           - ruff
           - ty
           - yamlfix
-          - pytest*
           - pip-audit
-          - griffe*
           - python-dotenv
+          - pytest
+          - pytest-randomly
+          - pytest-clarity
+          - pytest-xdist
+          - pytest*
+          - griffe
+          - griffe-typingdoc
+          - griffe*
         update-types:
           - minor
           - patch
@@ -60,14 +81,19 @@ updates:
           - openai
           - openai-agents
           - anthropic
-          - pydantic-ai*
-          - langchain*
-          - langgraph*
           - claude-agent-sdk
           - google-genai
           - google-adk
           - genai-prices
           - mcp
+          - pydantic-ai-slim
+          - pydantic-ai*
+          - langchain
+          - langchain-openai
+          - langchain-anthropic
+          - langchain*
+          - langgraph
+          - langgraph*
         update-types:
           - minor
           - patch
@@ -83,7 +109,18 @@ updates:
           - patch
 
       # Everything else: cyclopts, pydantic, rich, modal, typing-extensions.
+      #
+      # The excludes are load-bearing, not decorative. Without them this group
+      # scores 500 against the wildcard groups' ~95 and reabsorbs every
+      # `langchain-*` / `pytest-*` / `griffe-*` / `pydantic-ai-*` package,
+      # quietly undoing the split above.
       minor-and-patch:
+        exclude-patterns:
+          - pytest*
+          - griffe*
+          - pydantic-ai*
+          - langchain*
+          - langgraph*
         update-types:
           - minor
           - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,63 @@ updates:
     reviewers: [strickvl]
     labels: [dependencies]
     groups:
+      # Grouped by blast radius, not by semver magnitude. What decides how a
+      # bump PR must be tested is *where a failure would surface*, and a PR can
+      # only have one testing story. Batching packages whose failures surface in
+      # different places produces a PR that inherits the strictest verification
+      # requirement while offering the weakest reviewability, so nothing moves.
+      #
+      # Dependabot assigns each dependency to the FIRST group it matches, so the
+      # catch-all must stay last.
+
+      # Failures surface in CI and nowhere else, so a green pipeline is the
+      # complete verification. Safe to merge on green.
+      dev-tooling:
+        patterns:
+          - ruff
+          - ty
+          - yamlfix
+          - pytest*
+          - pip-audit
+          - griffe*
+          - python-dotenv
+        update-types:
+          - minor
+          - patch
+
+      # Failures surface in a user's runtime, and our tests mock these SDKs, so
+      # CI is structurally blind to them. Needs live provider runs before merge.
+      # See `tests/_gemini_fake_sdk.py` for the sharpest example: it substitutes
+      # a fake module tree, so the Gemini adapter's contract against the real
+      # SDK is never exercised.
+      adapters-and-llm-sdks:
+        patterns:
+          - openai
+          - openai-agents
+          - anthropic
+          - pydantic-ai*
+          - langchain*
+          - langgraph*
+          - claude-agent-sdk
+          - google-genai
+          - google-adk
+          - genai-prices
+          - mcp
+        update-types:
+          - minor
+          - patch
+
+      # The runtime Kitaru is built on. Bumps here move the floor under
+      # everything else, so they get their own PR rather than being buried in a
+      # multi-package diff.
+      zenml:
+        patterns:
+          - zenml
+        update-types:
+          - minor
+          - patch
+
+      # Everything else: cyclopts, pydantic, rich, modal, typing-extensions.
       minor-and-patch:
         update-types:
           - minor


### PR DESCRIPTION
## What this does

Splits the `uv` ecosystem's single `minor-and-patch` catch-all into groups keyed on **blast radius** rather than semver magnitude.

## Why

The `uv` config had one group catching every minor and patch bump, so Dependabot ships one giant PR a week. This week that is #544: **17 packages in a single atomic merge.**

Grouping on `update-types: [minor, patch]` sorts packages by *how far the version number moved*. But what decides whether a bump is safe to land is *what it touches*. Those are different axes, and picking the wrong one has a concrete cost: it produces a PR whose **risk is the maximum of its members** but whose **reviewability is the sum of them**.

#544 is the worked example. It welds `ty` — a type checker, whose failures can only ever appear in CI — to `google-genai`, whose failures appear in a user's runtime. You cannot take the safe 90% without also taking the risky 10%, so the whole thing has sat red all week.

It gets worse than "inconvenient". While triaging #544 we found that `google-genai` 2.10 **deletes `google.genai._interactions`**, the module `src/kitaru/adapters/gemini/__init__.py:11` imports by name. Kitaru survives only because a fallback module path was already written into the import tuple. And `tests/_gemini_fake_sdk.py` substitutes a fake `google.genai` module tree, so **CI never exercises that contract against the real SDK** — had the fallback not already been there, #544 would have merged green and broken at import for every Gemini user.

That is the argument for this change in one line: **the packages CI can verify and the packages CI is blind to should not share a merge button.**

## The grouping

Each group is defined by where a failure would surface, because that is what determines how the PR must be tested, and a PR can only have one testing story.

| Group | Packages | Where failures surface | Verification |
|---|---|---|---|
| `dev-tooling` | `ruff`, `ty`, `pytest*`, `pip-audit`, `griffe*`, `yamlfix`, `python-dotenv` | CI, and nowhere else | Green CI **is** the complete verification |
| `adapters-and-llm-sdks` | `openai`, `anthropic`, `openai-agents`, `pydantic-ai*`, `langchain*`, `langgraph*`, `claude-agent-sdk`, `google-genai`, `google-adk`, `genai-prices`, `mcp` | A user's runtime; our tests **mock** these SDKs | Needs live provider runs — green CI proves nothing |
| `zenml` | `zenml` | Everywhere (it is the floor) | Its own PR, so a regression is unambiguous |
| `minor-and-patch` | catch-all: `cyclopts`, `pydantic`, `rich`, `modal`, `typing-extensions` | Mixed, low | Green CI |

Majors stay **ungrouped**, exactly as before, so they keep arriving as individual PRs and keep getting individual scrutiny. The `griffe` major ignore is untouched. The `github-actions` and `npm` ecosystems are untouched.

## The specificity trap (read this before reviewing the patterns)

The first version of this PR was subtly broken, and review caught it. Recording the mechanism, because it is not in Dependabot's user-facing docs and it will bite anyone who edits this block.

**Dependabot does not assign a dependency to the first group it matches.** It scores every candidate group and takes the highest ([`pattern_specificity_calculator.rb`](https://github.com/dependabot/dependabot-core/blob/main/updater/lib/dependabot/updater/pattern_specificity_calculator.rb)):

| group declaration | score |
|---|---|
| exact name | **1000** |
| **no patterns at all** (a bare `update-types` catch-all) | **500** |
| wildcard | `100 - 10*wildcards + max(len-5, 0)` |
| universal `*` | 1 |

So `langchain*` scores `100 - 10 + max(10-5, 0)` = **95**, and loses to the bare `minor-and-patch` catch-all at **500**. Every `langchain-*` / `pytest-*` / `griffe-*` / `pydantic-ai-*` package would have been silently dragged back into the mixed PR, while the exact-named ones split correctly — a **half-working** split, which is worse than a visibly broken one. Confirmed upstream in dependabot/dependabot-core#14902, whose job logs read `Skipping ... belongs to more specific group 'minor-and-patch'`.

Two mitigations, both in the config:

1. **`exclude-patterns` on the catch-all.** This is load-bearing, not decorative. In `calculate_group_specificity_for_dependency`, `return 0 if excluded_by_group?` runs **before** the no-patterns 500 is awarded, so an excluded dependency scores the catch-all at 0 and the wildcard group's 95 wins. **Delete those excludes and the split silently un-does itself.**
2. **Every package we ship today is also listed by exact name** (score 1000), so the current split does not rely on mechanism (1) at all. The wildcards only carry *future* family members.

## Reviewer Notes

The diff is one file and adds no new mechanism — it is a re-partitioning of an existing `groups:` block. So review **the partition and the scoring**, not the YAML.

**1. Is each package in the right bucket?** The test is not "how risky does this feel" but "if this bump broke, where would I find out?". `mcp` is the one I would push back on hardest if you disagree — I filed it under adapters rather than the catch-all because `src/kitaru/mcp/` is a server users actually run, so a break lands in their runtime, not our pipeline. `genai-prices` is the other judgement call: it is a data package, but it changes recorded `actual_cost_usd` values, and this week's bump silently re-namespaced the whole OpenRouter price table (it happens to *fix* costs that were recording as `null`, but that is luck, not design).

**2. Do not remove the `exclude-patterns`.** See the section above. They look redundant next to the exact names; they are not. They are the only thing keeping a future `langchain-google` out of the mixed PR.

The risk if this is wrong is not a broken build — it is a **quieter** one: a package silently landing in a group whose testing story does not match it, which is the exact failure this PR exists to prevent.

A note on how the first version got through: I "verified" it with a simulation, and the simulation passed. It passed because I had implemented *first-match-wins* — it faithfully reproduced my assumption rather than Dependabot's behavior. **A simulation only tests the model you hand it, and here the model was the thing in doubt.** The reproduction below is a port of the real scoring function, so it can actually fail.

### Reproduction

The config is not executable, so verify it by porting Dependabot's real specificity algorithm and running the current packages plus hypothetical future ones through it. Save as `simulate_groups.py` and run `uv run --with pyyaml python simulate_groups.py`:

```python
"""Port of dependabot-core's PatternSpecificityCalculator. Highest score wins; order is irrelevant."""
import fnmatch, sys, yaml

EXACT, NO_PATTERNS, WILDCARD_BASE, PENALTY, UNIVERSAL, MIN, LEN_THRESHOLD = 1000, 500, 100, 10, 1, 1, 5

def pattern_score(pattern: str, dep: str) -> int:
    if pattern == dep: return EXACT
    if pattern == "*": return UNIVERSAL
    n = pattern.count("*")
    if n == 0: return NO_PATTERNS
    return max(WILDCARD_BASE - n * PENALTY + max(len(pattern) - LEN_THRESHOLD, 0), MIN)

def group_score(cfg: dict, dep: str) -> int:
    if any(fnmatch.fnmatch(dep, p) for p in cfg.get("exclude-patterns", [])): return 0
    pats = cfg.get("patterns")
    if pats is None: return NO_PATTERNS                      # bare catch-all
    matching = [p for p in pats if fnmatch.fnmatch(p, dep) or fnmatch.fnmatch(dep, p)]
    if not matching: return 0
    return max(pattern_score(p, dep) for p in matching)

groups = [u for u in yaml.safe_load(open(".github/dependabot.yml"))["updates"]
          if u["package-ecosystem"] == "uv"][0]["groups"]

def winner(dep):
    scores = {n: group_score(c, dep) for n, c in groups.items()}
    best = max(scores.values())
    return (max(scores, key=scores.get), best) if best > 0 else ("(ungrouped)", 0)

PR544 = ["cyclopts","genai-prices","openai","anthropic","typing-extensions","openai-agents",
         "langchain","langgraph","langchain-openai","langchain-anthropic","google-genai",
         "modal","mcp","ruff","ty","pytest","pip-audit"]
FUTURE = ["pytest-randomly","pytest-xdist","griffe-typingdoc","pydantic-ai-slim",
          "langchain-google","zenml","rich","pydantic"]

out = {}
for d in PR544:
    g, s = winner(d); out.setdefault(g, []).append(d)
for d in FUTURE:
    g, s = winner(d); print("  %-22s -> %-24s (score %d)" % (d, g, s))
for g in list(groups) + ["(ungrouped)"]:
    if g in out: print("%-24s (%d)  %s" % (g, len(out[g]), ", ".join(sorted(out[g]))))
print("total:", sum(len(v) for v in out.values()), "/ 17")

bad = [d for d in PR544 + FUTURE if winner(d)[0] == "minor-and-patch"
       and any(fnmatch.fnmatch(d, p) for p in ("langchain*","langgraph*","pytest*","griffe*","pydantic-ai*"))]
print("REGRESSION - wildcard families swallowed by the catch-all:", bad or "none")
sys.exit(1 if bad or sum(len(v) for v in out.values()) != 17 else 0)
```

Expected — exits 0. The **`langchain-google` line is the regression test**: it is reachable *only* via a wildcard, so it is the case that was broken before. It must land in `adapters-and-llm-sdks` at score 95, not in the catch-all. Note also `pydantic` correctly **not** being caught by `pydantic-ai*`.

```
  pytest-randomly        -> dev-tooling              (score 1000)
  griffe-typingdoc       -> dev-tooling              (score 1000)
  pydantic-ai-slim       -> adapters-and-llm-sdks    (score 1000)
  langchain-google       -> adapters-and-llm-sdks    (score 95)    <- the one that was broken
  zenml                  -> zenml                    (score 1000)
  pydantic               -> minor-and-patch          (score 500)   <- correctly not matched by pydantic-ai*

dev-tooling              (4)   pip-audit, pytest, ruff, ty
adapters-and-llm-sdks    (10)  anthropic, genai-prices, google-genai, langchain, langchain-anthropic,
                               langchain-openai, langgraph, mcp, openai, openai-agents
minor-and-patch          (3)   cyclopts, modal, typing-extensions
total: 17 / 17
REGRESSION - wildcard families swallowed by the catch-all: none
```

To see the bug the review caught, delete the `exclude-patterns` block from `minor-and-patch` and re-run: the four `langchain-*`/`pytest-*` families collapse back into the catch-all and the script exits 1.

That is the payoff: this week's single unmergeable PR becomes three, and the four dev-tooling bumps become mergeable on green CI alone.

After this lands, Dependabot re-evaluates and will close #544, replacing it with the split PRs. Expect the `adapters-and-llm-sdks` one to still need real work (a live Gemini run in particular) — that is the point; it is no longer blocking the others.

Local checks run: `just check` (all green). `just check`'s yaml recipe deliberately excludes `dependabot.yml`, so the config was validated by the simulation above.

## Follow-ups

- #546 — widen the `mcp<1.20.0` pin in the shipped `kitaru[mcp]` extra (it currently ships a vulnerable `mcp` to every `kitaru[mcp]` user).
- `tests/_gemini_fake_sdk.py` makes the Gemini adapter's real-SDK contract untestable in CI. Worth a follow-up so the next `google-genai` bump does not get the same free pass this one nearly did.
