### PR TITLE
Stop the Dependabot catch-all group duplicating packages into a second PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,23 +32,28 @@ updates:
       # different places produces a PR that inherits the strictest verification
       # requirement while offering the weakest reviewability, so nothing moves.
       #
-      # ORDER DOES NOT DECIDE THE WINNER. Dependabot scores every candidate
-      # group and takes the highest, it does not take the first match
-      # (updater/lib/dependabot/updater/pattern_specificity_calculator.rb):
+      # A CATCH-ALL GROUP MEANS "EVERYTHING", NOT "THE LEFTOVERS". Dependabot's
+      # specificity rules do not rescue you here, and getting this wrong
+      # duplicates packages across PRs rather than failing loudly.
       #
-      #   exact name .................... 1000
-      #   no patterns (a catch-all) ...... 500
-      #   wildcard ....................... 100 - 10*wildcards + max(len-5, 0)
-      #   universal '*' .................... 1
+      # `dependency_belongs_to_more_specific_group?` opens with
+      # `return false unless patterns&.any?`
+      # (updater/lib/dependabot/updater/pattern_specificity_calculator.rb), so a
+      # group with no `patterns` is never asked whether something else claims a
+      # dependency. It short-circuits and keeps every one it matches. The
+      # specificity score only ever strips a dependency out of a group that HAS
+      # patterns.
       #
-      # So a wildcard like `langchain*` scores 95 and LOSES to the bare
-      # `minor-and-patch` catch-all at 500, which silently drags the dependency
-      # back into the mixed PR. Exact names score 1000 and win, so both are
-      # listed: the exact name pins today's packages, the wildcard catches
-      # future family members. `exclude-patterns` on the catch-all is what makes
-      # the wildcards viable at all, since an excluded dependency scores the
-      # catch-all at 0. Removing those excludes silently un-splits the groups.
-      # See dependabot/dependabot-core#14902.
+      # So `exclude-patterns` below is not an optimization. It is the ONLY thing
+      # that removes a dependency from this catch-all. It must therefore list
+      # every pattern claimed by every group above it. Add a pattern up there
+      # and forget to exclude it down here, and that package ships in TWO PRs.
+      #
+      # Verified the hard way: an earlier revision excluded only the wildcard
+      # families and trusted exact names to win on specificity. Dependabot
+      # promptly opened #553 containing `openai`, `anthropic`, `mcp`,
+      # `google-genai`, `ruff` and `ty` -- all of which were already in their own
+      # group PRs. See dependabot/dependabot-core#14902 and #13665.
 
       # Failures surface in CI and nowhere else, so a green pipeline is the
       # complete verification. Safe to merge on green.
@@ -110,17 +115,35 @@ updates:
 
       # Everything else: cyclopts, pydantic, rich, modal, typing-extensions.
       #
-      # The excludes are load-bearing, not decorative. Without them this group
-      # scores 500 against the wildcard groups' ~95 and reabsorbs every
-      # `langchain-*` / `pytest-*` / `griffe-*` / `pydantic-ai-*` package,
-      # quietly undoing the split above.
+      # `exclude-patterns` MUST mirror every pattern from the three groups above.
+      # This group has no `patterns`, so Dependabot never asks whether another
+      # group claims a dependency (see the note at the top of `groups:`) and it
+      # will happily re-ship anything not listed here in a second PR. Keep this
+      # list in sync when you edit a group above.
       minor-and-patch:
         exclude-patterns:
+          # mirrors dev-tooling
+          - ruff
+          - ty
+          - yamlfix
+          - pip-audit
+          - python-dotenv
           - pytest*
           - griffe*
+          # mirrors adapters-and-llm-sdks
+          - openai
+          - openai-agents
+          - anthropic
+          - claude-agent-sdk
+          - google-genai
+          - google-adk
+          - genai-prices
+          - mcp
           - pydantic-ai*
           - langchain*
           - langgraph*
+          # mirrors zenml
+          - zenml
         update-types:
           - minor
           - patch


### PR DESCRIPTION
## What this does

Fixes #547. The blast-radius split does not currently work: **the groups overlap, so the same package ships in two PRs.**

Dependabot demonstrated it within minutes of #547 landing. It opened #553, a `minor-and-patch` PR containing:

`openai`, `anthropic`, `mcp`, `google-genai`, `genai-prices`, `openai-agents`, `ruff`, `ty`, `pip-audit`

Every one of those is **already in #549 (`dev-tooling`) or #550 (`adapters-and-llm-sdks`)**.

## Why it happened

#547 assumed Dependabot's specificity scoring would keep the catch-all off packages claimed by a more specific group. The scoring is real — exact names score 1000, a bare catch-all scores 500 — but it is **never consulted for a catch-all**. From [`pattern_specificity_calculator.rb`](https://github.com/dependabot/dependabot-core/blob/main/updater/lib/dependabot/updater/pattern_specificity_calculator.rb):

```ruby
def dependency_belongs_to_more_specific_group?(current_group, dep, ...)
  patterns = current_group.patterns
  return false unless patterns&.any?     # <-- a catch-all has no patterns
  ...                                    #     so it short-circuits and KEEPS the dep
```

The specificity check is only ever asked of a group that **has** patterns. It exists to strip a dependency *out of* a pattern-group when a more specific pattern-group claims it. A catch-all returns on line 1 and gives nothing up.

**So a bare `update-types`-only group does not mean "the leftovers". It means "everything, always."**

The evidence is right there in the shape of #553. #547 excluded only the wildcard families (`langchain*`, `pytest*`, ...) — and those are *precisely* the packages that correctly stayed out of it. Every package I "protected" with an exact name instead leaked straight in. The config was half-working, in exactly the way #547's own description warned was the worst outcome.

## The fix

`exclude-patterns` on the catch-all is not an optimization for the wildcard case — it is the **only** mechanism that removes anything from a catch-all. It now mirrors every pattern from all three groups above it, with a comment saying so and telling the next editor to keep it in sync.

## Reviewer Notes

One file, one list. The thing to check is that **`minor-and-patch.exclude-patterns` is a superset of every `patterns:` entry in `dev-tooling`, `adapters-and-llm-sdks` and `zenml`.** If a pattern exists up there and not down here, that package silently ships in two PRs.

The failure mode is worth naming because it is not a red build: it is **duplicate PRs racing each other into the same lockfile**. Merge #550 and then #553 and you get two conflicting `uv.lock` rewrites of the same packages. Nothing fails loudly; you just get lockfile churn and a merge conflict that looks like Dependabot being flaky.

That is also why the reproduction below asserts a different thing than #547's did. #547's script "verified" the config and passed, because it modeled *my belief* (specificity applies to everyone) rather than Dependabot's behavior. A simulation only tests the model you hand it, and the model was the bug. This one asserts the invariant that actually matters and that Dependabot can violate: **no package may appear in more than one group.**

### Reproduction

Save as `check_groups.py`, run `uv run --with pyyaml python check_groups.py`. It exits non-zero if any package lands in two groups, or if the catch-all's excludes drift out of sync with the groups above.

```python
import fnmatch, sys, yaml

cfg = yaml.safe_load(open(".github/dependabot.yml"))
groups = [u for u in cfg["updates"] if u["package-ecosystem"] == "uv"][0]["groups"]

def excluded(g, dep): return any(fnmatch.fnmatch(dep, p) for p in g.get("exclude-patterns", []))
def matches(g, dep):  return any(fnmatch.fnmatch(dep, p) for p in g.get("patterns", []))

def groups_for(dep):
    out = []
    for name, g in groups.items():
        if excluded(g, dep): continue
        if g.get("patterns") is None: out.append(name)   # catch-all: takes EVERYTHING
        elif matches(g, dep):         out.append(name)
    return out

DEPS = ["cyclopts","genai-prices","openai","anthropic","typing-extensions","openai-agents",
        "langchain","langgraph","langchain-openai","langchain-anthropic","google-genai",
        "modal","mcp","ruff","ty","pytest","pip-audit","zenml","pydantic","rich",
        "yamlfix","python-dotenv","griffe","griffe-typingdoc","pydantic-ai-slim",
        "pytest-randomly","pytest-xdist","claude-agent-sdk","google-adk","langchain-google"]

dupes = [(d, groups_for(d)) for d in sorted(DEPS) if len(groups_for(d)) > 1]
print("DUPLICATES:", dupes or "none")

catch = next((g for g in groups.values() if g.get("patterns") is None), None)
ex = catch.get("exclude-patterns", [])
missing = [(n, p) for n, g in groups.items() for p in g.get("patterns", [])
           if p not in ex and not any(fnmatch.fnmatch(p, e) for e in ex)]
print("EXCLUDES OUT OF SYNC:", missing or "none")

sys.exit(1 if dupes or missing else 0)
```

On `develop` today this **exits 1**, reporting `openai`, `anthropic`, `mcp`, `google-genai`, `genai-prices`, `openai-agents`, `ruff`, `ty` and `pip-audit` as duplicates — i.e. it reproduces #553. On this branch it exits 0:

```
DUPLICATES: none
EXCLUDES OUT OF SYNC: none
```

The resulting assignment, every package in exactly one group:

```
dev-tooling              (10)  griffe, griffe-typingdoc, pip-audit, pytest, pytest-randomly,
                               pytest-xdist, python-dotenv, ruff, ty, yamlfix
adapters-and-llm-sdks    (14)  anthropic, claude-agent-sdk, genai-prices, google-adk, google-genai,
                               langchain, langchain-anthropic, langchain-google, langchain-openai,
                               langgraph, mcp, openai, openai-agents, pydantic-ai-slim
zenml                    ( 1)  zenml
minor-and-patch          ( 5)  cyclopts, modal, pydantic, rich, typing-extensions
```

The real confirmation is not the script, though — it is Dependabot. After this merges it will re-evaluate and #553 should come back containing only `cyclopts`, `modal` and `typing-extensions`, with #549 and #550 keeping the rest to themselves.

Local checks run: `just check` (green). `just check`'s yaml recipe deliberately excludes `dependabot.yml`, so the config is validated by the script above.

## Note on #553

Leaving #553 open for now. Once this lands, Dependabot re-evaluates and should replace it with the correct 3-package version by itself. If it does not, it needs closing by hand — **do not merge it as it stands**, since it would rewrite `uv.lock` for packages that #549 and #550 are also rewriting.
