### PR TITLE
Bump `setuptools` to 83.0.0 for `PYSEC-2026-3447`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3403,11 +3403,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this does

Turns the `audit` job green again. A new advisory landed against `setuptools` a few hours ago — [`PYSEC-2026-3447`](https://osv.dev/vulnerability/PYSEC-2026-3447), affecting 82.0.1, fixed in **83.0.0** — and it is currently red on every open branch.

Like the `click` advisory earlier today (#545), **this is not caused by any pull request.** It was published upstream and arrives through the merge preview, so it shows up on branches that touch no Python at all.

Unlike `click`, this one is simply fixable. `setuptools` is transitive (pulled in by `zenml` and by `ruyaml` via `yamlfix`), nothing caps it, and `uv lock --upgrade-package setuptools` resolves straight to the fix version:

```console
$ uv lock --upgrade-package setuptools
Updated setuptools v82.0.1 -> v83.0.0
```

So this is a three-line lockfile bump, **not** another accepted-risk entry. `.github/pip-audit-ignored.txt` is untouched.

## Reviewer Notes

The diff is three lines of `uv.lock` and nothing else. There is no code to review, so the only questions worth your time are: *does it actually clear the advisory*, and *does upgrading setuptools break anything*.

The first is easy to confirm (below). The second is the one with any real risk: `setuptools` is a build-time dependency that `zenml` pulls in, so a break would show up at install or import rather than in a specific feature. That is why the check below is "run the whole suite", not "run a targeted test" — there is no targeted test to run, and the failure mode would be broad rather than narrow.

Worth noting what does **not** need re-verifying: the ignore list. The audit output still reports `ignored 10`, exactly as it did before this change, which confirms we fixed this advisory rather than suppressing it and that none of the existing suppressions shifted.

### Reproduction

Run the audit gate exactly as CI does (`.github/workflows/ci.yml`, `audit` job):

```bash
awk '/^(CVE|GHSA|PYSEC)-/ {printf "--ignore-vuln %s ", $1}' \
  .github/pip-audit-ignored.txt | xargs uv run pip-audit
```

On `develop` today this exits 123:

```
Found 1 known vulnerability, ignored 10 in 1 package
Name       Version ID              Fix Versions
---------- ------- --------------- ------------
setuptools 82.0.1  PYSEC-2026-3447 83.0.0
```

On this branch:

```
No known vulnerabilities found, 10 ignored
```

**The ignore count is the thing to check**: it is `10` both before and after. If this PR had accidentally suppressed the advisory instead of fixing it, that number would have gone to 11.

Confirm nothing caps `setuptools`, i.e. that the resolver was free to move and the lock was simply stale:

```bash
uv pip tree --package setuptools --invert
# setuptools v82.0.1
# ├── ruyaml v0.91.0 -> yamlfix
# └── zenml v0.96.1 -> kitaru
```

Local checks run: `just check` (green) and `just test` (**3545 passed, 29 skipped**).

## Context

This is the second new advisory to land during a single day's Dependabot triage — the first was `click` (#545, not fixable, suppressed with an upstream tracking issue at zenml-io/zenml#5077). Both arrived on branches that could not possibly have caused them, which is a useful tell: a check that fails on a PR with no causal path to it is the default branch's problem, not the PR's.
