### PR TITLE
Make the `fumadocs` npm group actually fire for minor and patch bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -171,10 +171,27 @@ updates:
     reviewers: [strickvl]
     labels: [dependencies]
     groups:
+      # The fumadocs packages must move in lockstep (fumadocs-core, -mdx, -ui
+      # and -python are a coupled family), which is what this group is for.
       fumadocs:
         patterns:
           - "fumadocs-*"
+      # `exclude-patterns` is what makes the group above actually work. Without
+      # it the group only ever fires for MAJOR bumps, and every minor/patch
+      # fumadocs bump is silently stolen by this catch-all.
+      #
+      # The reason is the same specificity trap documented in the `uv` block:
+      # the contest only runs between groups eligible for that update type. A
+      # major is not eligible for `minor-and-patch`, so `fumadocs` runs
+      # unopposed and wins. A minor/patch IS eligible, and then `fumadocs-*`
+      # (a wildcard, scoring ~94) loses to this pattern-less catch-all (500) and
+      # the packages are stripped out of the group they were written for.
+      #
+      # That is why #555 is titled "minor-and-patch" while containing nothing
+      # but fumadocs packages. See dependabot/dependabot-core#14902.
       minor-and-patch:
+        exclude-patterns:
+          - "fumadocs-*"
         update-types:
           - minor
           - patch


### PR DESCRIPTION
## What this does

Makes the `fumadocs` npm group actually do something. It has only ever fired for **major** bumps; every minor/patch fumadocs bump has been silently stolen by the `minor-and-patch` catch-all.

The evidence is sitting in the PR list right now: **#555 is titled "Bump the `minor-and-patch` group in /docs"** and contains nothing but `fumadocs-core`, `fumadocs-mdx`, `fumadocs-python` and `fumadocs-ui`. Those are exactly the four packages the `fumadocs` group exists to claim.

## Why it happens

Same specificity trap as the `uv` block (#554), with a twist that makes it much harder to spot.

The group-specificity contest only runs between groups **eligible for that update type** (`update_type_allowed?` in [`pattern_specificity_calculator.rb`](https://github.com/dependabot/dependabot-core/blob/main/updater/lib/dependabot/updater/pattern_specificity_calculator.rb)). So:

- A **major** fumadocs bump: `minor-and-patch` is not eligible (it only takes minor/patch), so `fumadocs` runs **unopposed** and wins. This is why PR #361 ("Bump the `fumadocs` group in /docs") exists — and why the group *looks* like it works.
- A **minor/patch** fumadocs bump: `minor-and-patch` **is** eligible. `fumadocs-*` is a wildcard scoring ~94; the pattern-less catch-all scores 500. The catch-all wins, and the packages are stripped out of the very group they were written for.

Nothing fails when this happens. The packages still get updated — they just arrive in the wrong PR. So the group has been quietly inert for most of its life, and the one PR that proves it "works" is the exception rather than the rule.

## Why it matters (it has been harmless by luck)

The fumadocs packages are a **coupled family**: `fumadocs-core`, `-mdx`, `-ui` and `-python` need matching versions, which is the entire reason the group exists.

Today they still move in lockstep, but only because #555 happens to contain the fumadocs family **and nothing else**. The first time a fumadocs minor bump coincides with an unrelated `next` or `react` bump, they get welded into a single PR — and then a fumadocs break blocks the unrelated packages. That is precisely the blast-radius problem the `uv` grouping was reworked to avoid in #547.

Which is not hypothetical: **#555 is red right now.** Its `build-deploy` fails because the new fumadocs passes `className` as a function across the server/client boundary, so `/reference/python/artifacts` cannot pre-render and the static export aborts. Had an unrelated docs package been in that PR, it would be stuck behind a fumadocs bug for no reason.

## Reviewer Notes

One added key: `exclude-patterns: ["fumadocs-*"]` on the npm catch-all. `exclude-patterns` is the only mechanism that removes a dependency from a pattern-less group, so it is what lets the `fumadocs` group keep what it claims.

The thing to sanity-check is the same invariant as #554: **every pattern claimed by a group above must be excluded from the catch-all below.** Here there is only one group and one pattern, so the check is short — but the rule is what matters, since it is the one that was violated.

Worth being explicit about what this does **not** fix: **#555 stays red.** This changes which PR future fumadocs bumps arrive in; it does nothing about the underlying fumadocs breaking change. #555 still needs its own investigation and should not be merged as it stands.

### Reproduction

The config is not executable, so verify it by assigning packages to groups and asserting nothing is duplicated or stolen. Run `uv run --with pyyaml python check.py`:

```python
import fnmatch, yaml
cfg = yaml.safe_load(open(".github/dependabot.yml"))
groups = [u for u in cfg["updates"] if u["package-ecosystem"] == "npm"][0]["groups"]

def excl(g, d):  return any(fnmatch.fnmatch(d, p) for p in g.get("exclude-patterns", []))
def match(g, d): return any(fnmatch.fnmatch(d, p) for p in g.get("patterns", []))

def groups_for(d):
    out = []
    for n, g in groups.items():
        if excl(g, d): continue
        if g.get("patterns") is None: out.append(n)   # catch-all takes EVERYTHING
        elif match(g, d):             out.append(n)
    return out

for d in ["fumadocs-core","fumadocs-mdx","fumadocs-ui","fumadocs-python",
          "next","react","shiki","@types/node","lucide-react"]:
    print("  %-18s -> %s" % (d, groups_for(d) or ["(ungrouped)"]))
```

On `develop` today, every `fumadocs-*` package resolves to **`minor-and-patch`** — reproducing #555. On this branch:

```
  fumadocs-core      -> ['fumadocs']
  fumadocs-mdx       -> ['fumadocs']
  fumadocs-ui        -> ['fumadocs']
  fumadocs-python    -> ['fumadocs']
  next               -> ['minor-and-patch']
  react              -> ['minor-and-patch']
  shiki              -> ['minor-and-patch']
  @types/node        -> ['minor-and-patch']
  lucide-react       -> ['minor-and-patch']
```

The four fumadocs packages land in their own group; everything else stays in the catch-all; nothing appears twice.

The real confirmation, as with #554, is Dependabot itself: after this merges, the next fumadocs bump should arrive as a **`fumadocs` group PR** rather than as a `minor-and-patch` one.

Local checks run: `just check` (green). `just check`'s yaml recipe deliberately excludes `dependabot.yml`, so the config is validated by the script above.
