### PR TITLE
Update MCP dependency

### DIFF
--- a/.github/pip-audit-ignored.txt
+++ b/.github/pip-audit-ignored.txt
@@ -24,20 +24,6 @@
 # Tracked upstream: https://github.com/zenml-io/zenml/issues/5077
 PYSEC-2026-2132  # click 8.2.1 -> 8.3.3 (CVE-2026-7246, `click.edit()` injection)
 
-# --- Blocked by our own cap in the shipped `kitaru[mcp]` extra. ------------
-# `pyproject.toml` declares `mcp>=1.19.0,<1.20.0`, so this is not merely a
-# stale lock: every `pip install kitaru[mcp]` resolves to a vulnerable 1.19.x,
-# and no version of the extra gets a user to the 1.23.0 fix.
-#
-# The cap was correct when written (`mcp>=1.20` needs `pyjwt>=2.10.1`, and
-# zenml used to hard-pin `pyjwt==2.7.*`), but that reason is gone: zenml now
-# requires `pyjwt[crypto]>=2.13.0`. Only our ceiling remains. Widening it
-# changes a published extra and needs the MCP server re-verified against the
-# newer SDK, so it is tracked separately rather than bundled into a bump.
-# Delete this entry once that lands.
-# Tracked: https://github.com/zenml-io/kitaru/issues/546
-CVE-2025-66416  # mcp 1.19 -> 1.23; blocked by our `mcp<1.20.0` pin, not upstream
-
 # --- Blocked by the fastapi pin in zenml's [server] extra. -----------------
 # zenml pins `fastapi>=0.120.1,<0.121.0`, and fastapi 0.120.x in turn requires
 # `starlette<0.50.0`. The fixes below all land in starlette 1.x, so they are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ modal = [
     "modal>=1.4,<2",
 ]
 mcp = [
-    "mcp>=1.19.0,<1.20.0",
+    "mcp>=1.23.0,<2",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -755,7 +755,8 @@ resolution-markers = [
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
-    { name = "starlette", version = "0.45.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "starlette", version = "0.45.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra != 'extra-6-kitaru-google-adk') or (extra == 'extra-6-kitaru-google-adk' and extra == 'extra-6-kitaru-local') or (extra == 'extra-6-kitaru-google-adk' and extra == 'group-6-kitaru-dev')" },
+    { name = "starlette", version = "0.49.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra != 'extra-6-kitaru-google-adk') or (extra == 'extra-6-kitaru-google-adk' and extra == 'extra-6-kitaru-local') or (extra == 'extra-6-kitaru-google-adk' and extra == 'group-6-kitaru-dev')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3f/3a/0bf90d5189d7f62dc2bd0523899629ca59b58ff4290d631cd3bb5c8889d4/fastapi-0.120.4.tar.gz", hash = "sha256:2d856bc847893ca4d77896d4504ffdec0fb04312b705065fca9104428eca3868", size = 339716, upload-time = "2025-10-31T18:37:28.81Z" }
@@ -1608,7 +1609,7 @@ requires-dist = [
     { name = "langchain-anthropic", marker = "extra == 'langgraph-anthropic'", specifier = ">=1.0,<2" },
     { name = "langchain-openai", marker = "extra == 'langgraph-openai'", specifier = ">=1.0,<2" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.1,<2" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.19.0,<1.20.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.23.0,<2" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.4,<2" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0,<3" },
     { name = "openai-agents", marker = "extra == 'openai-agents'", specifier = ">=0.15.0,<0.18.0" },
@@ -1949,7 +1950,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.19.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1958,16 +1959,20 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-6-kitaru-google-adk' and extra == 'extra-6-kitaru-local') or (extra == 'extra-6-kitaru-google-adk' and extra == 'group-6-kitaru-dev')" },
     { name = "sse-starlette" },
-    { name = "starlette", version = "0.45.3", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-6-kitaru-local' or extra == 'group-6-kitaru-dev' or extra != 'extra-6-kitaru-google-adk'" },
+    { name = "starlette", version = "0.45.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and extra != 'extra-6-kitaru-google-adk') or (extra == 'extra-6-kitaru-google-adk' and extra == 'extra-6-kitaru-local') or (extra == 'extra-6-kitaru-google-adk' and extra == 'group-6-kitaru-dev')" },
+    { name = "starlette", version = "0.49.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and extra != 'extra-6-kitaru-google-adk') or (extra == 'extra-6-kitaru-google-adk' and extra == 'extra-6-kitaru-local') or (extra == 'extra-6-kitaru-google-adk' and extra == 'group-6-kitaru-dev')" },
     { name = "starlette", version = "1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-6-kitaru-google-adk'" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten' or (extra == 'extra-6-kitaru-google-adk' and extra == 'extra-6-kitaru-local') or (extra == 'extra-6-kitaru-google-adk' and extra == 'group-6-kitaru-dev')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/2b/916852a5668f45d8787378461eaa1244876d77575ffef024483c94c0649c/mcp-1.19.0.tar.gz", hash = "sha256:213de0d3cd63f71bc08ffe9cc8d4409cc87acffd383f6195d2ce0457c021b5c1", size = 444163, upload-time = "2025-10-24T01:11:15.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/a3/3e71a875a08b6a830b88c40bc413bff01f1650f1efe8a054b5e90a9d4f56/mcp-1.19.0-py3-none-any.whl", hash = "sha256:f5907fe1c0167255f916718f376d05f09a830a215327a3ccdd5ec8a519f2e572", size = 170105, upload-time = "2025-10-24T01:11:14.151Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -3551,15 +3556,29 @@ name = "starlette"
 version = "0.45.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14'",
     "python_full_version < '3.14'",
 ]
 dependencies = [
-    { name = "anyio", marker = "extra == 'extra-6-kitaru-local' or extra == 'group-6-kitaru-dev' or extra != 'extra-6-kitaru-google-adk'" },
+    { name = "anyio", marker = "(python_full_version < '3.14' and extra != 'extra-6-kitaru-google-adk') or (extra == 'extra-6-kitaru-google-adk' and extra == 'extra-6-kitaru-local') or (extra == 'extra-6-kitaru-google-adk' and extra == 'group-6-kitaru-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ff/fb/2984a686808b89a6781526129a4b51266f678b2d2b97ab2d325e56116df8/starlette-0.45.3.tar.gz", hash = "sha256:2cbcba2a75806f8a41c722141486f37c28e30a0921c5f6fe4346cb0dcee1302f", size = 2574076, upload-time = "2025-01-24T11:17:36.535Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/61/f2b52e107b1fc8944b33ef56bf6ac4ebbe16d91b94d2b87ce013bf63fb84/starlette-0.45.3-py3-none-any.whl", hash = "sha256:dfb6d332576f136ec740296c7e8bb8c8a7125044e7c6da30744718880cdd059d", size = 71507, upload-time = "2025-01-24T11:17:34.182Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.49.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "anyio", marker = "(python_full_version >= '3.14' and extra != 'extra-6-kitaru-google-adk') or (extra == 'extra-6-kitaru-google-adk' and extra == 'extra-6-kitaru-local') or (extra == 'extra-6-kitaru-google-adk' and extra == 'group-6-kitaru-dev')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/1a/608df0b10b53b0beb96a37854ee05864d182ddd4b1156a22f1ad3860425a/starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284", size = 2655031, upload-time = "2025-11-01T15:12:26.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/e0/021c772d6a662f43b63044ab481dc6ac7592447605b5b35a957785363122/starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f", size = 74340, upload-time = "2025-11-01T15:12:24.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- raise the `kitaru[mcp]` security floor from MCP 1.19.0 to 1.23.0
- allow compatible MCP 1.x releases and lock the development environment to 1.28.1
- remove the obsolete `CVE-2025-66416` audit exception

Closes #546.

## Why

The previous `<1.20.0` ceiling forced every installation of `kitaru[mcp]` onto an MCP release affected by CVE-2025-66416. ZenML's former PyJWT constraint, which originally required that ceiling, has been removed. Kitaru and MCP now resolve together with PyJWT 2.13.0.

## Reviewer Notes

The source-of-truth change is the MCP range in `pyproject.toml`: `mcp>=1.23.0,<2`. The lower bound prevents vulnerable resolution, while the major-version ceiling avoids admitting a future breaking MCP 2.x release.

The lockfile resolves MCP 1.28.1. Its dependency metadata adds PyJWT crypto and typing dependencies, plus a Starlette 0.49.3 resolution for Python 3.14. The older Starlette entry remains for environments whose other constraints still require it.

No MCP server code changed. Existing schema tests exercise Kitaru's FastMCP registration contract at both the declared minimum and locked versions.

### Reproduction

1. Install the MCP extra with `uv sync --extra mcp`.
2. Run `uv run python -c "from importlib.metadata import version; print(version('mcp'))"` and confirm it prints `1.28.1`.
3. Run `uv run pytest -q tests/mcp/test_server.py tests/test_mcp_import_guard.py` and confirm all 170 tests pass.
4. Run `just audit` and confirm `CVE-2025-66416` is no longer reported or ignored.

Local checks run: MCP tests with both 1.23.0 and 1.28.1, a real stdio initialization and `tools/list` smoke test, `just check`, `just audit`, and the full test suite (`3601 passed, 29 skipped`).
