### PR TITLE
Update genai-prices to 0.0.71

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,6 +76,15 @@ updates:
           - minor
           - patch
 
+      # Pricing-data updates affect cost estimates rather than provider runtime
+      # behavior, so review and ship them independently from adapter SDK bumps.
+      genai-prices:
+        patterns:
+          - genai-prices
+        update-types:
+          - minor
+          - patch
+
       # Failures surface in a user's runtime, and our tests mock these SDKs, so
       # CI is structurally blind to them. Needs live provider runs before merge.
       # See `tests/_gemini_fake_sdk.py` for the sharpest example: it substitutes
@@ -89,7 +98,6 @@ updates:
           - claude-agent-sdk
           - google-genai
           - google-adk
-          - genai-prices
           - mcp
           - pydantic-ai-slim
           - pydantic-ai*
@@ -115,7 +123,7 @@ updates:
 
       # Everything else: cyclopts, pydantic, rich, modal, typing-extensions.
       #
-      # `exclude-patterns` MUST mirror every pattern from the three groups above.
+      # `exclude-patterns` MUST mirror every pattern from the four groups above.
       # This group has no `patterns`, so Dependabot never asks whether another
       # group claims a dependency (see the note at the top of `groups:`) and it
       # will happily re-ship anything not listed here in a second PR. Keep this
@@ -137,11 +145,12 @@ updates:
           - claude-agent-sdk
           - google-genai
           - google-adk
-          - genai-prices
           - mcp
           - pydantic-ai*
           - langchain*
           - langgraph*
+          # mirrors genai-prices
+          - genai-prices
           # mirrors zenml
           - zenml
         update-types:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ keywords = [
 ]
 dependencies = [
     "cyclopts>=3.0",
-    "genai-prices>=0.0.66,<0.1",
+    "genai-prices>=0.0.71,<0.1",
     "pydantic>=2.0",
     "rich>=12.0.0",
     "zenml[local]>=0.96.1",

--- a/uv.lock
+++ b/uv.lock
@@ -913,15 +913,15 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.66"
+version = "0.0.71"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/7c/c50fc8d18b283e9b56ff625d45dbe9577c676e1d16636c1011967182d813/genai_prices-0.0.66.tar.gz", hash = "sha256:f087dfe56da28a4c3933dcf846cf2b7111ba733cef674c0cbc66de80212bcd6b", size = 71130, upload-time = "2026-06-09T21:51:14.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e4/5072862613fba039da2b7c981a8649c6c6bbcb2863bd8bc81617c09ce5ee/genai_prices-0.0.71.tar.gz", hash = "sha256:de4db34ec38404f9ef383cb1ab29e204d16ccf27071af0b16d5747ee7affe36b", size = 82105, upload-time = "2026-07-10T00:38:30.491Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/87/1a36166f91906e47f430f6d4150ec6bfc0001032a363e49fc389021c0609/genai_prices-0.0.66-py3-none-any.whl", hash = "sha256:86b83f107c1cf04bb449a120cd8d4439ceb6843660d9128cde560eb511686d7b", size = 73745, upload-time = "2026-06-09T21:51:13.523Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/98/c06c1318f6834a26268a2d4280e4183f60c5ea92152aea841feff29826ff/genai_prices-0.0.71-py3-none-any.whl", hash = "sha256:1d13111563af2b1ce43ccfacf77b7ac3216ad704c644408a56e11b181fe0d128", size = 84586, upload-time = "2026-07-10T00:38:29.252Z" },
 ]
 
 [[package]]
@@ -1597,7 +1597,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.40.0,<1" },
     { name = "claude-agent-sdk", marker = "extra == 'claude-agent-sdk'", specifier = ">=0.1.58,<0.2" },
     { name = "cyclopts", specifier = ">=3.0" },
-    { name = "genai-prices", specifier = ">=0.0.66,<0.1" },
+    { name = "genai-prices", specifier = ">=0.0.71,<0.1" },
     { name = "google-adk", marker = "extra == 'google-adk'", specifier = ">=2.3.0,<3" },
     { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=2.8.0,<3" },
     { name = "kitaru", extras = ["anthropic"], marker = "extra == 'llm'" },


### PR DESCRIPTION
## Summary

- require `genai-prices` 0.0.71 or newer so Kitaru installations include the latest pricing catalog
- update the lockfile from 0.0.66 to 0.0.71 without changing unrelated packages
- move `genai-prices` into its own Dependabot group so pricing-data updates are reviewed separately from provider and adapter SDK changes

This extracts the pricing dependency update from the broader adapter and LLM SDK update in #568. Pricing catalog changes affect Kitaru's estimated costs, but they do not carry the same provider-runtime compatibility risks as SDK upgrades.

## Reviewer Notes

Kitaru calculates estimated LLM costs after provider calls using the installed `genai-prices` catalog. The previous dependency range allowed newer releases but did not guarantee the catalog containing GPT-5.6, Grok 4.5, and recent pricing corrections. This change raises the installation floor to 0.0.71 and keeps future catalog refreshes out of the adapter SDK Dependabot group.

The main review risk is dependency resolution: `pyproject.toml`, the Kitaru requirement recorded in `uv.lock`, and the locked package artifact must agree on 0.0.71. The Dependabot catch-all exclusion must also continue excluding `genai-prices`, otherwise Dependabot can generate duplicate update PRs.

### Reproduction

1. Run `uv sync`.
2. Run:
   ```bash
   uv run python - <<'PY'
   from genai_prices import Usage, calc_price

   price = calc_price(
       Usage(input_tokens=1_000_000, output_tokens=1_000_000),
       "gpt-5.6",
       provider_id="openai",
   )
   print(price.total_price)
   PY
   ```
3. Confirm the command prints a positive cost. With the 0.0.71 catalog it currently prints `35.0`.

Local checks run: `just check`, `just test` (3601 passed, 29 skipped), and `just build`. The built wheel metadata was also checked for `Requires-Dist: genai-prices<0.1,>=0.0.71`.
