### PR TITLE
Validate execution diff replay lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Execution diffs now reject blank selectors and explicit comparisons without recorded direct replay lineage, while deduplicating repeated selectors and aliases in first-occurrence order. (#565)
+
 ## [0.21.0] - 2026-07-14
 
 ### Added

--- a/docs/book/guides/replay-and-overrides.md
+++ b/docs/book/guides/replay-and-overrides.md
@@ -436,7 +436,7 @@ execution_diff = kitaru.diff("kr-original")
 execution_diff = kitaru.diff("kr-original", "kr-replay-a", "kr-replay-b")
 ```
 
-When replay executions are omitted, `kitaru.diff` discovers all runs whose `original_exec_id` matches the source.
+When replay executions are omitted, `kitaru.diff` discovers all runs whose `original_exec_id` matches the source. Explicit comparisons accept only recorded direct replays of the requested original. Kitaru rejects blank execution IDs and executions with missing or conflicting replay lineage instead of comparing unrelated runs. Repeated selectors, including different aliases for the same replay, are compared once in first-occurrence order.
 
 Diff many originals against their auto-discovered replays:
 

--- a/docs/book/guides/replay-and-overrides.md
+++ b/docs/book/guides/replay-and-overrides.md
@@ -436,7 +436,7 @@ execution_diff = kitaru.diff("kr-original")
 execution_diff = kitaru.diff("kr-original", "kr-replay-a", "kr-replay-b")
 ```
 
-When replay executions are omitted, `kitaru.diff` discovers all runs whose `original_exec_id` matches the source. Explicit comparisons accept only recorded direct replays of the requested original. Kitaru rejects blank execution IDs and executions with missing or conflicting replay lineage instead of comparing unrelated runs. Repeated selectors, including different aliases for the same replay, are compared once in first-occurrence order.
+When replay executions are omitted, `kitaru.diff` discovers all runs whose `original_exec_id` matches the source. An explicit single diff accepts only recorded direct replays of the requested original. Compare a replay chain one hop at a time: compare the original with its direct replay, then compare that replay with its own direct replay. Kitaru rejects blank execution IDs and executions with missing or conflicting replay lineage instead of comparing unrelated runs. Repeated selectors, including different aliases for the same replay, are compared once in first-occurrence order.
 
 Diff many originals against their auto-discovered replays:
 

--- a/src/kitaru/diff.py
+++ b/src/kitaru/diff.py
@@ -16,6 +16,7 @@ from kitaru._ui_urls import (
     resolve_ui_url_context,
 )
 from kitaru.client import KitaruClient
+from kitaru.errors import KitaruUsageError
 
 DEFAULT_COMPARE_FLOW_VERSION = "local"
 _AUTO_DISCOVERY_SCAN_LIMIT = 10_000
@@ -454,19 +455,17 @@ def _discover_replays(
     return replay_ids_by_original, warnings
 
 
-def _compare_execution(
+def _compare_loaded_executions(
     *,
     client: KitaruClient,
     original_execution: Execution,
-    replay_exec_ids: Sequence[str],
+    replay_executions: Sequence[Execution],
     warnings: Sequence[str],
     artifact_hash_cache: dict[str, str],
     ui_context: UiUrlContext | None,
 ) -> ExecutionDiff:
-    """Compare one loaded original against explicit replay execution IDs."""
     compared: list[tuple[str, list[CheckpointDiff]]] = []
-    for replay_exec_id in replay_exec_ids:
-        replay_execution = client.executions.get(replay_exec_id)
+    for replay_execution in replay_executions:
         pairs = _align_checkpoints(original_execution, replay_execution)
         checkpoint_diffs = [
             _compare_checkpoints(
@@ -477,9 +476,10 @@ def _compare_execution(
             )
             for original_cp, replay_cp in pairs
         ]
-        compared.append((replay_exec_id, checkpoint_diffs))
+        compared.append((replay_execution.exec_id, checkpoint_diffs))
 
     original_exec_id = original_execution.exec_id
+    replay_exec_ids = [execution.exec_id for execution in replay_executions]
     if replay_exec_ids:
         multi_url = build_compare_url_for_executions(
             server_url=None,
@@ -501,6 +501,52 @@ def _compare_execution(
     )
 
 
+def _normalize_execution_selector(selector: str, *, label: str) -> str:
+    normalized = selector.strip()
+    if not normalized:
+        raise KitaruUsageError(f"{label} must not be blank.")
+    return normalized
+
+
+def _resolve_explicit_replays(
+    client: KitaruClient,
+    *,
+    original_execution: Execution,
+    replay_selectors: Sequence[str],
+) -> list[Execution]:
+    original_exec_id = original_execution.exec_id
+    seen_selectors: set[str] = set()
+    seen_exec_ids: set[str] = set()
+    replay_executions: list[Execution] = []
+
+    for selector in replay_selectors:
+        if selector in seen_selectors:
+            continue
+        seen_selectors.add(selector)
+
+        replay_execution = client.executions.get(selector)
+        replay_original_exec_id = replay_execution.original_exec_id
+        if replay_original_exec_id is None:
+            raise KitaruUsageError(
+                f"Replay execution '{selector}' resolves to "
+                f"'{replay_execution.exec_id}', which has no recorded direct "
+                f"replay lineage to original execution '{original_exec_id}'."
+            )
+        if replay_original_exec_id != original_exec_id:
+            raise KitaruUsageError(
+                f"Replay execution '{selector}' resolves to "
+                f"'{replay_execution.exec_id}', whose recorded direct original "
+                f"is '{replay_original_exec_id}', not '{original_exec_id}'."
+            )
+
+        if replay_execution.exec_id in seen_exec_ids:
+            continue
+        seen_exec_ids.add(replay_execution.exec_id)
+        replay_executions.append(replay_execution)
+
+    return replay_executions
+
+
 def diff(
     original: str,
     *executions: str,
@@ -512,6 +558,18 @@ def diff(
     """
     from kitaru.analytics import AnalyticsEvent, track
 
+    normalized_original = _normalize_execution_selector(
+        original,
+        label="Original execution ID",
+    )
+    normalized_replays = [
+        _normalize_execution_selector(
+            selector,
+            label=f"Replay execution ID at position {index}",
+        )
+        for index, selector in enumerate(executions, start=1)
+    ]
+
     track(
         AnalyticsEvent.DIFF_REQUESTED,
         {
@@ -520,24 +578,40 @@ def diff(
         },
     )
     client = KitaruClient()
-    artifact_hash_cache: dict[str, str] = {}
-    ui_context = _client_ui_url_context(client)
-    original_execution = client.executions.get(original)
-    if executions:
-        replay_exec_ids = list(executions)
-        warnings: list[str] = []
-    else:
-        replay_ids_by_original, warnings = _discover_replays(
-            client,
-            flow_name=original_execution.flow_name,
-            original_exec_ids=[original_execution.exec_id],
-        )
-        replay_exec_ids = replay_ids_by_original[original_execution.exec_id]
+    original_execution = client.executions.get(normalized_original)
 
-    return _compare_execution(
+    if normalized_replays:
+        replay_executions = _resolve_explicit_replays(
+            client,
+            original_execution=original_execution,
+            replay_selectors=normalized_replays,
+        )
+        artifact_hash_cache: dict[str, str] = {}
+        ui_context = _client_ui_url_context(client)
+        return _compare_loaded_executions(
+            client=client,
+            original_execution=original_execution,
+            replay_executions=replay_executions,
+            warnings=[],
+            artifact_hash_cache=artifact_hash_cache,
+            ui_context=ui_context,
+        )
+
+    replay_ids_by_original, warnings = _discover_replays(
+        client,
+        flow_name=original_execution.flow_name,
+        original_exec_ids=[original_execution.exec_id],
+    )
+    artifact_hash_cache = {}
+    ui_context = _client_ui_url_context(client)
+    replay_executions = [
+        client.executions.get(replay_exec_id)
+        for replay_exec_id in replay_ids_by_original[original_execution.exec_id]
+    ]
+    return _compare_loaded_executions(
         client=client,
         original_execution=original_execution,
-        replay_exec_ids=replay_exec_ids,
+        replay_executions=replay_executions,
         warnings=warnings,
         artifact_hash_cache=artifact_hash_cache,
         ui_context=ui_context,
@@ -592,10 +666,14 @@ def _build_diff_matrix(exec_ids: Sequence[str] | Any) -> CohortDiff:
 
     diffs_by_id: dict[str, ExecutionDiff] = {}
     for exec_id, original_execution in originals_by_id.items():
-        diffs_by_id[exec_id] = _compare_execution(
+        replay_executions = [
+            client.executions.get(replay_exec_id)
+            for replay_exec_id in replay_ids_by_original[exec_id]
+        ]
+        diffs_by_id[exec_id] = _compare_loaded_executions(
             client=client,
             original_execution=original_execution,
-            replay_exec_ids=replay_ids_by_original[exec_id],
+            replay_executions=replay_executions,
             warnings=warnings_by_flow[original_execution.flow_name],
             artifact_hash_cache=artifact_hash_cache,
             ui_context=ui_context,

--- a/src/kitaru/diff.py
+++ b/src/kitaru/diff.py
@@ -622,7 +622,13 @@ def _build_diff_matrix(exec_ids: Sequence[str] | Any) -> CohortDiff:
     from kitaru.analytics import AnalyticsEvent, track
     from kitaru.cohort import coerce_exec_ids
 
-    resolved_ids = coerce_exec_ids(exec_ids)
+    resolved_ids = [
+        _normalize_execution_selector(
+            selector,
+            label=f"Execution ID at position {index}",
+        )
+        for index, selector in enumerate(coerce_exec_ids(exec_ids), start=1)
+    ]
     track(
         AnalyticsEvent.DIFF_REQUESTED,
         {

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1330,6 +1330,14 @@ def test_executions_diff_matrix_returns_renamed_payload() -> None:
     assert "cohort" not in payload
 
 
+def test_executions_diff_matrix_preserves_blank_selector_error() -> None:
+    with pytest.raises(
+        KitaruUsageError,
+        match="Execution ID at position 2 must not be blank",
+    ):
+        kitaru_executions_diff_matrix(["kr-original", "   "])
+
+
 def test_executions_diff_serializes_checkpoint_usage_deltas() -> None:
     result = object()
     serialized = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4605,6 +4605,37 @@ def test_executions_diff_matrix_json_uses_new_command_name(
     }
 
 
+def test_executions_diff_matrix_rejects_blank_selector_with_structured_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch("kitaru.diff.KitaruClient") as client_constructor,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(
+            [
+                "executions",
+                "diff-matrix",
+                "kr-original",
+                "   ",
+                "--output",
+                "json",
+            ]
+        )
+
+    assert exc_info.value.code == 1
+    client_constructor.assert_not_called()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err) == {
+        "command": "executions.diff_matrix",
+        "error": {
+            "message": "Execution ID at position 2 must not be blank.",
+            "type": "KitaruUsageError",
+        },
+    }
+
+
 def test_executions_diff_rejects_blank_replay_with_structured_error(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4605,6 +4605,37 @@ def test_executions_diff_matrix_json_uses_new_command_name(
     }
 
 
+def test_executions_diff_rejects_blank_replay_with_structured_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        patch("kitaru.diff.KitaruClient") as client_constructor,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(
+            [
+                "executions",
+                "diff",
+                "kr-original",
+                "   ",
+                "--output",
+                "json",
+            ]
+        )
+
+    assert exc_info.value.code == 1
+    client_constructor.assert_not_called()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err) == {
+        "command": "executions.diff",
+        "error": {
+            "message": "Replay execution ID at position 1 must not be blank.",
+            "type": "KitaruUsageError",
+        },
+    }
+
+
 def test_executions_diff_text_prints_discovery_warning(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -29,6 +29,7 @@ from kitaru.diff import (
     serialize_checkpoint_diff,
     serialize_execution_diff,
 )
+from kitaru.errors import KitaruUsageError
 from tests._diff_helpers import checkpoint_diff_from_usage_records
 
 _diff_module = import_module("kitaru.diff")
@@ -449,8 +450,202 @@ def test_diff_uses_loaded_original_id_and_resolves_ui_context_once() -> None:
         result = diff("kr-requested-alias", "kr-replay")
 
     assert result.original_exec_id == "kr-canonical"
+    assert [replay_id for replay_id, _ in result.compared] == ["kr-replay"]
+    assert fake_client.executions.get.call_args_list == [
+        call("kr-requested-alias"),
+        call("kr-replay"),
+    ]
     ui_context_mock.assert_called_once_with(fake_client)
     fake_client.executions._list_replays_for_originals.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("original", "replays", "expected_message"),
+    [
+        ("", (), "Original execution ID must not be blank."),
+        (" \t ", (), "Original execution ID must not be blank."),
+        (
+            "kr-original",
+            ("",),
+            "Replay execution ID at position 1 must not be blank.",
+        ),
+        (
+            "kr-original",
+            ("kr-replay", " \t "),
+            "Replay execution ID at position 2 must not be blank.",
+        ),
+    ],
+)
+def test_diff_rejects_blank_selectors_before_client_construction(
+    original: str,
+    replays: tuple[str, ...],
+    expected_message: str,
+) -> None:
+    with (
+        patch("kitaru.diff.KitaruClient") as client_constructor,
+        pytest.raises(KitaruUsageError) as exc_info,
+    ):
+        diff(original, *replays)
+
+    assert str(exc_info.value) == expected_message
+    client_constructor.assert_not_called()
+
+
+def test_diff_strips_surrounding_whitespace_before_lookup() -> None:
+    original = _execution("kr-original", checkpoints=[])
+    replay = _execution(
+        "kr-replay",
+        original_exec_id="kr-original",
+        checkpoints=[],
+    )
+    fake_client = MagicMock()
+    fake_client.executions.get.side_effect = [original, replay]
+
+    with (
+        patch("kitaru.diff.KitaruClient", return_value=fake_client),
+        patch("kitaru.diff._client_ui_url_context", return_value=None),
+    ):
+        result = diff("  original-alias  ", "\treplay-alias\n")
+
+    assert result.original_exec_id == "kr-original"
+    assert [replay_id for replay_id, _ in result.compared] == ["kr-replay"]
+    assert fake_client.executions.get.call_args_list == [
+        call("original-alias"),
+        call("replay-alias"),
+    ]
+
+
+def test_diff_rejects_same_flow_replay_linked_to_another_original() -> None:
+    original = _execution("kr-original", flow_id="flow-shared", checkpoints=[])
+    unrelated_replay = _execution(
+        "kr-unrelated-replay",
+        original_exec_id="kr-another-original",
+        flow_id="flow-shared",
+        checkpoints=[],
+    )
+    fake_client = MagicMock()
+    fake_client.executions.get.side_effect = [original, unrelated_replay]
+
+    with (
+        patch("kitaru.diff.KitaruClient", return_value=fake_client),
+        patch("kitaru.diff._align_checkpoints") as align_checkpoints,
+        pytest.raises(KitaruUsageError) as exc_info,
+    ):
+        diff("kr-original", "kr-unrelated-replay")
+
+    assert str(exc_info.value) == (
+        "Replay execution 'kr-unrelated-replay' resolves to "
+        "'kr-unrelated-replay', whose recorded direct original is "
+        "'kr-another-original', not 'kr-original'."
+    )
+    align_checkpoints.assert_not_called()
+
+
+def test_diff_rejects_replay_without_recorded_lineage() -> None:
+    original = _execution("kr-original", checkpoints=[])
+    unlinked_execution = _execution("kr-unlinked", checkpoints=[])
+    fake_client = MagicMock()
+    fake_client.executions.get.side_effect = [original, unlinked_execution]
+
+    with (
+        patch("kitaru.diff.KitaruClient", return_value=fake_client),
+        patch("kitaru.diff._align_checkpoints") as align_checkpoints,
+        pytest.raises(KitaruUsageError) as exc_info,
+    ):
+        diff("kr-original", "kr-unlinked")
+
+    assert str(exc_info.value) == (
+        "Replay execution 'kr-unlinked' resolves to 'kr-unlinked', which has no "
+        "recorded direct replay lineage to original execution 'kr-original'."
+    )
+    align_checkpoints.assert_not_called()
+
+
+def test_diff_stably_deduplicates_selectors_and_canonical_replay_ids() -> None:
+    original = _execution("kr-original", checkpoints=[])
+    replay_a = _execution(
+        "kr-replay-a",
+        original_exec_id="kr-original",
+        checkpoints=[],
+    )
+    replay_b = _execution(
+        "kr-replay-b",
+        original_exec_id="kr-original",
+        checkpoints=[],
+    )
+    fake_client = MagicMock()
+    fake_client.executions.get.side_effect = [
+        original,
+        replay_a,
+        replay_a,
+        replay_b,
+    ]
+    ui_context = UiUrlContext(
+        base_url="https://demo.kitaru.zenml.io",
+        route_kind="legacy",
+        source="connection_config",
+    )
+
+    with (
+        patch("kitaru.diff.KitaruClient", return_value=fake_client),
+        patch("kitaru.diff._client_ui_url_context", return_value=ui_context),
+    ):
+        result = diff(
+            " kr-original-alias ",
+            " replay-a ",
+            "replay-a",
+            " latest-replay-a ",
+            "latest-replay-a",
+            " replay-b ",
+        )
+
+    assert fake_client.executions.get.call_args_list == [
+        call("kr-original-alias"),
+        call("replay-a"),
+        call("latest-replay-a"),
+        call("replay-b"),
+    ]
+    assert [replay_id for replay_id, _ in result.compared] == [
+        "kr-replay-a",
+        "kr-replay-b",
+    ]
+    assert result.urls == [
+        "https://demo.kitaru.zenml.io/flows/flow-1/v/local/compare"
+        "?executions=kr-original,kr-replay-a,kr-replay-b"
+    ]
+
+
+def test_diff_validates_all_explicit_replays_before_checkpoint_comparison() -> None:
+    original = _execution("kr-original", checkpoints=[])
+    valid_replay = _execution(
+        "kr-valid-replay",
+        original_exec_id="kr-original",
+        checkpoints=[],
+    )
+    invalid_replay = _execution(
+        "kr-invalid-replay",
+        original_exec_id="kr-another-original",
+        checkpoints=[],
+    )
+    fake_client = MagicMock()
+    fake_client.executions.get.side_effect = [original, valid_replay, invalid_replay]
+
+    with (
+        patch("kitaru.diff.KitaruClient", return_value=fake_client),
+        patch("kitaru.diff._align_checkpoints") as align_checkpoints,
+        patch("kitaru.diff._client_ui_url_context") as ui_context_mock,
+        pytest.raises(KitaruUsageError),
+    ):
+        diff("kr-original", "kr-valid-replay", "kr-invalid-replay")
+
+    assert fake_client.executions.get.call_args_list == [
+        call("kr-original"),
+        call("kr-valid-replay"),
+        call("kr-invalid-replay"),
+    ]
+    align_checkpoints.assert_not_called()
+    ui_context_mock.assert_not_called()
+    fake_client._get_artifact_version.assert_not_called()
 
 
 def test_diff_cohort_uses_canonical_ids_for_aliases_and_duplicates() -> None:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -648,6 +648,31 @@ def test_diff_validates_all_explicit_replays_before_checkpoint_comparison() -> N
     fake_client._get_artifact_version.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("selectors", "blank_position"),
+    [
+        ([""], 1),
+        (["kr-original", "   "], 2),
+    ],
+)
+def test_diff_cohort_rejects_blank_selectors_before_loading_client(
+    selectors: list[str],
+    blank_position: int,
+) -> None:
+    from kitaru.diff import diff_cohort
+
+    with (
+        patch("kitaru.diff.KitaruClient") as client_constructor,
+        pytest.raises(
+            KitaruUsageError,
+            match=f"Execution ID at position {blank_position} must not be blank",
+        ),
+    ):
+        diff_cohort(selectors)
+
+    client_constructor.assert_not_called()
+
+
 def test_diff_cohort_uses_canonical_ids_for_aliases_and_duplicates() -> None:
     from kitaru.diff import diff_cohort
 


### PR DESCRIPTION
## Summary

- reject blank and whitespace-only execution diff selectors before client or backend work, including the shared diff-matrix path used by SDK `diff_cohort` / `diff_matrix`, CLI `executions diff-matrix`, and MCP
- require every explicit single-diff comparison target to be a recorded direct replay of the loaded canonical original
- normalize and deduplicate explicit single-diff selectors and canonical replay IDs while preserving first-occurrence order
- preserve diff-matrix duplicate-row semantics while applying one consistent selector-validation contract
- document direct-only replay lineage and compare replay chains one hop at a time
- track safe ancestor-to-descendant comparisons separately in follow-up issue #578

Explicit execution diffs previously accepted unrelated executions and could emit plausible but meaningless comparisons. Repeated selectors or aliases could also trigger duplicate lookups, comparison work, and URL entries. The matrix path also allowed blank or whitespace-only selectors to reach execution lookup instead of failing consistently at the shared core boundary.

## Reviewer Notes

### Implementation decisions

The core explicit-comparison behavior lives in `kitaru.diff.diff()`, so SDK, CLI, and MCP callers share the same lineage validation. The function normalizes every selector before constructing a client, loads the original to obtain its canonical execution ID, and resolves the complete explicit replay list before checkpoint alignment, artifact hashing, or URL construction. Each candidate must record that canonical ID in `original_exec_id`.

The shared `_build_diff_matrix()` path now reuses the same execution-selector normalizer before analytics or client construction. That gives SDK `diff_cohort` / `diff_matrix`, CLI `executions diff-matrix`, and MCP one blank-selector contract without moving diff-specific error labels into cohort coercion. It deliberately keeps the existing matrix behavior where repeated requested originals produce repeated rows.

The comparison helper receives loaded `Execution` objects and emits their canonical IDs. Normalized selector duplicates are skipped before lookup, while different aliases resolving to the same replay are collapsed after lookup. Auto-discovery still uses the existing bounded lightweight replay scan.

Explicit single diffs accept only recorded direct replays of the requested original. A replay chain must therefore be compared one hop at a time: original to direct replay, then that replay to its own direct replay. Safe ancestor-to-descendant comparisons need a separate contract and are tracked in #578.

### Reproduction

Use one original execution ID, one direct replay of it, and one unrelated execution:

```bash
ORIGINAL=kr-original
REPLAY=kr-direct-replay
UNRELATED=kr-unrelated

uv run kitaru executions diff "$ORIGINAL" "$UNRELATED" --output json
```

The unrelated comparison now exits with code 1 and reports a `KitaruUsageError` explaining that the recorded direct original does not match.

Then repeat the valid replay selector:

```bash
uv run kitaru executions diff "$ORIGINAL" "$REPLAY" "$REPLAY" --output json
```

The command succeeds with one entry in `compared`, and the compare URL contains the replay once. Different aliases resolving to the same replay collapse in the same first-occurrence order.

Verify the shared matrix boundary through the CLI:

```bash
uv run kitaru executions diff-matrix "$ORIGINAL" "   " --output json
```

The command exits with code 1 and renders a structured `KitaruUsageError`: `Execution ID at position 2 must not be blank.`

The equivalent SDK calls fail with the same core message before constructing a client:

```python
import kitaru

kitaru.diff_cohort(["kr-original", "   "])
kitaru.diff_matrix(["kr-original", "   "])
```

Invoking MCP `kitaru_executions_diff_matrix` with `{"exec_ids": ["kr-original", "   "]}` preserves that same `KitaruUsageError` for MCP error rendering.

For a replay chain `kr-original -> kr-replay-1 -> kr-replay-2`, compare `kr-original` with `kr-replay-1`, then compare `kr-replay-1` with `kr-replay-2`. Passing `kr-replay-2` directly against `kr-original` is rejected.

## Local checks run

- focused blank-selector regressions: `4 passed`
- `just test tests/test_diff.py`: `51 passed`
- `just check`: passed
- `just test`: `3615 passed, 29 skipped`
- `git diff --check`: passed

Fixes #565

