### PR TITLE
Extend `executions diff` checkpoint table with duration and artifact columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- The checkpoint table in `kitaru executions diff` text output now includes replay-minus-original duration deltas and per-role artifact comparison states (`unchanged`/`changed`/`unavailable`) alongside token and cost deltas, without printing artifact hashes or values. (#520)
+
 ### Fixed
 - Reporting now preserves physical retry identity, marks unavailable secret-list key metadata explicitly, accounts for unknown billing conservatively, and documents the distinct workload-token and incurred-cost diff bases. (#566)
 - Execution diffs now reject blank selectors and explicit comparisons without recorded direct replay lineage, while deduplicating repeated selectors and aliases in first-occurrence order. (#565)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- `kitaru executions diff` now shows a checkpoint-level table for each replay in its default text output, including status, duration, token, cost, and artifact comparisons. (#520)
+
 ## [0.21.0] - 2026-07-14
 
 ### Added

--- a/docs/book/guides/replay-and-overrides.md
+++ b/docs/book/guides/replay-and-overrides.md
@@ -463,19 +463,25 @@ The default `executions diff` output shows one row per checkpoint for each compa
 Diff for kr-original
   Compared against 1 replay execution(s).
 Checkpoint differences
-  Replay        Checkpoint          Result    Input Δ   Output Δ   Total Δ   Cost Δ (USD)
-  ------------  ------------------  --------  --------  ---------  --------  ------------
-  kr-replay-a   research            match     +0        +0         +0        +0.000000
-  kr-replay-a   write_draft         changed   -120      +40        -80       -0.001700
+  Replay        Checkpoint    Result    Duration Δ (ms)   Input Δ   Output Δ   Total Δ   Cost Δ (USD)   Artifacts
+  -----------   -----------   -------   ---------------   -------   --------   -------   ------------   ----------------
+  kr-replay-a   research      match     -8.0              +0        +0         +0        +0.000000      output=unchanged
+  kr-replay-a   write_draft   changed   +412.5            -120      +40        -80       -0.001700      output=changed
 Applied output overrides [kr-replay-a]:
   checkpoint family 'research' -> research, research_2
 ```
 
 The table reports `changed` when checkpoint status, token usage, cost, or
 artifact hashes differ. It uses `original only` when a source checkpoint has no
-replay match and `replay only` when a new checkpoint appears only in the replay. `n/a` means the
-corresponding token or cost delta is unavailable. `executions diff-matrix` keeps
-its existing summary-only text output.
+replay match and `replay only` when a new checkpoint appears only in the replay.
+Duration, token, and cost deltas are always **replay minus original**: a
+negative value means the replay was faster, used fewer tokens, or cost less.
+The `Artifacts` column lists each saved artifact role sorted by name —
+`unchanged` when both content hashes match, `changed` when both exist but
+differ, and `unavailable` when either hash is missing. Artifact hashes and
+values themselves are never printed. `n/a` means the corresponding metric or
+artifact comparison is unavailable, which is distinct from an explicit zero
+delta. `executions diff-matrix` keeps its existing summary-only text output.
 
 Each replay entry in JSON has an additive `applied_output_overrides` field. It
 contains only the selector, selector kind, resolved checkpoint invocation IDs,

--- a/docs/book/guides/replay-and-overrides.md
+++ b/docs/book/guides/replay-and-overrides.md
@@ -454,17 +454,19 @@ kitaru executions diff kr-original kr-replay-a
 
 ```text
 Diff for kr-original
-Compared against 1 replay execution(s).
+  Compared against 1 replay execution(s).
 Replay kr-replay-a checkpoints
-  Checkpoint   Status    Duration   Tokens                                 Cost       Artifacts
-  ----------   -------   --------   ------------------------------------   --------   ------------------------------------------------------
-  generate     same      +12.5 ms   input=+10, output=-5, total=+5         +0.0 USD   model=changed, output=unchanged, report=unavailable
-  publish      changed   n/a        n/a                                    n/a        n/a
+  Checkpoint   Status    Duration   Tokens                           Cost       Artifacts
+  ----------   -------   --------   ------------------------------   --------   ---------------------------------------------------
+  generate     same      +12.5 ms   input=+10, output=-5, total=+5   +0.0 USD   model=changed, output=unchanged, report=unavailable
+  publish      changed   n/a        n/a                              n/a        n/a
   ui: https://kitaru.example/compare
 ```
 
 `Status` is `same` when the original and replay checkpoint statuses match, and
-`changed` otherwise. Artifact roles are sorted by name. Each role is
+`changed` when both ran but their statuses differ. A checkpoint that ran only in
+the replay shows `added`, and one that ran only in the original shows `removed`.
+Artifact roles are sorted by name. Each role is
 `unchanged` when both hashes match, `changed` when both hashes exist but differ,
 or `unavailable` when either hash is missing. `n/a` means the optional metric or
 artifact comparison is not available.

--- a/docs/book/guides/replay-and-overrides.md
+++ b/docs/book/guides/replay-and-overrides.md
@@ -446,15 +446,42 @@ for row in matrix.rows:
     print(row.original_exec_id, row.urls)
 ```
 
-CLI:
+The default CLI output shows one checkpoint table for each replay:
+
+```bash
+kitaru executions diff kr-original kr-replay-a
+```
+
+```text
+Diff for kr-original
+Compared against 1 replay execution(s).
+Replay kr-replay-a checkpoints
+  Checkpoint   Status    Duration   Tokens                                 Cost       Artifacts
+  ----------   -------   --------   ------------------------------------   --------   ------------------------------------------------------
+  generate     same      +12.5 ms   input=+10, output=-5, total=+5         +0.0 USD   model=changed, output=unchanged, report=unavailable
+  publish      changed   n/a        n/a                                    n/a        n/a
+  ui: https://kitaru.example/compare
+```
+
+`Status` is `same` when the original and replay checkpoint statuses match, and
+`changed` otherwise. Artifact roles are sorted by name. Each role is
+`unchanged` when both hashes match, `changed` when both hashes exist but differ,
+or `unavailable` when either hash is missing. `n/a` means the optional metric or
+artifact comparison is not available.
+
+Duration, token, and cost signs are always **replay minus original**. A negative
+value means the replay used less time, fewer tokens, or less money; a positive
+value means it used more. Explicit zeroes remain visible.
+
+Use JSON output for automation or the diff matrix:
 
 ```bash
 kitaru executions diff kr-original kr-replay-a -o json
 kitaru executions diff-matrix kr-a kr-b kr-c -o json
 ```
 
-Checkpoint token and cost deltas in JSON output are always calculated as
-**replay minus original**. For example:
+Checkpoint token and cost deltas in JSON use the same subtraction rule. For
+example:
 
 ```json
 {

--- a/examples/end_to_end/replay_overrides_demo/README.md
+++ b/examples/end_to_end/replay_overrides_demo/README.md
@@ -221,16 +221,20 @@ In the dashboard executions list, filter by the `replay-overrides-demo` tag to f
 
 ## 5. Reading diffs for ship / no-ship
 
-Use compare view (primary) or export JSON for automation:
+Use the checkpoint-level CLI table for a quick terminal review, the dashboard
+compare view for deeper inspection, or exported JSON for automation:
 
 ```bash
+uv run kitaru executions diff <ORIGINAL_EXEC_ID> <REPLAY_EXEC_ID>
 uv run python demo.py diff-report <REPLAY_EXEC_ID>
 uv run python demo.py diff-matrix
 ```
 
-`diff-report` needs the replay child ID from the dashboard (compare tab or
-execution detail). Writes `reports/diff_report.json`. `diff-matrix` summarizes
-all originals against their tagged replay children → `reports/diff_matrix.json`.
+The CLI table shows status, duration, token, cost, and artifact changes for each
+checkpoint. `diff-report` needs the replay child ID from the dashboard (compare
+tab or execution detail) and writes `reports/diff_report.json`. `diff-matrix`
+summarizes all originals against their tagged replay children →
+`reports/diff_matrix.json`.
 
 **Ship if:** variant model/prompt keeps `risk_status` and `required_action` within
 policy for restricted account changes across the batch.

--- a/src/kitaru/_cli/_executions.py
+++ b/src/kitaru/_cli/_executions.py
@@ -160,10 +160,20 @@ def _checkpoint_diff_table_rows(checkpoints: object) -> list[list[str]]:
     for checkpoint in checkpoints:
         if not isinstance(checkpoint, Mapping):
             continue
+        original_call_id = checkpoint.get("original_call_id")
+        replay_call_id = checkpoint.get("replay_call_id")
+        if original_call_id is None and replay_call_id is not None:
+            status = "added"
+        elif original_call_id is not None and replay_call_id is None:
+            status = "removed"
+        elif checkpoint.get("status_match") is True:
+            status = "same"
+        else:
+            status = "changed"
         rows.append(
             [
                 str(checkpoint.get("name") or "unknown"),
-                "same" if checkpoint.get("status_match") is True else "changed",
+                status,
                 _format_signed_delta(
                     checkpoint.get("duration_delta_ms"),
                     unit=" ms",

--- a/src/kitaru/_cli/_executions.py
+++ b/src/kitaru/_cli/_executions.py
@@ -133,6 +133,29 @@ def _checkpoint_diff_status(checkpoint: Mapping[str, Any]) -> str:
     return "match"
 
 
+def _format_artifact_states(artifact_hashes: Any) -> str:
+    """Format role-sorted artifact comparisons without exposing hashes."""
+    if not isinstance(artifact_hashes, Mapping) or not artifact_hashes:
+        return "n/a"
+
+    states: list[str] = []
+    for role in sorted(artifact_hashes):
+        hashes = artifact_hashes[role]
+        if not isinstance(hashes, Mapping):
+            state = "unavailable"
+        else:
+            original_hash = hashes.get("original")
+            replay_hash = hashes.get("replay")
+            if original_hash is None or replay_hash is None:
+                state = "unavailable"
+            elif original_hash == replay_hash:
+                state = "unchanged"
+            else:
+                state = "changed"
+        states.append(f"{role}={state}")
+    return ", ".join(states)
+
+
 def _checkpoint_diff_table(
     payload: Mapping[str, Any],
 ) -> tuple[list[list[str]], list[str]]:
@@ -161,12 +184,16 @@ def _checkpoint_diff_table(
                     replay_exec_id,
                     str(checkpoint.get("name") or "unknown checkpoint"),
                     _checkpoint_diff_status(checkpoint),
+                    _format_diff_delta(
+                        checkpoint.get("duration_delta_ms"), decimal_places=1
+                    ),
                     _format_diff_delta(token_mapping.get("prompt_tokens")),
                     _format_diff_delta(token_mapping.get("completion_tokens")),
                     _format_diff_delta(token_mapping.get("total_tokens")),
                     _format_diff_delta(
                         checkpoint.get("cost_delta_usd"), decimal_places=6
                     ),
+                    _format_artifact_states(checkpoint.get("artifact_hashes")),
                 ]
             )
     return rows, empty_replay_ids
@@ -1849,12 +1876,15 @@ def diff_(
                 "Replay",
                 "Checkpoint",
                 "Result",
+                "Duration Δ (ms)",
                 "Input Δ",
                 "Output Δ",
                 "Total Δ",
                 "Cost Δ (USD)",
+                "Artifacts",
             ],
             checkpoint_rows,
+            rich_multiline_columns={"Artifacts": 18},
         )
     for replay_exec_id in empty_replay_ids:
         print(f"No checkpoint rows for replay {replay_exec_id}.")

--- a/src/kitaru/_cli/_executions.py
+++ b/src/kitaru/_cli/_executions.py
@@ -87,6 +87,100 @@ def _print_diff_warnings(payload: Mapping[str, Any]) -> None:
         _print_warning(f"Warning: {warning}")
 
 
+def _format_signed_delta(
+    value: object,
+    *,
+    unit: str = "",
+    precision: int | None = None,
+) -> str:
+    """Format an optional replay-minus-original value for diff tables."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "n/a"
+    if isinstance(value, float) and not math.isfinite(value):
+        return "n/a"
+    sign = "+" if value >= 0 else "-"
+    magnitude = abs(value)
+    if precision is None:
+        formatted = str(magnitude)
+    else:
+        formatted = f"{magnitude:.{precision}f}".rstrip("0").rstrip(".")
+        if "." not in formatted:
+            formatted += ".0"
+    return f"{sign}{formatted}{unit}"
+
+
+def _format_token_delta(token_delta: object) -> str:
+    """Format canonical token deltas in their fixed display order."""
+    if not isinstance(token_delta, Mapping):
+        return "n/a"
+
+    values = [
+        token_delta.get("prompt_tokens"),
+        token_delta.get("completion_tokens"),
+        token_delta.get("total_tokens"),
+    ]
+    if any(value is None for value in values):
+        return "n/a"
+
+    return ", ".join(
+        f"{label}={_format_signed_delta(value)}"
+        for label, value in zip(("input", "output", "total"), values, strict=True)
+    )
+
+
+def _format_artifact_states(artifact_hashes: object) -> str:
+    """Format role-sorted artifact comparisons without exposing hashes."""
+    if not isinstance(artifact_hashes, Mapping) or not artifact_hashes:
+        return "n/a"
+
+    states: list[str] = []
+    for role in sorted(artifact_hashes):
+        hashes = artifact_hashes[role]
+        if not isinstance(hashes, Mapping):
+            state = "unavailable"
+        else:
+            original_hash = hashes.get("original")
+            replay_hash = hashes.get("replay")
+            if original_hash is None or replay_hash is None:
+                state = "unavailable"
+            elif original_hash == replay_hash:
+                state = "unchanged"
+            else:
+                state = "changed"
+        states.append(f"{role}={state}")
+    return ", ".join(states)
+
+
+def _checkpoint_diff_table_rows(checkpoints: object) -> list[list[str]]:
+    """Convert serialized checkpoint diffs into presentation-only table rows."""
+    if not isinstance(checkpoints, list):
+        return []
+
+    rows: list[list[str]] = []
+    for checkpoint in checkpoints:
+        if not isinstance(checkpoint, Mapping):
+            continue
+        rows.append(
+            [
+                str(checkpoint.get("name") or "unknown"),
+                "same" if checkpoint.get("status_match") is True else "changed",
+                _format_signed_delta(
+                    checkpoint.get("duration_delta_ms"),
+                    unit=" ms",
+                    precision=3,
+                ),
+                _format_token_delta(checkpoint.get("token_delta")),
+                _format_signed_delta(
+                    checkpoint.get("cost_delta_usd"),
+                    unit=" USD",
+                    precision=6,
+                ),
+                _format_artifact_states(checkpoint.get("artifact_hashes")),
+            ]
+        )
+    return rows
+
+
 def _parse_json_value(raw_value: str, *, option_name: str) -> Any:
     """Parse a CLI JSON option value and surface user-friendly errors."""
     try:
@@ -1715,6 +1809,13 @@ def diff_(
         f"Diff for {original}",
         detail=f"Compared against {compared_count} replay execution(s).",
     )
+    for comparison in payload.get("compared", []):
+        _emit_table(
+            f"Replay {comparison['replay_exec_id']} checkpoints",
+            ["Checkpoint", "Status", "Duration", "Tokens", "Cost", "Artifacts"],
+            _checkpoint_diff_table_rows(comparison.get("checkpoints")),
+            rich_multiline_columns={"Tokens": 12, "Artifacts": 18},
+        )
     for url in payload.get("urls", []):
         print(f"  ui: {url}")
 

--- a/src/kitaru/_cli/_helpers.py
+++ b/src/kitaru/_cli/_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from types import ModuleType
@@ -413,15 +413,20 @@ def _render_rich_table(
     title: str,
     columns: list[str],
     table_rows: list[list[str]],
+    multiline_columns: Mapping[str, int] | None = None,
 ) -> None:
     """Render a Rich table inside the standard Kitaru panel."""
+    multiline_widths = {
+        column.lower().strip(): min_width
+        for column, min_width in (multiline_columns or {}).items()
+    }
     rich_table = Table(
         box=box.SIMPLE_HEAD,
         show_header=True,
         header_style="bold",
         show_lines=False,
         pad_edge=False,
-        collapse_padding=False,
+        collapse_padding=bool(multiline_widths),
         expand=False,
         show_edge=False,
     )
@@ -431,14 +436,23 @@ def _render_rich_table(
         rich_table.add_column(
             col,
             no_wrap=normalized in {"id", "status"},
-            overflow="fold" if normalized in {"flow", "stack"} else "ellipsis",
+            overflow=(
+                "fold"
+                if normalized in {"flow", "stack"} or normalized in multiline_widths
+                else "ellipsis"
+            ),
+            min_width=multiline_widths.get(normalized),
         )
 
     for row in table_rows:
         rendered: list[str | Text] = []
         for i, cell in enumerate(row):
             style = _table_cell_style(columns[i], cell, column_index=i)
-            rendered.append(Text(cell, style=style or ""))
+            normalized = columns[i].lower().strip()
+            rendered_cell = (
+                cell.replace(", ", "\n") if normalized in multiline_widths else cell
+            )
+            rendered.append(Text(rendered_cell, style=style or ""))
         rich_table.add_row(*rendered)
 
     Console().print(
@@ -475,6 +489,7 @@ def _emit_table(
     columns: list[str],
     table_rows: list[list[str]],
     empty_message: str = "none found",
+    rich_multiline_columns: Mapping[str, int] | None = None,
 ) -> None:
     """Render aligned columnar output with headers (rich panel or plain text)."""
     if not table_rows:
@@ -482,7 +497,12 @@ def _emit_table(
         return
 
     if _is_interactive():
-        _render_rich_table(title, columns, table_rows)
+        _render_rich_table(
+            title,
+            columns,
+            table_rows,
+            multiline_columns=rich_multiline_columns,
+        )
     else:
         print(_render_plain_table(title, columns, table_rows))
 

--- a/src/kitaru/_cli/_helpers.py
+++ b/src/kitaru/_cli/_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import importlib
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from types import ModuleType
@@ -413,15 +413,20 @@ def _render_rich_table(
     title: str,
     columns: list[str],
     table_rows: list[list[str]],
+    multiline_columns: Mapping[str, int] | None = None,
 ) -> None:
     """Render a Rich table inside the standard Kitaru panel."""
+    multiline_widths = {
+        column.lower().strip(): min_width
+        for column, min_width in (multiline_columns or {}).items()
+    }
     rich_table = Table(
         box=box.SIMPLE_HEAD,
         show_header=True,
         header_style="bold",
         show_lines=False,
         pad_edge=False,
-        collapse_padding=False,
+        collapse_padding=bool(multiline_widths),
         expand=False,
         show_edge=False,
     )
@@ -431,14 +436,23 @@ def _render_rich_table(
         rich_table.add_column(
             col,
             no_wrap=normalized in {"id", "status"},
-            overflow="fold" if normalized in {"flow", "stack"} else "ellipsis",
+            overflow=(
+                "fold"
+                if normalized in {"flow", "stack"} or normalized in multiline_widths
+                else "ellipsis"
+            ),
+            min_width=multiline_widths.get(normalized),
         )
 
     for row in table_rows:
         rendered: list[str | Text] = []
         for i, cell in enumerate(row):
             style = _table_cell_style(columns[i], cell, column_index=i)
-            rendered.append(Text(cell, style=style) if style else cell)
+            normalized = columns[i].lower().strip()
+            rendered_cell = (
+                cell.replace(", ", "\n") if normalized in multiline_widths else cell
+            )
+            rendered.append(Text(rendered_cell, style=style or ""))
         rich_table.add_row(*rendered)
 
     Console().print(
@@ -475,6 +489,7 @@ def _emit_table(
     columns: list[str],
     table_rows: list[list[str]],
     empty_message: str = "none found",
+    rich_multiline_columns: Mapping[str, int] | None = None,
 ) -> None:
     """Render aligned columnar output with headers (rich panel or plain text)."""
     if not table_rows:
@@ -482,7 +497,12 @@ def _emit_table(
         return
 
     if _is_interactive():
-        _render_rich_table(title, columns, table_rows)
+        _render_rich_table(
+            title,
+            columns,
+            table_rows,
+            multiline_columns=rich_multiline_columns,
+        )
     else:
         print(_render_plain_table(title, columns, table_rows))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4614,6 +4614,8 @@ def _serialized_execution_diff_for_cli() -> dict[str, Any]:
                 "checkpoints": [
                     {
                         "name": "generate",
+                        "original_call_id": "call-generate-original",
+                        "replay_call_id": "call-generate-replay",
                         "status_match": True,
                         "duration_delta_ms": 12.5,
                         "token_delta": {
@@ -4630,6 +4632,8 @@ def _serialized_execution_diff_for_cli() -> dict[str, Any]:
                     },
                     {
                         "name": "unpriced",
+                        "original_call_id": "call-unpriced-original",
+                        "replay_call_id": "call-unpriced-replay",
                         "status_match": False,
                         "duration_delta_ms": None,
                         "token_delta": None,
@@ -4643,6 +4647,8 @@ def _serialized_execution_diff_for_cli() -> dict[str, Any]:
                 "checkpoints": [
                     {
                         "name": "evaluate",
+                        "original_call_id": "call-evaluate-original",
+                        "replay_call_id": "call-evaluate-replay",
                         "status_match": True,
                         "duration_delta_ms": -8.0,
                         "token_delta": {
@@ -4680,7 +4686,8 @@ def test_executions_diff_text_renders_checkpoint_tables(
 
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
-    output = " ".join(captured.out.split())
+    raw_output = captured.out
+    output = " ".join(raw_output.split())
     assert "Compared against 2 replay execution(s)." in output
     assert "Replay kr-replay-a checkpoints" in output
     assert "Replay kr-replay-b checkpoints" in output
@@ -4691,20 +4698,19 @@ def test_executions_diff_text_renders_checkpoint_tables(
     assert "evaluate same -8.0 ms" in output
     assert "-0.0017 USD" in output
     if interactive:
-        for value in (
-            "input=+10",
-            "output=-5",
-            "total=+5",
-            "model=changed",
-            "output=unchanged",
-            "report=unavailable",
-            "input=+0",
-            "output=+0",
-            "total=+0",
-            "output=changed",
-        ):
-            assert value in output
-        assert "…" not in output
+        lines = raw_output.splitlines()
+        generate_line = next(i for i, line in enumerate(lines) if "input=+10" in line)
+        assert "model=changed" in lines[generate_line]
+        assert "output=-5" in lines[generate_line + 1]
+        assert "output=unchanged" in lines[generate_line + 1]
+        assert "total=+5" in lines[generate_line + 2]
+        assert "report=unavailable" in lines[generate_line + 2]
+
+        evaluate_line = next(i for i, line in enumerate(lines) if "input=+0" in line)
+        assert "output=changed" in lines[evaluate_line]
+        assert "output=+0" in lines[evaluate_line + 1]
+        assert "total=+0" in lines[evaluate_line + 2]
+        assert "…" not in raw_output
     else:
         assert "input=+10, output=-5, total=+5" in output
         artifact_states = "model=changed, output=unchanged, report=unavailable"
@@ -4758,6 +4764,36 @@ def test_executions_diff_text_renders_real_serialized_diff_safely(
                         cost_delta_usd=float("inf"),
                         artifact_hashes={},
                     ),
+                    CheckpointDiff(
+                        name="added",
+                        original_call_id=None,
+                        replay_call_id="call-added",
+                        status_match=False,
+                        duration_delta_ms=None,
+                        token_delta=None,
+                        cost_delta_usd=None,
+                        artifact_hashes={},
+                    ),
+                    CheckpointDiff(
+                        name="removed",
+                        original_call_id="call-removed",
+                        replay_call_id=None,
+                        status_match=False,
+                        duration_delta_ms=None,
+                        token_delta=None,
+                        cost_delta_usd=None,
+                        artifact_hashes={},
+                    ),
+                    CheckpointDiff(
+                        name="unknown-ids",
+                        original_call_id=None,
+                        replay_call_id=None,
+                        status_match=True,
+                        duration_delta_ms=None,
+                        token_delta=None,
+                        cost_delta_usd=None,
+                        artifact_hashes={},
+                    ),
                 ],
             )
         ],
@@ -4774,6 +4810,9 @@ def test_executions_diff_text_renders_real_serialized_diff_safely(
     assert "[/red] same +0.01 ms n/a +0.01 USD [/blue]=changed" in output
     assert "negative-zero same +0.0 ms n/a +0.0 USD n/a" in output
     assert "non-finite same n/a n/a n/a n/a" in output
+    assert "added added n/a n/a n/a n/a" in output
+    assert "removed removed n/a n/a n/a n/a" in output
+    assert "unknown-ids same n/a n/a n/a n/a" in output
 
 
 def test_executions_diff_text_renders_empty_checkpoint_section(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4605,6 +4605,199 @@ def test_executions_diff_matrix_json_uses_new_command_name(
     }
 
 
+def _serialized_execution_diff_for_cli() -> dict[str, Any]:
+    """Return a diff payload covering every text-rendering state."""
+    return {
+        "compared": [
+            {
+                "replay_exec_id": "kr-replay-a",
+                "checkpoints": [
+                    {
+                        "name": "generate",
+                        "status_match": True,
+                        "duration_delta_ms": 12.5,
+                        "token_delta": {
+                            "prompt_tokens": 10,
+                            "completion_tokens": -5,
+                            "total_tokens": 5,
+                        },
+                        "cost_delta_usd": 0.0,
+                        "artifact_hashes": {
+                            "report": {"original": None, "replay": "report-b"},
+                            "output": {"original": "same", "replay": "same"},
+                            "model": {"original": "model-a", "replay": "model-b"},
+                        },
+                    },
+                    {
+                        "name": "unpriced",
+                        "status_match": False,
+                        "duration_delta_ms": None,
+                        "token_delta": None,
+                        "cost_delta_usd": None,
+                        "artifact_hashes": {},
+                    },
+                ],
+            },
+            {
+                "replay_exec_id": "kr-replay-b",
+                "checkpoints": [
+                    {
+                        "name": "evaluate",
+                        "status_match": True,
+                        "duration_delta_ms": -8.0,
+                        "token_delta": {
+                            "prompt_tokens": 0,
+                            "completion_tokens": 0,
+                            "total_tokens": 0,
+                        },
+                        "cost_delta_usd": -0.0017,
+                        "artifact_hashes": {
+                            "output": {"original": "output-a", "replay": "output-b"}
+                        },
+                    }
+                ],
+            },
+        ],
+        "urls": ["https://kitaru.example/compare"],
+        "warnings": [],
+    }
+
+
+@pytest.mark.parametrize("interactive", [False, True], ids=["plain", "rich"])
+def test_executions_diff_text_renders_checkpoint_tables(
+    capsys: pytest.CaptureFixture[str],
+    interactive: bool,
+) -> None:
+    """Plain and rich output should expose the same checkpoint diff semantics."""
+    serialized = _serialized_execution_diff_for_cli()
+    with (
+        patch("kitaru.diff.diff", return_value=object()),
+        patch("kitaru.diff.serialize_execution_diff", return_value=serialized),
+        patch("kitaru._cli._helpers._is_interactive", return_value=interactive),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "diff", "kr-original"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    output = " ".join(captured.out.split())
+    assert "Compared against 2 replay execution(s)." in output
+    assert "Replay kr-replay-a checkpoints" in output
+    assert "Replay kr-replay-b checkpoints" in output
+    assert "Checkpoint Status Duration Tokens Cost Artifacts" in output
+    assert "generate same +12.5 ms" in output
+    assert "+0.0 USD" in output
+    assert "unpriced changed n/a n/a n/a n/a" in output
+    assert "evaluate same -8.0 ms" in output
+    assert "-0.0017 USD" in output
+    if interactive:
+        for value in (
+            "input=+10",
+            "output=-5",
+            "total=+5",
+            "model=changed",
+            "output=unchanged",
+            "report=unavailable",
+            "input=+0",
+            "output=+0",
+            "total=+0",
+            "output=changed",
+        ):
+            assert value in output
+        assert "…" not in output
+    else:
+        assert "input=+10, output=-5, total=+5" in output
+        artifact_states = "model=changed, output=unchanged, report=unavailable"
+        assert artifact_states in output
+        assert "input=+0, output=+0, total=+0" in output
+        assert "output=changed" in output
+    assert "ui: https://kitaru.example/compare" in output
+
+
+@pytest.mark.parametrize("interactive", [False, True], ids=["plain", "rich"])
+def test_executions_diff_text_renders_real_serialized_diff_safely(
+    capsys: pytest.CaptureFixture[str],
+    interactive: bool,
+) -> None:
+    """The presenter should safely render real serialized diff edge cases."""
+    from kitaru.diff import CheckpointDiff, ExecutionDiff
+
+    diff_result = ExecutionDiff(
+        original_exec_id="kr-original",
+        compared=[
+            (
+                "kr-replay",
+                [
+                    CheckpointDiff(
+                        name="[/red]",
+                        original_call_id="call-a",
+                        replay_call_id="call-b",
+                        status_match=True,
+                        duration_delta_ms=0.03 - 0.02,
+                        token_delta=None,
+                        cost_delta_usd=0.03 - 0.02,
+                        artifact_hashes={"[/blue]": ("hash-a", "hash-b")},
+                    ),
+                    CheckpointDiff(
+                        name="negative-zero",
+                        original_call_id="call-c",
+                        replay_call_id="call-d",
+                        status_match=True,
+                        duration_delta_ms=-0.0,
+                        token_delta=None,
+                        cost_delta_usd=-0.0,
+                        artifact_hashes={},
+                    ),
+                    CheckpointDiff(
+                        name="non-finite",
+                        original_call_id="call-e",
+                        replay_call_id="call-f",
+                        status_match=True,
+                        duration_delta_ms=float("nan"),
+                        token_delta=None,
+                        cost_delta_usd=float("inf"),
+                        artifact_hashes={},
+                    ),
+                ],
+            )
+        ],
+    )
+    with (
+        patch("kitaru.diff.diff", return_value=diff_result),
+        patch("kitaru._cli._helpers._is_interactive", return_value=interactive),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "diff", "kr-original"])
+
+    assert exc_info.value.code == 0
+    output = " ".join(capsys.readouterr().out.split())
+    assert "[/red] same +0.01 ms n/a +0.01 USD [/blue]=changed" in output
+    assert "negative-zero same +0.0 ms n/a +0.0 USD n/a" in output
+    assert "non-finite same n/a n/a n/a n/a" in output
+
+
+def test_executions_diff_text_renders_empty_checkpoint_section(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A compared replay without checkpoint rows should retain an empty section."""
+    serialized = {
+        "compared": [{"replay_exec_id": "kr-empty", "checkpoints": []}],
+        "urls": [],
+        "warnings": [],
+    }
+    with (
+        patch("kitaru.diff.diff", return_value=object()),
+        patch("kitaru.diff.serialize_execution_diff", return_value=serialized),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "diff", "kr-original"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "Replay kr-empty checkpoints" in output
+    assert "checkpoints: none found" in output
+
+
 def test_executions_diff_text_prints_discovery_warning(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ from kitaru._cli._executions import (
     _checkpoint_diff_status,
     _checkpoint_diff_table,
     _execution_statistics_table,
+    _format_artifact_states,
     _format_diff_delta,
     _print_applied_output_overrides,
 )
@@ -4811,12 +4812,18 @@ def test_checkpoint_diff_table_formats_rows_and_tracks_empty_replays() -> None:
                     "replay_exec_id": "kr-replay",
                     "checkpoints": [
                         _checkpoint_diff_payload(
+                            duration_delta_ms=12.5,
                             token_delta={
                                 "prompt_tokens": 10,
                                 "completion_tokens": -5,
                                 "total_tokens": 5,
                             },
                             cost_delta_usd=0.25,
+                            artifact_hashes={
+                                "report": {"original": None, "replay": "report-b"},
+                                "output": {"original": "same", "replay": "same"},
+                                "model": {"original": "model-a", "replay": "model-b"},
+                            },
                         )
                     ],
                 },
@@ -4830,13 +4837,54 @@ def test_checkpoint_diff_table_formats_rows_and_tracks_empty_replays() -> None:
             "kr-replay",
             "write_draft",
             "changed",
+            "+12.5",
             "+10",
             "-5",
             "+5",
             "+0.250000",
+            "model=changed, output=unchanged, report=unavailable",
         ]
     ]
     assert empty_replay_ids == ["kr-empty"]
+
+
+@pytest.mark.parametrize(
+    ("artifact_hashes", "expected"),
+    [
+        (None, "n/a"),
+        ({}, "n/a"),
+        ("not-a-mapping", "n/a"),
+        ({"output": "not-a-mapping"}, "output=unavailable"),
+        ({"output": {"original": "a", "replay": "a"}}, "output=unchanged"),
+        ({"output": {"original": "a", "replay": "b"}}, "output=changed"),
+        ({"output": {"original": None, "replay": "b"}}, "output=unavailable"),
+        (
+            {
+                "b-role": {"original": "x", "replay": "y"},
+                "a-role": {"original": "x", "replay": "x"},
+            },
+            "a-role=unchanged, b-role=changed",
+        ),
+    ],
+)
+def test_format_artifact_states(artifact_hashes: Any, expected: str) -> None:
+    assert _format_artifact_states(artifact_hashes) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (12.5, "+12.5"),
+        (-8.0, "-8.0"),
+        (-0.0, "-0.0"),
+        (0.0, "+0.0"),
+        (None, "n/a"),
+        (float("nan"), "n/a"),
+        (float("inf"), "n/a"),
+    ],
+)
+def test_format_diff_duration_delta(value: Any, expected: str) -> None:
+    assert _format_diff_delta(value, decimal_places=1) == expected
 
 
 def test_print_applied_output_overrides_distinguishes_evidence_states(
@@ -4950,6 +4998,110 @@ def test_executions_diff_rich_output_treats_checkpoint_name_as_literal(
 
     assert exc_info.value.code == 0
     assert "[/red]" in capsys.readouterr().out
+
+
+def test_executions_diff_rich_output_splits_artifact_states_across_lines(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COLUMNS", "200")
+    serialized = {
+        "compared": [
+            {
+                "replay_exec_id": "kr-replay",
+                "checkpoints": [
+                    _checkpoint_diff_payload(
+                        duration_delta_ms=12.5,
+                        artifact_hashes={
+                            "report": {"original": None, "replay": "report-b"},
+                            "output": {"original": "same", "replay": "same"},
+                            "model": {"original": "model-a", "replay": "model-b"},
+                        },
+                    )
+                ],
+                "applied_output_overrides": [],
+            }
+        ],
+        "urls": [],
+        "warnings": [],
+    }
+    with (
+        patch("kitaru.diff.diff", return_value=object()),
+        patch("kitaru.diff.serialize_execution_diff", return_value=serialized),
+        patch("kitaru._cli._helpers._is_interactive", return_value=True),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "diff", "kr-original", "kr-replay"])
+
+    assert exc_info.value.code == 0
+    lines = capsys.readouterr().out.splitlines()
+    row_line = next(i for i, line in enumerate(lines) if "model=changed" in line)
+    assert "+12.5" in lines[row_line]
+    assert "output=unchanged" in lines[row_line + 1]
+    assert "report=unavailable" in lines[row_line + 2]
+    assert "…" not in "\n".join(lines)
+
+
+def test_executions_diff_text_renders_real_serialized_diff(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from kitaru.diff import CheckpointDiff, ExecutionDiff
+
+    execution_diff = ExecutionDiff(
+        original_exec_id="kr-original",
+        compared=[
+            (
+                "kr-replay",
+                [
+                    CheckpointDiff(
+                        name="generate",
+                        original_call_id="call-generate-original",
+                        replay_call_id="call-generate-replay",
+                        status_match=True,
+                        duration_delta_ms=-0.0,
+                        token_delta={
+                            "prompt_tokens": 0,
+                            "completion_tokens": 0,
+                            "total_tokens": 0,
+                        },
+                        artifact_hashes={"output": ("same", "same")},
+                        cost_delta_usd=0.0,
+                    ),
+                    CheckpointDiff(
+                        name="removed",
+                        original_call_id="call-removed",
+                        replay_call_id=None,
+                        status_match=False,
+                        duration_delta_ms=None,
+                        token_delta=None,
+                        artifact_hashes={},
+                        cost_delta_usd=None,
+                    ),
+                    CheckpointDiff(
+                        name="added",
+                        original_call_id=None,
+                        replay_call_id="call-added",
+                        status_match=False,
+                        duration_delta_ms=None,
+                        token_delta=None,
+                        artifact_hashes={},
+                        cost_delta_usd=None,
+                    ),
+                ],
+            )
+        ],
+    )
+    with (
+        patch("kitaru.diff.diff", return_value=execution_diff),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "diff", "kr-original", "kr-replay"])
+
+    assert exc_info.value.code == 0
+    output = " ".join(capsys.readouterr().out.split())
+    assert "generate match -0.0 +0 +0 +0 +0.000000 output=unchanged" in output
+    assert "removed original only n/a n/a n/a n/a n/a n/a" in output
+    assert "added replay only n/a n/a n/a n/a n/a n/a" in output
 
 
 def test_executions_diff_text_prints_discovery_warning(


### PR DESCRIPTION
## Summary

- Extend the checkpoint table in the default text output of `kitaru executions diff` with the two columns issue #520 still required after #580 landed: a replay-minus-original `Duration Δ (ms)` column and a per-role `Artifacts` comparison column.
- Artifact roles render as `unchanged`/`changed`/`unavailable` states, sorted by role name; artifact hashes and values are never printed.
- In interactive Rich terminals the `Artifacts` cell splits one role per line so wide comparisons stay readable; plain/non-TTY output keeps single-line cells for stable test assertions.
- No JSON, SDK, or MCP contract changes: the new rendering consumes the existing `serialize_execution_diff` payload after the JSON early-return.

## History note

This branch originally implemented its own per-replay diff tables. While it was in review, #580 merged an overlapping combined checkpoint table (with richer `match`/`changed`/`original only`/`replay only` result semantics and applied-output-override evidence). The branch now keeps #580's renderer as the base and contributes only what was missing for #520: duration deltas and artifact-state visibility.

## Tests

- `just check`
- `just test` (3,680 passed, 29 skipped)

## Reviewer Notes

The change is confined to the CLI presenter and the shared table helper. `_checkpoint_diff_table` in `src/kitaru/_cli/_executions.py` gains two cells per row (duration via the existing `_format_diff_delta`, artifacts via the new `_format_artifact_states`), and `_emit_table`/`_render_rich_table` in `src/kitaru/_cli/_helpers.py` gain an opt-in `rich_multiline_columns` parameter — existing callers pass nothing and render exactly as before. The risky spot is the Rich path: multiline cells rely on `cell.replace(", ", "\n")` plus a `min_width`, and the regression test asserts actual line structure (role states on consecutive lines) so removing the split fails the test.

### Reproduction

1. From `examples/end_to_end/replay_overrides_demo`, follow the README setup and create an original plus replay, for example with `uv run python demo.py seed --count 1` followed by `uv run python demo.py code-swap`.
2. Run `uv run kitaru executions diff <ORIGINAL_EXEC_ID> <REPLAY_EXEC_ID>`.
3. Confirm the "Checkpoint differences" table now includes `Duration Δ (ms)` and `Artifacts` columns; artifact roles show state words only (no hashes), missing metrics show `n/a`, and explicit zero deltas stay visible as `+0` / `+0.000000`.
4. Run the same command with `-o json` and confirm the serialized envelope and field names are unchanged.
5. For deterministic edge-case coverage, run `uv run pytest tests/test_cli.py -k diff -n 0`; this covers duration/artifact formatting edge cases (NaN, infinity, negative zero, missing hashes), one-sided (`original only`/`replay only`) checkpoints through the production serializer, and the Rich multiline line-structure assertion.

Follow-up filed separately: #582 tracks rendering the same checkpoint tables in `kitaru executions diff-matrix` text output.

Closes #520
