### PR TITLE
Fix unattended LLM canary diagnostics

### DIFF
--- a/.agents/skills/kitaru-tests-release/SKILL.md
+++ b/.agents/skills/kitaru-tests-release/SKILL.md
@@ -150,7 +150,11 @@ Marketing site deployment is handled from `zenml-io-v2`.
 - `llm-integration.yml`: trusted weekly/manual live OpenAI/Anthropic provider
   checks. It has only `schedule` and `workflow_dispatch` triggers, runs paid
   tests outside PR CI, can target an exact ref/SHA, uploads logs/results only,
-  and sends compact Discord failure alerts via `DISCORD_WEBHOOK_SRE`.
+  and sends compact Discord failure alerts via `DISCORD_WEBHOOK_SRE`. Exact
+  validation evidence is the tested SHA plus run ID and attempt in
+  `llm-integration.provenance.json`. Run it again after environment-policy
+  changes. Before removing required reviewers, cancel stale waiting runs. Never
+  create a paid failure solely to test notifications.
 - `spellcheck.yml`: typo/spell checking on `develop` pushes and non-draft PRs.
 - `image-optimiser.yml`: PR-only compression for changed JPG/JPEG/PNG/WebP
   files in same-repo non-draft PRs.

--- a/.claude/skills/kitaru-release/SKILL.md
+++ b/.claude/skills/kitaru-release/SKILL.md
@@ -427,11 +427,12 @@ rm -rf /tmp/kitaru-llm-integration
 mkdir -p /tmp/kitaru-llm-integration
 gh run download <RUN_ID> -n llm-integration-results -D /tmp/kitaru-llm-integration
 cat /tmp/kitaru-llm-integration/llm-integration.summary.md
+cat /tmp/kitaru-llm-integration/llm-integration.provenance.json
 ```
 
-The summary must show the release ref or SHA you are about to release. The workflow run's own `headSha` is the trusted workflow ref, not necessarily the Kitaru ref under test, so do not rely on `headSha` alone. Use the artifact line `Tested SHA` as the identity anchor.
+Exact provider evidence is the tested SHA, workflow run ID, and run attempt recorded in `llm-integration.provenance.json`. The workflow run's own `headSha` is the trusted workflow ref, not necessarily the Kitaru ref under test, so do not rely on `headSha` alone.
 
-The live-provider workflow uses the GitHub Environment `live-provider-tests`. Configure `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `DISCORD_WEBHOOK_SRE` as secrets on that Environment, with `kitaru-admins` approval/restrictions. If the Environment has required reviewers, the live test job and Discord notification job can wait for approval before secrets are available.
+The `live-provider-tests` environment is restricted to `develop` and has no required reviewers, allowing scheduled and manual runs to proceed unattended. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `DISCORD_WEBHOOK_SRE` are repository secrets, not environment secrets. If correcting an environment that required approval, cancel stale waiting runs before removing the reviewer requirement, then rerun the canary after the policy change.
 
 If exact-ref evidence is needed and missing, trigger it manually from trusted workflow code while testing the release ref/SHA:
 
@@ -458,6 +459,8 @@ If it fails, inspect logs and stop:
 ```bash
 gh run view <RUN_ID> --log-failed
 ```
+
+Rerun the canary after any environment or approval-policy change. Never cause a paid provider failure solely to test notification delivery.
 
 Release evidence table to report to the user before Step 9:
 

--- a/.github/workflows/llm-integration.yml
+++ b/.github/workflows/llm-integration.yml
@@ -72,6 +72,7 @@ jobs:
       providers: ${{ steps.plan.outputs.providers }}
     steps:
       - name: Checkout trusted workflow ref
+        id: checkout_workflow
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
@@ -163,6 +164,7 @@ jobs:
           )
           reject_ref "Requested SHA '$requested_ref' is not reachable from develop, release/*, or v* tags."
       - name: Checkout Kitaru ref under test
+        id: checkout_tested_ref
         if: ${{ steps.trust.outputs.trusted == 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -170,6 +172,7 @@ jobs:
           path: kitaru
           persist-credentials: false
       - name: Install uv
+        id: setup_uv
         uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1  # v8.3.1
         with:
           python-version: '3.12'
@@ -255,12 +258,6 @@ jobs:
             printf 'tested_ref=%s\n' "$TESTED_REF"
             printf 'tested_sha=%s\n' "$tested_sha"
           } >> "$GITHUB_OUTPUT"
-          {
-            printf 'tested_ref=%s\n' "$TESTED_REF"
-            printf 'tested_sha=%s\n' "$tested_sha"
-            printf 'workflow_ref=%s\n' "$GITHUB_REF_NAME"
-            printf 'workflow_sha=%s\n' "$GITHUB_SHA"
-          } > ../llm-integration-results/metadata.env
       - name: Preflight selected live secrets
         id: secret_preflight
         shell: bash
@@ -484,6 +481,77 @@ jobs:
             exit 0
           fi
           echo "status=passed" > ../llm-integration-results/research-bot.status
+      - name: Record artifact provenance
+        id: provenance
+        if: always()
+        shell: bash
+        env:
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+            github.run_id }}
+          REQUESTED_REF: ${{ steps.trust.outputs.requested_ref }}
+          TESTED_REF: ${{ steps.identity.outputs.tested_ref }}
+          TESTED_SHA: ${{ steps.identity.outputs.tested_sha }}
+          SUITE: ${{ steps.plan.outputs.suite }}
+          PROVIDERS: ${{ steps.plan.outputs.providers }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+          results_dir = Path("llm-integration-results")
+          results_dir.mkdir(parents=True, exist_ok=True)
+          recorded_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+          def optional(name: str) -> str | None:
+              return os.environ.get(name) or None
+          providers = optional("PROVIDERS")
+          provenance = {
+              "schema_version": 1,
+              "repository": os.environ["REPOSITORY"],
+              "workflow_name": os.environ["WORKFLOW_NAME"],
+              "workflow_ref": os.environ["WORKFLOW_REF"],
+              "workflow_sha": os.environ["WORKFLOW_SHA"],
+              "event_name": os.environ["EVENT_NAME"],
+              "run_id": os.environ["RUN_ID"],
+              "run_attempt": os.environ["RUN_ATTEMPT"],
+              "run_url": os.environ["RUN_URL"],
+              "identity_recorded_at_utc": recorded_at,
+              "requested_ref": optional("REQUESTED_REF"),
+              "tested_ref": optional("TESTED_REF"),
+              "tested_sha": optional("TESTED_SHA"),
+              "suite": optional("SUITE"),
+              "providers": providers.split(",") if providers else None,
+          }
+          (results_dir / "llm-integration.provenance.json").write_text(
+              json.dumps(provenance, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          metadata = {
+              "tested_ref": os.environ.get("TESTED_REF", ""),
+              "tested_sha": os.environ.get("TESTED_SHA", ""),
+              "workflow_ref": os.environ["WORKFLOW_REF"],
+              "workflow_sha": os.environ["WORKFLOW_SHA"],
+              "event_name": os.environ["EVENT_NAME"],
+              "run_id": os.environ["RUN_ID"],
+              "run_attempt": os.environ["RUN_ATTEMPT"],
+              "run_url": os.environ["RUN_URL"],
+              "identity_recorded_at_utc": recorded_at,
+          }
+          (results_dir / "metadata.env").write_text(
+              "".join(f"{key}={value}\n" for key, value in metadata.items()),
+              encoding="utf-8",
+          )
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"identity_recorded_at_utc={recorded_at}\n")
+          PY
       - name: Summarize live-provider results
         id: summarize
         if: always()
@@ -491,6 +559,11 @@ jobs:
         env:
           TESTED_REF: ${{ steps.identity.outputs.tested_ref }}
           TESTED_SHA: ${{ steps.identity.outputs.tested_sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          IDENTITY_RECORDED_AT_UTC: ${{ steps.provenance.outputs.identity_recorded_at_utc }}
           SUITE: ${{ steps.plan.outputs.suite }}
           PROVIDERS: ${{ steps.plan.outputs.providers }}
           MARKER_EXPR: ${{ steps.plan.outputs.marker_expr }}
@@ -499,8 +572,13 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
             github.run_id }}
           WORKFLOW_NAME: ${{ github.workflow }}
+          WORKFLOW_CHECKOUT_OUTCOME: ${{ steps.checkout_workflow.outcome }}
+          TRUST_OUTCOME: ${{ steps.trust.outcome }}
+          TESTED_CHECKOUT_OUTCOME: ${{ steps.checkout_tested_ref.outcome }}
+          SETUP_UV_OUTCOME: ${{ steps.setup_uv.outcome }}
           PLAN_OUTCOME: ${{ steps.plan.outcome }}
           INSTALL_OUTCOME: ${{ steps.install_dependencies.outcome }}
+          PROVENANCE_OUTCOME: ${{ steps.provenance.outcome }}
           INIT_OUTCOME: ${{ steps.init_project.outcome }}
           IDENTITY_OUTCOME: ${{ steps.identity.outcome }}
           SECRET_PREFLIGHT_OUTCOME: ${{ steps.secret_preflight.outcome }}
@@ -512,6 +590,18 @@ jobs:
           summary_file="$results_dir/llm-integration.summary.md"
           discord_file="$results_dir/llm-integration.discord.md"
           : > "$failures_file"
+          if [ "${WORKFLOW_CHECKOUT_OUTCOME:-success}" = "failure" ]; then
+            echo "Trusted workflow ref checkout failed." >> "$failures_file"
+          fi
+          if [ "${TRUST_OUTCOME:-success}" = "failure" ]; then
+            echo "Requested Kitaru ref trust check failed." >> "$failures_file"
+          fi
+          if [ "${TESTED_CHECKOUT_OUTCOME:-success}" = "failure" ]; then
+            echo "Kitaru ref under test checkout failed." >> "$failures_file"
+          fi
+          if [ "${SETUP_UV_OUTCOME:-success}" = "failure" ]; then
+            echo "uv setup failed." >> "$failures_file"
+          fi
           if [ "${PLAN_OUTCOME:-success}" = "failure" ]; then
             echo "Live test plan resolution failed." >> "$failures_file"
           fi
@@ -526,6 +616,9 @@ jobs:
           fi
           if [ "${SECRET_PREFLIGHT_OUTCOME:-success}" = "failure" ]; then
             echo "Live secret preflight failed before writing its result file." >> "$failures_file"
+          fi
+          if [ "${PROVENANCE_OUTCOME:-success}" = "failure" ]; then
+            echo "Artifact provenance recording failed." >> "$failures_file"
           fi
           if [ -f "$results_dir/secret-preflight.failure" ]; then
             cat "$results_dir/secret-preflight.failure" >> "$failures_file"
@@ -575,6 +668,12 @@ jobs:
             echo "|---|---|"
             echo "| Tested ref | \`$TESTED_REF\` |"
             echo "| Tested SHA | \`$TESTED_SHA\` |"
+            echo "| Workflow SHA | \`$WORKFLOW_SHA\` |"
+            echo "| Event | \`$EVENT_NAME\` |"
+            echo "| Run ID | \`$RUN_ID\` |"
+            echo "| Run attempt | \`$RUN_ATTEMPT\` |"
+            echo "| Run URL | $RUN_URL |"
+            echo "| Identity recorded at (UTC) | \`$IDENTITY_RECORDED_AT_UTC\` |"
             echo "| Suite | \`$SUITE\` |"
             echo "| Providers | \`${PROVIDERS:-none}\` |"
             echo "| Pytest marker | \`$MARKER_EXPR\` |"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
+- Claude Agent SDK failures no longer copy raw `ResultMessage.result` content into Kitaru errors or durable failure records; allowlisted diagnostics remain available in durable records and live terminal events.
+- Live LLM integration runs now retain tested SHA, workflow run ID, and run-attempt provenance for release evidence.
 - Reporting now preserves physical retry identity, marks unavailable secret-list key metadata explicitly, accounts for unknown billing conservatively, and documents the distinct workload-token and incurred-cost diff bases. (#566)
 - Execution diffs now reject blank selectors and explicit comparisons without recorded direct replay lineage, while deduplicating repeated selectors and aliases in first-occurrence order. (#565)
 

--- a/docs/book/adapters/claude-agent-sdk.md
+++ b/docs/book/adapters/claude-agent-sdk.md
@@ -289,7 +289,13 @@ as:
 Failed Claude invocations raise an exception instead of returning a
 `ClaudeRunResult(status="failed")`. If the failure happens inside a Kitaru
 checkpoint, the adapter still records best-effort failure metadata before the
-exception propagates.
+exception propagates. For a failed error `ResultMessage`, Kitaru does not copy
+the result text into the exception, failed terminal live event, or durable
+failure records. The exception message and the `claude_result_diagnostic`
+attached to those records contain only `assistant_error`, `api_error_status`,
+and `subtype`. Normalized SDK message events are separate and may contain
+other allowlisted structural fields.
+Successful `final_text` and explicitly enabled capture artifacts are unchanged.
 
 ## Live streaming with Kitaru durability
 

--- a/src/kitaru/adapters/claude_agent_sdk/_agent.py
+++ b/src/kitaru/adapters/claude_agent_sdk/_agent.py
@@ -25,6 +25,7 @@ from ._kitaru_internal import is_inside_checkpoint, is_inside_flow
 from ._policy import ClaudeCapturePolicy
 from ._runner import (
     ClaudeInvocationPayload,
+    ClaudeResultMessageError,
     claude_agent_sdk_version,
     run_claude_invocation,
     run_claude_invocation_streamed,
@@ -834,18 +835,21 @@ class KitaruClaudeRunner:
             else:
                 artifacts["options_manifest"] = artifact_name
         if self._capture.emit_events:
+            metadata: dict[str, Any] = {
+                "sdk_version": claude_agent_sdk_version(),
+                "request_kind": request.kind,
+                "capture_failures": [
+                    failure.as_metadata() for failure in capture_failures
+                ],
+            }
+            if isinstance(error, ClaudeResultMessageError):
+                metadata["claude_result_diagnostic"] = error.diagnostic.as_metadata()
             tracker.record_invocation(
                 status="failed",
                 duration_ms=duration_ms,
                 artifacts=artifacts,
                 warnings=warnings,
-                metadata={
-                    "sdk_version": claude_agent_sdk_version(),
-                    "request_kind": request.kind,
-                    "capture_failures": [
-                        failure.as_metadata() for failure in capture_failures
-                    ],
-                },
+                metadata=metadata,
                 error=error,
             )
 

--- a/src/kitaru/adapters/claude_agent_sdk/_runner.py
+++ b/src/kitaru/adapters/claude_agent_sdk/_runner.py
@@ -17,6 +17,11 @@ from ._usage import normalize_usage
 from ._utils import elapsed_ms
 
 try:
+    from claude_agent_sdk import AssistantMessage as _SDK_ASSISTANT_MESSAGE_TYPE
+except (ImportError, AttributeError):
+    _SDK_ASSISTANT_MESSAGE_TYPE: type[Any] | None = None
+
+try:
     from claude_agent_sdk import ResultMessage as _SDK_RESULT_MESSAGE_TYPE
 except (ImportError, AttributeError):
     _SDK_RESULT_MESSAGE_TYPE: type[Any] | None = None
@@ -25,6 +30,53 @@ try:
     from claude_agent_sdk import StreamEvent as _SDK_STREAM_EVENT_TYPE
 except (ImportError, AttributeError):
     _SDK_STREAM_EVENT_TYPE: type[Any] | None = None
+
+
+_ALLOWED_ASSISTANT_ERROR_CATEGORIES = frozenset(
+    {
+        "authentication_failed",
+        "billing_error",
+        "rate_limit",
+        "invalid_request",
+        "server_error",
+        "unknown",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ClaudeResultDiagnostic:
+    """Allowlisted diagnostics for a failed Claude SDK result."""
+
+    assistant_error: str | None
+    api_error_status: int | None
+    subtype: str | None
+
+    @classmethod
+    def from_result_message(
+        cls,
+        final_message: Any,
+        *,
+        assistant_error: Any = None,
+    ) -> "ClaudeResultDiagnostic":
+        """Extract only safe diagnostic fields from an SDK failure."""
+        return cls(
+            assistant_error=_assistant_error_or_none(assistant_error),
+            api_error_status=_api_error_status_or_none(
+                getattr(final_message, "api_error_status", None)
+            ),
+            subtype=_diagnostic_subtype_or_none(
+                getattr(final_message, "subtype", None)
+            ),
+        )
+
+    def as_metadata(self) -> dict[str, str | int | None]:
+        """Return the stable diagnostic metadata representation."""
+        return {
+            "assistant_error": self.assistant_error,
+            "api_error_status": self.api_error_status,
+            "subtype": self.subtype,
+        }
 
 
 @dataclass(frozen=True)
@@ -103,6 +155,7 @@ async def _run_claude_invocation(
     started_at = time.perf_counter()
     messages: list[Any] = []
     final_message: Any | None = None
+    latest_assistant_error: str | None = None
 
     query_result = query(prompt=request.prompt, options=options)
     if inspect.isawaitable(query_result):
@@ -114,13 +167,20 @@ async def _run_claude_invocation(
             await _notify_stream_callback(on_event, message)
         if store_stream_events or not is_stream_event(message):
             messages.append(to_json_safe(message))
+        if is_assistant_message(message):
+            assistant_error = _assistant_error_or_none(getattr(message, "error", None))
+            if assistant_error is not None:
+                latest_assistant_error = assistant_error
         if is_result_message(message):
             final_message = message
 
     if final_message is None:
         raise RuntimeError("Claude Agent SDK did not return a final ResultMessage.")
     if bool(getattr(final_message, "is_error", False)):
-        raise ClaudeResultMessageError(final_message)
+        raise ClaudeResultMessageError(
+            final_message,
+            assistant_error=latest_assistant_error,
+        )
 
     session_id = _string_or_none(getattr(final_message, "session_id", None))
     transcript_path: str | None = None
@@ -166,6 +226,15 @@ async def _notify_stream_callback(on_event: Callable[[Any], Any], message: Any) 
         return
 
 
+def is_assistant_message(message: Any) -> bool:
+    """Return whether a message looks like Claude's AssistantMessage."""
+    if _SDK_ASSISTANT_MESSAGE_TYPE is not None and isinstance(
+        message, _SDK_ASSISTANT_MESSAGE_TYPE
+    ):
+        return True
+    return type(message).__name__ == "AssistantMessage"
+
+
 def is_result_message(message: Any) -> bool:
     """Return whether ``message`` looks like Claude's final ``ResultMessage``."""
     if _SDK_RESULT_MESSAGE_TYPE is not None and isinstance(
@@ -185,25 +254,46 @@ def is_stream_event(message: Any) -> bool:
 
 
 class ClaudeResultMessageError(RuntimeError):
-    """Claude SDK final error that separates raised and live-event messages."""
+    """Claude SDK final error containing only allowlisted diagnostics."""
 
-    def __init__(self, final_message: Any) -> None:
-        self.safe_live_message = format_result_error(
-            final_message, include_result=False
+    def __init__(self, final_message: Any, *, assistant_error: Any = None) -> None:
+        self.diagnostic = ClaudeResultDiagnostic.from_result_message(
+            final_message,
+            assistant_error=assistant_error,
         )
-        super().__init__(format_result_error(final_message, include_result=True))
+        message = format_result_error(self.diagnostic)
+        self.safe_live_message = message
+        super().__init__(message)
 
 
-def format_result_error(final_message: Any, *, include_result: bool = True) -> str:
-    """Format a Claude final error message without assuming SDK details."""
-    subtype = getattr(final_message, "subtype", None)
-    result = getattr(final_message, "result", None)
+def format_result_error(diagnostic: ClaudeResultDiagnostic) -> str:
+    """Format a failed Claude result without content-bearing SDK fields."""
     parts = ["Claude Agent SDK returned an error ResultMessage"]
-    if subtype:
-        parts.append(f"subtype={subtype!r}")
-    if include_result and result:
-        parts.append(f"result={result!r}")
+    if diagnostic.assistant_error is not None:
+        parts.append(f"assistant_error={diagnostic.assistant_error!r}")
+    if diagnostic.api_error_status is not None:
+        parts.append(f"api_error_status={diagnostic.api_error_status}")
+    if diagnostic.subtype is not None:
+        parts.append(f"subtype={diagnostic.subtype!r}")
     return "; ".join(parts)
+
+
+def _assistant_error_or_none(value: Any) -> str | None:
+    if type(value) is str and value in _ALLOWED_ASSISTANT_ERROR_CATEGORIES:
+        return value
+    return None
+
+
+def _api_error_status_or_none(value: Any) -> int | None:
+    if type(value) is int:
+        return value
+    return None
+
+
+def _diagnostic_subtype_or_none(value: Any) -> str | None:
+    if type(value) is str:
+        return value
+    return None
 
 
 def _load_transcript(

--- a/src/kitaru/adapters/claude_agent_sdk/_streaming.py
+++ b/src/kitaru/adapters/claude_agent_sdk/_streaming.py
@@ -12,6 +12,13 @@ from kitaru.adapters._streaming_utils import (
     safe_string,
 )
 
+from ._runner import (
+    ClaudeResultMessageError,
+    _api_error_status_or_none,
+    _assistant_error_or_none,
+    _diagnostic_subtype_or_none,
+)
+
 CLAUDE_STREAM_STARTED = "claude_agent_sdk.stream.started"
 CLAUDE_STREAM_EVENT = "claude_agent_sdk.stream.event"
 CLAUDE_STREAM_COMPLETED = "claude_agent_sdk.stream.completed"
@@ -85,6 +92,13 @@ class ClaudeStreamPublisher(BaseStreamPublisher):
     def failed(self, error: BaseException) -> None:
         self._clear_tool_state()
         self._publish_failed(error)
+
+    def _failed_fields(self, error: BaseException) -> dict[str, Any]:
+        if isinstance(error, ClaudeResultMessageError):
+            return {
+                "claude_result_diagnostic": error.diagnostic.as_metadata(),
+            }
+        return {}
 
     def _normalize_publishable(self, item: Any) -> tuple[str, dict[str, Any]]:
         return CLAUDE_STREAM_EVENT, self.normalize_message(item)
@@ -293,6 +307,9 @@ class ClaudeStreamPublisher(BaseStreamPublisher):
         stop_reason = safe_string(getattr(message, "stop_reason", None))
         if stop_reason is not None:
             payload["stop_reason"] = stop_reason
+        assistant_error = _assistant_error_or_none(getattr(message, "error", None))
+        if assistant_error is not None:
+            payload["assistant_error"] = assistant_error
         return payload
 
     def _normalize_user_message(self, message: Any) -> dict[str, Any]:
@@ -326,7 +343,7 @@ class ClaudeStreamPublisher(BaseStreamPublisher):
         return payload
 
     def _normalize_result_message(self, message: Any) -> dict[str, Any]:
-        subtype = safe_string(getattr(message, "subtype", None))
+        subtype = _diagnostic_subtype_or_none(getattr(message, "subtype", None))
         is_error = bool(getattr(message, "is_error", False))
         payload = self._base_payload(
             category="result_message",
@@ -345,6 +362,11 @@ class ClaudeStreamPublisher(BaseStreamPublisher):
             payload["session_id"] = session_id
         if subtype is not None:
             payload["subtype"] = subtype
+        api_error_status = _api_error_status_or_none(
+            getattr(message, "api_error_status", None)
+        )
+        if api_error_status is not None:
+            payload["api_error_status"] = api_error_status
         stop_reason = safe_string(getattr(message, "stop_reason", None))
         if stop_reason is not None:
             payload["stop_reason"] = stop_reason

--- a/src/kitaru/adapters/claude_agent_sdk/_tracking.py
+++ b/src/kitaru/adapters/claude_agent_sdk/_tracking.py
@@ -95,6 +95,7 @@ class EventTracker:
     _session_id: str | None = None
     _transcript_path: str | None = None
     _warnings: list[str] = field(default_factory=list)
+    _metadata: dict[str, Any] = field(default_factory=dict)
     _lock: threading.Lock = field(
         default_factory=threading.Lock, init=False, repr=False
     )
@@ -137,6 +138,7 @@ class EventTracker:
             self._session_id = session_id
             self._transcript_path = transcript_path
             self._warnings = list(warnings or [])
+            self._metadata = dict(metadata or {})
             event_id = f"{self.runner_name}_{self.run_label}_invocation_1"
             self._events = [
                 ClaudeAdapterEvent(
@@ -172,6 +174,7 @@ class EventTracker:
             "session_id": self._session_id,
             "transcript_path": self._transcript_path,
             "warnings": self._warnings,
+            "metadata": self._metadata,
             "error": (
                 error_from_exception(self._error).model_dump(mode="json")
                 if self._error is not None

--- a/tests/test_claude_agent_sdk_invocation_strategy.py
+++ b/tests/test_claude_agent_sdk_invocation_strategy.py
@@ -33,8 +33,9 @@ def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     sdk.__dict__["messages"] = messages
 
     class AssistantMessage:
-        def __init__(self, text: str) -> None:
+        def __init__(self, text: str, *, error: object | None = None) -> None:
             self.text = text
+            self.error = error
 
     class StreamEvent:
         def __init__(self, event: dict[str, object]) -> None:
@@ -57,17 +58,20 @@ def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
             self,
             *,
             session_id: str = "session-123",
-            result: str = "done",
+            result: object = "done",
             is_error: bool = False,
+            api_error_status: object | None = None,
+            subtype: object = "success",
         ) -> None:
             self.session_id = session_id
             self.result = result
             self.is_error = is_error
+            self.api_error_status = api_error_status
             self.usage = {"input_tokens": 3, "output_tokens": 5}
             self.total_cost_usd = 0.04
             self.model_usage = {"claude-sonnet": {"input_tokens": 3}}
             self.stop_reason = "end_turn"
-            self.subtype = "success"
+            self.subtype = subtype
             self.num_turns = 1
             self.duration_ms = 12.5
             self.duration_api_ms = 10.0
@@ -725,8 +729,11 @@ def test_failed_invocation_manifest_build_failure_preserves_sdk_error(
         capture=claude_adapter.ClaudeCapturePolicy(fail_on_artifact_capture_error=True),
     )
 
-    with pytest.raises(RuntimeError, match="permission denied"):
+    with pytest.raises(RuntimeError, match="error ResultMessage") as exc_info:
         runner.run_sync(claude_adapter.ClaudeRunRequest.start("hello"))
+
+    assert type(exc_info.value).__name__ == "ClaudeResultMessageError"
+    assert "permission denied" not in str(exc_info.value)
 
 
 def test_failed_invocation_capture_failure_preserves_sdk_error(
@@ -750,8 +757,11 @@ def test_failed_invocation_capture_failure_preserves_sdk_error(
         capture=claude_adapter.ClaudeCapturePolicy(fail_on_artifact_capture_error=True),
     )
 
-    with pytest.raises(RuntimeError, match="permission denied"):
+    with pytest.raises(RuntimeError, match="error ResultMessage") as exc_info:
         runner.run_sync(claude_adapter.ClaudeRunRequest.start("hello"))
+
+    assert type(exc_info.value).__name__ == "ClaudeResultMessageError"
+    assert "permission denied" not in str(exc_info.value)
 
 
 def test_event_persistence_failure_is_non_fatal_by_default(
@@ -1632,8 +1642,130 @@ def test_runner_raises_when_sdk_result_is_error(
         name="claude",
     )
 
-    with pytest.raises(RuntimeError, match="error ResultMessage"):
+    with pytest.raises(RuntimeError, match="error ResultMessage") as exc_info:
         runner.run_sync(claude_adapter.ClaudeRunRequest.start("hello"))
+
+    assert "permission denied" not in str(exc_info.value)
+
+
+def test_failed_result_diagnostic_is_safe_and_persisted(
+    claude_adapter: types.ModuleType,
+    fake_sdk: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_inline_scope(monkeypatch)
+    saved: list[tuple[str, object]] = []
+    logs: list[dict[str, object]] = []
+    _patch_direct_execution_persistence(
+        monkeypatch,
+        save_event=lambda name, value, *, type: saved.append((name, value)),
+        log_event=lambda **kwargs: logs.append(kwargs),
+    )
+    assistant_message = fake_sdk.__dict__["AssistantMessage"]
+    result_message = fake_sdk.__dict__["ResultMessage"]
+    secret = "SECRET_RESULT_TEXT_SHOULD_NOT_LEAK"
+    cast(list[object], fake_sdk.__dict__["messages"])[:] = [
+        assistant_message("first", error="rate_limit"),
+        assistant_message("second", error="billing_error"),
+        assistant_message("ignored", error="not_allowlisted"),
+        result_message(
+            is_error=True,
+            result=secret,
+            api_error_status=529,
+            subtype="success",
+        ),
+    ]
+    runner = claude_adapter.KitaruClaudeRunner(
+        allow_direct_execution_inside_checkpoint=True,
+        name="claude",
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        runner.run_sync(claude_adapter.ClaudeRunRequest.start("hello"))
+
+    expected_diagnostic = {
+        "assistant_error": "billing_error",
+        "api_error_status": 529,
+        "subtype": "success",
+    }
+    assert type(exc_info.value).__name__ == "ClaudeResultMessageError"
+    assert str(exc_info.value) == (
+        "Claude Agent SDK returned an error ResultMessage; "
+        "assistant_error='billing_error'; api_error_status=529; "
+        "subtype='success'"
+    )
+    assert secret not in str(exc_info.value)
+
+    event_log = next(value for name, value in saved if name.startswith("event_log__"))
+    run_summary = next(
+        value for name, value in saved if name.startswith("run_summary__")
+    )
+    event = cast(list[dict[str, Any]], event_log)[0]
+    summary = cast(dict[str, Any], run_summary)
+    assert event["metadata"]["claude_result_diagnostic"] == expected_diagnostic
+    assert summary["metadata"]["claude_result_diagnostic"] == expected_diagnostic
+    assert event["error"]["message"] == str(exc_info.value)
+    assert summary["error"]["message"] == str(exc_info.value)
+    assert secret not in repr(saved)
+    assert secret not in repr(logs)
+
+
+@pytest.mark.parametrize(
+    "api_error_status",
+    [
+        True,
+        type("IntSubclass", (int,), {})(529),
+        SimpleNamespace(secret="SECRET_HOSTILE_API_STATUS"),
+    ],
+)
+def test_failed_result_diagnostic_rejects_hostile_values(
+    claude_adapter: types.ModuleType,
+    fake_sdk: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    api_error_status: object,
+) -> None:
+    class HostileValue:
+        def __str__(self) -> str:
+            return "SECRET_HOSTILE_VALUE"
+
+        def __repr__(self) -> str:
+            return "SECRET_HOSTILE_VALUE"
+
+    _patch_inline_scope(monkeypatch)
+    saved: list[tuple[str, object]] = []
+    _patch_direct_execution_persistence(
+        monkeypatch,
+        save_event=lambda name, value, *, type: saved.append((name, value)),
+    )
+    assistant_message = fake_sdk.__dict__["AssistantMessage"]
+    result_message = fake_sdk.__dict__["ResultMessage"]
+    cast(list[object], fake_sdk.__dict__["messages"])[:] = [
+        assistant_message("ignored", error=HostileValue()),
+        result_message(
+            is_error=True,
+            result=HostileValue(),
+            api_error_status=api_error_status,
+            subtype=HostileValue(),
+        ),
+    ]
+    runner = claude_adapter.KitaruClaudeRunner(
+        allow_direct_execution_inside_checkpoint=True,
+        name="claude",
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        runner.run_sync(claude_adapter.ClaudeRunRequest.start("hello"))
+
+    assert str(exc_info.value) == ("Claude Agent SDK returned an error ResultMessage")
+    assert "SECRET_HOSTILE" not in str(exc_info.value)
+    event_log = next(value for name, value in saved if name.startswith("event_log__"))
+    event = cast(list[dict[str, Any]], event_log)[0]
+    assert event["metadata"]["claude_result_diagnostic"] == {
+        "assistant_error": None,
+        "api_error_status": None,
+        "subtype": None,
+    }
+    assert "SECRET_HOSTILE" not in repr(saved)
 
 
 def test_transcript_path_rejects_non_ascii_cwd(

--- a/tests/test_claude_agent_sdk_invocation_strategy.py
+++ b/tests/test_claude_agent_sdk_invocation_strategy.py
@@ -1606,7 +1606,11 @@ def test_runner_raises_when_sdk_returns_no_result_message(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _patch_inline_scope(monkeypatch)
-    _patch_direct_execution_persistence(monkeypatch)
+    saved: list[tuple[str, object]] = []
+    _patch_direct_execution_persistence(
+        monkeypatch,
+        save_event=lambda name, value, *, type: saved.append((name, value)),
+    )
     assistant_message = fake_sdk.__dict__["AssistantMessage"]
     cast(list[object], fake_sdk.__dict__["messages"])[:] = [
         assistant_message("not final")
@@ -1618,6 +1622,15 @@ def test_runner_raises_when_sdk_returns_no_result_message(
 
     with pytest.raises(RuntimeError, match="did not return a final ResultMessage"):
         runner.run_sync(claude_adapter.ClaudeRunRequest.start("hello"))
+
+    event_log = next(value for name, value in saved if name.startswith("event_log__"))
+    run_summary = next(
+        value for name, value in saved if name.startswith("run_summary__")
+    )
+    event = cast(list[dict[str, Any]], event_log)[0]
+    summary = cast(dict[str, Any], run_summary)
+    assert "claude_result_diagnostic" not in event["metadata"]
+    assert "claude_result_diagnostic" not in summary["metadata"]
 
 
 def test_runner_raises_when_sdk_result_is_error(
@@ -1648,7 +1661,7 @@ def test_runner_raises_when_sdk_result_is_error(
     assert "permission denied" not in str(exc_info.value)
 
 
-def test_failed_result_diagnostic_is_safe_and_persisted(
+def test_failed_result_diagnostic_is_safe_sticky_and_persisted(
     claude_adapter: types.ModuleType,
     fake_sdk: types.ModuleType,
     monkeypatch: pytest.MonkeyPatch,
@@ -1667,6 +1680,7 @@ def test_failed_result_diagnostic_is_safe_and_persisted(
     cast(list[object], fake_sdk.__dict__["messages"])[:] = [
         assistant_message("first", error="rate_limit"),
         assistant_message("second", error="billing_error"),
+        assistant_message("later without error"),
         assistant_message("ignored", error="not_allowlisted"),
         result_message(
             is_error=True,

--- a/tests/test_claude_agent_sdk_streaming.py
+++ b/tests/test_claude_agent_sdk_streaming.py
@@ -42,11 +42,13 @@ def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
             model: str = "claude-sonnet",
             stop_reason: str = "end_turn",
             usage: object | None = None,
+            error: object | None = None,
         ) -> None:
             self.content = content or []
             self.model = model
             self.stop_reason = stop_reason
             self.usage = usage
+            self.error = error
 
     class UserMessage:
         def __init__(
@@ -94,16 +96,19 @@ def fake_sdk(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
             result: str = "final secret result text",
             structured_output: object | None = None,
             is_error: bool = False,
+            api_error_status: object | None = None,
+            subtype: object = "success",
         ) -> None:
             self.session_id = session_id
             self.result = result
             self.structured_output = structured_output
             self.is_error = is_error
+            self.api_error_status = api_error_status
             self.usage = {"input_tokens": 3, "output_tokens": 5}
             self.total_cost_usd = 0.04
             self.model_usage = {"claude-sonnet": {"input_tokens": 3}}
             self.stop_reason = "end_turn"
-            self.subtype = "success"
+            self.subtype = subtype
             self.num_turns = 1
             self.duration_ms = 12.5
             self.duration_api_ms = 10.0
@@ -602,31 +607,100 @@ def test_error_result_message_does_not_leak_result_to_live_payloads(
     published = _capture_published(monkeypatch)
     secret = "SECRET_RESULT_TEXT_SHOULD_NOT_LEAK"
     fake_sdk.__dict__["messages"][:] = [
-        fake_sdk.ResultMessage(is_error=True, result=secret)
+        fake_sdk.AssistantMessage(error="rate_limit"),
+        fake_sdk.ResultMessage(
+            is_error=True,
+            result=secret,
+            api_error_status=529,
+        ),
     ]
 
     with pytest.raises(RuntimeError) as exc_info:
         _run_stream_direct(claude_adapter, monkeypatch)
 
-    # Non-stream/durable callers still see the detailed raised error.
-    assert secret in str(exc_info.value)
+    assert secret not in str(exc_info.value)
 
     payloads = [payload for _, payload, _ in published]
     assert [kind for kind, _, _ in published] == [
         claude_adapter.CLAUDE_STREAM_STARTED,
         claude_adapter.CLAUDE_STREAM_EVENT,
+        claude_adapter.CLAUDE_STREAM_EVENT,
         claude_adapter.CLAUDE_STREAM_FAILED,
     ]
+    assert (
+        len(
+            [
+                kind
+                for kind, _, _ in published
+                if kind in claude_adapter.CLAUDE_STREAM_TERMINAL_EVENT_KINDS
+            ]
+        )
+        == 1
+    )
+    assert published[-1][2] is True
     assert secret not in repr(payloads)
+
+    assistant_payload = payloads[1]
+    result_payload = payloads[2]
+    assert assistant_payload["assistant_error"] == "rate_limit"
+    assert result_payload["api_error_status"] == 529
+    assert result_payload["subtype"] == "success"
+
     failed_payload = payloads[-1]
+    expected_diagnostic = {
+        "assistant_error": "rate_limit",
+        "api_error_status": 529,
+        "subtype": "success",
+    }
     assert failed_payload["category"] == "lifecycle"
     assert failed_payload["error_type"] == "ClaudeResultMessageError"
+    assert failed_payload["claude_result_diagnostic"] == expected_diagnostic
     assert failed_payload["message"] == (
-        "Claude Agent SDK returned an error ResultMessage; subtype='success'"
+        "Claude Agent SDK returned an error ResultMessage; "
+        "assistant_error='rate_limit'; api_error_status=529; subtype='success'"
     )
     assert failed_payload["display"] == (
         "Claude Agent SDK stream failed: Claude Agent SDK returned an error "
-        "ResultMessage; subtype='success'"
+        "ResultMessage; assistant_error='rate_limit'; api_error_status=529; "
+        "subtype='success'"
+    )
+
+
+def test_stream_diagnostics_reject_hostile_values(
+    claude_adapter: types.ModuleType,
+    fake_sdk: types.ModuleType,
+) -> None:
+    class HostileValue:
+        def __str__(self) -> str:
+            return "SECRET_HOSTILE_STREAM_VALUE"
+
+        def __repr__(self) -> str:
+            return "SECRET_HOSTILE_STREAM_VALUE"
+
+    class IntSubclass(int):
+        pass
+
+    streaming_module = importlib.import_module(
+        "kitaru.adapters.claude_agent_sdk._streaming"
+    )
+    publisher = streaming_module.ClaudeStreamPublisher(runner_name="claude")
+    assistant_payload = publisher.normalize_message(
+        fake_sdk.AssistantMessage(error=HostileValue())
+    )
+    result_payload = publisher.normalize_message(
+        fake_sdk.ResultMessage(
+            is_error=True,
+            result=HostileValue(),
+            api_error_status=IntSubclass(529),
+            subtype=HostileValue(),
+        )
+    )
+
+    assert "assistant_error" not in assistant_payload
+    assert "api_error_status" not in result_payload
+    assert "subtype" not in result_payload
+    assert "SECRET_HOSTILE_STREAM_VALUE" not in repr(
+        [assistant_payload, result_payload]
     )
 
 


### PR DESCRIPTION
## Summary

- preserve safe Claude API failure diagnostics across exceptions, stream events, and durable metadata
- prevent raw Claude result text from leaking into Kitaru-created failure records
- add immutable run-attempt provenance to LLM integration artifacts and summaries
- make setup failures visible in artifacts and Discord diagnostics
- update live-test release guidance and Claude adapter documentation

Partially addresses #562.

## Validation

- 100 targeted deterministic Claude adapter tests passed
- `just check`
- `git diff --check`
- final Oracle review completed; all actionable findings addressed

No deliberately failing or additional paid-provider test was run.

## Operational changes already applied

- cancelled stale scheduled run `27539331378`
- removed required reviewers from the `live-provider-tests` environment
- restricted the environment deployment policy to `develop`
- left provider and Discord credentials as repository secrets
- did not rotate or move secrets

## Reviewer Notes

1. Run the deterministic regression coverage:

   ```bash
   just test -n 0 \
     tests/test_claude_agent_sdk_invocation_strategy.py \
     tests/test_claude_agent_sdk_streaming.py
   uv run pytest -n 0 tests/test_provider_spend_guard.py  # 17 tests
   ```

2. Inspect the error-result fixtures and confirm that `assistant_error`, exact-integer `api_error_status`, and `subtype` survive while sentinel raw result text is absent from exceptions, stream payloads, and persisted metadata.

3. Inspect `.github/workflows/llm-integration.yml` and verify that `llm-integration.provenance.json`, `metadata.env`, and the Markdown summary agree on run ID, attempt, event, tested SHA, and workflow SHA.

4. After merge, dispatch one bounded Anthropic-only `provider-core` run against the exact merged `develop` SHA. Do not intentionally provoke a provider failure merely to test Discord.

