### PR TITLE
Fix reporting contract gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Reporting now preserves physical retry identity, marks unavailable secret-list key metadata explicitly, accounts for unknown billing conservatively, and documents the distinct workload-token and incurred-cost diff bases. (#566)
+
 ## [0.21.0] - 2026-07-14
 
 ### Added

--- a/docs/book/agent-native/mcp-server.md
+++ b/docs/book/agent-native/mcp-server.md
@@ -164,13 +164,15 @@ Secret tools:
 - `kitaru_secrets_list`
 
 `kitaru_secrets_list` accepts `page` and `size` (defaults: `1` and `20`) and
-returns only metadata for each secret: `id`, `name`, `visibility`, `keys`, and
-`has_missing_values`. It never returns secret values. Pages beyond the available
-results return `[]`.
+returns only metadata for each secret: `id`, `name`, `visibility`, `keys`,
+`keys_known`, and `has_missing_values`. It never returns secret values. Pages
+beyond the available results return `[]`.
 
-When listing secrets, `keys` and `has_missing_values` may be unpopulated because
-the backend does not include key names in list responses. These fields are
-meaningful in `kitaru_secrets_create` responses and the CLI `secrets show` path.
+List responses use `keys_known=false` because the backend does not include key
+metadata there. In that state, `keys=[]` and `has_missing_values=false` mean the
+metadata is unavailable, not that the secret is empty or fully readable.
+`kitaru_secrets_create` returns `keys_known=true`, so its `keys` and
+`has_missing_values` fields are authoritative.
 
 `kitaru_secrets_create` also returns metadata only. The MCP server intentionally
 does not expose `kitaru_secrets_delete`; use the CLI or Python SDK for deletion.
@@ -534,6 +536,13 @@ For diffs, use:
 
 - `kitaru_executions_diff` for one original execution against one or more replays;
 - `kitaru_executions_diff_matrix` for many original executions against their auto-discovered replays.
+
+Both tools calculate deltas as replay minus original, but tokens and cost use
+different accounting bases. `token_delta` measures workload tokens, including
+model work that the replay reused. It is null only when neither side has
+canonical usage. `cost_delta_usd` measures incurred display cost, and explicitly
+reused work contributes zero. It is null when either side contains unpriced work
+that was not explicitly reused.
 
 Replay does not support `wait.*` overrides. If the replayed execution reaches a
 wait, resolve it through the normal input flow afterward.

--- a/docs/book/guides/execution-management.md
+++ b/docs/book/guides/execution-management.md
@@ -250,8 +250,14 @@ adapters, Kitaru records canonical `llm_usage_v1` metadata on the checkpoint
 that made or reused the provider work. One usage record usually means one
 provider interaction or one adapter-level graph/agent invocation, depending on
 which adapter produced it. When the execution finishes, Kitaru reads those
-checkpoint records and writes two execution-level views. `FlowHandle.wait()` and
-`FlowHandle.get()` can populate missing summaries for older executions or executions where the finish-time summary was not written:
+checkpoint records and writes two execution-level views. Checkpoint-owned records
+expose the physical attempt ID as `checkpoint_id` and the normalized checkpoint
+name as `checkpoint_name` when the producer did not set those fields itself.
+This keeps retry attempts distinct. Records written only at execution level stay
+unattributed unless their producer supplied checkpoint identity.
+
+`FlowHandle.wait()` and `FlowHandle.get()` can populate missing summaries for
+older executions or executions where the finish-time summary was not written:
 
 - `llm_usage_summary_v1` is the inspection view. `kitaru executions get` and the
   Python client parse it into `execution.llm_usage_summary`. It tells you what
@@ -276,6 +282,19 @@ Cost fields are intentionally split:
   Adapter-level user calculators also write this field.
 - `display_cost_usd` uses actual cost for a record when present, otherwise
   estimated cost. Treat it as observability, not as a billing invoice.
+
+Aggregation follows the `non_reused_is_incurred_v1` policy recorded in each
+summary's `cost_policy` field. Every usage record counts as incurred unless its
+`billing_effect` is explicitly `reused_not_incurred`. An `unknown` record
+therefore contributes to workload and incurred counts and tokens. Its price
+contributes to display cost when available, and a missing price makes incurred
+cost incomplete. Mock mode keeps `billing_effect="unknown"` because it does not
+claim that a provider call occurred, but summaries still apply this conservative
+rule.
+
+Kitaru does not eagerly rewrite all stored summaries after this policy changes.
+A summary with any other policy marker is treated as stale and is refreshed when
+Kitaru next performs its normal execution aggregation.
 
 Automatic `genai-prices` cost estimates are on by default. After the provider
 or adapter call succeeds, Kitaru sends the known provider, model name, and token

--- a/docs/book/guides/replay-and-overrides.md
+++ b/docs/book/guides/replay-and-overrides.md
@@ -468,16 +468,34 @@ Checkpoint token and cost deltas in JSON output are always calculated as
 ```
 
 The token object always uses the keys `prompt_tokens`, `completion_tokens`, and
-`total_tokens`. A negative value means the replay used fewer tokens than the
-original; a positive value means it used more. A recorded model call with zero
-tokens produces a three-key object containing zeroes, while `token_delta: null`
-means neither checkpoint has a model usage record.
+`total_tokens`. It measures workload, including model work reused by the replay.
+A negative value means the replay workload used fewer tokens than the original;
+a positive value means it used more. A recorded model call with zero tokens
+produces a three-key object containing zeroes, while `token_delta: null` means
+neither checkpoint has a model usage record.
 
-The cost follows the same subtraction rule. `cost_delta_usd: null` means at
-least one model call that was not explicitly reused has neither usable actual
-cost nor a usable estimate, so Kitaru cannot calculate a trustworthy
-difference. Reused checkpoint work contributes zero cost because the provider
-call was not made again.
+The cost follows the same subtraction rule but measures incurred display cost.
+`cost_delta_usd: null` means at least one model call that was not explicitly
+reused has neither usable actual cost nor a usable estimate, so Kitaru cannot
+calculate a trustworthy difference. Reused checkpoint work contributes zero
+cost because the provider call was not made again.
+
+For example, a replay that fully reuses the original model work can keep the
+same workload while avoiding all provider spend:
+
+```json
+{
+  "token_delta": {
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "total_tokens": 0
+  },
+  "cost_delta_usd": -0.0025
+}
+```
+
+The zero token delta says the recorded workload is unchanged. The negative cost
+delta says the replay avoided the original $0.0025 of provider spend.
 
 `ExecutionDiff.urls` links to the Kitaru UI compare view — one URL listing the original and every compared replay, whether discovered automatically or passed explicitly:
 

--- a/docs/book/guides/secrets.md
+++ b/docs/book/guides/secrets.md
@@ -80,10 +80,11 @@ kitaru secrets delete openai-creds
 ## Use secrets from Python
 
 Create and delete helpers return `SecretSummary`, a metadata-only model that
-lists key names but never includes raw secret values:
+never includes raw secret values. Its `keys_known` field tells you whether
+`keys` and `has_missing_values` are authoritative:
 
 ```python
-from kitaru import create_secret, delete_secret, get_secret
+from kitaru import create_secret, delete_secret, get_secret, list_secrets
 
 created = create_secret(
     "github-creds",
@@ -100,8 +101,20 @@ private_created = create_secret(
 secret = get_secret("github-creds")
 token = secret.get("GITHUB_TOKEN")
 
+listed = list_secrets()
+for summary in listed:
+    print(summary.name, summary.keys_known)  # keys_known is False for list results
+
 deleted = delete_secret("github-creds")
 ```
+
+`create_secret()` and `delete_secret()` receive authoritative key metadata, so
+`keys_known=True` and `keys` is authoritative, including when it is empty.
+`list_secrets()` deliberately uses metadata-only backend responses and does not
+load each secret individually. Its summaries therefore use `keys_known=False`,
+`keys=[]`, and `has_missing_values=False`. Those empty and false values mean the
+key metadata was unavailable, not that the stored secret has no keys or missing
+values.
 
 `get_secret()` performs an exact lookup by secret name or ID. It returns a
 Kitaru `Secret` model with `.name`, `.id`, `.values: dict[str, str]`, and
@@ -145,8 +158,10 @@ raw secret values from checkpoints unless that is explicitly intended.
 ## MCP support
 
 The Kitaru MCP server exposes `kitaru_secrets_create` for metadata-only secret
-creation from MCP clients. It intentionally does not expose secret deletion; use
-the CLI or Python SDK when you need to delete a secret.
+creation and `kitaru_secrets_list` for paginated discovery without values. List
+results follow the same `keys_known=False` contract described above. The server
+intentionally does not expose secret deletion; use the CLI or Python SDK when
+you need to delete a secret.
 
 ## Related reference pages
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1849,6 +1849,9 @@ run_test "kitaru secrets set smoke secret" \
 run_test "SDK get_secret()" \
     env SMOKE_SECRET_NAME="$SMOKE_SECRET_NAME" \
     $UV_RUN python -c 'import os; from kitaru import get_secret; s = get_secret(os.environ["SMOKE_SECRET_NAME"]); assert s.get("SMOKE_TOKEN") == "smoke-value"'
+run_test "SDK list_secrets() key metadata contract" \
+    env SMOKE_SECRET_NAME="$SMOKE_SECRET_NAME" \
+    $UV_RUN python -c 'import os; from kitaru import list_secrets; matches = [s for s in list_secrets() if s.name == os.environ["SMOKE_SECRET_NAME"]]; assert len(matches) == 1; s = matches[0]; assert s.keys == []; assert s.keys_known is False; assert s.has_missing_values is False; assert "smoke-value" not in s.model_dump_json()'
 run_test "kitaru secrets delete smoke secret" \
     $UV_RUN kitaru secrets delete "$SMOKE_SECRET_NAME"
 

--- a/src/kitaru/_cli/_executions.py
+++ b/src/kitaru/_cli/_executions.py
@@ -1688,7 +1688,14 @@ def diff_(
     ],
     output: OutputFormatOption = "text",
 ) -> None:
-    """Compare an original execution against replay executions."""
+    """Compare an original execution against replay executions.
+
+    Token deltas are replay minus original workload tokens, including reused
+    model work. Cost deltas are replay minus original incurred display cost,
+    where explicitly reused work contributes zero. Token deltas are null only
+    when neither side has canonical usage; cost deltas are null when either side
+    has unpriced work that is not explicitly reused.
+    """
     from kitaru.diff import diff, serialize_execution_diff
 
     command = "executions.diff"
@@ -1727,7 +1734,13 @@ def diff_matrix_(
     ],
     output: OutputFormatOption = "text",
 ) -> None:
-    """Diff many original executions against their auto-discovered replays."""
+    """Diff originals against replays using workload-token and incurred-cost bases.
+
+    Deltas are replay minus original. Tokens include reused model work; cost
+    excludes explicitly reused work. Token deltas are null only when neither
+    side has canonical usage, while cost deltas are null when either side has
+    unpriced work that is not explicitly reused.
+    """
     from kitaru.diff import diff_cohort, serialize_cohort_diff
 
     command = "executions.diff_matrix"

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -293,6 +293,7 @@ def _map_checkpoint_attempt(
         ended_at=step.end_time,
         metadata=_to_plain_dict(step.run_metadata),
         failure=failure,
+        _checkpoint_name=checkpoint_name,
         _raw_status=str(getattr(step.status, "value", step.status)).strip().lower(),
         _replay_reused=(
             replay_skipped_steps is not None

--- a/src/kitaru/_client/_models.py
+++ b/src/kitaru/_client/_models.py
@@ -404,6 +404,7 @@ class CheckpointAttempt:
     ended_at: datetime | None
     metadata: dict[str, Any]
     failure: FailureInfo | None
+    _checkpoint_name: str | None = field(default=None, repr=False, compare=False)
     _raw_status: str | None = field(default=None, repr=False, compare=False)
     _replay_reused: bool = field(default=False, repr=False, compare=False)
 
@@ -415,13 +416,19 @@ class CheckpointAttempt:
         return usage_records_from_metadata(
             self.metadata,
             source_attempt_id=self.attempt_id,
+            default_checkpoint_id=self.attempt_id,
+            default_checkpoint_name=self._checkpoint_name,
             reused=reused,
             reused_cache_status=reused_cache_status,
         )
 
     @property
     def llm_usage_records(self) -> list[dict[str, Any]]:
-        """Canonical LLM usage records persisted on this attempt."""
+        """Canonical usage records attributed to this physical attempt.
+
+        Missing checkpoint identity fields default to this attempt's step-run ID
+        and normalized checkpoint name. Explicit producer identity is preserved.
+        """
         return [
             strip_usage_record_bookkeeping(record)
             for record in self._llm_usage_records_with_bookkeeping()
@@ -479,11 +486,19 @@ class CheckpointCall:
             records.extend(attempt._llm_usage_records_with_bookkeeping())
         if records:
             return records
-        return usage_records_from_metadata(self.metadata)
+        return usage_records_from_metadata(
+            self.metadata,
+            default_checkpoint_id=self.call_id,
+            default_checkpoint_name=self.name,
+        )
 
     @property
     def llm_usage_records(self) -> list[dict[str, Any]]:
-        """Canonical LLM usage records persisted on this checkpoint."""
+        """Canonical usage records for this checkpoint and its attempts.
+
+        Attempt records retain physical-attempt identity. If no attempt records
+        exist, missing identity fields on call metadata default to this call.
+        """
         return [
             strip_usage_record_bookkeeping(record)
             for record in self._llm_usage_records_with_bookkeeping()
@@ -533,7 +548,12 @@ class Execution:
 
     @property
     def llm_usage_records(self) -> list[dict[str, Any]]:
-        """Canonical LLM usage records from execution and checkpoint metadata."""
+        """Canonical usage records from execution and checkpoint metadata.
+
+        Checkpoint-owned records carry attempt-aware identity when producer
+        identity is absent. Execution-level records remain unattributed unless
+        their producer supplied checkpoint identity explicitly.
+        """
         checkpoint_records: list[dict[str, Any]] = []
         checkpoint_identities: set[tuple[str | None, str | None]] = set()
         for checkpoint in self.checkpoints:

--- a/src/kitaru/_inspection_serialization.py
+++ b/src/kitaru/_inspection_serialization.py
@@ -447,14 +447,17 @@ def serialize_secret_summary(secret: Any) -> dict[str, Any]:
 
     if isinstance(secret, SecretSummary):
         keys = sorted(secret.keys)
+        keys_known = secret.keys_known
     else:
         keys = sorted(str(key) for key in secret.values)
+        keys_known = True
 
     return {
         "id": str(secret.id),
         "name": secret.name,
         "visibility": "private" if secret.private else "public",
         "keys": keys,
+        "keys_known": keys_known,
         "has_missing_values": bool(getattr(secret, "has_missing_values", False)),
     }
 

--- a/src/kitaru/_llm_usage.py
+++ b/src/kitaru/_llm_usage.py
@@ -22,6 +22,7 @@ from pydantic_core import to_jsonable_python
 LLM_USAGE_METADATA_KEY = "llm_usage_v1"
 LLM_USAGE_SUMMARY_METADATA_KEY = "llm_usage_summary_v1"
 LLM_USAGE_SCHEMA_VERSION = 1
+LLM_USAGE_COST_POLICY = "non_reused_is_incurred_v1"
 
 LLM_FLAT_USAGE_RECORD_COUNT_KEY = "kitaru_llm_usage_record_count_v1"
 LLM_FLAT_INCURRED_USAGE_RECORD_COUNT_KEY = "kitaru_llm_incurred_usage_record_count_v1"
@@ -994,6 +995,7 @@ def parse_usage_records(
     value: Any,
     *,
     source_attempt_id: str | None = None,
+    default_checkpoint_id: str | None = None,
     default_checkpoint_name: str | None = None,
     reused: bool = False,
     reused_cache_status: LLMCacheStatus = "checkpoint_cache_hit",
@@ -1023,6 +1025,11 @@ def parse_usage_records(
             continue
         normalized = dict(record)
         if (
+            normalized.get("checkpoint_id") is None
+            and default_checkpoint_id is not None
+        ):
+            normalized["checkpoint_id"] = default_checkpoint_id
+        if (
             normalized.get("checkpoint_name") is None
             and default_checkpoint_name is not None
         ):
@@ -1040,6 +1047,7 @@ def usage_records_from_metadata(
     metadata: Mapping[str, Any],
     *,
     source_attempt_id: str | None = None,
+    default_checkpoint_id: str | None = None,
     default_checkpoint_name: str | None = None,
     reused: bool = False,
     reused_cache_status: LLMCacheStatus = "checkpoint_cache_hit",
@@ -1048,6 +1056,7 @@ def usage_records_from_metadata(
     return parse_usage_records(
         metadata.get(LLM_USAGE_METADATA_KEY),
         source_attempt_id=source_attempt_id,
+        default_checkpoint_id=default_checkpoint_id,
         default_checkpoint_name=default_checkpoint_name,
         reused=reused,
         reused_cache_status=reused_cache_status,
@@ -1095,11 +1104,7 @@ def empty_usage_summary() -> dict[str, Any]:
         "records_without_cost_count": 0,
         "adapters": [],
         "models": [],
-        "cost_policy": (
-            "display_cost_usd uses actual_cost_usd when present for a record, "
-            "otherwise estimated_cost_usd. It is an observability estimate, "
-            "not an invoice."
-        ),
+        "cost_policy": LLM_USAGE_COST_POLICY,
         "warnings": [],
     }
 
@@ -1109,13 +1114,16 @@ def aggregate_usage_records_with_cost_completeness(
 ) -> tuple[dict[str, Any], bool]:
     """Aggregate records and report whether any incurred cost is unavailable.
 
-    Duplicate records are skipped only when they came from the same source
-    attempt and have the same record identity. The same logical record ID on a
-    later retry attempt is counted again because that second attempt could have
-    made a second provider call.
+    The ``non_reused_is_incurred_v1`` policy treats every record as incurred
+    unless its billing effect is explicitly ``reused_not_incurred``. This keeps
+    incurred counts, tokens, display cost, and cost completeness on the same
+    conservative basis. Duplicate records are skipped only when they came from
+    the same source attempt and have the same record identity. The same logical
+    record ID on a later retry attempt is counted again because that second
+    attempt could have made a second provider call.
     """
     summary = empty_usage_summary()
-    has_unpriced_non_reused_record = False
+    has_unpriced_incurred_record = False
     adapters: set[str] = set()
     models: set[str] = set()
     warnings: list[str] = []
@@ -1136,7 +1144,7 @@ def aggregate_usage_records_with_cost_completeness(
 
         billing_effect = record.get("billing_effect")
         is_reused = billing_effect == "reused_not_incurred"
-        is_incurred = billing_effect == "incurred"
+        is_incurred = not is_reused
 
         summary["usage_record_count"] += 1
         if is_incurred:
@@ -1164,7 +1172,7 @@ def aggregate_usage_records_with_cost_completeness(
 
         actual_cost = _record_cost(record, "actual_cost_usd")
         estimated_cost = _record_cost(record, "estimated_cost_usd")
-        if not is_reused:
+        if is_incurred:
             if actual_cost is not None:
                 summary["actual_cost_usd"] += actual_cost
             if estimated_cost is not None:
@@ -1175,8 +1183,8 @@ def aggregate_usage_records_with_cost_completeness(
                 summary["display_cost_usd"] += estimated_cost
         if actual_cost is None and estimated_cost is None:
             summary["records_without_cost_count"] += 1
-            if not is_reused:
-                has_unpriced_non_reused_record = True
+            if is_incurred:
+                has_unpriced_incurred_record = True
 
         adapter = record.get("adapter")
         if isinstance(adapter, str):
@@ -1194,7 +1202,7 @@ def aggregate_usage_records_with_cost_completeness(
     summary["adapters"] = sorted(adapters)
     summary["models"] = sorted(models)
     summary["warnings"] = warnings
-    return summary, has_unpriced_non_reused_record
+    return summary, has_unpriced_incurred_record
 
 
 def aggregate_usage_records(records: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
@@ -1320,8 +1328,7 @@ def metadata_has_complete_usage_summary(metadata: Mapping[str, Any]) -> bool:
 
     if any(not isinstance(summary.get(key), list) for key in _SUMMARY_LIST_FIELDS):
         return False
-    cost_policy = summary.get("cost_policy")
-    return isinstance(cost_policy, str) and bool(cost_policy.strip())
+    return summary.get("cost_policy") == LLM_USAGE_COST_POLICY
 
 
 def execution_metadata_from_records(

--- a/src/kitaru/_terminal_usage.py
+++ b/src/kitaru/_terminal_usage.py
@@ -99,6 +99,7 @@ def _persist_terminal_llm_usage_metadata(
             step_records = usage_records_from_metadata(
                 _metadata_mapping(getattr(step, "run_metadata", None)),
                 source_attempt_id=str(step.id),
+                default_checkpoint_id=str(step.id),
                 default_checkpoint_name=_normalize_checkpoint_name(
                     str(getattr(step, "name", ""))
                 ),

--- a/src/kitaru/diff.py
+++ b/src/kitaru/diff.py
@@ -23,7 +23,15 @@ _AUTO_DISCOVERY_SCAN_LIMIT = 10_000
 
 @dataclass(frozen=True)
 class CheckpointDiff:
-    """Per-checkpoint comparison between an original and replay execution."""
+    """Per-checkpoint comparison between an original and replay execution.
+
+    ``token_delta`` is replay minus original workload tokens and includes model
+    work reused by the replay. It is ``None`` only when neither checkpoint has
+    canonical usage records. ``cost_delta_usd`` is replay minus original
+    incurred display cost, so explicitly reused work contributes zero. It is
+    ``None`` when either checkpoint has unpriced work that is not explicitly
+    reused.
+    """
 
     name: str
     original_call_id: str | None
@@ -376,6 +384,7 @@ def _resolve_compare_flow_version(execution: Execution) -> str:
 
 
 def serialize_checkpoint_diff(item: CheckpointDiff) -> dict[str, Any]:
+    """Serialize replay-minus-original workload and incurred-cost deltas."""
     return {
         "name": item.name,
         "original_call_id": item.original_call_id,

--- a/src/kitaru/mcp/server.py
+++ b/src/kitaru/mcp/server.py
@@ -535,7 +535,14 @@ def kitaru_executions_diff(
     original: str,
     executions: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Compare an original execution against replay executions."""
+    """Compare an original execution against replay executions.
+
+    Token deltas are replay minus original workload tokens, including reused
+    model work. Cost deltas are replay minus original incurred display cost,
+    where explicitly reused work contributes zero. Token deltas are null only
+    when neither side has canonical usage; cost deltas are null when either side
+    has unpriced work that is not explicitly reused.
+    """
 
     def _diff() -> dict[str, Any]:
         from kitaru.diff import diff, serialize_execution_diff
@@ -555,7 +562,13 @@ def kitaru_executions_diff(
 def kitaru_executions_diff_matrix(
     exec_ids: list[str],
 ) -> dict[str, Any]:
-    """Diff many original executions against their auto-discovered replays."""
+    """Diff originals against replays using workload-token and incurred-cost bases.
+
+    Deltas are replay minus original. Tokens include reused model work; cost
+    excludes explicitly reused work. Token deltas are null only when neither
+    side has canonical usage, while cost deltas are null when either side has
+    unpriced work that is not explicitly reused.
+    """
 
     def _diff_matrix() -> dict[str, Any]:
         from kitaru.diff import diff_matrix, serialize_diff_matrix

--- a/src/kitaru/secrets.py
+++ b/src/kitaru/secrets.py
@@ -46,14 +46,26 @@ class Secret(BaseModel):
 class SecretSummary(BaseModel):
     """Metadata-only view of a stored secret.
 
-    This model is safe to return from write/delete operations because it lists
-    key names but never includes raw secret values.
+    This model never includes raw secret values. ``keys`` is authoritative only
+    when ``keys_known`` is true, including when it is an empty list. When
+    ``keys_known`` is false, the backend did not provide key metadata, so
+    ``keys=[]`` and ``has_missing_values=False`` do not describe the stored
+    values.
+
+    Attributes:
+        name: Secret name.
+        id: Backend secret ID, normalized to a string.
+        private: Whether the backend marks the secret as private.
+        keys: Sorted secret key names when ``keys_known`` is true.
+        keys_known: Whether ``keys`` and ``has_missing_values`` are authoritative.
+        has_missing_values: Whether any known key lacks a readable value.
     """
 
     name: str
     id: str
     private: bool
     keys: list[str]
+    keys_known: bool = True
     has_missing_values: bool = False
 
     model_config = ConfigDict(frozen=True)
@@ -200,7 +212,9 @@ def _secret_from_response(secret_response: Any) -> Secret:
     )
 
 
-def _secret_summary_from_response(secret_response: Any) -> SecretSummary:
+def _secret_summary_from_response(
+    secret_response: Any, *, keys_known: bool
+) -> SecretSummary:
     """Convert a backend secret response into safe metadata."""
     name, secret_id = _extract_backend_name_and_id(secret_response)
 
@@ -208,8 +222,13 @@ def _secret_summary_from_response(secret_response: Any) -> SecretSummary:
         name=name,
         id=secret_id,
         private=bool(getattr(secret_response, "private", False)),
-        keys=_secret_keys_from_response(secret_response),
-        has_missing_values=bool(getattr(secret_response, "has_missing_values", False)),
+        keys=_secret_keys_from_response(secret_response) if keys_known else [],
+        keys_known=keys_known,
+        has_missing_values=(
+            bool(getattr(secret_response, "has_missing_values", False))
+            if keys_known
+            else False
+        ),
     )
 
 
@@ -237,18 +256,23 @@ def list_secrets() -> list[SecretSummary]:
     """
     try:
         client = _ZenMLClient()
-        first_page = client.list_secrets(page=1, size=_SECRETS_BACKEND_SCAN_SIZE)
+        first_page = client.list_secrets(
+            page=1,
+            size=_SECRETS_BACKEND_SCAN_SIZE,
+            hydrate=False,
+        )
         summaries = [
-            _secret_summary_from_response(secret_response)
+            _secret_summary_from_response(secret_response, keys_known=False)
             for secret_response in first_page.items
         ]
 
         for page_number in range(2, first_page.total_pages + 1):
             summaries.extend(
-                _secret_summary_from_response(secret_response)
+                _secret_summary_from_response(secret_response, keys_known=False)
                 for secret_response in client.list_secrets(
                     page=page_number,
                     size=_SECRETS_BACKEND_SCAN_SIZE,
+                    hydrate=False,
                 ).items
             )
 
@@ -306,7 +330,7 @@ def create_secret(
             f"Failed to create secret `{normalized_name}`: {exc}"
         ) from exc
 
-    summary = _secret_summary_from_response(secret_response)
+    summary = _secret_summary_from_response(secret_response, keys_known=True)
     track(
         AnalyticsEvent.SECRET_UPSERTED,
         {"operation": "created", "key_count": len(normalized_values)},
@@ -325,7 +349,7 @@ def delete_secret(name_or_id: str) -> SecretSummary:
         ) from exc
 
     secret_response = _get_secret_response_exact(normalized_name_or_id, client=client)
-    summary = _secret_summary_from_response(secret_response)
+    summary = _secret_summary_from_response(secret_response, keys_known=True)
 
     try:
         client.delete_secret(name_id_or_prefix=summary.id)

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -14,6 +14,7 @@ import pytest
 import kitaru._interface_executions as execution_interface
 import kitaru._interface_stacks as stack_interface
 from kitaru._flow_loading import _load_flow_target as _load_shared_flow_target
+from kitaru._llm_usage import LLM_USAGE_METADATA_KEY, build_usage_record
 from kitaru.client import ExecutionStatistics, ExecutionStatisticsGroup, ExecutionStatus
 from kitaru.config import (
     ActiveEnvironmentVariable,
@@ -566,6 +567,22 @@ def test_executions_get_returns_full_execution(
     sample_execution,
 ) -> None:
     """Get tool should return detailed execution payload."""
+    usage_record = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="write-call",
+        total_tokens=8,
+    )
+    checkpoint = sample_execution.checkpoints[0]
+    attempt = replace(
+        checkpoint.attempts[0],
+        metadata={LLM_USAGE_METADATA_KEY: {"write-call": usage_record}},
+        _checkpoint_name=checkpoint.name,
+    )
+    sample_execution = replace(
+        sample_execution,
+        checkpoints=[replace(checkpoint, attempts=[attempt])],
+    )
     mock_kitaru_client.executions.get.return_value = sample_execution
 
     with patch("kitaru.client.KitaruClient", return_value=mock_kitaru_client):
@@ -573,6 +590,10 @@ def test_executions_get_returns_full_execution(
 
     assert payload["exec_id"] == sample_execution.exec_id
     assert payload["checkpoints"][0]["name"] == "write_summary"
+    attempt_record = payload["checkpoints"][0]["attempts"][0]["llm_usage_records"][0]
+    assert attempt_record["checkpoint_id"] == "attempt-1"
+    assert attempt_record["checkpoint_name"] == "write_summary"
+    assert payload["llm_usage_records"][0]["checkpoint_id"] == "attempt-1"
 
 
 def test_executions_latest_with_stack_filter(
@@ -1533,7 +1554,8 @@ def test_secrets_list_uses_default_pagination() -> None:
             name=f"secret-{index:02d}",
             id=f"secret-id-{index:02d}",
             private=False,
-            keys=["API_KEY"],
+            keys=[],
+            keys_known=False,
         )
         for index in range(25)
     ]
@@ -1557,7 +1579,8 @@ def test_secrets_list_applies_non_default_pagination_without_resorting() -> None
             name=name,
             id=f"secret-id-{index}",
             private=False,
-            keys=["API_KEY"],
+            keys=[],
+            keys_known=False,
         )
         for index, name in enumerate(["zeta", "alpha", "gamma", "beta", "delta"])
     ]
@@ -1581,7 +1604,8 @@ def test_secrets_list_returns_empty_for_out_of_range_page() -> None:
             name="openai-creds",
             id="secret-id",
             private=False,
-            keys=["OPENAI_API_KEY"],
+            keys=[],
+            keys_known=False,
         )
     ]
 
@@ -1600,14 +1624,15 @@ def test_secrets_list_returns_metadata_only_for_public_and_private_secrets() -> 
             name="shared-creds",
             id="public-id",
             private=False,
-            keys=["OPENAI_API_KEY"],
-            has_missing_values=True,
+            keys=[],
+            keys_known=False,
         ),
         SecretSummary(
             name="personal-creds",
             id="private-id",
             private=True,
-            keys=["ANTHROPIC_API_KEY"],
+            keys=[],
+            keys_known=False,
         ),
     ]
 
@@ -1622,14 +1647,16 @@ def test_secrets_list_returns_metadata_only_for_public_and_private_secrets() -> 
             "id": "public-id",
             "name": "shared-creds",
             "visibility": "public",
-            "keys": ["OPENAI_API_KEY"],
-            "has_missing_values": True,
+            "keys": [],
+            "keys_known": False,
+            "has_missing_values": False,
         },
         {
             "id": "private-id",
             "name": "personal-creds",
             "visibility": "private",
-            "keys": ["ANTHROPIC_API_KEY"],
+            "keys": [],
+            "keys_known": False,
             "has_missing_values": False,
         },
     ]
@@ -1642,6 +1669,7 @@ def test_secrets_list_returns_empty_keys_when_backend_omits_value_metadata() -> 
         id="secret-id",
         private=False,
         keys=[],
+        keys_known=False,
         has_missing_values=False,
     )
 
@@ -1657,6 +1685,7 @@ def test_secrets_list_returns_empty_keys_when_backend_omits_value_metadata() -> 
             "name": "provider-creds",
             "visibility": "public",
             "keys": [],
+            "keys_known": False,
             "has_missing_values": False,
         }
     ]
@@ -1714,6 +1743,7 @@ def test_secrets_create_returns_metadata_without_values() -> None:
         "name": "openai-creds",
         "visibility": "public",
         "keys": ["OPENAI_API_KEY"],
+        "keys_known": True,
         "has_missing_values": False,
     }
     assert "values" not in payload

--- a/tests/test_checkpoint_retry_grouping.py
+++ b/tests/test_checkpoint_retry_grouping.py
@@ -3,6 +3,7 @@
 from zenml.client import Client as ZenMLClient
 
 from kitaru import KitaruClient, checkpoint, flow
+from kitaru._llm_usage import build_usage_record, log_usage_record_best_effort
 
 
 def test_real_zenml_retry_maps_to_one_checkpoint_call(
@@ -13,6 +14,14 @@ def test_real_zenml_retry_maps_to_one_checkpoint_call(
     @checkpoint(retries=1, runtime="inline", cache=False)
     def research() -> str:
         calls["count"] += 1
+        log_usage_record_best_effort(
+            build_usage_record(
+                adapter="kitaru.llm",
+                surface="direct_llm",
+                record_id="research-call",
+                total_tokens=calls["count"],
+            )
+        )
         if calls["count"] == 1:
             raise RuntimeError("fail once")
         return "ok"
@@ -87,4 +96,15 @@ def test_real_zenml_retry_maps_to_one_checkpoint_call(
         "failed",
         "completed",
     ]
+    assert [
+        attempt.llm_usage_records[0]["checkpoint_id"]
+        for attempt in checkpoint_call.attempts
+    ] == [str(step.id) for step in raw_attempts]
+    assert [
+        attempt.llm_usage_records[0]["checkpoint_name"]
+        for attempt in checkpoint_call.attempts
+    ] == [checkpoint_call.name, checkpoint_call.name]
+    assert [
+        record["checkpoint_id"] for record in checkpoint_call.llm_usage_records
+    ] == [str(step.id) for step in raw_attempts]
     assert checkpoint_call.failure is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from kitaru._client._statistics import (
     LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS_DISPLAY,
     normalize_execution_statistics_metrics,
 )
+from kitaru._llm_usage import LLM_USAGE_METADATA_KEY, build_usage_record
 from kitaru.analytics import AnalyticsEvent
 from kitaru.cli import (
     ActiveConfigSelectionProvenance,
@@ -148,6 +149,7 @@ def _checkpoint_stub(
     name: str,
     status: ExecutionStatus,
     original_call_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> CheckpointCall:
     """Build a complete checkpoint-call-shaped object for CLI tests."""
     return CheckpointCall(
@@ -162,7 +164,7 @@ def _checkpoint_stub(
         status=status,
         started_at=None,
         ended_at=None,
-        metadata={},
+        metadata=metadata or {},
         original_call_id=original_call_id,
         parent_call_ids=[],
         failure=None,
@@ -2687,6 +2689,12 @@ def test_executions_get_json_contract_is_unchanged(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """Text-only checkpoint guidance must not enter the JSON envelope."""
+    usage_record = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="write-call",
+        total_tokens=8,
+    )
     execution = _execution_stub(
         exec_id="kr-123",
         flow_name="content_pipeline",
@@ -2697,6 +2705,7 @@ def test_executions_get_json_contract_is_unchanged(
                 name="write",
                 status=ExecutionStatus.FAILED,
                 original_call_id="call-write-1",
+                metadata={LLM_USAGE_METADATA_KEY: {"write-call": usage_record}},
             )
         ],
     )
@@ -2710,10 +2719,14 @@ def test_executions_get_json_contract_is_unchanged(
         app(["executions", "get", "kr-123", "--output", "json"])
 
     assert exc_info.value.code == 0
-    assert json.loads(capsys.readouterr().out) == {
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
         "command": "executions.get",
         "item": serialize_execution(cast(Execution, execution)),
     }
+    checkpoint_record = payload["item"]["checkpoints"][0]["llm_usage_records"][0]
+    assert checkpoint_record["checkpoint_id"] == "call-write-2"
+    assert checkpoint_record["checkpoint_name"] == "write"
 
 
 def test_executions_get_renders_malformed_llm_usage_summary_honestly(
@@ -5934,6 +5947,7 @@ def test_secrets_set_json_output_accepts_output_after_assignments(
     assert payload["item"]["name"] == "openai-creds"
     assert payload["item"]["result"] == "created"
     assert payload["item"]["visibility"] == "public"
+    assert payload["item"]["keys_known"] is True
 
 
 def test_secrets_show_hides_values_by_default(
@@ -5997,8 +6011,12 @@ def test_secrets_list_renders_shared_order(
 ) -> None:
     """`kitaru secrets list` should render the SDK's deterministic order."""
     secrets = [
-        SecretSummary(name="alpha", id="secret-a", private=True, keys=[]),
-        SecretSummary(name="zeta", id="secret-z", private=False, keys=[]),
+        SecretSummary(
+            name="alpha", id="secret-a", private=True, keys=[], keys_known=False
+        ),
+        SecretSummary(
+            name="zeta", id="secret-z", private=False, keys=[], keys_known=False
+        ),
     ]
 
     with (
@@ -6021,12 +6039,13 @@ def test_secrets_list_renders_shared_order(
 def test_secrets_list_json_contains_metadata_without_values(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """JSON list output should include key names but never secret values."""
+    """JSON list output should identify unavailable keys without values."""
     secret = SecretSummary(
         name="openai-creds",
         id="secret-id",
         private=True,
-        keys=["OPENAI_API_KEY"],
+        keys=[],
+        keys_known=False,
         has_missing_values=False,
     )
 
@@ -6045,7 +6064,8 @@ def test_secrets_list_json_contains_metadata_without_values(
                 "id": "secret-id",
                 "name": "openai-creds",
                 "visibility": "private",
-                "keys": ["OPENAI_API_KEY"],
+                "keys": [],
+                "keys_known": False,
                 "has_missing_values": False,
             }
         ],
@@ -6058,9 +6078,15 @@ def test_secrets_list_paginates_after_shared_ordering(
 ) -> None:
     """The CLI should slice the complete list after the SDK has ordered it."""
     secrets = [
-        SecretSummary(name="alpha", id="secret-a", private=True, keys=[]),
-        SecretSummary(name="beta", id="secret-b", private=False, keys=[]),
-        SecretSummary(name="zeta", id="secret-z", private=False, keys=[]),
+        SecretSummary(
+            name="alpha", id="secret-a", private=True, keys=[], keys_known=False
+        ),
+        SecretSummary(
+            name="beta", id="secret-b", private=False, keys=[], keys_known=False
+        ),
+        SecretSummary(
+            name="zeta", id="secret-z", private=False, keys=[], keys_known=False
+        ),
     ]
 
     with (

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -151,6 +151,26 @@ def test_checkpoint_diff_uses_canonical_records_for_signed_usage_deltas(
     assert result.cost_delta_usd == expected_cost
 
 
+def test_fully_reused_replay_keeps_workload_tokens_and_avoids_cost() -> None:
+    original = _usage_record(actual_cost_usd=0.25)
+    replay = _usage_record(
+        actual_cost_usd=0.25,
+        billing_effect="reused_not_incurred",
+    )
+
+    result = checkpoint_diff_from_usage_records(
+        original_records=[original],
+        replay_records=[replay],
+    )
+
+    assert result.token_delta == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+    }
+    assert result.cost_delta_usd == -0.25
+
+
 @pytest.mark.parametrize(
     ("original_present", "expected_sign"),
     [(True, -1), (False, 1)],
@@ -207,6 +227,7 @@ def test_checkpoint_diff_distinguishes_no_usage_from_zero_valued_usage() -> None
         (_usage_record(actual_cost_usd=0.0), 0.0),
         (_usage_record(), None),
         (_usage_record(billing_effect="reused_not_incurred"), 0.0),
+        (_usage_record(estimated_cost_usd=0.35, billing_effect="unknown"), 0.35),
         (_usage_record(billing_effect="unknown"), None),
     ],
 )

--- a/tests/test_generate_sdk_docs.py
+++ b/tests/test_generate_sdk_docs.py
@@ -296,7 +296,12 @@ class TestExtractApi:
         secrets_module = filtered.get("modules", {}).get("secrets", {})
 
         assert "Secret" in secrets_module.get("classes", {})
-        assert "SecretSummary" in secrets_module.get("classes", {})
+        secret_summary = secrets_module.get("classes", {})["SecretSummary"]
+        summary_attributes = {
+            attribute["name"] for attribute in secret_summary.get("attributes", [])
+        }
+
+        assert "keys_known" in summary_attributes
         assert "Client" not in secrets_module.get("classes", {})
         assert "ZenKeyError" not in secrets_module.get("classes", {})
         assert "create_secret" in secrets_module.get("functions", {})

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -20,6 +20,7 @@ from kitaru._checkpoint_metadata import (
     adapter_checkpoint_metadata,
 )
 from kitaru._client._mappers import _map_checkpoint_call
+from kitaru._llm_usage import LLM_USAGE_METADATA_KEY, build_usage_record
 from kitaru.client import (
     ArtifactRef,
     CheckpointAttempt,
@@ -77,6 +78,7 @@ from kitaru.inspection import (
     to_jsonable,
     uses_stale_local_server_url,
 )
+from kitaru.secrets import SecretSummary
 
 
 @dataclass(frozen=True)
@@ -148,14 +150,27 @@ def _sample_artifact(name: str = "research_context") -> ArtifactRef:
     )
 
 
+def _sample_llm_usage_record() -> dict[str, Any]:
+    return build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="research-call",
+        total_tokens=12,
+    )
+
+
 def _sample_checkpoint_attempt() -> CheckpointAttempt:
     return CheckpointAttempt(
         attempt_id="attempt-1",
         status=ExecutionStatus.FAILED,
         started_at=datetime(2026, 3, 14, 10, 0, tzinfo=UTC),
         ended_at=datetime(2026, 3, 14, 10, 5, tzinfo=UTC),
-        metadata={"retry": 1},
+        metadata={
+            "retry": 1,
+            LLM_USAGE_METADATA_KEY: {"research-call": _sample_llm_usage_record()},
+        },
         failure=_sample_failure(),
+        _checkpoint_name="research",
     )
 
 
@@ -549,14 +564,23 @@ def test_serialize_checkpoint_attempt_contract() -> None:
         "status": "failed",
         "started_at": "2026-03-14T10:00:00+00:00",
         "ended_at": "2026-03-14T10:05:00+00:00",
-        "metadata": {"retry": 1},
+        "metadata": {
+            "retry": 1,
+            LLM_USAGE_METADATA_KEY: {"research-call": _sample_llm_usage_record()},
+        },
         "failure": {
             "message": "Checkpoint failed",
             "exception_type": "ValueError",
             "traceback": "Traceback...\nValueError: boom",
             "origin": "user_code",
         },
-        "llm_usage_records": [],
+        "llm_usage_records": [
+            {
+                **_sample_llm_usage_record(),
+                "checkpoint_id": "attempt-1",
+                "checkpoint_name": "research",
+            }
+        ],
     }
 
 
@@ -590,14 +614,25 @@ def test_serialize_checkpoint_call_contract() -> None:
                 "status": "failed",
                 "started_at": "2026-03-14T10:00:00+00:00",
                 "ended_at": "2026-03-14T10:05:00+00:00",
-                "metadata": {"retry": 1},
+                "metadata": {
+                    "retry": 1,
+                    LLM_USAGE_METADATA_KEY: {
+                        "research-call": _sample_llm_usage_record()
+                    },
+                },
                 "failure": {
                     "message": "Checkpoint failed",
                     "exception_type": "ValueError",
                     "traceback": "Traceback...\nValueError: boom",
                     "origin": "user_code",
                 },
-                "llm_usage_records": [],
+                "llm_usage_records": [
+                    {
+                        **_sample_llm_usage_record(),
+                        "checkpoint_id": "attempt-1",
+                        "checkpoint_name": "research",
+                    }
+                ],
             }
         ],
         "artifacts": [
@@ -610,7 +645,13 @@ def test_serialize_checkpoint_call_contract() -> None:
                 "metadata": {"source": "notes"},
             }
         ],
-        "llm_usage_records": [],
+        "llm_usage_records": [
+            {
+                **_sample_llm_usage_record(),
+                "checkpoint_id": "attempt-1",
+                "checkpoint_name": "research",
+            }
+        ],
     }
 
 
@@ -741,6 +782,8 @@ def test_serialize_execution_contract() -> None:
     assert payload["original_exec_id"] == "kr-100"
     assert payload["checkpoints"][0]["name"] == "research"
     assert payload["checkpoints"][0]["checkpoint_type"] == "tool_call"
+    assert payload["llm_usage_records"][0]["checkpoint_id"] == "attempt-1"
+    assert payload["llm_usage_records"][0]["checkpoint_name"] == "research"
     assert payload["artifacts"][0]["name"] == "final_summary"
     assert payload["pending_wait"]["wait_id"] == "wait-1"
 
@@ -1601,7 +1644,27 @@ def test_serialize_secret_summary_contract() -> None:
     assert payload["name"] == "openai-credentials"
     assert payload["visibility"] == "public"
     assert payload["keys"] == ["API_KEY", "REGION"]
+    assert payload["keys_known"] is True
     assert payload["has_missing_values"] is True
+
+
+def test_serialize_secret_summary_preserves_unknown_keys() -> None:
+    secret = SecretSummary(
+        name="provider-creds",
+        id="secret-id",
+        private=False,
+        keys=[],
+        keys_known=False,
+    )
+
+    assert serialize_secret_summary(secret) == {
+        "id": "secret-id",
+        "name": "provider-creds",
+        "visibility": "public",
+        "keys": [],
+        "keys_known": False,
+        "has_missing_values": False,
+    }
 
 
 def test_serialize_secret_detail_contract() -> None:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -14,7 +14,10 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
-from kitaru._llm_usage import LLM_USAGE_METADATA_KEY
+from kitaru._llm_usage import (
+    LLM_USAGE_METADATA_KEY,
+    aggregate_usage_records_with_cost_completeness,
+)
 from kitaru.analytics import AnalyticsEvent
 from kitaru.config import (
     ResolvedModelSelection,
@@ -1472,9 +1475,17 @@ def test_llm_mock_response_skips_provider_sdk(
     assert output == "mocked answer"
     mock_openai.assert_not_called()
     mock_anthropic.assert_not_called()
-    # Artifacts and metadata should still be persisted
+    # Artifacts and metadata should still be persisted.
     mock_save.assert_called()
     mock_log.assert_called_once()
+    usage_record = _single_usage_record(mock_log)
+    assert usage_record["billing_effect"] == "unknown"
+    summary, has_unpriced_incurred_record = (
+        aggregate_usage_records_with_cost_completeness([usage_record])
+    )
+    assert summary["incurred_usage_record_count"] == 1
+    assert summary["incurred_total_tokens"] == 0
+    assert has_unpriced_incurred_record is True
 
 
 def test_llm_mock_response_works_with_unsupported_provider(

--- a/tests/test_llm_usage.py
+++ b/tests/test_llm_usage.py
@@ -20,6 +20,7 @@ from kitaru._llm_usage import (
     LLM_FLAT_INCURRED_USAGE_RECORD_COUNT_KEY,
     LLM_FLAT_REUSED_TOTAL_TOKENS_KEY,
     LLM_FLAT_REUSED_USAGE_RECORD_COUNT_KEY,
+    LLM_USAGE_COST_POLICY,
     LLM_USAGE_METADATA_KEY,
     LLM_USAGE_SUMMARY_METADATA_KEY,
     LLMBillingEffect,
@@ -35,6 +36,7 @@ from kitaru._llm_usage import (
     execution_metadata_from_records,
     flat_usage_metadata_from_records,
     log_usage_record_best_effort,
+    metadata_has_complete_usage_summary,
     metadata_matches_flat_usage_metadata,
     parse_usage_summary,
     usage_records_from_metadata,
@@ -637,6 +639,42 @@ def test_aggregate_preserves_explicit_zero_total_tokens() -> None:
     assert summary["incurred_total_tokens"] == 0
 
 
+def test_unknown_priced_record_uses_conservative_incurred_accounting() -> None:
+    record = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        input_tokens=11,
+        output_tokens=4,
+        total_tokens=17,
+        actual_cost_usd=0.25,
+        estimated_cost_usd=0.4,
+        billing_effect="unknown",
+    )
+
+    summary, has_unpriced_incurred_record = (
+        aggregate_usage_records_with_cost_completeness([record])
+    )
+
+    assert summary["cost_policy"] == LLM_USAGE_COST_POLICY
+    assert summary["usage_record_count"] == 1
+    assert summary["incurred_usage_record_count"] == 1
+    assert summary["reused_usage_record_count"] == 0
+    assert summary["input_tokens"] == 11
+    assert summary["output_tokens"] == 4
+    assert summary["total_tokens"] == 17
+    assert summary["incurred_input_tokens"] == 11
+    assert summary["incurred_output_tokens"] == 4
+    assert summary["incurred_total_tokens"] == 17
+    assert summary["reused_input_tokens"] == 0
+    assert summary["reused_output_tokens"] == 0
+    assert summary["reused_total_tokens"] == 0
+    assert summary["actual_cost_usd"] == 0.25
+    assert summary["estimated_cost_usd"] == 0.4
+    assert summary["display_cost_usd"] == 0.25
+    assert summary["records_without_cost_count"] == 0
+    assert has_unpriced_incurred_record is False
+
+
 def test_reused_records_do_not_add_incurred_cost_or_tokens() -> None:
     record = build_usage_record(
         adapter="pydantic_ai",
@@ -661,12 +699,15 @@ def test_reused_records_do_not_add_incurred_cost_or_tokens() -> None:
 
 
 @pytest.mark.parametrize(
-    ("billing_effect", "expected_missing_cost_count"),
-    [("reused_not_incurred", 0), ("unknown", 1)],
+    ("billing_effect", "expected_incurred"),
+    [
+        ("reused_not_incurred", False),
+        ("unknown", True),
+    ],
 )
 def test_unpriced_records_track_internal_cost_completeness(
     billing_effect: LLMBillingEffect,
-    expected_missing_cost_count: int,
+    expected_incurred: bool,
 ) -> None:
     record = build_usage_record(
         adapter="pydantic_ai",
@@ -676,13 +717,89 @@ def test_unpriced_records_track_internal_cost_completeness(
         billing_effect=billing_effect,
     )
 
-    summary, has_unpriced_non_reused_record = (
+    summary, has_unpriced_incurred_record = (
         aggregate_usage_records_with_cost_completeness([record])
     )
 
+    assert summary["usage_record_count"] == 1
+    assert summary["incurred_usage_record_count"] == int(expected_incurred)
+    assert summary["reused_usage_record_count"] == int(not expected_incurred)
+    assert summary["total_tokens"] == 15
+    assert summary["incurred_total_tokens"] == (15 if expected_incurred else 0)
+    assert summary["reused_total_tokens"] == (0 if expected_incurred else 15)
+    assert summary["actual_cost_usd"] == 0.0
+    assert summary["estimated_cost_usd"] == 0.0
+    assert summary["display_cost_usd"] == 0.0
     assert summary["records_without_cost_count"] == 1
-    assert has_unpriced_non_reused_record is bool(expected_missing_cost_count)
+    assert has_unpriced_incurred_record is expected_incurred
     assert "non_reused_records_without_cost_count" not in summary
+
+
+def test_mixed_unknown_records_keep_cost_completeness_conservative() -> None:
+    priced_unknown = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        input_tokens=10,
+        output_tokens=5,
+        estimated_cost_usd=0.3,
+        billing_effect="unknown",
+    )
+    unpriced_unknown = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        input_tokens=6,
+        output_tokens=3,
+        billing_effect="unknown",
+    )
+    reused = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        input_tokens=100,
+        output_tokens=20,
+        billing_effect="reused_not_incurred",
+    )
+
+    summary, has_unpriced_incurred_record = (
+        aggregate_usage_records_with_cost_completeness(
+            [priced_unknown, unpriced_unknown, reused]
+        )
+    )
+
+    assert summary["usage_record_count"] == 3
+    assert summary["incurred_usage_record_count"] == 2
+    assert summary["reused_usage_record_count"] == 1
+    assert summary["input_tokens"] == 116
+    assert summary["output_tokens"] == 28
+    assert summary["total_tokens"] == 144
+    assert summary["incurred_input_tokens"] == 16
+    assert summary["incurred_output_tokens"] == 8
+    assert summary["incurred_total_tokens"] == 24
+    assert summary["reused_input_tokens"] == 100
+    assert summary["reused_output_tokens"] == 20
+    assert summary["reused_total_tokens"] == 120
+    assert summary["actual_cost_usd"] == 0.0
+    assert summary["estimated_cost_usd"] == 0.3
+    assert summary["display_cost_usd"] == 0.3
+    assert summary["records_without_cost_count"] == 2
+    assert has_unpriced_incurred_record is True
+
+
+def test_old_usage_cost_policy_is_not_trusted_as_current() -> None:
+    record = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        total_tokens=1,
+        actual_cost_usd=0.0,
+    )
+    metadata = execution_metadata_from_records([record])
+
+    assert metadata_has_complete_usage_summary(metadata) is True
+    summary = parse_usage_summary(metadata[LLM_USAGE_SUMMARY_METADATA_KEY])
+    assert summary is not None
+    summary["cost_policy"] = "display cost prefers actual cost, then estimated cost"
+    metadata[LLM_USAGE_SUMMARY_METADATA_KEY] = summary
+
+    assert metadata_has_complete_usage_summary(metadata) is False
 
 
 def test_retry_attempts_with_same_record_id_are_counted_separately() -> None:
@@ -714,6 +831,45 @@ def test_retry_attempts_with_same_record_id_are_counted_separately() -> None:
 
     assert summary["usage_record_count"] == 2
     assert summary["incurred_total_tokens"] == 24
+
+
+def test_usage_record_defaults_only_fill_missing_checkpoint_identity() -> None:
+    missing_identity = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="missing-identity",
+        total_tokens=5,
+    )
+    explicit_identity = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="explicit-identity",
+        checkpoint_id="producer-checkpoint-id",
+        checkpoint_name="producer_checkpoint_name",
+        total_tokens=7,
+    )
+
+    records = usage_records_from_metadata(
+        {
+            LLM_USAGE_METADATA_KEY: {
+                "missing": missing_identity,
+                "explicit": explicit_identity,
+            }
+        },
+        default_checkpoint_id="attempt-1",
+        default_checkpoint_name="model_call",
+    )
+
+    records_by_id = {record["record_id"]: record for record in records}
+    assert records_by_id["missing-identity"]["checkpoint_id"] == "attempt-1"
+    assert records_by_id["missing-identity"]["checkpoint_name"] == "model_call"
+    assert (
+        records_by_id["explicit-identity"]["checkpoint_id"] == "producer-checkpoint-id"
+    )
+    assert (
+        records_by_id["explicit-identity"]["checkpoint_name"]
+        == "producer_checkpoint_name"
+    )
 
 
 def test_duplicate_record_from_same_attempt_is_counted_once() -> None:
@@ -1084,6 +1240,8 @@ def test_cached_checkpoint_attempt_public_records_are_marked_reused() -> None:
     assert records[0]["billing_effect"] == "reused_not_incurred"
     assert records[0]["cache_status"] == "checkpoint_cache_hit"
     assert records[0]["cost"]["actual_cost_usd"] == 1.25
+    assert records[0]["checkpoint_id"] == "attempt-cached"
+    assert records[0]["checkpoint_name"] == "cached_call"
     assert "_source_attempt_id" not in records[0]
 
 
@@ -1121,6 +1279,8 @@ def test_replay_like_mapped_attempt_preserves_persisted_incurred_record() -> Non
     assert len(records) == 1
     assert records[0]["billing_effect"] == "incurred"
     assert records[0]["cache_status"] == "executed"
+    assert records[0]["checkpoint_id"] == "attempt-mapped-tail"
+    assert records[0]["checkpoint_name"] == "write"
 
 
 def test_mapped_execution_uses_replay_skip_metadata_for_public_records(
@@ -1229,6 +1389,7 @@ def test_replay_like_raw_status_preserves_persisted_incurred_record() -> None:
         ended_at=None,
         metadata={LLM_USAGE_METADATA_KEY: {"replay-tail-call": record}},
         failure=None,
+        _checkpoint_name="write",
         _raw_status="replay_reused",
     )
 
@@ -1237,6 +1398,8 @@ def test_replay_like_raw_status_preserves_persisted_incurred_record() -> None:
     assert len(records) == 1
     assert records[0]["billing_effect"] == "incurred"
     assert records[0]["cache_status"] == "executed"
+    assert records[0]["checkpoint_id"] == "attempt-tail"
+    assert records[0]["checkpoint_name"] == "write"
 
 
 def test_replay_skipped_attempt_public_records_are_marked_reused() -> None:
@@ -1255,6 +1418,7 @@ def test_replay_skipped_attempt_public_records_are_marked_reused() -> None:
         ended_at=None,
         metadata={LLM_USAGE_METADATA_KEY: {"replay-upstream-call": record}},
         failure=None,
+        _checkpoint_name="fetch",
         _raw_status="replay_reused",
         _replay_reused=True,
     )
@@ -1264,6 +1428,33 @@ def test_replay_skipped_attempt_public_records_are_marked_reused() -> None:
     assert len(records) == 1
     assert records[0]["billing_effect"] == "reused_not_incurred"
     assert records[0]["cache_status"] == "replay_reused"
+    assert records[0]["checkpoint_id"] == "attempt-upstream"
+    assert records[0]["checkpoint_name"] == "fetch"
+
+
+def test_checkpoint_call_usage_record_fallback_uses_call_identity() -> None:
+    record = build_usage_record(
+        adapter="kitaru.llm",
+        surface="direct_llm",
+        record_id="call-fallback",
+        total_tokens=5,
+    )
+    checkpoint = CheckpointCall(
+        call_id="call-1",
+        name="model_call",
+        status=ExecutionStatus.COMPLETED,
+        started_at=None,
+        ended_at=None,
+        metadata={LLM_USAGE_METADATA_KEY: {"fallback": record}},
+        original_call_id=None,
+        parent_call_ids=[],
+        failure=None,
+        attempts=[],
+        artifacts=[],
+    )
+
+    assert checkpoint.llm_usage_records[0]["checkpoint_id"] == "call-1"
+    assert checkpoint.llm_usage_records[0]["checkpoint_name"] == "model_call"
 
 
 def test_execution_llm_usage_records_include_unique_run_level_records() -> None:
@@ -1281,6 +1472,14 @@ def test_execution_llm_usage_records_include_unique_run_level_records() -> None:
         event_id="run-only-event",
         total_tokens=7,
     )
+    attributed_run_record = build_usage_record(
+        adapter="openai_agents",
+        surface="runner_call",
+        record_id="attributed-run",
+        checkpoint_id="producer-checkpoint-id",
+        checkpoint_name="producer_checkpoint",
+        total_tokens=3,
+    )
     duplicate_run_record = dict(checkpoint_record)
     attempt = CheckpointAttempt(
         attempt_id="attempt-1",
@@ -1289,6 +1488,7 @@ def test_execution_llm_usage_records_include_unique_run_level_records() -> None:
         ended_at=None,
         metadata={LLM_USAGE_METADATA_KEY: {"checkpoint": checkpoint_record}},
         failure=None,
+        _checkpoint_name="model_call",
     )
     checkpoint = CheckpointCall(
         call_id="call-1",
@@ -1315,6 +1515,7 @@ def test_execution_llm_usage_records_include_unique_run_level_records() -> None:
             LLM_USAGE_METADATA_KEY: {
                 "duplicate": duplicate_run_record,
                 "run-only": run_level_record,
+                "attributed-run": attributed_run_record,
             }
         },
         status_reason=None,
@@ -1331,6 +1532,14 @@ def test_execution_llm_usage_records_include_unique_run_level_records() -> None:
 
     assert [record["record_id"] for record in records] == [
         "run-only",
+        "attributed-run",
         "same-record",
     ]
+    records_by_id = {record["record_id"]: record for record in records}
+    assert records_by_id["run-only"]["checkpoint_id"] is None
+    assert records_by_id["run-only"]["checkpoint_name"] is None
+    assert records_by_id["attributed-run"]["checkpoint_id"] == "producer-checkpoint-id"
+    assert records_by_id["attributed-run"]["checkpoint_name"] == "producer_checkpoint"
+    assert records_by_id["same-record"]["checkpoint_id"] == "attempt-1"
+    assert records_by_id["same-record"]["checkpoint_name"] == "model_call"
     assert all("_source_attempt_id" not in record for record in records)

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -15,6 +15,7 @@ from kitaru.secrets import (
     Secret,
     SecretSummary,
     _read_secret_values,
+    _secret_summary_from_response,
     create_secret,
     delete_secret,
     get_secret,
@@ -68,15 +69,15 @@ def test_list_secrets_scans_all_backend_pages_at_fixed_size() -> None:
         summaries = list_secrets()
 
     assert client.list_secrets.call_args_list == [
-        call(page=1, size=50),
-        call(page=2, size=50),
-        call(page=3, size=50),
+        call(page=1, size=50, hydrate=False),
+        call(page=2, size=50, hydrate=False),
+        call(page=3, size=50, hydrate=False),
     ]
     assert [summary.name for summary in summaries] == ["alpha", "bravo", "charlie"]
 
 
 def test_list_secrets_returns_metadata_without_raw_values() -> None:
-    """SDK listing should normalize IDs and expose key names, not values."""
+    """SDK listing should not infer key metadata or expose raw values."""
     client = Mock()
     client.list_secrets.return_value = SimpleNamespace(
         items=[
@@ -99,9 +100,11 @@ def test_list_secrets_returns_metadata_without_raw_values() -> None:
         "name": "provider-creds",
         "id": "123",
         "private": True,
-        "keys": ["A_KEY", "Z_TOKEN"],
-        "has_missing_values": True,
+        "keys": [],
+        "keys_known": False,
+        "has_missing_values": False,
     }
+    client.get_secret.assert_not_called()
 
 
 def test_list_secrets_returns_empty_keys_without_backend_values() -> None:
@@ -128,6 +131,7 @@ def test_list_secrets_returns_empty_keys_without_backend_values() -> None:
             id="secret-id",
             private=False,
             keys=[],
+            keys_known=False,
             has_missing_values=False,
         )
     ]
@@ -189,8 +193,8 @@ def test_list_secrets_maps_later_page_failure_to_backend_error() -> None:
         list_secrets()
 
     assert client.list_secrets.call_args_list == [
-        call(page=1, size=50),
-        call(page=2, size=50),
+        call(page=1, size=50, hydrate=False),
+        call(page=2, size=50, hydrate=False),
     ]
 
 
@@ -283,12 +287,31 @@ def test_create_secret_creates_public_secret_by_default() -> None:
         id="123",
         private=False,
         keys=["COUNT", "OPENAI_API_KEY"],
+        keys_known=True,
         has_missing_values=False,
     )
     track_mock.assert_called_once_with(
         AnalyticsEvent.SECRET_UPSERTED,
         {"operation": "created", "key_count": 2},
     )
+
+
+def test_secret_summary_marks_authoritative_empty_keys_as_known() -> None:
+    """An authoritative empty mapping should remain distinguishable."""
+    summary = _secret_summary_from_response(
+        SimpleNamespace(
+            name="empty-creds",
+            id="secret-id",
+            private=False,
+            values={},
+            has_missing_values=False,
+        ),
+        keys_known=True,
+    )
+
+    assert summary.keys == []
+    assert summary.keys_known is True
+    assert summary.has_missing_values is False
 
 
 def test_create_secret_forwards_private_flag() -> None:
@@ -315,6 +338,7 @@ def test_create_secret_forwards_private_flag() -> None:
         private=True,
     )
     assert summary.private is True
+    assert summary.keys_known is True
 
 
 @pytest.mark.parametrize(
@@ -405,6 +429,7 @@ def test_delete_secret_resolves_exact_secret_and_deletes_by_id() -> None:
         id="123",
         private=False,
         keys=["OPENAI_API_KEY"],
+        keys_known=True,
     )
 
 


### PR DESCRIPTION
## Summary

- attribute canonical LLM usage records to the physical checkpoint attempt that produced or reused them
- distinguish unknown secret key metadata from an authoritative empty key list without hydrating every secret
- count every record as incurred unless it is explicitly reused, and invalidate summaries written under the previous accounting policy
- clarify that checkpoint diff tokens measure workload while cost measures incurred/display spend
- update regression coverage, SDK/CLI/MCP contracts, docs, smoke assertions, and the changelog

## Why

Issue #566 identified four places where the reported shape or terminology could mislead consumers even though the underlying provider usage was generally recorded correctly. These changes repair the reporting boundaries without adding Kitaru-specific persistence, N+1 secret reads, or new diff payload fields.

## Key decisions

- Checkpoint identity is filled at the SDK read boundary from the physical ZenML step-run attempt. Explicit producer identity remains authoritative, and true execution-level records remain unattributed.
- `SecretSummary.keys_known` is additive. List responses use `false` because ZenML intentionally omits key metadata; create and delete summaries remain authoritative.
- Only `reused_not_incurred` is classified as non-incurred. A stable policy token causes older derived summaries to be recomputed when normal aggregation runs, without an eager migration.
- Existing `token_delta` and `cost_delta_usd` fields and arithmetic are unchanged. Their different accounting bases are now explicit.

## Reviewer Notes

The main behavior now converges at shared SDK boundaries. Checkpoint records are enriched while metadata is mapped into `CheckpointAttempt` and `CheckpointCall`, so SDK inspection, CLI JSON, and MCP all receive the same identity. The highest-risk detail is retry attribution: earlier attempts must keep their own step-run IDs rather than inheriting the visible checkpoint call's final ID.

Secret listing deliberately does not fetch individual secrets. Review the `keys_known` transition together with the shared serializer: `keys=[]` with `keys_known=false` means the backend did not provide key metadata, not that the secret is empty. No values should appear in list output.

For accounting, review the single non-reused predicate and the exact policy-token check together. Reused work must retain workload tokens while contributing no incurred cost, and old derived summaries must not be trusted under the new rule.

### Reproduction

1. Run the retry regression and confirm the two usage records receive distinct physical attempt IDs:
   ```bash
   just test tests/test_checkpoint_retry_grouping.py
   ```
2. With a local Kitaru server, create a secret and inspect list JSON:
   ```bash
   uv run kitaru secrets set review-secret API_KEY=test-value
   uv run kitaru secrets list --output json
   uv run kitaru secrets delete review-secret
   ```
   The list item should contain `"keys": []` and `"keys_known": false`, and must not contain the value.
3. Run the accounting and diff regressions:
   ```bash
   just test tests/test_llm_usage.py tests/test_diff.py
   ```
   The reused replay case keeps a zero workload-token delta while reporting lower incurred cost; priced and unpriced `unknown` records follow the conservative incurred rule.

Local checks run: `just check`; full `just test` with 3,618 passed and 21 skipped. The environment-dependent end-to-end smoke suite was not run.

Fixes #566
