### PR TITLE
Fix retry parent call IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Detailed execution graphs now resolve downstream parent call IDs to the visible successful checkpoint after a retry, instead of retaining the hidden failed attempt ID. (#564)
+
 ## [0.21.0] - 2026-07-14
 
 ### Added

--- a/src/kitaru/_client/_mappers.py
+++ b/src/kitaru/_client/_mappers.py
@@ -356,6 +356,7 @@ def _map_checkpoint_call(
     client: KitaruClient,
     attempts_by_lineage: Mapping[str, list[StepRunResponse]],
     replay_skipped_steps: set[str] | None = None,
+    visible_call_id_by_attempt_id: Mapping[str, str] | None = None,
 ) -> CheckpointCall:
     """Map a ZenML step run into a Kitaru checkpoint call."""
     producing_call = _normalize_checkpoint_name(step.name)
@@ -429,6 +430,13 @@ def _map_checkpoint_call(
     if step.original_step_run_id is not None:
         original_call_id = str(step.original_step_run_id)
 
+    parent_call_ids = [str(parent_id) for parent_id in step.parent_step_ids]
+    if visible_call_id_by_attempt_id is not None:
+        parent_call_ids = [
+            visible_call_id_by_attempt_id.get(parent_id, parent_id)
+            for parent_id in parent_call_ids
+        ]
+
     return CheckpointCall(
         call_id=str(step.id),
         name=producing_call,
@@ -437,7 +445,7 @@ def _map_checkpoint_call(
         ended_at=step.end_time,
         metadata=metadata,
         original_call_id=original_call_id,
-        parent_call_ids=[str(parent_id) for parent_id in step.parent_step_ids],
+        parent_call_ids=parent_call_ids,
         failure=failure,
         attempts=attempts,
         artifacts=artifacts,
@@ -671,6 +679,12 @@ def _map_execution(
             if visible_step is not None:
                 latest_steps_by_lineage[lineage_key] = visible_step
 
+        visible_call_id_by_attempt_id = {
+            str(attempt.id): str(visible_step.id)
+            for lineage_key, visible_step in latest_steps_by_lineage.items()
+            for attempt in attempts_by_lineage[lineage_key]
+        }
+
         for step in latest_steps_by_lineage.values():
             checkpoints.append(
                 _map_checkpoint_call(
@@ -678,6 +692,7 @@ def _map_execution(
                     client=client,
                     attempts_by_lineage=attempts_by_lineage,
                     replay_skipped_steps=replay_skipped_steps,
+                    visible_call_id_by_attempt_id=visible_call_id_by_attempt_id,
                 )
             )
 

--- a/tests/test_checkpoint_retry_grouping.py
+++ b/tests/test_checkpoint_retry_grouping.py
@@ -17,9 +17,13 @@ def test_real_zenml_retry_maps_to_one_checkpoint_call(
             raise RuntimeError("fail once")
         return "ok"
 
+    @checkpoint(runtime="inline", cache=False)
+    def publish(result: str) -> str:
+        return f"published: {result}"
+
     @flow(cache=False)
     def retry_once() -> None:
-        research()
+        publish(research())
 
     handle = retry_once.run()
     handle.wait()
@@ -46,6 +50,7 @@ def test_real_zenml_retry_maps_to_one_checkpoint_call(
                 if step.original_step_run_id is not None
                 else None
             ),
+            "parent_step_ids": [str(parent_id) for parent_id in step.parent_step_ids],
             "invocation_id": step.spec.invocation_id,
             "created": step.created,
             "start_time": step.start_time,
@@ -53,21 +58,27 @@ def test_real_zenml_retry_maps_to_one_checkpoint_call(
         }
         for step in raw_attempts
     ]
+    research_attempts = [step for step in raw_attempts if step.name == "research"]
+    publish_attempts = [step for step in raw_attempts if step.name == "publish"]
 
     assert calls["count"] == 2
-    assert len(raw_attempts) == 2, diagnostics
-    assert [step.version for step in raw_attempts] == [1, 2], diagnostics
-    assert len({step.name for step in raw_attempts}) == 1, diagnostics
+    assert len(raw_attempts) == 3, diagnostics
+    assert len(research_attempts) == 2, diagnostics
+    assert len(publish_attempts) == 1, diagnostics
+    assert [step.version for step in research_attempts] == [1, 2], diagnostics
     assert [step.spec.invocation_id for step in raw_attempts] == [
         step.name for step in raw_attempts
     ], diagnostics
-    assert [step.original_step_run_id for step in raw_attempts] == [None, None], (
-        diagnostics
-    )
-    assert [step.status.value for step in raw_attempts] == [
+    assert [step.original_step_run_id for step in raw_attempts] == [
+        None,
+        None,
+        None,
+    ], diagnostics
+    assert [step.status.value for step in research_attempts] == [
         "retried",
         "completed",
     ], diagnostics
+    assert publish_attempts[0].status.value == "completed", diagnostics
     assert all(
         step.created is not None
         and step.start_time is not None
@@ -75,16 +86,31 @@ def test_real_zenml_retry_maps_to_one_checkpoint_call(
         for step in raw_attempts
     ), diagnostics
 
+    hidden_retried_id = str(research_attempts[0].id)
+    visible_successful_id = str(research_attempts[1].id)
+    raw_publish_parent_ids = [
+        str(parent_id) for parent_id in publish_attempts[0].parent_step_ids
+    ]
+    assert raw_publish_parent_ids == [hidden_retried_id], diagnostics
+    assert raw_publish_parent_ids != [visible_successful_id], diagnostics
+
     execution = KitaruClient().executions.get(handle.exec_id)
 
-    assert len(execution.checkpoints) == 1
-    checkpoint_call = execution.checkpoints[0]
-    assert checkpoint_call.status.value == "completed"
-    assert [attempt.attempt_id for attempt in checkpoint_call.attempts] == [
-        str(step.id) for step in raw_attempts
+    assert len(execution.checkpoints) == 2
+    checkpoints_by_name = {
+        checkpoint_call.name: checkpoint_call
+        for checkpoint_call in execution.checkpoints
+    }
+    research_call = checkpoints_by_name["research"]
+    publish_call = checkpoints_by_name["publish"]
+    assert research_call.call_id == visible_successful_id
+    assert research_call.status.value == "completed"
+    assert [attempt.attempt_id for attempt in research_call.attempts] == [
+        str(step.id) for step in research_attempts
     ]
-    assert [attempt.status.value for attempt in checkpoint_call.attempts] == [
+    assert [attempt.status.value for attempt in research_call.attempts] == [
         "failed",
         "completed",
     ]
-    assert checkpoint_call.failure is None
+    assert research_call.failure is None
+    assert publish_call.parent_call_ids == [research_call.call_id]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -193,6 +193,7 @@ class _DummyStep:
         step_id: UUID | None = None,
         version: int = 1,
         original_step_run_id: UUID | None = None,
+        parent_step_ids: list[UUID] | None = None,
         run_metadata: dict[str, Any] | None = None,
         exception_traceback: str | None = None,
         spec: Any | None = None,
@@ -206,7 +207,7 @@ class _DummyStep:
         self.end_time = None
         self.run_metadata = run_metadata or {}
         self.original_step_run_id = original_step_run_id
-        self.parent_step_ids: list[UUID] = []
+        self.parent_step_ids = list(parent_step_ids or [])
         self.inputs = inputs or {}
         self.outputs = outputs
         self.spec = spec
@@ -2575,6 +2576,69 @@ def test_get_surfaces_checkpoint_attempt_history() -> None:
     assert checkpoint.attempts[1].status == ExecutionStatus.COMPLETED
     assert checkpoint.attempts[1].failure is None
     assert checkpoint.failure is None
+
+
+def test_get_normalizes_retry_parent_ids_to_visible_checkpoint_calls() -> None:
+    hidden_attempt = _DummyStep(
+        name="research",
+        version=1,
+        status=ZenMLExecutionStatus.RETRIED,
+        outputs={},
+    )
+    visible_attempt = _DummyStep(
+        name="research",
+        version=2,
+        status=ZenMLExecutionStatus.COMPLETED,
+        outputs={},
+    )
+    downstream = _DummyStep(
+        name="publish",
+        status=ZenMLExecutionStatus.COMPLETED,
+        outputs={},
+        parent_step_ids=[hidden_attempt.id],
+    )
+    run = _DummyRun(
+        status=ZenMLExecutionStatus.COMPLETED,
+        flow_name="flow_a",
+        steps={
+            visible_attempt.name: visible_attempt,
+            downstream.name: downstream,
+        },
+    )
+
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection(),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
+        client_mock.list_run_steps.return_value = SimpleNamespace(
+            items=[
+                _as_step_run(hidden_attempt),
+                _as_step_run(visible_attempt),
+                _as_step_run(downstream),
+            ]
+        )
+
+        client = KitaruClient()
+        execution = client.executions.get(str(run.id))
+
+    checkpoints_by_name = {
+        checkpoint.name: checkpoint for checkpoint in execution.checkpoints
+    }
+    assert checkpoints_by_name["research"].call_id == str(visible_attempt.id)
+    assert checkpoints_by_name["publish"].parent_call_ids == [
+        checkpoints_by_name["research"].call_id
+    ]
+    public_call_ids = {checkpoint.call_id for checkpoint in execution.checkpoints}
+    assert all(
+        parent_call_id in public_call_ids
+        for checkpoint in execution.checkpoints
+        for parent_call_id in checkpoint.parent_call_ids
+    )
 
 
 def test_get_merges_run_step_into_partial_attempt_history() -> None:


### PR DESCRIPTION
## Summary

- map every retry attempt ID to the visible checkpoint call ID when building detailed execution graphs
- preserve unknown parent IDs and existing degraded-history behavior
- cover the behavior with deterministic mapper and real-ZenML regressions
- document the fix in the changelog

## Reviewer Notes

Reproduce the original behavior with the real-runtime regression:

```bash
uv sync --extra local
uv run kitaru init
just test -n 0 tests/test_checkpoint_retry_grouping.py::test_real_zenml_retry_maps_to_one_checkpoint_call
```

The test confirms that ZenML records the downstream checkpoint's raw parent as the hidden retried attempt, while Kitaru now exposes the selected successful checkpoint ID in `parent_call_ids`.

Additional validation completed:

- `just check`
- `just test`: 3,602 passed, 29 skipped
- `git diff --check`

Fixes #564
