### PR TITLE
Improve execution diff visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Execution diffs now reject blank selectors and explicit comparisons without recorded direct replay lineage, while deduplicating repeated selectors and aliases in first-occurrence order. (#565)
+- `kitaru executions diff` now shows useful checkpoint comparison rows in its default text output, and diff serialization includes redacted evidence that replay output overrides were applied without exposing override values. (#563)
 
 ## [0.21.0] - 2026-07-14
 

--- a/docs/book/guides/replay-and-overrides.md
+++ b/docs/book/guides/replay-and-overrides.md
@@ -449,9 +449,64 @@ for row in matrix.rows:
 CLI:
 
 ```bash
+# Compact checkpoint comparison in the default text output
+kitaru executions diff kr-original kr-replay-a
+
+# Complete structured results
 kitaru executions diff kr-original kr-replay-a -o json
 kitaru executions diff-matrix kr-a kr-b kr-c -o json
 ```
+
+The default `executions diff` output shows one row per checkpoint for each compared replay:
+
+```text
+Diff for kr-original
+  Compared against 1 replay execution(s).
+Checkpoint differences
+  Replay        Checkpoint          Result    Input Δ   Output Δ   Total Δ   Cost Δ (USD)
+  ------------  ------------------  --------  --------  ---------  --------  ------------
+  kr-replay-a   research            match     +0        +0         +0        +0.000000
+  kr-replay-a   write_draft         changed   -120      +40        -80       -0.001700
+Applied output overrides [kr-replay-a]:
+  checkpoint family 'research' -> research, research_2
+```
+
+The table reports `changed` when checkpoint status, token usage, cost, or
+artifact hashes differ. It uses `original only` when a source checkpoint has no
+replay match and `replay only` when a new checkpoint appears only in the replay. `n/a` means the
+corresponding token or cost delta is unavailable. `executions diff-matrix` keeps
+its existing summary-only text output.
+
+Each replay entry in JSON has an additive `applied_output_overrides` field. It
+contains only the selector, selector kind, resolved checkpoint invocation IDs,
+and the fact that the `output` field was overridden:
+
+```json
+{
+  "replay_exec_id": "kr-replay-a",
+  "applied_output_overrides": [
+    {
+      "selector_kind": "checkpoint",
+      "selector": "research",
+      "matched_invocation_ids": ["research", "research_2"],
+      "field": "output"
+    }
+  ]
+}
+```
+
+The replacement value is never included. `applied_output_overrides: null` means
+the evidence is unavailable, as with an older replay or malformed metadata.
+`applied_output_overrides: []` proves that the replay was recorded with no
+output override. Matrix JSON includes the same field inside each compared replay.
+This is submission-time evidence from the resolved replay plan, not confirmation
+that a downstream checkpoint completed; use the checkpoint status rows to see
+what actually ran.
+
+An output override remains a downstream injection, not a replacement artifact.
+Kitaru skips the targeted checkpoint, passes the supplied value to downstream
+checkpoint inputs, and continues to report the source checkpoint's recorded
+artifact. Its original and replay artifact hashes therefore remain the same.
 
 Checkpoint token and cost deltas in JSON output are always calculated as
 **replay minus original**. For example:

--- a/src/kitaru/_cli/_executions.py
+++ b/src/kitaru/_cli/_executions.py
@@ -87,6 +87,125 @@ def _print_diff_warnings(payload: Mapping[str, Any]) -> None:
         _print_warning(f"Warning: {warning}")
 
 
+def _format_diff_delta(value: Any, *, decimal_places: int | None = None) -> str:
+    """Format one signed numeric delta for compact diff output."""
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return "n/a"
+    if isinstance(value, float) and not math.isfinite(value):
+        return "n/a"
+    if decimal_places is None:
+        return f"{value:+d}" if isinstance(value, int) else "n/a"
+    return f"{value:+.{decimal_places}f}"
+
+
+def _checkpoint_diff_status(checkpoint: Mapping[str, Any]) -> str:
+    """Return the compact result label for one checkpoint diff."""
+    original_present = checkpoint.get("original_call_id") is not None
+    replay_present = checkpoint.get("replay_call_id") is not None
+    if original_present and not replay_present:
+        return "original only"
+    if replay_present and not original_present:
+        return "replay only"
+    if checkpoint.get("status_match") is not True:
+        return "changed"
+
+    token_delta = checkpoint.get("token_delta")
+    if isinstance(token_delta, Mapping) and any(
+        isinstance(value, int | float) and not isinstance(value, bool) and value != 0
+        for value in token_delta.values()
+    ):
+        return "changed"
+
+    cost_delta = checkpoint.get("cost_delta_usd")
+    if (
+        isinstance(cost_delta, int | float)
+        and not isinstance(cost_delta, bool)
+        and cost_delta != 0
+    ):
+        return "changed"
+
+    artifact_hashes = checkpoint.get("artifact_hashes")
+    if isinstance(artifact_hashes, Mapping) and any(
+        isinstance(hashes, Mapping) and hashes.get("original") != hashes.get("replay")
+        for hashes in artifact_hashes.values()
+    ):
+        return "changed"
+    return "match"
+
+
+def _checkpoint_diff_table(
+    payload: Mapping[str, Any],
+) -> tuple[list[list[str]], list[str]]:
+    """Build compact checkpoint rows and identify compared replays without rows."""
+    rows: list[list[str]] = []
+    empty_replay_ids: list[str] = []
+    compared = payload.get("compared", [])
+    if not isinstance(compared, list):
+        return rows, empty_replay_ids
+
+    for comparison in compared:
+        if not isinstance(comparison, Mapping):
+            continue
+        replay_exec_id = str(comparison.get("replay_exec_id") or "unknown replay")
+        checkpoints = comparison.get("checkpoints", [])
+        if not isinstance(checkpoints, list) or not checkpoints:
+            empty_replay_ids.append(replay_exec_id)
+            continue
+        for checkpoint in checkpoints:
+            if not isinstance(checkpoint, Mapping):
+                continue
+            token_delta = checkpoint.get("token_delta")
+            token_mapping = token_delta if isinstance(token_delta, Mapping) else {}
+            rows.append(
+                [
+                    replay_exec_id,
+                    str(checkpoint.get("name") or "unknown checkpoint"),
+                    _checkpoint_diff_status(checkpoint),
+                    _format_diff_delta(token_mapping.get("prompt_tokens")),
+                    _format_diff_delta(token_mapping.get("completion_tokens")),
+                    _format_diff_delta(token_mapping.get("total_tokens")),
+                    _format_diff_delta(
+                        checkpoint.get("cost_delta_usd"), decimal_places=6
+                    ),
+                ]
+            )
+    return rows, empty_replay_ids
+
+
+def _print_applied_output_overrides(payload: Mapping[str, Any]) -> None:
+    """Print redacted output override evidence associated with each replay."""
+    compared = payload.get("compared", [])
+    if not isinstance(compared, list):
+        return
+
+    for comparison in compared:
+        if not isinstance(comparison, Mapping):
+            continue
+        replay_exec_id = str(comparison.get("replay_exec_id") or "unknown replay")
+        overrides = comparison.get("applied_output_overrides")
+        if overrides is None:
+            print(f"Applied output overrides: unavailable [{replay_exec_id}]")
+            continue
+        if not isinstance(overrides, list) or not overrides:
+            continue
+
+        print(f"Applied output overrides [{replay_exec_id}]:")
+        for override in overrides:
+            if not isinstance(override, Mapping):
+                continue
+            selector_kind = override.get("selector_kind")
+            kind_label = (
+                "checkpoint family" if selector_kind == "checkpoint" else "invocation"
+            )
+            selector = str(override.get("selector") or "unknown selector")
+            raw_ids = override.get("matched_invocation_ids", [])
+            matched_ids = (
+                [str(item) for item in raw_ids] if isinstance(raw_ids, list) else []
+            )
+            resolved = ", ".join(matched_ids) or "no resolved checkpoint IDs"
+            print(f"  {kind_label} '{selector}' -> {resolved}")
+
+
 def _parse_json_value(raw_value: str, *, option_name: str) -> Any:
     """Parse a CLI JSON option value and surface user-friendly errors."""
     try:
@@ -1715,6 +1834,24 @@ def diff_(
         f"Diff for {original}",
         detail=f"Compared against {compared_count} replay execution(s).",
     )
+    checkpoint_rows, empty_replay_ids = _checkpoint_diff_table(payload)
+    if checkpoint_rows:
+        _emit_table(
+            "Checkpoint differences",
+            [
+                "Replay",
+                "Checkpoint",
+                "Result",
+                "Input Δ",
+                "Output Δ",
+                "Total Δ",
+                "Cost Δ (USD)",
+            ],
+            checkpoint_rows,
+        )
+    for replay_exec_id in empty_replay_ids:
+        print(f"No checkpoint rows for replay {replay_exec_id}.")
+    _print_applied_output_overrides(payload)
     for url in payload.get("urls", []):
         print(f"  ui: {url}")
 

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -1829,6 +1829,7 @@ class _ExecutionsAPI:
                         submission_id=submission_id,
                         tag=tag,
                         steps_to_skip=replay_plan.steps_to_skip,
+                        replay_plan=replay_plan.document,
                     )
                 row_status: Literal["submitted", "completed", "failed"] = "submitted"
                 if wait:

--- a/src/kitaru/diff.py
+++ b/src/kitaru/diff.py
@@ -17,6 +17,7 @@ from kitaru._ui_urls import (
 )
 from kitaru.client import KitaruClient
 from kitaru.errors import KitaruUsageError
+from kitaru.replay import AppliedOutputOverride, parse_replay_output_overrides_metadata
 
 DEFAULT_COMPARE_FLOW_VERSION = "local"
 _AUTO_DISCOVERY_SCAN_LIMIT = 10_000
@@ -44,6 +45,9 @@ class ExecutionDiff:
     compared: list[tuple[str, list[CheckpointDiff]]] = field(default_factory=list)
     urls: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
+    applied_output_overrides: dict[str, list[AppliedOutputOverride] | None] = field(
+        default_factory=dict
+    )
 
 
 @dataclass(frozen=True)
@@ -392,6 +396,14 @@ def serialize_checkpoint_diff(item: CheckpointDiff) -> dict[str, Any]:
     }
 
 
+def _serialize_applied_output_overrides(
+    overrides: list[AppliedOutputOverride] | None,
+) -> list[dict[str, Any]] | None:
+    if overrides is None:
+        return None
+    return [override.to_json() for override in overrides]
+
+
 def serialize_execution_diff(item: ExecutionDiff) -> dict[str, Any]:
     return {
         "original_exec_id": item.original_exec_id,
@@ -402,6 +414,9 @@ def serialize_execution_diff(item: ExecutionDiff) -> dict[str, Any]:
                     serialize_checkpoint_diff(checkpoint)
                     for checkpoint in checkpoint_diffs
                 ],
+                "applied_output_overrides": _serialize_applied_output_overrides(
+                    item.applied_output_overrides.get(replay_exec_id)
+                ),
             }
             for replay_exec_id, checkpoint_diffs in item.compared
         ],
@@ -465,7 +480,17 @@ def _compare_loaded_executions(
     ui_context: UiUrlContext | None,
 ) -> ExecutionDiff:
     compared: list[tuple[str, list[CheckpointDiff]]] = []
+    applied_output_overrides: dict[str, list[AppliedOutputOverride] | None] = {}
     for replay_execution in replay_executions:
+        replay_exec_id = replay_execution.exec_id
+        replay_metadata = (
+            replay_execution.metadata
+            if isinstance(replay_execution.metadata, Mapping)
+            else {}
+        )
+        applied_output_overrides[replay_exec_id] = (
+            parse_replay_output_overrides_metadata(replay_metadata)
+        )
         pairs = _align_checkpoints(original_execution, replay_execution)
         checkpoint_diffs = [
             _compare_checkpoints(
@@ -498,6 +523,7 @@ def _compare_loaded_executions(
         compared=compared,
         urls=compare_urls,
         warnings=list(warnings),
+        applied_output_overrides=applied_output_overrides,
     )
 
 

--- a/src/kitaru/flow.py
+++ b/src/kitaru/flow.py
@@ -2241,6 +2241,7 @@ class _FlowDefinition:
                 submission_id=replay_submission_id or new_replay_submission_id(),
                 tag=replay_tag,
                 steps_to_skip=replay_plan.steps_to_skip,
+                replay_plan=replay_plan.document,
             )
 
         _emit_kitaru_execution_url(replayed_run)

--- a/src/kitaru/replay.py
+++ b/src/kitaru/replay.py
@@ -322,18 +322,32 @@ def replay_output_overrides_metadata(
         ("checkpoint", document.checkpoint_overrides),
         ("invocation", document.invocation_overrides),
     )
+    configured_overrides: list[tuple[_ReplaySelectorKind, str, tuple[str, ...]]] = []
+    effective_owner: dict[str, tuple[_ReplaySelectorKind, str]] = {}
     for selector_kind, overrides in override_groups:
         for selector, override in overrides.items():
             if "output" not in override:
                 continue
-            entry = AppliedOutputOverride(
-                selector_kind=selector_kind,
-                selector=selector,
-                matched_invocation_ids=document.matched_invocation_ids(
-                    selector_kind, selector
-                ),
+            matched_invocation_ids = document.matched_invocation_ids(
+                selector_kind, selector
             )
-            entries.append(entry.to_json())
+            configured_overrides.append(
+                (selector_kind, selector, matched_invocation_ids)
+            )
+            for invocation_id in matched_invocation_ids:
+                effective_owner[invocation_id] = (selector_kind, selector)
+
+    for selector_kind, selector, matched_invocation_ids in configured_overrides:
+        entry = AppliedOutputOverride(
+            selector_kind=selector_kind,
+            selector=selector,
+            matched_invocation_ids=tuple(
+                invocation_id
+                for invocation_id in matched_invocation_ids
+                if effective_owner[invocation_id] == (selector_kind, selector)
+            ),
+        )
+        entries.append(entry.to_json())
     return {REPLAY_OUTPUT_OVERRIDES_METADATA_KEY: entries}
 
 

--- a/src/kitaru/replay.py
+++ b/src/kitaru/replay.py
@@ -44,6 +44,13 @@ _PYDANTIC_AI_TURN_KIND = "turn"
 logger = logging.getLogger(__name__)
 
 REPLAY_SKIPPED_STEPS_METADATA_KEY = "kitaru_replay_skipped_steps_v1"
+REPLAY_OUTPUT_OVERRIDES_METADATA_KEY = "kitaru_replay_output_overrides_v1"
+_ReplaySelectorKind = Literal["checkpoint", "invocation"]
+
+
+def _matched_target_key(selector_kind: _ReplaySelectorKind, selector: str) -> str:
+    return f"{selector_kind}:{selector}"
+
 
 REPLAY_RESERVED_KWARGS = frozenset(
     {
@@ -73,6 +80,15 @@ class ReplayPlanDocument:
     skip: list[str] = field(default_factory=list)
     matched_targets: dict[str, list[str]] = field(default_factory=dict)
 
+    def matched_invocation_ids(
+        self,
+        selector_kind: _ReplaySelectorKind,
+        selector: str,
+    ) -> tuple[str, ...]:
+        return tuple(
+            self.matched_targets.get(_matched_target_key(selector_kind, selector), [])
+        )
+
     def to_json(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "flow_overrides": self.flow_overrides,
@@ -85,6 +101,23 @@ class ReplayPlanDocument:
                 key: list(value) for key, value in self.matched_targets.items()
             }
         return payload
+
+
+@dataclass(frozen=True)
+class AppliedOutputOverride:
+    """Value-free evidence that a replay output override was applied."""
+
+    selector_kind: _ReplaySelectorKind
+    selector: str
+    matched_invocation_ids: tuple[str, ...]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "selector_kind": self.selector_kind,
+            "selector": self.selector,
+            "matched_invocation_ids": list(self.matched_invocation_ids),
+            "field": "output",
+        }
 
 
 @dataclass(frozen=True)
@@ -277,6 +310,78 @@ def _safe_apply_replay_tag(replay_exec_id: str, tag: str | None) -> None:
         )
 
 
+def replay_output_overrides_metadata(
+    document: ReplayPlanDocument,
+) -> dict[str, Any]:
+    """Project a resolved replay plan into value-free output override evidence."""
+    entries: list[dict[str, Any]] = []
+    override_groups: tuple[
+        tuple[_ReplaySelectorKind, Mapping[str, Mapping[str, Any]]],
+        ...,
+    ] = (
+        ("checkpoint", document.checkpoint_overrides),
+        ("invocation", document.invocation_overrides),
+    )
+    for selector_kind, overrides in override_groups:
+        for selector, override in overrides.items():
+            if "output" not in override:
+                continue
+            entry = AppliedOutputOverride(
+                selector_kind=selector_kind,
+                selector=selector,
+                matched_invocation_ids=document.matched_invocation_ids(
+                    selector_kind, selector
+                ),
+            )
+            entries.append(entry.to_json())
+    return {REPLAY_OUTPUT_OVERRIDES_METADATA_KEY: entries}
+
+
+def parse_replay_output_overrides_metadata(
+    metadata: Mapping[str, Any],
+) -> list[AppliedOutputOverride] | None:
+    """Parse value-free replay output override evidence safely."""
+    if REPLAY_OUTPUT_OVERRIDES_METADATA_KEY not in metadata:
+        return None
+    raw_value = metadata[REPLAY_OUTPUT_OVERRIDES_METADATA_KEY]
+    if isinstance(raw_value, str):
+        try:
+            raw_value = json.loads(raw_value)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    if not isinstance(raw_value, list):
+        return None
+
+    parsed: list[AppliedOutputOverride] = []
+    for raw_entry in raw_value:
+        if not isinstance(raw_entry, Mapping):
+            return None
+        selector_kind = raw_entry.get("selector_kind")
+        selector = raw_entry.get("selector")
+        matched_invocation_ids = raw_entry.get("matched_invocation_ids")
+        field_name = raw_entry.get("field")
+        if (
+            selector_kind not in ("checkpoint", "invocation")
+            or not isinstance(selector, str)
+            or not selector
+            or not isinstance(matched_invocation_ids, list)
+            or not all(
+                isinstance(invocation_id, str) and invocation_id
+                for invocation_id in matched_invocation_ids
+            )
+            or field_name != "output"
+        ):
+            return None
+        parsed.append(
+            AppliedOutputOverride(
+                selector_kind=selector_kind,
+                selector=selector,
+                matched_invocation_ids=tuple(matched_invocation_ids),
+            )
+        )
+    return parsed
+
+
 def replay_skipped_steps_metadata(steps_to_skip: Iterable[str]) -> dict[str, Any]:
     """Return deterministic replay skip metadata for an execution."""
     skipped_steps = sorted(
@@ -315,26 +420,45 @@ def safe_persist_replay_submission_metadata(
     submission_id: str,
     tag: str | None,
     steps_to_skip: Iterable[str] | None = None,
+    replay_plan: ReplayPlanDocument | None = None,
 ) -> None:
     """Best-effort replay correlation metadata and tag persistence."""
+    baseline_metadata: dict[str, Any] = {
+        "submission_id": submission_id,
+        "original_exec_id": original_exec_id,
+    }
+    if steps_to_skip is not None:
+        baseline_metadata.update(replay_skipped_steps_metadata(steps_to_skip))
+    if tag:
+        baseline_metadata["replay_tag"] = tag
+
+    baseline_persisted = False
     try:
         from kitaru.logging import log_to_execution
 
-        metadata: dict[str, Any] = {
-            "submission_id": submission_id,
-            "original_exec_id": original_exec_id,
-        }
-        if steps_to_skip is not None:
-            metadata.update(replay_skipped_steps_metadata(steps_to_skip))
-        if tag:
-            metadata["replay_tag"] = tag
-        log_to_execution(replay_exec_id, **metadata)
+        log_to_execution(replay_exec_id, **baseline_metadata)
+        baseline_persisted = True
     except Exception:
         logger.debug(
             "Failed to persist replay metadata for %s.",
             replay_exec_id,
             exc_info=True,
         )
+
+    # Keep the established metadata write independent from the optional
+    # versioned evidence. Neither request is retried after an ambiguous failure.
+    if baseline_persisted and replay_plan is not None:
+        try:
+            log_to_execution(
+                replay_exec_id,
+                **replay_output_overrides_metadata(replay_plan),
+            )
+        except Exception:
+            logger.debug(
+                "Failed to persist replay output override metadata for %s.",
+                replay_exec_id,
+                exc_info=True,
+            )
     _safe_apply_replay_tag(replay_exec_id, tag)
 
 
@@ -1068,7 +1192,7 @@ def _build_effective_overrides(
 
     for selector, entry in checkpoint_entries.items():
         matches = _resolve_checkpoint_scope_selector(selector, checkpoints)
-        matched_targets[f"checkpoint:{selector}"] = [
+        matched_targets[_matched_target_key("checkpoint", selector)] = [
             checkpoint.invocation_id for checkpoint in matches
         ]
         for checkpoint in matches:
@@ -1076,7 +1200,9 @@ def _build_effective_overrides(
 
     for selector, entry in invocation_entries.items():
         checkpoint = _resolve_checkpoint_selector(selector, checkpoints)
-        matched_targets[f"invocation:{selector}"] = [checkpoint.invocation_id]
+        matched_targets[_matched_target_key("invocation", selector)] = [
+            checkpoint.invocation_id
+        ]
         _put_target_override(effective, checkpoint, entry)
 
     for invocation_id, entry in effective.items():
@@ -1274,8 +1400,10 @@ def build_replay_plan(
 
 
 __all__ = [
+    "REPLAY_OUTPUT_OVERRIDES_METADATA_KEY",
     "REPLAY_RESERVED_KWARGS",
     "REPLAY_SKIPPED_STEPS_METADATA_KEY",
+    "AppliedOutputOverride",
     "ReplayFailureRow",
     "ReplayPlan",
     "ReplayPlanDocument",
@@ -1286,10 +1414,12 @@ __all__ = [
     "build_replay_plan",
     "build_replay_request_document",
     "new_replay_submission_id",
+    "parse_replay_output_overrides_metadata",
     "parse_replay_skipped_steps_metadata",
     "plan_requires_runtime_transport",
     "replay_at_skip_reason",
     "replay_at_status",
+    "replay_output_overrides_metadata",
     "replay_skipped_steps_metadata",
     "replay_step_invocation_id",
     "safe_compare_url_for_executions",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,13 @@ from zenml.exceptions import EntityExistsError
 from zenml.zen_stores.rest_zen_store import RestZenStore
 
 import kitaru.config as config_module
-from kitaru._cli._executions import _execution_statistics_table
+from kitaru._cli._executions import (
+    _checkpoint_diff_status,
+    _checkpoint_diff_table,
+    _execution_statistics_table,
+    _format_diff_delta,
+    _print_applied_output_overrides,
+)
 from kitaru._client._models import AuthAPIKey, AuthAPIKeyWithValue, AuthServiceAccount
 from kitaru._client._statistics import (
     LLM_EXECUTION_STATISTICS_METRIC_SHORTCUTS_DISPLAY,
@@ -4590,9 +4596,23 @@ def test_executions_diff_matrix_json_uses_new_command_name(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """`executions diff-matrix` should replace the old diff-cohort command."""
+    serialized = {
+        "rows": [
+            {
+                "original_exec_id": "kr-a",
+                "compared": [
+                    {
+                        "replay_exec_id": "kr-replay-a",
+                        "checkpoints": [],
+                        "applied_output_overrides": [],
+                    }
+                ],
+            }
+        ]
+    }
     with (
         patch("kitaru.diff.diff_cohort", return_value=object()) as diff_cohort,
-        patch("kitaru.diff.serialize_cohort_diff", return_value={"rows": []}),
+        patch("kitaru.diff.serialize_cohort_diff", return_value=serialized),
         pytest.raises(SystemExit) as exc_info,
     ):
         app(["executions", "diff-matrix", "kr-a", "kr-b", "-o", "json"])
@@ -4601,7 +4621,7 @@ def test_executions_diff_matrix_json_uses_new_command_name(
     diff_cohort.assert_called_once_with(["kr-a", "kr-b"])
     assert json.loads(capsys.readouterr().out) == {
         "command": "executions.diff_matrix",
-        "item": {"rows": []},
+        "item": serialized,
     }
 
 
@@ -4667,6 +4687,222 @@ def test_executions_diff_rejects_blank_replay_with_structured_error(
     }
 
 
+def _checkpoint_diff_payload(**updates: Any) -> dict[str, Any]:
+    payload = {
+        "name": "write_draft",
+        "original_call_id": "original",
+        "replay_call_id": "replay",
+        "status_match": False,
+        "token_delta": None,
+        "cost_delta_usd": None,
+    }
+    payload.update(updates)
+    return payload
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (10, "+10"),
+        (1_234_567, "+1234567"),
+        (-1_234_567, "-1234567"),
+        (0, "+0"),
+        (0.0, "n/a"),
+        (None, "n/a"),
+        (True, "n/a"),
+        (float("inf"), "n/a"),
+    ],
+)
+def test_format_diff_delta(value: Any, expected: str) -> None:
+    assert _format_diff_delta(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0.00003, "+0.000030"),
+        (-0.0017, "-0.001700"),
+        (0.0, "+0.000000"),
+        (None, "n/a"),
+        (True, "n/a"),
+        (float("inf"), "n/a"),
+    ],
+)
+def test_format_diff_cost_delta(value: Any, expected: str) -> None:
+    assert _format_diff_delta(value, decimal_places=6) == expected
+
+
+@pytest.mark.parametrize(
+    ("original_call_id", "replay_call_id", "status_match", "expected"),
+    [
+        ("original", "replay", True, "match"),
+        ("original", "replay", False, "changed"),
+        ("original", None, False, "original only"),
+        (None, "replay", False, "replay only"),
+    ],
+)
+def test_checkpoint_diff_status(
+    original_call_id: str | None,
+    replay_call_id: str | None,
+    status_match: bool,
+    expected: str,
+) -> None:
+    assert (
+        _checkpoint_diff_status(
+            {
+                "original_call_id": original_call_id,
+                "replay_call_id": replay_call_id,
+                "status_match": status_match,
+            }
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"token_delta": {"prompt_tokens": 1}},
+        {"cost_delta_usd": 0.000001},
+        {"artifact_hashes": {"output": {"original": "hash-a", "replay": "hash-b"}}},
+    ],
+)
+def test_checkpoint_diff_status_detects_content_changes(
+    updates: dict[str, Any],
+) -> None:
+    checkpoint = _checkpoint_diff_payload(status_match=True, **updates)
+
+    assert _checkpoint_diff_status(checkpoint) == "changed"
+
+
+def test_checkpoint_diff_status_matches_unchanged_content() -> None:
+    checkpoint = _checkpoint_diff_payload(
+        status_match=True,
+        token_delta={
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        },
+        cost_delta_usd=0.0,
+        artifact_hashes={"output": {"original": "same-hash", "replay": "same-hash"}},
+    )
+
+    assert _checkpoint_diff_status(checkpoint) == "match"
+
+
+def test_checkpoint_diff_table_formats_rows_and_tracks_empty_replays() -> None:
+    rows, empty_replay_ids = _checkpoint_diff_table(
+        {
+            "compared": [
+                {
+                    "replay_exec_id": "kr-replay",
+                    "checkpoints": [
+                        _checkpoint_diff_payload(
+                            token_delta={
+                                "prompt_tokens": 10,
+                                "completion_tokens": -5,
+                                "total_tokens": 5,
+                            },
+                            cost_delta_usd=0.25,
+                        )
+                    ],
+                },
+                {"replay_exec_id": "kr-empty", "checkpoints": []},
+            ]
+        }
+    )
+
+    assert rows == [
+        [
+            "kr-replay",
+            "write_draft",
+            "changed",
+            "+10",
+            "-5",
+            "+5",
+            "+0.250000",
+        ]
+    ]
+    assert empty_replay_ids == ["kr-empty"]
+
+
+def test_print_applied_output_overrides_distinguishes_evidence_states(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _print_applied_output_overrides(
+        {
+            "compared": [
+                {
+                    "replay_exec_id": "kr-populated",
+                    "applied_output_overrides": [
+                        {
+                            "selector_kind": "checkpoint",
+                            "selector": "lookup",
+                            "matched_invocation_ids": ["lookup_1", "lookup_2"],
+                        }
+                    ],
+                },
+                {
+                    "replay_exec_id": "kr-unavailable",
+                    "applied_output_overrides": None,
+                },
+                {
+                    "replay_exec_id": "kr-empty",
+                    "applied_output_overrides": [],
+                },
+            ]
+        }
+    )
+
+    output = capsys.readouterr().out
+    assert "Applied output overrides [kr-populated]:" in output
+    assert "checkpoint family 'lookup' -> lookup_1, lookup_2" in output
+    assert "Applied output overrides: unavailable [kr-unavailable]" in output
+    assert "kr-empty" not in output
+
+
+def test_executions_diff_text_renders_compact_result(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    serialized = {
+        "compared": [
+            {
+                "replay_exec_id": "kr-replay",
+                "checkpoints": [_checkpoint_diff_payload()],
+                "applied_output_overrides": [
+                    {
+                        "selector_kind": "invocation",
+                        "selector": "write_draft",
+                        "matched_invocation_ids": ["write_draft"],
+                    }
+                ],
+            },
+            {
+                "replay_exec_id": "kr-empty",
+                "checkpoints": [],
+                "applied_output_overrides": [],
+            },
+        ],
+        "urls": ["https://example.test/compare"],
+        "warnings": [],
+    }
+    with (
+        patch("kitaru.diff.diff", return_value=object()),
+        patch("kitaru.diff.serialize_execution_diff", return_value=serialized),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "diff", "kr-original", "kr-replay", "kr-empty"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "Compared against 2 replay execution(s)." in output
+    assert "Checkpoint differences" in output
+    assert "write_draft" in output
+    assert "No checkpoint rows for replay kr-empty." in output
+    assert "Applied output overrides [kr-replay]:" in output
+    assert "https://example.test/compare" in output
+
+
 def test_executions_diff_text_prints_discovery_warning(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -4708,6 +4944,8 @@ def test_executions_diff_matrix_text_deduplicates_discovery_warnings(
     captured = capsys.readouterr()
     assert captured.err.count(f"Warning: {warning}") == 1
     assert "Compared 2 original execution(s)." in captured.out
+    assert "Checkpoint differences" not in captured.out
+    assert "Applied output overrides" not in captured.out
 
 
 def test_executions_diff_json_serializes_checkpoint_usage_deltas(
@@ -4717,6 +4955,8 @@ def test_executions_diff_json_serializes_checkpoint_usage_deltas(
     serialized = {
         "compared": [
             {
+                "replay_exec_id": "kr-replay",
+                "applied_output_overrides": [],
                 "checkpoints": [
                     {
                         "token_delta": {
@@ -4726,7 +4966,7 @@ def test_executions_diff_json_serializes_checkpoint_usage_deltas(
                         },
                         "cost_delta_usd": 0.25,
                     }
-                ]
+                ],
             }
         ]
     }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6307,6 +6307,7 @@ def test_replay_falls_back_to_pipeline_source_when_flow_missing() -> None:
         flow_name="sample_flow",
     )
     project_events: list[tuple[str, str | None]] = []
+    persisted_metadata: dict[str, Any] = {}
 
     @contextmanager
     def _project_context(project: str | None) -> Iterator[None]:
@@ -6320,7 +6321,8 @@ def test_replay_falls_back_to_pipeline_source_when_flow_missing() -> None:
         assert project_events == [("enter", "production")]
         return _as_pipeline_run(replayed_run)
 
-    def _persist_submission(**_kwargs: Any) -> None:
+    def _persist_submission(**kwargs: Any) -> None:
+        persisted_metadata.update(kwargs)
         assert project_events == [
             ("enter", "production"),
             ("exit", "production"),
@@ -6373,6 +6375,7 @@ def test_replay_falls_back_to_pipeline_source_when_flow_missing() -> None:
     assert replay_kwargs["pipeline_run"] == source_run.id
     assert replay_kwargs["skip"] == {"fetch"}
     assert submission.results[0].replay_exec_id == str(replayed_run.id)
+    assert persisted_metadata["replay_plan"] == submission.plan
     replay_handle = submission.results[0].handle
     assert replay_handle is not None
     assert replay_handle._project == "production"

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -24,12 +24,15 @@ from kitaru._llm_usage import (
 )
 from kitaru._ui_urls import UiUrlContext
 from kitaru.diff import (
+    CohortDiff,
     ExecutionDiff,
     diff,
     serialize_checkpoint_diff,
+    serialize_diff_matrix,
     serialize_execution_diff,
 )
 from kitaru.errors import KitaruUsageError
+from kitaru.replay import REPLAY_OUTPUT_OVERRIDES_METADATA_KEY, AppliedOutputOverride
 from tests._diff_helpers import checkpoint_diff_from_usage_records
 
 _diff_module = import_module("kitaru.diff")
@@ -327,6 +330,90 @@ def _execution(
         project_id=project_id,
         project_name=project_name,
     )
+
+
+def test_diff_associates_and_serializes_output_override_evidence() -> None:
+    original = _execution("kr-original", checkpoints=[])
+    replay_with_override = _execution(
+        "kr-replay-populated",
+        original_exec_id="kr-original",
+        checkpoints=[],
+        metadata={
+            REPLAY_OUTPUT_OVERRIDES_METADATA_KEY: [
+                {
+                    "selector_kind": "checkpoint",
+                    "selector": "lookup",
+                    "matched_invocation_ids": ["lookup_1", "lookup_2"],
+                    "field": "output",
+                }
+            ]
+        },
+    )
+    replay_without_override = _execution(
+        "kr-replay-empty",
+        original_exec_id="kr-original",
+        checkpoints=[],
+        metadata={REPLAY_OUTPUT_OVERRIDES_METADATA_KEY: []},
+    )
+    old_replay = _execution(
+        "kr-replay-unavailable",
+        original_exec_id="kr-original",
+        checkpoints=[],
+        metadata={REPLAY_OUTPUT_OVERRIDES_METADATA_KEY: "malformed"},
+    )
+    fake_client = MagicMock()
+    fake_client.executions.get.side_effect = [
+        original,
+        replay_with_override,
+        replay_without_override,
+        old_replay,
+    ]
+
+    with (
+        patch("kitaru.diff.KitaruClient", return_value=fake_client),
+        patch("kitaru.diff._client_ui_url_context", return_value=None),
+    ):
+        result = diff(
+            "kr-original",
+            "replay-populated-alias",
+            "replay-empty-alias",
+            "replay-unavailable-alias",
+        )
+
+    assert result.applied_output_overrides == {
+        "kr-replay-populated": [
+            AppliedOutputOverride(
+                selector_kind="checkpoint",
+                selector="lookup",
+                matched_invocation_ids=("lookup_1", "lookup_2"),
+            )
+        ],
+        "kr-replay-empty": [],
+        "kr-replay-unavailable": None,
+    }
+    serialized = serialize_execution_diff(result)
+    assert serialized["compared"][0]["applied_output_overrides"] == [
+        {
+            "selector_kind": "checkpoint",
+            "selector": "lookup",
+            "matched_invocation_ids": ["lookup_1", "lookup_2"],
+            "field": "output",
+        }
+    ]
+    assert serialized["compared"][1]["applied_output_overrides"] == []
+    assert serialized["compared"][2]["applied_output_overrides"] is None
+
+
+def test_diff_matrix_serialization_includes_output_override_evidence() -> None:
+    row = ExecutionDiff(
+        original_exec_id="kr-original",
+        compared=[("kr-replay", [])],
+        applied_output_overrides={"kr-replay": []},
+    )
+
+    payload = serialize_diff_matrix(CohortDiff(rows=[row]))
+
+    assert payload["rows"][0]["compared"][0]["applied_output_overrides"] == []
 
 
 def test_diff_aligns_checkpoints_by_original_call_id() -> None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -82,7 +82,7 @@ from kitaru.flow import (
     flow,
 )
 from kitaru.inspection import ActiveConfigSelectionProvenance
-from kitaru.replay import ReplayPlan
+from kitaru.replay import ReplayPlan, ReplayPlanDocument
 from kitaru.replay_context import (
     KITARU_REPLAY_CONTEXT_ENV,
     ReplayRuntimeContext,
@@ -4353,6 +4353,10 @@ def test_replay_submits_pipeline_replay_and_persists_frozen_spec() -> None:
         input_overrides={"topic": "new topic"},
         step_input_overrides={"write": {"research": "edited"}},
         runtime_context=ReplayRuntimeContext(at="write"),
+        document=ReplayPlanDocument(
+            invocation_overrides={"research": {"output": "edited"}},
+            matched_targets={"invocation:research": ["research"]},
+        ),
     )
 
     with (
@@ -4402,6 +4406,7 @@ def test_replay_submits_pipeline_replay_and_persists_frozen_spec() -> None:
         submission_id=submission.submission_id,
         tag=None,
         steps_to_skip={"fetch"},
+        replay_plan=replay_plan.document,
     )
     build_frozen_spec_call = base_pipeline.with_options.call_args
     docker_settings = build_frozen_spec_call.kwargs["settings"]["docker"]

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1241,7 +1241,7 @@ def test_code_override_rejects_non_tool_checkpoint() -> None:
         )
 
 
-def test_replay_output_override_metadata_is_value_free_and_fans_out() -> None:
+def test_replay_output_override_metadata_is_value_free_and_effective() -> None:
     replacement_value = "secret replacement value"
     document = ReplayPlanDocument(
         checkpoint_overrides={
@@ -1265,7 +1265,7 @@ def test_replay_output_override_metadata_is_value_free_and_fans_out() -> None:
             {
                 "selector_kind": "checkpoint",
                 "selector": "lookup",
-                "matched_invocation_ids": ["lookup_1", "lookup_2"],
+                "matched_invocation_ids": ["lookup_1"],
                 "field": "output",
             },
             {

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -18,14 +19,18 @@ from kitaru._checkpoint_metadata import (
 )
 from kitaru.errors import KitaruStateError, KitaruUsageError
 from kitaru.replay import (
+    REPLAY_OUTPUT_OVERRIDES_METADATA_KEY,
     REPLAY_SKIPPED_STEPS_METADATA_KEY,
+    AppliedOutputOverride,
     ReplayPlanDocument,
     ReplayResultRow,
     ReplaySubmission,
     build_replay_plan,
+    parse_replay_output_overrides_metadata,
     parse_replay_skipped_steps_metadata,
     plan_requires_runtime_transport,
     replay_at_status,
+    replay_output_overrides_metadata,
     replay_skipped_steps_metadata,
     safe_persist_replay_submission_metadata,
 )
@@ -1236,6 +1241,107 @@ def test_code_override_rejects_non_tool_checkpoint() -> None:
         )
 
 
+def test_replay_output_override_metadata_is_value_free_and_fans_out() -> None:
+    replacement_value = "secret replacement value"
+    document = ReplayPlanDocument(
+        checkpoint_overrides={
+            "lookup": {"output": replacement_value},
+            "other": {"input": {"query": "not persisted"}},
+        },
+        invocation_overrides={
+            "lookup_2": {"output": {"private": replacement_value}},
+        },
+        matched_targets={
+            "checkpoint:lookup": ["lookup_1", "lookup_2"],
+            "checkpoint:other": ["other"],
+            "invocation:lookup_2": ["lookup_2"],
+        },
+    )
+
+    metadata = replay_output_overrides_metadata(document)
+
+    assert metadata == {
+        REPLAY_OUTPUT_OVERRIDES_METADATA_KEY: [
+            {
+                "selector_kind": "checkpoint",
+                "selector": "lookup",
+                "matched_invocation_ids": ["lookup_1", "lookup_2"],
+                "field": "output",
+            },
+            {
+                "selector_kind": "invocation",
+                "selector": "lookup_2",
+                "matched_invocation_ids": ["lookup_2"],
+                "field": "output",
+            },
+        ]
+    }
+    assert replacement_value not in str(metadata)
+
+
+def test_parse_replay_output_override_metadata_distinguishes_known_none() -> None:
+    assert parse_replay_output_overrides_metadata({}) is None
+    assert (
+        parse_replay_output_overrides_metadata(
+            {REPLAY_OUTPUT_OVERRIDES_METADATA_KEY: []}
+        )
+        == []
+    )
+    assert (
+        parse_replay_output_overrides_metadata(
+            {REPLAY_OUTPUT_OVERRIDES_METADATA_KEY: "[]"}
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    "raw_value",
+    [
+        None,
+        "not json",
+        {},
+        [{"selector_kind": "checkpoint"}],
+        [
+            {
+                "selector_kind": "checkpoint",
+                "selector": "lookup",
+                "matched_invocation_ids": [3],
+                "field": "output",
+            }
+        ],
+    ],
+)
+def test_parse_replay_output_override_metadata_rejects_malformed_values(
+    raw_value: Any,
+) -> None:
+    assert (
+        parse_replay_output_overrides_metadata(
+            {REPLAY_OUTPUT_OVERRIDES_METADATA_KEY: raw_value}
+        )
+        is None
+    )
+
+
+def test_parse_replay_output_override_metadata_accepts_json_string() -> None:
+    raw_entry = {
+        "selector_kind": "invocation",
+        "selector": "lookup_2",
+        "matched_invocation_ids": ["lookup_2"],
+        "field": "output",
+    }
+
+    assert parse_replay_output_overrides_metadata(
+        {REPLAY_OUTPUT_OVERRIDES_METADATA_KEY: json.dumps([raw_entry])}
+    ) == [
+        AppliedOutputOverride(
+            selector_kind="invocation",
+            selector="lookup_2",
+            matched_invocation_ids=("lookup_2",),
+        )
+    ]
+
+
 def test_replay_skipped_steps_metadata_is_deterministic() -> None:
     assert replay_skipped_steps_metadata({"write", "fetch"}) == {
         REPLAY_SKIPPED_STEPS_METADATA_KEY: ["fetch", "write"]
@@ -1303,6 +1409,68 @@ def test_replay_submission_metadata_uses_pipeline_run_update_for_tags(
     assert calls["run_id"] == "replay-a"
     assert isinstance(calls["run_update"], PipelineRunUpdate)
     assert calls["run_update"].add_tags == ["batch-eval"]
+
+
+@pytest.mark.parametrize("fail_optional_write", [False, True])
+def test_replay_submission_metadata_writes_override_evidence_separately(
+    monkeypatch: pytest.MonkeyPatch,
+    fail_optional_write: bool,
+) -> None:
+    logged: list[dict[str, Any]] = []
+
+    def fake_log_to_execution(_run_id: str, **metadata: Any) -> None:
+        logged.append(metadata)
+        if fail_optional_write and REPLAY_OUTPUT_OVERRIDES_METADATA_KEY in metadata:
+            raise RuntimeError("backend rejected new metadata")
+
+    monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
+
+    safe_persist_replay_submission_metadata(
+        replay_exec_id="replay-a",
+        original_exec_id="orig-a",
+        submission_id="rs-test",
+        tag=None,
+        steps_to_skip={"fetch"},
+        replay_plan=ReplayPlanDocument(),
+    )
+
+    assert logged == [
+        {
+            "submission_id": "rs-test",
+            "original_exec_id": "orig-a",
+            REPLAY_SKIPPED_STEPS_METADATA_KEY: ["fetch"],
+        },
+        {REPLAY_OUTPUT_OVERRIDES_METADATA_KEY: []},
+    ]
+
+
+def test_replay_submission_metadata_does_not_retry_failed_baseline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged: list[dict[str, Any]] = []
+
+    def fake_log_to_execution(_run_id: str, **metadata: Any) -> None:
+        logged.append(metadata)
+        raise RuntimeError("backend unavailable")
+
+    monkeypatch.setattr("kitaru.logging.log_to_execution", fake_log_to_execution)
+
+    safe_persist_replay_submission_metadata(
+        replay_exec_id="replay-a",
+        original_exec_id="orig-a",
+        submission_id="rs-test",
+        tag=None,
+        steps_to_skip={"fetch"},
+        replay_plan=ReplayPlanDocument(),
+    )
+
+    assert logged == [
+        {
+            "submission_id": "rs-test",
+            "original_exec_id": "orig-a",
+            REPLAY_SKIPPED_STEPS_METADATA_KEY: ["fetch"],
+        }
+    ]
 
 
 def test_replay_submission_to_json_excludes_handles() -> None:


### PR DESCRIPTION
## Summary

- render per-checkpoint status, token deltas, and cost deltas in the default `kitaru executions diff` text output
- persist value-free evidence for applied replay output overrides and expose it through SDK/JSON diff results
- preserve existing replay behavior, including source artifact reuse and downstream override injection
- document the new output and add regression coverage for legacy, malformed, empty, and populated metadata

Fixes #563.

## Reviewer Notes

The change has two connected paths. First, `src/kitaru/replay.py` derives a redacted metadata record from the resolved replay plan. It stores selector kind, selector, resolved invocation IDs, and the fixed `output` field name, but never the override value. Existing replay correlation metadata is written first; the optional override evidence is written separately so a failure cannot cause duplicate baseline writes or fail replay submission.

Second, `src/kitaru/diff.py` associates that evidence with each replay while leaving checkpoint alignment and artifact hashing unchanged. `src/kitaru/_cli/_executions.py` renders the already-serialized checkpoint data as a compact table. Older executions without the new metadata remain diffable and report override evidence as unavailable.

The branch is rebased onto the replay-lineage validation from #574. Override evidence is parsed from the preloaded replay execution and keyed by its resolved `exec_id`, not by the user-supplied selector.

The text table’s `Result` column reports `changed` when checkpoint status, token usage, cost, or artifact hashes differ; `match` means all four dimensions are unchanged. Duration is intentionally excluded because ordinary timing variance would make most replay rows appear changed.

The main review risks are accidental persistence or display of override values, changing source artifact semantics, and associating evidence with the wrong replay in multi-replay diffs. The regression tests exercise those boundaries.

### Reproduction

1. Run a flow where one checkpoint output feeds a later checkpoint.
2. Replay it with a checkpoint output override, for example:

   ```python
   client.executions.replay(
       original_exec_id,
       checkpoint_overrides={"research": {"output": "edited notes"}},
       wait=True,
   )
   ```

3. Run `kitaru executions diff <original-id> <replay-id>`.
4. Confirm the default text output includes checkpoint rows with status, token deltas, and cost deltas, followed by a redacted applied-output-override annotation.
5. Run the command with `--output json` and confirm `compared[*].applied_output_overrides` identifies the selector and matched invocation IDs without containing `edited notes`.
6. Confirm the overridden source checkpoint still reuses its original artifact hash; the override is injected into downstream inputs rather than materialized as a replacement artifact.

### Local checks run

- `just check`
- `just test` (`3,662 passed`, `29 skipped`)
- `git diff --check`
- `/simplify` reuse, quality, and efficiency review
- Oracle review of the final patch
