### PR TITLE
Add flow and execution deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Flow and execution deletion is now available through the SDK, `kitaru flow delete` and `kitaru executions delete` CLI commands, and MCP tools.
+
 ### Changed
 - The checkpoint table in `kitaru executions diff` text output now includes replay-minus-original duration deltas and per-role artifact comparison states (`unchanged`/`changed`/`unavailable`) alongside token and cost deltas, without printing artifact hashes or values. (#520)
 

--- a/docs/book/agent-native/mcp-server.md
+++ b/docs/book/agent-native/mcp-server.md
@@ -129,6 +129,7 @@ Execution tools:
 
 - `kitaru_executions_list`
 - `kitaru_executions_get`
+- `kitaru_executions_delete`
 - `kitaru_executions_latest`
 - `kitaru_executions_statistics`
 - `get_execution_logs`
@@ -142,6 +143,10 @@ Execution tools:
 - `kitaru_executions_cohort`
 - `kitaru_executions_diff`
 - `kitaru_executions_diff_matrix`
+
+Flow tools:
+
+- `kitaru_flows_delete`
 
 Deployment tools:
 
@@ -385,6 +390,43 @@ Pass flow inputs as `args` (a JSON object) and optionally specify a `stack`:
 
 When `stack` is provided, the tool passes it to `.run(stack=...)` so the
 execution targets that stack.
+
+## Deletion tools
+
+The MCP server exposes two direct lifecycle mutations:
+
+| Tool | Argument | Successful acknowledgement |
+|---|---|---|
+| `kitaru_executions_delete` | `exec_id: str` | `{"exec_id": "<exec-id>", "deleted": true}` |
+| `kitaru_flows_delete` | `flow: str` | `{"flow": "<flow>", "deleted": true}` |
+
+`kitaru_executions_delete` removes one execution. If that execution is active,
+the tool removes its stored metadata without stopping the underlying workload.
+The workload can continue consuming compute and may later fail when it tries to
+update metadata that no longer exists.
+
+`kitaru_flows_delete` removes the whole flow, including its saved deployment
+versions and executions. It has the same behavior for every active execution in
+the flow: their workloads are not stopped when their metadata is deleted. Shared
+artifacts are not deleted. To remove only one saved version, use
+`kitaru_deployments_delete(flow=..., version=...)` instead.
+
+Cancel active executions and wait for them to terminate before calling either
+deletion tool.
+
+These tools mutate stored state as soon as the MCP call is authorized. They do
+not prompt and their schemas do not accept `yes`, `confirm`, or `force`. An MCP
+client must obtain any required user approval before it calls either tool.
+
+Example calls:
+
+```json
+{"exec_id": "kr-a8f3c2"}
+```
+
+```json
+{"flow": "research_agent"}
+```
 
 ## Deployment tools
 

--- a/docs/book/guides/authentication.md
+++ b/docs/book/guides/authentication.md
@@ -141,6 +141,9 @@ kitaru auth api-keys list ci-runner
 kitaru auth api-keys delete ci-runner old-key --yes
 ```
 
+Deletion prompts in text mode. With `--output json`, pass `--yes`; otherwise
+Kitaru refuses the deletion and writes one JSON error document to stderr.
+
 ## SDK usage
 
 The Python SDK exposes the same OSS-first auth-management surface:

--- a/docs/book/guides/deployments.md
+++ b/docs/book/guides/deployments.md
@@ -278,6 +278,46 @@ kitaru flow tag research_agent default --version 2 --exclusive
 kitaru flow deployments delete research_agent --version 1
 ```
 
+### Delete one version or the whole flow
+
+These operations have different scopes:
+
+- `kitaru flow deployments delete FLOW --version VERSION` deletes one saved
+  deployment version. An exclusive tag must be moved first, as shown above.
+- `kitaru flow delete FLOW` deletes the whole flow, including all of its saved
+  deployment versions and executions.
+
+Whole-flow deletion is destructive and prompts for confirmation:
+
+```bash
+kitaru flow delete research_agent
+kitaru flow delete research_agent --yes  # approved non-interactive use
+```
+
+With `--output json`, `--yes` is required. This keeps stdout and stderr
+machine-readable by avoiding an interactive prompt in structured-output mode.
+
+{% hint style="warning" %}
+Deleting a flow does not stop workloads for its active executions. It removes
+their stored metadata while those workloads can continue consuming compute and
+may later fail when they try to update metadata that no longer exists. Cancel all
+active executions and wait for them to terminate before deleting the flow.
+{% endhint %}
+
+The equivalent Python call is:
+
+```python
+from kitaru import KitaruClient
+
+KitaruClient().flows.delete("research_agent")
+```
+
+Deleting a whole flow removes its saved versions and executions, but it does not
+delete shared artifacts. Kitaru does not walk through those records or delete
+artifacts separately. The active runtime applies the flow's stored
+relationships, which avoids removing an artifact that another flow or execution
+still uses.
+
 ### Shared tags
 
 Non-exclusive tags can point to more than one version. A common mixed pattern

--- a/docs/book/guides/execution-management.md
+++ b/docs/book/guides/execution-management.md
@@ -440,7 +440,7 @@ runner already exited), call `resume(...)`:
 execution = client.executions.resume(exec_id)
 ```
 
-## Replay, retry, and cancel
+## Replay, retry, cancel, and delete
 
 Replay is the core of the improve loop: it re-executes a recorded run into a
 **new** execution from a checkpoint boundary, optionally with inputs changed.
@@ -478,6 +478,61 @@ cancelled = client.executions.cancel(exec_id)
 For the full replay/diff workflow, see the
 [ZenML Learn Agents guide](https://docs.zenml.io/user-guides/agents-guide).
 
+### Delete an execution
+
+Cancellation and deletion have different effects. `cancel(...)` asks a running
+execution to stop and keeps its record available for inspection. `delete(...)`
+removes the execution record.
+
+{% hint style="warning" %}
+Deleting an active execution removes its stored metadata without stopping the
+underlying workload. That workload can continue consuming compute and may later
+fail when it tries to update metadata that no longer exists. Cancel the execution
+and wait for it to terminate before deleting it.
+{% endhint %}
+
+Delete by execution ID through the client namespace:
+
+```python
+client.executions.delete(exec_id)
+```
+
+If you already fetched the execution, the model convenience method performs the
+same deletion:
+
+```python
+execution = client.executions.get(exec_id)
+execution.delete()
+```
+
+`Execution` is a frozen snapshot. Calling `execution.delete()` does not mutate
+that Python object, but refreshing it or fetching the same ID again will fail
+once the deletion has succeeded.
+
+The CLI prompts before deleting. Pass `--yes` (or `-y`) when a person has already
+approved the deletion and the command runs non-interactively:
+
+```bash
+kitaru executions delete kr-a8f3c2
+kitaru executions delete kr-a8f3c2 --yes
+```
+
+With `--output json`, `--yes` is required. This keeps stdout and stderr
+machine-readable by avoiding an interactive prompt in structured-output mode.
+
+MCP callers use the direct mutation tool and receive a minimal acknowledgement:
+
+```text
+kitaru_executions_delete(exec_id="kr-a8f3c2")
+```
+
+```json
+{"exec_id": "kr-a8f3c2", "deleted": true}
+```
+
+The MCP tool does not prompt or accept a confirmation argument. The MCP caller
+must obtain any required user approval before invoking it.
+
 ## Execution convenience methods
 
 `Execution` objects returned by `client.executions.get(...)` also expose
@@ -491,15 +546,18 @@ retried = execution.retry()          # retry a failed execution
 resumed = execution.resume()         # resume after wait input
 cancelled = execution.cancel()       # cancel a running execution
 replayed = execution.replay(at="write_draft", checkpoint_overrides={"research": {"output": "Edited notes"}})
+execution.delete()                    # permanently delete the execution record
 
 checkpoints = execution.list_checkpoints()
 artifacts = execution.list_artifacts()
 ```
 
-These are equivalent to calling `client.executions.retry(exec_id)` etc.
-`refresh`, `retry`, `resume`, and `cancel` return a new `Execution` snapshot
-rather than mutating the existing object; `replay` returns a `ReplaySubmission`
-describing the new replay execution(s).
+These are equivalent to calling the corresponding method on
+`client.executions`. `refresh`, `retry`, `resume`, and `cancel` return a new
+`Execution` snapshot rather than mutating the existing object; `replay` returns
+a `ReplaySubmission` describing the new replay execution(s). `delete` returns
+`None`, and the frozen snapshot remains unchanged after the stored execution is
+deleted.
 
 ## Inspect or abort waits programmatically
 
@@ -563,6 +621,7 @@ kitaru executions resume kr-a8f3c2
 kitaru executions replay kr-a8f3c2 --at write_draft --flow-overrides '{"topic":"New topic"}' --checkpoint-overrides '{"research":{"output":"Edited notes"}}'
 kitaru executions retry kr-a8f3c2
 kitaru executions cancel kr-a8f3c2
+kitaru executions delete kr-a8f3c2 --yes
 ```
 
 ## Query executions through MCP
@@ -582,6 +641,7 @@ Then use tool calls like:
 - `kitaru_executions_input(exec_id=..., wait=..., value=...)` (MCP requires explicit `wait`)
 - `kitaru_executions_abort_wait(exec_id=..., wait=...)`
 - `kitaru_executions_resume(exec_id=...)`
+- `kitaru_executions_delete(exec_id=...)`
 - `get_execution_logs(exec_id=...)`
 - `kitaru_artifacts_get(artifact_id=...)`
 - `kitaru_status()`

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1598,6 +1598,7 @@ run_test "kitaru build --help"            $UV_RUN kitaru build --help
 run_test "kitaru deploy --help"           $UV_RUN kitaru deploy --help
 run_test "kitaru invoke --help"           $UV_RUN kitaru invoke --help
 run_test "kitaru flow --help"             $UV_RUN kitaru flow --help
+run_test "kitaru flow delete --help"      $UV_RUN kitaru flow delete --help
 run_test "kitaru flow deployments --help" $UV_RUN kitaru flow deployments --help
 run_test "kitaru flow deployments curl --help" $UV_RUN kitaru flow deployments curl --help
 run_test "kitaru flow list"               $UV_RUN kitaru flow list
@@ -1943,6 +1944,7 @@ run_test "Wait/resume example import contract" \
     $UV_RUN python -c 'from importlib.util import module_from_spec, spec_from_file_location; from pathlib import Path; path = Path("examples/features/execution_management/wait_and_resume.py"); spec = spec_from_file_location("wait_and_resume_smoke", path); assert spec and spec.loader; module = module_from_spec(spec); spec.loader.exec_module(module); details = module.ReleaseDetails(notes="Bug fixes", major_version=2); assert details.major_version == 2; source = path.read_text(); assert "approve_release" in source and "release_details" in source and "timeout=3600" in source and "timeout=60" in source'
 run_test "Replay with overrides"   timed 120 $UV_RUN examples/features/replay/replay_with_overrides.py
 run_test "executions replay --help" $UV_RUN kitaru executions replay --help
+run_test "executions delete --help" $UV_RUN kitaru executions delete --help
 run_test "executions diff --help"   $UV_RUN kitaru executions diff --help
 run_test "executions diff-matrix --help" $UV_RUN kitaru executions diff-matrix --help
 run_test "executions cohort --help" $UV_RUN kitaru executions cohort --help

--- a/src/kitaru/__init__.py
+++ b/src/kitaru/__init__.py
@@ -29,8 +29,9 @@ Current status:
   ``configure()``, stack lifecycle helpers (``list_stacks()``,
   ``current_stack()``, ``use_stack()``, ``create_stack()``,
   ``delete_stack()``), model alias helpers via CLI
-  (``kitaru model register/list``), ``KitaruClient`` execution/artifact APIs
-  (`get/list/latest/logs/statistics/input/retry/resume/cancel/replay` +
+  (``kitaru model register/list``), ``KitaruClient.flows.delete()``,
+  ``KitaruClient`` execution/artifact APIs
+  (`get/list/latest/logs/statistics/input/retry/resume/cancel/replay/delete` +
   artifacts), a typed Kitaru exception hierarchy with failure journaling
   (``Execution.failure``, ``CheckpointCall.attempts``), and live-event watching
   (``KitaruClient.executions.events(...)``).
@@ -39,7 +40,7 @@ Current status:
 The CLI also supports global runtime log-store configuration via
 ``kitaru log-store set/show/reset``, stack lifecycle via
 ``kitaru stack list/current/use/create/delete``, and execution lifecycle commands via
-``kitaru executions get/list/logs/statistics/input/replay/retry/resume/cancel``.
+``kitaru executions get/list/logs/statistics/input/replay/retry/resume/cancel/delete``.
 """
 
 # ZenML must be imported explicitly here so that its init_logging() runs

--- a/src/kitaru/_cli/_auth.py
+++ b/src/kitaru/_cli/_auth.py
@@ -23,6 +23,7 @@ from ._helpers import (
     OutputFormatOption,
     PaginationPageOption,
     PaginationSizeOption,
+    _confirm_delete,
     _emit_json_item,
     _emit_json_items,
     _emit_pagination_note,
@@ -31,7 +32,6 @@ from ._helpers import (
     _exit_with_error,
     _format_table_timestamp,
     _format_timestamp,
-    _is_input_interactive,
     _print_success,
     _resolve_output_format,
     _validate_pagination,
@@ -199,30 +199,6 @@ def _api_key_table_rows(api_keys: list[AuthAPIKey]) -> list[list[str]]:
 def _auth_management_client() -> Any:
     """Return the public SDK client configured for server-level auth management."""
     return cli_dependencies().auth_management_client()
-
-
-def _confirm_delete(
-    *,
-    command: str,
-    output: CLIOutputFormat,
-    yes: bool,
-    description: str,
-) -> None:
-    """Require explicit confirmation before destructive auth deletes."""
-    if yes:
-        return
-    if not _is_input_interactive():
-        _exit_with_error(
-            command,
-            f"Non-interactive environment requires --yes to delete {description}.",
-            output=output,
-        )
-    try:
-        response = input(f"Delete {description}? [y/N] ")
-    except (EOFError, KeyboardInterrupt):
-        response = ""
-    if response.strip().lower() not in {"y", "yes"}:
-        _exit_with_error(command, "Deletion aborted.", output=output)
 
 
 # ---------------------------------------------------------------------------
@@ -473,7 +449,10 @@ def service_accounts_delete(
     *,
     yes: Annotated[
         bool,
-        Parameter(alias=["-y"], help="Skip confirmation prompt."),
+        Parameter(
+            alias=["-y"],
+            help="Skip confirmation prompt. Required with --output json.",
+        ),
     ] = False,
     output: OutputFormatOption = "text",
 ) -> None:
@@ -767,7 +746,10 @@ def api_keys_delete(
     *,
     yes: Annotated[
         bool,
-        Parameter(alias=["-y"], help="Skip confirmation prompt."),
+        Parameter(
+            alias=["-y"],
+            help="Skip confirmation prompt. Required with --output json.",
+        ),
     ] = False,
     output: OutputFormatOption = "text",
 ) -> None:

--- a/src/kitaru/_cli/_executions.py
+++ b/src/kitaru/_cli/_executions.py
@@ -43,10 +43,12 @@ from kitaru.inspection import (
 from . import executions_app
 from ._dependencies import cli_dependencies
 from ._helpers import (
+    _ACTIVE_EXECUTION_DELETE_WARNING,
     DEFAULT_LIST_PAGE,
     DEFAULT_LIST_SIZE,
     OutputFormatOption,
     SnapshotSection,
+    _confirm_delete,
     _emit_json_item,
     _emit_json_items,
     _emit_pagination_note,
@@ -1792,6 +1794,48 @@ def resume_(
         f"Resumed execution: {execution.exec_id}",
         detail=f"Status: {execution.status.value}",
     )
+
+
+@executions_app.command
+def delete_(
+    exec_id: Annotated[
+        str,
+        Parameter(help="Execution ID."),
+    ],
+    *,
+    yes: Annotated[
+        bool,
+        Parameter(
+            alias=["-y"],
+            help="Skip confirmation prompt. Required with --output json.",
+        ),
+    ] = False,
+    output: OutputFormatOption = "text",
+) -> None:
+    """Delete an execution."""
+    command = "executions.delete"
+    output_format = _resolve_output_format(output)
+    _confirm_delete(
+        command=command,
+        output=output_format,
+        yes=yes,
+        description=f"execution `{exec_id}`",
+        warning=_ACTIVE_EXECUTION_DELETE_WARNING,
+    )
+
+    run_with_cli_error_boundary(
+        lambda: cli_dependencies().kitaru_client().executions.delete(exec_id),
+        command=command,
+        output=output_format,
+        exit_with_error=_exit_with_error,
+    )
+    item = {"exec_id": exec_id, "deleted": True}
+
+    if output_format == CLIOutputFormat.JSON:
+        _emit_json_item(command, item, output=output_format)
+        return
+
+    _print_success(f"Deleted execution: {exec_id}")
 
 
 @executions_app.command

--- a/src/kitaru/_cli/_flows.py
+++ b/src/kitaru/_cli/_flows.py
@@ -57,11 +57,13 @@ from ._executions import (
     _parse_json_object,
 )
 from ._helpers import (
+    _ACTIVE_EXECUTION_DELETE_WARNING,
     DEFAULT_LIST_PAGE,
     DEFAULT_LIST_SIZE,
     OutputFormatOption,
     PaginationPageOption,
     PaginationSizeOption,
+    _confirm_delete,
     _emit_json_item,
     _emit_json_items,
     _emit_pagination_note,
@@ -729,6 +731,45 @@ def show(
             ("Tags", ", ".join(sorted(item["tags"].keys())) or "none"),
         ],
     )
+
+
+@flow_app.command(name="delete")
+def delete_flow(
+    flow: Annotated[str, Parameter(help="Flow name, ID, or ID prefix.")],
+    *,
+    yes: Annotated[
+        bool,
+        Parameter(
+            alias=["-y"],
+            help="Skip confirmation prompt. Required with --output json.",
+        ),
+    ] = False,
+    output: OutputFormatOption = "text",
+) -> None:
+    """Delete a flow, including its saved deployment versions and executions."""
+    command = "flow.delete"
+    output_format = _resolve_output_format(output)
+    _confirm_delete(
+        command=command,
+        output=output_format,
+        yes=yes,
+        description=(f"flow `{flow}` and its saved deployment versions and executions"),
+        warning=_ACTIVE_EXECUTION_DELETE_WARNING,
+    )
+
+    run_with_cli_error_boundary(
+        lambda: cli_dependencies().kitaru_client().flows.delete(flow),
+        command=command,
+        output=output_format,
+        exit_with_error=_exit_with_error,
+    )
+    item = {"flow": flow, "deleted": True}
+
+    if output_format == CLIOutputFormat.JSON:
+        _emit_json_item(command, item, output=output_format)
+        return
+
+    _print_success(f"Deleted flow: {flow}")
 
 
 @flow_deployments_app.command

--- a/src/kitaru/_cli/_helpers.py
+++ b/src/kitaru/_cli/_helpers.py
@@ -69,6 +69,11 @@ PaginationSizeOption = Annotated[
     Parameter(help="Number of items to return per page."),
 ]
 
+_ACTIVE_EXECUTION_DELETE_WARNING = (
+    "Deleting metadata for active executions does not stop their workloads. "
+    "Cancel active executions and wait for termination before deleting."
+)
+
 
 def _format_timestamp(value: datetime | None) -> str:
     """Format optional timestamps for CLI output."""
@@ -106,6 +111,41 @@ def _is_interactive(*, stderr: bool = False) -> bool:
 def _is_input_interactive() -> bool:
     """Check whether stdin is an interactive terminal for user prompts."""
     return hasattr(sys.stdin, "isatty") and sys.stdin.isatty()
+
+
+def _confirm_delete(
+    *,
+    command: str,
+    output: CLIOutputFormat,
+    yes: bool,
+    description: str,
+    warning: str | None = None,
+) -> None:
+    """Require explicit confirmation before a destructive delete."""
+    if yes:
+        return
+    if output == CLIOutputFormat.JSON:
+        _exit_with_error(
+            command,
+            f"JSON output requires --yes to delete {description}.",
+            output=output,
+        )
+    if not _is_input_interactive():
+        _exit_with_error(
+            command,
+            f"Non-interactive environment requires --yes to delete {description}.",
+            output=output,
+        )
+
+    if warning:
+        print(f"Warning: {warning}", file=sys.stderr)
+    print(f"Delete {description}? [y/N] ", end="", file=sys.stderr, flush=True)
+    try:
+        response = input()
+    except (EOFError, KeyboardInterrupt):
+        response = ""
+    if response.strip().lower() not in {"y", "yes"}:
+        _exit_with_error(command, "Deletion aborted.", output=output)
 
 
 def _value_style(value: str) -> str:

--- a/src/kitaru/_client/_models.py
+++ b/src/kitaru/_client/_models.py
@@ -594,6 +594,13 @@ class Execution:
         """Cancel this execution."""
         return self._client.executions.cancel(self.exec_id)
 
+    def delete(self) -> None:
+        """Delete this execution.
+
+        This frozen object is a snapshot and is not changed after deletion.
+        """
+        self._client.executions.delete(self.exec_id)
+
     def replay(
         self,
         *,

--- a/src/kitaru/analytics.py
+++ b/src/kitaru/analytics.py
@@ -48,6 +48,7 @@ class AnalyticsEvent(StrEnum):
     FLOW_FAILED = "Kitaru flow failed"
     FLOW_TERMINAL = "Kitaru flow terminal"
     FLOW_REPLAYED = "Kitaru flow replayed"
+    FLOW_DELETED = "Kitaru flow deleted"
     REPLAY_REQUESTED = "Kitaru flow replay requested"
     REPLAY_FAILED = "Kitaru flow replay failed"
     REPLAY_MANY_REQUESTED = "Kitaru flow replay many requested"
@@ -60,6 +61,7 @@ class AnalyticsEvent(StrEnum):
     EXECUTION_RETRIED = "Kitaru execution retried"
     EXECUTION_RESUMED = "Kitaru execution resumed"
     EXECUTION_CANCELLED = "Kitaru execution cancelled"
+    EXECUTION_DELETED = "Kitaru execution deleted"
     EXECUTION_STATISTICS_QUERIED = "Kitaru execution statistics queried"
 
     # Feature adoption

--- a/src/kitaru/client.py
+++ b/src/kitaru/client.py
@@ -1164,6 +1164,24 @@ def _list_status_filter_value(public_status: ExecutionStatus) -> str:
     return status_value
 
 
+class _FlowsAPI:
+    """Namespace for flow lifecycle operations."""
+
+    def __init__(self, client: KitaruClient) -> None:
+        self._client_ref = client
+
+    def delete(self, name: str) -> None:
+        """Delete a flow and its backend-associated records."""
+        try:
+            self._client_ref._client().delete_pipeline(
+                name_id_or_prefix=name,
+                project=self._client_ref._project,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(f"Failed to delete flow {name!r}: {exc}") from exc
+        track(AnalyticsEvent.FLOW_DELETED, {})
+
+
 class _ExecutionsAPI:
     """Namespace for execution lifecycle and inspection operations."""
 
@@ -1912,6 +1930,19 @@ class _ExecutionsAPI:
         """Get and map one execution by ID."""
         run = self._client_ref._get_pipeline_run(exec_id, hydrate=True)
         return _map_execution(run=run, client=self._client_ref, include_details=True)
+
+    def delete(self, exec_id: str) -> None:
+        """Delete an execution."""
+        try:
+            self._client_ref._client().delete_pipeline_run(
+                name_id_or_prefix=exec_id,
+                project=self._client_ref._project,
+            )
+        except Exception as exc:
+            raise KitaruBackendError(
+                f"Failed to delete execution {exec_id!r}: {exc}"
+            ) from exc
+        track(AnalyticsEvent.EXECUTION_DELETED, {})
 
     def _list_replays_for_originals(
         self,
@@ -3140,7 +3171,7 @@ class _ProjectScopedAPIUnavailable:
     def __getattr__(self, name: str) -> NoReturn:
         raise KitaruUsageError(
             "This Kitaru client has no active project. Set KITARU_PROJECT "
-            "before using execution, artifact, or deployment APIs."
+            "before using flow, execution, artifact, or deployment APIs."
         )
 
 
@@ -3189,7 +3220,7 @@ class _ProjectsAPI:
 
 
 class KitaruClient:
-    """Client for Kitaru executions, artifacts, deployments, projects, and auth."""
+    """Client for Kitaru flows, executions, and related project-scoped APIs."""
 
     def __init__(
         self,
@@ -3237,10 +3268,12 @@ class KitaruClient:
         self.projects = _ProjectsAPI(self)
         if not _require_project and self._project is None:
             unavailable = _ProjectScopedAPIUnavailable()
+            self.flows = unavailable
             self.executions = unavailable
             self.artifacts = unavailable
             self.deployments = unavailable
         else:
+            self.flows = _FlowsAPI(self)
             self.executions = _ExecutionsAPI(self)
             self.artifacts = _ArtifactsAPI(self)
             self.deployments = _DeploymentsAPI(self)

--- a/src/kitaru/mcp/server.py
+++ b/src/kitaru/mcp/server.py
@@ -160,6 +160,22 @@ def kitaru_executions_get(exec_id: str) -> dict[str, Any]:
 
 
 @tracked_mcp_tool
+def kitaru_executions_delete(exec_id: str) -> dict[str, Any]:
+    """Delete one execution.
+
+    Deleting an active execution does not stop its workload. The workload can
+    continue consuming compute and later fail when it updates deleted metadata.
+    Cancel the execution and wait for termination before calling this tool.
+    """
+
+    def _delete() -> dict[str, Any]:
+        client_api.KitaruClient().executions.delete(exec_id)
+        return {"exec_id": exec_id, "deleted": True}
+
+    return run_with_mcp_error_boundary(_delete)
+
+
+@tracked_mcp_tool
 def kitaru_executions_latest(
     status: str | None = None,
     flow: str | None = None,
@@ -348,6 +364,22 @@ def kitaru_deployments_get(
         return inspection.serialize_deployment(deployment)
 
     return run_with_mcp_error_boundary(_get)
+
+
+@tracked_mcp_tool
+def kitaru_flows_delete(flow: str) -> dict[str, Any]:
+    """Delete a flow and all its saved deployment versions and executions.
+
+    Deleting active execution metadata does not stop the underlying workloads.
+    They can continue consuming compute and later fail when they update deleted
+    metadata. Cancel active executions and wait for termination first.
+    """
+
+    def _delete() -> dict[str, Any]:
+        client_api.KitaruClient().flows.delete(flow)
+        return {"flow": flow, "deleted": True}
+
+    return run_with_mcp_error_boundary(_delete)
 
 
 @tracked_mcp_tool

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -51,6 +51,7 @@ from kitaru.mcp.server import (
     kitaru_deployments_untag,
     kitaru_executions_abort_wait,
     kitaru_executions_cancel,
+    kitaru_executions_delete,
     kitaru_executions_diff,
     kitaru_executions_diff_matrix,
     kitaru_executions_get,
@@ -62,6 +63,7 @@ from kitaru.mcp.server import (
     kitaru_executions_retry,
     kitaru_executions_run,
     kitaru_executions_statistics,
+    kitaru_flows_delete,
     kitaru_info,
     kitaru_projects_current,
     kitaru_projects_list,
@@ -83,6 +85,7 @@ _REGISTERED_MCP_TOOL_FUNCTIONS = (
     kitaru_executions_list,
     kitaru_executions_statistics,
     kitaru_executions_get,
+    kitaru_executions_delete,
     kitaru_executions_latest,
     get_execution_logs,
     kitaru_executions_run,
@@ -91,6 +94,7 @@ _REGISTERED_MCP_TOOL_FUNCTIONS = (
     kitaru_deployments_list,
     kitaru_deployments_get,
     kitaru_deployments_delete,
+    kitaru_flows_delete,
     kitaru_deployments_tag,
     kitaru_deployments_untag,
     kitaru_executions_abort_wait,
@@ -145,6 +149,17 @@ def _mcp_tool_schemas_by_name() -> dict[str, dict[str, Any]]:
     return {tool.name: tool.inputSchema for tool in tools}
 
 
+def test_delete_tool_descriptions_warn_about_active_workloads() -> None:
+    """Destructive MCP tools should expose the active-workload warning."""
+    tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+
+    for tool_name in ("kitaru_executions_delete", "kitaru_flows_delete"):
+        description = tools[tool_name].description or ""
+        assert "does not stop" in description
+        assert "continue consuming compute" in description
+        assert "wait for termination" in description
+
+
 def test_fastmcp_registers_public_tools_with_expected_input_schemas() -> None:
     tool_schemas = _mcp_tool_schemas_by_name()
     expected_names = {func.__name__ for func in _REGISTERED_MCP_TOOL_FUNCTIONS}
@@ -163,6 +178,17 @@ def test_fastmcp_registers_public_tools_with_expected_input_schemas() -> None:
     abort_wait_schema = tool_schemas["kitaru_executions_abort_wait"]
     assert set(abort_wait_schema["properties"]) == {"exec_id", "wait"}
     assert abort_wait_schema["required"] == ["exec_id", "wait"]
+
+    flow_delete_schema = tool_schemas["kitaru_flows_delete"]
+    assert set(flow_delete_schema["properties"]) == {"flow"}
+    assert flow_delete_schema["required"] == ["flow"]
+
+    execution_delete_schema = tool_schemas["kitaru_executions_delete"]
+    assert set(execution_delete_schema["properties"]) == {"exec_id"}
+    assert execution_delete_schema["required"] == ["exec_id"]
+
+    for schema in (flow_delete_schema, execution_delete_schema):
+        assert not {"yes", "confirm", "force"} & set(schema["properties"])
 
     invoke_schema = tool_schemas["kitaru_deployments_invoke"]
     assert set(invoke_schema["properties"]) == {
@@ -1087,6 +1113,28 @@ def test_deployments_delete_delegates_by_version(
         version=2,
     )
     assert payload == {"flow": "content_pipeline", "version": 2, "deleted": True}
+
+
+def test_flows_delete_delegates_and_acknowledges(
+    mock_kitaru_client: MagicMock,
+) -> None:
+    """kitaru_flows_delete should delegate the cascade to the SDK."""
+    with patch("kitaru.client.KitaruClient", return_value=mock_kitaru_client):
+        payload = kitaru_flows_delete("content_pipeline")
+
+    mock_kitaru_client.flows.delete.assert_called_once_with("content_pipeline")
+    assert payload == {"flow": "content_pipeline", "deleted": True}
+
+
+def test_executions_delete_delegates_and_acknowledges(
+    mock_kitaru_client: MagicMock,
+) -> None:
+    """kitaru_executions_delete should delegate directly to the SDK."""
+    with patch("kitaru.client.KitaruClient", return_value=mock_kitaru_client):
+        payload = kitaru_executions_delete("kr-123")
+
+    mock_kitaru_client.executions.delete.assert_called_once_with("kr-123")
+    assert payload == {"exec_id": "kr-123", "deleted": True}
 
 
 def test_deployments_tag_delegates_and_serializes(

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -150,6 +150,7 @@ def test_flow_lifecycle_event_canonical_strings() -> None:
     assert AnalyticsEvent.FLOW_ATTEMPTED == "Kitaru flow attempted"
     assert AnalyticsEvent.FLOW_SUBMITTED == "Kitaru flow submitted"
     assert AnalyticsEvent.FLOW_FAILED == "Kitaru flow failed"
+    assert AnalyticsEvent.FLOW_DELETED == "Kitaru flow deleted"
     assert AnalyticsEvent.REPLAY_REQUESTED == "Kitaru flow replay requested"
     assert AnalyticsEvent.REPLAY_FAILED == "Kitaru flow replay failed"
 
@@ -167,6 +168,7 @@ def test_core_funnel_event_canonical_strings() -> None:
     assert AnalyticsEvent.EXECUTION_RETRIED == "Kitaru execution retried"
     assert AnalyticsEvent.EXECUTION_RESUMED == "Kitaru execution resumed"
     assert AnalyticsEvent.EXECUTION_CANCELLED == "Kitaru execution cancelled"
+    assert AnalyticsEvent.EXECUTION_DELETED == "Kitaru execution deleted"
     assert (
         AnalyticsEvent.EXECUTION_STATISTICS_QUERIED
         == "Kitaru execution statistics queried"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1020,6 +1020,7 @@ def test_auth_delete_requires_yes_in_non_interactive_mode(
 
     with (
         patch("kitaru.cli.KitaruClient.for_auth_management", return_value=fake_client),
+        patch("kitaru._cli._helpers._is_input_interactive", return_value=False),
         pytest.raises(SystemExit) as exc_info,
     ):
         app(["auth", "service-accounts", "delete", "ci-runner"])
@@ -1029,6 +1030,61 @@ def test_auth_delete_requires_yes_in_non_interactive_mode(
     captured = capsys.readouterr()
     assert captured.out == ""
     assert "requires --yes" in captured.err
+
+
+@pytest.mark.parametrize(
+    ("args", "delete_namespace", "command"),
+    [
+        (
+            ["auth", "service-accounts", "delete", "ci-runner", "-o", "json"],
+            "service_accounts",
+            "auth.service-accounts.delete",
+        ),
+        (
+            [
+                "auth",
+                "api-keys",
+                "delete",
+                "ci-runner",
+                "default",
+                "-o",
+                "json",
+            ],
+            "api_keys",
+            "auth.api-keys.delete",
+        ),
+    ],
+)
+def test_auth_delete_json_requires_yes_without_prompt(
+    args: list[str],
+    delete_namespace: str,
+    command: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON deletion should refuse with one error document instead of prompting."""
+    service_accounts = Mock()
+    api_keys = Mock()
+    fake_client = _auth_management_client_stub(
+        service_accounts=service_accounts,
+        api_keys=api_keys,
+    )
+
+    with (
+        patch("kitaru.cli.KitaruClient.for_auth_management", return_value=fake_client),
+        patch("kitaru._cli._helpers._is_input_interactive", return_value=True),
+        patch("builtins.input", return_value="yes") as input_mock,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(args)
+
+    assert exc_info.value.code == 1
+    input_mock.assert_not_called()
+    getattr(fake_client.auth, delete_namespace).delete.assert_not_called()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["command"] == command
+    assert payload["error"]["message"].startswith("JSON output requires --yes")
 
 
 def test_auth_delete_with_yes_runs_and_returns_json(
@@ -1047,7 +1103,9 @@ def test_auth_delete_with_yes_runs_and_returns_json(
 
     assert exc_info.value.code == 0
     service_accounts.delete.assert_called_once_with("ci-runner")
-    payload = json.loads(capsys.readouterr().out)
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    payload = json.loads(captured.out)
     assert payload == {
         "command": "auth.service-accounts.delete",
         "item": {"name_or_id": "ci-runner", "deleted": True},
@@ -1081,7 +1139,9 @@ def test_auth_api_key_delete_with_yes_runs_and_returns_json(
 
     assert exc_info.value.code == 0
     api_keys.delete.assert_called_once_with("ci-runner", "default")
-    payload = json.loads(capsys.readouterr().out)
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    payload = json.loads(captured.out)
     assert payload == {
         "command": "auth.api-keys.delete",
         "item": {
@@ -2131,6 +2191,205 @@ def test_flow_list_json_groups_deployment_backed_flows(
     assert payload["count"] == 2
     assert payload["items"][0]["flow"] == "alpha"
     assert payload["items"][0]["latest_version"] == 2
+
+
+def test_flow_delete_with_yes_delegates_and_prints_success(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--yes` should delete through the flow namespace without a prompt."""
+    fake_client = Mock()
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["flow", "delete", "demo_flow", "--yes"])
+
+    assert exc_info.value.code == 0
+    fake_client.flows.delete.assert_called_once_with("demo_flow")
+    fake_client.deployments.delete.assert_not_called()
+    assert capsys.readouterr().out == "Deleted flow: demo_flow\n"
+
+
+def test_flow_delete_interactive_acceptance_warns_about_cascade(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Interactive confirmation should describe and then perform the cascade."""
+    fake_client = Mock()
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        patch("kitaru._cli._helpers._is_input_interactive", return_value=True),
+        patch("builtins.input", return_value="YeS") as input_mock,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["flow", "delete", "demo_flow"])
+
+    assert exc_info.value.code == 0
+    input_mock.assert_called_once_with()
+    fake_client.flows.delete.assert_called_once_with("demo_flow")
+    captured = capsys.readouterr()
+    assert "Deleted flow: demo_flow" in captured.out
+    assert "does not stop their workloads" in captured.err
+    assert captured.err.endswith(
+        "Delete flow `demo_flow` and its saved deployment versions and "
+        "executions? [y/N] "
+    )
+
+
+@pytest.mark.parametrize(
+    ("args", "delete_namespace", "command"),
+    [
+        (
+            ["flow", "delete", "demo_flow", "-o", "json"],
+            "flows",
+            "flow.delete",
+        ),
+        (
+            ["executions", "delete", "kr-123", "-o", "json"],
+            "executions",
+            "executions.delete",
+        ),
+    ],
+)
+def test_cli_delete_json_requires_yes_without_prompt(
+    args: list[str],
+    delete_namespace: str,
+    command: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON deletion should refuse with one error document instead of prompting."""
+    fake_client = Mock()
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        patch("kitaru._cli._helpers._is_input_interactive", return_value=True),
+        patch("builtins.input", return_value="yes") as input_mock,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(args)
+
+    assert exc_info.value.code == 1
+    input_mock.assert_not_called()
+    getattr(fake_client, delete_namespace).delete.assert_not_called()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["command"] == command
+    assert payload["error"]["message"].startswith("JSON output requires --yes")
+
+
+@pytest.mark.parametrize(
+    ("args", "delete_namespace", "expected"),
+    [
+        (
+            ["flow", "delete", "demo_flow", "--yes", "-o", "json"],
+            "flows",
+            {
+                "command": "flow.delete",
+                "item": {"flow": "demo_flow", "deleted": True},
+            },
+        ),
+        (
+            ["executions", "delete", "kr-123", "--yes", "-o", "json"],
+            "executions",
+            {
+                "command": "executions.delete",
+                "item": {"exec_id": "kr-123", "deleted": True},
+            },
+        ),
+    ],
+)
+def test_cli_delete_json_with_yes_emits_json_only(
+    args: list[str],
+    delete_namespace: str,
+    expected: dict[str, Any],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Confirmed JSON deletion should emit one document and no prompt text."""
+    fake_client = Mock()
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(args)
+
+    assert exc_info.value.code == 0
+    getattr(fake_client, delete_namespace).delete.assert_called_once()
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert json.loads(captured.out) == expected
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["flow", "delete", "demo_flow"],
+        ["executions", "delete", "kr-123"],
+    ],
+)
+def test_cli_delete_requires_yes_in_non_interactive_mode(
+    args: list[str],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """New destructive commands should fail before SDK mutation without --yes."""
+    fake_client = Mock()
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        patch("kitaru._cli._helpers._is_input_interactive", return_value=False),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(args)
+
+    assert exc_info.value.code == 1
+    assert fake_client.method_calls == []
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "requires --yes" in captured.err
+
+
+@pytest.mark.parametrize(
+    ("args", "delete_namespace", "command"),
+    [
+        (
+            ["flow", "delete", "demo_flow", "--yes", "-o", "json"],
+            "flows",
+            "flow.delete",
+        ),
+        (
+            ["executions", "delete", "kr-123", "--yes", "-o", "json"],
+            "executions",
+            "executions.delete",
+        ),
+    ],
+)
+def test_cli_delete_serializes_sdk_errors(
+    args: list[str],
+    delete_namespace: str,
+    command: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """SDK deletion failures should use the structured CLI error contract."""
+    fake_client = Mock()
+    getattr(fake_client, delete_namespace).delete.side_effect = KitaruBackendError(
+        "backend unavailable"
+    )
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(args)
+
+    assert exc_info.value.code == 1
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["command"] == command
+    assert payload["error"] == {
+        "type": "KitaruBackendError",
+        "message": "backend unavailable",
+    }
 
 
 def test_flow_deployments_logs_explicit_exec_id_skips_deployment_resolution(
@@ -5305,6 +5564,48 @@ def test_executions_cancel_reports_success(
     output = capsys.readouterr().out
     assert "Cancelled execution: kr-123" in output
     assert "Status: cancelled" in output
+
+
+def test_executions_delete_short_yes_returns_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`-y` should bypass confirmation and emit the execution acknowledgement."""
+    fake_client = Mock()
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "delete", "kr-123", "-y", "-o", "json"])
+
+    assert exc_info.value.code == 0
+    fake_client.executions.delete.assert_called_once_with("kr-123")
+    fake_client.flows.delete.assert_not_called()
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert json.loads(captured.out) == {
+        "command": "executions.delete",
+        "item": {"exec_id": "kr-123", "deleted": True},
+    }
+
+
+def test_executions_delete_interactive_refusal_aborts_before_mutation(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An interactive refusal should not call the SDK."""
+    fake_client = Mock()
+
+    with (
+        patch("kitaru.cli.KitaruClient", return_value=fake_client),
+        patch("kitaru._cli._helpers._is_input_interactive", return_value=True),
+        patch("builtins.input", return_value="no"),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        app(["executions", "delete", "kr-123"])
+
+    assert exc_info.value.code == 1
+    fake_client.executions.delete.assert_not_called()
+    assert "Deletion aborted." in capsys.readouterr().err
 
 
 def test_login_delegates_to_remote_connect(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -668,6 +668,7 @@ def test_client_initializes_namespaces() -> None:
     ):
         client = KitaruClient()
 
+    assert hasattr(client, "flows")
     assert hasattr(client, "executions")
     assert hasattr(client, "artifacts")
     assert hasattr(client, "deployments")
@@ -749,6 +750,8 @@ def test_project_management_client_blocks_project_scoped_apis_without_project() 
     ):
         client = KitaruClient.for_project_management()
 
+    with pytest.raises(KitaruUsageError, match="flow"):
+        client.flows.delete("flow-a")
     with pytest.raises(KitaruUsageError, match="KITARU_PROJECT"):
         client.executions.list()
     with pytest.raises(KitaruUsageError, match="KITARU_PROJECT"):
@@ -4514,6 +4517,123 @@ def test_statistics_backend_failure_raises_backend_error() -> None:
 
         with pytest.raises(KitaruBackendError, match="database offline"):
             client.executions.statistics()
+
+
+def test_flow_delete_calls_one_project_scoped_backend_mutation_and_tracks() -> None:
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection("project-a"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch("kitaru.client.track") as track_mock,
+    ):
+        client_mock = client_cls.return_value
+        client = KitaruClient()
+
+        result = client.flows.delete("flow-name-or-prefix")
+
+    assert result is None
+    client_mock.delete_pipeline.assert_called_once_with(
+        name_id_or_prefix="flow-name-or-prefix",
+        project="project-a",
+    )
+    track_mock.assert_called_once_with(AnalyticsEvent.FLOW_DELETED, {})
+
+
+def test_execution_delete_calls_one_project_scoped_backend_mutation_and_tracks() -> (
+    None
+):
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection("project-a"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch("kitaru.client.track") as track_mock,
+    ):
+        client_mock = client_cls.return_value
+        client = KitaruClient()
+
+        result = client.executions.delete("execution-name-or-id")
+
+    assert result is None
+    client_mock.delete_pipeline_run.assert_called_once_with(
+        name_id_or_prefix="execution-name-or-id",
+        project="project-a",
+    )
+    track_mock.assert_called_once_with(AnalyticsEvent.EXECUTION_DELETED, {})
+
+
+@pytest.mark.parametrize(
+    ("namespace_name", "backend_method", "identifier", "operation"),
+    [
+        ("flows", "delete_pipeline", "flow-a", "flow"),
+        ("executions", "delete_pipeline_run", "exec-a", "execution"),
+    ],
+)
+def test_deletion_translates_backend_exceptions_and_skips_analytics(
+    namespace_name: str,
+    backend_method: str,
+    identifier: str,
+    operation: str,
+) -> None:
+    backend_error = ValueError("backend unavailable")
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection("project-a"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+        patch("kitaru.client.track") as track_mock,
+    ):
+        client_mock = client_cls.return_value
+        getattr(client_mock, backend_method).side_effect = backend_error
+        client = KitaruClient()
+
+        with pytest.raises(
+            KitaruBackendError,
+            match=rf"Failed to delete {operation}.*{identifier}.*backend unavailable",
+        ) as exc_info:
+            getattr(client, namespace_name).delete(identifier)
+
+    assert exc_info.value.__cause__ is backend_error
+    assert client_mock.method_calls == [
+        getattr(call, backend_method)(
+            name_id_or_prefix=identifier,
+            project="project-a",
+        )
+    ]
+    track_mock.assert_not_called()
+
+
+def test_execution_delete_delegates_through_originating_client_without_mutation() -> (
+    None
+):
+    run = _DummyRun(
+        status=ZenMLExecutionStatus.COMPLETED,
+        flow_name="flow_a",
+    )
+    with (
+        patch(
+            "kitaru.client.resolve_connection_config",
+            return_value=_resolved_connection("project-a"),
+        ),
+        patch("kitaru.client.Client") as client_cls,
+    ):
+        client_mock = client_cls.return_value
+        client_mock.get_pipeline_run.return_value = _as_pipeline_run(run)
+        client_mock.list_run_steps.return_value = SimpleNamespace(items=[])
+        client = KitaruClient()
+        execution = client.executions.get(str(run.id))
+        snapshot_fields = (execution.exec_id, execution.status)
+
+        with patch.object(client.executions, "delete") as delete_mock:
+            result = execution.delete()
+
+    assert result is None
+    delete_mock.assert_called_once_with(str(run.id))
+    assert (execution.exec_id, execution.status) == snapshot_fields
 
 
 def test_latest_raises_when_no_execution_matches() -> None:

--- a/tests/test_deletion_integration.py
+++ b/tests/test_deletion_integration.py
@@ -1,0 +1,136 @@
+"""Local-store integration tests for flow and execution deletion."""
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+from zenml import ExternalArtifact, pipeline, step
+from zenml.client import Client as ZenMLClient
+
+from kitaru import KitaruClient
+
+
+@step(enable_cache=False)
+def _consume_shared_deletion_artifact(value: dict[str, Any]) -> bool:
+    """Consume one shared artifact so ZenML records its run relationships."""
+    return bool(value["shared"])
+
+
+def _external_artifact_reference(artifact_id: str) -> ExternalArtifact:
+    """Build the ID-backed state that ZenML creates after uploading by value."""
+    reference = ExternalArtifact(value=None)
+    reference.id = UUID(artifact_id)
+    return reference
+
+
+@pipeline(enable_cache=False)
+def _deletion_cascade_flow(shared_artifact_id: str) -> None:
+    """Flow deleted by the cascade integration test."""
+    _consume_shared_deletion_artifact(_external_artifact_reference(shared_artifact_id))
+
+
+@pipeline(enable_cache=False)
+def _deletion_preserved_flow(shared_artifact_id: str) -> None:
+    """Flow that keeps using the shared artifact after another flow is deleted."""
+    _consume_shared_deletion_artifact(_external_artifact_reference(shared_artifact_id))
+
+
+@pipeline(enable_cache=False)
+def _execution_isolation_flow(shared_artifact_id: str) -> None:
+    """Flow run twice to verify that one execution can be deleted in isolation."""
+    _consume_shared_deletion_artifact(_external_artifact_reference(shared_artifact_id))
+
+
+def _upload_shared_artifact(zenml_client: ZenMLClient) -> Any:
+    """Upload and return one artifact version for multiple runs to consume."""
+    artifact_id = ExternalArtifact(value={"shared": True}).upload_by_value()
+    return zenml_client.get_artifact_version(artifact_id)
+
+
+def _assert_run_consumes_artifact(run: Any, artifact_id: Any) -> None:
+    """Assert that the run's only step references the uploaded artifact as input."""
+    step_runs = run.steps
+    assert len(step_runs) == 1
+    step_run = next(iter(step_runs.values()))
+    assert list(step_run.inputs) == ["value"]
+    assert [artifact.id for artifact in step_run.inputs["value"]] == [artifact_id]
+
+
+@pytest.mark.usefixtures("primed_zenml")
+def test_flow_delete_cascades_and_preserves_shared_artifact() -> None:
+    """Whole-flow deletion should use the local store's real cascade relationships."""
+    zenml_client = ZenMLClient()
+    shared_artifact = _upload_shared_artifact(zenml_client)
+
+    deleted_run = _deletion_cascade_flow(str(shared_artifact.id))
+    preserved_run = _deletion_preserved_flow(str(shared_artifact.id))
+    assert deleted_run is not None
+    assert preserved_run is not None
+    assert deleted_run.pipeline is not None
+    assert deleted_run.snapshot is not None
+    _assert_run_consumes_artifact(deleted_run, shared_artifact.id)
+    _assert_run_consumes_artifact(preserved_run, shared_artifact.id)
+
+    kitaru_client = KitaruClient()
+    flow_name = deleted_run.pipeline.name
+    deployment = kitaru_client.deployments.create(
+        flow=flow_name,
+        source_snapshot=deleted_run.snapshot,
+    )
+    pipeline_id = deleted_run.pipeline.id
+    deployment_snapshot_id = deployment.deployment_id
+
+    assert (
+        zenml_client.get_snapshot(deployment_snapshot_id).id == deleted_run.snapshot.id
+    )
+    assert zenml_client.get_pipeline_run(deleted_run.id).id == deleted_run.id
+    assert zenml_client.get_pipeline_run(preserved_run.id).id == preserved_run.id
+
+    kitaru_client.flows.delete(flow_name)
+
+    with pytest.raises(KeyError):
+        zenml_client.get_pipeline(pipeline_id)
+    with pytest.raises(KeyError):
+        zenml_client.get_snapshot(deployment_snapshot_id)
+    with pytest.raises(KeyError):
+        zenml_client.get_pipeline_run(deleted_run.id)
+
+    assert zenml_client.get_pipeline_run(preserved_run.id).id == preserved_run.id
+    preserved_artifact = zenml_client.get_artifact_version(shared_artifact.id)
+    assert preserved_artifact.load() == {"shared": True}
+
+
+@pytest.mark.usefixtures("primed_zenml")
+def test_execution_delete_leaves_other_execution_and_shared_artifact_intact() -> None:
+    """Deleting one execution should not affect another run of the same flow."""
+    zenml_client = ZenMLClient()
+    shared_artifact = _upload_shared_artifact(zenml_client)
+    first_run = _execution_isolation_flow(str(shared_artifact.id))
+    second_run = _execution_isolation_flow(str(shared_artifact.id))
+    assert first_run is not None
+    assert second_run is not None
+    assert first_run.pipeline is not None
+    assert first_run.snapshot is not None
+    _assert_run_consumes_artifact(first_run, shared_artifact.id)
+    _assert_run_consumes_artifact(second_run, shared_artifact.id)
+
+    kitaru_client = KitaruClient()
+    flow_name = first_run.pipeline.name
+    pipeline_id = first_run.pipeline.id
+    deployment = kitaru_client.deployments.create(
+        flow=flow_name,
+        source_snapshot=first_run.snapshot,
+    )
+
+    kitaru_client.executions.delete(str(first_run.id))
+
+    with pytest.raises(KeyError):
+        zenml_client.get_pipeline_run(first_run.id)
+
+    assert zenml_client.get_pipeline_run(second_run.id).id == second_run.id
+    assert zenml_client.get_pipeline(pipeline_id).name == flow_name
+    assert (
+        zenml_client.get_snapshot(deployment.deployment_id).id == first_run.snapshot.id
+    )
+    preserved_artifact = zenml_client.get_artifact_version(shared_artifact.id)
+    assert preserved_artifact.load() == {"shared": True}

--- a/tests/test_generate_cli_docs.py
+++ b/tests/test_generate_cli_docs.py
@@ -150,6 +150,7 @@ class TestBuildCommandTree:
         assert [sub.name for sub in executions.subcommands] == [
             "cancel",
             "cohort",
+            "delete",
             "diff",
             "diff-matrix",
             "get",
@@ -161,6 +162,14 @@ class TestBuildCommandTree:
             "retry",
             "statistics",
         ]
+
+        execution_delete = _find_command(tree, "executions", "delete")
+        assert execution_delete.parameters[0].names == ["EXEC-ID"]
+        option_names = [
+            set(parameter.names) for parameter in execution_delete.parameters
+        ]
+        assert {"--yes", "-y"} in option_names
+        assert {"--output", "-o"} in option_names
 
     def test_auth_tree_includes_service_accounts_and_api_keys(self) -> None:
         from kitaru.cli import app
@@ -198,12 +207,20 @@ class TestBuildCommandTree:
         tree = build_command_tree(app)
         flow = _find_command(tree, "flow")
         assert [sub.name for sub in flow.subcommands] == [
+            "delete",
             "deployments",
             "list",
             "show",
             "tag",
             "untag",
         ]
+
+        flow_delete = _find_command(tree, "flow", "delete")
+        assert flow_delete.parameters[0].names == ["FLOW"]
+        option_names = [set(parameter.names) for parameter in flow_delete.parameters]
+        assert {"--yes", "-y"} in option_names
+        assert {"--output", "-o"} in option_names
+
         deployments = _find_command(tree, "flow", "deployments")
         assert [sub.name for sub in deployments.subcommands] == [
             "curl",
@@ -212,6 +229,29 @@ class TestBuildCommandTree:
             "logs",
             "show",
         ]
+
+    @pytest.mark.parametrize(
+        "command_path",
+        [
+            ("auth", "service-accounts", "delete"),
+            ("auth", "api-keys", "delete"),
+            ("flow", "delete"),
+            ("executions", "delete"),
+        ],
+    )
+    def test_delete_yes_help_states_json_requirement(
+        self,
+        command_path: tuple[str, ...],
+    ) -> None:
+        from kitaru.cli import app
+
+        command = _find_command(build_command_tree(app), *command_path)
+        yes_option = next(
+            parameter for parameter in command.parameters if "--yes" in parameter.names
+        )
+        assert yes_option.help == (
+            "Skip confirmation prompt. Required with --output json."
+        )
 
     def test_builds_canonical_docs_urls_for_nested_commands(self) -> None:
         from kitaru.cli import app
@@ -554,6 +594,7 @@ class TestWriteDocsTree:
         assert meta["pages"] == [
             "cancel",
             "cohort",
+            "delete",
             "diff",
             "diff-matrix",
             "get",


### PR DESCRIPTION
## Summary

- add project-scoped SDK deletion for flows and executions, including `Execution.delete()`
- add confirmation-gated CLI commands and direct MCP deletion tools
- preserve ZenML cascade semantics, warn that deleting metadata does not stop active workloads, and keep JSON output parseable
- add unit, CLI, MCP, documentation, smoke, and local-store cascade coverage

## Testing

- `just check`
- `just test` (3,723 passed, 21 skipped on the final full rerun)
- `just build`
- `just generate-docs`
- `just docs-build`
- `just test tests/test_deletion_integration.py`
- `git diff --check`

`just docs-validate` remains unavailable because the existing Just recipe calls a missing `validate:export` script in `docs/package.json`.

## Reviewer Notes

Suggested reproduction:

1. Run `kitaru flow delete --help` and `kitaru executions delete --help`.
2. Run `just test tests/test_deletion_integration.py` to exercise real flow cascade, shared-artifact preservation, and single-execution isolation.
3. Check JSON safety with `kitaru executions delete <id> --output json`: without `--yes` it returns a structured error; with `--yes` it emits one JSON acknowledgement.
4. Review the active-workload warnings in the CLI confirmations and MCP tool descriptions. Deletion intentionally delegates to ZenML and does not cancel workloads first.

Closes #585
