### PR TITLE
Align README trace-import example with the real import API

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,11 @@ from kitaru import KitaruClient
 
 client = KitaruClient()
 client.executions.import_traces("support-traces.jsonl", format="otel")
-client.executions.import_traces("langfuse://trace/8f3a91c2", name="ticket-48211")
+client.imports.langfuse(
+    "langfuse-observations.jsonl",
+    source_project_id="prod",
+    agent_name="support-agent",
+)
 ```
 
 Every run is now a trace you can replay:


### PR DESCRIPTION
## What and why

Follow-up to #587. The README's Langfuse import line invented its own API (`client.executions.import_traces("langfuse://trace/…", name=…)`). The actual feature — #584, `feat/langfuse-trace-import` — ships `client.imports.langfuse(path, source_project_id=, agent_name=, ...)` over Langfuse observation JSONL exports. This PR updates that one line to the real call.

The generic OTel line (`client.executions.import_traces("support-traces.jsonl", format="otel")`) and the surrounding prose stay as-is — that's the intended forward-looking surface, kept deliberately.

## Reviewer Notes

One file, one block, one line changed in substance. The Langfuse call shows the minimal required arguments (`path`, `source_project_id`, `agent_name`); note the implementation's default is a dry-run plan — the README omits `dry_run=False` / `confirm_data_storage=True` for brevity. Since #584 is still a draft, this snippet must follow if its surface changes — sequencing-wise it may make sense to land this with or right after #584.

### Reproduction

On a checkout of `feat/langfuse-trace-import`: `python -c "from kitaru import KitaruClient; help(KitaruClient().imports.langfuse)"` — the signature should match the README's Langfuse call. `typos` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)