### PR TITLE
Support cloud storage for local stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - The checkpoint table in `kitaru executions diff` text output now includes replay-minus-original duration deltas and per-role artifact comparison states (`unchanged`/`changed`/`unavailable`) alongside token and cost deltas, without printing artifact hashes or values. (#520)
 
 ### Fixed
-<<<<<<< fix/llm-integration-canary
+- Stack creation now verifies discovered service connectors before reusing them for local cloud storage or Modal stacks, failing fast with an actionable error instead of letting runs fail later; `--no-verify` skips the check.
+- `--credentials aws-profile:NAME` is now rejected when connected to a remote ZenML server, because the server cannot resolve AWS profiles that only exist on the local machine; portable `aws-access-keys`/`aws-session-token` credentials remain supported.
 - Claude Agent SDK failures no longer copy raw `ResultMessage.result` content into Kitaru errors or durable failure records; allowlisted diagnostics remain available in durable records and live terminal events.
 - Live LLM integration runs now retain tested SHA, workflow run ID, and run-attempt provenance for release evidence.
-=======
 - Detailed execution graphs now resolve downstream parent call IDs to the visible successful checkpoint after a retry, instead of retaining the hidden failed attempt ID. (#564)
->>>>>>> develop
 - Reporting now preserves physical retry identity, marks unavailable secret-list key metadata explicitly, accounts for unknown billing conservatively, and documents the distinct workload-token and incurred-cost diff bases. (#566)
 - Execution diffs now reject blank selectors and explicit comparisons without recorded direct replay lineage, while deduplicating repeated selectors and aliases in first-occurrence order. (#565)
 - `kitaru executions diff` now shows useful checkpoint comparison rows in its default text output, and diff serialization includes redacted evidence that replay output overrides were applied without exposing override values. (#563)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Local stacks can now use S3, GCS, or Azure Blob/ADLS artifact storage while keeping flow execution local, with existing-connector reuse and ambient provider credentials when explicit credentials are not supplied. (#593)
 - Flow and execution deletion is now available through the SDK, `kitaru flow delete` and `kitaru executions delete` CLI commands, and MCP tools.
 
 ### Changed

--- a/docs/book/stacks/README.md
+++ b/docs/book/stacks/README.md
@@ -127,10 +127,20 @@ this order:
 1. If you pass `--credentials`, Kitaru creates a connector for those
    credentials.
 2. Otherwise, Kitaru reuses one matching connector from the configured Kitaru
-   server when available.
+   server when available. Kitaru verifies that the connector can still
+   authenticate before linking it, so a stale connector fails at stack creation
+   with a clear message instead of at run time. Pass `--no-verify` to link the
+   connector without this check.
 3. If no connector matches, the runner uses the cloud provider credentials
    available on the machine where the flow runs, such as an AWS profile, Google
    Application Default Credentials, or Azure environment and CLI credentials.
+
+When you are connected to a remote Kitaru server, `--credentials
+aws-profile:NAME` is rejected: the server resolves connector credentials at run
+time and has no access to the AWS profiles on your machine. Use portable
+credentials instead, such as `aws-access-keys:KEY:SECRET` or
+`aws-session-token:KEY:SECRET:TOKEN` (`aws configure export-credentials
+--profile NAME` prints the current values for a profile).
 
 The bucket or container must already exist. Deleting the stack removes Kitaru's
 stack records and created components, but never deletes the bucket, container, or

--- a/docs/book/stacks/README.md
+++ b/docs/book/stacks/README.md
@@ -102,6 +102,40 @@ If you want to create the stack without switching to it yet:
 kitaru stack create dev --no-activate
 ```
 
+## Use cloud storage with a local runner
+
+You can keep flow execution on your machine while storing checkpoints in cloud
+storage:
+
+```bash
+kitaru stack create local-cloud \
+  --type local \
+  --artifact-store s3://my-bucket/kitaru
+```
+
+Local stacks accept these storage URI forms:
+
+- Amazon S3: `s3://bucket/path`
+- Google Cloud Storage: `gs://bucket/path`
+- Azure Blob Storage: `az://container/path`
+- Azure Data Lake Storage: `abfs://container/path` or
+  `abfss://container/path`
+
+You do not normally need another authentication flag. Kitaru uses credentials in
+this order:
+
+1. If you pass `--credentials`, Kitaru creates a connector for those
+   credentials.
+2. Otherwise, Kitaru reuses one matching connector from the configured Kitaru
+   server when available.
+3. If no connector matches, the runner uses the cloud provider credentials
+   available on the machine where the flow runs, such as an AWS profile, Google
+   Application Default Credentials, or Azure environment and CLI credentials.
+
+The bucket or container must already exist. Deleting the stack removes Kitaru's
+stack records and created components, but never deletes the bucket, container, or
+stored objects.
+
 ## Create a remote stack
 
 Today, the CLI and MCP server can provision six shipped stack types:

--- a/docs/book/stacks/modal-stacks.md
+++ b/docs/book/stacks/modal-stacks.md
@@ -117,11 +117,11 @@ The cloud credential fields are optional. Use them when you want Kitaru to creat
 | `--region` | Cloud provider region when the provider needs one. For AWS-backed Modal stacks, this is the S3/ECR connector region and must match the ECR registry host. For GCP-backed Modal stacks, Kitaru can check it against GAR/GCR when the registry host includes a location. |
 | `--subscription-id` | Azure subscription ID for Azure Blob/ADLS + ACR Modal stacks |
 | `--credentials` | Cloud credential reference, such as `aws-profile:ml-team`, `gcp-service-account:/path/to/key.json`, or `azure-access-token:...` |
-| `--no-verify` | Skip cloud connector verification when Kitaru is creating a connector. It does not affect existing-connector discovery and does not request a connector by itself; pair it with the needed cloud input, such as `--region`, `--subscription-id`, or `--credentials`. |
+| `--no-verify` | Skip cloud connector verification during stack creation. This covers both a new connector Kitaru creates from explicit credentials and existing server-side connectors Kitaru discovers and reuses. |
 
 Top-level `--region` is **not** Modal placement. If you want to steer where Modal places work, set it through `--extra orchestrator.region=...` / `--extra orchestrator.cloud=...` instead.
 
-`aws-profile:PROFILE` is only safe when the ZenML connector runtime can see that AWS profile. On a remote ZenML server, your laptop's SSO profile is usually invisible to the server. Prefer reusing an existing server-side connector for remote Modal stacks, or pass credentials that the server can use directly.
+`aws-profile:PROFILE` is only safe when the ZenML connector runtime can see that AWS profile, so Kitaru rejects it when you are connected to a remote ZenML server — the server cannot see your laptop's AWS profiles. Prefer reusing an existing server-side connector for remote Modal stacks, or pass portable credentials such as `aws-access-keys:KEY:SECRET` or `aws-session-token:KEY:SECRET:TOKEN`.
 
 ## Set advanced Modal defaults
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -415,6 +415,7 @@ CURRENT_SECTION="Preflight"
 RESULT_RECORDS_FILE=$(mktemp "${TMPDIR:-/tmp}/kitaru-smoke-results.XXXXXX")
 RECORDING_FAILED=false
 GEMINI_SANDBOX_FUNCTION_SMOKE_STACK=""
+SMOKE_LOCAL_CLOUD_STACK=""
 GOOGLE_ADK_SMOKE_ENV=""
 PRO_PROJECT_SMOKE_CREATED_PROJECT=""
 PRO_PROJECT_SMOKE_LOGGED_IN=false
@@ -1312,6 +1313,10 @@ cleanup() {
         timed 60 $UV_RUN kitaru stack delete \
             "$GEMINI_SANDBOX_FUNCTION_SMOKE_STACK" --recursive &>/dev/null || true
     fi
+    if [[ -n "${SMOKE_LOCAL_CLOUD_STACK:-}" ]]; then
+        timed 60 $UV_RUN kitaru stack delete \
+            "$SMOKE_LOCAL_CLOUD_STACK" --recursive &>/dev/null || true
+    fi
     if [[ -n "${GOOGLE_ADK_SMOKE_ENV:-}" ]]; then
         rm -rf "$GOOGLE_ADK_SMOKE_ENV"
     fi
@@ -1586,6 +1591,20 @@ run_test "kitaru stack list"             $UV_RUN kitaru stack list
 run_test "kitaru stack current"          $UV_RUN kitaru stack current
 run_test "kitaru stack create help mentions modal" \
     bash -c "$UV_RUN kitaru stack create --help | grep -q modal"
+run_test "kitaru stack create help mentions local cloud storage" \
+    bash -c "$UV_RUN kitaru stack create --help | grep -q 'Local stacks can use S3, GCS, or Azure storage'"
+SMOKE_LOCAL_CLOUD_STACK="kitaru-smoke-local-cloud-$$"
+run_test "create connectorless local S3 stack" \
+    $UV_RUN kitaru stack create "$SMOKE_LOCAL_CLOUD_STACK" \
+        --type local \
+        --artifact-store s3://kitaru-smoke-placeholder/artifacts \
+        --no-activate
+run_test "inspect connectorless local S3 stack" \
+    bash -c "$UV_RUN kitaru stack show \"$SMOKE_LOCAL_CLOUD_STACK\" --output json | $UV_RUN python -c 'import json,sys; item=json.load(sys.stdin)[\"item\"]; components=item[\"components\"]; assert any(c[\"role\"] == \"runner\" and c[\"backend\"] == \"local\" for c in components); assert any(c[\"role\"] == \"storage\" and c[\"backend\"] == \"s3\" for c in components)'"
+if run_test "delete connectorless local S3 stack" \
+    $UV_RUN kitaru stack delete "$SMOKE_LOCAL_CLOUD_STACK" --recursive; then
+    SMOKE_LOCAL_CLOUD_STACK=""
+fi
 run_test "kitaru model list"             $UV_RUN kitaru model list
 run_test "kitaru analytics status"       $UV_RUN kitaru analytics status
 run_test "kitaru analytics opt-in --help"  $UV_RUN kitaru analytics opt-in --help

--- a/src/kitaru/_cli/_stacks.py
+++ b/src/kitaru/_cli/_stacks.py
@@ -380,8 +380,9 @@ def create(
         str | None,
         Parameter(
             help=(
-                "Artifact store URI for remote stacks. Modal accepts s3://, gs://, "
-                "az://, abfs://, or abfss://; other stack types may require one "
+                "Artifact store URI. Local stacks accept s3://, gs://, az://, "
+                "abfs://, or abfss:// cloud storage and normally discover "
+                "authentication; remote stack types may require one "
                 "provider-specific URI scheme."
             )
         ),
@@ -413,10 +414,10 @@ def create(
         str | None,
         Parameter(
             help=(
-                "Cloud provider region for Kubernetes, Vertex, SageMaker, "
-                "AzureML, or credentialed Modal stack components. Optional for "
-                "AzureML. For Modal, this is the cloud artifact/registry region "
-                "where applicable; Modal placement uses "
+                "Cloud provider region for remote stacks or credentialed S3 "
+                "storage on a local stack. Optional for AzureML and normally "
+                "discovered for local S3 storage. For Modal, this is the cloud "
+                "artifact/registry region where applicable; Modal placement uses "
                 "--extra orchestrator.region=... instead."
             )
         ),
@@ -426,7 +427,8 @@ def create(
         Parameter(
             help=(
                 "Azure subscription ID for AzureML stacks or credentialed "
-                "Azure-backed Modal stack components."
+                "Azure storage on local or Modal stacks. Local stacks normally "
+                "discover it from the configured credentials."
             )
         ),
     ] = None,
@@ -450,9 +452,10 @@ def create(
         str | None,
         Parameter(
             help=(
-                "Optional cloud credentials reference for Kubernetes, Vertex, "
-                "SageMaker, AzureML, or credentialed Modal stack components. "
-                "Modal API credentials are separate: use "
+                "Optional cloud credentials reference for remote stacks or cloud "
+                "storage on a local stack. Without it, local stacks reuse a "
+                "matching connector or use ambient provider credentials. Modal "
+                "API credentials are separate: use "
                 "--extra orchestrator.token_id=... and token_secret=... for "
                 "Modal tokens."
             )
@@ -485,14 +488,17 @@ def create(
         bool | None,
         Parameter(
             help=(
-                "Skip cloud connector verification for Kubernetes, Vertex, "
-                "SageMaker, AzureML, or credentialed Modal stack components."
+                "Skip verification when explicit credentials create a new cloud "
+                "connector for a local or remote stack."
             )
         ),
     ] = None,
     output: OutputFormatOption = "text",
 ) -> None:
-    """Create a local, Kubernetes, Vertex AI, SageMaker, AzureML, or Modal stack."""
+    """Create a local, Kubernetes, Vertex AI, SageMaker, AzureML, or Modal stack.
+
+    Local stacks can use S3, GCS, or Azure storage while keeping execution local.
+    """
     command = "stack.create"
     output_format = _resolve_output_format(output)
 

--- a/src/kitaru/_cli/_stacks.py
+++ b/src/kitaru/_cli/_stacks.py
@@ -488,8 +488,9 @@ def create(
         bool | None,
         Parameter(
             help=(
-                "Skip verification when explicit credentials create a new cloud "
-                "connector for a local or remote stack."
+                "Skip cloud connector verification during stack creation, both "
+                "for new connectors created from explicit credentials and for "
+                "existing server-side connectors Kitaru discovers and reuses."
             )
         ),
     ] = None,

--- a/src/kitaru/_config/_stacks.py
+++ b/src/kitaru/_config/_stacks.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import configparser
 import difflib
+import json
+import os
 import re
 from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
 from contextlib import suppress
@@ -14,7 +17,7 @@ from typing import Any, Literal
 from urllib.parse import urlparse
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 from zenml.artifact_stores.local_artifact_store import LocalArtifactStoreFlavor
 from zenml.client import Client
 from zenml.constants import DOCKER_REGISTRY_RESOURCE_TYPE
@@ -120,7 +123,7 @@ class StackType(StrEnum):
 
 
 class CloudProvider(StrEnum):
-    """Supported cloud providers for remote stacks."""
+    """Supported cloud providers for stack resources."""
 
     AWS = "aws"
     GCP = "gcp"
@@ -224,6 +227,31 @@ class ModalStackSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class LocalCloudArtifactStoreSpec(BaseModel):
+    """Cloud storage configuration for a local-runner stack."""
+
+    artifact_store: str
+    region: str | None = None
+    subscription_id: str | None = None
+    credentials: str | None = None
+    verify: bool = True
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("artifact_store")
+    @classmethod
+    def validate_artifact_store(cls, value: str) -> str:
+        """Validate and normalize the cloud artifact-store URI."""
+        normalized = value.strip()
+        _infer_cloud_provider_from_artifact_store(normalized)
+        return normalized
+
+    @property
+    def provider(self) -> CloudProvider:
+        """Return the cloud provider implied by the artifact-store URI."""
+        return _infer_cloud_provider_from_artifact_store(self.artifact_store)
+
+
 RemoteStackSpec = (
     KubernetesStackSpec
     | VertexStackSpec
@@ -235,15 +263,15 @@ RemoteStackSpec = (
 
 @dataclass(frozen=True)
 class _ResolvedConnectorSpec:
-    """Resolved ZenML connector information for remote stack creation."""
+    """Resolved ZenML connector information for stack creation."""
 
     connector_info: ServiceConnectorInfo
     verify_resource_type: str
 
 
 @dataclass(frozen=True)
-class _ModalConnectorReference:
-    """Existing service connector selected for one Modal component."""
+class _ExistingConnectorReference:
+    """Existing service connector selected for one stack component."""
 
     connector_id: UUID
     resource_id: str
@@ -253,13 +281,13 @@ class _ModalConnectorReference:
 class _ResolvedModalExistingConnectors:
     """Existing Modal storage and registry service connectors."""
 
-    artifact_store: _ModalConnectorReference
-    container_registry: _ModalConnectorReference
+    artifact_store: _ExistingConnectorReference
+    container_registry: _ExistingConnectorReference
 
 
 @dataclass(frozen=True)
-class _ModalConnectorLookup:
-    """Connector discovery inputs for one Modal component."""
+class _ConnectorLookup:
+    """Connector discovery inputs for one stack component."""
 
     component_label: str
     connector_type: str
@@ -269,10 +297,10 @@ class _ModalConnectorLookup:
 
 
 @dataclass(frozen=True)
-class _ModalConnectorDiscoveryResult:
-    """Connector discovery result for one Modal component."""
+class _ConnectorDiscoveryResult:
+    """Connector discovery result for one stack component."""
 
-    lookup: _ModalConnectorLookup
+    lookup: _ConnectorLookup
     scoped_matches: tuple[Any, ...]
     unscoped_matches: tuple[Any, ...]
 
@@ -841,7 +869,7 @@ def _container_registry_resource_id(
     return normalized_registry.rstrip("/")
 
 
-def _normalize_modal_connector_resource_id(resource_id: str | None) -> str | None:
+def _normalize_connector_resource_id(resource_id: str | None) -> str | None:
     """Normalize a service connector resource ID for tolerant comparisons."""
     if resource_id is None:
         return None
@@ -852,11 +880,11 @@ def _normalize_modal_connector_resource_id(resource_id: str | None) -> str | Non
     return normalized.rstrip("/")
 
 
-def _modal_artifact_store_resource_id_variants(
+def _artifact_store_connector_resource_id_variants(
     resource_id: str,
     provider: CloudProvider,
 ) -> frozenset[str]:
-    """Return acceptable connector resource IDs for a Modal artifact store."""
+    """Return acceptable connector resource IDs for an artifact store."""
     parsed = urlparse(resource_id)
     variants = {resource_id.rstrip("/")}
     if parsed.netloc:
@@ -864,7 +892,7 @@ def _modal_artifact_store_resource_id_variants(
     return frozenset(
         normalized
         for value in variants
-        if (normalized := _normalize_modal_connector_resource_id(value)) is not None
+        if (normalized := _normalize_connector_resource_id(value)) is not None
     )
 
 
@@ -883,11 +911,11 @@ def _modal_container_registry_resource_id_variants(
     return frozenset(
         normalized
         for value in variants
-        if (normalized := _normalize_modal_connector_resource_id(value)) is not None
+        if (normalized := _normalize_connector_resource_id(value)) is not None
     )
 
 
-def _modal_connector_type(provider: CloudProvider) -> str:
+def _connector_type(provider: CloudProvider) -> str:
     """Return the provider-specific service connector type."""
     return {
         CloudProvider.AWS: AWS_CONNECTOR_TYPE,
@@ -896,7 +924,7 @@ def _modal_connector_type(provider: CloudProvider) -> str:
     }[provider]
 
 
-def _modal_artifact_store_connector_resource_type(provider: CloudProvider) -> str:
+def _artifact_store_connector_resource_type(provider: CloudProvider) -> str:
     """Return the provider-specific artifact-store connector resource type."""
     return {
         CloudProvider.AWS: S3_RESOURCE_TYPE,
@@ -905,7 +933,7 @@ def _modal_artifact_store_connector_resource_type(provider: CloudProvider) -> st
     }[provider]
 
 
-def _modal_connector_type_matches(connector: Any, connector_type: str) -> bool:
+def _connector_type_matches(connector: Any, connector_type: str) -> bool:
     """Return whether a connector model reports the expected connector type."""
     raw_type = getattr(connector, "type", None)
     if raw_type is None:
@@ -917,7 +945,7 @@ def _modal_connector_type_matches(connector: Any, connector_type: str) -> bool:
     return str(raw_type) == connector_type
 
 
-def _modal_connector_resource_type_matches(connector: Any, resource_type: str) -> bool:
+def _connector_resource_type_matches(connector: Any, resource_type: str) -> bool:
     """Return whether a connector model supports the expected resource type."""
     raw_resource_types = getattr(connector, "resource_types", None)
     if raw_resource_types is None:
@@ -932,14 +960,12 @@ def _modal_connector_resource_type_matches(connector: Any, resource_type: str) -
     return resource_type in connector_resource_types
 
 
-def _modal_connector_resource_id(connector: Any) -> str | None:
+def _connector_resource_id(connector: Any) -> str | None:
     """Return a connector resource ID normalized for discovery matching."""
-    return _normalize_modal_connector_resource_id(
-        getattr(connector, "resource_id", None)
-    )
+    return _normalize_connector_resource_id(getattr(connector, "resource_id", None))
 
 
-def _modal_connector_label(connector: Any) -> str:
+def _connector_label(connector: Any) -> str:
     """Render a connector for user-facing discovery errors."""
     name = _normalize_stack_detail_value(getattr(connector, "name", None))
     connector_id = _normalize_stack_detail_value(getattr(connector, "id", None))
@@ -952,10 +978,10 @@ def _modal_connector_label(connector: Any) -> str:
     return label
 
 
-def _modal_existing_connector_reference(
+def _existing_connector_reference(
     connector: Any,
     resource_id: str,
-) -> _ModalConnectorReference:
+) -> _ExistingConnectorReference:
     """Build a stack-request connector reference from a ZenML connector model."""
     connector_id_raw = getattr(connector, "id", None)
     try:
@@ -963,19 +989,19 @@ def _modal_existing_connector_reference(
     except (TypeError, ValueError, AttributeError) as exc:
         raise KitaruBackendError(
             "ZenML returned a matching service connector without a UUID id: "
-            f"{_modal_connector_label(connector)}"
+            f"{_connector_label(connector)}"
         ) from exc
-    return _ModalConnectorReference(
+    return _ExistingConnectorReference(
         connector_id=connector_id,
         resource_id=resource_id,
     )
 
 
-def _collect_modal_connector_candidates(
+def _collect_connector_candidates(
     client: Client,
-    lookup: _ModalConnectorLookup,
-) -> _ModalConnectorDiscoveryResult:
-    """Collect scoped and unscoped Modal connector candidates."""
+    lookup: _ConnectorLookup,
+) -> _ConnectorDiscoveryResult:
+    """Collect scoped and unscoped connector candidates."""
     scoped_matches: list[Any] = []
     unscoped_matches: list[Any] = []
     page = 1
@@ -997,14 +1023,12 @@ def _collect_modal_connector_candidates(
                 "runtime."
             )
         for connector in connector_page:
-            if not _modal_connector_type_matches(connector, lookup.connector_type):
+            if not _connector_type_matches(connector, lookup.connector_type):
                 continue
-            if not _modal_connector_resource_type_matches(
-                connector, lookup.resource_type
-            ):
+            if not _connector_resource_type_matches(connector, lookup.resource_type):
                 continue
 
-            connector_resource_id = _modal_connector_resource_id(connector)
+            connector_resource_id = _connector_resource_id(connector)
             if connector_resource_id is None:
                 unscoped_matches.append(connector)
             elif connector_resource_id in lookup.acceptable_resource_ids:
@@ -1018,15 +1042,15 @@ def _collect_modal_connector_candidates(
         if page >= total_pages:
             break
         page += 1
-    return _ModalConnectorDiscoveryResult(
+    return _ConnectorDiscoveryResult(
         lookup=lookup,
         scoped_matches=tuple(scoped_matches),
         unscoped_matches=tuple(unscoped_matches),
     )
 
 
-def _selected_modal_connector_matches(
-    discovery: _ModalConnectorDiscoveryResult,
+def _selected_connector_matches(
+    discovery: _ConnectorDiscoveryResult,
 ) -> tuple[Any, ...]:
     """Return the connector candidates used after scoped/unscoped precedence."""
     if discovery.scoped_matches:
@@ -1034,7 +1058,7 @@ def _selected_modal_connector_matches(
     return discovery.unscoped_matches
 
 
-def _modal_connector_lookup_message(lookup: _ModalConnectorLookup) -> str:
+def _connector_lookup_message(lookup: _ConnectorLookup) -> str:
     """Render what Kitaru looked for during existing connector discovery."""
     return (
         f"{lookup.component_label} connector type '{lookup.connector_type}', "
@@ -1063,19 +1087,19 @@ def _resolve_modal_existing_connectors(
         spec.container_registry,
         provider,
     )
-    connector_type = _modal_connector_type(provider)
+    connector_type = _connector_type(provider)
     lookups = (
-        _ModalConnectorLookup(
+        _ConnectorLookup(
             component_label="artifact store",
             connector_type=connector_type,
-            resource_type=_modal_artifact_store_connector_resource_type(provider),
+            resource_type=_artifact_store_connector_resource_type(provider),
             target_resource_id=artifact_resource_id,
-            acceptable_resource_ids=_modal_artifact_store_resource_id_variants(
+            acceptable_resource_ids=_artifact_store_connector_resource_id_variants(
                 artifact_resource_id,
                 provider,
             ),
         ),
-        _ModalConnectorLookup(
+        _ConnectorLookup(
             component_label="container registry",
             connector_type=connector_type,
             resource_type=DOCKER_REGISTRY_RESOURCE_TYPE,
@@ -1087,10 +1111,10 @@ def _resolve_modal_existing_connectors(
         ),
     )
     discoveries = tuple(
-        _collect_modal_connector_candidates(client, lookup) for lookup in lookups
+        _collect_connector_candidates(client, lookup) for lookup in lookups
     )
     selected_matches = tuple(
-        _selected_modal_connector_matches(discovery) for discovery in discoveries
+        _selected_connector_matches(discovery) for discovery in discoveries
     )
     if all(not matches for matches in selected_matches):
         return None
@@ -1106,11 +1130,11 @@ def _resolve_modal_existing_connectors(
     ambiguous = [*scoped_ambiguous, *unscoped_ambiguous]
     if ambiguous:
         details = "; ".join(
-            f"{_modal_connector_lookup_message(discovery.lookup)} matched "
-            f"{len(_selected_modal_connector_matches(discovery))} connectors: "
+            f"{_connector_lookup_message(discovery.lookup)} matched "
+            f"{len(_selected_connector_matches(discovery))} connectors: "
             + ", ".join(
-                _modal_connector_label(match)
-                for match in _selected_modal_connector_matches(discovery)
+                _connector_label(match)
+                for match in _selected_connector_matches(discovery)
             )
             for discovery in ambiguous
         )
@@ -1132,12 +1156,11 @@ def _resolve_modal_existing_connectors(
             if len(matches) == 1
         ]
         found_text = "; ".join(
-            f"found {_modal_connector_label(match)} for "
-            f"{discovery.lookup.component_label}"
+            f"found {_connector_label(match)} for {discovery.lookup.component_label}"
             for discovery, match in found
         )
         missing_text = "; ".join(
-            _modal_connector_lookup_message(discovery.lookup) for discovery in missing
+            _connector_lookup_message(discovery.lookup) for discovery in missing
         )
         raise KitaruUsageError(
             "Kitaru found only part of the existing service connector pair needed "
@@ -1148,15 +1171,56 @@ def _resolve_modal_existing_connectors(
         )
 
     return _ResolvedModalExistingConnectors(
-        artifact_store=_modal_existing_connector_reference(
+        artifact_store=_existing_connector_reference(
             selected_matches[0][0],
             artifact_resource_id,
         ),
-        container_registry=_modal_existing_connector_reference(
+        container_registry=_existing_connector_reference(
             selected_matches[1][0],
             registry_resource_id,
         ),
     )
+
+
+def _resolve_local_cloud_existing_connector(
+    spec: LocalCloudArtifactStoreSpec,
+    *,
+    client: Client,
+) -> _ExistingConnectorReference | None:
+    """Find one existing connector for a local stack's cloud storage."""
+    if spec.credentials is not None:
+        return None
+
+    artifact_store_uri = (
+        _normalize_azure_artifact_store_uri(spec.artifact_store)
+        if spec.provider == CloudProvider.AZURE
+        else spec.artifact_store
+    )
+    resource_id = _artifact_store_resource_id(artifact_store_uri, spec.provider)
+    lookup = _ConnectorLookup(
+        component_label="artifact store",
+        connector_type=_connector_type(spec.provider),
+        resource_type=_artifact_store_connector_resource_type(spec.provider),
+        target_resource_id=resource_id,
+        acceptable_resource_ids=_artifact_store_connector_resource_id_variants(
+            resource_id,
+            spec.provider,
+        ),
+    )
+    discovery = _collect_connector_candidates(client, lookup)
+    matches = _selected_connector_matches(discovery)
+    if not matches:
+        return None
+    if len(matches) > 1:
+        candidates = ", ".join(_connector_label(match) for match in matches)
+        raise KitaruUsageError(
+            "Kitaru found ambiguous existing service connectors for this local "
+            f"stack. {_connector_lookup_message(lookup)} matched "
+            f"{len(matches)} connectors: {candidates}. Narrow the connectors to "
+            "one matching resource or pass explicit cloud credentials so Kitaru "
+            "creates a new connector."
+        )
+    return _existing_connector_reference(matches[0], resource_id)
 
 
 def _modal_cloud_connector_inputs_requested(spec: ModalStackSpec) -> bool:
@@ -1290,15 +1354,52 @@ def _merge_managed_labels(labels: dict[str, str] | None) -> dict[str, str]:
     return merged_labels
 
 
+def _discover_aws_region(profile_name: str | None) -> str:
+    """Resolve an AWS region from boto-compatible environment and config."""
+    environment_region = os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+    if environment_region and environment_region.strip():
+        return environment_region.strip()
+
+    selected_profile = (
+        profile_name
+        or os.getenv("AWS_PROFILE")
+        or os.getenv("AWS_DEFAULT_PROFILE")
+        or "default"
+    )
+    config_path = Path(
+        os.getenv("AWS_CONFIG_FILE", str(Path.home() / ".aws" / "config"))
+    ).expanduser()
+    parser = configparser.RawConfigParser()
+    try:
+        parser.read(config_path, encoding="utf-8")
+    except (OSError, configparser.Error) as exc:
+        raise KitaruUsageError(
+            f"Unable to read AWS boto config '{config_path}': {exc}"
+        ) from exc
+
+    section = (
+        "default" if selected_profile == "default" else f"profile {selected_profile}"
+    )
+    configured_region = parser.get(section, "region", fallback=None)
+    if configured_region and configured_region.strip():
+        return configured_region.strip()
+
+    raise KitaruUsageError(
+        "Cannot discover an AWS region for the new cloud connector. Pass "
+        "`--region`, set AWS_REGION or AWS_DEFAULT_REGION, or configure `region` "
+        f"for the '{selected_profile}' profile in '{config_path}'."
+    )
+
+
 def _resolve_aws_connector_spec(
     *,
-    region: str,
+    region: str | None,
     credentials: str | None,
 ) -> _ResolvedConnectorSpec:
     """Translate Kitaru AWS credentials into ZenML connector info."""
     normalized_credentials = credentials.strip() if credentials else None
     auth_method = "implicit"
-    configuration: dict[str, Any] = {"region": region}
+    configuration: dict[str, Any] = {}
 
     if normalized_credentials:
         method, separator, raw_value = normalized_credentials.partition(":")
@@ -1357,6 +1458,14 @@ def _resolve_aws_connector_spec(
                 "aws-profile, aws-access-keys, aws-session-token."
             )
 
+    resolved_region = region.strip() if region and region.strip() else None
+    if resolved_region is None:
+        profile_value = configuration.get("profile_name")
+        resolved_region = _discover_aws_region(
+            str(profile_value) if profile_value is not None else None
+        )
+    configuration["region"] = resolved_region
+
     return _ResolvedConnectorSpec(
         connector_info=ServiceConnectorInfo(
             type=AWS_CONNECTOR_TYPE,
@@ -1367,28 +1476,88 @@ def _resolve_aws_connector_spec(
     )
 
 
+def _discover_gcp_adc_project_id() -> str:
+    """Resolve the active GCP project from Application Default Credentials."""
+    try:
+        import google.auth
+    except ImportError as exc:
+        raise KitaruUsageError(
+            "GCP project discovery requires google-auth. Install the GCP "
+            "dependencies or use gcp-service-account:/path/to/key.json."
+        ) from exc
+
+    try:
+        _, project_id = google.auth.default()
+    except Exception as exc:
+        raise KitaruUsageError(
+            "Unable to load GCP Application Default Credentials while discovering "
+            f"the project ID: {exc}"
+        ) from exc
+    if project_id is None or not project_id.strip():
+        raise KitaruUsageError(
+            "Cannot discover a GCP project ID from Application Default "
+            "Credentials. Set GOOGLE_CLOUD_PROJECT, configure ADC with a quota "
+            "project, or use gcp-service-account:/path/to/key.json."
+        )
+    return project_id.strip()
+
+
+def _gcp_project_id_from_service_account_json(
+    service_account_json: str,
+    *,
+    credential_path: Path,
+) -> str:
+    """Read the project ID required by a GCP service connector."""
+    try:
+        payload = json.loads(service_account_json)
+    except json.JSONDecodeError as exc:
+        raise KitaruUsageError(
+            f"GCP service account file '{credential_path}' is not valid JSON: {exc}"
+        ) from exc
+    if not isinstance(payload, Mapping):
+        raise KitaruUsageError(
+            f"GCP service account file '{credential_path}' must contain a JSON object."
+        )
+    project_id = payload.get("project_id")
+    if not isinstance(project_id, str) or not project_id.strip():
+        raise KitaruUsageError(
+            f"GCP service account file '{credential_path}' does not contain a "
+            "non-empty project_id."
+        )
+    return project_id.strip()
+
+
 def _resolve_gcp_connector_spec(
     *,
-    container_registry: str,
+    container_registry: str | None = None,
+    project_id: str | None = None,
     credentials: str | None,
 ) -> _ResolvedConnectorSpec:
     """Translate Kitaru GCP credentials into ZenML connector info."""
-    project_id = _infer_gcp_project_id_from_container_registry(container_registry)
+    resolved_project_id = project_id
+    if resolved_project_id is None and container_registry is not None:
+        resolved_project_id = _infer_gcp_project_id_from_container_registry(
+            container_registry
+        )
+
     normalized_credentials = credentials.strip() if credentials else None
     auth_method = "implicit"
-    configuration: dict[str, Any] = {"project_id": project_id}
+    configuration: dict[str, Any] = {}
+    service_account_json: str | None = None
+    credential_path: Path | None = None
 
-    if normalized_credentials:
+    if normalized_credentials and normalized_credentials.lower() != "implicit":
         method, separator, raw_value = normalized_credentials.partition(":")
         if not separator:
             raise KitaruUsageError(
-                "Invalid GCP credentials format. Use "
+                "Invalid GCP credentials format. Use implicit or "
                 "gcp-service-account:/path/to/key.json."
             )
         normalized_method = method.strip().lower()
         if normalized_method != "gcp-service-account":
             raise KitaruUsageError(
-                "Unsupported GCP credentials method. Use: gcp-service-account."
+                "Unsupported GCP credentials method. Use implicit or "
+                "gcp-service-account."
             )
 
         credential_path_raw = raw_value.strip()
@@ -1403,7 +1572,17 @@ def _resolve_gcp_connector_spec(
             ) from exc
 
         auth_method = "service-account"
-        configuration.update({"service_account_json": service_account_json})
+        configuration["service_account_json"] = service_account_json
+
+    if resolved_project_id is None:
+        if service_account_json is not None and credential_path is not None:
+            resolved_project_id = _gcp_project_id_from_service_account_json(
+                service_account_json,
+                credential_path=credential_path,
+            )
+        else:
+            resolved_project_id = _discover_gcp_adc_project_id()
+    configuration["project_id"] = resolved_project_id
 
     return _ResolvedConnectorSpec(
         connector_info=ServiceConnectorInfo(
@@ -1417,13 +1596,15 @@ def _resolve_gcp_connector_spec(
 
 def _resolve_azure_connector_spec(
     *,
-    subscription_id: str,
+    subscription_id: str | None,
     credentials: str | None,
 ) -> _ResolvedConnectorSpec:
     """Translate Kitaru Azure credentials into ZenML connector info."""
     normalized_credentials = credentials.strip() if credentials else None
     auth_method = "implicit"
-    configuration: dict[str, Any] = {"subscription_id": subscription_id}
+    configuration: dict[str, Any] = {}
+    if subscription_id is not None:
+        configuration["subscription_id"] = subscription_id
 
     if normalized_credentials:
         if normalized_credentials.lower() == "implicit":
@@ -1480,6 +1661,27 @@ def _resolve_azure_connector_spec(
         ),
         verify_resource_type=AZURE_RESOURCE_TYPE,
     )
+
+
+def _resolve_local_cloud_connector_spec(
+    spec: LocalCloudArtifactStoreSpec,
+) -> _ResolvedConnectorSpec | None:
+    """Build a new connector only when local cloud credentials are explicit."""
+    if spec.credentials is None:
+        return None
+    if spec.provider == CloudProvider.AWS:
+        return _resolve_aws_connector_spec(
+            region=spec.region,
+            credentials=spec.credentials,
+        )
+    if spec.provider == CloudProvider.GCP:
+        return _resolve_gcp_connector_spec(credentials=spec.credentials)
+    if spec.provider == CloudProvider.AZURE:
+        return _resolve_azure_connector_spec(
+            subscription_id=spec.subscription_id,
+            credentials=spec.credentials,
+        )
+    raise KitaruUsageError(f"Unsupported cloud provider: {spec.provider}")
 
 
 def _resolve_kubernetes_connector_spec(
@@ -1544,6 +1746,86 @@ def _add_remote_sandbox_component_info(
         sandbox_flavor=sandbox_flavor,
         configuration=configuration,
     )
+
+
+def _build_local_cloud_stack_request(
+    name: str,
+    *,
+    spec: LocalCloudArtifactStoreSpec,
+    connector_spec: _ResolvedConnectorSpec | None = None,
+    existing_connector: _ExistingConnectorReference | None = None,
+    labels: dict[str, str] | None,
+    component_overrides: StackComponentConfigOverrides | None = None,
+    sandbox_flavor: str = _sandbox_components.LOCAL_SANDBOX_FLAVOR,
+) -> StackRequest:
+    """Build a one-shot local-runner stack with cloud storage."""
+    if connector_spec is not None and existing_connector is not None:
+        raise KitaruUsageError(
+            "Local cloud stack creation cannot both create and reuse a connector."
+        )
+
+    merged_labels = _merge_managed_labels(labels)
+    if existing_connector is not None:
+        merged_labels[_STACK_REUSED_SERVICE_CONNECTORS_LABEL_KEY] = (
+            _STACK_REUSED_SERVICE_CONNECTORS_LABEL_VALUE
+        )
+    artifact_store_uri = (
+        _normalize_azure_artifact_store_uri(spec.artifact_store)
+        if spec.provider == CloudProvider.AZURE
+        else spec.artifact_store
+    )
+
+    connector_kwargs: dict[str, Any] = {}
+    service_connectors: list[UUID | ServiceConnectorInfo] = []
+    resource_id = _artifact_store_resource_id(artifact_store_uri, spec.provider)
+    if connector_spec is not None:
+        service_connectors = _build_connector_services_list(connector_spec)
+        connector_kwargs = {
+            "service_connector_index": 0,
+            "service_connector_resource_id": resource_id,
+        }
+    elif existing_connector is not None:
+        service_connectors = [existing_connector.connector_id]
+        connector_kwargs = {
+            "service_connector_index": 0,
+            "service_connector_resource_id": existing_connector.resource_id,
+        }
+
+    stack_request = StackRequest(
+        name=name,
+        labels=merged_labels,
+        components={
+            StackComponentType.ORCHESTRATOR: [
+                ComponentInfo(
+                    flavor=StackType.LOCAL.value,
+                    configuration=_build_component_configuration(
+                        {},
+                        overrides=component_overrides,
+                        target=StackComponentTarget.ORCHESTRATOR,
+                    ),
+                )
+            ],
+            StackComponentType.ARTIFACT_STORE: [
+                ComponentInfo(
+                    flavor=_artifact_store_flavor(spec.provider),
+                    **connector_kwargs,
+                    configuration=_build_component_configuration(
+                        {"path": artifact_store_uri},
+                        overrides=component_overrides,
+                        target=StackComponentTarget.ARTIFACT_STORE,
+                    ),
+                )
+            ],
+        },
+        service_connectors=service_connectors,
+    )
+    assert stack_request.components is not None
+    _add_remote_sandbox_component_info(
+        stack_request.components,
+        sandbox_flavor=sandbox_flavor,
+        component_overrides=component_overrides,
+    )
+    return stack_request
 
 
 def _build_kubernetes_stack_request(
@@ -2000,35 +2282,35 @@ def _get_required_stack_component(
     """Return the single component of a required stack type from a stack model."""
     raw_components = getattr(stack_model, "components", None)
     if not isinstance(raw_components, Mapping):
-        raise KitaruStateError(
-            "Unable to inspect components from the created remote stack."
-        )
+        raise KitaruStateError("Unable to inspect components from the created stack.")
 
     components = raw_components.get(component_type, [])
     if len(components) != 1:
         raise KitaruStateError(
-            "Created remote stack is missing the expected "
-            f"{component_type.value} component."
+            f"Created stack is missing the expected {component_type.value} component."
         )
     return components[0]
+
+
+_DEFAULT_ONE_SHOT_REQUIRED_COMPONENTS: tuple[
+    tuple[StackComponentType, _StackComponentKind], ...
+] = (
+    (StackComponentType.ORCHESTRATOR, "orchestrator"),
+    (StackComponentType.ARTIFACT_STORE, "artifact_store"),
+    (StackComponentType.CONTAINER_REGISTRY, "container_registry"),
+)
 
 
 def _extract_remote_stack_components(
     stack_model: Any,
     *,
+    required_components: tuple[
+        tuple[StackComponentType, _StackComponentKind], ...
+    ] = _DEFAULT_ONE_SHOT_REQUIRED_COMPONENTS,
     require_connector_metadata: bool = True,
     connector_required_component_types: frozenset[StackComponentType] | None = None,
-    additional_required_components: tuple[
-        tuple[StackComponentType, _StackComponentKind], ...
-    ] = (),
 ) -> tuple[tuple[str, ...], tuple[str, ...], bool]:
-    """Extract created component and connector names from a hydrated stack."""
-    required_components = (
-        (StackComponentType.ORCHESTRATOR, "orchestrator"),
-        (StackComponentType.ARTIFACT_STORE, "artifact_store"),
-        (StackComponentType.CONTAINER_REGISTRY, "container_registry"),
-        *additional_required_components,
-    )
+    """Extract component and connector names from a hydrated one-shot stack."""
     if not require_connector_metadata:
         connector_required_component_types = frozenset()
     if connector_required_component_types is None:
@@ -2052,7 +2334,7 @@ def _extract_remote_stack_components(
         component_name = str(getattr(component, "name", "")).strip()
         if not component_name:
             raise KitaruStateError(
-                "Unable to inspect components from the created remote stack."
+                "Unable to inspect components from the created stack."
             )
         component_labels.append(_format_stack_component_label(component_name, kind))
 
@@ -2078,15 +2360,19 @@ def _extract_remote_stack_components(
             in connector_required_component_types,
         )
 
-    for sandbox_component in _stack_component_models_for_type(
-        stack_model,
-        StackComponentType.SANDBOX,
-    ):
-        _collect_component(
-            sandbox_component,
-            kind=_sandbox_components.SANDBOX_COMPONENT_KIND,
-            require_connector_metadata=False,
-        )
+    required_component_types = {
+        component_type for component_type, _ in required_components
+    }
+    if StackComponentType.SANDBOX not in required_component_types:
+        for sandbox_component in _stack_component_models_for_type(
+            stack_model,
+            StackComponentType.SANDBOX,
+        ):
+            _collect_component(
+                sandbox_component,
+                kind=_sandbox_components.SANDBOX_COMPONENT_KIND,
+                require_connector_metadata=False,
+            )
 
     return tuple(component_labels), tuple(connector_names), missing_connector_metadata
 
@@ -2103,24 +2389,27 @@ def _stack_type_display_name(stack_type: StackType) -> str:
     }.get(stack_type, str(stack_type))
 
 
-def _create_remote_stack_operation(
+def _create_one_shot_stack_operation(
     name: str,
     *,
     stack_type: StackType,
     connector_spec: _ResolvedConnectorSpec | None,
     stack_request: StackRequest,
     resource_summary: dict[str, str],
-    connector_required_component_types: frozenset[StackComponentType] | None = None,
-    additional_required_components: tuple[
+    required_components: tuple[
         tuple[StackComponentType, _StackComponentKind], ...
-    ] = (),
+    ] = _DEFAULT_ONE_SHOT_REQUIRED_COMPONENTS,
+    connector_required_component_types: frozenset[StackComponentType] | None = None,
+    dependency_error_predicate: Callable[[BaseException], bool] | None = None,
+    dependency_error_hint: str | None = None,
     activate: bool = True,
     verify: bool = True,
     client_factory: Callable[[], Any] = Client,
+    client: Any | None = None,
 ) -> _StackCreateResult:
-    """Create a remote stack via ZenML's one-shot stack API."""
+    """Create a stack via ZenML's validated one-shot stack API."""
     selector = _normalize_stack_selector(name)
-    client = client_factory()
+    client = client if client is not None else client_factory()
 
     if any(
         stack_model.name == selector for stack_model in _iter_available_stacks(client)
@@ -2130,14 +2419,18 @@ def _create_remote_stack_operation(
     previous_active_stack = str(client.active_stack_model.name) if activate else None
     stack_label = _stack_type_display_name(stack_type)
 
+    def _raise_dependency_error(exc: BaseException) -> None:
+        if (
+            dependency_error_predicate is not None
+            and dependency_error_hint is not None
+            and dependency_error_predicate(exc)
+        ):
+            raise KitaruUsageError(dependency_error_hint) from exc
+
     try:
         _prevalidate_stack_request_components(stack_request)
     except Exception as exc:
-        if (
-            stack_type == StackType.MODAL
-            and _exception_chain_has_missing_modal_dependency(exc)
-        ):
-            raise KitaruUsageError(_MODAL_INSTALL_HINT) from exc
+        _raise_dependency_error(exc)
         raise
 
     if connector_spec is not None:
@@ -2160,22 +2453,14 @@ def _create_remote_stack_operation(
     try:
         client._validate_stack_configuration(stack_request)
     except (ValueError, ValidationError) as exc:
-        if (
-            stack_type == StackType.MODAL
-            and _exception_chain_has_missing_modal_dependency(exc)
-        ):
-            raise KitaruUsageError(_MODAL_INSTALL_HINT) from exc
+        _raise_dependency_error(exc)
         raise KitaruUsageError(
             f"Invalid {stack_label} stack configuration for '{selector}'. "
             f"ZenML rejected the final stack request after Kitaru prevalidated "
             f"the component defaults: {exc}"
         ) from exc
     except Exception as exc:
-        if (
-            stack_type == StackType.MODAL
-            and _exception_chain_has_missing_modal_dependency(exc)
-        ):
-            raise KitaruUsageError(_MODAL_INSTALL_HINT) from exc
+        _raise_dependency_error(exc)
         raise KitaruBackendError(
             f"Failed to validate {stack_label} stack '{selector}': {exc}"
         ) from exc
@@ -2193,9 +2478,9 @@ def _create_remote_stack_operation(
     components_created, service_connectors_created, missing_connector_metadata = (
         _extract_remote_stack_components(
             created_stack,
+            required_components=required_components,
             require_connector_metadata=require_connector_metadata,
             connector_required_component_types=connector_required_component_types,
-            additional_required_components=additional_required_components,
         )
     )
     if missing_connector_metadata:
@@ -2207,9 +2492,9 @@ def _create_remote_stack_operation(
             components_created, service_connectors_created, _ = (
                 _extract_remote_stack_components(
                     refreshed_stack,
+                    required_components=required_components,
                     require_connector_metadata=require_connector_metadata,
                     connector_required_component_types=connector_required_component_types,
-                    additional_required_components=additional_required_components,
                 )
             )
 
@@ -3058,6 +3343,74 @@ def _show_stack_operation(
     )
 
 
+def _create_local_cloud_stack_operation(
+    name: str,
+    *,
+    spec: LocalCloudArtifactStoreSpec,
+    activate: bool = True,
+    labels: dict[str, str] | None = None,
+    component_overrides: StackComponentConfigOverrides | None = None,
+    sandbox_flavor: str = _sandbox_components.LOCAL_SANDBOX_FLAVOR,
+    client_factory: Callable[[], Any] = Client,
+) -> _StackCreateResult:
+    """Create a local-runner stack backed by cloud artifact storage."""
+    selector = _normalize_stack_selector(name)
+    if spec.credentials is None and not spec.verify:
+        raise KitaruUsageError(
+            "`verify=False` only applies when explicit credentials create a new "
+            "cloud connector."
+        )
+
+    connector_spec = _resolve_local_cloud_connector_spec(spec)
+    existing_connector: _ExistingConnectorReference | None = None
+    operation_client: Any | None = None
+    if connector_spec is None:
+        operation_client = client_factory()
+        existing_connector = _resolve_local_cloud_existing_connector(
+            spec,
+            client=operation_client,
+        )
+
+    stack_request = _build_local_cloud_stack_request(
+        selector,
+        spec=spec,
+        connector_spec=connector_spec,
+        existing_connector=existing_connector,
+        labels=labels,
+        component_overrides=component_overrides,
+        sandbox_flavor=sandbox_flavor,
+    )
+    resource_summary = {
+        "provider": spec.provider.value,
+        "artifact_store": spec.artifact_store,
+        "sandbox": sandbox_flavor,
+    }
+    if spec.region is not None:
+        resource_summary["region"] = spec.region
+    if spec.subscription_id is not None:
+        resource_summary["subscription_id"] = spec.subscription_id
+
+    return _create_one_shot_stack_operation(
+        selector,
+        stack_type=StackType.LOCAL,
+        connector_spec=connector_spec,
+        stack_request=stack_request,
+        resource_summary=resource_summary,
+        required_components=(
+            (StackComponentType.ORCHESTRATOR, "orchestrator"),
+            (StackComponentType.ARTIFACT_STORE, "artifact_store"),
+            (StackComponentType.SANDBOX, "sandbox"),
+        ),
+        connector_required_component_types=frozenset(
+            {StackComponentType.ARTIFACT_STORE}
+        ),
+        activate=activate,
+        verify=spec.verify,
+        client_factory=client_factory,
+        client=operation_client,
+    )
+
+
 def _create_kubernetes_stack_operation(
     name: str,
     *,
@@ -3079,7 +3432,7 @@ def _create_kubernetes_stack_operation(
         component_overrides=component_overrides,
         sandbox_flavor=sandbox_flavor,
     )
-    return _create_remote_stack_operation(
+    return _create_one_shot_stack_operation(
         selector,
         stack_type=StackType.KUBERNETES,
         connector_spec=connector_spec,
@@ -3123,7 +3476,7 @@ def _create_vertex_stack_operation(
         component_overrides=component_overrides,
         sandbox_flavor=sandbox_flavor,
     )
-    return _create_remote_stack_operation(
+    return _create_one_shot_stack_operation(
         selector,
         stack_type=StackType.VERTEX,
         connector_spec=connector_spec,
@@ -3165,7 +3518,7 @@ def _create_sagemaker_stack_operation(
         component_overrides=component_overrides,
         sandbox_flavor=sandbox_flavor,
     )
-    return _create_remote_stack_operation(
+    return _create_one_shot_stack_operation(
         selector,
         stack_type=StackType.SAGEMAKER,
         connector_spec=connector_spec,
@@ -3220,7 +3573,7 @@ def _create_azureml_stack_operation(
         resource_summary["region"] = spec.region
     if sandbox_flavor is not None:
         resource_summary["sandbox"] = sandbox_flavor
-    return _create_remote_stack_operation(
+    return _create_one_shot_stack_operation(
         selector,
         stack_type=StackType.AZUREML,
         connector_spec=connector_spec,
@@ -3248,19 +3601,14 @@ def _create_modal_stack_operation(
     provider = _infer_cloud_provider_from_artifact_store(spec.artifact_store)
     connector_spec = _resolve_modal_connector_spec(spec, provider=provider)
     existing_connectors: _ResolvedModalExistingConnectors | None = None
-    operation_client_factory: Callable[[], Any] = client_factory
+    operation_client: Any | None = None
     if connector_spec is None:
-        discovery_client = client_factory()
+        operation_client = client_factory()
         existing_connectors = _resolve_modal_existing_connectors(
             spec,
             provider=provider,
-            client=discovery_client,
+            client=operation_client,
         )
-
-        def _discovered_client_factory() -> Any:
-            return discovery_client
-
-        operation_client_factory = _discovered_client_factory
     stack_request = _build_modal_stack_request(
         selector,
         spec=spec,
@@ -3281,24 +3629,28 @@ def _create_modal_stack_operation(
         resource_summary["subscription_id"] = spec.subscription_id
     if sandbox_flavor is not None:
         resource_summary["sandbox"] = sandbox_flavor
-    return _create_remote_stack_operation(
+    return _create_one_shot_stack_operation(
         selector,
         stack_type=StackType.MODAL,
         connector_spec=connector_spec,
         stack_request=stack_request,
         resource_summary=resource_summary,
+        required_components=(
+            *_DEFAULT_ONE_SHOT_REQUIRED_COMPONENTS,
+            (StackComponentType.IMAGE_BUILDER, "image_builder"),
+        ),
         connector_required_component_types=frozenset(
             {
                 StackComponentType.ARTIFACT_STORE,
                 StackComponentType.CONTAINER_REGISTRY,
             }
         ),
-        additional_required_components=(
-            (StackComponentType.IMAGE_BUILDER, "image_builder"),
-        ),
+        dependency_error_predicate=_exception_chain_has_missing_modal_dependency,
+        dependency_error_hint=_MODAL_INSTALL_HINT,
         activate=activate,
         verify=spec.verify,
-        client_factory=operation_client_factory,
+        client_factory=client_factory,
+        client=operation_client,
     )
 
 
@@ -3309,10 +3661,12 @@ def _create_stack_operation(
     activate: bool = True,
     labels: dict[str, str] | None = None,
     remote_spec: RemoteStackSpec | None = None,
+    local_cloud_artifact_store_spec: LocalCloudArtifactStoreSpec | None = None,
     component_overrides: StackComponentConfigOverrides | None = None,
     sandbox_flavor: str | None = None,
     operation_overrides: dict[StackType, Callable[..., _StackCreateResult]]
     | None = None,
+    local_cloud_operation_override: Callable[..., _StackCreateResult] | None = None,
 ) -> _StackCreateResult:
     """Create a stack by dispatching to the requested stack type flow."""
     dispatch: dict[StackType, Callable[..., _StackCreateResult]] = {
@@ -3337,7 +3691,21 @@ def _create_stack_operation(
         }
         if component_overrides is not None:
             local_kwargs["component_overrides"] = component_overrides
+        if local_cloud_artifact_store_spec is not None:
+            local_cloud_operation = (
+                local_cloud_operation_override or _create_local_cloud_stack_operation
+            )
+            return local_cloud_operation(
+                name,
+                spec=local_cloud_artifact_store_spec,
+                **local_kwargs,
+            )
         return dispatch[StackType.LOCAL](name, **local_kwargs)
+
+    if local_cloud_artifact_store_spec is not None:
+        raise KitaruUsageError(
+            "Cloud artifact-store specs for local runners require --type local."
+        )
 
     operation = dispatch.get(stack_type)
     if operation is None:

--- a/src/kitaru/_config/_stacks.py
+++ b/src/kitaru/_config/_stacks.py
@@ -28,7 +28,7 @@ from zenml.container_registries.gcp_container_registry import (
     GCPContainerRegistryFlavor,
 )
 from zenml.enums import ContainerRegistryFlavor, StackComponentType
-from zenml.exceptions import EntityExistsError
+from zenml.exceptions import AuthorizationException, EntityExistsError
 from zenml.image_builders.local_image_builder import LocalImageBuilderFlavor
 from zenml.integrations.aws import (
     AWS_CONNECTOR_TYPE,
@@ -79,6 +79,7 @@ from zenml.models.v2.core.stack import StackRequest
 from zenml.models.v2.misc.info_models import ComponentInfo, ServiceConnectorInfo
 from zenml.orchestrators.local.local_orchestrator import LocalOrchestratorFlavor
 from zenml.stack.utils import validate_stack_component_config
+from zenml.zen_stores.rest_zen_store import RestZenStore
 
 from kitaru._config import _sandbox_stack_components as _sandbox_components
 from kitaru._modal_registry import (
@@ -285,6 +286,10 @@ class _ResolvedConnectorSpec:
 
     connector_info: ServiceConnectorInfo
     verify_resource_type: str
+    # Set when the credentials are a pointer into this machine's local state
+    # (e.g. an AWS profile name) that a remote ZenML server cannot resolve.
+    # Each resolver decides portability where it builds the configuration.
+    machine_local_credential: str | None = None
 
 
 @dataclass(frozen=True)
@@ -1057,8 +1062,16 @@ def _connector_label(connector: Any) -> str:
 def _existing_connector_reference(
     connector: Any,
     resource_id: str,
+    *,
+    client: Client,
+    lookup: _ConnectorLookup,
+    verify: bool,
 ) -> _ExistingConnectorReference:
-    """Build a stack-request connector reference from a ZenML connector model."""
+    """Build a stack-request connector reference from a ZenML connector model.
+
+    Every reuse path must construct its reference through this function, so
+    verification cannot be silently skipped by a future discovery path.
+    """
     connector_id_raw = getattr(connector, "id", None)
     try:
         connector_id = UUID(str(connector_id_raw))
@@ -1067,10 +1080,44 @@ def _existing_connector_reference(
             "ZenML returned a matching service connector without a UUID id: "
             f"{_connector_label(connector)}"
         ) from exc
+    if verify:
+        _verify_existing_connector(
+            client,
+            connector_id=connector_id,
+            connector_label=_connector_label(connector),
+            lookup=lookup,
+        )
     return _ExistingConnectorReference(
         connector_id=connector_id,
         resource_id=resource_id,
     )
+
+
+def _verify_existing_connector(
+    client: Client,
+    *,
+    connector_id: UUID,
+    connector_label: str,
+    lookup: _ConnectorLookup,
+) -> None:
+    """Fail fast when a reused connector cannot authenticate to its resource."""
+    try:
+        client.verify_service_connector(
+            connector_id,
+            resource_type=lookup.resource_type,
+            resource_id=lookup.target_resource_id,
+            list_resources=False,
+        )
+    except AuthorizationException as exc:
+        raise KitaruUsageError(
+            f"Kitaru found existing service connector "
+            f"{connector_label} for the {lookup.component_label} "
+            f"({lookup.target_resource_id}), but it failed verification: {exc}. "
+            "Pass explicit cloud credentials so Kitaru creates a working "
+            "connector, fix or delete the broken connector on the ZenML server, "
+            "or skip verification (`--no-verify` on the CLI, `verify=False` in "
+            "the SDK/MCP) to link it anyway."
+        ) from exc
 
 
 def _collect_connector_candidates(
@@ -1250,10 +1297,16 @@ def _resolve_modal_existing_connectors(
         artifact_store=_existing_connector_reference(
             selected_matches[0][0],
             artifact_resource_id,
+            client=client,
+            lookup=lookups[0],
+            verify=spec.verify,
         ),
         container_registry=_existing_connector_reference(
             selected_matches[1][0],
             registry_resource_id,
+            client=client,
+            lookup=lookups[1],
+            verify=spec.verify,
         ),
     )
 
@@ -1263,7 +1316,7 @@ def _resolve_local_cloud_existing_connector(
     *,
     client: Client,
 ) -> _ExistingConnectorReference | None:
-    """Find one existing connector for a local stack's cloud storage."""
+    """Find one verified existing connector for a local stack's cloud storage."""
     if spec.credentials is not None:
         return None
 
@@ -1296,7 +1349,13 @@ def _resolve_local_cloud_existing_connector(
             "one matching resource or pass explicit cloud credentials so Kitaru "
             "creates a new connector."
         )
-    return _existing_connector_reference(matches[0], resource_id)
+    return _existing_connector_reference(
+        matches[0],
+        resource_id,
+        client=client,
+        lookup=lookup,
+        verify=spec.verify,
+    )
 
 
 def _modal_cloud_connector_inputs_requested(spec: ModalStackSpec) -> bool:
@@ -1327,13 +1386,6 @@ def _validate_modal_cloud_connector_inputs(
         )
 
     if not _modal_cloud_connector_inputs_requested(spec):
-        if not spec.verify:
-            raise KitaruUsageError(
-                "`verify=False` only applies when Kitaru is creating a cloud "
-                "connector for a Modal stack. Add the needed cloud connector "
-                "input, such as `region`, `subscription_id`, or `credentials`, "
-                "or remove `verify=False`."
-            )
         return
 
     if provider == CloudProvider.AWS:
@@ -1535,8 +1587,8 @@ def _resolve_aws_connector_spec(
             )
 
     resolved_region = region.strip() if region and region.strip() else None
+    profile_value = configuration.get("profile_name")
     if resolved_region is None:
-        profile_value = configuration.get("profile_name")
         resolved_region = _discover_aws_region(
             str(profile_value) if profile_value is not None else None
         )
@@ -1549,6 +1601,9 @@ def _resolve_aws_connector_spec(
             configuration=dict(configuration),
         ),
         verify_resource_type=AWS_RESOURCE_TYPE,
+        machine_local_credential=(
+            f"aws-profile:{profile_value}" if profile_value is not None else None
+        ),
     )
 
 
@@ -2474,6 +2529,45 @@ def _stack_type_display_name(stack_type: StackType) -> str:
     }.get(stack_type, str(stack_type))
 
 
+_LOCAL_SERVER_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _zen_store_is_remote(client: Client) -> bool:
+    """Return whether the client talks to a ZenML server on another machine."""
+    zen_store = client.zen_store
+    if not isinstance(zen_store, RestZenStore):
+        return False
+    hostname = urlparse(str(zen_store.url)).hostname
+    return hostname not in _LOCAL_SERVER_HOSTNAMES
+
+
+def _reject_machine_local_connector_credentials(
+    client: Client,
+    connector_spec: _ResolvedConnectorSpec,
+) -> None:
+    """Reject connector credentials a remote ZenML server cannot resolve.
+
+    An `aws-profile:` credential stores only the profile name on the connector.
+    The server resolves the connector at runtime and looks the profile up in its
+    own AWS config, where it does not exist, so stack creation would succeed and
+    every run would fail.
+    """
+    credential = connector_spec.machine_local_credential
+    if credential is None or not _zen_store_is_remote(client):
+        return
+    _, _, profile_name = credential.partition(":")
+    raise KitaruUsageError(
+        f"Cannot use `{credential}` credentials while connected "
+        "to a remote ZenML server. The AWS profile only exists in this "
+        "machine's `~/.aws/config`, but the remote server is what resolves the "
+        "connector's credentials at runtime, so every run would fail with a "
+        "missing-profile error. Pass portable credentials instead: "
+        "`aws-access-keys:KEY:SECRET` or `aws-session-token:KEY:SECRET:TOKEN` "
+        "(`aws configure export-credentials --profile "
+        f"{profile_name}` prints the current values)."
+    )
+
+
 def _create_one_shot_stack_operation(
     name: str,
     *,
@@ -2495,6 +2589,9 @@ def _create_one_shot_stack_operation(
     """Create a stack via ZenML's validated one-shot stack API."""
     selector = _normalize_stack_selector(name)
     client = client if client is not None else client_factory()
+
+    if connector_spec is not None:
+        _reject_machine_local_connector_credentials(client, connector_spec)
 
     if any(
         stack_model.name == selector for stack_model in _iter_available_stacks(client)
@@ -3442,12 +3539,6 @@ def _create_local_cloud_stack_operation(
 ) -> _StackCreateResult:
     """Create a local-runner stack backed by cloud artifact storage."""
     selector = _normalize_stack_selector(name)
-    if spec.credentials is None and not spec.verify:
-        raise KitaruUsageError(
-            "`verify=False` only applies when explicit credentials create a new "
-            "cloud connector."
-        )
-
     connector_spec = _resolve_local_cloud_connector_spec(spec)
     existing_connector: _ExistingConnectorReference | None = None
     operation_client: Any | None = None

--- a/src/kitaru/_config/_stacks.py
+++ b/src/kitaru/_config/_stacks.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, NoReturn
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -130,6 +130,24 @@ class CloudProvider(StrEnum):
     AZURE = "azure"
 
 
+_LOCAL_CLOUD_PROVIDER_BY_SCHEME = {
+    "s3": CloudProvider.AWS,
+    "gs": CloudProvider.GCP,
+    "az": CloudProvider.AZURE,
+    "abfs": CloudProvider.AZURE,
+    "abfss": CloudProvider.AZURE,
+}
+_LOCAL_CLOUD_SIMPLE_AUTHORITY_PATTERN = re.compile(
+    r"[A-Za-z0-9$](?:[A-Za-z0-9._$-]*[A-Za-z0-9$])?"
+)
+_LOCAL_CLOUD_ABFS_AUTHORITY_PATTERN = re.compile(
+    r"[A-Za-z0-9$](?:[A-Za-z0-9.$-]*[A-Za-z0-9$])?"
+    r"@[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?"
+    r"\.dfs\.core\.windows\.net",
+    re.IGNORECASE,
+)
+
+
 class StackComponentTarget(StrEnum):
     """Logical stack component targets used for advanced config overrides."""
 
@@ -236,20 +254,20 @@ class LocalCloudArtifactStoreSpec(BaseModel):
     credentials: str | None = None
     verify: bool = True
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
 
     @field_validator("artifact_store")
     @classmethod
     def validate_artifact_store(cls, value: str) -> str:
         """Validate and normalize the cloud artifact-store URI."""
         normalized = value.strip()
-        _infer_cloud_provider_from_artifact_store(normalized)
+        _validate_local_cloud_artifact_store_uri(normalized)
         return normalized
 
     @property
     def provider(self) -> CloudProvider:
         """Return the cloud provider implied by the artifact-store URI."""
-        return _infer_cloud_provider_from_artifact_store(self.artifact_store)
+        return _validate_local_cloud_artifact_store_uri(self.artifact_store)
 
 
 RemoteStackSpec = (
@@ -501,6 +519,26 @@ def _build_component_configuration(
     """Merge base component config with user-provided overrides."""
     return _merge_configuration_dicts(
         base, _component_override_values(overrides, target)
+    )
+
+
+def _build_local_cloud_artifact_store_configuration(
+    artifact_store_uri: str,
+    *,
+    overrides: StackComponentConfigOverrides | None,
+) -> dict[str, Any]:
+    """Merge artifact-store overrides without replacing the validated URI."""
+    artifact_store_overrides = _component_override_values(
+        overrides, StackComponentTarget.ARTIFACT_STORE
+    )
+    override_path = artifact_store_overrides.pop("path", artifact_store_uri)
+    if override_path != artifact_store_uri:
+        raise KitaruUsageError(
+            "`artifact_store.path` cannot override the validated cloud artifact-store "
+            "URI. Set the cloud location through `artifact_store` instead."
+        )
+    return _merge_configuration_dicts(
+        {"path": artifact_store_uri}, artifact_store_overrides
     )
 
 
@@ -816,6 +854,44 @@ def _normalize_azure_artifact_store_uri(artifact_store_uri: str) -> str:
     if artifact_store_uri.startswith("abfss://"):
         return "abfs://" + artifact_store_uri.removeprefix("abfss://")
     return artifact_store_uri
+
+
+def _validate_local_cloud_artifact_store_uri(
+    artifact_store_uri: str,
+    *,
+    field_label: str = "Artifact store",
+) -> CloudProvider:
+    """Validate a local stack's cloud URI without exposing rejected values."""
+
+    def _raise_invalid_uri() -> NoReturn:
+        raise KitaruUsageError(
+            f"{field_label} must be an s3://, gs://, az://, abfs://, or abfss:// "
+            "URI with a bucket or container name and without query parameters, "
+            "fragments, embedded credentials, or ports."
+        )
+
+    try:
+        parsed = urlparse(artifact_store_uri)
+    except ValueError:
+        _raise_invalid_uri()
+
+    provider = _LOCAL_CLOUD_PROVIDER_BY_SCHEME.get(parsed.scheme)
+    if (
+        provider is None
+        or not artifact_store_uri.startswith(f"{parsed.scheme}://")
+        or not parsed.netloc
+        or "?" in artifact_store_uri
+        or "#" in artifact_store_uri
+    ):
+        _raise_invalid_uri()
+
+    authority_pattern = _LOCAL_CLOUD_SIMPLE_AUTHORITY_PATTERN
+    if parsed.scheme in {"abfs", "abfss"} and "@" in parsed.netloc:
+        authority_pattern = _LOCAL_CLOUD_ABFS_AUTHORITY_PATTERN
+    if authority_pattern.fullmatch(parsed.netloc) is None:
+        _raise_invalid_uri()
+
+    return provider
 
 
 def _infer_cloud_provider_from_artifact_store(
@@ -1668,6 +1744,16 @@ def _resolve_local_cloud_connector_spec(
 ) -> _ResolvedConnectorSpec | None:
     """Build a new connector only when local cloud credentials are explicit."""
     if spec.credentials is None:
+        metadata_fields = []
+        if spec.region is not None:
+            metadata_fields.append("region")
+        if spec.subscription_id is not None:
+            metadata_fields.append("subscription_id")
+        if metadata_fields:
+            raise KitaruUsageError(
+                f"{_format_option_list(metadata_fields)} require `credentials` "
+                "because they configure a new cloud connector."
+            )
         return None
     if spec.provider == CloudProvider.AWS:
         return _resolve_aws_connector_spec(
@@ -1809,10 +1895,9 @@ def _build_local_cloud_stack_request(
                 ComponentInfo(
                     flavor=_artifact_store_flavor(spec.provider),
                     **connector_kwargs,
-                    configuration=_build_component_configuration(
-                        {"path": artifact_store_uri},
+                    configuration=_build_local_cloud_artifact_store_configuration(
+                        artifact_store_uri,
                         overrides=component_overrides,
-                        target=StackComponentTarget.ARTIFACT_STORE,
                     ),
                 )
             ],
@@ -2517,7 +2602,9 @@ def _create_one_shot_stack_operation(
         previous_active_stack=previous_active_stack,
         components_created=components_created,
         stack_type=stack_type.value,
-        service_connectors_created=service_connectors_created,
+        service_connectors_created=(
+            service_connectors_created if connector_spec is not None else ()
+        ),
         resources=resource_summary,
     )
 

--- a/src/kitaru/_interface_stacks.py
+++ b/src/kitaru/_interface_stacks.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import dataclasses
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Protocol
+from typing import Any, Literal, NoReturn, Protocol
+from urllib.parse import urlparse
 
 import yaml
 from zenml.utils import yaml_utils
@@ -17,6 +19,7 @@ from kitaru._config._stacks import (
     AzureMLStackSpec,
     CloudProvider,
     KubernetesStackSpec,
+    LocalCloudArtifactStoreSpec,
     ModalStackSpec,
     RemoteStackSpec,
     SagemakerStackSpec,
@@ -115,6 +118,22 @@ _PROVIDER_URI_DESCRIPTIONS: dict[StackType, tuple[str, str]] = {
     StackType.SAGEMAKER: ("SageMaker", "an s3://"),
     StackType.AZUREML: ("AzureML", "an az://, abfs://, or abfss://"),
 }
+_LOCAL_CLOUD_PROVIDER_BY_SCHEME = {
+    "s3": CloudProvider.AWS,
+    "gs": CloudProvider.GCP,
+    "az": CloudProvider.AZURE,
+    "abfs": CloudProvider.AZURE,
+    "abfss": CloudProvider.AZURE,
+}
+_LOCAL_CLOUD_SIMPLE_AUTHORITY_PATTERN = re.compile(
+    r"[A-Za-z0-9$](?:[A-Za-z0-9._$-]*[A-Za-z0-9$])?"
+)
+_LOCAL_CLOUD_ABFS_AUTHORITY_PATTERN = re.compile(
+    r"[A-Za-z0-9$](?:[A-Za-z0-9.$-]*[A-Za-z0-9$])?"
+    r"@[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?"
+    r"\.dfs\.core\.windows\.net",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -189,6 +208,7 @@ class ManageStackCreateRequest:
     activate: bool
     stack_type: StackType
     remote_spec: RemoteStackSpec | None = None
+    local_cloud_artifact_store_spec: LocalCloudArtifactStoreSpec | None = None
     sandbox_flavor: str | None = None
     component_overrides: StackComponentConfigOverrides = field(
         default_factory=StackComponentConfigOverrides
@@ -240,6 +260,7 @@ class _CreateStackOperation(Protocol):
         stack_type: StackType,
         activate: bool,
         remote_spec: RemoteStackSpec | None,
+        local_cloud_artifact_store_spec: LocalCloudArtifactStoreSpec | None = None,
         component_overrides: StackComponentConfigOverrides | None = None,
         sandbox_flavor: str | None = None,
     ) -> stack_ops._StackCreateResult: ...
@@ -372,6 +393,45 @@ def infer_cloud_provider(artifact_store_uri: str) -> CloudProvider:
         f"Cannot infer cloud provider from '{artifact_store_uri}'. "
         "Use an s3://, gs://, az://, abfs://, or abfss:// URI."
     )
+
+
+def _validate_local_cloud_artifact_store_uri(
+    artifact_store_uri: str,
+    *,
+    labels: StackOptionLabels,
+) -> CloudProvider:
+    """Validate a local stack's cloud URI without exposing rejected values."""
+
+    def _raise_invalid_uri() -> NoReturn:
+        raise ValueError(
+            f"{labels.field_labels['artifact_store']} must be an s3://, gs://, "
+            "az://, abfs://, or abfss:// URI with a bucket or container name "
+            "and without query parameters, fragments, embedded credentials, "
+            "or ports."
+        )
+
+    try:
+        parsed = urlparse(artifact_store_uri)
+    except ValueError:
+        _raise_invalid_uri()
+
+    provider = _LOCAL_CLOUD_PROVIDER_BY_SCHEME.get(parsed.scheme)
+    if (
+        provider is None
+        or not artifact_store_uri.startswith(f"{parsed.scheme}://")
+        or not parsed.netloc
+        or "?" in artifact_store_uri
+        or "#" in artifact_store_uri
+    ):
+        _raise_invalid_uri()
+
+    authority_pattern = _LOCAL_CLOUD_SIMPLE_AUTHORITY_PATTERN
+    if parsed.scheme in {"abfs", "abfss"} and "@" in parsed.netloc:
+        authority_pattern = _LOCAL_CLOUD_ABFS_AUTHORITY_PATTERN
+    if authority_pattern.fullmatch(parsed.netloc) is None:
+        _raise_invalid_uri()
+
+    return provider
 
 
 def _modal_cloud_connector_inputs_requested(
@@ -911,6 +971,113 @@ def validate_component_override_targets(
         )
 
 
+def build_local_cloud_artifact_store_spec(
+    *,
+    stack_type: StackType,
+    artifact_store: str | None,
+    container_registry: str | None,
+    cluster: str | None,
+    region: str | None,
+    subscription_id: str | None,
+    resource_group: str | None,
+    workspace: str | None,
+    execution_role: str | None,
+    namespace: str | None,
+    credentials: str | None,
+    sandbox: str | None,
+    verify: bool,
+    labels: StackOptionLabels,
+) -> LocalCloudArtifactStoreSpec | None:
+    """Build optional cloud-storage configuration for a local stack."""
+    if stack_type != StackType.LOCAL:
+        return None
+
+    normalized_artifact_store = normalize_optional_stack_string(artifact_store)
+    provided_fields = {
+        "artifact_store": artifact_store is not None,
+        "container_registry": container_registry is not None,
+        "cluster": cluster is not None,
+        "region": region is not None,
+        "subscription_id": subscription_id is not None,
+        "resource_group": resource_group is not None,
+        "workspace": workspace is not None,
+        "execution_role": execution_role is not None,
+        "namespace": namespace is not None,
+        "credentials": credentials is not None,
+        "sandbox": sandbox is not None,
+        "verify": not verify,
+    }
+    cloud_storage_fields = ("credentials", "region", "subscription_id", "verify")
+    if artifact_store is None:
+        fields_requiring_storage = [
+            field_name
+            for field_name in cloud_storage_fields
+            if provided_fields[field_name]
+        ]
+        if fields_requiring_storage:
+            raise ValueError(
+                _render_field_labels(fields_requiring_storage, labels=labels)
+                + f" require {labels.field_labels['artifact_store']} with an "
+                "s3://, gs://, az://, abfs://, or abfss:// URI for a local stack."
+            )
+        _validate_explicit_field_usage(
+            stack_type=stack_type,
+            provided_fields={**provided_fields, "artifact_store": False},
+            labels=labels,
+        )
+        return None
+
+    if normalized_artifact_store is None:
+        raise ValueError(f"{labels.field_labels['artifact_store']} cannot be empty.")
+
+    _validate_explicit_field_usage(
+        stack_type=stack_type,
+        provided_fields={
+            **provided_fields,
+            "artifact_store": False,
+            "region": False,
+            "subscription_id": False,
+            "credentials": False,
+            "verify": False,
+        },
+        labels=labels,
+    )
+    normalized_region = normalize_optional_stack_string(region)
+    normalized_subscription_id = normalize_optional_stack_string(subscription_id)
+    normalized_credentials = normalize_optional_stack_string(credentials)
+    if credentials is not None and normalized_credentials is None:
+        raise ValueError(f"{labels.field_labels['credentials']} cannot be empty.")
+
+    provider = _validate_local_cloud_artifact_store_uri(
+        normalized_artifact_store,
+        labels=labels,
+    )
+    if provider != CloudProvider.AWS and normalized_region is not None:
+        raise ValueError(
+            f"{labels.field_labels['region']} only applies to s3:// storage for "
+            "local stacks."
+        )
+    if provider != CloudProvider.AZURE and normalized_subscription_id is not None:
+        raise ValueError(
+            f"{labels.field_labels['subscription_id']} only applies to Azure "
+            "storage for local stacks."
+        )
+    if not verify and normalized_credentials is None:
+        raise ValueError(
+            f"{labels.field_labels['verify']} only applies when "
+            f"{labels.field_labels['credentials']} asks Kitaru to create a new "
+            "cloud connector."
+        )
+
+    return LocalCloudArtifactStoreSpec(
+        artifact_store=normalized_artifact_store,
+        region=normalized_region,
+        subscription_id=normalized_subscription_id,
+        credentials=normalized_credentials,
+        verify=verify,
+    )
+
+
 def build_remote_stack_spec(
     *,
     stack_type: StackType,
@@ -929,6 +1096,9 @@ def build_remote_stack_spec(
     labels: StackOptionLabels,
 ) -> RemoteStackSpec | None:
     """Validate interface inputs and build a remote stack spec when needed."""
+    if stack_type == StackType.LOCAL:
+        return None
+
     provided_fields = {
         "artifact_store": artifact_store is not None,
         "container_registry": container_registry is not None,
@@ -948,9 +1118,6 @@ def build_remote_stack_spec(
         provided_fields=provided_fields,
         labels=labels,
     )
-
-    if stack_type == StackType.LOCAL:
-        return None
 
     normalized_artifact_store = normalize_optional_stack_string(artifact_store)
     normalized_container_registry = normalize_optional_stack_string(container_registry)
@@ -1133,6 +1300,23 @@ def build_stack_create_request(
             "only apply when the created stack has a sandbox."
         )
 
+    local_cloud_artifact_store_spec = build_local_cloud_artifact_store_spec(
+        stack_type=normalized_stack_type,
+        artifact_store=artifact_store,
+        container_registry=container_registry,
+        cluster=cluster,
+        region=region,
+        subscription_id=subscription_id,
+        resource_group=resource_group,
+        workspace=workspace,
+        execution_role=execution_role,
+        namespace=namespace,
+        credentials=credentials,
+        sandbox=sandbox,
+        verify=verify,
+        labels=labels,
+    )
+
     return ManageStackCreateRequest(
         name=name,
         activate=activate,
@@ -1153,6 +1337,7 @@ def build_stack_create_request(
             verify=verify,
             labels=labels,
         ),
+        local_cloud_artifact_store_spec=local_cloud_artifact_store_spec,
         sandbox_flavor=normalized_sandbox,
         component_overrides=apply_async_override(
             component_overrides,
@@ -1315,6 +1500,10 @@ def execute_stack_create_request(
         "activate": request.activate,
         "remote_spec": request.remote_spec,
     }
+    if request.local_cloud_artifact_store_spec is not None:
+        create_kwargs["local_cloud_artifact_store_spec"] = (
+            request.local_cloud_artifact_store_spec
+        )
     if request.sandbox_flavor is not None:
         create_kwargs["sandbox_flavor"] = request.sandbox_flavor
     if not request.component_overrides.is_empty():

--- a/src/kitaru/_interface_stacks.py
+++ b/src/kitaru/_interface_stacks.py
@@ -397,7 +397,6 @@ def _validate_modal_cloud_connector_inputs(
     region: str | None,
     subscription_id: str | None,
     credentials: str | None,
-    verify: bool,
     labels: StackOptionLabels,
 ) -> None:
     """Reject impossible Modal cloud credential combinations early."""
@@ -415,16 +414,6 @@ def _validate_modal_cloud_connector_inputs(
         subscription_id=subscription_id,
         credentials=credentials,
     ):
-        if not verify:
-            raise ValueError(
-                f"{labels.field_labels['verify']} only applies when Kitaru is "
-                "creating a cloud connector for a Modal stack. Add the needed "
-                "cloud connector input, such as "
-                f"{labels.field_labels['region']}, "
-                f"{labels.field_labels['subscription_id']}, or "
-                f"{labels.field_labels['credentials']}, or remove "
-                f"{labels.field_labels['verify']}."
-            )
         return
 
     region_label = labels.field_labels["region"]
@@ -1005,13 +994,6 @@ def build_local_cloud_artifact_store_spec(
             f"{labels.field_labels['subscription_id']} only applies to Azure "
             "storage for local stacks."
         )
-    if not verify and normalized_credentials is None:
-        raise ValueError(
-            f"{labels.field_labels['verify']} only applies when "
-            f"{labels.field_labels['credentials']} asks Kitaru to create a new "
-            "cloud connector."
-        )
-
     return LocalCloudArtifactStoreSpec(
         artifact_store=normalized_artifact_store,
         region=normalized_region,
@@ -1177,7 +1159,6 @@ def build_remote_stack_spec(
             region=normalized_region,
             subscription_id=normalized_subscription_id,
             credentials=normalized_credentials,
-            verify=verify,
             labels=labels,
         )
         return ModalStackSpec(

--- a/src/kitaru/_interface_stacks.py
+++ b/src/kitaru/_interface_stacks.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import dataclasses
-import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, NoReturn, Protocol
-from urllib.parse import urlparse
+from typing import Any, Literal, Protocol
 
 import yaml
 from zenml.utils import yaml_utils
@@ -118,22 +116,6 @@ _PROVIDER_URI_DESCRIPTIONS: dict[StackType, tuple[str, str]] = {
     StackType.SAGEMAKER: ("SageMaker", "an s3://"),
     StackType.AZUREML: ("AzureML", "an az://, abfs://, or abfss://"),
 }
-_LOCAL_CLOUD_PROVIDER_BY_SCHEME = {
-    "s3": CloudProvider.AWS,
-    "gs": CloudProvider.GCP,
-    "az": CloudProvider.AZURE,
-    "abfs": CloudProvider.AZURE,
-    "abfss": CloudProvider.AZURE,
-}
-_LOCAL_CLOUD_SIMPLE_AUTHORITY_PATTERN = re.compile(
-    r"[A-Za-z0-9$](?:[A-Za-z0-9._$-]*[A-Za-z0-9$])?"
-)
-_LOCAL_CLOUD_ABFS_AUTHORITY_PATTERN = re.compile(
-    r"[A-Za-z0-9$](?:[A-Za-z0-9.$-]*[A-Za-z0-9$])?"
-    r"@[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?"
-    r"\.dfs\.core\.windows\.net",
-    re.IGNORECASE,
-)
 
 
 @dataclass(frozen=True)
@@ -393,45 +375,6 @@ def infer_cloud_provider(artifact_store_uri: str) -> CloudProvider:
         f"Cannot infer cloud provider from '{artifact_store_uri}'. "
         "Use an s3://, gs://, az://, abfs://, or abfss:// URI."
     )
-
-
-def _validate_local_cloud_artifact_store_uri(
-    artifact_store_uri: str,
-    *,
-    labels: StackOptionLabels,
-) -> CloudProvider:
-    """Validate a local stack's cloud URI without exposing rejected values."""
-
-    def _raise_invalid_uri() -> NoReturn:
-        raise ValueError(
-            f"{labels.field_labels['artifact_store']} must be an s3://, gs://, "
-            "az://, abfs://, or abfss:// URI with a bucket or container name "
-            "and without query parameters, fragments, embedded credentials, "
-            "or ports."
-        )
-
-    try:
-        parsed = urlparse(artifact_store_uri)
-    except ValueError:
-        _raise_invalid_uri()
-
-    provider = _LOCAL_CLOUD_PROVIDER_BY_SCHEME.get(parsed.scheme)
-    if (
-        provider is None
-        or not artifact_store_uri.startswith(f"{parsed.scheme}://")
-        or not parsed.netloc
-        or "?" in artifact_store_uri
-        or "#" in artifact_store_uri
-    ):
-        _raise_invalid_uri()
-
-    authority_pattern = _LOCAL_CLOUD_SIMPLE_AUTHORITY_PATTERN
-    if parsed.scheme in {"abfs", "abfss"} and "@" in parsed.netloc:
-        authority_pattern = _LOCAL_CLOUD_ABFS_AUTHORITY_PATTERN
-    if authority_pattern.fullmatch(parsed.netloc) is None:
-        _raise_invalid_uri()
-
-    return provider
 
 
 def _modal_cloud_connector_inputs_requested(
@@ -1048,9 +991,9 @@ def build_local_cloud_artifact_store_spec(
     if credentials is not None and normalized_credentials is None:
         raise ValueError(f"{labels.field_labels['credentials']} cannot be empty.")
 
-    provider = _validate_local_cloud_artifact_store_uri(
+    provider = stack_ops._validate_local_cloud_artifact_store_uri(
         normalized_artifact_store,
-        labels=labels,
+        field_label=labels.field_labels["artifact_store"],
     )
     if provider != CloudProvider.AWS and normalized_region is not None:
         raise ValueError(

--- a/src/kitaru/config.py
+++ b/src/kitaru/config.py
@@ -121,6 +121,7 @@ VertexStackSpec = _config_stacks.VertexStackSpec
 SagemakerStackSpec = _config_stacks.SagemakerStackSpec
 AzureMLStackSpec = _config_stacks.AzureMLStackSpec
 ModalStackSpec = _config_stacks.ModalStackSpec
+LocalCloudArtifactStoreSpec = _config_stacks.LocalCloudArtifactStoreSpec
 RemoteStackSpec = _config_stacks.RemoteStackSpec
 StackComponentConfigOverrides = _config_stacks.StackComponentConfigOverrides
 _ResolvedConnectorSpec = _config_stacks._ResolvedConnectorSpec
@@ -607,6 +608,27 @@ def _show_stack_operation(name_or_id: str) -> StackDetails:
     )
 
 
+def _create_local_cloud_stack_operation(
+    name: str,
+    *,
+    spec: LocalCloudArtifactStoreSpec,
+    activate: bool = True,
+    labels: dict[str, str] | None = None,
+    component_overrides: StackComponentConfigOverrides | None = None,
+    sandbox_flavor: str = "local",
+) -> _StackCreateResult:
+    """Create a local-runner stack with cloud artifact storage."""
+    return _config_stacks._create_local_cloud_stack_operation(
+        name,
+        spec=spec,
+        activate=activate,
+        labels=labels,
+        component_overrides=component_overrides,
+        sandbox_flavor=sandbox_flavor,
+        client_factory=Client,
+    )
+
+
 def _create_kubernetes_stack_operation(
     name: str,
     *,
@@ -719,6 +741,7 @@ def _create_stack_operation(
     activate: bool = True,
     labels: dict[str, str] | None = None,
     remote_spec: RemoteStackSpec | None = None,
+    local_cloud_artifact_store_spec: LocalCloudArtifactStoreSpec | None = None,
     component_overrides: StackComponentConfigOverrides | None = None,
     sandbox_flavor: str | None = None,
 ) -> _StackCreateResult:
@@ -729,8 +752,10 @@ def _create_stack_operation(
         activate=activate,
         labels=labels,
         remote_spec=remote_spec,
+        local_cloud_artifact_store_spec=local_cloud_artifact_store_spec,
         component_overrides=component_overrides,
         sandbox_flavor=sandbox_flavor,
+        local_cloud_operation_override=_create_local_cloud_stack_operation,
         operation_overrides=cast(
             dict[StackType, Callable[..., _StackCreateResult]],
             {

--- a/src/kitaru/mcp/server.py
+++ b/src/kitaru/mcp/server.py
@@ -803,10 +803,16 @@ def manage_stack(
     """Create or delete a local, Kubernetes, Vertex AI, SageMaker, AzureML,
     or Modal stack.
 
+    Local stacks default to a local runner, storage, and sandbox. Set
+    `artifact_store` to an s3://, gs://, az://, abfs://, or abfss:// URI to keep
+    the runner local while storing artifacts in the cloud. Without `credentials`,
+    Kitaru reuses a matching connector when available, then falls back to ambient
+    provider credentials on the machine running the flow.
+
     For remote stacks, `sandbox` attaches a sandbox only when provided. Use
     `sandbox="modal"` to attach a Modal sandbox component to a Modal stack.
-    Local stacks default to `local`. `async_mode` is the MCP equivalent of CLI
-    `--async`.
+    `async_mode` is the MCP equivalent of CLI `--async` and is not valid for
+    local stacks.
     """
 
     def _manage_stack() -> dict[str, Any]:

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -2577,12 +2577,18 @@ def test_manage_stack_create_modal_rejects_aws_credentials_without_region() -> N
     mock_create_stack.assert_not_called()
 
 
-def test_manage_stack_create_modal_rejects_no_verify_without_connector_input() -> None:
-    """MCP Modal verify=False should not request a cloud connector by itself."""
-    with (
-        patch("kitaru._config._stacks._create_stack_operation") as mock_create_stack,
-        pytest.raises(ValueError, match="only applies when Kitaru is creating"),
-    ):
+def test_manage_stack_create_modal_accepts_no_verify_without_connector_input() -> None:
+    """MCP Modal verify=False should also cover reused service connectors."""
+    with patch("kitaru._config._stacks._create_stack_operation") as mock_create_stack:
+        mock_create_stack.return_value = SimpleNamespace(
+            stack=StackInfo(id="stack-modal-id", name="prod-modal", is_active=False),
+            previous_active_stack=None,
+            components_created=(),
+            stack_type="modal",
+            service_connectors_created=(),
+            resources={},
+        )
+
         manage_stack(
             "create",
             "prod-modal",
@@ -2592,7 +2598,10 @@ def test_manage_stack_create_modal_rejects_no_verify_without_connector_input() -
             verify=False,
         )
 
-    mock_create_stack.assert_not_called()
+    modal_spec = mock_create_stack.call_args.kwargs["remote_spec"]
+    assert isinstance(modal_spec, ModalStackSpec)
+    assert modal_spec.verify is False
+    assert modal_spec.credentials is None
 
 
 def test_manage_stack_create_modal_rejects_mismatched_connectorless_resources() -> None:

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -22,6 +22,7 @@ from kitaru.config import (
     CloudProvider,
     ImageSettings,
     KubernetesStackSpec,
+    LocalCloudArtifactStoreSpec,
     ModalStackSpec,
     ProjectInfo,
     SagemakerStackSpec,
@@ -158,6 +159,16 @@ def test_delete_tool_descriptions_warn_about_active_workloads() -> None:
         assert "does not stop" in description
         assert "continue consuming compute" in description
         assert "wait for termination" in description
+
+
+def test_manage_stack_description_documents_local_cloud_storage() -> None:
+    """The MCP tool description should explain the local cloud-storage contract."""
+    tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+    description = tools["manage_stack"].description or ""
+
+    assert "runner local while storing artifacts in the cloud" in description
+    assert "ambient" in description
+    assert "provider credentials on the machine running the flow" in description
 
 
 def test_fastmcp_registers_public_tools_with_expected_input_schemas() -> None:
@@ -2761,48 +2772,94 @@ def test_manage_stack_create_kubernetes_requires_required_fields(
     mock_create_stack.assert_not_called()
 
 
-_REMOTE_STACK_TYPE_ERROR = (
-    'Remote stack options require `stack_type="kubernetes"`, '
-    '`stack_type="vertex"`, `stack_type="sagemaker"`, '
-    '`stack_type="azureml"`, or `stack_type="modal"`'
+@pytest.mark.parametrize(
+    ("artifact_store", "provider"),
+    [
+        ("s3://my-bucket/kitaru", CloudProvider.AWS),
+        ("gs://my-bucket/kitaru", CloudProvider.GCP),
+        ("az://container/kitaru", CloudProvider.AZURE),
+        ("abfs://container/kitaru", CloudProvider.AZURE),
+        ("abfss://container/kitaru", CloudProvider.AZURE),
+    ],
 )
-_CLOUD_CONNECTOR_STACK_TYPE_ERROR = (
-    'Remote stack options require `stack_type="kubernetes"`, '
-    '`stack_type="vertex"`, `stack_type="sagemaker"`, '
-    '`stack_type="azureml"`, or `stack_type="modal"`'
-)
+def test_manage_stack_create_local_accepts_cloud_artifact_store(
+    artifact_store: str,
+    provider: CloudProvider,
+) -> None:
+    """MCP should produce the shared local-cloud request for every provider."""
+    with patch("kitaru._config._stacks._create_stack_operation") as mock_create_stack:
+        mock_create_stack.return_value = SimpleNamespace(
+            stack=StackInfo(id="stack-dev-id", name="dev", is_active=False),
+            previous_active_stack=None,
+            components_created=(
+                "dev (orchestrator)",
+                "dev (artifact_store)",
+                "dev (sandbox)",
+            ),
+            stack_type="local",
+            service_connectors_created=(),
+            resources={
+                "provider": provider.value,
+                "artifact_store": artifact_store,
+                "connector_mode": "ambient",
+            },
+        )
+
+        payload = manage_stack(
+            "create",
+            "dev",
+            activate=False,
+            artifact_store=artifact_store,
+        )
+
+    assert mock_create_stack.call_args.kwargs["remote_spec"] is None
+    assert mock_create_stack.call_args.kwargs["activate"] is False
+    spec = mock_create_stack.call_args.kwargs["local_cloud_artifact_store_spec"]
+    assert isinstance(spec, LocalCloudArtifactStoreSpec)
+    assert spec.artifact_store == artifact_store
+    assert spec.provider == provider
+    assert spec.credentials is None
+    assert payload["resources"]["artifact_store"] == artifact_store
 
 
 @pytest.mark.parametrize(
     ("extra_kwargs", "expected_message"),
     [
-        ({"artifact_store": "s3://my-bucket/kitaru"}, _REMOTE_STACK_TYPE_ERROR),
         (
             {
                 "container_registry": (
                     "123456789012.dkr.ecr.eu-west-1.amazonaws.com/kitaru"
                 )
             },
-            _REMOTE_STACK_TYPE_ERROR,
+            'Remote stack options require `stack_type="kubernetes"`',
         ),
         (
             {"cluster": "cluster-1"},
             'Kubernetes-only options require `stack_type="kubernetes"`: `cluster`',
         ),
-        ({"region": "eu-west-1"}, _CLOUD_CONNECTOR_STACK_TYPE_ERROR),
         (
             {"namespace": "ml-team"},
             'Kubernetes-only options require `stack_type="kubernetes"`: `namespace`',
         ),
-        ({"credentials": "implicit"}, _CLOUD_CONNECTOR_STACK_TYPE_ERROR),
-        ({"verify": False}, _CLOUD_CONNECTOR_STACK_TYPE_ERROR),
+        (
+            {"region": "eu-west-1"},
+            r"`region` require `artifact_store` with an s3://",
+        ),
+        (
+            {"credentials": "implicit"},
+            r"`credentials` require `artifact_store` with an s3://",
+        ),
+        (
+            {"verify": False},
+            r"`verify` require `artifact_store` with an s3://",
+        ),
     ],
 )
-def test_manage_stack_create_local_rejects_kubernetes_only_options(
+def test_manage_stack_create_local_rejects_incompatible_options(
     extra_kwargs: dict[str, Any],
     expected_message: str,
 ) -> None:
-    """Local MCP create should reject remote-stack inputs."""
+    """Local MCP create should reject fields without their required local storage."""
     with (
         patch("kitaru._config._stacks._create_stack_operation") as mock_create_stack,
         pytest.raises(ValueError, match=expected_message),
@@ -3324,10 +3381,7 @@ def test_manage_stack_create_local_rejects_azureml_only_options() -> None:
         patch("kitaru._config._stacks._create_stack_operation") as mock_create_stack,
         pytest.raises(
             ValueError,
-            match=(
-                'Stack-specific options require `stack_type="azureml"` or '
-                '`stack_type="modal"`: `subscription_id`'
-            ),
+            match=(r"`subscription_id` require `artifact_store` with an s3://"),
         ),
     ):
         manage_stack(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,9 +55,11 @@ from kitaru.config import (
     KITARU_MODEL_REGISTRY_ENV,
     ActiveEnvironmentVariable,
     AzureMLStackSpec,
+    CloudProvider,
     ImageSettings,
     KitaruConfig,
     KubernetesStackSpec,
+    LocalCloudArtifactStoreSpec,
     ModalStackSpec,
     ModelAliasConfig,
     ModelRegistryConfig,
@@ -7653,34 +7655,137 @@ def test_stack_create_json_output(capsys: pytest.CaptureFixture[str]) -> None:
     }
 
 
-def test_stack_create_rejects_kubernetes_flags_for_local_stack(
+@pytest.mark.parametrize(
+    ("artifact_store", "provider"),
+    [
+        ("s3://bucket/kitaru", CloudProvider.AWS),
+        ("gs://bucket/kitaru", CloudProvider.GCP),
+        ("az://container/kitaru", CloudProvider.AZURE),
+        ("abfs://container/kitaru", CloudProvider.AZURE),
+        ("abfss://container/kitaru", CloudProvider.AZURE),
+    ],
+)
+def test_stack_create_local_accepts_cloud_artifact_store(
+    artifact_store: str,
+    provider: CloudProvider,
+) -> None:
+    """Bare cloud URIs should use the shared local-cloud request path."""
+    with (
+        patch("kitaru.cli._create_stack_operation") as mock_create_stack,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        mock_create_stack.return_value = _stack_create_result_stub()
+        app(["stack", "create", "dev", "--artifact-store", artifact_store])
+
+    assert exc_info.value.code == 0
+    assert mock_create_stack.call_args.kwargs["remote_spec"] is None
+    spec = mock_create_stack.call_args.kwargs["local_cloud_artifact_store_spec"]
+    assert isinstance(spec, LocalCloudArtifactStoreSpec)
+    assert spec.artifact_store == artifact_store
+    assert spec.provider == provider
+    assert spec.credentials is None
+    assert mock_create_stack.call_args.kwargs["sandbox_flavor"] == "local"
+
+
+def test_stack_create_local_cloud_no_activate() -> None:
+    """Local cloud-storage creation should preserve --no-activate."""
+    with (
+        patch("kitaru.cli._create_stack_operation") as mock_create_stack,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        mock_create_stack.return_value = _stack_create_result_stub(
+            is_active=False,
+            previous_active_stack=None,
+        )
+        app(
+            [
+                "stack",
+                "create",
+                "dev",
+                "--artifact-store",
+                "s3://bucket/kitaru",
+                "--no-activate",
+            ]
+        )
+
+    assert exc_info.value.code == 0
+    assert mock_create_stack.call_args.kwargs["activate"] is False
+
+
+def test_stack_create_local_cloud_json_serializes_resources(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Local stack creation should reject remote-stack flags."""
-    with pytest.raises(SystemExit) as exc_info:
-        app(["stack", "create", "dev", "--artifact-store", "s3://bucket/kitaru"])
+    """Local cloud-storage JSON should include the backend resource summary."""
+    with (
+        patch("kitaru.cli._create_stack_operation") as mock_create_stack,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        mock_create_stack.return_value = _stack_create_result_stub(
+            resources={
+                "provider": "aws",
+                "artifact_store": "s3://bucket/kitaru",
+                "connector_mode": "ambient",
+            }
+        )
+        app(
+            [
+                "stack",
+                "create",
+                "dev",
+                "--artifact-store",
+                "s3://bucket/kitaru",
+                "--output",
+                "json",
+            ]
+        )
 
-    assert exc_info.value.code == 1
-    assert (
-        "Remote stack options require --type kubernetes, --type vertex, "
-        "--type sagemaker, --type azureml, or --type modal: --artifact-store"
-        in capsys.readouterr().err
-    )
+    assert exc_info.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["item"]["stack_type"] == "local"
+    assert payload["item"]["resources"] == {
+        "provider": "aws",
+        "artifact_store": "s3://bucket/kitaru",
+        "connector_mode": "ambient",
+    }
 
 
-def test_stack_create_rejects_blank_kubernetes_flags_for_local_stack(
+def test_stack_create_rejects_blank_local_artifact_store(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Blank remote-stack flag values still count as explicit local-stack inputs."""
+    """An explicitly blank local artifact-store URI should fail validation."""
     with pytest.raises(SystemExit) as exc_info:
         app(["stack", "create", "dev", "--artifact-store", "   "])
 
     assert exc_info.value.code == 1
+    assert "--artifact-store cannot be empty." in capsys.readouterr().err
+
+
+def test_stack_create_local_cloud_fields_require_artifact_store(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Connector fields should require cloud storage on local stacks."""
+    with pytest.raises(SystemExit) as exc_info:
+        app(["stack", "create", "dev", "--credentials", "aws-profile:demo"])
+
+    assert exc_info.value.code == 1
     assert (
-        "Remote stack options require --type kubernetes, --type vertex, "
-        "--type sagemaker, --type azureml, or --type modal: --artifact-store"
-        in capsys.readouterr().err
+        "--credentials require --artifact-store with an s3://, gs://, az://, "
+        "abfs://, or abfss:// URI for a local stack." in capsys.readouterr().err
     )
+
+
+def test_stack_create_help_documents_local_cloud_storage(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Stack-create help should advertise cloud storage for local runners."""
+    with pytest.raises(SystemExit) as exc_info:
+        app(["stack", "create", "--help"])
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "Local stacks can use S3, GCS, or Azure storage" in output
+    assert "Artifact store URI. Local stacks accept s3://" in output
+    assert "abfss:// cloud storage" in output
 
 
 def test_stack_create_kubernetes_requires_all_mandatory_flags(
@@ -7854,8 +7959,8 @@ def test_stack_create_local_rejects_azureml_only_flags(
 
     assert exc_info.value.code == 1
     assert (
-        "Stack-specific options require --type azureml or --type modal: "
-        "--subscription-id" in capsys.readouterr().err
+        "--subscription-id require --artifact-store with an s3://, gs://, az://, "
+        "abfs://, or abfss:// URI for a local stack." in capsys.readouterr().err
     )
 
 
@@ -9595,6 +9700,43 @@ activate: true
         remote_spec=None,
         sandbox_flavor="local",
     )
+
+
+def test_stack_create_from_file_builds_local_cloud_stack(tmp_path: Path) -> None:
+    """YAML local cloud storage should build the same request as CLI flags."""
+    stack_file = _write_stack_create_file(
+        tmp_path,
+        """
+name: yaml-local-cloud
+type: local
+artifact_store: gs://bucket/kitaru
+activate: false
+""".strip(),
+    )
+
+    with (
+        patch("kitaru.cli._create_stack_operation") as mock_create_stack,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        mock_create_stack.return_value = _stack_create_result_stub(
+            name="yaml-local-cloud",
+            is_active=False,
+            previous_active_stack=None,
+        )
+        app(["stack", "create", "--file", str(stack_file)])
+
+    assert exc_info.value.code == 0
+    assert mock_create_stack.call_args.kwargs["activate"] is False
+    spec = mock_create_stack.call_args.kwargs["local_cloud_artifact_store_spec"]
+    assert isinstance(spec, LocalCloudArtifactStoreSpec)
+    assert spec.model_dump(mode="json") == {
+        "artifact_store": "gs://bucket/kitaru",
+        "region": None,
+        "subscription_id": None,
+        "credentials": None,
+        "verify": True,
+    }
+    assert spec.provider == CloudProvider.GCP
 
 
 def test_stack_create_from_file_builds_kubernetes_stack(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8649,11 +8649,13 @@ def test_stack_create_modal_rejects_aws_credentials_without_region(
     assert "--extra orchestrator.region" in stderr
 
 
-def test_stack_create_modal_rejects_no_verify_without_cloud_connector_input(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
-    """--no-verify should not request a Modal cloud connector by itself."""
-    with pytest.raises(SystemExit) as exc_info:
+def test_stack_create_modal_accepts_no_verify_without_cloud_connector_input() -> None:
+    """--no-verify should also cover reused Modal service connectors."""
+    with (
+        patch("kitaru.cli._create_stack_operation") as mock_create_stack,
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        mock_create_stack.return_value = _stack_create_result_stub()
         app(
             [
                 "stack",
@@ -8669,11 +8671,10 @@ def test_stack_create_modal_rejects_no_verify_without_cloud_connector_input(
             ]
         )
 
-    assert exc_info.value.code == 1
-    stderr = capsys.readouterr().err
-    assert "--no-verify only applies when Kitaru is creating" in stderr
-    assert "--region" in stderr
-    assert "--credentials" in stderr
+    assert exc_info.value.code == 0
+    modal_spec = mock_create_stack.call_args.kwargs["remote_spec"]
+    assert modal_spec.verify is False
+    assert modal_spec.credentials is None
 
 
 def test_stack_create_modal_rejects_mismatched_credentialed_registry(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,6 +49,7 @@ from kitaru.config import (
     ImageSettings,
     KitaruConfig,
     KubernetesStackSpec,
+    LocalCloudArtifactStoreSpec,
     ModalStackSpec,
     ModelAliasConfig,
     ModelRegistryConfig,
@@ -61,6 +62,7 @@ from kitaru.config import (
     _coerce_image_input,
     _create_azureml_stack_operation,
     _create_kubernetes_stack_operation,
+    _create_local_cloud_stack_operation,
     _create_modal_stack_operation,
     _create_sagemaker_stack_operation,
     _create_stack_operation,
@@ -211,6 +213,40 @@ def _stack_model(
         name=name,
         labels=labels or {},
         components=stack_components,
+    )
+
+
+def _local_cloud_stack_model(
+    *,
+    stack_id: str = "stack-local-cloud-id",
+    name: str = "local-cloud",
+    storage_flavor: str = "s3",
+    connector_name: str | None = None,
+) -> SimpleNamespace:
+    """Return a hydrated local-runner/cloud-storage stack model stub."""
+    connector = (
+        SimpleNamespace(name=connector_name) if connector_name is not None else None
+    )
+    return _stack_model(
+        stack_id=stack_id,
+        name=name,
+        labels={"kitaru.managed": "true"},
+        components={
+            StackComponentType.ORCHESTRATOR: [
+                _stack_component("orc-id", f"{name}-orchestrator", flavor="local")
+            ],
+            StackComponentType.ARTIFACT_STORE: [
+                _stack_component(
+                    "art-id",
+                    f"{name}-artifacts",
+                    flavor=storage_flavor,
+                    connector=connector,
+                )
+            ],
+            StackComponentType.SANDBOX: [
+                _stack_component("sandbox-id", f"{name}-sandbox", flavor="local")
+            ],
+        },
     )
 
 
@@ -2047,6 +2083,673 @@ def test_create_stack_dispatcher_rejects_unsupported_stack_type() -> None:
         )
 
     mock_client.assert_not_called()
+
+
+def test_create_stack_dispatcher_routes_local_cloud_requests() -> None:
+    """Only local stacks carrying cloud storage should use the hybrid operation."""
+    spec = LocalCloudArtifactStoreSpec(
+        artifact_store="s3://bucket/path",
+    )
+    expected_result = SimpleNamespace(name="local-cloud-result")
+
+    with patch(
+        "kitaru.config._create_local_cloud_stack_operation",
+        return_value=expected_result,
+    ) as mock_create_local_cloud:
+        result = _create_stack_operation(
+            "dev",
+            local_cloud_artifact_store_spec=spec,
+            activate=False,
+        )
+
+    mock_create_local_cloud.assert_called_once_with(
+        "dev",
+        spec=spec,
+        activate=False,
+        labels=None,
+        sandbox_flavor="local",
+    )
+    assert result is expected_result
+
+
+@pytest.mark.parametrize(
+    ("artifact_store", "provider", "flavor", "normalized_path", "resource_type"),
+    [
+        ("s3://bucket/path", CloudProvider.AWS, "s3", "s3://bucket/path", "s3-bucket"),
+        (
+            "gs://bucket/path",
+            CloudProvider.GCP,
+            "gcp",
+            "gs://bucket/path",
+            "gcs-bucket",
+        ),
+        (
+            "az://container/path",
+            CloudProvider.AZURE,
+            "azure",
+            "az://container/path",
+            "blob-container",
+        ),
+        (
+            "abfs://container/path",
+            CloudProvider.AZURE,
+            "azure",
+            "abfs://container/path",
+            "blob-container",
+        ),
+        (
+            "abfss://container/path",
+            CloudProvider.AZURE,
+            "azure",
+            "abfs://container/path",
+            "blob-container",
+        ),
+    ],
+)
+def test_create_local_cloud_stack_operation_builds_connectorless_request(
+    artifact_store: str,
+    provider: CloudProvider,
+    flavor: str,
+    normalized_path: str,
+    resource_type: str,
+) -> None:
+    """Bare cloud URIs should use ambient credentials on the local runner."""
+    default = _stack_model(stack_id="stack-default-id", name="default")
+    created_stack = _local_cloud_stack_model(name="dev", storage_flavor=flavor)
+    client_mock = Mock()
+    client_mock.active_stack_model = default
+    client_mock.list_service_connectors.return_value = []
+    client_mock.list_stacks.return_value = _FakeStackPage(
+        items=[default],
+        total_pages=1,
+        max_size=50,
+    )
+    client_mock.zen_store = Mock()
+    client_mock.zen_store.create_stack.return_value = created_stack
+
+    with patch("kitaru.config.Client", return_value=client_mock):
+        result = _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store=artifact_store,
+            ),
+            activate=False,
+        )
+
+    client_mock.create_service_connector.assert_not_called()
+    client_mock.list_service_connectors.assert_called_once_with(
+        connector_type=provider.value,
+        resource_type=resource_type,
+        page=1,
+        size=100,
+        hydrate=True,
+    )
+    stack_request = client_mock._validate_stack_configuration.call_args.args[0]
+    assert stack_request.service_connectors == []
+    assert set(stack_request.components) == {
+        StackComponentType.ORCHESTRATOR,
+        StackComponentType.ARTIFACT_STORE,
+        StackComponentType.SANDBOX,
+    }
+    orchestrator = stack_request.components[StackComponentType.ORCHESTRATOR][0]
+    storage = stack_request.components[StackComponentType.ARTIFACT_STORE][0]
+    sandbox = stack_request.components[StackComponentType.SANDBOX][0]
+    assert orchestrator.flavor == "local"
+    assert storage.flavor == flavor
+    assert storage.configuration == {"path": normalized_path}
+    assert getattr(storage, "service_connector_index", None) is None
+    assert sandbox.flavor == "local"
+    assert result.components_created == (
+        "dev-orchestrator (orchestrator)",
+        "dev-artifacts (artifact_store)",
+        "dev-sandbox (sandbox)",
+    )
+    assert result.service_connectors_created == ()
+    assert result.resources == {
+        "provider": provider.value,
+        "artifact_store": artifact_store,
+        "sandbox": "local",
+    }
+
+
+@pytest.mark.parametrize("connector_resource_id", ["s3://bucket", None])
+def test_create_local_cloud_stack_operation_reuses_scoped_or_unscoped_connector(
+    connector_resource_id: str | None,
+) -> None:
+    """One matching storage connector should take precedence over ambient auth."""
+    connector_id = "00000000-0000-0000-0000-000000000123"
+    connector = _service_connector_model(
+        connector_id=connector_id,
+        name="existing-s3",
+        connector_type="aws",
+        resource_type="s3-bucket",
+        resource_id=connector_resource_id,
+    )
+    default = _stack_model(stack_id="stack-default-id", name="default")
+    created_stack = _local_cloud_stack_model(
+        name="dev",
+        connector_name="existing-s3",
+    )
+    client_mock = Mock()
+    client_mock.active_stack_model = default
+    client_mock.list_service_connectors.return_value = [connector]
+    client_mock.list_stacks.return_value = _FakeStackPage(
+        items=[default],
+        total_pages=1,
+        max_size=50,
+    )
+    client_mock.zen_store = Mock()
+    client_mock.zen_store.create_stack.return_value = created_stack
+
+    with patch("kitaru.config.Client", return_value=client_mock):
+        result = _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="s3://bucket/path",
+            ),
+            activate=False,
+        )
+
+    stack_request = client_mock._validate_stack_configuration.call_args.args[0]
+    assert stack_request.labels == {
+        "kitaru.managed": "true",
+        "kitaru.reused_service_connectors": "true",
+    }
+    assert stack_request.service_connectors == [UUID(connector_id)]
+    storage = stack_request.components[StackComponentType.ARTIFACT_STORE][0]
+    assert storage.service_connector_index == 0
+    assert storage.service_connector_resource_id == "s3://bucket"
+    assert result.service_connectors_created == ("existing-s3",)
+
+
+@pytest.mark.parametrize(
+    (
+        "artifact_store",
+        "provider",
+        "connector_type",
+        "resource_type",
+        "connector_resource_id",
+        "expected_resource_id",
+    ),
+    [
+        (
+            "gs://bucket/path",
+            CloudProvider.GCP,
+            "gcp",
+            "gcs-bucket",
+            "gs://bucket",
+            "gs://bucket",
+        ),
+        (
+            "abfss://container/path",
+            CloudProvider.AZURE,
+            "azure",
+            "blob-container",
+            "abfs://container",
+            "abfs://container",
+        ),
+    ],
+)
+def test_local_cloud_connector_reuse_supports_gcp_and_azure(
+    artifact_store: str,
+    provider: CloudProvider,
+    connector_type: str,
+    resource_type: str,
+    connector_resource_id: str,
+    expected_resource_id: str,
+) -> None:
+    """The shared single-storage lookup should work for every provider."""
+    connector_id = "00000000-0000-0000-0000-000000000123"
+    client_mock = Mock()
+    client_mock.list_service_connectors.return_value = [
+        _service_connector_model(
+            connector_id=connector_id,
+            name="existing-storage",
+            connector_type=connector_type,
+            resource_type=resource_type,
+            resource_id=connector_resource_id,
+        )
+    ]
+
+    reference = config_stacks_module._resolve_local_cloud_existing_connector(
+        LocalCloudArtifactStoreSpec(
+            artifact_store=artifact_store,
+        ),
+        client=client_mock,
+    )
+
+    assert reference is not None
+    assert reference.connector_id == UUID(connector_id)
+    assert reference.resource_id == expected_resource_id
+    client_mock.list_service_connectors.assert_called_once_with(
+        connector_type=connector_type,
+        resource_type=resource_type,
+        page=1,
+        size=100,
+        hydrate=True,
+    )
+
+
+def test_create_local_cloud_stack_operation_prefers_scoped_connector() -> None:
+    """A resource-scoped connector should beat an unscoped provider connector."""
+    broad = _service_connector_model(
+        connector_id="00000000-0000-0000-0000-000000000001",
+        name="broad-aws",
+        connector_type="aws",
+        resource_type="s3-bucket",
+        resource_id=None,
+    )
+    scoped_id = "00000000-0000-0000-0000-000000000002"
+    scoped = _service_connector_model(
+        connector_id=scoped_id,
+        name="scoped-s3",
+        connector_type="aws",
+        resource_type="s3-bucket",
+        resource_id="s3://bucket",
+    )
+    default = _stack_model(stack_id="stack-default-id", name="default")
+    client_mock = Mock()
+    client_mock.active_stack_model = default
+    client_mock.list_service_connectors.return_value = [broad, scoped]
+    client_mock.list_stacks.return_value = _FakeStackPage(
+        items=[default],
+        total_pages=1,
+        max_size=50,
+    )
+    client_mock.zen_store = Mock()
+    client_mock.zen_store.create_stack.return_value = _local_cloud_stack_model(
+        name="dev",
+        connector_name="scoped-s3",
+    )
+
+    with patch("kitaru.config.Client", return_value=client_mock):
+        _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="s3://bucket/path",
+            ),
+            activate=False,
+        )
+
+    stack_request = client_mock._validate_stack_configuration.call_args.args[0]
+    assert stack_request.service_connectors == [UUID(scoped_id)]
+
+
+def test_create_local_cloud_stack_operation_rejects_ambiguous_connectors() -> None:
+    """Equally specific storage connectors should require explicit disambiguation."""
+    connectors = [
+        _service_connector_model(
+            connector_id=f"00000000-0000-0000-0000-00000000000{index}",
+            name=f"s3-{index}",
+            connector_type="aws",
+            resource_type="s3-bucket",
+            resource_id="s3://bucket",
+        )
+        for index in (1, 2)
+    ]
+    client_mock = Mock()
+    client_mock.list_service_connectors.return_value = connectors
+
+    with (
+        patch("kitaru.config.Client", return_value=client_mock),
+        pytest.raises(
+            KitaruUsageError,
+            match=r"ambiguous existing service connectors.*s3-1.*s3-2",
+        ),
+    ):
+        _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="s3://bucket/path",
+            ),
+            activate=False,
+        )
+
+    client_mock.zen_store.create_stack.assert_not_called()
+
+
+def test_create_local_cloud_aws_connector_discovers_profile_region(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit AWS credentials should create and verify one connector."""
+    aws_config = tmp_path / "aws-config"
+    aws_config.write_text("[profile team]\nregion = eu-west-2\n", encoding="utf-8")
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_config))
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    client_mock = Mock()
+    client_mock.active_stack_model = _stack_model(
+        stack_id="stack-default-id",
+        name="default",
+    )
+    client_mock.list_stacks.return_value = _FakeStackPage(
+        items=[client_mock.active_stack_model],
+        total_pages=1,
+        max_size=50,
+    )
+    client_mock.zen_store = Mock()
+    client_mock.zen_store.create_stack.return_value = _local_cloud_stack_model(
+        name="dev",
+        connector_name="dev-aws",
+    )
+
+    with patch("kitaru.config.Client", return_value=client_mock):
+        _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="s3://bucket/path",
+                credentials="aws-profile:team",
+                verify=False,
+            ),
+            activate=False,
+        )
+
+    client_mock.list_service_connectors.assert_not_called()
+    client_mock.create_service_connector.assert_called_once_with(
+        name="dev",
+        connector_type="aws",
+        resource_type="aws-generic",
+        auth_method="implicit",
+        configuration={"profile_name": "team", "region": "eu-west-2"},
+        verify=False,
+        list_resources=False,
+        register=False,
+    )
+
+
+def test_local_cloud_aws_connector_reports_missing_region(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AWS connector creation should explain how to supply missing metadata."""
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "missing-config"))
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+    with pytest.raises(
+        KitaruUsageError,
+        match=r"Cannot discover an AWS region.*--region.*AWS_DEFAULT_REGION",
+    ):
+        config_stacks_module._resolve_local_cloud_connector_spec(
+            LocalCloudArtifactStoreSpec(
+                artifact_store="s3://bucket/path",
+                credentials="aws-access-keys:test-access-key:test-secret-key",
+            )
+        )
+
+
+def test_create_local_cloud_gcp_connector_uses_service_account_project(
+    tmp_path: Path,
+) -> None:
+    """GCP connector creation should read project_id from service-account JSON."""
+    credential_path = tmp_path / "service-account.json"
+    credential_json = json.dumps(
+        {"type": "service_account", "project_id": "demo-project"}
+    )
+    credential_path.write_text(credential_json, encoding="utf-8")
+    client_mock = Mock()
+    client_mock.active_stack_model = _stack_model(
+        stack_id="stack-default-id",
+        name="default",
+    )
+    client_mock.list_stacks.return_value = _FakeStackPage(
+        items=[client_mock.active_stack_model],
+        total_pages=1,
+        max_size=50,
+    )
+    client_mock.zen_store = Mock()
+    client_mock.zen_store.create_stack.return_value = _local_cloud_stack_model(
+        name="dev",
+        storage_flavor="gcp",
+        connector_name="dev-gcp",
+    )
+
+    with patch("kitaru.config.Client", return_value=client_mock):
+        _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="gs://bucket/path",
+                credentials=f"gcp-service-account:{credential_path}",
+            ),
+            activate=False,
+        )
+
+    client_mock.list_service_connectors.assert_not_called()
+    client_mock.create_service_connector.assert_called_once_with(
+        name="dev",
+        connector_type="gcp",
+        resource_type="gcp-generic",
+        auth_method="service-account",
+        configuration={
+            "service_account_json": credential_json,
+            "project_id": "demo-project",
+        },
+        verify=True,
+        list_resources=False,
+        register=False,
+    )
+
+
+def test_local_cloud_gcp_implicit_connector_uses_adc_project() -> None:
+    """An explicit implicit reference should create a connector using ADC metadata."""
+    with patch.object(
+        config_stacks_module,
+        "_discover_gcp_adc_project_id",
+        return_value="adc-project",
+    ):
+        connector_spec = config_stacks_module._resolve_local_cloud_connector_spec(
+            LocalCloudArtifactStoreSpec(
+                artifact_store="gs://bucket/path",
+                credentials="implicit",
+            )
+        )
+
+    assert connector_spec is not None
+    assert connector_spec.connector_info.auth_method == "implicit"
+    assert connector_spec.connector_info.configuration == {"project_id": "adc-project"}
+
+
+def test_local_cloud_gcp_connector_rejects_missing_service_account_project(
+    tmp_path: Path,
+) -> None:
+    """Service-account connector metadata should fail before any cloud call."""
+    credential_path = tmp_path / "service-account.json"
+    credential_path.write_text('{"type": "service_account"}', encoding="utf-8")
+
+    with pytest.raises(
+        KitaruUsageError, match="does not contain a non-empty project_id"
+    ):
+        config_stacks_module._resolve_local_cloud_connector_spec(
+            LocalCloudArtifactStoreSpec(
+                artifact_store="gs://bucket/path",
+                credentials=f"gcp-service-account:{credential_path}",
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("subscription_id", "expected_configuration"),
+    [
+        (None, {"token": "token-123"}),
+        (
+            "00000000-0000-0000-0000-000000000123",
+            {
+                "subscription_id": "00000000-0000-0000-0000-000000000123",
+                "token": "token-123",
+            },
+        ),
+    ],
+)
+def test_local_cloud_azure_connector_allows_optional_subscription(
+    subscription_id: str | None,
+    expected_configuration: dict[str, str],
+) -> None:
+    """Azure should defer subscription discovery unless an override is supplied."""
+    connector_spec = config_stacks_module._resolve_local_cloud_connector_spec(
+        LocalCloudArtifactStoreSpec(
+            artifact_store="az://container/path",
+            subscription_id=subscription_id,
+            credentials="azure-access-token:token-123",
+        )
+    )
+
+    assert connector_spec is not None
+    assert connector_spec.connector_info.auth_method == "access-token"
+    assert connector_spec.connector_info.configuration == expected_configuration
+
+
+def test_create_local_cloud_azure_connector_without_subscription() -> None:
+    """Explicit Azure credentials should create a connector before one-shot create."""
+    default = _stack_model(stack_id="stack-default-id", name="default")
+    client_mock = Mock()
+    client_mock.active_stack_model = default
+    client_mock.list_stacks.return_value = _FakeStackPage(
+        items=[default],
+        total_pages=1,
+        max_size=50,
+    )
+    client_mock.zen_store = Mock()
+    client_mock.zen_store.create_stack.return_value = _local_cloud_stack_model(
+        name="dev",
+        storage_flavor="azure",
+        connector_name="dev-azure",
+    )
+
+    with patch("kitaru.config.Client", return_value=client_mock):
+        _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="abfss://container/path",
+                credentials="azure-access-token:token-123",
+            ),
+            activate=False,
+        )
+
+    client_mock.list_service_connectors.assert_not_called()
+    client_mock.create_service_connector.assert_called_once_with(
+        name="dev",
+        connector_type="azure",
+        resource_type="azure-generic",
+        auth_method="access-token",
+        configuration={"token": "token-123"},
+        verify=True,
+        list_resources=False,
+        register=False,
+    )
+    stack_request = client_mock._validate_stack_configuration.call_args.args[0]
+    storage = stack_request.components[StackComponentType.ARTIFACT_STORE][0]
+    assert storage.configuration == {"path": "abfs://container/path"}
+    assert storage.service_connector_resource_id == "abfs://container"
+
+
+def test_build_local_cloud_stack_request_merges_component_overrides() -> None:
+    """Hybrid one-shot requests should preserve local override behavior."""
+    request = config_stacks_module._build_local_cloud_stack_request(
+        "dev",
+        spec=LocalCloudArtifactStoreSpec(
+            artifact_store="s3://bucket/path",
+        ),
+        labels=None,
+        component_overrides=StackComponentConfigOverrides(
+            orchestrator={"synchronous": False},
+            artifact_store={"client_kwargs": {"endpoint_url": "http://minio:9000"}},
+            sandbox={"timeout": 900},
+        ),
+    )
+
+    orchestrator = cast(
+        ComponentInfo,
+        request.components[StackComponentType.ORCHESTRATOR][0],
+    )
+    storage = cast(
+        ComponentInfo,
+        request.components[StackComponentType.ARTIFACT_STORE][0],
+    )
+    sandbox = cast(
+        ComponentInfo,
+        request.components[StackComponentType.SANDBOX][0],
+    )
+    assert orchestrator.configuration == {"synchronous": False}
+    assert storage.configuration == {
+        "path": "s3://bucket/path",
+        "client_kwargs": {"endpoint_url": "http://minio:9000"},
+    }
+    assert sandbox.configuration == {"timeout": 900}
+
+
+def test_create_local_cloud_stack_operation_reports_activation_failure() -> None:
+    """Activation failure should leave the one-shot-created stack recoverable."""
+    default = _stack_model(stack_id="stack-default-id", name="default")
+    client_mock = Mock()
+    client_mock.active_stack_model = default
+    client_mock.list_service_connectors.return_value = []
+    client_mock.list_stacks.return_value = _FakeStackPage(
+        items=[default],
+        total_pages=1,
+        max_size=50,
+    )
+    client_mock.zen_store = Mock()
+    client_mock.zen_store.create_stack.return_value = _local_cloud_stack_model(
+        name="dev"
+    )
+    client_mock.activate_stack.side_effect = RuntimeError("activation unavailable")
+
+    with (
+        patch("kitaru.config.Client", return_value=client_mock),
+        pytest.raises(
+            KitaruBackendError,
+            match=r"remains available.*kitaru stack use dev",
+        ),
+    ):
+        _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="s3://bucket/path",
+            ),
+        )
+
+    client_mock.zen_store.create_stack.assert_called_once()
+    client_mock.activate_stack.assert_called_once_with("stack-local-cloud-id")
+
+
+def test_extract_remote_stack_components_accepts_explicit_component_contract() -> None:
+    """The extractor default and hybrid contracts should not assume one registry."""
+    remote_stack = _kubernetes_stack_model(
+        stack_id="stack-remote-id",
+        name="remote",
+        connector_name="remote-connector",
+    )
+    components, connectors, missing = (
+        config_stacks_module._extract_remote_stack_components(remote_stack)
+    )
+    assert components == (
+        "dev-orchestrator (orchestrator)",
+        "dev-artifacts (artifact_store)",
+        "dev-registry (container_registry)",
+    )
+    assert connectors == ("remote-connector",)
+    assert missing is False
+
+    local_stack = _local_cloud_stack_model(name="local-cloud")
+    components, connectors, missing = (
+        config_stacks_module._extract_remote_stack_components(
+            local_stack,
+            required_components=(
+                (StackComponentType.ORCHESTRATOR, "orchestrator"),
+                (StackComponentType.ARTIFACT_STORE, "artifact_store"),
+                (StackComponentType.SANDBOX, "sandbox"),
+            ),
+            require_connector_metadata=False,
+        )
+    )
+    assert components == (
+        "local-cloud-orchestrator (orchestrator)",
+        "local-cloud-artifacts (artifact_store)",
+        "local-cloud-sandbox (sandbox)",
+    )
+    assert connectors == ()
+    assert missing is False
 
 
 def test_create_kubernetes_stack_operation_creates_aws_stack_and_activates() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2113,6 +2113,28 @@ def test_create_stack_dispatcher_routes_local_cloud_requests() -> None:
 
 
 @pytest.mark.parametrize(
+    "artifact_store",
+    [
+        "s3://access-key:secret@bucket/path",
+        "s3://bucket/path?X-Amz-Signature=secret",
+        "s3://bucket:443/path",
+    ],
+)
+def test_local_cloud_spec_rejects_unsafe_uri_without_echoing_it(
+    artifact_store: str,
+) -> None:
+    """Direct spec construction should enforce the non-leaking URI boundary."""
+    with pytest.raises(ValueError) as exc_info:
+        LocalCloudArtifactStoreSpec(artifact_store=artifact_store)
+
+    message = str(exc_info.value)
+    assert artifact_store not in message
+    assert "without query parameters, fragments, embedded credentials, or ports" in (
+        message
+    )
+
+
+@pytest.mark.parametrize(
     ("artifact_store", "provider", "flavor", "normalized_path", "resource_type"),
     [
         ("s3://bucket/path", CloudProvider.AWS, "s3", "s3://bucket/path", "s3-bucket"),
@@ -2226,7 +2248,8 @@ def test_create_local_cloud_stack_operation_reuses_scoped_or_unscoped_connector(
         resource_id=connector_resource_id,
     )
     default = _stack_model(stack_id="stack-default-id", name="default")
-    created_stack = _local_cloud_stack_model(
+    created_stack = _local_cloud_stack_model(name="dev")
+    hydrated_stack = _local_cloud_stack_model(
         name="dev",
         connector_name="existing-s3",
     )
@@ -2240,6 +2263,7 @@ def test_create_local_cloud_stack_operation_reuses_scoped_or_unscoped_connector(
     )
     client_mock.zen_store = Mock()
     client_mock.zen_store.create_stack.return_value = created_stack
+    client_mock.get_stack.return_value = hydrated_stack
 
     with patch("kitaru.config.Client", return_value=client_mock):
         result = _create_local_cloud_stack_operation(
@@ -2259,7 +2283,8 @@ def test_create_local_cloud_stack_operation_reuses_scoped_or_unscoped_connector(
     storage = stack_request.components[StackComponentType.ARTIFACT_STORE][0]
     assert storage.service_connector_index == 0
     assert storage.service_connector_resource_id == "s3://bucket"
-    assert result.service_connectors_created == ("existing-s3",)
+    client_mock.get_stack.assert_called_once_with("stack-local-cloud-id", hydrate=True)
+    assert result.service_connectors_created == ()
 
 
 @pytest.mark.parametrize(
@@ -2456,6 +2481,31 @@ def test_create_local_cloud_aws_connector_discovers_profile_region(
         list_resources=False,
         register=False,
     )
+
+
+@pytest.mark.parametrize(
+    ("artifact_store", "metadata_field", "metadata_value"),
+    [
+        ("s3://bucket/path", "region", "eu-west-1"),
+        ("az://container/path", "subscription_id", "subscription-123"),
+    ],
+)
+def test_local_cloud_connector_metadata_requires_credentials(
+    artifact_store: str,
+    metadata_field: str,
+    metadata_value: str,
+) -> None:
+    """Connector metadata must not be ignored on connectorless requests."""
+    spec = LocalCloudArtifactStoreSpec(
+        artifact_store=artifact_store,
+        **{metadata_field: metadata_value},
+    )
+
+    with pytest.raises(
+        KitaruUsageError,
+        match=rf"`{metadata_field}` require `credentials`",
+    ):
+        config_stacks_module._resolve_local_cloud_connector_spec(spec)
 
 
 def test_local_cloud_aws_connector_reports_missing_region(
@@ -2676,6 +2726,29 @@ def test_build_local_cloud_stack_request_merges_component_overrides() -> None:
         "client_kwargs": {"endpoint_url": "http://minio:9000"},
     }
     assert sandbox.configuration == {"timeout": 900}
+
+
+def test_build_local_cloud_stack_request_rejects_path_override() -> None:
+    """Component overrides cannot bypass the validated artifact-store URI."""
+    rejected_path = "s3://access-key:secret@other-bucket/path"
+
+    with pytest.raises(KitaruUsageError) as exc_info:
+        config_stacks_module._build_local_cloud_stack_request(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="s3://bucket/path",
+            ),
+            labels=None,
+            component_overrides=StackComponentConfigOverrides(
+                artifact_store={
+                    "path": rejected_path,
+                    "client_kwargs": {"endpoint_url": "http://minio:9000"},
+                },
+            ),
+        )
+
+    assert rejected_path not in str(exc_info.value)
+    assert "artifact_store.path" in str(exc_info.value)
 
 
 def test_create_local_cloud_stack_operation_reports_activation_failure() -> None:
@@ -3730,10 +3803,7 @@ def test_create_modal_stack_operation_reuses_existing_aws_connectors(
         "uri": "339712793861.dkr.ecr.eu-central-1.amazonaws.com",
         "default_repository": "zenml-k8s-3794f302c1ca",
     }
-    assert result.service_connectors_created == (
-        "aws-k8s-stack-s3",
-        "aws-k8s-stack-ecr",
-    )
+    assert result.service_connectors_created == ()
 
 
 def test_create_modal_stack_operation_prefers_specific_over_unscoped_connectors(
@@ -3905,7 +3975,7 @@ def test_create_modal_stack_operation_reuses_shared_unscoped_connector_once(
         registry.service_connector_resource_id
         == "123456789012.dkr.ecr.eu-central-1.amazonaws.com"
     )
-    assert result.service_connectors_created == ("aws_connector",)
+    assert result.service_connectors_created == ()
 
 
 def test_create_modal_stack_operation_rejects_multiple_unscoped_connectors(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,9 +21,10 @@ import pytest
 from zenml.config.docker_settings import DockerSettings
 from zenml.constants import ENV_ZENML_ACTIVE_PROJECT_ID, ENV_ZENML_ACTIVE_STACK_ID
 from zenml.enums import StackComponentType
-from zenml.exceptions import EntityExistsError
+from zenml.exceptions import AuthorizationException, EntityExistsError
 from zenml.models.v2.misc.info_models import ComponentInfo
 from zenml.utils import io_utils, yaml_utils
+from zenml.zen_stores.rest_zen_store import RestZenStore
 
 import kitaru.config as config_module
 from kitaru._config import _stacks as config_stacks_module
@@ -2283,8 +2284,99 @@ def test_create_local_cloud_stack_operation_reuses_scoped_or_unscoped_connector(
     storage = stack_request.components[StackComponentType.ARTIFACT_STORE][0]
     assert storage.service_connector_index == 0
     assert storage.service_connector_resource_id == "s3://bucket"
+    client_mock.verify_service_connector.assert_called_once_with(
+        UUID(connector_id),
+        resource_type="s3-bucket",
+        resource_id="s3://bucket",
+        list_resources=False,
+    )
     client_mock.get_stack.assert_called_once_with("stack-local-cloud-id", hydrate=True)
     assert result.service_connectors_created == ()
+
+
+def test_create_local_cloud_stack_operation_rejects_broken_reused_connector() -> None:
+    """A reused connector that fails verification should abort stack creation."""
+    connector = _service_connector_model(
+        connector_id="00000000-0000-0000-0000-000000000123",
+        name="existing-s3",
+        connector_type="aws",
+        resource_type="s3-bucket",
+        resource_id=None,
+    )
+    default = _stack_model(stack_id="stack-default-id", name="default")
+    client_mock = Mock()
+    client_mock.active_stack_model = default
+    client_mock.list_service_connectors.return_value = [connector]
+    client_mock.list_stacks.return_value = _FakeStackPage(
+        items=[default],
+        total_pages=1,
+        max_size=50,
+    )
+    client_mock.verify_service_connector.side_effect = AuthorizationException(
+        "expired credentials"
+    )
+
+    with (
+        patch("kitaru.config.Client", return_value=client_mock),
+        pytest.raises(KitaruUsageError) as exc_info,
+    ):
+        _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="s3://bucket/path",
+            ),
+            activate=False,
+        )
+
+    message = str(exc_info.value)
+    assert "existing-s3" in message
+    assert "failed verification" in message
+    assert "expired credentials" in message
+    assert "credentials" in message
+    client_mock.zen_store.create_stack.assert_not_called()
+
+
+def test_create_local_cloud_stack_operation_no_verify_skips_reused_check() -> None:
+    """verify=False should link a reused connector without a health check."""
+    connector_id = "00000000-0000-0000-0000-000000000123"
+    connector = _service_connector_model(
+        connector_id=connector_id,
+        name="existing-s3",
+        connector_type="aws",
+        resource_type="s3-bucket",
+        resource_id=None,
+    )
+    default = _stack_model(stack_id="stack-default-id", name="default")
+    created_stack = _local_cloud_stack_model(name="dev")
+    hydrated_stack = _local_cloud_stack_model(
+        name="dev",
+        connector_name="existing-s3",
+    )
+    client_mock = Mock()
+    client_mock.active_stack_model = default
+    client_mock.list_service_connectors.return_value = [connector]
+    client_mock.list_stacks.return_value = _FakeStackPage(
+        items=[default],
+        total_pages=1,
+        max_size=50,
+    )
+    client_mock.zen_store = Mock()
+    client_mock.zen_store.create_stack.return_value = created_stack
+    client_mock.get_stack.return_value = hydrated_stack
+
+    with patch("kitaru.config.Client", return_value=client_mock):
+        _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="s3://bucket/path",
+                verify=False,
+            ),
+            activate=False,
+        )
+
+    client_mock.verify_service_connector.assert_not_called()
+    stack_request = client_mock._validate_stack_configuration.call_args.args[0]
+    assert stack_request.service_connectors == [UUID(connector_id)]
 
 
 @pytest.mark.parametrize(
@@ -2481,6 +2573,79 @@ def test_create_local_cloud_aws_connector_discovers_profile_region(
         list_resources=False,
         register=False,
     )
+
+
+def _profile_credentials_client_mock(*, server_url: str) -> Mock:
+    """Return a client mock whose zen store looks like a REST server."""
+    client_mock = Mock()
+    client_mock.active_stack_model = _stack_model(
+        stack_id="stack-default-id",
+        name="default",
+    )
+    client_mock.list_stacks.return_value = _FakeStackPage(
+        items=[client_mock.active_stack_model],
+        total_pages=1,
+        max_size=50,
+    )
+    client_mock.zen_store = Mock(spec=RestZenStore)
+    client_mock.zen_store.url = server_url
+    client_mock.zen_store.create_stack.return_value = _local_cloud_stack_model(
+        name="dev",
+        connector_name="dev-aws",
+    )
+    return client_mock
+
+
+def test_create_local_cloud_rejects_profile_credentials_on_remote_server() -> None:
+    """aws-profile credentials cannot be resolved by a remote ZenML server."""
+    client_mock = _profile_credentials_client_mock(
+        server_url="https://zenml.example.com"
+    )
+
+    with (
+        patch("kitaru.config.Client", return_value=client_mock),
+        pytest.raises(KitaruUsageError) as exc_info,
+    ):
+        _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="s3://bucket/path",
+                credentials="aws-profile:team",
+                region="eu-west-2",
+                verify=False,
+            ),
+            activate=False,
+        )
+
+    message = str(exc_info.value)
+    assert "aws-profile:team" in message
+    assert "remote ZenML server" in message
+    assert "aws-session-token" in message
+    client_mock.create_service_connector.assert_not_called()
+    client_mock.zen_store.create_stack.assert_not_called()
+
+
+def test_create_local_cloud_allows_profile_credentials_on_localhost_server() -> None:
+    """A localhost server shares this machine's AWS config, so profiles work."""
+    client_mock = _profile_credentials_client_mock(server_url="http://localhost:8237")
+
+    with patch("kitaru.config.Client", return_value=client_mock):
+        _create_local_cloud_stack_operation(
+            "dev",
+            spec=LocalCloudArtifactStoreSpec(
+                artifact_store="s3://bucket/path",
+                credentials="aws-profile:team",
+                region="eu-west-2",
+                verify=False,
+            ),
+            activate=False,
+        )
+
+    client_mock.create_service_connector.assert_called_once()
+    configuration = client_mock.create_service_connector.call_args.kwargs[
+        "configuration"
+    ]
+    assert configuration["profile_name"] == "team"
 
 
 @pytest.mark.parametrize(
@@ -3691,8 +3856,10 @@ def test_create_modal_stack_operation_creates_stack_without_connector(
     }
 
 
+@pytest.mark.parametrize("verify", [True, False])
 def test_create_modal_stack_operation_reuses_existing_aws_connectors(
     monkeypatch: pytest.MonkeyPatch,
+    verify: bool,
 ) -> None:
     """Modal create should reuse matching server-side S3 and ECR connectors."""
     _install_fake_modal_package(monkeypatch)
@@ -3701,6 +3868,7 @@ def test_create_modal_stack_operation_reuses_existing_aws_connectors(
         container_registry=(
             "339712793861.dkr.ecr.eu-central-1.amazonaws.com/zenml-k8s-3794f302c1ca"
         ),
+        verify=verify,
     )
     s3_connector_id = "f964c5e4-d060-442c-8f35-af977bb3c3f8"
     ecr_connector_id = "f058457a-1194-4c4a-bc1c-de5a345e783a"
@@ -3803,6 +3971,23 @@ def test_create_modal_stack_operation_reuses_existing_aws_connectors(
         "uri": "339712793861.dkr.ecr.eu-central-1.amazonaws.com",
         "default_repository": "zenml-k8s-3794f302c1ca",
     }
+    if verify:
+        assert client_mock.verify_service_connector.call_args_list == [
+            call(
+                UUID(s3_connector_id),
+                resource_type="s3-bucket",
+                resource_id="s3://zenml-k8s-339712793861-3794f302c1ca",
+                list_resources=False,
+            ),
+            call(
+                UUID(ecr_connector_id),
+                resource_type="docker-registry",
+                resource_id="339712793861.dkr.ecr.eu-central-1.amazonaws.com",
+                list_resources=False,
+            ),
+        ]
+    else:
+        client_mock.verify_service_connector.assert_not_called()
     assert result.service_connectors_created == ()
 
 
@@ -4473,27 +4658,6 @@ def test_create_modal_stack_operation_rejects_aws_credentials_without_region(
                 artifact_store="s3://bucket/path",
                 container_registry="123456789012.dkr.ecr.eu-west-1.amazonaws.com/repo",
                 credentials="aws-profile:ml-team",
-            ),
-            client_factory=client_factory,
-        )
-
-    client_factory.assert_not_called()
-
-
-def test_create_modal_stack_operation_rejects_no_verify_without_connector_input(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Modal verify=False should not create a cloud connector by itself."""
-    _install_fake_modal_package(monkeypatch)
-    client_factory = Mock(name="client_factory")
-
-    with pytest.raises(KitaruUsageError, match="only applies when Kitaru is creating"):
-        config_module._config_stacks._create_modal_stack_operation(
-            "modal-dev",
-            spec=ModalStackSpec(
-                artifact_store="s3://bucket/path",
-                container_registry="123456789012.dkr.ecr.eu-west-1.amazonaws.com/repo",
-                verify=False,
             ),
             client_factory=client_factory,
         )

--- a/tests/test_interface_stacks.py
+++ b/tests/test_interface_stacks.py
@@ -1,0 +1,245 @@
+"""Tests for stack requests shared by CLI, YAML, and MCP interfaces."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from kitaru._config._stacks import (
+    CloudProvider,
+    LocalCloudArtifactStoreSpec,
+    StackType,
+    VertexStackSpec,
+)
+from kitaru._interface_stacks import (
+    CLI_STACK_OPTION_LABELS,
+    ManageStackCreateRequest,
+    build_stack_create_request,
+    execute_stack_create_request,
+)
+
+
+def _build_request(**updates: Any) -> ManageStackCreateRequest:
+    inputs: dict[str, Any] = {
+        "name": "dev",
+        "activate": True,
+        "stack_type": "local",
+        "artifact_store": None,
+        "container_registry": None,
+        "cluster": None,
+        "region": None,
+        "subscription_id": None,
+        "resource_group": None,
+        "workspace": None,
+        "execution_role": None,
+        "namespace": None,
+        "credentials": None,
+        "sandbox": None,
+        "verify": True,
+        "labels": CLI_STACK_OPTION_LABELS,
+    }
+    inputs.update(updates)
+    return build_stack_create_request(**inputs)
+
+
+def test_fully_local_request_keeps_cloud_storage_spec_absent() -> None:
+    """Omitting artifact storage should retain the existing fully local path."""
+    request = _build_request()
+
+    assert request.stack_type == StackType.LOCAL
+    assert request.remote_spec is None
+    assert request.local_cloud_artifact_store_spec is None
+    assert request.sandbox_flavor == "local"
+
+
+@pytest.mark.parametrize(
+    ("artifact_store", "provider"),
+    [
+        ("s3://bucket/path", CloudProvider.AWS),
+        ("gs://bucket/path", CloudProvider.GCP),
+        ("az://container/path", CloudProvider.AZURE),
+        ("abfs://container/path", CloudProvider.AZURE),
+        ("abfss://container/path", CloudProvider.AZURE),
+        (
+            "abfs://filesystem@account.dfs.core.windows.net/path",
+            CloudProvider.AZURE,
+        ),
+        (
+            "abfss://filesystem@account.dfs.core.windows.net/path",
+            CloudProvider.AZURE,
+        ),
+    ],
+)
+def test_local_cloud_uri_builds_separate_storage_spec(
+    artifact_store: str,
+    provider: CloudProvider,
+) -> None:
+    """All supported cloud URI forms should produce the shared hybrid spec."""
+    request = _build_request(artifact_store=f"  {artifact_store}  ")
+
+    assert request.remote_spec is None
+    spec = request.local_cloud_artifact_store_spec
+    assert spec is not None
+    assert spec == LocalCloudArtifactStoreSpec(
+        artifact_store=artifact_store,
+    )
+    assert spec.provider == provider
+    assert request.sandbox_flavor == "local"
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value", "label"),
+    [
+        ("credentials", "aws-profile:team", "--credentials"),
+        ("region", "eu-west-1", "--region"),
+        ("subscription_id", "subscription", "--subscription-id"),
+        ("verify", False, "--no-verify"),
+    ],
+)
+def test_local_cloud_fields_require_artifact_store(
+    field_name: str,
+    value: Any,
+    label: str,
+) -> None:
+    """Credential controls without cloud storage should have a targeted error."""
+    with pytest.raises(
+        ValueError,
+        match=rf"{label}.*require --artifact-store",
+    ):
+        _build_request(**{field_name: value})
+
+
+def test_local_cloud_uri_requires_bucket_or_container() -> None:
+    """A provider scheme without a resource should fail during request building."""
+    with pytest.raises(ValueError, match="with a bucket or container name"):
+        _build_request(artifact_store="s3://")
+
+
+@pytest.mark.parametrize(
+    "artifact_store",
+    [
+        "s3://access-key:secret@bucket/path",
+        "s3://bucket:443/path",
+        "s3://bucket/path?X-Amz-Signature=secret",
+        "gs://bucket/path#private-fragment",
+        "az://container/path?sig=secret",
+        "az://container@account.blob.core.windows.net/path",
+        "abfss://filesystem@untrusted.example.com/path",
+        "s3://[malformed-authority/path",
+        "https://secret.example.com/path",
+    ],
+)
+def test_local_cloud_uri_rejects_unsafe_values_without_echoing_them(
+    artifact_store: str,
+) -> None:
+    """Rejected URIs should not expose embedded credentials or signed values."""
+    with pytest.raises(ValueError) as exc_info:
+        _build_request(artifact_store=artifact_store)
+
+    message = str(exc_info.value)
+    assert artifact_store not in message
+    assert "without query parameters, fragments, embedded credentials, or ports" in (
+        message
+    )
+
+
+def test_local_connectorless_storage_rejects_no_verify() -> None:
+    """Verification only applies to newly created explicit connectors."""
+    with pytest.raises(
+        ValueError,
+        match="--no-verify only applies when --credentials",
+    ):
+        _build_request(
+            artifact_store="s3://bucket/path",
+            verify=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("artifact_store", "updates", "message"),
+    [
+        (
+            "gs://bucket/path",
+            {"region": "us-central1"},
+            "--region only applies to s3://",
+        ),
+        (
+            "s3://bucket/path",
+            {"subscription_id": "subscription"},
+            "--subscription-id only applies to Azure",
+        ),
+    ],
+)
+def test_local_cloud_rejects_irrelevant_provider_hints(
+    artifact_store: str,
+    updates: dict[str, str],
+    message: str,
+) -> None:
+    """Provider hints should not be silently ignored for another provider."""
+    with pytest.raises(ValueError, match=message):
+        _build_request(artifact_store=artifact_store, **updates)
+
+
+def test_local_cloud_keeps_registry_and_async_fields_disabled() -> None:
+    """Cloud storage should not turn a local stack into a remote runner."""
+    with pytest.raises(ValueError, match="Remote stack options require"):
+        _build_request(
+            artifact_store="s3://bucket/path",
+            container_registry="registry.example.com/repo",
+        )
+    with pytest.raises(ValueError, match="--async requires"):
+        _build_request(
+            artifact_store="s3://bucket/path",
+            async_enabled=True,
+        )
+
+
+def test_remote_stack_request_contract_is_unchanged() -> None:
+    """Existing remote stack types should still use only RemoteStackSpec."""
+    request = _build_request(
+        stack_type="vertex",
+        artifact_store="gs://bucket/path",
+        container_registry="us-docker.pkg.dev/demo/repo",
+        region="us-central1",
+    )
+
+    assert request.local_cloud_artifact_store_spec is None
+    assert request.remote_spec == VertexStackSpec(
+        artifact_store="gs://bucket/path",
+        container_registry="us-docker.pkg.dev/demo/repo",
+        region="us-central1",
+    )
+
+
+def test_execute_stack_create_request_forwards_local_cloud_spec() -> None:
+    """All interface surfaces should dispatch the same validated hybrid request."""
+    spec = LocalCloudArtifactStoreSpec(
+        artifact_store="s3://bucket/path",
+    )
+    request = ManageStackCreateRequest(
+        name="dev",
+        activate=False,
+        stack_type=StackType.LOCAL,
+        local_cloud_artifact_store_spec=spec,
+        sandbox_flavor="local",
+    )
+    expected = SimpleNamespace(stack=SimpleNamespace(name="dev"))
+    operation = Mock(return_value=expected)
+
+    result = execute_stack_create_request(
+        request,
+        create_stack_operation=operation,
+    )
+
+    operation.assert_called_once_with(
+        "dev",
+        stack_type=StackType.LOCAL,
+        activate=False,
+        remote_spec=None,
+        local_cloud_artifact_store_spec=spec,
+        sandbox_flavor="local",
+    )
+    assert result is expected

--- a/tests/test_interface_stacks.py
+++ b/tests/test_interface_stacks.py
@@ -146,16 +146,17 @@ def test_local_cloud_uri_rejects_unsafe_values_without_echoing_them(
     )
 
 
-def test_local_connectorless_storage_rejects_no_verify() -> None:
-    """Verification only applies to newly created explicit connectors."""
-    with pytest.raises(
-        ValueError,
-        match="--no-verify only applies when --credentials",
-    ):
-        _build_request(
-            artifact_store="s3://bucket/path",
-            verify=False,
-        )
+def test_local_connectorless_storage_accepts_no_verify() -> None:
+    """--no-verify without credentials skips reused-connector verification."""
+    request = _build_request(
+        artifact_store="s3://bucket/path",
+        verify=False,
+    )
+
+    spec = request.local_cloud_artifact_store_spec
+    assert spec is not None
+    assert spec.verify is False
+    assert spec.credentials is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Let local-runner stacks use S3, GCS, Azure Blob, or ADLS artifact storage while keeping the local runner and sandbox.
- Expose the same validated request through the Python API, CLI, YAML config, and MCP tool.
- Add documentation, changelog notes, and smoke coverage for the new local cloud-storage path.
- Reject signed, credential-bearing, malformed, or otherwise unsafe local cloud URIs without echoing the rejected value.
- Verify discovered service connectors before reusing them (local-cloud and Modal paths), so a stale connector fails at create time with guidance instead of at run time.
- Reject `aws-profile:` credentials when connected to a remote ZenML server, for every connector-creating stack type.

## Why

Previously, choosing cloud artifact storage also required choosing a remote runner stack. This prevented users from running workflows locally while persisting artifacts in an existing cloud bucket or container.

## Credential precedence

When no explicit credential reference is supplied, Kitaru first looks for an existing matching ZenML service connector. A resource-scoped connector takes precedence over an unscoped provider connector. If exactly one suitable connector exists, Kitaru reuses it and marks the stack so recursive deletion preserves that connector. If no connector matches, Kitaru creates a connectorless stack that relies on ambient credentials. Ambiguous matches fail with guidance instead of choosing arbitrarily.

Before a discovered connector is linked, Kitaru verifies it can still authenticate against the target resource; a broken connector aborts stack creation with an actionable error instead of producing a stack whose every run fails. `--no-verify` (SDK/MCP: `verify=False`) skips connector verification on both paths: reused existing connectors and new connectors created from explicit credentials.

Passing `--credentials` bypasses connector discovery and creates a new provider connector. `aws-profile:` credentials are rejected when the client is connected to a remote ZenML server (localhost servers exempt), because the server resolves connector credentials at run time and cannot see profiles that only exist in the client machine's `~/.aws/config`; portable `aws-access-keys`/`aws-session-token` forms remain supported. Connectors created with the stack remain eligible for cleanup, while the one-shot ZenML create path rolls back partially created components and connectors if creation fails.

## Important implementation decisions

- Local cloud storage uses a dedicated `LocalCloudArtifactStoreSpec` rather than treating a local stack as a remote stack.
- Stack creation still uses ZenML's validated one-shot stack API, so component creation, connector registration, rollback, and activation retain one lifecycle boundary.
- Supported storage schemes are `s3://`, `gs://`, `az://`, `abfs://`, and `abfss://`. Valid ADLS authorities such as `filesystem@account.dfs.core.windows.net` are preserved.
- Local URI validation rejects query strings, fragments, ports, embedded credentials, and unsupported authority forms before the URI can be persisted or returned.
- Existing fully local requests and all remote-stack payloads remain unchanged.

## Tests

- `just check`
- `just test` (`3790 passed, 29 skipped`)
- Focused interface suite (`28 passed`)
- Focused local-cloud config, CLI, and MCP selection (`49 passed`)

## Reviewer Notes

The main behavior to inspect is the decision made after the local stack request is validated: explicit credentials create a connector, one unambiguous existing connector is reused, and no match produces a connectorless cloud artifact store. The local orchestrator and sandbox must remain local in every case. Please also check the lifecycle labels used to prevent recursive deletion from removing reused connectors, and the URI validation boundary that keeps signed values and embedded secrets out of payloads and errors.

Two hardening behaviors were added after live testing on a real remote server. First, `_existing_connector_reference` in `src/kitaru/_config/_stacks.py` now verifies a reused connector before linking it — this is the single function every reuse path must pass through, so a future discovery path cannot skip verification by accident. If the verification RPC reports an authorization failure, creation stops with a message naming the connector and the escape hatches. Second, `_resolve_aws_connector_spec` marks profile-based credentials as machine-local via a typed `machine_local_credential` field on `_ResolvedConnectorSpec`, and the shared `_create_one_shot_stack_operation` choke point rejects such credentials whenever the ZenML server is remote — creation used to succeed and then every run failed with a missing-profile error resolved on the server side. The risky spots to review are the verification call siting (does any reuse path bypass it?) and the remote-server predicate in `_zen_store_is_remote` (REST store plus non-localhost hostname).

To reproduce the new failure modes: point stack creation at a bucket whose only matching connector has expired credentials and expect a create-time verification error naming that connector; then retry with `--credentials aws-profile:NAME` against a remote server and expect the profile rejection with the `aws configure export-credentials` hint.

### Reproduction

Replace `YOUR-BUCKET` with an S3 bucket available through your ambient AWS credentials or an existing matching service connector:

```bash
uv sync --extra local
uv run kitaru init
uv run kitaru stack create local-s3 \
  --type local \
  --artifact-store s3://YOUR-BUCKET/kitaru \
  --no-activate
uv run kitaru stack show local-s3
```

The created stack should report a local runner, an S3 artifact store, and a local sandbox, with no container registry. It should not replace the active stack because `--no-activate` was used.

Closes #593

