### PR TITLE
Fix `provider-extended` live adapter checks for Claude Agent SDK and LangGraph

### DIFF
--- a/tests/live/test_anthropic_adapter_behavior.py
+++ b/tests/live/test_anthropic_adapter_behavior.py
@@ -1,6 +1,9 @@
 # ruff: noqa: E402
 """Provider-extended live behavior checks for the Claude Agent SDK adapter."""
 
+from typing import Any, cast
+from uuid import uuid4
+
 import pytest
 
 pytestmark = [
@@ -11,17 +14,23 @@ pytestmark = [
 
 pytest.importorskip("claude_agent_sdk")
 
+from claude_agent_sdk import ClaudeAgentOptions
+
+from kitaru import flow
 from kitaru.adapters.claude_agent_sdk import (
     ClaudeCapturePolicy,
     ClaudeRunRequest,
     KitaruClaudeRunner,
 )
-from kitaru.runtime import _checkpoint_scope
 
 _PROMPT = (
     "Answer in one short sentence: Claude Agent SDK live adapter behavior check. "
     "Do not use tools, Bash, or files."
 )
+# Pin the model and ignore local Claude Code settings: without this the
+# bundled Claude Code CLI falls back to the developer's personal default-model
+# setting (~/.claude), which the ANTHROPIC_API_KEY may not be able to access.
+_MODEL = "claude-haiku-4-5-20251001"
 _CAPTURE_USEFUL_ARTIFACTS = ClaudeCapturePolicy(
     emit_events=True,
     save_prompt=True,
@@ -33,46 +42,62 @@ _CAPTURE_USEFUL_ARTIFACTS = ClaudeCapturePolicy(
 )
 
 
+def _pinned_model_options(request: ClaudeRunRequest) -> ClaudeAgentOptions:
+    return ClaudeAgentOptions(
+        model=_MODEL,
+        cwd=request.cwd,
+        max_turns=request.max_turns,
+        setting_sources=[],
+    )
+
+
 def _runner(name: str) -> KitaruClaudeRunner:
     return KitaruClaudeRunner(
         name=name,
+        options_factory=_pinned_model_options,
         capture=_CAPTURE_USEFUL_ARTIFACTS,
-        allow_direct_execution_inside_checkpoint=True,
+        checkpoint_config={"cache": False},
     )
+
+
+@flow
+def claude_live_stream_flow(nonce: str, cwd: str) -> dict[str, Any]:
+    """Run one streaming Claude Agent SDK invocation as a real checkpoint."""
+    request = ClaudeRunRequest.start(f"{_PROMPT} Nonce: {nonce}.", cwd=cwd, max_turns=1)
+    result = _runner("kitaru-live-claude-stream").run_stream_sync(request)
+    return result.model_dump(mode="json")
+
+
+@flow
+def claude_live_capture_flow(nonce: str, cwd: str) -> dict[str, Any]:
+    """Run one non-streaming Claude Agent SDK invocation as a real checkpoint."""
+    request = ClaudeRunRequest.start(f"{_PROMPT} Nonce: {nonce}.", cwd=cwd, max_turns=1)
+    result = _runner("kitaru-live-claude-capture").run_sync(request)
+    return result.model_dump(mode="json")
 
 
 def test_claude_agent_sdk_live_streaming_records_event_artifacts(tmp_path) -> None:
     """The streaming path completes and records persisted lifecycle evidence."""
-    request = ClaudeRunRequest.start(_PROMPT, cwd=str(tmp_path), max_turns=1)
+    handle = claude_live_stream_flow.run(uuid4().hex, str(tmp_path))
+    result = cast(dict[str, Any], handle.wait())
 
-    with _checkpoint_scope(
-        name="live_claude_adapter_behavior_stream",
-        checkpoint_type="agent_call",
-    ):
-        result = _runner("kitaru-live-claude-stream").run_stream_sync(request)
-
-    assert result.status == "completed"
-    assert result.final_text is not None
-    assert result.final_text.strip()
-    assert result.event_log_artifact_name is not None
-    assert result.run_summary_artifact_name is not None
+    assert result["status"] == "completed"
+    assert result["final_text"] is not None
+    assert result["final_text"].strip()
+    assert result["event_log_artifact_name"] is not None
+    assert result["run_summary_artifact_name"] is not None
 
 
 def test_claude_agent_sdk_live_capture_records_result_artifacts(tmp_path) -> None:
     """The non-streaming path records useful result metadata/artifact names."""
-    request = ClaudeRunRequest.start(_PROMPT, cwd=str(tmp_path), max_turns=1)
+    handle = claude_live_capture_flow.run(uuid4().hex, str(tmp_path))
+    result = cast(dict[str, Any], handle.wait())
 
-    with _checkpoint_scope(
-        name="live_claude_adapter_behavior_capture",
-        checkpoint_type="agent_call",
-    ):
-        result = _runner("kitaru-live-claude-capture").run_sync(request)
-
-    assert result.status == "completed"
-    assert result.final_text is not None
-    assert result.final_text.strip()
-    assert result.messages_artifact_name is not None
-    assert result.options_manifest_artifact_name is not None
-    assert result.output_artifact_name is not None
-    assert result.event_log_artifact_name is not None
-    assert result.run_summary_artifact_name is not None
+    assert result["status"] == "completed"
+    assert result["final_text"] is not None
+    assert result["final_text"].strip()
+    assert result["messages_artifact_name"] is not None
+    assert result["options_manifest_artifact_name"] is not None
+    assert result["output_artifact_name"] is not None
+    assert result["event_log_artifact_name"] is not None
+    assert result["run_summary_artifact_name"] is not None

--- a/tests/live/test_anthropic_adapter_behavior.py
+++ b/tests/live/test_anthropic_adapter_behavior.py
@@ -76,7 +76,9 @@ def claude_live_capture_flow(nonce: str, cwd: str) -> dict[str, Any]:
     return result.model_dump(mode="json")
 
 
-def test_claude_agent_sdk_live_streaming_records_event_artifacts(tmp_path) -> None:
+def test_claude_agent_sdk_live_streaming_records_event_artifacts(
+    primed_zenml, tmp_path
+) -> None:
     """The streaming path completes and records persisted lifecycle evidence."""
     handle = claude_live_stream_flow.run(uuid4().hex, str(tmp_path))
     result = cast(dict[str, Any], handle.wait())
@@ -88,7 +90,9 @@ def test_claude_agent_sdk_live_streaming_records_event_artifacts(tmp_path) -> No
     assert result["run_summary_artifact_name"] is not None
 
 
-def test_claude_agent_sdk_live_capture_records_result_artifacts(tmp_path) -> None:
+def test_claude_agent_sdk_live_capture_records_result_artifacts(
+    primed_zenml, tmp_path
+) -> None:
     """The non-streaming path records useful result metadata/artifact names."""
     handle = claude_live_capture_flow.run(uuid4().hex, str(tmp_path))
     result = cast(dict[str, Any], handle.wait())

--- a/tests/live/test_google_adk_provider_behavior.py
+++ b/tests/live/test_google_adk_provider_behavior.py
@@ -157,7 +157,9 @@ async def _run_tool_turn() -> Any:
     return result
 
 
-def test_google_adk_runner_call_with_gemini_captures_function_call() -> None:
+def test_google_adk_runner_call_with_gemini_captures_function_call(
+    primed_zenml,
+) -> None:
     """The Google ADK adapter captures a real Gemini function/tool turn."""
     prepare_live_google_credentials()
 

--- a/tests/live/test_openai_adapter_behavior.py
+++ b/tests/live/test_openai_adapter_behavior.py
@@ -161,7 +161,7 @@ def _openai_tool_runner(tool_calls: list[str]) -> KitaruRunner:
     )
 
 
-def test_openai_agents_live_tool_call_records_result_evidence() -> None:
+def test_openai_agents_live_tool_call_records_result_evidence(primed_zenml) -> None:
     """The OpenAI Agents adapter can run and record a real local tool call."""
     tool_calls: list[str] = []
     runner = _openai_tool_runner(tool_calls)
@@ -181,7 +181,9 @@ def test_openai_agents_live_tool_call_records_result_evidence() -> None:
     assert result.output_artifact_name is not None
 
 
-def test_openai_agents_live_streaming_records_lifecycle_evidence() -> None:
+def test_openai_agents_live_streaming_records_lifecycle_evidence(
+    primed_zenml,
+) -> None:
     """The OpenAI Agents streaming adapter exposes durable run evidence."""
     agent = agents.Agent(
         name=f"kitaru-live-openai-stream-{uuid4().hex[:8]}",
@@ -241,7 +243,7 @@ def pydantic_ai_live_behavior_flow(nonce: str) -> dict[str, Any]:
     return {"answer": result.output.model_dump(), "tool_calls": tool_calls}
 
 
-def test_pydantic_ai_live_tool_and_structured_output_metadata() -> None:
+def test_pydantic_ai_live_tool_and_structured_output_metadata(primed_zenml) -> None:
     """PydanticAI records real model/tool events and structured output."""
     handle = pydantic_ai_live_behavior_flow.run(uuid4().hex)
     hydrated = _wait_for_hydrated_run(handle.exec_id)
@@ -335,7 +337,9 @@ def langgraph_live_calls_flow(nonce: str) -> dict[str, Any]:
     return persist_langgraph_live_summary(summary)
 
 
-def test_langgraph_live_calls_mode_records_model_and_tool_evidence() -> None:
+def test_langgraph_live_calls_mode_records_model_and_tool_evidence(
+    primed_zenml,
+) -> None:
     """LangGraph calls mode records real model/tool behavior through Kitaru."""
     nonce = uuid4().hex
     handle = langgraph_live_calls_flow.run(nonce)

--- a/tests/live/test_openai_adapter_behavior.py
+++ b/tests/live/test_openai_adapter_behavior.py
@@ -115,6 +115,28 @@ def _event_kinds(event_map: Mapping[str, list[dict[str, Any]]]) -> set[str]:
     return {str(event.get("kind")) for event in _events(event_map)}
 
 
+def _langgraph_events(
+    event_map: Mapping[str, Any], *, exec_id: str
+) -> list[dict[str, Any]]:
+    """Collect LangGraph events from full or lightweight run metadata.
+
+    When the tracker flushes inside a checkpoint it records only a lightweight
+    pointer (`artifact_name`, `event_count`, ...) and persists the full event
+    list as an artifact, so follow the pointer in that case.
+    """
+    client = KitaruClient()
+    events: list[dict[str, Any]] = []
+    for payload in event_map.values():
+        if isinstance(payload, list):
+            events.extend(cast(list[dict[str, Any]], payload))
+            continue
+        artifact_name = cast(str, payload["artifact_name"])
+        refs = client.artifacts.list(exec_id, name=artifact_name, limit=1)
+        assert refs, f"No artifact named {artifact_name!r} on execution {exec_id}."
+        events.extend(cast(list[dict[str, Any]], refs[0].load()))
+    return events
+
+
 def _openai_tool_runner(tool_calls: list[str]) -> KitaruRunner:
     @agents.function_tool
     def lookup_live_marker(marker: str) -> str:
@@ -339,15 +361,13 @@ def test_langgraph_live_calls_mode_records_model_and_tool_evidence() -> None:
     assert any(name.startswith("tool_call__add_one_live_") for name in checkpoint_names)
 
     hydrated = _wait_for_hydrated_run(handle.exec_id)
-    event_map = cast(
-        dict[str, list[dict[str, Any]]],
-        _metadata_dict_from_steps(hydrated, LANGGRAPH_EVENTS_METADATA_KEY),
-    )
+    event_map = _metadata_dict_from_steps(hydrated, LANGGRAPH_EVENTS_METADATA_KEY)
     summary_map = cast(
         dict[str, dict[str, Any]],
         _metadata_dict_from_steps(hydrated, LANGGRAPH_RUN_SUMMARIES_METADATA_KEY),
     )
-    event_kinds = _event_kinds(event_map)
+    events = _langgraph_events(event_map, exec_id=handle.exec_id)
+    event_kinds = {str(event.get("kind")) for event in events}
     run_summary = next(iter(summary_map.values()))
 
     assert {"model_call", "tool_call"} <= event_kinds


### PR DESCRIPTION
## What this fixes

The first completed `provider-extended` dispatch of the LLM integration workflow (run 29898785275) failed with 3 of 8 live pytest checks red plus the Google ADK check. These tests merged in #492 but had never actually executed in CI before that dispatch — the scheduled runs only cover `provider-core` — so all three pytest failures turned out to be latent defects in the tests themselves, not regressions in the adapters.

### Claude Agent SDK live tests (2 failures)

The two tests ran `KitaruClaudeRunner` inside a synthetic `_checkpoint_scope` with no real execution behind it. In that state `kitaru.save()` always raises (`requires an active execution ID inside @checkpoint`), the adapter swallows the error into `capture_failures`, and every artifact-name field comes back `None` — so the artifact assertions could never pass as written. The tests now run the runner inside a real `@flow`, matching the pattern of the passing sibling adapter tests, so the runner opens a genuine invocation checkpoint and artifact capture works.

They also now pin the model and pass `setting_sources=[]` so the bundled Claude Code CLI ignores the developer's personal default-model setting. Without this the tests fail locally with an unrelated model-access 404 whenever the developer's own Claude Code default model isn't available to the `ANTHROPIC_API_KEY` in use.

### LangGraph calls-mode live test (1 failure)

In calls mode the LangGraph tracker flushes run metadata from inside a checkpoint, so it records the *lightweight* shape — a pointer dict (`artifact_name`, `event_count`, `event_ids_in_order`) with the full event list persisted as an artifact — rather than the inline event-dict list the test assumed. Iterating the pointer dict yields string keys, hence the `AttributeError: 'str' object has no attribute 'get'`. The test now uses a `_langgraph_events()` helper that accepts both shapes and follows the artifact pointer via `KitaruClient.artifacts(...).load()` when needed.

### Google ADK check (no code change)

The `403 API_KEY_SERVICE_BLOCKED` failure was an API-key restriction: the CI Gemini key's allowlist covered only the Vertex AI service, not the Gemini API (`generativelanguage.googleapis.com`) that the ADK check calls. The key's allowlist has been widened on the Google Cloud side; no repo or secret change was needed. The previously blocked call now returns 200 and the isolated ADK check passes locally.

## Reviewer Notes

The story of this change is entirely about how live adapter tests obtain a persistence context. The risky spot is `tests/live/test_anthropic_adapter_behavior.py`: the old version validated nothing about artifact capture (the saves failed silently every time), while the new version exercises the real path — runner at flow scope, invocation checkpoint, `kitaru.save()` against a real execution. If the rewrite were wrong in the same way the original was, the artifact-name assertions would go back to being unsatisfiable, so the thing to check is that the flows call the runner directly in the flow body (not inside another checkpoint) and that the assertions read the serialized `ClaudeRunResult` from `handle.wait()`.

In `tests/live/test_openai_adapter_behavior.py`, `_langgraph_events()` is the piece worth a close look: it must not mask a genuinely broken full-shape payload. It only follows the artifact pointer when the metadata value is not a list, and it still asserts the pointed-to artifact exists before loading it.

Both trust-check-rejected dispatch attempts against this branch (29901330344, 29901625046) failed at the gate by design — the workflow only runs trusted refs — so the pre-merge evidence is local; the post-merge `provider-extended` dispatch on `develop` is the end-to-end confirmation.

### Reproduction

With `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` set, run the same selection CI uses:

```bash
uv run pytest tests/live -m "(live_openai or live_anthropic) and provider_extended" --tb=short
```

Expect 6 passed, 2 skipped (the same shape the failing CI run reported as 3 passed / 3 failed / 2 skipped). For the ADK check, with `GEMINI_API_KEY` set:

```bash
uv run --frozen --python 3.12 --no-dev --extra google-adk --with pytest \
  pytest tests/live/test_google_adk_provider_behavior.py -m live_gemini
```

Expect 1 passed. After merging, dispatch `llm-integration.yml` with `suite=provider-extended` and `include_google_adk=true` against `develop` and expect the summary artifact to report zero failures.

### Local checks run

`just check` and `just test` (3790 passed, 29 skipped) both green; both live suites verified against real providers as above.

## Update: `primed_zenml` across the live suite

Following review feedback, all flow-running live tests (the two new Claude tests, the PydanticAI/LangGraph/OpenAI Agents tests, and the Google ADK test) now request the `primed_zenml` fixture so ZenML's store initializes eagerly instead of on first touch from a background flow thread. The review suggested adding it only to the two new Claude tests, but none of the sibling live tests used it either, so it is applied suite-wide for consistency with the convention documented in `tests/conftest.py`. Both live suites re-verified green with the fixture in place (extended suite 6 passed / 2 skipped; ADK check 1 passed).
