### PR TITLE
Bump `gitpython` and `pyasn1` in `uv.lock` to clear five pip-audit findings

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -938,14 +938,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/fd/df0bafa4eb5ea2f51e1adee9f7a94c8e62c5d180e65117045dfca3439c8a/gitpython-3.1.52.tar.gz", hash = "sha256:de0a8ad86274c6e75ae8b37dd055ba68f19818c813108642263227b20775b48e", size = 223726, upload-time = "2026-07-16T03:15:59.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/90/04dff7c1e176bb1c3011ef1647393d368790da710d8dde1cdcfad301f45a/gitpython-3.1.52-py3-none-any.whl", hash = "sha256:79a36ee1f83523214a3f72d56cf1c4e490d577dc61af77e43dfe5862bd9da01a", size = 215366, upload-time = "2026-07-16T03:15:58.239Z" },
 ]
 
 [[package]]
@@ -2664,11 +2664,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What and why

The `audit` CI job is failing on develop-based branches (first seen on #607's run) because `pip-audit` flags five new vulnerabilities in the locked dependency set:

| Package | Locked | Findings | Fixed in |
|---|---|---|---|
| `gitpython` | 3.1.50 | GHSA-2f96-g7mh-g2hx, GHSA-v396-v7q4-x2qj, GHSA-956x-8gvw-wg5v | 3.1.51 |
| `pyasn1` | 0.6.3 | CVE-2026-59885, CVE-2026-59886 | 0.6.4 |

Both packages are transitive dependencies (`gitpython` via `zenml`, `pyasn1` via the Google auth chain) with no upper version pins anywhere in our tree, so no `pip-audit` exception was needed — a targeted lock refresh (`uv lock --upgrade-package gitpython --upgrade-package pyasn1`) resolves all five findings. Result: `gitpython` 3.1.50 → 3.1.52, `pyasn1` 0.6.3 → 0.6.4. No changes to `.github/pip-audit-ignored.txt`.

## Reviewer Notes

This is a lock-file-only change — the diff is 6 lines swapped in `uv.lock` and nothing else. The only risk would be if either patch release changed behavior our code relies on: `gitpython` 3.1.51/3.1.52 are security patches for the three GHSAs above, and `pyasn1` 0.6.4 is the CVE fix release. The full test suite (3790 passed, 29 skipped) and `just check` both pass locally with the new lock, and both packages are only reached through ZenML/Google-auth internals, not called directly by Kitaru code.

### Reproduction

Run the audit exactly as CI does:

```bash
uv sync --frozen
awk '/^(CVE|GHSA|PYSEC)-/ {printf "--ignore-vuln %s ", $1}' \
  .github/pip-audit-ignored.txt | xargs uv run pip-audit
```

On `develop` this exits 123 with the five findings above; on this branch it prints `No known vulnerabilities found, 8 ignored`.

Local checks run: `just check`, `just test` (all green).