### PR TITLE
Fix lock ordering deadlocks and locking gaps

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -10469,7 +10469,7 @@
     },
     "/v1/experiment-runs/{experiment_run_id}/cancel": {
       "post": {
-        "description": "Request cancellation of a running experiment run.\n\nClients observe HTTP 200 on success, 404 when no run has this id, and\n409 when the run is not running.\n\nArgs:\n    experiment_run_id: Id of the run.\n    service: Experiment run service.\n    actor: Caller context.\n\nReturns:\n    Run carrying the cancel request.",
+        "description": "Request cancellation of a running experiment run.\n\nClients observe HTTP 200 on success, 404 when no run has this id, and\n409 when the run is not running.\n\nArgs:\n    experiment_run_id: Id of the run.\n    actor: Caller context.\n    cancel: Run cancellation flow, committed across its own transactions.\n\nReturns:\n    Run carrying the cancel request.",
         "operationId": "cancel_experiment_run_v1_experiment_runs__experiment_run_id__cancel_post",
         "parameters": [
           {

--- a/src/kitaru/api_models/v1/task.py
+++ b/src/kitaru/api_models/v1/task.py
@@ -16,9 +16,9 @@
 import uuid
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Literal, Self
+from typing import Annotated, Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from kitaru.api_models.v1.base import (
     JsonValue,
@@ -28,7 +28,6 @@ from kitaru.api_models.v1.base import (
     TimestampedResponseModel,
 )
 from kitaru.api_models.v1.filter import FilterableListParams
-from kitaru.base import FrozenModel
 
 
 class TaskKind(StrEnum):
@@ -124,52 +123,6 @@ class TaskUpdateRequest(RequestModel):
 
 class TaskListParams(FilterableListParams):
     """Task list params."""
-
-
-class LabelSelector(FrozenModel):
-    """Label selector."""
-
-    key: str = Field(description="Label key.")
-    values: list[str] = Field(min_length=1, description="Values the label may take.")
-    required: bool = Field(
-        default=False, description="Whether a task lacking the key fails the match."
-    )
-
-
-class WorkerScope(FrozenModel):
-    """Worker scope."""
-
-    kinds: list[TaskKind] | None = Field(
-        default=None, description="Task kinds the worker claims."
-    )
-    selectors: list[LabelSelector] | None = Field(
-        default=None,
-        description="Label selectors the worker claims, combined by conjunction.",
-    )
-    job_id: uuid.UUID | None = Field(
-        default=None, description="Job the worker claims tasks from."
-    )
-
-    @model_validator(mode="after")
-    def _validate_scope(self) -> Self:
-        """Reject empty scope lists and duplicate selector keys.
-
-        Raises:
-            ValueError: kinds or selectors is set but empty, or two selectors
-                share a key.
-
-        Returns:
-            The validated scope.
-        """
-        if self.kinds is not None and not self.kinds:
-            raise ValueError("kinds must not be empty when set")
-        if self.selectors is not None:
-            if not self.selectors:
-                raise ValueError("selectors must not be empty when set")
-            keys = [selector.key for selector in self.selectors]
-            if len(set(keys)) != len(keys):
-                raise ValueError("selector keys must be unique")
-        return self
 
 
 class TaskClaimRequest(RequestModel):

--- a/src/kitaru/api_models/v1/worker.py
+++ b/src/kitaru/api_models/v1/worker.py
@@ -15,8 +15,9 @@
 
 import uuid
 from datetime import datetime
+from typing import Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from kitaru.api_models.v1.base import (
     OwnedResponseModel,
@@ -25,7 +26,54 @@ from kitaru.api_models.v1.base import (
     ResponseModel,
 )
 from kitaru.api_models.v1.filter import FilterableListParams
-from kitaru.api_models.v1.task import WorkerScope
+from kitaru.api_models.v1.task import TaskKind
+from kitaru.base import FrozenModel
+
+
+class LabelSelector(FrozenModel):
+    """Label selector."""
+
+    key: str = Field(description="Label key.")
+    values: list[str] = Field(min_length=1, description="Values the label may take.")
+    required: bool = Field(
+        default=False, description="Whether a task lacking the key fails the match."
+    )
+
+
+class WorkerScope(FrozenModel):
+    """Worker scope."""
+
+    kinds: list[TaskKind] | None = Field(
+        default=None, description="Task kinds the worker claims."
+    )
+    selectors: list[LabelSelector] | None = Field(
+        default=None,
+        description="Label selectors the worker claims, combined by conjunction.",
+    )
+    job_id: uuid.UUID | None = Field(
+        default=None, description="Job the worker claims tasks from."
+    )
+
+    @model_validator(mode="after")
+    def _validate_scope(self) -> Self:
+        """Reject empty scope lists and duplicate selector keys.
+
+        Raises:
+            ValueError: kinds or selectors is set but empty, or two selectors
+                share a key.
+
+        Returns:
+            The validated scope.
+        """
+        if self.kinds is not None and not self.kinds:
+            raise ValueError("kinds must not be empty when set")
+        if self.selectors is not None:
+            if not self.selectors:
+                raise ValueError("selectors must not be empty when set")
+            keys = [selector.key for selector in self.selectors]
+            if len(set(keys)) != len(keys):
+                raise ValueError("selector keys must be unique")
+        return self
 
 
 class WorkerRuntime(RequestModel):

--- a/src/kitaru/server/adapters/db/errors.py
+++ b/src/kitaru/server/adapters/db/errors.py
@@ -14,7 +14,49 @@
 """Database error introspection."""
 
 import asyncpg
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import DBAPIError, IntegrityError
+
+
+def _has_driver_cause(exc: DBAPIError, driver_error: type[BaseException]) -> bool:
+    """Report whether a driver error of a class underlies a database error.
+
+    Args:
+        exc: Database error to inspect.
+        driver_error: Driver error class to look for.
+
+    Returns:
+        Whether the class appears in the error's cause chain.
+    """
+    cause: BaseException | None = exc.orig
+    while cause is not None:
+        if isinstance(cause, driver_error):
+            return True
+        cause = cause.__cause__
+    return False
+
+
+def is_deadlock(exc: DBAPIError) -> bool:
+    """Report whether a database error is a deadlock cancellation.
+
+    Args:
+        exc: Database error to inspect.
+
+    Returns:
+        Whether the driver reports a deadlock.
+    """
+    return _has_driver_cause(exc, asyncpg.exceptions.DeadlockDetectedError)
+
+
+def is_lock_not_available(exc: DBAPIError) -> bool:
+    """Report whether a database error is a NOWAIT acquisition finding a held row.
+
+    Args:
+        exc: Database error to inspect.
+
+    Returns:
+        Whether the driver reports the lock as unavailable.
+    """
+    return _has_driver_cause(exc, asyncpg.exceptions.LockNotAvailableError)
 
 
 def violated_constraint(exc: IntegrityError) -> str | None:

--- a/src/kitaru/server/adapters/db/orm/job.py
+++ b/src/kitaru/server/adapters/db/orm/job.py
@@ -16,7 +16,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKeyConstraint, Index, String, Text
+from sqlalchemy import DateTime, ForeignKeyConstraint, Index, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from kitaru.api_models.v1.job import JobKind, JobStatus
@@ -34,6 +34,11 @@ STATUS_LENGTH = 32
 JOB_OWNER_ID_FOREIGN_KEY = foreign_key_name("job", ["owner_id"])
 JOB_KIND_INDEX = index_name("job", ["kind"])
 JOB_STATUS_INDEX = index_name("job", ["status"])
+# Partial index covering the sweep's cancel propagation scan, which reads only
+# the few jobs a cancel request ever reached.
+JOB_CANCEL_REQUESTED_AT_INDEX = index_name("job", ["cancel_requested_at"])
+
+CANCEL_REQUESTED_PREDICATE = "cancel_requested_at IS NOT NULL"
 
 
 class JobORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -46,6 +51,11 @@ class JobORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         ),
         Index(JOB_KIND_INDEX, "kind"),
         Index(JOB_STATUS_INDEX, "status"),
+        Index(
+            JOB_CANCEL_REQUESTED_AT_INDEX,
+            "cancel_requested_at",
+            postgresql_where=text(CANCEL_REQUESTED_PREDICATE),
+        ),
     )
 
     owner_id: Mapped[uuid.UUID]

--- a/src/kitaru/server/adapters/db/orm/task.py
+++ b/src/kitaru/server/adapters/db/orm/task.py
@@ -40,7 +40,13 @@ from kitaru.server.adapters.db.orm.orm_utils import (
     index_name,
     unique_constraint_name,
 )
-from kitaru.server.domain.task import AgentTask, EvaluationTask, ImportTask, Task
+from kitaru.server.domain.task import (
+    TERMINAL_TASK_STATUSES,
+    AgentTask,
+    EvaluationTask,
+    ImportTask,
+    Task,
+)
 
 KIND_LENGTH = 16
 STATUS_LENGTH = 16
@@ -65,6 +71,8 @@ TASK_INPUT_SESSION_ID_INDEX = index_name("task", ["input_session_id"])
 TASK_PENDING_ID_INDEX = index_name("task", ["id"])
 TASK_PENDING_LABELS_INDEX = index_name("task", ["labels"])
 TASK_STALENESS_INDEX = index_name("task", ["heartbeat_at", "claimed_at"])
+
+TERMINAL_STATUS_VALUES = [status.value for status in TERMINAL_TASK_STATUSES]
 
 PENDING_PREDICATE = "status = 'pending'"
 IN_FLIGHT_PREDICATE = "status IN ('claimed', 'running')"

--- a/src/kitaru/server/adapters/db/orm/worker.py
+++ b/src/kitaru/server/adapters/db/orm/worker.py
@@ -20,8 +20,7 @@ from sqlalchemy import DateTime, ForeignKeyConstraint, Index, String, UniqueCons
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
-from kitaru.api_models.v1.task import WorkerScope
-from kitaru.api_models.v1.worker import WorkerRuntime
+from kitaru.api_models.v1.worker import WorkerRuntime, WorkerScope
 from kitaru.server.adapters.db.orm.base import (
     Base,
     TimestampMixin,

--- a/src/kitaru/server/adapters/db/repositories/base.py
+++ b/src/kitaru/server/adapters/db/repositories/base.py
@@ -54,11 +54,13 @@ class BaseSQLRepository(Generic[RowT]):
         """
         raise NotImplementedError
 
-    async def _get_row(self, entity_id: uuid.UUID) -> RowT:
+    async def _get_row(self, entity_id: uuid.UUID, exclusive: bool = False) -> RowT:
         """Load a row by id.
 
         Args:
             entity_id: Id of the row.
+            exclusive: Whether to lock the row for the duration of the
+                transaction.
 
         Raises:
             NotFoundError: No row has this id.
@@ -66,16 +68,22 @@ class BaseSQLRepository(Generic[RowT]):
         Returns:
             Stored row.
         """
-        row = await self._session.get(self.orm_class, entity_id)
+        row = await self._session.get(
+            self.orm_class, entity_id, with_for_update=exclusive
+        )
         if row is None:
             raise self._not_found(entity_id)
         return row
 
-    async def _load_by_ids(self, ids: Sequence[uuid.UUID]) -> dict[uuid.UUID, RowT]:
+    async def _load_by_ids(
+        self, ids: Sequence[uuid.UUID], exclusive: bool = False
+    ) -> dict[uuid.UUID, RowT]:
         """Load rows by id into a dict keyed by id, missing ids omitted.
 
         Args:
             ids: Ids of the rows.
+            exclusive: Whether to lock the rows in id order for the duration
+                of the transaction.
 
         Returns:
             Rows keyed by id.
@@ -83,6 +91,8 @@ class BaseSQLRepository(Generic[RowT]):
         if not ids:
             return {}
         statement = select(self.orm_class).where(self.orm_class.id.in_(ids))
+        if exclusive:
+            statement = statement.order_by(self.orm_class.id.asc()).with_for_update()
         rows = (await self._session.scalars(statement)).all()
         return {row.id: row for row in rows}
 

--- a/src/kitaru/server/adapters/db/repositories/cohort_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/cohort_repository.py
@@ -90,11 +90,7 @@ class SQLCohortRepository(BaseSQLRepository[CohortORM]):
         Returns:
             Stored cohort.
         """
-        row = await self._session.get(
-            self.orm_class, cohort_id, with_for_update=exclusive
-        )
-        if row is None:
-            raise CohortNotFound(cohort_id)
+        row = await self._get_row(cohort_id, exclusive=exclusive)
         return row.to_domain()
 
     async def query(

--- a/src/kitaru/server/adapters/db/repositories/cohort_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/cohort_repository.py
@@ -76,11 +76,13 @@ class SQLCohortRepository(BaseSQLRepository[CohortORM]):
         )
         return row.to_domain()
 
-    async def get(self, cohort_id: uuid.UUID) -> Cohort:
+    async def get(self, cohort_id: uuid.UUID, exclusive: bool = False) -> Cohort:
         """Load a cohort by id.
 
         Args:
             cohort_id: Id of the cohort.
+            exclusive: Whether to lock the row for the duration of the
+                transaction.
 
         Raises:
             CohortNotFound: No cohort has this id.
@@ -88,7 +90,11 @@ class SQLCohortRepository(BaseSQLRepository[CohortORM]):
         Returns:
             Stored cohort.
         """
-        row = await self._get_row(cohort_id)
+        row = await self._session.get(
+            self.orm_class, cohort_id, with_for_update=exclusive
+        )
+        if row is None:
+            raise CohortNotFound(cohort_id)
         return row.to_domain()
 
     async def query(

--- a/src/kitaru/server/adapters/db/repositories/cohort_version_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/cohort_version_repository.py
@@ -104,11 +104,15 @@ class SQLCohortVersionRepository(BaseSQLRepository[CohortVersionORM]):
         await self._flush()
         return row.to_domain()
 
-    async def get(self, cohort_version_id: uuid.UUID) -> CohortVersion:
+    async def get(
+        self, cohort_version_id: uuid.UUID, exclusive: bool = False
+    ) -> CohortVersion:
         """Load a cohort version by id.
 
         Args:
             cohort_version_id: Id of the cohort version.
+            exclusive: Whether to lock the row for the duration of the
+                transaction.
 
         Raises:
             CohortVersionIdNotFound: No cohort version has this id.
@@ -116,7 +120,11 @@ class SQLCohortVersionRepository(BaseSQLRepository[CohortVersionORM]):
         Returns:
             Stored cohort version.
         """
-        row = await self._get_row(cohort_version_id)
+        row = await self._session.get(
+            self.orm_class, cohort_version_id, with_for_update=exclusive
+        )
+        if row is None:
+            raise CohortVersionIdNotFound(cohort_version_id)
         return row.to_domain()
 
     async def get_by_number(self, cohort_id: uuid.UUID, version: int) -> CohortVersion:

--- a/src/kitaru/server/adapters/db/repositories/cohort_version_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/cohort_version_repository.py
@@ -120,11 +120,7 @@ class SQLCohortVersionRepository(BaseSQLRepository[CohortVersionORM]):
         Returns:
             Stored cohort version.
         """
-        row = await self._session.get(
-            self.orm_class, cohort_version_id, with_for_update=exclusive
-        )
-        if row is None:
-            raise CohortVersionIdNotFound(cohort_version_id)
+        row = await self._get_row(cohort_version_id, exclusive=exclusive)
         return row.to_domain()
 
     async def get_by_number(self, cohort_id: uuid.UUID, version: int) -> CohortVersion:

--- a/src/kitaru/server/adapters/db/repositories/experiment_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/experiment_repository.py
@@ -112,11 +112,7 @@ class SQLExperimentRepository(BaseSQLRepository[ExperimentORM]):
         Returns:
             Stored experiment.
         """
-        row = await self._session.get(
-            self.orm_class, experiment_id, with_for_update=exclusive
-        )
-        if row is None:
-            raise ExperimentNotFound(experiment_id)
+        row = await self._get_row(experiment_id, exclusive=exclusive)
         return row.to_domain()
 
     async def query(

--- a/src/kitaru/server/adapters/db/repositories/experiment_run_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/experiment_run_repository.py
@@ -105,11 +105,7 @@ class SQLExperimentRunRepository(BaseSQLRepository[ExperimentRunORM]):
         Returns:
             Stored experiment run.
         """
-        row = await self._session.get(
-            self.orm_class, experiment_run_id, with_for_update=exclusive
-        )
-        if row is None:
-            raise ExperimentRunNotFound(experiment_run_id)
+        row = await self._get_row(experiment_run_id, exclusive=exclusive)
         return row.to_domain()
 
     async def query(

--- a/src/kitaru/server/adapters/db/repositories/job_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/job_repository.py
@@ -108,6 +108,30 @@ class SQLJobRepository(BaseSQLRepository[JobORM]):
         rows = await self._load_by_ids(job_ids)
         return {job_id: row.to_domain() for job_id, row in rows.items()}
 
+    async def get_many_locked(
+        self, job_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, Job]:
+        """Bulk-lock and load jobs by id, keyed by id, missing ids omitted.
+
+        Rows are locked in id order.
+
+        Args:
+            job_ids: Ids of the jobs to load.
+
+        Returns:
+            Locked jobs keyed by id.
+        """
+        if not job_ids:
+            return {}
+        statement = (
+            select(JobORM)
+            .where(JobORM.id.in_(list(job_ids)))
+            .order_by(JobORM.id.asc())
+            .with_for_update()
+        )
+        rows = (await self._session.scalars(statement)).all()
+        return {row.id: row.to_domain() for row in rows}
+
     async def query(self, job_filter: JobFilter) -> tuple[list[Job], str | None]:
         """Query jobs matching a filter.
 
@@ -143,6 +167,32 @@ class SQLJobRepository(BaseSQLRepository[JobORM]):
         row.apply(job)
         await self._flush()
         return row.to_domain()
+
+    async def update_many(self, jobs: list[Job]) -> list[Job]:
+        """Persist changes to many existing jobs in one round trip.
+
+        Every job row is already loaded and locked in the session's identity
+        map by ``get_many_locked``, so ``_get_row`` resolves from memory and
+        the changes flush as one batch.
+
+        Args:
+            jobs: Jobs with modified fields.
+
+        Raises:
+            JobNotFound: A job id matches no job.
+
+        Returns:
+            Stored jobs with the updated timestamp renewed, in the same order.
+        """
+        if not jobs:
+            return []
+        rows = []
+        for job in jobs:
+            row = await self._get_row(job.id)
+            row.apply(job)
+            rows.append(row)
+        await self._flush()
+        return [row.to_domain() for row in rows]
 
     async def delete(self, job_id: uuid.UUID) -> None:
         """Delete a job by id, cascading its tasks.

--- a/src/kitaru/server/adapters/db/repositories/job_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/job_repository.py
@@ -16,20 +16,24 @@
 import uuid
 from collections.abc import Mapping, Sequence
 
-from sqlalchemy import select
+from sqlalchemy import not_, or_, select
 
+from kitaru.api_models.v1.task import TaskStatus
 from kitaru.server.adapters.db.filtering import FilterBinding, compile_filter_expression
 from kitaru.server.adapters.db.orm.job import JobORM
+from kitaru.server.adapters.db.orm.task import TERMINAL_STATUS_VALUES, TaskORM
 from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.job import JobFilter
 from kitaru.server.domain.base import NotFoundError
-from kitaru.server.domain.job import Job, JobNotFound
+from kitaru.server.domain.job import TERMINAL_JOB_STATUSES, Job, JobNotFound
 
 JOB_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
     "kind": JobORM.kind,
     "status": JobORM.status,
 }
+
+TERMINAL_JOB_STATUS_VALUES = [status.value for status in TERMINAL_JOB_STATUSES]
 
 
 class SQLJobRepository(BaseSQLRepository[JobORM]):
@@ -91,9 +95,7 @@ class SQLJobRepository(BaseSQLRepository[JobORM]):
         Returns:
             Stored job.
         """
-        row = await self._session.get(self.orm_class, job_id, with_for_update=exclusive)
-        if row is None:
-            raise JobNotFound(job_id)
+        row = await self._get_row(job_id, exclusive=exclusive)
         return row.to_domain()
 
     async def get_many(self, job_ids: Sequence[uuid.UUID]) -> dict[uuid.UUID, Job]:
@@ -121,16 +123,41 @@ class SQLJobRepository(BaseSQLRepository[JobORM]):
         Returns:
             Locked jobs keyed by id.
         """
-        if not job_ids:
-            return {}
-        statement = (
-            select(JobORM)
-            .where(JobORM.id.in_(list(job_ids)))
-            .order_by(JobORM.id.asc())
-            .with_for_update()
+        rows = await self._load_by_ids(job_ids, exclusive=True)
+        return {job_id: row.to_domain() for job_id, row in rows.items()}
+
+    async def list_unpropagated_cancel_ids(self, limit: int) -> list[uuid.UUID]:
+        """Read the ids of canceling jobs whose live tasks still owe the stamp.
+
+        A live task owes the stamp when it carries no cancel request of its
+        own, or when it is still pending and has to move straight to
+        canceled. Rows are read without locking.
+
+        Args:
+            limit: Maximum number of ids to read.
+
+        Returns:
+            Ids of the canceling jobs in ascending order.
+        """
+        owing = select(TaskORM.id).where(
+            TaskORM.job_id == JobORM.id,
+            not_(TaskORM.status.in_(TERMINAL_STATUS_VALUES)),
+            or_(
+                TaskORM.cancel_requested_at.is_(None),
+                TaskORM.status == TaskStatus.PENDING.value,
+            ),
         )
-        rows = (await self._session.scalars(statement)).all()
-        return {row.id: row.to_domain() for row in rows}
+        statement = (
+            select(JobORM.id)
+            .where(
+                JobORM.cancel_requested_at.is_not(None),
+                not_(JobORM.status.in_(TERMINAL_JOB_STATUS_VALUES)),
+                owing.exists(),
+            )
+            .order_by(JobORM.id.asc())
+            .limit(limit)
+        )
+        return list((await self._session.scalars(statement)).all())
 
     async def query(self, job_filter: JobFilter) -> tuple[list[Job], str | None]:
         """Query jobs matching a filter.

--- a/src/kitaru/server/adapters/db/repositories/job_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/job_repository.py
@@ -224,10 +224,46 @@ class SQLJobRepository(BaseSQLRepository[JobORM]):
     async def delete(self, job_id: uuid.UUID) -> None:
         """Delete a job by id, cascading its tasks.
 
+        The job's task rows are locked in id order before the job row, since
+        the delete's cascade would otherwise lock them unordered after it.
+
         Args:
             job_id: Id of the job.
 
         Raises:
             JobNotFound: No job has this id.
         """
+        await self._lock_task_rows([job_id])
         await self._delete_row(job_id)
+
+    async def delete_many(self, job_ids: Sequence[uuid.UUID]) -> None:
+        """Delete many jobs by id, cascading their tasks.
+
+        The jobs' task rows are locked in id order across all jobs before
+        the job rows, which are deleted in ascending id order.
+
+        Args:
+            job_ids: Ids of the jobs.
+
+        Raises:
+            JobNotFound: A job id matches no job.
+        """
+        if not job_ids:
+            return
+        await self._lock_task_rows(job_ids)
+        for job_id in sorted(job_ids):
+            await self._delete_row(job_id)
+
+    async def _lock_task_rows(self, job_ids: Sequence[uuid.UUID]) -> None:
+        """Lock the jobs' task rows in id order.
+
+        Args:
+            job_ids: Ids the tasks belong to.
+        """
+        statement = (
+            select(TaskORM.id)
+            .where(TaskORM.job_id.in_(list(job_ids)))
+            .order_by(TaskORM.id.asc())
+            .with_for_update()
+        )
+        await self._session.execute(statement)

--- a/src/kitaru/server/adapters/db/repositories/replay_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/replay_repository.py
@@ -137,6 +137,23 @@ class SQLReplayRepository(BaseSQLRepository[ReplayORM]):
         row = (await self._session.scalars(statement)).one_or_none()
         return row.to_domain() if row is not None else None
 
+    async def get_many_by_job_ids(
+        self, job_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, Replay]:
+        """Bulk-load the replay of each job, keyed by job id.
+
+        Args:
+            job_ids: Ids of the jobs.
+
+        Returns:
+            Replays keyed by job id, jobs without a replay omitted.
+        """
+        if not job_ids:
+            return {}
+        statement = select(ReplayORM).where(ReplayORM.job_id.in_(list(job_ids)))
+        rows = (await self._session.scalars(statement)).all()
+        return {row.job_id: row.to_domain() for row in rows}
+
     async def query(
         self, replay_filter: ReplayFilter
     ) -> tuple[list[Replay], str | None]:
@@ -195,6 +212,32 @@ class SQLReplayRepository(BaseSQLRepository[ReplayORM]):
         row.apply(replay)
         await self._flush()
         return row.to_domain()
+
+    async def update_many(self, replays: list[Replay]) -> list[Replay]:
+        """Persist changes to many existing replays in one round trip.
+
+        No replay row is locked ahead of this call, so the rows are applied
+        in id order, the first lock each row's update takes is acquired in
+        the same order every caller touching many replay rows takes.
+
+        Args:
+            replays: Replays with modified fields.
+
+        Raises:
+            ReplayNotFound: A replay id matches no replay.
+
+        Returns:
+            Stored replays with the updated timestamp renewed, in id order.
+        """
+        if not replays:
+            return []
+        rows = []
+        for replay in sorted(replays, key=lambda replay: replay.id):
+            row = await self._get_row(replay.id)
+            row.apply(replay)
+            rows.append(row)
+        await self._flush()
+        return [row.to_domain() for row in rows]
 
     async def count_by_status(self, experiment_run_id: uuid.UUID) -> ReplayStatusCounts:
         """Count an experiment run's replays by status.

--- a/src/kitaru/server/adapters/db/repositories/session_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/session_repository.py
@@ -184,11 +184,7 @@ class SQLSessionRepository(BaseSQLRepository[SessionORM]):
         Returns:
             Stored session.
         """
-        row = await self._session.get(
-            self.orm_class, session_id, with_for_update=exclusive
-        )
-        if row is None:
-            raise SessionNotFound(session_id)
+        row = await self._get_row(session_id, exclusive=exclusive)
         return row.to_domain()
 
     async def query(

--- a/src/kitaru/server/adapters/db/repositories/task_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/task_repository.py
@@ -320,19 +320,23 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         await self._session.flush()
         return {task_id: cancel_requested_at for task_id, cancel_requested_at in rows}
 
-    async def stamp_cancel_requested(self, job_id: uuid.UUID, now: datetime) -> None:
-        """Stamp cancel_requested_at on the job's non-terminal tasks lacking it.
+    async def stamp_cancel_requested(
+        self, job_ids: Sequence[uuid.UUID], now: datetime
+    ) -> None:
+        """Stamp cancel_requested_at on the jobs' non-terminal tasks lacking it.
 
-        Rows are locked in id order.
+        Rows are locked in id order across all jobs.
 
         Args:
-            job_id: Id the tasks belong to.
+            job_ids: Ids the tasks belong to.
             now: Current time.
         """
+        if not job_ids:
+            return
         locked = (
             select(TaskORM.id)
             .where(
-                TaskORM.job_id == job_id,
+                TaskORM.job_id.in_(list(job_ids)),
                 not_(TaskORM.status.in_(TERMINAL_STATUS_VALUES)),
                 TaskORM.cancel_requested_at.is_(None),
             )

--- a/src/kitaru/server/adapters/db/repositories/task_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/task_repository.py
@@ -19,7 +19,8 @@ from datetime import datetime
 
 from sqlalchemy import ColumnElement, func, not_, or_, select, update
 
-from kitaru.api_models.v1.task import TaskKind, TaskStatus, WorkerScope
+from kitaru.api_models.v1.task import TaskKind, TaskStatus
+from kitaru.api_models.v1.worker import WorkerScope
 from kitaru.server.adapters.db.filtering import FilterBinding, compile_filter_expression
 from kitaru.server.adapters.db.orm.job import JobORM
 from kitaru.server.adapters.db.orm.task import (

--- a/src/kitaru/server/adapters/db/repositories/task_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/task_repository.py
@@ -21,6 +21,7 @@ from sqlalchemy import ColumnElement, func, not_, or_, select, update
 
 from kitaru.api_models.v1.task import TaskKind, TaskStatus, WorkerScope
 from kitaru.server.adapters.db.filtering import FilterBinding, compile_filter_expression
+from kitaru.server.adapters.db.orm.job import JobORM
 from kitaru.server.adapters.db.orm.task import (
     TASK_EVALUATOR_PAIR_UNIQUE_CONSTRAINT,
     TERMINAL_STATUS_VALUES,
@@ -332,7 +333,9 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
 
         Writes only the heartbeat column, so a stamp cannot overwrite fields
         concurrent writers committed since the caller last read the tasks.
-        Rows are locked in id order.
+        Task rows are locked in id order. The owning job row is joined for
+        its own cancel request, which reaches a task before the sweep stamps
+        it, and joining leaves that row unlocked.
 
         Args:
             task_ids: Candidate task ids.
@@ -340,7 +343,8 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
             now: Current time.
 
         Returns:
-            Cancel request time by id for every stamped task.
+            Cancel request time of the task, falling back to its job's, by id
+            for every stamped task.
         """
         if not task_ids:
             return {}
@@ -356,9 +360,12 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         )
         statement = (
             update(TaskORM)
-            .where(TaskORM.id.in_(locked))
+            .where(TaskORM.id.in_(locked), JobORM.id == TaskORM.job_id)
             .values(heartbeat_at=now, updated=now)
-            .returning(TaskORM.id, TaskORM.cancel_requested_at)
+            .returning(
+                TaskORM.id,
+                func.coalesce(TaskORM.cancel_requested_at, JobORM.cancel_requested_at),
+            )
             .execution_options(synchronize_session=False)
         )
         rows = (await self._session.execute(statement)).all()

--- a/src/kitaru/server/adapters/db/repositories/task_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/task_repository.py
@@ -210,6 +210,31 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         rows = (await self._session.scalars(statement)).all()
         return [row.to_domain() for row in rows]
 
+    async def list_by_jobs(
+        self, job_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, list[Task]]:
+        """Bulk-load every task of many jobs, grouped by job id in creation order.
+
+        Args:
+            job_ids: Ids the tasks belong to.
+
+        Returns:
+            Tasks keyed by job id in creation order, jobs without tasks
+            omitted.
+        """
+        if not job_ids:
+            return {}
+        statement = (
+            select(TaskORM)
+            .where(TaskORM.job_id.in_(list(job_ids)))
+            .order_by(TaskORM.job_id.asc(), TaskORM.id.asc())
+        )
+        rows = (await self._session.scalars(statement)).all()
+        tasks_by_job: dict[uuid.UUID, list[Task]] = {}
+        for row in rows:
+            tasks_by_job.setdefault(row.job_id, []).append(row.to_domain())
+        return tasks_by_job
+
     async def update(self, task: Task) -> Task:
         """Persist changes to an existing task.
 
@@ -351,6 +376,54 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         )
         await self._session.execute(statement)
         await self._session.flush()
+
+    async def cancel_pending(
+        self, job_ids: Sequence[uuid.UUID], now: datetime
+    ) -> list[Task]:
+        """Move each still-pending task of the jobs straight to canceled.
+
+        Rows are locked in id order across all jobs.
+
+        Args:
+            job_ids: Ids the tasks belong to.
+            now: Current time.
+
+        Returns:
+            Canceled tasks.
+        """
+        if not job_ids:
+            return []
+        locked = (
+            select(TaskORM.id)
+            .where(
+                TaskORM.job_id.in_(list(job_ids)),
+                TaskORM.status == TaskStatus.PENDING.value,
+            )
+            .order_by(TaskORM.id.asc())
+            .with_for_update()
+        )
+        statement = (
+            update(TaskORM)
+            .where(TaskORM.id.in_(locked))
+            .values(
+                status=TaskStatus.CANCELED.value,
+                ended_at=now,
+                cancel_requested_at=func.coalesce(TaskORM.cancel_requested_at, now),
+                updated=now,
+            )
+            .returning(TaskORM.id)
+            .execution_options(synchronize_session="fetch")
+        )
+        canceled_ids = (await self._session.scalars(statement)).all()
+        await self._session.flush()
+        if not canceled_ids:
+            return []
+        rows = await self._session.scalars(
+            select(TaskORM)
+            .where(TaskORM.id.in_(canceled_ids))
+            .order_by(TaskORM.id.asc())
+        )
+        return [row.to_domain() for row in rows]
 
     async def get_scored_evaluator_version_ids(
         self, input_session_id: uuid.UUID

--- a/src/kitaru/server/adapters/db/repositories/task_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/task_repository.py
@@ -23,6 +23,7 @@ from kitaru.api_models.v1.task import TaskKind, TaskStatus, WorkerScope
 from kitaru.server.adapters.db.filtering import FilterBinding, compile_filter_expression
 from kitaru.server.adapters.db.orm.task import (
     TASK_EVALUATOR_PAIR_UNIQUE_CONSTRAINT,
+    TERMINAL_STATUS_VALUES,
     TaskORM,
 )
 from kitaru.server.adapters.db.pagination import paginate
@@ -30,14 +31,12 @@ from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.task import TaskFilter
 from kitaru.server.domain.base import NotFoundError
 from kitaru.server.domain.task import (
-    TERMINAL_TASK_STATUSES,
     DuplicateEvaluationTask,
     Task,
     TaskNotFound,
 )
 
 IN_FLIGHT_STATUS_VALUES = [TaskStatus.CLAIMED.value, TaskStatus.RUNNING.value]
-TERMINAL_STATUS_VALUES = [status.value for status in TERMINAL_TASK_STATUSES]
 
 _LAST_SEEN = func.coalesce(TaskORM.heartbeat_at, TaskORM.claimed_at)
 
@@ -147,11 +146,7 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         Returns:
             Stored task.
         """
-        row = await self._session.get(
-            self.orm_class, task_id, with_for_update=exclusive
-        )
-        if row is None:
-            raise TaskNotFound(task_id)
+        row = await self._get_row(task_id, exclusive=exclusive)
         return row.to_domain()
 
     async def get_many(self, task_ids: Sequence[uuid.UUID]) -> dict[uuid.UUID, Task]:
@@ -285,25 +280,50 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         await self._flush()
         return [row.to_domain() for row in rows]
 
-    async def claim_stale(self, cutoff: datetime, limit: int) -> list[Task]:
-        """Lock in-flight tasks whose last heartbeat is older than a cutoff.
+    async def claim_stale(self, task_id: uuid.UUID, cutoff: datetime) -> Task | None:
+        """Lock one task by id if it is still in flight and older than a cutoff.
+
+        The row is locked with ``FOR UPDATE SKIP LOCKED``, so concurrent
+        sweeps take disjoint tasks. Staleness is re-checked on the locked
+        row because the candidate read ran unlocked.
 
         Args:
+            task_id: Id of the candidate task.
             cutoff: Bound the last heartbeat must be older than.
-            limit: Maximum number of tasks to lock.
 
         Returns:
-            Locked stale tasks.
+            Locked stale task, or ``None`` when it is contended or no longer
+            stale.
         """
         statement = (
             select(TaskORM)
+            .where(
+                TaskORM.id == task_id,
+                TaskORM.status.in_(IN_FLIGHT_STATUS_VALUES),
+                cutoff > _LAST_SEEN,
+            )
+            .with_for_update(skip_locked=True)
+        )
+        row = (await self._session.scalars(statement)).one_or_none()
+        return row.to_domain() if row is not None else None
+
+    async def list_stale_ids(self, cutoff: datetime, limit: int) -> list[uuid.UUID]:
+        """Read the ids of in-flight tasks whose last heartbeat is older than a cutoff.
+
+        Args:
+            cutoff: Bound the last heartbeat must be older than.
+            limit: Maximum number of ids to read.
+
+        Returns:
+            Ids of the stale tasks in ascending order.
+        """
+        statement = (
+            select(TaskORM.id)
             .where(TaskORM.status.in_(IN_FLIGHT_STATUS_VALUES), cutoff > _LAST_SEEN)
             .order_by(TaskORM.id.asc())
             .limit(limit)
-            .with_for_update(skip_locked=True)
         )
-        rows = (await self._session.scalars(statement)).all()
-        return [row.to_domain() for row in rows]
+        return list((await self._session.scalars(statement)).all())
 
     async def stamp_heartbeats(
         self, task_ids: Sequence[uuid.UUID], worker_id: uuid.UUID, now: datetime
@@ -344,6 +364,32 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         rows = (await self._session.execute(statement)).all()
         await self._session.flush()
         return {task_id: cancel_requested_at for task_id, cancel_requested_at in rows}
+
+    async def lock_by_jobs(
+        self, job_ids: Sequence[uuid.UUID], nowait: bool = False
+    ) -> None:
+        """Lock the jobs' non-terminal task rows in id order.
+
+        Args:
+            job_ids: Ids the tasks belong to.
+            nowait: Whether to fail instead of waiting when another
+                transaction holds one of the rows.
+
+        Raises:
+            DBAPIError: ``nowait`` is set and a row is held elsewhere.
+        """
+        if not job_ids:
+            return
+        statement = (
+            select(TaskORM.id)
+            .where(
+                TaskORM.job_id.in_(list(job_ids)),
+                not_(TaskORM.status.in_(TERMINAL_STATUS_VALUES)),
+            )
+            .order_by(TaskORM.id.asc())
+            .with_for_update(nowait=nowait)
+        )
+        await self._session.execute(statement)
 
     async def stamp_cancel_requested(
         self, job_ids: Sequence[uuid.UUID], now: datetime

--- a/src/kitaru/server/adapters/rest/dependencies.py
+++ b/src/kitaru/server/adapters/rest/dependencies.py
@@ -488,6 +488,7 @@ def get_session_node_service(
     return SessionNodeService(
         repository=SQLSessionNodeRepository(session),
         session_repository=SQLSessionRepository(session),
+        task_repository=SQLTaskRepository(session),
     )
 
 

--- a/src/kitaru/server/adapters/rest/routers/experiment_runs.py
+++ b/src/kitaru/server/adapters/rest/routers/experiment_runs.py
@@ -36,6 +36,7 @@ from kitaru.server.adapters.rest.mapping.experiment_runs import (
     experiment_run_to_response,
 )
 from kitaru.server.adapters.rest.mapping.jobs import job_to_response
+from kitaru.server.api.run_cancellation import RunCanceler, get_run_canceler
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.services.experiment_run_service import (
     ExperimentRunService,
@@ -145,6 +146,7 @@ async def cancel_experiment_run(
     experiment_run_id: uuid.UUID,
     service: Annotated[ExperimentRunService, Depends(get_experiment_run_service)],
     actor: Annotated[AuthContext, Depends(authorize)],
+    cancel: Annotated[RunCanceler, Depends(get_run_canceler)],
 ) -> ExperimentRunResponse:
     """Request cancellation of a running experiment run.
 
@@ -155,9 +157,10 @@ async def cancel_experiment_run(
         experiment_run_id: Id of the run.
         service: Experiment run service.
         actor: Caller context.
+        cancel: Run cancellation flow, committed across its own transactions.
 
     Returns:
         Run carrying the cancel request.
     """
-    run, counts = await service.cancel_run(experiment_run_id, actor=actor)
+    run, counts = await cancel(experiment_run_id, actor)
     return experiment_run_to_response(run, counts)

--- a/src/kitaru/server/adapters/rest/routers/experiment_runs.py
+++ b/src/kitaru/server/adapters/rest/routers/experiment_runs.py
@@ -144,7 +144,6 @@ async def list_experiment_run_jobs(
 @router.post("/{experiment_run_id}/cancel")
 async def cancel_experiment_run(
     experiment_run_id: uuid.UUID,
-    service: Annotated[ExperimentRunService, Depends(get_experiment_run_service)],
     actor: Annotated[AuthContext, Depends(authorize)],
     cancel: Annotated[RunCanceler, Depends(get_run_canceler)],
 ) -> ExperimentRunResponse:
@@ -155,7 +154,6 @@ async def cancel_experiment_run(
 
     Args:
         experiment_run_id: Id of the run.
-        service: Experiment run service.
         actor: Caller context.
         cancel: Run cancellation flow, committed across its own transactions.
 

--- a/src/kitaru/server/api/app.py
+++ b/src/kitaru/server/api/app.py
@@ -20,6 +20,7 @@ from importlib.metadata import version
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from sqlalchemy.exc import DBAPIError
 
 from kitaru.analytics.client import AnalyticsClient
 from kitaru.analytics.source import (
@@ -31,6 +32,7 @@ from kitaru.analytics.source import (
 from kitaru.api_models.v1.info import AuthScheme
 from kitaru.server.adapters.auth.control_plane import ControlPlaneClient
 from kitaru.server.adapters.auth.passwords import BcryptPasswordHasher
+from kitaru.server.adapters.db.errors import is_deadlock
 from kitaru.server.adapters.db.repositories.account_repository import (
     SQLAccountRepository,
 )
@@ -126,6 +128,24 @@ def _register_domain_exception_handlers(app: FastAPI) -> None:
     async def domain_error(request: Request, exc: DomainError) -> JSONResponse:
         _ = request
         return JSONResponse(status_code=500, content={"detail": str(exc)})
+
+
+def _register_deadlock_exception_handler(app: FastAPI) -> None:
+    """Register the JSON error response for a deadlock-canceled transaction.
+
+    Clients receive HTTP 503 with the usual ``detail`` message. Any other
+    database error propagates unchanged.
+
+    Args:
+        app: FastAPI application that will serve the v1 API.
+    """
+
+    @app.exception_handler(DBAPIError)
+    async def deadlock(request: Request, exc: DBAPIError) -> JSONResponse:
+        _ = request
+        if not is_deadlock(exc):
+            raise exc
+        return JSONResponse(status_code=503, content={"detail": "Deadlock detected"})
 
 
 def _register_token_grant_exception_handler(app: FastAPI) -> None:
@@ -236,6 +256,7 @@ def create_app(settings: APISettings) -> FastAPI:
     # Replaced with a live client at startup under the control plane scheme.
     app.state.control_plane_client = None
     _register_domain_exception_handlers(app)
+    _register_deadlock_exception_handler(app)
     _register_token_grant_exception_handler(app)
     app.middleware("http")(_set_analytics_source)
     # FastAPIInstrumentor registers its middleware last, which makes the

--- a/src/kitaru/server/api/composition.py
+++ b/src/kitaru/server/api/composition.py
@@ -33,8 +33,8 @@ from kitaru.server.adapters.db.repositories.replay_repository import (
 from kitaru.server.adapters.db.repositories.task_repository import SQLTaskRepository
 from kitaru.server.application.events import (
     EventDispatcher,
-    JobSettled,
-    ReplaySettled,
+    JobsSettled,
+    ReplaysSettled,
     TaskTerminal,
 )
 from kitaru.server.application.interfaces.evaluation_repository import (
@@ -102,17 +102,17 @@ def register_subscribers(
         ),
     )
     dispatcher.register(
-        JobSettled,
+        JobsSettled,
         partial(
-            replay_pipeline.settle_replay,
+            replay_pipeline.settle_replays,
             replay_repository=replay_repository,
             dispatcher=dispatcher,
         ),
     )
     dispatcher.register(
-        ReplaySettled,
+        ReplaysSettled,
         partial(
-            run_finalization.finalize_run_if_drained,
+            run_finalization.finalize_runs_if_drained,
             replay_repository=replay_repository,
             experiment_run_repository=experiment_run_repository,
             analytics=analytics,

--- a/src/kitaru/server/api/main.py
+++ b/src/kitaru/server/api/main.py
@@ -37,7 +37,7 @@ def main() -> None:
     """Run the API server."""
     settings = APISettings()
     uvicorn.run(
-        app(settings),
+        app(),
         host=settings.HOST,
         port=settings.PORT,
         log_level=settings.LOG_LEVEL.lower(),

--- a/src/kitaru/server/api/run_cancellation.py
+++ b/src/kitaru/server/api/run_cancellation.py
@@ -50,11 +50,9 @@ async def cancel_run(
 ) -> tuple[ExperimentRun, ReplayStatusCounts]:
     """Mark a run canceling, then cancel its jobs in a second transaction.
 
-    Marking the run touches only the run row and commits, so the second
-    transaction never holds the run row lock while reaching for a task row.
-    That transaction takes its locks in the task, job, replay, run order the
-    reporting and claiming paths take. Doing all of it at once deadlocks
-    against a worker reporting one of those tasks.
+    The first transaction locks the run row alone and commits, so the second
+    takes its task, job, replay, and run locks in that order without already
+    holding the run row.
 
     A run left canceling by a failure part way through is finished by calling
     this again, because marking an already canceling run is a no-op.

--- a/src/kitaru/server/api/run_cancellation.py
+++ b/src/kitaru/server/api/run_cancellation.py
@@ -48,14 +48,13 @@ async def cancel_run(
     settings: APISettings,
     analytics: AnalyticsClient,
 ) -> tuple[ExperimentRun, ReplayStatusCounts]:
-    """Mark a run canceling, then cancel each of its jobs in its own transaction.
+    """Mark a run canceling, then cancel its jobs in a second transaction.
 
-    Every transaction here takes its locks in the task, job, run order the
-    reporting and claiming paths take. Marking the run touches only the run
-    row and commits, and each job is cancelled and committed on its own, so
-    no transaction ever holds the run row lock while reaching for another
-    job's task rows. Doing all of it at once deadlocks against a worker
-    reporting one of those tasks.
+    Marking the run touches only the run row and commits, so the second
+    transaction never holds the run row lock while reaching for a task row.
+    That transaction takes its locks in the task, job, replay, run order the
+    reporting and claiming paths take. Doing all of it at once deadlocks
+    against a worker reporting one of those tasks.
 
     A run left canceling by a failure part way through is finished by calling
     this again, because marking an already canceling run is a no-op.
@@ -86,13 +85,7 @@ async def cancel_run(
     async for session in database.get_async_session():
         try:
             service = _build_service(session, settings, analytics)
-            job_ids = await service.list_cancelable_job_ids(
-                experiment_run_id, actor=actor
-            )
-            for job_id in job_ids:
-                await service.cancel_run_job(job_id, actor=actor)
-                await session.commit()
-            result = await service.get_run(experiment_run_id, actor=actor)
+            result = await service.cancel_run_jobs(experiment_run_id, actor=actor)
             await session.commit()
             return result
         except Exception:
@@ -138,8 +131,6 @@ def get_run_canceler(
     async def cancel(
         experiment_run_id: uuid.UUID, actor: AuthContext
     ) -> tuple[ExperimentRun, ReplayStatusCounts]:
-        return await cancel_run(
-            experiment_run_id, actor, database, settings, analytics
-        )
+        return await cancel_run(experiment_run_id, actor, database, settings, analytics)
 
     return cancel

--- a/src/kitaru/server/api/run_cancellation.py
+++ b/src/kitaru/server/api/run_cancellation.py
@@ -1,0 +1,145 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Experiment run cancellation, split across transactions to order its locks."""
+
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Annotated
+
+from fastapi import Depends, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from kitaru.analytics.client import AnalyticsClient
+from kitaru.server.adapters.rest.dependencies import (
+    get_analytics_client,
+    get_app_settings,
+    get_experiment_run_service,
+    get_server_analytics,
+)
+from kitaru.server.api.config import APISettings
+from kitaru.server.application.models.auth import AuthContext
+from kitaru.server.application.models.replay import ReplayStatusCounts
+from kitaru.server.application.services.experiment_run_service import (
+    ExperimentRunService,
+)
+from kitaru.server.database.service import DatabaseService
+from kitaru.server.domain.experiment_run import ExperimentRun
+
+RunCanceler = Callable[
+    [uuid.UUID, AuthContext], Awaitable[tuple[ExperimentRun, ReplayStatusCounts]]
+]
+
+
+async def cancel_run(
+    experiment_run_id: uuid.UUID,
+    actor: AuthContext,
+    database: DatabaseService,
+    settings: APISettings,
+    analytics: AnalyticsClient,
+) -> tuple[ExperimentRun, ReplayStatusCounts]:
+    """Mark a run canceling, then cancel each of its jobs in its own transaction.
+
+    Every transaction here takes its locks in the task, job, run order the
+    reporting and claiming paths take. Marking the run touches only the run
+    row and commits, and each job is cancelled and committed on its own, so
+    no transaction ever holds the run row lock while reaching for another
+    job's task rows. Doing all of it at once deadlocks against a worker
+    reporting one of those tasks.
+
+    A run left canceling by a failure part way through is finished by calling
+    this again, because marking an already canceling run is a no-op.
+
+    Args:
+        experiment_run_id: Id of the run.
+        actor: Caller context.
+        database: Database service the phases open sessions against.
+        settings: API settings for this process.
+        analytics: Analytics client for this process.
+
+    Raises:
+        ExperimentRunNotFound: No run has this id.
+        IllegalExperimentRunStatusTransition: The run is not running.
+
+    Returns:
+        Run carrying the cancel request, and its replay counts by status.
+    """
+    async for session in database.get_async_session():
+        try:
+            service = _build_service(session, settings, analytics)
+            await service.mark_run_canceling(experiment_run_id, actor=actor)
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+    async for session in database.get_async_session():
+        try:
+            service = _build_service(session, settings, analytics)
+            job_ids = await service.list_cancelable_job_ids(
+                experiment_run_id, actor=actor
+            )
+            for job_id in job_ids:
+                await service.cancel_run_job(job_id, actor=actor)
+                await session.commit()
+            result = await service.get_run(experiment_run_id, actor=actor)
+            await session.commit()
+            return result
+        except Exception:
+            await session.rollback()
+            raise
+    raise RuntimeError("Database service yielded no session.")
+
+
+def _build_service(
+    session: AsyncSession, settings: APISettings, analytics: AnalyticsClient
+) -> ExperimentRunService:
+    """Build a run service the same way a request does.
+
+    Args:
+        session: Session the service binds its repositories to.
+        settings: API settings for this process.
+        analytics: Analytics client for this process.
+
+    Returns:
+        Experiment run service.
+    """
+    tracker = get_server_analytics(session, settings, analytics)
+    return get_experiment_run_service(session, tracker)
+
+
+def get_run_canceler(
+    request: Request,
+    settings: Annotated[APISettings, Depends(get_app_settings)],
+    analytics: Annotated[AnalyticsClient, Depends(get_analytics_client)],
+) -> RunCanceler:
+    """Return the run cancellation flow, bound to this process.
+
+    Args:
+        request: Incoming request.
+        settings: API settings for this process.
+        analytics: Analytics client for this process.
+
+    Returns:
+        Callable cancelling a run across its own transactions.
+    """
+    database: DatabaseService = request.app.state.database
+
+    async def cancel(
+        experiment_run_id: uuid.UUID, actor: AuthContext
+    ) -> tuple[ExperimentRun, ReplayStatusCounts]:
+        return await cancel_run(
+            experiment_run_id, actor, database, settings, analytics
+        )
+
+    return cancel

--- a/src/kitaru/server/api/task_sweeper.py
+++ b/src/kitaru/server/api/task_sweeper.py
@@ -103,7 +103,7 @@ async def _read_candidates(
 async def sweep_once(
     database: DatabaseService, settings: APISettings, analytics: AnalyticsClient
 ) -> None:
-    """Rescue stale tasks and propagate pending job cancels, one item per transaction.
+    """Propagate pending job cancels and rescue stale tasks, one item per transaction.
 
     A candidate another replica already holds is skipped and picked up on a
     later tick. A failing item logs and leaves the remaining items to run.
@@ -115,14 +115,11 @@ async def sweep_once(
     """
     now = datetime.now(UTC)
     task_ids, job_ids = await _read_candidates(database, settings, analytics, now)
-    for task_id in task_ids:
-        await _run_unit(
-            database,
-            settings,
-            analytics,
-            partial(TaskService.sweep_stale_task, task_id=task_id, now=now),
-            f"stale task {task_id}",
-        )
+    # Propagate first. The rescue chooses between canceling and requeuing by
+    # reading the task's own cancel_requested_at, so a stale task of a
+    # canceling job whose stamp has not landed yet is requeued instead of
+    # canceled, burning a retry attempt and leaving a window for a worker to
+    # claim it.
     for job_id in job_ids:
         await _run_unit(
             database,
@@ -130,6 +127,14 @@ async def sweep_once(
             analytics,
             partial(TaskService.propagate_job_cancel, job_id=job_id),
             f"cancel propagation for job {job_id}",
+        )
+    for task_id in task_ids:
+        await _run_unit(
+            database,
+            settings,
+            analytics,
+            partial(TaskService.sweep_stale_task, task_id=task_id, now=now),
+            f"stale task {task_id}",
         )
 
 

--- a/src/kitaru/server/api/task_sweeper.py
+++ b/src/kitaru/server/api/task_sweeper.py
@@ -11,46 +11,126 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Background stale-task sweep loop."""
+"""Background stale-task and cancel-propagation sweep loop."""
 
 import asyncio
 import contextlib
 import logging
+import uuid
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
+from functools import partial
+
+from sqlalchemy.exc import DBAPIError
 
 from kitaru.analytics.client import AnalyticsClient
+from kitaru.server.adapters.db.errors import is_lock_not_available
 from kitaru.server.adapters.rest.dependencies import (
     get_server_analytics,
     get_task_service,
 )
 from kitaru.server.api.config import APISettings
+from kitaru.server.application.services.task_service import TaskService
 from kitaru.server.database.service import DatabaseService
 
 logger = logging.getLogger(__name__)
 
+SweepUnit = Callable[[TaskService], Awaitable[None]]
 
-async def sweep_once(
-    database: DatabaseService, settings: APISettings, analytics: AnalyticsClient
+
+async def _run_unit(
+    database: DatabaseService,
+    settings: APISettings,
+    analytics: AnalyticsClient,
+    unit: SweepUnit,
+    label: str,
 ) -> None:
-    """Sweep stale tasks once, in one session, and commit the result.
+    """Run one sweep unit in its own transaction and commit it.
 
-    Builds the task service the same way a request does, so a settlement
-    the sweep applies dispatches through the same event subscribers.
+    Builds the task service the same way a request does, so a settlement the
+    unit applies dispatches through the same event subscribers. A failure
+    rolls the unit back and leaves the remaining units to run.
 
     Args:
-        database: Database service the sweep opens a session against.
+        database: Database service the unit opens a session against.
         settings: API settings for this process.
         analytics: Analytics client for this process.
+        unit: Work to run against the service.
+        label: Name of the unit for the failure log.
+    """
+    async for session in database.get_async_session():
+        try:
+            tracker = get_server_analytics(session, settings, analytics)
+            await unit(get_task_service(session, settings, tracker))
+            await session.commit()
+        except Exception as exc:
+            await session.rollback()
+            if isinstance(exc, DBAPIError) and is_lock_not_available(exc):
+                logger.debug("Sweep unit %s skipped a contended row.", label)
+            else:
+                logger.warning("Sweep unit %s failed: %s", label, exc)
+
+
+async def _read_candidates(
+    database: DatabaseService,
+    settings: APISettings,
+    analytics: AnalyticsClient,
+    now: datetime,
+) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+    """Read the stale task ids and the canceling job ids without locking.
+
+    Args:
+        database: Database service the read opens a session against.
+        settings: API settings for this process.
+        analytics: Analytics client for this process.
+        now: Current time.
+
+    Returns:
+        Stale task ids and job ids owing a cancel propagation.
     """
     async for session in database.get_async_session():
         try:
             tracker = get_server_analytics(session, settings, analytics)
             service = get_task_service(session, settings, tracker)
-            await service.sweep_stale_tasks(datetime.now(UTC))
-            await session.commit()
-        except Exception:
+            task_ids = await service.list_stale_task_ids(now)
+            job_ids = await service.list_unpropagated_cancel_job_ids()
+            return task_ids, job_ids
+        finally:
             await session.rollback()
-            raise
+    return [], []
+
+
+async def sweep_once(
+    database: DatabaseService, settings: APISettings, analytics: AnalyticsClient
+) -> None:
+    """Rescue stale tasks and propagate pending job cancels, one item per transaction.
+
+    A candidate another replica already holds is skipped and picked up on a
+    later tick. A failing item logs and leaves the remaining items to run.
+
+    Args:
+        database: Database service the sweep opens sessions against.
+        settings: API settings for this process.
+        analytics: Analytics client for this process.
+    """
+    now = datetime.now(UTC)
+    task_ids, job_ids = await _read_candidates(database, settings, analytics, now)
+    for task_id in task_ids:
+        await _run_unit(
+            database,
+            settings,
+            analytics,
+            partial(TaskService.sweep_stale_task, task_id=task_id, now=now),
+            f"stale task {task_id}",
+        )
+    for job_id in job_ids:
+        await _run_unit(
+            database,
+            settings,
+            analytics,
+            partial(TaskService.propagate_job_cancel, job_id=job_id),
+            f"cancel propagation for job {job_id}",
+        )
 
 
 async def _run_sweep_loop(
@@ -75,10 +155,25 @@ async def _run_sweep_loop(
         await asyncio.sleep(interval_seconds)
 
 
+def _log_sweeper_exit(task: asyncio.Task[None]) -> None:
+    """Log a sweep loop that stopped running.
+
+    Args:
+        task: Finished sweep task.
+    """
+    if task.cancelled():
+        return
+    exception = task.exception()
+    if exception is None:
+        logger.error("Stale task sweep loop exited without an error.")
+    else:
+        logger.error("Stale task sweep loop died: %s", exception, exc_info=exception)
+
+
 def start_task_sweeper(
     database: DatabaseService, settings: APISettings, analytics: AnalyticsClient
 ) -> asyncio.Task[None] | None:
-    """Start the background stale-task sweep loop unless it is disabled.
+    """Start the background sweep loop unless it is disabled.
 
     Args:
         database: Database service the sweep opens sessions against.
@@ -90,11 +185,13 @@ def start_task_sweeper(
     """
     if settings.TASK_SWEEP_INTERVAL_SECONDS <= 0:
         return None
-    return asyncio.create_task(
+    task = asyncio.create_task(
         _run_sweep_loop(
             database, settings, analytics, settings.TASK_SWEEP_INTERVAL_SECONDS
         )
     )
+    task.add_done_callback(_log_sweeper_exit)
+    return task
 
 
 async def stop_task_sweeper(task: asyncio.Task[None] | None) -> None:

--- a/src/kitaru/server/application/AGENTS.md
+++ b/src/kitaru/server/application/AGENTS.md
@@ -27,6 +27,25 @@
 - A use case that reads a row's status and writes a transition based on it
   must load the row with `get(..., exclusive=True)`. An unlocked transition is
   last-writer-wins, so a racing cancel or claim is silently reverted.
+- Row locks follow four rules. They are what keeps concurrent claims, task
+  reports, cancels, and sweeps from deadlocking, so a change that breaks one
+  of them is a defect even when the tests pass.
+  1. One total order across lock classes: task rows, then session rows, then
+     job rows, then replay rows, then the run row. Ascending id within a
+     class.
+  2. A transaction computes the full set of rows it will lock in a class
+     before locking any of them, and takes them in a single ordered
+     acquisition. Never lock, discover more work, then lock again in the same
+     class. Re-locking rows already held is always fine.
+  3. Plain reads never lock and are always safe regardless of held locks.
+  4. Skipping is allowed only when the transaction will never reach for the
+     skipped rows later. In practice: `SKIP LOCKED` on a claim whose
+     transaction touches only the claimed rows, `NOWAIT` on an
+     all-or-nothing acquisition where failure aborts the whole transaction.
+- A use case that would have to lock a second, unbounded set of rows to
+  finish its work stamps the intent instead and lets the background sweep
+  carry it out in its own transaction. Widening a hot-path transaction to
+  cover the follow-up work breaks rule 2.
 - Uniqueness is enforced by database constraints, not by lookups. Do not
   pre-check before a write, the repository translates the constraint violation
   into the domain error.

--- a/src/kitaru/server/application/events.py
+++ b/src/kitaru/server/application/events.py
@@ -37,17 +37,17 @@ class TaskTerminal(Event):
 
 
 @dataclass(frozen=True)
-class JobSettled(Event):
-    """Job settled event."""
+class JobsSettled(Event):
+    """Jobs settled event."""
 
-    job: Job
+    jobs: list[Job]
 
 
 @dataclass(frozen=True)
-class ReplaySettled(Event):
-    """Replay settled event."""
+class ReplaysSettled(Event):
+    """Replays settled event."""
 
-    replay: Replay
+    replays: list[Replay]
 
 
 EventT = TypeVar("EventT", bound=Event)

--- a/src/kitaru/server/application/interfaces/cohort_repository.py
+++ b/src/kitaru/server/application/interfaces/cohort_repository.py
@@ -37,11 +37,13 @@ class CohortRepository(Protocol):
         """
         ...
 
-    async def get(self, cohort_id: uuid.UUID) -> Cohort:
+    async def get(self, cohort_id: uuid.UUID, exclusive: bool = False) -> Cohort:
         """Load a cohort by id.
 
         Args:
             cohort_id: Id of the cohort.
+            exclusive: Whether to lock the row for the duration of the
+                transaction.
 
         Raises:
             CohortNotFound: No cohort has this id.

--- a/src/kitaru/server/application/interfaces/cohort_version_repository.py
+++ b/src/kitaru/server/application/interfaces/cohort_version_repository.py
@@ -46,11 +46,15 @@ class CohortVersionRepository(Protocol):
         """
         ...
 
-    async def get(self, cohort_version_id: uuid.UUID) -> CohortVersion:
+    async def get(
+        self, cohort_version_id: uuid.UUID, exclusive: bool = False
+    ) -> CohortVersion:
         """Load a cohort version by id.
 
         Args:
             cohort_version_id: Id of the cohort version.
+            exclusive: Whether to lock the row for the duration of the
+                transaction.
 
         Raises:
             CohortVersionIdNotFound: No cohort version has this id.

--- a/src/kitaru/server/application/interfaces/job_repository.py
+++ b/src/kitaru/server/application/interfaces/job_repository.py
@@ -88,6 +88,21 @@ class JobRepository(Protocol):
         """
         ...
 
+    async def list_unpropagated_cancel_ids(self, limit: int) -> list[uuid.UUID]:
+        """Read the ids of canceling jobs whose live tasks still owe the stamp.
+
+        A live task owes the stamp when it carries no cancel request of its
+        own, or when it is still pending and has to move straight to
+        canceled. Rows are read without locking.
+
+        Args:
+            limit: Maximum number of ids to read.
+
+        Returns:
+            Ids of the canceling jobs in ascending order.
+        """
+        ...
+
     async def query(self, job_filter: JobFilter) -> tuple[list[Job], str | None]:
         """Query jobs matching a filter.
 

--- a/src/kitaru/server/application/interfaces/job_repository.py
+++ b/src/kitaru/server/application/interfaces/job_repository.py
@@ -73,6 +73,21 @@ class JobRepository(Protocol):
         """
         ...
 
+    async def get_many_locked(
+        self, job_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, Job]:
+        """Bulk-lock and load jobs by id, keyed by id, missing ids omitted.
+
+        Rows are locked in id order in one statement.
+
+        Args:
+            job_ids: Ids of the jobs to load.
+
+        Returns:
+            Locked jobs keyed by id.
+        """
+        ...
+
     async def query(self, job_filter: JobFilter) -> tuple[list[Job], str | None]:
         """Query jobs matching a filter.
 
@@ -95,6 +110,20 @@ class JobRepository(Protocol):
 
         Returns:
             Stored job with the updated timestamp renewed.
+        """
+        ...
+
+    async def update_many(self, jobs: list[Job]) -> list[Job]:
+        """Persist changes to many existing jobs in one round trip.
+
+        Args:
+            jobs: Jobs with modified fields.
+
+        Raises:
+            JobNotFound: A job id matches no job.
+
+        Returns:
+            Stored jobs with the updated timestamp renewed, in the same order.
         """
         ...
 

--- a/src/kitaru/server/application/interfaces/job_repository.py
+++ b/src/kitaru/server/application/interfaces/job_repository.py
@@ -152,3 +152,17 @@ class JobRepository(Protocol):
             JobNotFound: No job has this id.
         """
         ...
+
+    async def delete_many(self, job_ids: Sequence[uuid.UUID]) -> None:
+        """Delete many jobs by id, cascading their tasks.
+
+        The jobs' task rows are locked in id order across all jobs before
+        the job rows, which are deleted in ascending id order.
+
+        Args:
+            job_ids: Ids of the jobs.
+
+        Raises:
+            JobNotFound: A job id matches no job.
+        """
+        ...

--- a/src/kitaru/server/application/interfaces/replay_repository.py
+++ b/src/kitaru/server/application/interfaces/replay_repository.py
@@ -76,6 +76,19 @@ class ReplayRepository(Protocol):
         """
         ...
 
+    async def get_many_by_job_ids(
+        self, job_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, Replay]:
+        """Bulk-load the replay of each job, keyed by job id.
+
+        Args:
+            job_ids: Ids of the jobs.
+
+        Returns:
+            Replays keyed by job id, jobs without a replay omitted.
+        """
+        ...
+
     async def query(
         self, replay_filter: ReplayFilter
     ) -> tuple[list[Replay], str | None]:
@@ -113,6 +126,21 @@ class ReplayRepository(Protocol):
 
         Returns:
             Stored replay with the updated timestamp renewed.
+        """
+        ...
+
+    async def update_many(self, replays: list[Replay]) -> list[Replay]:
+        """Persist changes to many existing replays in one round trip.
+
+        Args:
+            replays: Replays with modified fields.
+
+        Raises:
+            ReplayNotFound: A replay id matches no replay.
+
+        Returns:
+            Stored replays with the updated timestamp renewed, in the same
+            order.
         """
         ...
 

--- a/src/kitaru/server/application/interfaces/task_repository.py
+++ b/src/kitaru/server/application/interfaces/task_repository.py
@@ -195,7 +195,8 @@ class TaskRepository(Protocol):
             now: Current time.
 
         Returns:
-            Cancel request time by id for every stamped task.
+            Cancel request time of the task, falling back to its job's, by id
+            for every stamped task.
         """
         ...
 

--- a/src/kitaru/server/application/interfaces/task_repository.py
+++ b/src/kitaru/server/application/interfaces/task_repository.py
@@ -152,18 +152,32 @@ class TaskRepository(Protocol):
         """
         ...
 
-    async def claim_stale(self, cutoff: datetime, limit: int) -> list[Task]:
-        """Lock in-flight tasks whose last heartbeat is older than a cutoff.
+    async def claim_stale(self, task_id: uuid.UUID, cutoff: datetime) -> Task | None:
+        """Lock one task by id if it is still in flight and older than a cutoff.
 
-        Rows are locked with ``FOR UPDATE SKIP LOCKED``, so concurrent sweeps
-        take disjoint tasks.
+        The row is locked with ``FOR UPDATE SKIP LOCKED``, so concurrent
+        sweeps take disjoint tasks. Staleness is re-checked on the locked
+        row because the candidate read ran unlocked.
+
+        Args:
+            task_id: Id of the candidate task.
+            cutoff: Bound the last heartbeat must be older than.
+
+        Returns:
+            Locked stale task, or ``None`` when it is contended or no longer
+            stale.
+        """
+        ...
+
+    async def list_stale_ids(self, cutoff: datetime, limit: int) -> list[uuid.UUID]:
+        """Read the ids of in-flight tasks whose last heartbeat is older than a cutoff.
 
         Args:
             cutoff: Bound the last heartbeat must be older than.
-            limit: Maximum number of tasks to lock.
+            limit: Maximum number of ids to read.
 
         Returns:
-            Locked stale tasks.
+            Ids of the stale tasks in ascending order.
         """
         ...
 
@@ -182,6 +196,18 @@ class TaskRepository(Protocol):
 
         Returns:
             Cancel request time by id for every stamped task.
+        """
+        ...
+
+    async def lock_by_jobs(
+        self, job_ids: Sequence[uuid.UUID], nowait: bool = False
+    ) -> None:
+        """Lock the jobs' non-terminal task rows in id order.
+
+        Args:
+            job_ids: Ids the tasks belong to.
+            nowait: Whether to fail instead of waiting when another
+                transaction holds one of the rows.
         """
         ...
 

--- a/src/kitaru/server/application/interfaces/task_repository.py
+++ b/src/kitaru/server/application/interfaces/task_repository.py
@@ -104,6 +104,20 @@ class TaskRepository(Protocol):
         """
         ...
 
+    async def list_by_jobs(
+        self, job_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, list[Task]]:
+        """Bulk-load every task of many jobs, grouped by job id in creation order.
+
+        Args:
+            job_ids: Ids the tasks belong to.
+
+        Returns:
+            Tasks keyed by job id in creation order, jobs without tasks
+            omitted.
+        """
+        ...
+
     async def update(self, task: Task) -> Task:
         """Persist changes to an existing task.
 
@@ -179,6 +193,20 @@ class TaskRepository(Protocol):
         Args:
             job_ids: Ids the tasks belong to.
             now: Current time.
+        """
+        ...
+
+    async def cancel_pending(
+        self, job_ids: Sequence[uuid.UUID], now: datetime
+    ) -> list[Task]:
+        """Move each still-pending task of the jobs straight to canceled.
+
+        Args:
+            job_ids: Ids the tasks belong to.
+            now: Current time.
+
+        Returns:
+            Canceled tasks.
         """
         ...
 

--- a/src/kitaru/server/application/interfaces/task_repository.py
+++ b/src/kitaru/server/application/interfaces/task_repository.py
@@ -18,7 +18,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import Protocol
 
-from kitaru.api_models.v1.task import WorkerScope
+from kitaru.api_models.v1.worker import WorkerScope
 from kitaru.server.application.models.task import TaskFilter
 from kitaru.server.domain.task import Task
 

--- a/src/kitaru/server/application/interfaces/task_repository.py
+++ b/src/kitaru/server/application/interfaces/task_repository.py
@@ -171,11 +171,13 @@ class TaskRepository(Protocol):
         """
         ...
 
-    async def stamp_cancel_requested(self, job_id: uuid.UUID, now: datetime) -> None:
-        """Stamp cancel_requested_at on the job's non-terminal tasks lacking it.
+    async def stamp_cancel_requested(
+        self, job_ids: Sequence[uuid.UUID], now: datetime
+    ) -> None:
+        """Stamp cancel_requested_at on the jobs' non-terminal tasks lacking it.
 
         Args:
-            job_id: Id the tasks belong to.
+            job_ids: Ids the tasks belong to.
             now: Current time.
         """
         ...

--- a/src/kitaru/server/application/services/cohort_version_service.py
+++ b/src/kitaru/server/application/services/cohort_version_service.py
@@ -145,7 +145,11 @@ class CohortVersionService:
         Returns:
             Created cohort version.
         """
-        cohort = await self._cohorts.get(cohort_id)
+        # The delta defaults to the latest version's members, so the cohort
+        # row is locked for the read as well as the version bump. Reading it
+        # unlocked lets two concurrent deltas build on the same base and the
+        # later version silently drop the earlier one's change.
+        cohort = await self._cohorts.get(cohort_id, exclusive=True)
         base_members = await self._resolve_base_members(cohort, command.baseline_id)
         new_members = apply_membership_delta(
             base_members, command.add_session_ids, command.remove_session_ids

--- a/src/kitaru/server/application/services/experiment_run_service.py
+++ b/src/kitaru/server/application/services/experiment_run_service.py
@@ -158,39 +158,38 @@ class ExperimentRunService:
         run.cancel()
         await self._repository.update(run)
 
-    async def list_cancelable_job_ids(
+    async def cancel_run_jobs(
         self, experiment_run_id: uuid.UUID, actor: AuthContext
-    ) -> list[uuid.UUID]:
-        """List the jobs of the run's replays that have not settled.
+    ) -> tuple[ExperimentRun, ReplayStatusCounts]:
+        """Cancel every unsettled job of a canceling run in two passes.
+
+        The first pass stamps every job's cancel request and takes only
+        task and job locks: pending tasks move straight to canceled and
+        claimed or running tasks are stamped for their worker or the sweep
+        to settle. The second pass settles each drained job, which locks
+        replay rows and the run row. By then every stamped task row is
+        held, so no reporter is partway through the task, job, replay, run
+        lock order and the tail locks cannot invert against one.
 
         Args:
             experiment_run_id: Id of the run.
             actor: Caller context.
 
+        Raises:
+            ExperimentRunNotFound: No run has this id.
+
         Returns:
-            Job ids to cancel, in replay order.
+            Run carrying the cancel request, and its replay counts by status.
         """
         _ = actor
         replays = await self._replays.list_by_experiment_run(experiment_run_id)
-        return [replay.job_id for replay in replays if not replay.settled]
-
-    async def cancel_run_job(self, job_id: uuid.UUID, actor: AuthContext) -> None:
-        """Cancel one job of a canceling run.
-
-        Pending tasks move straight to canceled and claimed or running tasks
-        are stamped for their worker or the sweep to settle. The caller
-        commits between jobs, so this never holds the run row lock the
-        settlement takes while reaching for the next job's task rows.
-
-        Args:
-            job_id: Id of the job.
-            actor: Caller context.
-
-        Raises:
-            JobNotFound: No job has this id.
-        """
-        _ = actor
-        await self._transitions.cancel_job(job_id)
+        job_ids = [replay.job_id for replay in replays if not replay.settled]
+        await self._transitions.request_jobs_cancel(job_ids)
+        for job_id in job_ids:
+            await self._transitions.settle_job_if_drained(job_id)
+        run = await self._repository.get(experiment_run_id)
+        counts = await self._replays.count_by_status(experiment_run_id)
+        return run, counts
 
     async def delete_run(
         self, experiment_run_id: uuid.UUID, actor: AuthContext

--- a/src/kitaru/server/application/services/experiment_run_service.py
+++ b/src/kitaru/server/application/services/experiment_run_service.py
@@ -160,10 +160,7 @@ class ExperimentRunService:
         for replay in await self._replays.list_by_experiment_run(experiment_run_id):
             if replay.settled:
                 continue
-            job = await self._jobs.get(replay.job_id, exclusive=True)
-            if job.settled:
-                continue
-            await self._transitions.cancel_job(job)
+            await self._transitions.cancel_job(replay.job_id)
         run = await self._repository.get(experiment_run_id)
         counts = await self._replays.count_by_status(experiment_run_id)
         return run, counts

--- a/src/kitaru/server/application/services/experiment_run_service.py
+++ b/src/kitaru/server/application/services/experiment_run_service.py
@@ -138,10 +138,9 @@ class ExperimentRunService:
     ) -> None:
         """Move a running run to canceling, leaving an already canceling run alone.
 
-        Locks the run row and nothing else, so the caller commits and releases
-        it before the cancellation takes any task or job lock. Finalization
-        reads the canceling status to settle the run as canceled, so the run
-        has to carry it before its jobs drain.
+        Locks the run row and nothing else. Finalization reads the canceling
+        status to settle the run as canceled, so the run has to carry it
+        before its jobs drain.
 
         Args:
             experiment_run_id: Id of the run.
@@ -163,15 +162,8 @@ class ExperimentRunService:
     ) -> tuple[ExperimentRun, ReplayStatusCounts]:
         """Cancel every unsettled job of a canceling run in two passes.
 
-        The first pass stamps every job's cancel request and takes only
-        task and job locks: pending tasks move straight to canceled and
-        claimed or running tasks are stamped for their worker or the sweep
-        to settle. The second pass settles every drained job in one bulk
-        read and one bulk write, and its ``JobsSettled`` drives the replay
-        settlement and run finalization, all in the task, job, replay, run
-        lock order. By then every stamped task row is held, so no reporter
-        is partway through that order and the tail locks cannot invert
-        against one.
+        Locks the jobs' live task rows, then their job rows, then the replay
+        and run rows the settlement of the second pass reaches.
 
         Args:
             experiment_run_id: Id of the run.

--- a/src/kitaru/server/application/services/experiment_run_service.py
+++ b/src/kitaru/server/application/services/experiment_run_service.py
@@ -189,8 +189,8 @@ class ExperimentRunService:
     ) -> None:
         """Delete an experiment run and its jobs.
 
-        Each job delete cascades its tasks and replay row, so the run row's
-        own delete has nothing left to cascade.
+        The job deletes cascade their tasks and replay rows, so the run
+        row's own delete has nothing left to cascade.
 
         Args:
             experiment_run_id: Id of the run.
@@ -201,6 +201,6 @@ class ExperimentRunService:
         """
         _ = actor
         await self._repository.get(experiment_run_id)
-        for replay in await self._replays.list_by_experiment_run(experiment_run_id):
-            await self._jobs.delete(replay.job_id)
+        replays = await self._replays.list_by_experiment_run(experiment_run_id)
+        await self._jobs.delete_many([replay.job_id for replay in replays])
         await self._repository.delete(experiment_run_id)

--- a/src/kitaru/server/application/services/experiment_run_service.py
+++ b/src/kitaru/server/application/services/experiment_run_service.py
@@ -15,6 +15,7 @@
 
 import uuid
 
+from kitaru.api_models.v1.experiment_run import ExperimentRunStatus
 from kitaru.server.application.interfaces.experiment_run_repository import (
     ExperimentRunRepository,
 )
@@ -132,15 +133,15 @@ class ExperimentRunService:
             )
         )
 
-    async def cancel_run(
+    async def mark_run_canceling(
         self, experiment_run_id: uuid.UUID, actor: AuthContext
-    ) -> tuple[ExperimentRun, ReplayStatusCounts]:
-        """Request cancellation of a running experiment run.
+    ) -> None:
+        """Move a running run to canceling, leaving an already canceling run alone.
 
-        Every non-settled replay's job is canceled the way job cancellation
-        works: pending tasks move straight to canceled, claimed and running
-        tasks are stamped for their worker or the sweep to settle. A run
-        whose jobs are already fully drained finalizes within this call.
+        Locks the run row and nothing else, so the caller commits and releases
+        it before the cancellation takes any task or job lock. Finalization
+        reads the canceling status to settle the run as canceled, so the run
+        has to carry it before its jobs drain.
 
         Args:
             experiment_run_id: Id of the run.
@@ -149,21 +150,47 @@ class ExperimentRunService:
         Raises:
             ExperimentRunNotFound: No run has this id.
             IllegalExperimentRunStatusTransition: The run is not running.
-
-        Returns:
-            Run carrying the cancel request, and its replay counts by status.
         """
         _ = actor
         run = await self._repository.get(experiment_run_id, exclusive=True)
+        if run.status is ExperimentRunStatus.CANCELING:
+            return
         run.cancel()
         await self._repository.update(run)
-        for replay in await self._replays.list_by_experiment_run(experiment_run_id):
-            if replay.settled:
-                continue
-            await self._transitions.cancel_job(replay.job_id)
-        run = await self._repository.get(experiment_run_id)
-        counts = await self._replays.count_by_status(experiment_run_id)
-        return run, counts
+
+    async def list_cancelable_job_ids(
+        self, experiment_run_id: uuid.UUID, actor: AuthContext
+    ) -> list[uuid.UUID]:
+        """List the jobs of the run's replays that have not settled.
+
+        Args:
+            experiment_run_id: Id of the run.
+            actor: Caller context.
+
+        Returns:
+            Job ids to cancel, in replay order.
+        """
+        _ = actor
+        replays = await self._replays.list_by_experiment_run(experiment_run_id)
+        return [replay.job_id for replay in replays if not replay.settled]
+
+    async def cancel_run_job(self, job_id: uuid.UUID, actor: AuthContext) -> None:
+        """Cancel one job of a canceling run.
+
+        Pending tasks move straight to canceled and claimed or running tasks
+        are stamped for their worker or the sweep to settle. The caller
+        commits between jobs, so this never holds the run row lock the
+        settlement takes while reaching for the next job's task rows.
+
+        Args:
+            job_id: Id of the job.
+            actor: Caller context.
+
+        Raises:
+            JobNotFound: No job has this id.
+        """
+        _ = actor
+        await self._transitions.cancel_job(job_id)
 
     async def delete_run(
         self, experiment_run_id: uuid.UUID, actor: AuthContext

--- a/src/kitaru/server/application/services/experiment_run_service.py
+++ b/src/kitaru/server/application/services/experiment_run_service.py
@@ -166,10 +166,12 @@ class ExperimentRunService:
         The first pass stamps every job's cancel request and takes only
         task and job locks: pending tasks move straight to canceled and
         claimed or running tasks are stamped for their worker or the sweep
-        to settle. The second pass settles each drained job, which locks
-        replay rows and the run row. By then every stamped task row is
-        held, so no reporter is partway through the task, job, replay, run
-        lock order and the tail locks cannot invert against one.
+        to settle. The second pass settles every drained job in one bulk
+        read and one bulk write, and its ``JobsSettled`` drives the replay
+        settlement and run finalization, all in the task, job, replay, run
+        lock order. By then every stamped task row is held, so no reporter
+        is partway through that order and the tail locks cannot invert
+        against one.
 
         Args:
             experiment_run_id: Id of the run.
@@ -185,8 +187,7 @@ class ExperimentRunService:
         replays = await self._replays.list_by_experiment_run(experiment_run_id)
         job_ids = [replay.job_id for replay in replays if not replay.settled]
         await self._transitions.request_jobs_cancel(job_ids)
-        for job_id in job_ids:
-            await self._transitions.settle_job_if_drained(job_id)
+        await self._transitions.settle_jobs_if_drained(job_ids)
         run = await self._repository.get(experiment_run_id)
         counts = await self._replays.count_by_status(experiment_run_id)
         return run, counts

--- a/src/kitaru/server/application/services/experiment_service.py
+++ b/src/kitaru/server/application/services/experiment_service.py
@@ -386,7 +386,11 @@ class ExperimentService:
             Created run and its replay counts by status.
         """
         experiment = await self._repository.get(experiment_id, exclusive=True)
-        cohort_version = await self._cohort_versions.get(command.cohort_version_id)
+        # Locked so a concurrent delete of this version cannot land between
+        # the read and the run row that references it.
+        cohort_version = await self._cohort_versions.get(
+            command.cohort_version_id, exclusive=True
+        )
         if cohort_version.session_count == 0:
             raise ValidationError(f"Cohort version {cohort_version.id} has no sessions")
         agent_version = await resolve_runnable_agent_version(

--- a/src/kitaru/server/application/services/job_service.py
+++ b/src/kitaru/server/application/services/job_service.py
@@ -233,17 +233,6 @@ class JobService:
         """
         return await add_task(task, self._repository, self._tasks)
 
-    async def advance_job(self, job_id: uuid.UUID) -> None:
-        """Propagate an abort failure and settle the job once its tasks drain.
-
-        Args:
-            job_id: Id of the job.
-
-        Raises:
-            JobNotFound: No job has this id.
-        """
-        await self._transitions.advance_job(job_id)
-
     async def create_session_run(
         self, command: SessionRunCreate, actor: AuthContext
     ) -> Job:

--- a/src/kitaru/server/application/services/job_service.py
+++ b/src/kitaru/server/application/services/job_service.py
@@ -188,10 +188,10 @@ class JobService:
             Job carrying the cancel request.
         """
         _ = actor
-        job = await self._repository.get(job_id, exclusive=True)
+        job = await self._repository.get(job_id)
         if job.settled:
             raise JobAlreadySettled(job_id)
-        return await self._transitions.cancel_job(job)
+        return await self._transitions.cancel_job(job_id)
 
     async def delete_job(self, job_id: uuid.UUID, actor: AuthContext) -> None:
         """Delete a job, cascading its tasks.

--- a/src/kitaru/server/application/services/replay_pipeline.py
+++ b/src/kitaru/server/application/services/replay_pipeline.py
@@ -20,8 +20,8 @@ from kitaru.api_models.v1.job import JobKind, JobStatus
 from kitaru.api_models.v1.task import TaskOnFailure, TaskStatus
 from kitaru.server.application.events import (
     EventDispatcher,
-    JobSettled,
-    ReplaySettled,
+    JobsSettled,
+    ReplaysSettled,
     TaskTerminal,
 )
 from kitaru.server.application.interfaces.experiment_repository import (
@@ -246,24 +246,16 @@ async def append_result_evaluations(
     await replay_repository.update(replay)
 
 
-async def settle_replay(
-    event: JobSettled,
-    replay_repository: ReplayRepository,
-    dispatcher: EventDispatcher,
-) -> None:
-    """Map a job's settlement outcome onto its replay and emit ReplaySettled.
-
-    A no-op when the job holds no replay.
+def _apply_job_settlement(replay: Replay, job: Job) -> bool:
+    """Apply a settled job's outcome onto its replay.
 
     Args:
-        event: JobSettled event.
-        replay_repository: Replay repository.
-        dispatcher: Event dispatcher to emit ``ReplaySettled`` on.
+        replay: Replay to update.
+        job: Job that settled.
+
+    Returns:
+        Whether the job's status mapped onto a replay transition.
     """
-    job = event.job
-    replay = await replay_repository.get_by_job_id(job.id)
-    if replay is None:
-        return
     if job.status is JobStatus.COMPLETED:
         replay.complete()
     elif job.status is JobStatus.FAILED:
@@ -271,6 +263,37 @@ async def settle_replay(
     elif job.status is JobStatus.CANCELED:
         replay.cancel()
     else:
+        return False
+    return True
+
+
+async def settle_replays(
+    event: JobsSettled,
+    replay_repository: ReplayRepository,
+    dispatcher: EventDispatcher,
+) -> None:
+    """Map settled jobs' outcomes onto their replays and emit ReplaysSettled.
+
+    A job holding no replay is skipped. The updated replays publish a
+    single ``ReplaysSettled``.
+
+    Args:
+        event: JobsSettled event.
+        replay_repository: Replay repository.
+        dispatcher: Event dispatcher to emit ``ReplaysSettled`` on.
+    """
+    replays_by_job_id = await replay_repository.get_many_by_job_ids(
+        [job.id for job in event.jobs]
+    )
+    changed: list[Replay] = []
+    for job in event.jobs:
+        replay = replays_by_job_id.get(job.id)
+        if replay is None:
+            continue
+        if not _apply_job_settlement(replay, job):
+            continue
+        changed.append(replay)
+    if not changed:
         return
-    stored = await replay_repository.update(replay)
-    await dispatcher.dispatch(ReplaySettled(replay=stored))
+    stored = await replay_repository.update_many(changed)
+    await dispatcher.dispatch(ReplaysSettled(replays=stored))

--- a/src/kitaru/server/application/services/resource_access.py
+++ b/src/kitaru/server/application/services/resource_access.py
@@ -15,6 +15,7 @@
 
 import uuid
 
+from kitaru.server.application.interfaces.task_repository import TaskRepository
 from kitaru.server.application.models.auth import (
     AuthContext,
     GrantKind,
@@ -28,6 +29,30 @@ from kitaru.server.domain.task import (
     ScriptPluginSpec,
     TaskSpec,
 )
+
+
+async def check_task_attempt(actor: AuthContext, tasks: TaskRepository) -> None:
+    """Require a task principal's token to name the task's current attempt.
+
+    A requeue leaves the superseded attempt's token unexpired, and the task
+    id it carries stays valid across attempts, so the attempt has to be
+    checked against the stored task.
+
+    An account principal always passes.
+
+    Args:
+        actor: Caller context.
+        tasks: Task repository.
+
+    Raises:
+        TaskNotFound: The principal names a task that no longer exists.
+        TaskAttemptMismatch: The token is fenced by an attempt the task has
+            moved past.
+    """
+    if not isinstance(actor.principal, TaskPrincipal):
+        return
+    task = await tasks.get(actor.principal.task_id)
+    task.check_attempt(actor.principal.attempt)
 
 
 def build_task_grants(spec: TaskSpec) -> dict[GrantKind, frozenset[uuid.UUID]]:

--- a/src/kitaru/server/application/services/run_finalization.py
+++ b/src/kitaru/server/application/services/run_finalization.py
@@ -13,11 +13,12 @@
 #  permissions and limitations under the License.
 """Experiment run finalization, driven off the run's replay rows."""
 
+import uuid
 from datetime import UTC, datetime
 
 from kitaru.analytics.events import AnalyticsEvent
 from kitaru.api_models.v1.experiment_run import ExperimentRunStatus
-from kitaru.server.application.events import ReplaySettled
+from kitaru.server.application.events import ReplaysSettled
 from kitaru.server.application.interfaces.experiment_run_repository import (
     ExperimentRunRepository,
 )
@@ -26,8 +27,39 @@ from kitaru.server.application.services import analytics_events
 from kitaru.server.application.services.server_analytics import ServerAnalytics
 
 
-async def finalize_run_if_drained(
-    event: ReplaySettled,
+async def finalize_runs_if_drained(
+    event: ReplaysSettled,
+    replay_repository: ReplayRepository,
+    experiment_run_repository: ExperimentRunRepository,
+    analytics: ServerAnalytics | None = None,
+) -> None:
+    """Finalize the settled replays' runs once all of their replays settled.
+
+    Standalone replays are skipped and each run is finalized once however
+    many of its replays the event carries.
+
+    Args:
+        event: ReplaysSettled event.
+        replay_repository: Replay repository, for the drained counts.
+        experiment_run_repository: Experiment run repository.
+        analytics: Analytics tracker, None skips tracking.
+    """
+    run_ids = {
+        replay.experiment_run_id
+        for replay in event.replays
+        if replay.experiment_run_id is not None
+    }
+    for run_id in sorted(run_ids):
+        await _finalize_run(
+            run_id,
+            replay_repository,
+            experiment_run_repository,
+            analytics,
+        )
+
+
+async def _finalize_run(
+    experiment_run_id: uuid.UUID,
     replay_repository: ReplayRepository,
     experiment_run_repository: ExperimentRunRepository,
     analytics: ServerAnalytics | None = None,
@@ -35,27 +67,24 @@ async def finalize_run_if_drained(
     """Finalize a run once every one of its replays has settled.
 
     Cancellation wins over everything, then any failed or canceled replay
-    fails the run, otherwise the run completes. A no-op when the settled
-    replay is standalone or the run still has live replays.
+    fails the run, otherwise the run completes. A no-op when the run still
+    has live replays.
 
-    The run row is locked before the drained count is read, so two replays of
-    the same run settling concurrently serialize on the lock instead of both
-    reading the other's still-uncommitted settlement and skipping
-    finalization, which would stall the run forever.
+    The run row is locked before the drained count is read, so two callers
+    settling replays of the same run concurrently serialize on the lock
+    instead of both reading the other's still-uncommitted settlement and
+    skipping finalization, which would stall the run forever.
 
     Args:
-        event: ReplaySettled event.
+        experiment_run_id: Id of the run.
         replay_repository: Replay repository, for the drained count.
         experiment_run_repository: Experiment run repository.
         analytics: Analytics tracker, None skips tracking.
     """
-    replay = event.replay
-    if replay.experiment_run_id is None:
-        return
-    run = await experiment_run_repository.get(replay.experiment_run_id, exclusive=True)
+    run = await experiment_run_repository.get(experiment_run_id, exclusive=True)
     if run.settled:
         return
-    counts = await replay_repository.count_by_status(replay.experiment_run_id)
+    counts = await replay_repository.count_by_status(experiment_run_id)
     if counts.non_settled > 0:
         return
     if run.status is ExperimentRunStatus.CANCELING:

--- a/src/kitaru/server/application/services/session_node_service.py
+++ b/src/kitaru/server/application/services/session_node_service.py
@@ -94,7 +94,11 @@ class SessionNodeService:
         Returns:
             Stored nodes in batch order.
         """
-        session = await self._sessions.get(session_id)
+        # Node ids are minted for indexes this read does not find, so two
+        # concurrent batches for one index would both insert and collide on
+        # the (session, index) key. The lock also stabilizes the pre-image
+        # the rollup deltas are computed against.
+        session = await self._sessions.get(session_id, exclusive=True)
         check_task_session_write(session_id, session.task_id, actor)
         await check_task_attempt(actor, self._tasks)
         session.check_node_ingest()

--- a/src/kitaru/server/application/services/session_node_service.py
+++ b/src/kitaru/server/application/services/session_node_service.py
@@ -23,12 +23,14 @@ from kitaru.server.application.interfaces.session_node_repository import (
 from kitaru.server.application.interfaces.session_repository import (
     SessionRepository,
 )
+from kitaru.server.application.interfaces.task_repository import TaskRepository
 from kitaru.server.application.models.auth import AuthContext, TaskPrincipal
 from kitaru.server.application.models.session_node import (
     SessionNodeFilter,
     SessionNodeUpsert,
 )
 from kitaru.server.application.services.resource_access import (
+    check_task_attempt,
     check_task_session_read,
     check_task_session_write,
 )
@@ -48,6 +50,7 @@ class SessionNodeService:
         self,
         repository: SessionNodeRepository,
         session_repository: SessionRepository,
+        task_repository: TaskRepository,
     ) -> None:
         """Initialize the service.
 
@@ -55,9 +58,11 @@ class SessionNodeService:
             repository: Session node repository.
             session_repository: Session repository, for the ingest gate and
                 the rollup update.
+            task_repository: Task repository, for the attempt fence.
         """
         self._repository = repository
         self._sessions = session_repository
+        self._tasks = task_repository
 
     async def ingest_nodes(
         self,
@@ -91,6 +96,7 @@ class SessionNodeService:
         """
         session = await self._sessions.get(session_id)
         check_task_session_write(session_id, session.task_id, actor)
+        await check_task_attempt(actor, self._tasks)
         session.check_node_ingest()
         if not batch:
             return []

--- a/src/kitaru/server/application/services/session_service.py
+++ b/src/kitaru/server/application/services/session_service.py
@@ -32,6 +32,7 @@ from kitaru.server.application.models.session import (
 from kitaru.server.application.services import analytics_events
 from kitaru.server.application.services.agent_version_resolution import resolve_agent_id
 from kitaru.server.application.services.resource_access import (
+    check_task_attempt,
     check_task_session_read,
     check_task_session_write,
 )
@@ -274,6 +275,7 @@ class SessionService:
         """
         session = await self._repository.get(session_id, exclusive=True)
         check_task_session_write(session_id, session.task_id, actor)
+        await check_task_attempt(actor, self._tasks)
         fields = command.model_fields_set
         if {"status", "outputs", "error", "ended_at"} & fields:
             previous_status = session.status

--- a/src/kitaru/server/application/services/task_service.py
+++ b/src/kitaru/server/application/services/task_service.py
@@ -75,7 +75,7 @@ class TaskService:
             repository: Task repository.
             worker_repository: Worker repository.
             session_repository: Session repository.
-            job_repository: Job repository, for the owning job's owner id.
+            job_repository: Job repository.
             spec_builder: Task execution spec builder.
             transitions: Task transition dispatch.
             policy: Task execution policy.
@@ -91,10 +91,7 @@ class TaskService:
     async def claim_tasks(
         self, max_tasks: int, actor: WorkerAuthContext
     ) -> list[ClaimedTask]:
-        """Sweep stale tasks, then claim pending tasks matching the worker's scope.
-
-        The sweep runs first so a task whose worker died is back in the queue
-        before this claim reads it.
+        """Claim pending tasks matching the worker's scope.
 
         Args:
             max_tasks: Maximum number of tasks to claim.
@@ -113,17 +110,17 @@ class TaskService:
         worker = await self._workers.get(worker_id)
         now = datetime.now(UTC)
         await self._workers.update_last_seen_at(worker_id, now)
-        await self.sweep_stale_tasks(now)
         claimed = await self._repository.claim_pending(
             worker.scope, worker_id, max_tasks, now
         )
-        owners = await self._jobs.get_many(list({task.job_id for task in claimed}))
-        started_jobs: set[uuid.UUID] = set()
+        job_ids = sorted({task.job_id for task in claimed})
+        owners = await self._jobs.get_many(job_ids)
+        # Start the jobs in ascending id order so this transaction locks job
+        # rows in the order the cancellation path locks them in.
+        for job_id in job_ids:
+            await self._transitions.start_job(job_id)
         results: list[ClaimedTask] = []
         for task in claimed:
-            if task.job_id not in started_jobs:
-                await self._transitions.start_job(task.job_id)
-                started_jobs.add(task.job_id)
             results.append(
                 ClaimedTask(
                     task=task,
@@ -292,30 +289,75 @@ class TaskService:
             raise IllegalTaskStatusTransition(task_id, task.status, command.status)
         return await self._apply_status(task, transition)
 
-    async def sweep_stale_tasks(self, now: datetime) -> None:
-        """Settle or requeue in-flight tasks that stopped heartbeating.
+    async def list_stale_task_ids(self, now: datetime) -> list[uuid.UUID]:
+        """Read the ids of in-flight tasks that stopped heartbeating.
+
+        Takes no lock.
 
         Args:
             now: Current time.
+
+        Returns:
+            Ids of the stale tasks in ascending order.
         """
         cutoff = now - timedelta(seconds=self._policy.heartbeat_timeout_seconds)
-        stale = await self._repository.claim_stale(
+        return await self._repository.list_stale_ids(
             cutoff, self._policy.sweep_batch_limit
         )
-        for task in stale:
-            if task.cancel_requested_at is not None:
-                await self._apply_status(task, partial(Task.cancel, now=now))
-            elif task.attempt < self._policy.retry_limit:
-                await self._unlink_result_session(task)
-                await self._apply_status(task, Task.requeue)
-            else:
-                error = (
-                    f"Task stopped reporting after {task.attempt} attempts "
-                    "and was abandoned"
-                )
-                await self._apply_status(
-                    task, partial(Task.abandon, error=error, now=now)
-                )
+
+    async def sweep_stale_task(self, task_id: uuid.UUID, now: datetime) -> None:
+        """Settle or requeue one in-flight task that stopped heartbeating.
+
+        Locks the task row, then the result session row a requeue frees, then
+        the job row. A task another sweep holds, or one that resumed
+        reporting, is left alone.
+
+        Args:
+            task_id: Id of the candidate task.
+            now: Current time.
+        """
+        cutoff = now - timedelta(seconds=self._policy.heartbeat_timeout_seconds)
+        task = await self._repository.claim_stale(task_id, cutoff)
+        if task is None:
+            return
+        if task.cancel_requested_at is not None:
+            await self._apply_status(task, partial(Task.cancel, now=now))
+        elif task.attempt < self._policy.retry_limit:
+            await self._unlink_result_session(task)
+            await self._apply_status(task, Task.requeue)
+        else:
+            error = (
+                f"Task stopped reporting after {task.attempt} attempts "
+                "and was abandoned"
+            )
+            await self._apply_status(task, partial(Task.abandon, error=error, now=now))
+
+    async def list_unpropagated_cancel_job_ids(self) -> list[uuid.UUID]:
+        """Read the ids of canceling jobs whose live tasks still owe the stamp.
+
+        Takes no lock.
+
+        Returns:
+            Ids of the canceling jobs in ascending order.
+        """
+        return await self._jobs.list_unpropagated_cancel_ids(
+            self._policy.sweep_batch_limit
+        )
+
+    async def propagate_job_cancel(self, job_id: uuid.UUID) -> None:
+        """Carry a job's cancel request to its live tasks and settle it if drained.
+
+        Locks the job's live task rows in one id-ordered acquisition, then
+        the job row.
+
+        Args:
+            job_id: Id of the job.
+
+        Raises:
+            DBAPIError: Another transaction holds one of the task rows.
+        """
+        await self._transitions.request_jobs_cancel([job_id], nowait=True)
+        await self._transitions.settle_job_if_drained(job_id)
 
     async def _apply_status(
         self, task: Task, transition: Callable[[Task], None]
@@ -334,9 +376,9 @@ class TaskService:
     def _with_staleness(self, task: Task, now: datetime) -> Task:
         """Return a task carrying the status the next sweep would write.
 
-        Nothing sweeps while no worker claims, so a read reports what the
-        stored row will become rather than the attempt that stopped
-        reporting.
+        A read between the heartbeat timeout and the sweep tick that acts on
+        it reports what the stored row will become rather than the attempt
+        that stopped reporting.
 
         Args:
             task: Stored task.

--- a/src/kitaru/server/application/services/task_service.py
+++ b/src/kitaru/server/application/services/task_service.py
@@ -39,6 +39,7 @@ from kitaru.server.application.models.task import (
     TaskPolicy,
     TaskUpdate,
 )
+from kitaru.server.application.services.resource_access import check_task_attempt
 from kitaru.server.application.services.task_spec import TaskSpecBuilder
 from kitaru.server.application.services.task_transitions import TaskTransitions
 from kitaru.server.domain.task import (
@@ -233,6 +234,7 @@ class TaskService:
             actor.principal.task_id != task_id
         ):
             raise TaskAccessDenied(task_id)
+        await check_task_attempt(actor, self._repository)
         task = await self._repository.get(task_id)
         return await self._spec_builder.build_spec(task)
 

--- a/src/kitaru/server/application/services/task_service.py
+++ b/src/kitaru/server/application/services/task_service.py
@@ -139,8 +139,8 @@ class TaskService:
         """Stamp the heartbeat on the tasks the caller still owns.
 
         A reported task the caller no longer owns, that no longer exists, that
-        already reached a terminal status, or whose cancellation was
-        requested comes back for the worker to stop.
+        already reached a terminal status, or whose cancellation was requested
+        on the task or on its job comes back for the worker to stop.
 
         Args:
             worker_id: Id of the reporting worker.

--- a/src/kitaru/server/application/services/task_transitions.py
+++ b/src/kitaru/server/application/services/task_transitions.py
@@ -106,9 +106,6 @@ class TaskTransitions:
     ) -> Task:
         """Persist a transition and publish TaskTerminal without advancing the job.
 
-        Batch callers move many tasks toward the same status and advance the
-        job once after the batch instead of once per task.
-
         Args:
             task: Task to transition.
             transition: Domain method application deciding the new status.
@@ -145,7 +142,9 @@ class TaskTransitions:
         await self._jobs.update(job)
 
     async def advance_job(self, job_id: uuid.UUID) -> Job:
-        """Propagate an abort failure and settle the job once its tasks drain.
+        """Stamp an abort failure on the job and settle it once its tasks drain.
+
+        Locks the job row and no task row.
 
         Args:
             job_id: Id of the job.
@@ -156,30 +155,45 @@ class TaskTransitions:
         Returns:
             Loaded job, settled if this call drained its tasks.
         """
+        job = await self._jobs.get(job_id, exclusive=True)
+        # Read the tasks after the job row lock to prevent race conditions
+        # during concurrent task settlements.
         tasks = await self._tasks.list_by_job(job_id)
-        if any(
+        await self._request_cancel_on_abort(job, tasks)
+        return await self._settle_drained_job(job, tasks)
+
+    async def _request_cancel_on_abort(self, job: Job, tasks: list[Task]) -> None:
+        """Stamp the job's cancel request when one of its aborting tasks failed.
+
+        Locks no task row, so live siblings keep their status until the
+        sweep's propagation backstop reaches them.
+
+        Args:
+            job: Job loaded under its row lock.
+            tasks: Every task of the job.
+        """
+        if job.settled or job.cancel_requested_at is not None:
+            return
+        if not any(
             task.counted_hard_failure and task.on_failure is TaskOnFailure.ABORT
             for task in tasks
         ):
-            await self._propagate_abort(job_id)
-        job = await self._jobs.get(job_id, exclusive=True)
-        return await self._settle_drained_job(job)
+            return
+        job.request_cancel(datetime.now(UTC))
+        await self._jobs.update(job)
 
-    async def _settle_drained_job(self, job: Job) -> Job:
+    async def _settle_drained_job(self, job: Job, tasks: list[Task]) -> Job:
         """Settle a locked job once every one of its tasks is terminal.
 
         Args:
             job: Job loaded under its row lock.
+            tasks: Every task of the job, read after the job row lock.
 
         Returns:
             Job, settled if this call drained its tasks.
         """
         if job.settled:
             return job
-
-        # Read the tasks after the job row lock to prevent race conditions
-        # during concurrent task settlements.
-        tasks = await self._tasks.list_by_job(job.id)
         if not tasks or not all(task.terminal for task in tasks):
             return job
         status, error = _settlement_outcome(tasks)
@@ -209,44 +223,42 @@ class TaskTransitions:
                 TaskTerminal(task=task, previous_status=TaskStatus.PENDING)
             )
 
-    async def _propagate_abort(self, job_id: uuid.UUID) -> None:
-        """Cancel-request every live sibling and cancel the pending ones.
-
-        Args:
-            job_id: Id of the job.
-        """
-        now = datetime.now(UTC)
-        await self._tasks.stamp_cancel_requested([job_id], now)
-        await self._cancel_pending_tasks([job_id], now)
-
-    async def request_jobs_cancel(self, job_ids: Sequence[uuid.UUID]) -> None:
+    async def request_jobs_cancel(
+        self, job_ids: Sequence[uuid.UUID], nowait: bool = False
+    ) -> None:
         """Stamp the cancel request on each job and cancel their pending tasks.
 
-        Every task row is locked in one id-ordered statement before any job
-        row, which is the order the reporting and claiming paths take, and
-        the order the heartbeat stamp locks task rows in. Locking task rows
-        job by job or a job row first deadlocks against a worker reporting
-        or heartbeating one of these tasks. The jobs are not settled here,
-        so no replay or run lock is taken.
+        Locks the jobs' live task rows in one id-ordered acquisition, then
+        their job rows. A job id matching no job, or a settled job, is
+        skipped.
 
         Args:
             job_ids: Ids of the jobs.
+            nowait: Whether to fail instead of waiting when another
+                transaction holds one of the task rows.
 
         Raises:
-            JobNotFound: A job id matches no job.
+            DBAPIError: ``nowait`` is set and a task row is held elsewhere.
         """
         now = datetime.now(UTC)
+        await self._tasks.lock_by_jobs(job_ids, nowait=nowait)
         await self._tasks.stamp_cancel_requested(job_ids, now)
         await self._cancel_pending_tasks(job_ids, now)
+        jobs = await self._jobs.get_many_locked(job_ids)
+        canceling: list[Job] = []
         for job_id in job_ids:
-            job = await self._jobs.get(job_id, exclusive=True)
-            if job.settled:
+            job = jobs.get(job_id)
+            if job is None or job.settled:
                 continue
             job.request_cancel(now)
-            await self._jobs.update(job)
+            canceling.append(job)
+        if canceling:
+            await self._jobs.update_many(canceling)
 
     async def settle_job_if_drained(self, job_id: uuid.UUID) -> Job:
         """Settle a job once every one of its tasks is terminal.
+
+        Locks the job row and no task row.
 
         Args:
             job_id: Id of the job.
@@ -258,14 +270,15 @@ class TaskTransitions:
             Loaded job, settled if its tasks have drained.
         """
         job = await self._jobs.get(job_id, exclusive=True)
-        return await self._settle_drained_job(job)
+        tasks = await self._tasks.list_by_job(job_id)
+        return await self._settle_drained_job(job, tasks)
 
     async def settle_jobs_if_drained(self, job_ids: Sequence[uuid.UUID]) -> None:
         """Settle every drained job among many in one bulk read and one bulk write.
 
-        Jobs are locked in id order in one statement. A job that already
-        settled, or still has a non-terminal task, is left untouched. The
-        newly settled jobs publish a single ``JobsSettled``.
+        Locks the job rows in one id-ordered acquisition and no task row. A
+        job that already settled, or still has a non-terminal task, is left
+        untouched. The newly settled jobs publish a single ``JobsSettled``.
 
         Args:
             job_ids: Ids of the jobs.

--- a/src/kitaru/server/application/services/task_transitions.py
+++ b/src/kitaru/server/application/services/task_transitions.py
@@ -160,12 +160,23 @@ class TaskTransitions:
         ):
             await self._propagate_abort(job_id, tasks)
         job = await self._jobs.get(job_id, exclusive=True)
+        return await self._settle_drained_job(job)
+
+    async def _settle_drained_job(self, job: Job) -> Job:
+        """Settle a locked job once every one of its tasks is terminal.
+
+        Args:
+            job: Job loaded under its row lock.
+
+        Returns:
+            Job, settled if this call drained its tasks.
+        """
         if job.settled:
             return job
 
         # Read the tasks after the job row lock to prevent race conditions
         # during concurrent task settlements.
-        tasks = await self._tasks.list_by_job(job_id)
+        tasks = await self._tasks.list_by_job(job.id)
         if not tasks or not all(task.terminal for task in tasks):
             return job
         status, error = _settlement_outcome(tasks)
@@ -206,22 +217,31 @@ class TaskTransitions:
         await self._tasks.stamp_cancel_requested(job_id, now)
         await self._cancel_pending_tasks(tasks, now)
 
-    async def cancel_job(self, job: Job) -> Job:
+    async def cancel_job(self, job_id: uuid.UUID) -> Job:
         """Stamp the cancel request on a job and cancel its pending tasks.
 
+        Every task row is locked before the job row, which is the order the
+        reporting and claiming paths take. Locking the job row first
+        deadlocks against a worker reporting one of these tasks.
+
         Args:
-            job: Job to cancel, loaded exclusively.
+            job_id: Id of the job.
+
+        Raises:
+            JobNotFound: No job has this id.
 
         Returns:
             Stored job carrying the cancel request.
         """
         now = datetime.now(UTC)
+        await self._tasks.stamp_cancel_requested(job_id, now)
+        await self._cancel_pending_tasks(await self._tasks.list_by_job(job_id), now)
+        job = await self._jobs.get(job_id, exclusive=True)
+        if job.settled:
+            return job
         job.request_cancel(now)
         stored = await self._jobs.update(job)
-        await self._tasks.stamp_cancel_requested(job.id, now)
-        await self._cancel_pending_tasks(await self._tasks.list_by_job(job.id), now)
-        await self.advance_job(job.id)
-        return await self._jobs.get(stored.id)
+        return await self._settle_drained_job(stored)
 
     def _track_task_terminal(self, task: Task, job: Job) -> None:
         """Track a task's transition to a terminal status by kind.

--- a/src/kitaru/server/application/services/task_transitions.py
+++ b/src/kitaru/server/application/services/task_transitions.py
@@ -16,12 +16,15 @@
 import uuid
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
-from functools import partial
 
 from kitaru.analytics.events import AnalyticsEvent
 from kitaru.api_models.v1.job import JobStatus
 from kitaru.api_models.v1.task import TaskOnFailure, TaskStatus
-from kitaru.server.application.events import EventDispatcher, JobSettled, TaskTerminal
+from kitaru.server.application.events import (
+    EventDispatcher,
+    JobsSettled,
+    TaskTerminal,
+)
 from kitaru.server.application.interfaces.job_repository import JobRepository
 from kitaru.server.application.interfaces.task_repository import TaskRepository
 from kitaru.server.application.services import analytics_events
@@ -79,7 +82,7 @@ class TaskTransitions:
         The ordered sequence runs inside the caller's transaction: the
         transition is persisted, a terminal status publishes ``TaskTerminal``
         so subscribers can append work before the job is checked, and the job
-        advances afterward, publishing ``JobSettled`` when it settles.
+        advances afterward, publishing ``JobsSettled`` when it settles.
 
         Args:
             task: Task to transition.
@@ -158,7 +161,7 @@ class TaskTransitions:
             task.counted_hard_failure and task.on_failure is TaskOnFailure.ABORT
             for task in tasks
         ):
-            await self._propagate_abort(job_id, tasks)
+            await self._propagate_abort(job_id)
         job = await self._jobs.get(job_id, exclusive=True)
         return await self._settle_drained_job(job)
 
@@ -188,34 +191,33 @@ class TaskTransitions:
                 analytics_events.build_job_completed_properties(job, tasks),
             )
         settled = await self._jobs.update(job)
-        await self._dispatcher.dispatch(JobSettled(job=settled))
+        await self._dispatcher.dispatch(JobsSettled(jobs=[settled]))
         return settled
 
-    async def _cancel_pending_tasks(self, tasks: list[Task], now: datetime) -> None:
-        """Move each still-pending task in the list straight to canceled.
+    async def _cancel_pending_tasks(
+        self, job_ids: Sequence[uuid.UUID], now: datetime
+    ) -> None:
+        """Move each still-pending task of the jobs straight to canceled.
 
         Args:
-            tasks: Candidate tasks, in creation order.
+            job_ids: Ids the tasks belong to.
             now: Current time.
         """
-        for task in tasks:
-            if task.status is not TaskStatus.PENDING:
-                continue
-            current = await self._tasks.get(task.id, exclusive=True)
-            if current.status is not TaskStatus.PENDING:
-                continue
-            await self._write_transition(current, partial(Task.request_cancel, now=now))
+        canceled = await self._tasks.cancel_pending(job_ids, now)
+        for task in canceled:
+            await self._dispatcher.dispatch(
+                TaskTerminal(task=task, previous_status=TaskStatus.PENDING)
+            )
 
-    async def _propagate_abort(self, job_id: uuid.UUID, tasks: list[Task]) -> None:
+    async def _propagate_abort(self, job_id: uuid.UUID) -> None:
         """Cancel-request every live sibling and cancel the pending ones.
 
         Args:
             job_id: Id of the job.
-            tasks: Every task of the job, in creation order.
         """
         now = datetime.now(UTC)
         await self._tasks.stamp_cancel_requested([job_id], now)
-        await self._cancel_pending_tasks(tasks, now)
+        await self._cancel_pending_tasks([job_id], now)
 
     async def request_jobs_cancel(self, job_ids: Sequence[uuid.UUID]) -> None:
         """Stamp the cancel request on each job and cancel their pending tasks.
@@ -235,8 +237,7 @@ class TaskTransitions:
         """
         now = datetime.now(UTC)
         await self._tasks.stamp_cancel_requested(job_ids, now)
-        for job_id in job_ids:
-            await self._cancel_pending_tasks(await self._tasks.list_by_job(job_id), now)
+        await self._cancel_pending_tasks(job_ids, now)
         for job_id in job_ids:
             job = await self._jobs.get(job_id, exclusive=True)
             if job.settled:
@@ -258,6 +259,42 @@ class TaskTransitions:
         """
         job = await self._jobs.get(job_id, exclusive=True)
         return await self._settle_drained_job(job)
+
+    async def settle_jobs_if_drained(self, job_ids: Sequence[uuid.UUID]) -> None:
+        """Settle every drained job among many in one bulk read and one bulk write.
+
+        Jobs are locked in id order in one statement. A job that already
+        settled, or still has a non-terminal task, is left untouched. The
+        newly settled jobs publish a single ``JobsSettled``.
+
+        Args:
+            job_ids: Ids of the jobs.
+        """
+        if not job_ids:
+            return
+        jobs = await self._jobs.get_many_locked(job_ids)
+        tasks_by_job = await self._tasks.list_by_jobs(job_ids)
+        settled: list[Job] = []
+        for job_id in job_ids:
+            job = jobs.get(job_id)
+            if job is None or job.settled:
+                continue
+            tasks = tasks_by_job.get(job_id, [])
+            if not tasks or not all(task.terminal for task in tasks):
+                continue
+            status, error = _settlement_outcome(tasks)
+            job.settle(status, error, datetime.now(UTC))
+            if self._analytics is not None:
+                self._analytics.track(
+                    job.owner_id,
+                    AnalyticsEvent.JOB_COMPLETED,
+                    analytics_events.build_job_completed_properties(job, tasks),
+                )
+            settled.append(job)
+        if not settled:
+            return
+        stored = await self._jobs.update_many(settled)
+        await self._dispatcher.dispatch(JobsSettled(jobs=stored))
 
     async def cancel_job(self, job_id: uuid.UUID) -> Job:
         """Stamp the cancel request on a job and settle it if that drained it.

--- a/src/kitaru/server/application/services/task_transitions.py
+++ b/src/kitaru/server/application/services/task_transitions.py
@@ -14,7 +14,7 @@
 """Task status transition dispatch and job settlement."""
 
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from functools import partial
 
@@ -214,15 +214,53 @@ class TaskTransitions:
             tasks: Every task of the job, in creation order.
         """
         now = datetime.now(UTC)
-        await self._tasks.stamp_cancel_requested(job_id, now)
+        await self._tasks.stamp_cancel_requested([job_id], now)
         await self._cancel_pending_tasks(tasks, now)
 
-    async def cancel_job(self, job_id: uuid.UUID) -> Job:
-        """Stamp the cancel request on a job and cancel its pending tasks.
+    async def request_jobs_cancel(self, job_ids: Sequence[uuid.UUID]) -> None:
+        """Stamp the cancel request on each job and cancel their pending tasks.
 
-        Every task row is locked before the job row, which is the order the
-        reporting and claiming paths take. Locking the job row first
-        deadlocks against a worker reporting one of these tasks.
+        Every task row is locked in one id-ordered statement before any job
+        row, which is the order the reporting and claiming paths take, and
+        the order the heartbeat stamp locks task rows in. Locking task rows
+        job by job or a job row first deadlocks against a worker reporting
+        or heartbeating one of these tasks. The jobs are not settled here,
+        so no replay or run lock is taken.
+
+        Args:
+            job_ids: Ids of the jobs.
+
+        Raises:
+            JobNotFound: A job id matches no job.
+        """
+        now = datetime.now(UTC)
+        await self._tasks.stamp_cancel_requested(job_ids, now)
+        for job_id in job_ids:
+            await self._cancel_pending_tasks(await self._tasks.list_by_job(job_id), now)
+        for job_id in job_ids:
+            job = await self._jobs.get(job_id, exclusive=True)
+            if job.settled:
+                continue
+            job.request_cancel(now)
+            await self._jobs.update(job)
+
+    async def settle_job_if_drained(self, job_id: uuid.UUID) -> Job:
+        """Settle a job once every one of its tasks is terminal.
+
+        Args:
+            job_id: Id of the job.
+
+        Raises:
+            JobNotFound: No job has this id.
+
+        Returns:
+            Loaded job, settled if its tasks have drained.
+        """
+        job = await self._jobs.get(job_id, exclusive=True)
+        return await self._settle_drained_job(job)
+
+    async def cancel_job(self, job_id: uuid.UUID) -> Job:
+        """Stamp the cancel request on a job and settle it if that drained it.
 
         Args:
             job_id: Id of the job.
@@ -233,15 +271,8 @@ class TaskTransitions:
         Returns:
             Stored job carrying the cancel request.
         """
-        now = datetime.now(UTC)
-        await self._tasks.stamp_cancel_requested(job_id, now)
-        await self._cancel_pending_tasks(await self._tasks.list_by_job(job_id), now)
-        job = await self._jobs.get(job_id, exclusive=True)
-        if job.settled:
-            return job
-        job.request_cancel(now)
-        stored = await self._jobs.update(job)
-        return await self._settle_drained_job(stored)
+        await self.request_jobs_cancel([job_id])
+        return await self.settle_job_if_drained(job_id)
 
     def _track_task_terminal(self, task: Task, job: Job) -> None:
         """Track a task's transition to a terminal status by kind.

--- a/src/kitaru/server/application/services/worker_service.py
+++ b/src/kitaru/server/application/services/worker_service.py
@@ -16,8 +16,7 @@
 import uuid
 from datetime import UTC, datetime
 
-from kitaru.api_models.v1.task import WorkerScope
-from kitaru.api_models.v1.worker import WorkerRuntime
+from kitaru.api_models.v1.worker import WorkerRuntime, WorkerScope
 from kitaru.server.application.interfaces.worker_repository import WorkerRepository
 from kitaru.server.application.models.auth import AuthContext, WorkerPrincipal
 from kitaru.server.application.models.worker import WorkerFilter

--- a/src/kitaru/server/database/migrations/versions/001_initial.py
+++ b/src/kitaru/server/database/migrations/versions/001_initial.py
@@ -169,6 +169,12 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
     )
     with op.batch_alter_table("job", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_job_cancel_requested_at",
+            ["cancel_requested_at"],
+            unique=False,
+            postgresql_where=sa.text("cancel_requested_at IS NOT NULL"),
+        )
         batch_op.create_index("ix_job_kind", ["kind"], unique=False)
         batch_op.create_index("ix_job_status", ["status"], unique=False)
 
@@ -936,6 +942,7 @@ def downgrade() -> None:
 
     op.drop_table("plugin")
     with op.batch_alter_table("job", schema=None) as batch_op:
+        batch_op.drop_index("ix_job_cancel_requested_at")
         batch_op.drop_index("ix_job_kind")
         batch_op.drop_index("ix_job_status")
 

--- a/src/kitaru/server/domain/task.py
+++ b/src/kitaru/server/domain/task.py
@@ -22,11 +22,9 @@ from pydantic import Field, field_validator
 
 from kitaru.api_models.v1.evaluation import EvaluationResult
 from kitaru.api_models.v1.task import (
-    LabelSelector,
     TaskKind,
     TaskOnFailure,
     TaskStatus,
-    WorkerScope,
 )
 from kitaru.base import FrozenModel
 from kitaru.server.domain.base import (
@@ -49,7 +47,6 @@ __all__ = [
     "ImportTaskDetails",
     "InvalidTaskEnv",
     "InvalidTaskResult",
-    "LabelSelector",
     "PackagePluginSpec",
     "PayloadSpec",
     "PluginSpec",
@@ -63,7 +60,6 @@ __all__ = [
     "TaskResultSessionMissing",
     "TaskRunSpec",
     "TaskSpec",
-    "WorkerScope",
 ]
 
 TERMINAL_TASK_STATUSES = frozenset(

--- a/src/kitaru/server/domain/worker.py
+++ b/src/kitaru/server/domain/worker.py
@@ -18,8 +18,7 @@ from datetime import datetime
 
 from pydantic import Field
 
-from kitaru.api_models.v1.task import WorkerScope
-from kitaru.api_models.v1.worker import WorkerRuntime
+from kitaru.api_models.v1.worker import WorkerRuntime, WorkerScope
 from kitaru.server.domain.base import DomainModel, ForbiddenError, NotFoundError
 from kitaru.server.domain.ids import uuid7
 from kitaru.server.domain.names import Name

--- a/src/kitaru/worker/config.py
+++ b/src/kitaru/worker/config.py
@@ -19,7 +19,7 @@ from typing import Any
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from kitaru.api_models.v1.task import WorkerScope
+from kitaru.api_models.v1.worker import WorkerScope
 from kitaru.worker.heartbeat import DEFAULT_HEARTBEAT_INTERVAL_SECONDS
 
 RUN_POLL_INTERVAL_SECONDS = 2.0

--- a/tests/api_models/test_worker_models.py
+++ b/tests/api_models/test_worker_models.py
@@ -11,12 +11,13 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Tests for task API models."""
+"""Tests for worker API models."""
 
 import pytest
 from pydantic import ValidationError
 
-from kitaru.api_models.v1.task import LabelSelector, TaskKind, WorkerScope
+from kitaru.api_models.v1.task import TaskKind
+from kitaru.api_models.v1.worker import LabelSelector, WorkerScope
 
 
 def test_empty_kinds_rejected() -> None:

--- a/tests/client/test_experiment_runs.py
+++ b/tests/client/test_experiment_runs.py
@@ -15,6 +15,7 @@
 
 import uuid
 from collections.abc import AsyncGenerator
+from functools import partial
 
 import pytest
 
@@ -50,9 +51,15 @@ from kitaru.server.adapters.rest.dependencies import (
 )
 from kitaru.server.api.app import create_app
 from kitaru.server.api.config import APISettings
+from kitaru.server.api.run_cancellation import get_run_canceler
 from kitaru.server.application.models.auth import AuthContext
+from kitaru.server.application.models.replay import ReplayStatusCounts
+from kitaru.server.application.services.experiment_run_service import (
+    ExperimentRunService,
+)
 from kitaru.server.domain.account import Account
 from kitaru.server.domain.agent_version import RunSpec
+from kitaru.server.domain.experiment_run import ExperimentRun
 from kitaru.server.domain.plugin import PluginKind, ScriptPluginSource
 
 ACCOUNT = Account(id=uuid.uuid4(), name="ann")
@@ -62,6 +69,18 @@ ACCOUNT = Account(id=uuid.uuid4(), name="ann")
 def services() -> ReplayServices:
     """Provide fake-backed experiment, replay, and run services."""
     return build_replay_services()
+
+
+async def _cancel_run(
+    service: ExperimentRunService, experiment_run_id: uuid.UUID, actor: AuthContext
+) -> tuple[ExperimentRun, ReplayStatusCounts]:
+    """Drive both cancellation phases against one fake-backed service."""
+    await service.mark_run_canceling(experiment_run_id, actor=actor)
+    for job_id in await service.list_cancelable_job_ids(
+        experiment_run_id, actor=actor
+    ):
+        await service.cancel_run_job(job_id, actor=actor)
+    return await service.get_run(experiment_run_id, actor=actor)
 
 
 @pytest.fixture
@@ -81,6 +100,9 @@ async def api_client(services: ReplayServices) -> AsyncGenerator[KitaruAPIClient
         services.experiment_run_service
     )
     app.dependency_overrides[authorize] = lambda: AuthContext(account=ACCOUNT)
+    app.dependency_overrides[get_run_canceler] = lambda: partial(
+        _cancel_run, services.experiment_run_service
+    )
     async with asgi_api_client(app) as client:
         yield client
 

--- a/tests/client/test_experiment_runs.py
+++ b/tests/client/test_experiment_runs.py
@@ -76,11 +76,7 @@ async def _cancel_run(
 ) -> tuple[ExperimentRun, ReplayStatusCounts]:
     """Drive both cancellation phases against one fake-backed service."""
     await service.mark_run_canceling(experiment_run_id, actor=actor)
-    for job_id in await service.list_cancelable_job_ids(
-        experiment_run_id, actor=actor
-    ):
-        await service.cancel_run_job(job_id, actor=actor)
-    return await service.get_run(experiment_run_id, actor=actor)
+    return await service.cancel_run_jobs(experiment_run_id, actor=actor)
 
 
 @pytest.fixture

--- a/tests/client/test_sessions.py
+++ b/tests/client/test_sessions.py
@@ -81,7 +81,9 @@ async def api_client() -> AsyncGenerator[KitaruAPIClient, None]:
         agent_version_repository=FakeAgentVersionRepository(FakeAgentRepository()),
     )
     node_service = SessionNodeService(
-        repository=node_repository, session_repository=session_repository
+        repository=node_repository,
+        session_repository=session_repository,
+        task_repository=FakeTaskRepository(),
     )
     app.dependency_overrides[get_session_service] = lambda: session_service
     app.dependency_overrides[get_session_node_service] = lambda: node_service

--- a/tests/client/test_workers.py
+++ b/tests/client/test_workers.py
@@ -39,13 +39,13 @@ from conftest import (
     mint_worker_token,
 )
 from kitaru.api_models.v1.filter import FilterCondition, FilterOp
-from kitaru.api_models.v1.task import WorkerScope
 from kitaru.api_models.v1.worker import (
     WorkerCreateRequest,
     WorkerHeartbeatRequest,
     WorkerListParams,
     WorkerRegistrationResponse,
     WorkerRuntime,
+    WorkerScope,
 )
 from kitaru.client.api_client import KitaruAPIClient
 from kitaru.client.exceptions import NotFoundError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4671,6 +4671,9 @@ class FakeTaskRepository:
         """
         self._tasks: dict[uuid.UUID, Task] = {}
         self._sessions = sessions
+        # Assigned after construction, since the fake job repository takes
+        # this repository in its own constructor.
+        self.jobs: FakeJobRepository | None = None
 
     def _check_evaluator_pair(self, task: Task) -> None:
         """Mirror the unique (job_id, input_session_id, plugin_version_id) key.
@@ -4942,7 +4945,8 @@ class FakeTaskRepository:
             now: Current time.
 
         Returns:
-            Cancel request time by id for every stamped task.
+            Cancel request time of the task, falling back to its job's, by id
+            for every stamped task.
         """
         stamped: dict[uuid.UUID, datetime | None] = {}
         for task_id in task_ids:
@@ -4960,6 +4964,10 @@ class FakeTaskRepository:
                 }
             )
             stamped[task_id] = task.cancel_requested_at
+            if stamped[task_id] is None and self.jobs is not None:
+                owner = (await self.jobs.get_many([task.job_id])).get(task.job_id)
+                if owner is not None:
+                    stamped[task_id] = owner.cancel_requested_at
         return stamped
 
     async def lock_by_jobs(
@@ -5277,6 +5285,7 @@ def _build_task_substrate() -> TaskSubstrate:
     workers = FakeWorkerRepository()
     tasks = FakeTaskRepository(sessions=sessions)
     jobs = FakeJobRepository(tasks=tasks)
+    tasks.jobs = jobs
     return TaskSubstrate(
         sessions=sessions,
         agents=agents,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4546,6 +4546,34 @@ class FakeJobRepository:
         """
         return await self.get_many(job_ids)
 
+    async def list_unpropagated_cancel_ids(self, limit: int) -> list[uuid.UUID]:
+        """Read the ids of canceling jobs whose live tasks still owe the stamp.
+
+        Args:
+            limit: Maximum number of ids to read.
+
+        Returns:
+            Ids of the canceling jobs in ascending order.
+        """
+        if self._tasks is None:
+            return []
+        owing: list[uuid.UUID] = []
+        for job_id in sorted(self._jobs):
+            job = self._jobs[job_id]
+            if job.cancel_requested_at is None or job.settled:
+                continue
+            tasks = await self._tasks.list_by_job(job_id)
+            if any(
+                not task.terminal
+                and (
+                    task.cancel_requested_at is None
+                    or task.status is TaskStatus.PENDING
+                )
+                for task in tasks
+            ):
+                owing.append(job_id)
+        return owing[:limit]
+
     async def query(self, job_filter: JobFilter) -> tuple[list[Job], str | None]:
         """Query jobs matching a filter.
 
@@ -4854,26 +4882,42 @@ class FakeTaskRepository:
             claimed.append(await self.update(claimed_task))
         return claimed
 
-    async def claim_stale(self, cutoff: datetime, limit: int) -> list[Task]:
-        """Lock in-flight tasks whose last heartbeat is older than a cutoff.
+    async def claim_stale(self, task_id: uuid.UUID, cutoff: datetime) -> Task | None:
+        """Lock one task by id if it is still in flight and older than a cutoff.
+
+        Args:
+            task_id: Id of the candidate task.
+            cutoff: Bound the last heartbeat must be older than.
+
+        Returns:
+            Locked stale task, or ``None`` when it is no longer stale.
+        """
+        task = self._tasks.get(task_id)
+        if task is None or task.status not in (TaskStatus.CLAIMED, TaskStatus.RUNNING):
+            return None
+        if not _is_stale_before(task, cutoff):
+            return None
+        return task.model_copy()
+
+    async def list_stale_ids(self, cutoff: datetime, limit: int) -> list[uuid.UUID]:
+        """Read the ids of in-flight tasks whose last heartbeat is older than a cutoff.
 
         Args:
             cutoff: Bound the last heartbeat must be older than.
-            limit: Maximum number of tasks to lock.
+            limit: Maximum number of ids to read.
 
         Returns:
-            Locked stale tasks.
+            Ids of the stale tasks in ascending order.
         """
         stale = sorted(
             (
-                task
+                task.id
                 for task in self._tasks.values()
                 if task.status in (TaskStatus.CLAIMED, TaskStatus.RUNNING)
                 and _is_stale_before(task, cutoff)
             ),
-            key=lambda task: task.id,
         )
-        return [task.model_copy() for task in stale[:limit]]
+        return stale[:limit]
 
     async def stamp_heartbeats(
         self, task_ids: Sequence[uuid.UUID], worker_id: uuid.UUID, now: datetime
@@ -4905,6 +4949,21 @@ class FakeTaskRepository:
             )
             stamped[task_id] = task.cancel_requested_at
         return stamped
+
+    async def lock_by_jobs(
+        self, job_ids: Sequence[uuid.UUID], nowait: bool = False
+    ) -> None:
+        """Lock the jobs' non-terminal task rows in id order.
+
+        Row locking has no in-memory counterpart, a single process never
+        contends with itself.
+
+        Args:
+            job_ids: Ids the tasks belong to.
+            nowait: Whether to fail instead of waiting when another
+                transaction holds one of the rows.
+        """
+        _ = job_ids, nowait
 
     async def stamp_cancel_requested(
         self, job_ids: Sequence[uuid.UUID], now: datetime

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3855,6 +3855,24 @@ class FakeReplayRepository:
                 return replay.model_copy()
         return None
 
+    async def get_many_by_job_ids(
+        self, job_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, Replay]:
+        """Bulk-load the replay of each job, keyed by job id.
+
+        Args:
+            job_ids: Ids of the jobs.
+
+        Returns:
+            Replays keyed by job id, jobs without a replay omitted.
+        """
+        job_id_set = set(job_ids)
+        return {
+            replay.job_id: replay.model_copy()
+            for replay in self._replays.values()
+            if replay.job_id in job_id_set
+        }
+
     async def query(
         self, replay_filter: ReplayFilter
     ) -> tuple[list[Replay], str | None]:
@@ -3913,6 +3931,23 @@ class FakeReplayRepository:
         updated = replay.model_copy(update={"created": stored.created, "updated": now})
         self._replays[replay.id] = updated
         return updated.model_copy()
+
+    async def update_many(self, replays: list[Replay]) -> list[Replay]:
+        """Persist changes to many existing replays in one round trip.
+
+        Args:
+            replays: Replays with modified fields.
+
+        Raises:
+            ReplayNotFound: A replay id matches no replay.
+
+        Returns:
+            Stored replays with the updated timestamp renewed, in id order.
+        """
+        return [
+            await self.update(replay)
+            for replay in sorted(replays, key=lambda replay: replay.id)
+        ]
 
     async def count_by_status(self, experiment_run_id: uuid.UUID) -> ReplayStatusCounts:
         """Count an experiment run's replays by status.
@@ -4495,6 +4530,22 @@ class FakeJobRepository:
             if job_id in self._jobs
         }
 
+    async def get_many_locked(
+        self, job_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, Job]:
+        """Bulk-lock and load jobs by id, keyed by id, missing ids omitted.
+
+        Row locking has no in-memory counterpart, a single process never
+        contends with itself.
+
+        Args:
+            job_ids: Ids of the jobs to load.
+
+        Returns:
+            Locked jobs keyed by id.
+        """
+        return await self.get_many(job_ids)
+
     async def query(self, job_filter: JobFilter) -> tuple[list[Job], str | None]:
         """Query jobs matching a filter.
 
@@ -4537,6 +4588,20 @@ class FakeJobRepository:
         )
         self._jobs[job.id] = renewed
         return renewed.model_copy()
+
+    async def update_many(self, jobs: list[Job]) -> list[Job]:
+        """Persist changes to many existing jobs in one round trip.
+
+        Args:
+            jobs: Jobs with modified fields.
+
+        Raises:
+            JobNotFound: A job id matches no job.
+
+        Returns:
+            Stored jobs with the updated timestamp renewed, in the same order.
+        """
+        return [await self.update(job) for job in jobs]
 
     async def delete(self, job_id: uuid.UUID) -> None:
         """Delete a job by id, cascading its tasks.
@@ -4713,6 +4778,25 @@ class FakeTaskRepository:
         tasks = [task for task in self._tasks.values() if task.job_id == job_id]
         return [task.model_copy() for task in sorted(tasks, key=lambda task: task.id)]
 
+    async def list_by_jobs(
+        self, job_ids: Sequence[uuid.UUID]
+    ) -> dict[uuid.UUID, list[Task]]:
+        """Bulk-load every task of many jobs, grouped by job id in creation order.
+
+        Args:
+            job_ids: Ids the tasks belong to.
+
+        Returns:
+            Tasks keyed by job id in creation order, jobs without tasks
+            omitted.
+        """
+        job_id_set = set(job_ids)
+        tasks_by_job: dict[uuid.UUID, list[Task]] = {}
+        for task in sorted(self._tasks.values(), key=lambda task: task.id):
+            if task.job_id in job_id_set:
+                tasks_by_job.setdefault(task.job_id, []).append(task.model_copy())
+        return tasks_by_job
+
     async def update(self, task: Task) -> Task:
         """Persist changes to an existing task.
 
@@ -4842,6 +4926,27 @@ class FakeTaskRepository:
                     "updated": _renewed_timestamp(task.updated),
                 }
             )
+
+    async def cancel_pending(
+        self, job_ids: Sequence[uuid.UUID], now: datetime
+    ) -> list[Task]:
+        """Move each still-pending task of the jobs straight to canceled.
+
+        Args:
+            job_ids: Ids the tasks belong to.
+            now: Current time.
+
+        Returns:
+            Canceled tasks.
+        """
+        canceled: list[Task] = []
+        for task in sorted(self._tasks.values(), key=lambda task: task.id):
+            if task.job_id not in job_ids or task.status is not TaskStatus.PENDING:
+                continue
+            canceled_task = task.model_copy()
+            canceled_task.request_cancel(now)
+            canceled.append(await self.update(canceled_task))
+        return canceled
 
     def cascade_job_delete(self, job_id: uuid.UUID) -> None:
         """Drop the tasks of a deleted job, mirroring the cascading key.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,8 +45,8 @@ from kitaru.api_models.v1.job import JobKind, JobStatus
 from kitaru.api_models.v1.replay import ReplayStatus
 from kitaru.api_models.v1.session import SessionOrigin, TokenUsage
 from kitaru.api_models.v1.tag import TagResourceType
-from kitaru.api_models.v1.task import TaskOnFailure, TaskStatus, WorkerScope
-from kitaru.api_models.v1.worker import WorkerRuntime
+from kitaru.api_models.v1.task import TaskOnFailure, TaskStatus
+from kitaru.api_models.v1.worker import WorkerRuntime, WorkerScope
 from kitaru.client.api_client import KitaruAPIClient
 from kitaru.client.client_id import ENV_CLIENT_ID
 from kitaru.client.credential_store import CredentialStore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2534,11 +2534,12 @@ class FakeCohortRepository:
         self._cohorts[stored.id] = stored
         return stored.model_copy()
 
-    async def get(self, cohort_id: uuid.UUID) -> Cohort:
+    async def get(self, cohort_id: uuid.UUID, exclusive: bool = False) -> Cohort:
         """Load a cohort by id.
 
         Args:
             cohort_id: Id of the cohort.
+            exclusive: Ignored, the fake holds no rows to lock.
 
         Raises:
             CohortNotFound: No cohort has this id.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4646,6 +4646,18 @@ class FakeJobRepository:
         if self._tasks is not None:
             self._tasks.cascade_job_delete(job_id)
 
+    async def delete_many(self, job_ids: Sequence[uuid.UUID]) -> None:
+        """Delete many jobs by id, cascading their tasks.
+
+        Args:
+            job_ids: Ids of the jobs.
+
+        Raises:
+            JobNotFound: A job id matches no job.
+        """
+        for job_id in sorted(job_ids):
+            await self.delete(job_id)
+
 
 class FakeTaskRepository:
     """In-memory task repository."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4822,15 +4822,17 @@ class FakeTaskRepository:
             stamped[task_id] = task.cancel_requested_at
         return stamped
 
-    async def stamp_cancel_requested(self, job_id: uuid.UUID, now: datetime) -> None:
-        """Stamp cancel_requested_at on the job's non-terminal tasks lacking it.
+    async def stamp_cancel_requested(
+        self, job_ids: Sequence[uuid.UUID], now: datetime
+    ) -> None:
+        """Stamp cancel_requested_at on the jobs' non-terminal tasks lacking it.
 
         Args:
-            job_id: Id the tasks belong to.
+            job_ids: Ids the tasks belong to.
             now: Current time.
         """
         for task_id, task in list(self._tasks.items()):
-            if task.job_id != job_id or task.terminal:
+            if task.job_id not in job_ids or task.terminal:
                 continue
             if task.cancel_requested_at is not None:
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2736,11 +2736,14 @@ class FakeCohortVersionRepository:
             self._sessions._mark_cohort_member(session_id)
         return stored.model_copy()
 
-    async def get(self, cohort_version_id: uuid.UUID) -> CohortVersion:
+    async def get(
+        self, cohort_version_id: uuid.UUID, exclusive: bool = False
+    ) -> CohortVersion:
         """Load a cohort version by id.
 
         Args:
             cohort_version_id: Id of the cohort version.
+            exclusive: Ignored, the fake holds no rows to lock.
 
         Raises:
             CohortVersionIdNotFound: No cohort version has this id.

--- a/tests/server/test_deadlock_handler.py
+++ b/tests/server/test_deadlock_handler.py
@@ -1,0 +1,64 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for the deadlock exception handler."""
+
+import httpx
+import pytest
+from asyncpg.exceptions import DeadlockDetectedError
+from fastapi import FastAPI
+from sqlalchemy.exc import DBAPIError
+
+from conftest import local_settings
+from kitaru.server.api.app import create_app
+
+
+def _deadlock_error() -> DBAPIError:
+    """Build a database error chained like a driver-reported deadlock."""
+    adapter_error = Exception("adapter error")
+    adapter_error.__cause__ = DeadlockDetectedError("deadlock detected")
+    return DBAPIError("UPDATE task", None, adapter_error)
+
+
+def create_app_with_error_probes() -> FastAPI:
+    """Create the app with extra routes raising database errors."""
+    app = create_app(local_settings())
+
+    @app.get("/probe-deadlock")
+    async def raise_deadlock() -> None:
+        """Raise a database error caused by a deadlock."""
+        raise _deadlock_error()
+
+    @app.get("/probe-dbapi-error")
+    async def raise_dbapi_error() -> None:
+        """Raise a database error without a deadlock cause."""
+        raise DBAPIError("UPDATE task", None, Exception("adapter error"))
+
+    return app
+
+
+async def test_deadlock_maps_to_503() -> None:
+    """Turn a transaction killed by a deadlock into HTTP 503."""
+    transport = httpx.ASGITransport(app=create_app_with_error_probes())
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/probe-deadlock")
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Deadlock detected"}
+
+
+async def test_other_database_errors_propagate() -> None:
+    """Leave a database error without a deadlock cause unhandled."""
+    transport = httpx.ASGITransport(app=create_app_with_error_probes())
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with pytest.raises(DBAPIError):
+            await client.get("/probe-dbapi-error")

--- a/tests/server/test_events.py
+++ b/tests/server/test_events.py
@@ -15,7 +15,7 @@
 
 import uuid
 
-from kitaru.server.application.events import EventDispatcher, JobSettled
+from kitaru.server.application.events import EventDispatcher, JobsSettled
 from kitaru.server.domain.job import Job, JobKind, JobStatus
 
 
@@ -24,18 +24,18 @@ async def test_dispatch_runs_handlers_in_registration_order() -> None:
     dispatcher = EventDispatcher()
     calls = []
 
-    async def first(event: JobSettled) -> None:
-        calls.append(("first", event.job.id))
+    async def first(event: JobsSettled) -> None:
+        calls.append(("first", event.jobs[0].id))
 
-    async def second(event: JobSettled) -> None:
-        calls.append(("second", event.job.id))
+    async def second(event: JobsSettled) -> None:
+        calls.append(("second", event.jobs[0].id))
 
-    dispatcher.register(JobSettled, first)
-    dispatcher.register(JobSettled, second)
+    dispatcher.register(JobsSettled, first)
+    dispatcher.register(JobsSettled, second)
     job = Job(
         owner_id=uuid.uuid4(), kind=JobKind.SESSION_RUN, status=JobStatus.COMPLETED
     )
 
-    await dispatcher.dispatch(JobSettled(job))
+    await dispatcher.dispatch(JobsSettled([job]))
 
     assert calls == [("first", job.id), ("second", job.id)]

--- a/tests/server/test_experiment_runs_api.py
+++ b/tests/server/test_experiment_runs_api.py
@@ -16,6 +16,7 @@
 import json
 import uuid
 from collections.abc import AsyncGenerator
+from functools import partial
 
 import httpx
 import pytest
@@ -39,11 +40,17 @@ from kitaru.server.adapters.rest.dependencies import (
 )
 from kitaru.server.api.app import create_app
 from kitaru.server.api.config import APISettings
+from kitaru.server.api.run_cancellation import get_run_canceler
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.models.experiment import ExperimentCreate
+from kitaru.server.application.models.replay import ReplayStatusCounts
 from kitaru.server.application.models.replay_config import EvaluatorConfigInput
+from kitaru.server.application.services.experiment_run_service import (
+    ExperimentRunService,
+)
 from kitaru.server.domain.account import Account
 from kitaru.server.domain.agent_version import RunSpec
+from kitaru.server.domain.experiment_run import ExperimentRun
 from kitaru.server.domain.plugin import PluginKind, ScriptPluginSource
 
 ACCOUNT = Account(id=uuid.uuid4(), name="ann")
@@ -53,6 +60,18 @@ ACCOUNT = Account(id=uuid.uuid4(), name="ann")
 def services() -> ReplayServices:
     """Provide fake-backed experiment, replay, and run services."""
     return build_replay_services()
+
+
+async def _cancel_run(
+    service: ExperimentRunService, experiment_run_id: uuid.UUID, actor: AuthContext
+) -> tuple[ExperimentRun, ReplayStatusCounts]:
+    """Drive both cancellation phases against one fake-backed service."""
+    await service.mark_run_canceling(experiment_run_id, actor=actor)
+    for job_id in await service.list_cancelable_job_ids(
+        experiment_run_id, actor=actor
+    ):
+        await service.cancel_run_job(job_id, actor=actor)
+    return await service.get_run(experiment_run_id, actor=actor)
 
 
 @pytest.fixture
@@ -72,6 +91,9 @@ async def client(services: ReplayServices) -> AsyncGenerator[httpx.AsyncClient, 
         services.experiment_run_service
     )
     app.dependency_overrides[authorize] = lambda: AuthContext(account=ACCOUNT)
+    app.dependency_overrides[get_run_canceler] = lambda: partial(
+        _cancel_run, services.experiment_run_service
+    )
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         yield client

--- a/tests/server/test_experiment_runs_api.py
+++ b/tests/server/test_experiment_runs_api.py
@@ -67,11 +67,7 @@ async def _cancel_run(
 ) -> tuple[ExperimentRun, ReplayStatusCounts]:
     """Drive both cancellation phases against one fake-backed service."""
     await service.mark_run_canceling(experiment_run_id, actor=actor)
-    for job_id in await service.list_cancelable_job_ids(
-        experiment_run_id, actor=actor
-    ):
-        await service.cancel_run_job(job_id, actor=actor)
-    return await service.get_run(experiment_run_id, actor=actor)
+    return await service.cancel_run_jobs(experiment_run_id, actor=actor)
 
 
 @pytest.fixture

--- a/tests/server/test_job_repository.py
+++ b/tests/server/test_job_repository.py
@@ -214,3 +214,29 @@ async def test_delete_not_found(setup: Setup) -> None:
     missing_id = uuid.uuid4()
     with pytest.raises(JobNotFound, match=f"Job {missing_id} was not found"):
         await repository.delete(missing_id)
+
+
+async def test_delete_many(setup: Setup) -> None:
+    """Delete many stored jobs."""
+    repository, owner_id = setup
+    first = await repository.create(_job(owner_id))
+    second = await repository.create(_job(owner_id))
+    await repository.delete_many([second.id, first.id])
+    for job_id in (first.id, second.id):
+        with pytest.raises(JobNotFound):
+            await repository.get(job_id)
+
+
+async def test_delete_many_empty(setup: Setup) -> None:
+    """Bulk-delete with no jobs is a no-op."""
+    repository, _ = setup
+    await repository.delete_many([])
+
+
+async def test_delete_many_not_found(setup: Setup) -> None:
+    """Raise when bulk-deleting a job that does not exist."""
+    repository, owner_id = setup
+    created = await repository.create(_job(owner_id))
+    missing_id = uuid.uuid4()
+    with pytest.raises(JobNotFound):
+        await repository.delete_many([created.id, missing_id])

--- a/tests/server/test_job_service.py
+++ b/tests/server/test_job_service.py
@@ -456,10 +456,19 @@ async def test_settlement_precedence_failed_over_canceled_over_completed(
         TaskUpdate(status=TaskStatus.FAILED, error="boom"),
         actor=build_task_actor(ACTOR.account, failing.id, 1, worker.id),
     )
-    # Abort propagation only stamps the still-claimed sibling, it does not
-    # settle the job until every task reaches a terminal status.
+    # The report stamps the job alone. It does not settle the job until every
+    # task reaches a terminal status, and it leaves the sibling row untouched
+    # for the sweep's propagation backstop.
     job_after = await services.jobs.get(job.id)
     assert job_after.status is JobStatus.RUNNING
+    assert job_after.cancel_requested_at is not None
+
+    sibling_after = await services.tasks.get(sibling.id)
+    assert sibling_after.status is TaskStatus.CLAIMED
+    assert sibling_after.cancel_requested_at is None
+
+    assert await services.task_service.list_unpropagated_cancel_job_ids() == [job.id]
+    await services.task_service.propagate_job_cancel(job.id)
 
     sibling_after = await services.tasks.get(sibling.id)
     assert sibling_after.status is TaskStatus.CLAIMED

--- a/tests/server/test_replay_pipeline.py
+++ b/tests/server/test_replay_pipeline.py
@@ -752,10 +752,7 @@ async def test_duplicate_replay_for_the_same_baseline_in_a_run_conflicts(
 async def _cancel_run(services: ReplayServices, run_id: uuid.UUID) -> None:
     """Drive the two cancellation phases the way the endpoint does."""
     await services.experiment_run_service.mark_run_canceling(run_id, actor=ACTOR)
-    for job_id in await services.experiment_run_service.list_cancelable_job_ids(
-        run_id, actor=ACTOR
-    ):
-        await services.experiment_run_service.cancel_run_job(job_id, actor=ACTOR)
+    await services.experiment_run_service.cancel_run_jobs(run_id, actor=ACTOR)
 
 
 async def test_run_cancel_pending_only_run_cancels_immediately(
@@ -809,9 +806,7 @@ async def test_marking_an_already_canceling_run_is_a_no_op(
     marked, _ = await services.experiment_run_service.get_run(run.id, actor=ACTOR)
     assert marked.status is ExperimentRunStatus.CANCELING
     await _cancel_run(services, run.id)
-    canceled_run, _ = await services.experiment_run_service.get_run(
-        run.id, actor=ACTOR
-    )
+    canceled_run, _ = await services.experiment_run_service.get_run(run.id, actor=ACTOR)
     assert canceled_run.status is ExperimentRunStatus.CANCELED
 
 

--- a/tests/server/test_replay_pipeline.py
+++ b/tests/server/test_replay_pipeline.py
@@ -350,6 +350,10 @@ async def test_agent_task_failure_cancels_baseline_tasks_and_fails_replay(
         actor=build_task_actor(ACTOR.account, agent_task.id, 1, worker.id),
     )
 
+    job_after = await services.jobs.get(bundle.replay.job_id)
+    assert job_after.cancel_requested_at is not None
+    await services.task_service.propagate_job_cancel(bundle.replay.job_id)
+
     baseline_after = await services.tasks.get(baseline_task.id)
     assert baseline_after.status is TaskStatus.CLAIMED
     assert baseline_after.cancel_requested_at is not None
@@ -406,6 +410,8 @@ async def test_baseline_evaluator_failure_fails_the_replay(
         TaskUpdate(status=TaskStatus.FAILED, error="scoring failed"),
         actor=build_task_actor(ACTOR.account, baseline_task.id, 1, worker.id),
     )
+
+    await services.task_service.propagate_job_cancel(bundle.replay.job_id)
 
     agent_after = await services.tasks.get(agent_task.id)
     assert agent_after.cancel_requested_at is not None

--- a/tests/server/test_replay_pipeline.py
+++ b/tests/server/test_replay_pipeline.py
@@ -749,6 +749,15 @@ async def test_duplicate_replay_for_the_same_baseline_in_a_run_conflicts(
         )
 
 
+async def _cancel_run(services: ReplayServices, run_id: uuid.UUID) -> None:
+    """Drive the two cancellation phases the way the endpoint does."""
+    await services.experiment_run_service.mark_run_canceling(run_id, actor=ACTOR)
+    for job_id in await services.experiment_run_service.list_cancelable_job_ids(
+        run_id, actor=ACTOR
+    ):
+        await services.experiment_run_service.cancel_run_job(job_id, actor=ACTOR)
+
+
 async def test_run_cancel_pending_only_run_cancels_immediately(
     services: ReplayServices,
 ) -> None:
@@ -767,12 +776,43 @@ async def test_run_cancel_pending_only_run_cancels_immediately(
         actor=ACTOR,
     )
 
-    canceled_run, counts = await services.experiment_run_service.cancel_run(
+    await _cancel_run(services, run.id)
+    canceled_run, counts = await services.experiment_run_service.get_run(
         run.id, actor=ACTOR
     )
     assert canceled_run.status is ExperimentRunStatus.CANCELED
     assert counts.canceled == 2
     assert counts.non_settled == 0
+
+
+async def test_marking_an_already_canceling_run_is_a_no_op(
+    services: ReplayServices,
+) -> None:
+    """Re-marking a canceling run leaves it alone so a retry can finish phase two."""
+    agent_version = await _agent_version_with_run_spec(services)
+    experiment_id, _ = await _create_experiment_with_evaluator(services)
+    session = await _baseline_session(services, agent_version)
+    cohort_version = await _cohort_version(
+        services, agent_version.agent_id, [session.id]
+    )
+    run, _ = await services.experiment_service.start_run(
+        experiment_id,
+        ExperimentRunCreate(
+            cohort_version_id=cohort_version.id, agent_version_id=agent_version.id
+        ),
+        actor=ACTOR,
+    )
+
+    await services.experiment_run_service.mark_run_canceling(run.id, actor=ACTOR)
+    await services.experiment_run_service.mark_run_canceling(run.id, actor=ACTOR)
+
+    marked, _ = await services.experiment_run_service.get_run(run.id, actor=ACTOR)
+    assert marked.status is ExperimentRunStatus.CANCELING
+    await _cancel_run(services, run.id)
+    canceled_run, _ = await services.experiment_run_service.get_run(
+        run.id, actor=ACTOR
+    )
+    assert canceled_run.status is ExperimentRunStatus.CANCELED
 
 
 async def test_run_cancel_in_flight_task_keeps_status_until_it_terminates(
@@ -806,7 +846,8 @@ async def test_run_cancel_in_flight_task_keeps_status_until_it_terminates(
         10, actor=build_worker_actor(ACTOR.account, worker.id)
     )
 
-    canceling_run, _ = await services.experiment_run_service.cancel_run(
+    await _cancel_run(services, run.id)
+    canceling_run, _ = await services.experiment_run_service.get_run(
         run.id, actor=ACTOR
     )
     assert canceling_run.status is ExperimentRunStatus.CANCELING
@@ -870,7 +911,7 @@ async def test_finalize_precedence_canceling_beats_failure(
         10, actor=build_worker_actor(ACTOR.account, worker.id)
     )
 
-    await services.experiment_run_service.cancel_run(run.id, actor=ACTOR)
+    await _cancel_run(services, run.id)
 
     tasks_a, _ = await services.task_service.list_tasks(
         TaskFilter(job_id=replay_a.job_id), actor=ACTOR

--- a/tests/server/test_run_finalization.py
+++ b/tests/server/test_run_finalization.py
@@ -21,9 +21,9 @@ from conftest import FakeExperimentRunRepository, FakeReplayRepository, create_r
 from kitaru.analytics.events import AnalyticsEvent
 from kitaru.api_models.v1.experiment_run import ExperimentRunStatus
 from kitaru.api_models.v1.replay import ReplayStatus
-from kitaru.server.application.events import ReplaySettled
+from kitaru.server.application.events import ReplaysSettled
 from kitaru.server.application.services.run_finalization import (
-    finalize_run_if_drained,
+    finalize_runs_if_drained,
 )
 from kitaru.server.application.services.server_analytics import ServerAnalytics
 from kitaru.server.domain.experiment_run import ExperimentRun
@@ -58,7 +58,7 @@ async def _drained_run(
     run_repository: FakeExperimentRunRepository,
     replay_repository: FakeReplayRepository,
     status: ReplayStatus,
-) -> tuple[ReplaySettled, uuid.UUID]:
+) -> tuple[ReplaysSettled, uuid.UUID]:
     """Store a run with its single, now-settled replay and return the settled event."""
     started_at = datetime.now(UTC) - timedelta(seconds=5)
     run = await run_repository.create(
@@ -81,10 +81,10 @@ async def _drained_run(
         experiment_run_id=run.id,
         status=status,
     )
-    return ReplaySettled(replay=replay), run.id
+    return ReplaysSettled(replays=[replay]), run.id
 
 
-async def test_finalize_run_if_drained_tracks_experiment_run_completed() -> None:
+async def test_finalize_runs_if_drained_tracks_experiment_run_completed() -> None:
     """Fire EXPERIMENT_RUN_COMPLETED with the outcome, replay count, and duration."""
     run_repository = FakeExperimentRunRepository()
     replay_repository = FakeReplayRepository()
@@ -93,7 +93,7 @@ async def test_finalize_run_if_drained_tracks_experiment_run_completed() -> None
     )
     analytics = _RecordingAnalytics()
 
-    await finalize_run_if_drained(
+    await finalize_runs_if_drained(
         event,
         replay_repository=replay_repository,
         experiment_run_repository=run_repository,
@@ -109,7 +109,7 @@ async def test_finalize_run_if_drained_tracks_experiment_run_completed() -> None
     assert properties["duration_seconds"] >= 0
 
 
-async def test_finalize_run_if_drained_without_analytics_tracker() -> None:
+async def test_finalize_runs_if_drained_without_analytics_tracker() -> None:
     """Finalize a run normally when no analytics tracker is configured."""
     run_repository = FakeExperimentRunRepository()
     replay_repository = FakeReplayRepository()
@@ -117,7 +117,7 @@ async def test_finalize_run_if_drained_without_analytics_tracker() -> None:
         run_repository, replay_repository, ReplayStatus.COMPLETED
     )
 
-    await finalize_run_if_drained(
+    await finalize_runs_if_drained(
         event,
         replay_repository=replay_repository,
         experiment_run_repository=run_repository,

--- a/tests/server/test_run_finalization_pg.py
+++ b/tests/server/test_run_finalization_pg.py
@@ -50,9 +50,9 @@ from kitaru.server.adapters.db.repositories.replay_repository import (
 from kitaru.server.adapters.db.repositories.session_repository import (
     SQLSessionRepository,
 )
-from kitaru.server.application.events import ReplaySettled
+from kitaru.server.application.events import ReplaysSettled
 from kitaru.server.application.services.run_finalization import (
-    finalize_run_if_drained,
+    finalize_runs_if_drained,
 )
 from kitaru.server.domain.account import Account
 from kitaru.server.domain.agent import Agent
@@ -78,14 +78,14 @@ async def _settle_and_finalize(session: AsyncSession, replay_id: uuid.UUID) -> N
     replay = await replay_repository.get(replay_id)
     replay.complete()
     replay = await replay_repository.update(replay)
-    await finalize_run_if_drained(
-        ReplaySettled(replay=replay),
+    await finalize_runs_if_drained(
+        ReplaysSettled(replays=[replay]),
         replay_repository=replay_repository,
         experiment_run_repository=run_repository,
     )
 
 
-async def test_finalize_run_if_drained_serializes_concurrent_settlements() -> None:
+async def test_finalize_runs_if_drained_serializes_concurrent_settlements() -> None:
     """Two replays of one run settling in overlapping transactions still finalize it.
 
     Regression test for a race in run finalization: it used to count

--- a/tests/server/test_session_node_service.py
+++ b/tests/server/test_session_node_service.py
@@ -46,6 +46,7 @@ from kitaru.server.application.services.session_service import SessionService
 from kitaru.server.domain.account import Account
 from kitaru.server.domain.session import SessionAccessDenied
 from kitaru.server.domain.session_node import SessionNodeParentNotFound
+from kitaru.server.domain.task import AgentTask
 
 ACTOR = AuthContext(account=Account(id=uuid.uuid4(), name="ann"))
 
@@ -63,13 +64,22 @@ def node_repository() -> FakeSessionNodeRepository:
 
 
 @pytest.fixture
+def task_repository() -> FakeTaskRepository:
+    """Provide a fake task repository."""
+    return FakeTaskRepository()
+
+
+@pytest.fixture
 def service(
     node_repository: FakeSessionNodeRepository,
     session_repository: FakeSessionRepository,
+    task_repository: FakeTaskRepository,
 ) -> SessionNodeService:
     """Provide a session node service backed by the fake repositories."""
     return SessionNodeService(
-        repository=node_repository, session_repository=session_repository
+        repository=node_repository,
+        session_repository=session_repository,
+        task_repository=task_repository,
     )
 
 
@@ -469,10 +479,15 @@ async def test_ingest_nodes_denies_a_task_principal_for_its_input_session(
 
 
 async def test_ingest_nodes_allows_a_task_principal_for_its_own_session(
-    service: SessionNodeService, session_repository: FakeSessionRepository
+    service: SessionNodeService,
+    session_repository: FakeSessionRepository,
+    task_repository: FakeTaskRepository,
 ) -> None:
     """Allow a task principal to ingest nodes into the session it owns."""
-    task_id = uuid.uuid4()
+    task = await task_repository.create(
+        AgentTask(job_id=uuid.uuid4(), agent_version_id=uuid.uuid4(), attempt=1)
+    )
+    task_id = task.id
     session = await create_session(
         session_repository,
         uuid.uuid4(),

--- a/tests/server/test_session_nodes_api.py
+++ b/tests/server/test_session_nodes_api.py
@@ -76,7 +76,9 @@ async def client(
         agent_version_repository=FakeAgentVersionRepository(FakeAgentRepository()),
     )
     node_service = SessionNodeService(
-        repository=node_repository, session_repository=session_repository
+        repository=node_repository,
+        session_repository=session_repository,
+        task_repository=FakeTaskRepository(),
     )
     app.dependency_overrides[get_session_service] = lambda: session_service
     app.dependency_overrides[get_session_node_service] = lambda: node_service

--- a/tests/server/test_session_service.py
+++ b/tests/server/test_session_service.py
@@ -61,6 +61,7 @@ from kitaru.server.domain.session import (
     SessionStatusCannotBeCleared,
 )
 from kitaru.server.domain.task import (
+    AgentTask,
     Task,
     TaskNotFound,
     TaskNotRunning,
@@ -976,10 +977,15 @@ async def test_update_session_denies_a_task_principal_for_another_tasks_session(
 
 
 async def test_update_session_allows_a_task_principal_for_its_own_session(
-    service: SessionService, repository: FakeSessionRepository
+    service: SessionService,
+    repository: FakeSessionRepository,
+    task_repository: FakeTaskRepository,
 ) -> None:
     """Allow a task principal to update the session linked to its own task."""
-    task_id = uuid.uuid4()
+    task = await task_repository.create(
+        AgentTask(job_id=uuid.uuid4(), agent_version_id=uuid.uuid4(), attempt=1)
+    )
+    task_id = task.id
     session = await create_session(
         repository, uuid.uuid4(), uuid.uuid4(), task_id=task_id
     )

--- a/tests/server/test_sessions_api.py
+++ b/tests/server/test_sessions_api.py
@@ -154,7 +154,9 @@ async def client(
         agent_version_repository=agent_version_repository,
     )
     node_service = SessionNodeService(
-        repository=node_repository, session_repository=session_repository
+        repository=node_repository,
+        session_repository=session_repository,
+        task_repository=task_repository,
     )
     tag_service = TagService(repository=tag_repository)
     evaluation_service = EvaluationService(
@@ -851,7 +853,9 @@ def _build_task_scoped_app(
         agent_version_repository=FakeAgentVersionRepository(FakeAgentRepository()),
     )
     app.dependency_overrides[get_session_node_service] = lambda: SessionNodeService(
-        repository=node_repository, session_repository=session_repository
+        repository=node_repository,
+        session_repository=session_repository,
+        task_repository=task_repository,
     )
     app.dependency_overrides[get_evaluation_service] = lambda: EvaluationService(
         repository=evaluation_repository, session_repository=session_repository

--- a/tests/server/test_task_cancellation_pg.py
+++ b/tests/server/test_task_cancellation_pg.py
@@ -1,0 +1,468 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Concurrency tests for task cancellation against PostgreSQL."""
+
+import asyncio
+import uuid
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from conftest import pg_session_with_engine, postgres_available
+from kitaru.api_models.v1.job import JobKind, JobStatus
+from kitaru.api_models.v1.task import TaskStatus, WorkerScope
+from kitaru.api_models.v1.worker import WorkerRuntime
+from kitaru.server.adapters.db.encryption import AesGcmCipher
+from kitaru.server.adapters.db.errors import is_lock_not_available
+from kitaru.server.adapters.db.repositories.account_repository import (
+    SQLAccountRepository,
+)
+from kitaru.server.adapters.db.repositories.agent_repository import SQLAgentRepository
+from kitaru.server.adapters.db.repositories.agent_version_repository import (
+    SQLAgentVersionRepository,
+)
+from kitaru.server.adapters.db.repositories.blob_repository import SQLBlobRepository
+from kitaru.server.adapters.db.repositories.job_repository import SQLJobRepository
+from kitaru.server.adapters.db.repositories.plugin_repository import (
+    SQLPluginRepository,
+)
+from kitaru.server.adapters.db.repositories.secret_repository import (
+    SQLSecretRepository,
+)
+from kitaru.server.adapters.db.repositories.session_repository import (
+    SQLSessionRepository,
+)
+from kitaru.server.adapters.db.repositories.task_repository import SQLTaskRepository
+from kitaru.server.adapters.db.repositories.worker_repository import (
+    SQLWorkerRepository,
+)
+from kitaru.server.application.events import EventDispatcher, TaskTerminal
+from kitaru.server.application.models.auth import (
+    TaskAuthContext,
+    TaskPrincipal,
+    WorkerAuthContext,
+    WorkerPrincipal,
+)
+from kitaru.server.application.models.task import TaskPolicy, TaskUpdate
+from kitaru.server.application.services.task_service import TaskService
+from kitaru.server.application.services.task_spec import TaskSpecBuilder
+from kitaru.server.application.services.task_transitions import TaskTransitions
+from kitaru.server.domain.account import Account
+from kitaru.server.domain.agent import Agent
+from kitaru.server.domain.agent_version import AgentVersion, RunSpec
+from kitaru.server.domain.job import Job
+from kitaru.server.domain.task import AgentTask, Task
+from kitaru.server.domain.worker import Worker
+
+TASK_LOW_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+TASK_HIGH_ID = uuid.UUID("ffffffff-ffff-ffff-ffff-fffffffffff2")
+JOB_LOW_ID = uuid.UUID("00000000-0000-0000-0000-00000000000a")
+JOB_HIGH_ID = uuid.UUID("ffffffff-ffff-ffff-ffff-fffffffffffb")
+
+
+def _build_task_service(
+    session: AsyncSession, dispatcher: EventDispatcher
+) -> TaskService:
+    """Build a task service on the SQL repositories of one session."""
+    policy = TaskPolicy()
+    spec_builder = TaskSpecBuilder(
+        agent_version_repository=SQLAgentVersionRepository(session),
+        plugin_repository=SQLPluginRepository(session),
+        blob_repository=SQLBlobRepository(session),
+        secret_repository=SQLSecretRepository(
+            session, AesGcmCipher("test-encryption-key")
+        ),
+        policy=policy,
+    )
+    transitions = TaskTransitions(
+        task_repository=SQLTaskRepository(session),
+        job_repository=SQLJobRepository(session),
+        dispatcher=dispatcher,
+    )
+    return TaskService(
+        repository=SQLTaskRepository(session),
+        worker_repository=SQLWorkerRepository(session),
+        session_repository=SQLSessionRepository(session),
+        job_repository=SQLJobRepository(session),
+        spec_builder=spec_builder,
+        transitions=transitions,
+        policy=policy,
+    )
+
+
+def _build_transitions(session: AsyncSession) -> TaskTransitions:
+    """Build task transitions on the SQL repositories of one session."""
+    return TaskTransitions(
+        task_repository=SQLTaskRepository(session),
+        job_repository=SQLJobRepository(session),
+        dispatcher=EventDispatcher(),
+    )
+
+
+async def _wait_for_lock_wait(
+    session_factory: async_sessionmaker[AsyncSession], blocked: asyncio.Event
+) -> None:
+    """Set the event once a backend on this database waits on a row lock."""
+    async with session_factory() as session:
+        for _ in range(400):
+            rows = (
+                await session.execute(
+                    text(
+                        "SELECT pid FROM pg_stat_activity "
+                        "WHERE wait_event_type = 'Lock' "
+                        "AND datname = current_database()"
+                    )
+                )
+            ).all()
+            await session.rollback()
+            if rows:
+                break
+            await asyncio.sleep(0.01)
+        blocked.set()
+
+
+async def test_hard_failure_report_survives_concurrent_job_cancel() -> None:
+    """A worker reporting an aborting hard failure survives a concurrent cancel.
+
+    Regression test for a lock-order deadlock: the report path used to lock
+    only the reported task row before abort propagation locked the job's
+    remaining task rows in ascending id order, while the cancellation path
+    locks every task row in one ascending id-ordered statement. Reporting a
+    high-id task while a cancel was in flight made the two transactions
+    acquire the same rows in opposite orders, and PostgreSQL killed one of
+    them. The report path now stamps the job alone and leaves the siblings to
+    the sweep, so it holds one task row and cannot cycle against the cancel.
+    """
+    if not await postgres_available():
+        pytest.skip("PostgreSQL is not reachable")
+
+    async with pg_session_with_engine() as (seed_session, engine):
+        now = datetime.now(UTC)
+        owner = await SQLAccountRepository(seed_session).create(Account(name="owner"))
+        agent = await SQLAgentRepository(seed_session).create(
+            Agent(owner_id=owner.id, name="agent")
+        )
+        agent_version = await SQLAgentVersionRepository(seed_session).create(
+            AgentVersion(owner_id=owner.id, agent_id=agent.id)
+        )
+        worker = await SQLWorkerRepository(seed_session).register(
+            Worker(
+                owner_id=owner.id,
+                name="worker",
+                scope=WorkerScope(),
+                runtime=WorkerRuntime(platform="bare"),
+                last_seen_at=now,
+            )
+        )
+        job = await SQLJobRepository(seed_session).create(
+            Job(owner_id=owner.id, kind=JobKind.REPLAY, status=JobStatus.RUNNING)
+        )
+        for task_id in (TASK_LOW_ID, TASK_HIGH_ID):
+            await SQLTaskRepository(seed_session).create(
+                AgentTask(
+                    id=task_id,
+                    job_id=job.id,
+                    agent_version_id=agent_version.id,
+                    status=TaskStatus.RUNNING,
+                    attempt=1,
+                    worker_id=worker.id,
+                    claimed_at=now,
+                    heartbeat_at=now,
+                    started_at=now,
+                )
+            )
+        await seed_session.commit()
+
+        session_factory = async_sessionmaker(
+            bind=engine, class_=AsyncSession, expire_on_commit=False
+        )
+        reporter_at_barrier = asyncio.Event()
+        canceler_blocked = asyncio.Event()
+
+        async def report_failure() -> str:
+            async with session_factory() as session:
+                dispatcher = EventDispatcher()
+
+                async def hold_at_terminal(event: TaskTerminal) -> None:
+                    _ = event
+                    reporter_at_barrier.set()
+                    await asyncio.wait_for(canceler_blocked.wait(), timeout=20)
+
+                dispatcher.register(TaskTerminal, hold_at_terminal)
+                service = _build_task_service(session, dispatcher)
+                actor = TaskAuthContext(
+                    account=owner,
+                    principal=TaskPrincipal(
+                        task_id=TASK_HIGH_ID,
+                        attempt=1,
+                        worker_id=worker.id,
+                        job_id=job.id,
+                    ),
+                )
+                try:
+                    await service.update_task(
+                        TASK_HIGH_ID,
+                        TaskUpdate(status=TaskStatus.FAILED, error="boom"),
+                        actor,
+                    )
+                    await session.commit()
+                    return "ok"
+                except Exception as exc:
+                    await session.rollback()
+                    return type(exc).__name__
+
+        async def cancel_job() -> str:
+            await asyncio.wait_for(reporter_at_barrier.wait(), timeout=20)
+            async with session_factory() as session:
+                transitions = _build_transitions(session)
+                try:
+                    await transitions.cancel_job(job.id)
+                    await session.commit()
+                    return "ok"
+                except Exception as exc:
+                    await session.rollback()
+                    return type(exc).__name__
+
+        async def release_reporter() -> None:
+            await asyncio.wait_for(reporter_at_barrier.wait(), timeout=20)
+            # Give the canceler a moment to reach its first task row lock.
+            await asyncio.sleep(0.05)
+            await _wait_for_lock_wait(session_factory, canceler_blocked)
+
+        results = await asyncio.wait_for(
+            asyncio.gather(report_failure(), cancel_job(), release_reporter()),
+            timeout=30,
+        )
+        assert results[:2] == ["ok", "ok"]
+
+        async with session_factory() as verify_session:
+            tasks = SQLTaskRepository(verify_session)
+            failed = await tasks.get(TASK_HIGH_ID)
+            assert failed.status is TaskStatus.FAILED
+            sibling = await tasks.get(TASK_LOW_ID)
+            assert sibling.cancel_requested_at is not None
+
+
+async def test_job_cancel_survives_concurrent_task_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancel pass and a concurrent worker claim lock job rows in one order.
+
+    Regression test for a lock-order deadlock: the cancellation path used to
+    lock job rows one at a time in caller-supplied order while the claim
+    path started jobs in claimed-task order, so a cancel pass racing a claim
+    of freshly appended tasks could acquire two job rows in opposite orders,
+    and PostgreSQL killed one of the transactions. The cancellation path now
+    locks every task row, then the job rows, each in one id-ordered
+    statement, and the claim path starts jobs in ascending id order.
+    """
+    if not await postgres_available():
+        pytest.skip("PostgreSQL is not reachable")
+
+    async with pg_session_with_engine() as (seed_session, engine):
+        now = datetime.now(UTC)
+        owner = await SQLAccountRepository(seed_session).create(Account(name="owner"))
+        agent = await SQLAgentRepository(seed_session).create(
+            Agent(owner_id=owner.id, name="agent")
+        )
+        agent_version = await SQLAgentVersionRepository(seed_session).create(
+            AgentVersion(
+                owner_id=owner.id,
+                agent_id=agent.id,
+                run_spec=RunSpec(command="run.sh", timeout_seconds=60),
+            )
+        )
+        worker = await SQLWorkerRepository(seed_session).register(
+            Worker(
+                owner_id=owner.id,
+                name="worker",
+                scope=WorkerScope(),
+                runtime=WorkerRuntime(platform="bare"),
+                last_seen_at=now,
+            )
+        )
+        for job_id in (JOB_LOW_ID, JOB_HIGH_ID):
+            await SQLJobRepository(seed_session).create(
+                Job(
+                    id=job_id,
+                    owner_id=owner.id,
+                    kind=JobKind.REPLAY,
+                    status=JobStatus.RUNNING,
+                )
+            )
+        await seed_session.commit()
+
+        session_factory = async_sessionmaker(
+            bind=engine, class_=AsyncSession, expire_on_commit=False
+        )
+        canceler_past_task_statements = asyncio.Event()
+        tasks_appended = asyncio.Event()
+        claimer_locked_first_job = asyncio.Event()
+        canceler_blocked = asyncio.Event()
+
+        real_cancel_pending = SQLTaskRepository.cancel_pending
+
+        async def paused_cancel_pending(
+            self: SQLTaskRepository, job_ids: Sequence[uuid.UUID], now: datetime
+        ) -> list[Task]:
+            canceled = await real_cancel_pending(self, job_ids, now)
+            canceler_past_task_statements.set()
+            await asyncio.wait_for(tasks_appended.wait(), timeout=20)
+            return canceled
+
+        monkeypatch.setattr(SQLTaskRepository, "cancel_pending", paused_cancel_pending)
+
+        real_start_job = TaskTransitions.start_job
+        started_job_ids: list[uuid.UUID] = []
+
+        async def paused_start_job(self: TaskTransitions, job_id: uuid.UUID) -> None:
+            await real_start_job(self, job_id)
+            started_job_ids.append(job_id)
+            if len(started_job_ids) == 1:
+                claimer_locked_first_job.set()
+                await asyncio.wait_for(canceler_blocked.wait(), timeout=20)
+
+        monkeypatch.setattr(TaskTransitions, "start_job", paused_start_job)
+
+        async def cancel_jobs() -> str:
+            async with session_factory() as session:
+                transitions = _build_transitions(session)
+                try:
+                    await transitions.request_jobs_cancel([JOB_LOW_ID, JOB_HIGH_ID])
+                    await session.commit()
+                    return "ok"
+                except Exception as exc:
+                    await session.rollback()
+                    return type(exc).__name__
+
+        async def claim_tasks() -> str:
+            async with session_factory() as session:
+                service = _build_task_service(session, EventDispatcher())
+                actor = WorkerAuthContext(
+                    account=owner, principal=WorkerPrincipal(worker_id=worker.id)
+                )
+                try:
+                    claimed = await service.claim_tasks(10, actor=actor)
+                    await session.commit()
+                    return f"ok:{len(claimed)}"
+                except Exception as exc:
+                    await session.rollback()
+                    return type(exc).__name__
+
+        canceler = asyncio.create_task(cancel_jobs())
+        await asyncio.wait_for(canceler_past_task_statements.wait(), timeout=20)
+
+        # Append the pending tasks after the canceler's task statements ran,
+        # so the claim races only the canceler's job row locks. The lower
+        # task id belongs to the higher job id, which put the claim's job
+        # locks in claimed-task order ahead of the fix.
+        async with session_factory() as append_session:
+            repository = SQLTaskRepository(append_session)
+            for task_id, job_id in (
+                (TASK_LOW_ID, JOB_HIGH_ID),
+                (TASK_HIGH_ID, JOB_LOW_ID),
+            ):
+                await repository.create(
+                    AgentTask(
+                        id=task_id,
+                        job_id=job_id,
+                        agent_version_id=agent_version.id,
+                    )
+                )
+            await append_session.commit()
+
+        claimer = asyncio.create_task(claim_tasks())
+        await asyncio.wait_for(claimer_locked_first_job.wait(), timeout=20)
+        tasks_appended.set()
+        monitor = asyncio.create_task(
+            _wait_for_lock_wait(session_factory, canceler_blocked)
+        )
+
+        results = await asyncio.wait_for(
+            asyncio.gather(canceler, claimer, monitor), timeout=30
+        )
+        assert results[:2] == ["ok", "ok:2"]
+
+        async with session_factory() as verify_session:
+            jobs = SQLJobRepository(verify_session)
+            for job_id in (JOB_LOW_ID, JOB_HIGH_ID):
+                job = await jobs.get(job_id)
+                assert job.cancel_requested_at is not None
+
+
+async def test_cancel_propagation_skips_a_job_another_sweep_holds() -> None:
+    """A second sweeper's NOWAIT propagation fails fast instead of waiting.
+
+    Two replicas run the propagation backstop over the same candidate job.
+    The first holds the job's task rows, and the second has to give up that
+    job and move on rather than block the rest of its tick behind it.
+    """
+    if not await postgres_available():
+        pytest.skip("PostgreSQL is not reachable")
+
+    async with pg_session_with_engine() as (seed_session, engine):
+        now = datetime.now(UTC)
+        owner = await SQLAccountRepository(seed_session).create(Account(name="owner"))
+        agent = await SQLAgentRepository(seed_session).create(
+            Agent(owner_id=owner.id, name="agent")
+        )
+        agent_version = await SQLAgentVersionRepository(seed_session).create(
+            AgentVersion(owner_id=owner.id, agent_id=agent.id)
+        )
+        job = await SQLJobRepository(seed_session).create(
+            Job(
+                owner_id=owner.id,
+                kind=JobKind.REPLAY,
+                status=JobStatus.RUNNING,
+                cancel_requested_at=now,
+            )
+        )
+        await SQLTaskRepository(seed_session).create(
+            AgentTask(
+                id=TASK_LOW_ID,
+                job_id=job.id,
+                agent_version_id=agent_version.id,
+                status=TaskStatus.RUNNING,
+                attempt=1,
+                claimed_at=now,
+                heartbeat_at=now,
+                started_at=now,
+            )
+        )
+        await seed_session.commit()
+
+        session_factory = async_sessionmaker(
+            bind=engine, class_=AsyncSession, expire_on_commit=False
+        )
+        async with session_factory() as holder:
+            await SQLTaskRepository(holder).lock_by_jobs([job.id])
+            async with session_factory() as sweeper:
+                with pytest.raises(DBAPIError) as raised:
+                    await asyncio.wait_for(
+                        _build_transitions(sweeper).request_jobs_cancel(
+                            [job.id], nowait=True
+                        ),
+                        timeout=10,
+                    )
+                await sweeper.rollback()
+            assert is_lock_not_available(raised.value)
+            await holder.rollback()
+
+        async with session_factory() as verify_session:
+            task = await SQLTaskRepository(verify_session).get(TASK_LOW_ID)
+            assert task.cancel_requested_at is None

--- a/tests/server/test_task_cancellation_pg.py
+++ b/tests/server/test_task_cancellation_pg.py
@@ -466,3 +466,116 @@ async def test_cancel_propagation_skips_a_job_another_sweep_holds() -> None:
         async with session_factory() as verify_session:
             task = await SQLTaskRepository(verify_session).get(TASK_LOW_ID)
             assert task.cancel_requested_at is None
+
+
+async def test_job_cancel_survives_concurrent_job_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A job cancel and a concurrent job delete lock task rows in one order.
+
+    Regression test for a lock-order deadlock: the job delete used to lock
+    the job row first and let the delete's cascade lock the task rows
+    unordered after it, while the cancellation path locks every task row
+    before the job row. A cancel holding the task rows while a delete held
+    the job row made the two transactions wait on each other, and PostgreSQL
+    killed one of them. The delete now locks the task rows in id order
+    before the job row.
+    """
+    if not await postgres_available():
+        pytest.skip("PostgreSQL is not reachable")
+
+    async with pg_session_with_engine() as (seed_session, engine):
+        now = datetime.now(UTC)
+        owner = await SQLAccountRepository(seed_session).create(Account(name="owner"))
+        agent = await SQLAgentRepository(seed_session).create(
+            Agent(owner_id=owner.id, name="agent")
+        )
+        agent_version = await SQLAgentVersionRepository(seed_session).create(
+            AgentVersion(owner_id=owner.id, agent_id=agent.id)
+        )
+        worker = await SQLWorkerRepository(seed_session).register(
+            Worker(
+                owner_id=owner.id,
+                name="worker",
+                scope=WorkerScope(),
+                runtime=WorkerRuntime(platform="bare"),
+                last_seen_at=now,
+            )
+        )
+        job = await SQLJobRepository(seed_session).create(
+            Job(owner_id=owner.id, kind=JobKind.REPLAY, status=JobStatus.RUNNING)
+        )
+        for task_id in (TASK_LOW_ID, TASK_HIGH_ID):
+            await SQLTaskRepository(seed_session).create(
+                AgentTask(
+                    id=task_id,
+                    job_id=job.id,
+                    agent_version_id=agent_version.id,
+                    status=TaskStatus.RUNNING,
+                    attempt=1,
+                    worker_id=worker.id,
+                    claimed_at=now,
+                    heartbeat_at=now,
+                    started_at=now,
+                )
+            )
+        await seed_session.commit()
+
+        session_factory = async_sessionmaker(
+            bind=engine, class_=AsyncSession, expire_on_commit=False
+        )
+        canceler_past_task_statements = asyncio.Event()
+        deleter_blocked = asyncio.Event()
+
+        real_cancel_pending = SQLTaskRepository.cancel_pending
+
+        async def paused_cancel_pending(
+            self: SQLTaskRepository, job_ids: Sequence[uuid.UUID], now: datetime
+        ) -> list[Task]:
+            canceled = await real_cancel_pending(self, job_ids, now)
+            canceler_past_task_statements.set()
+            await asyncio.wait_for(deleter_blocked.wait(), timeout=20)
+            return canceled
+
+        monkeypatch.setattr(SQLTaskRepository, "cancel_pending", paused_cancel_pending)
+
+        async def cancel_job() -> str:
+            async with session_factory() as session:
+                transitions = _build_transitions(session)
+                try:
+                    await transitions.cancel_job(job.id)
+                    await session.commit()
+                    return "ok"
+                except Exception as exc:
+                    await session.rollback()
+                    return type(exc).__name__
+
+        async def delete_job() -> str:
+            await asyncio.wait_for(canceler_past_task_statements.wait(), timeout=20)
+            async with session_factory() as session:
+                try:
+                    await SQLJobRepository(session).delete(job.id)
+                    await session.commit()
+                    return "ok"
+                except Exception as exc:
+                    await session.rollback()
+                    return type(exc).__name__
+
+        async def release_canceler() -> None:
+            await asyncio.wait_for(canceler_past_task_statements.wait(), timeout=20)
+            # Give the deleter a moment to reach its first task row lock.
+            await asyncio.sleep(0.05)
+            await _wait_for_lock_wait(session_factory, deleter_blocked)
+
+        results = await asyncio.wait_for(
+            asyncio.gather(cancel_job(), delete_job(), release_canceler()),
+            timeout=30,
+        )
+        assert results[:2] == ["ok", "ok"]
+
+        async with session_factory() as verify_session:
+            assert await SQLJobRepository(verify_session).get_many([job.id]) == {}
+            remaining = await SQLTaskRepository(verify_session).get_many(
+                [TASK_LOW_ID, TASK_HIGH_ID]
+            )
+            assert remaining == {}

--- a/tests/server/test_task_cancellation_pg.py
+++ b/tests/server/test_task_cancellation_pg.py
@@ -25,8 +25,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from conftest import pg_session_with_engine, postgres_available
 from kitaru.api_models.v1.job import JobKind, JobStatus
-from kitaru.api_models.v1.task import TaskStatus, WorkerScope
-from kitaru.api_models.v1.worker import WorkerRuntime
+from kitaru.api_models.v1.task import TaskStatus
+from kitaru.api_models.v1.worker import WorkerRuntime, WorkerScope
 from kitaru.server.adapters.db.encryption import AesGcmCipher
 from kitaru.server.adapters.db.errors import is_lock_not_available
 from kitaru.server.adapters.db.repositories.account_repository import (

--- a/tests/server/test_task_repository.py
+++ b/tests/server/test_task_repository.py
@@ -421,20 +421,44 @@ async def test_claim_pending_job_pin(setup: Setup) -> None:
 
 
 async def test_claim_stale(setup: Setup) -> None:
-    """Lock in-flight tasks whose last heartbeat predates the cutoff."""
+    """Lock one in-flight task whose last heartbeat predates the cutoff."""
     task = await setup.tasks.create(_agent_task(setup))
     claimed = await setup.tasks.claim_pending(
         WorkerScope(), setup.worker_id, 10, datetime.now(UTC) - timedelta(hours=1)
     )
     assert len(claimed) == 1
 
-    stale = await setup.tasks.claim_stale(datetime.now(UTC), 10)
-    assert [t.id for t in stale] == [task.id]
+    stale = await setup.tasks.claim_stale(task.id, datetime.now(UTC))
+    assert stale is not None
+    assert stale.id == task.id
 
     not_yet_stale = await setup.tasks.claim_stale(
-        datetime.now(UTC) - timedelta(hours=2), 10
+        task.id, datetime.now(UTC) - timedelta(hours=2)
     )
-    assert not_yet_stale == []
+    assert not_yet_stale is None
+
+
+async def test_list_stale_ids(setup: Setup) -> None:
+    """Read the ids of in-flight tasks whose last heartbeat predates the cutoff."""
+    task = await setup.tasks.create(_agent_task(setup))
+    await setup.tasks.claim_pending(
+        WorkerScope(), setup.worker_id, 10, datetime.now(UTC) - timedelta(hours=1)
+    )
+
+    assert await setup.tasks.list_stale_ids(datetime.now(UTC), 10) == [task.id]
+    assert (
+        await setup.tasks.list_stale_ids(datetime.now(UTC) - timedelta(hours=2), 10)
+        == []
+    )
+
+
+async def test_lock_by_jobs(setup: Setup) -> None:
+    """Lock the job's non-terminal task rows without altering them."""
+    task = await setup.tasks.create(_agent_task(setup))
+    await setup.tasks.lock_by_jobs([setup.job_id])
+    await setup.tasks.lock_by_jobs([setup.job_id], nowait=True)
+    await setup.tasks.lock_by_jobs([])
+    assert await setup.tasks.get(task.id) == task
 
 
 async def test_stamp_cancel_requested_skips_terminal_tasks(setup: Setup) -> None:

--- a/tests/server/test_task_repository.py
+++ b/tests/server/test_task_repository.py
@@ -53,6 +53,7 @@ from kitaru.server.adapters.db.repositories.task_repository import SQLTaskReposi
 from kitaru.server.adapters.db.repositories.worker_repository import (
     SQLWorkerRepository,
 )
+from kitaru.server.application.interfaces.job_repository import JobRepository
 from kitaru.server.application.interfaces.task_repository import TaskRepository
 from kitaru.server.application.models.task import TaskFilter
 from kitaru.server.domain.account import Account
@@ -78,6 +79,7 @@ class Setup(NamedTuple):
     """Task repository under test, plus rows a task can reference."""
 
     tasks: TaskRepository
+    jobs: JobRepository
     owner_id: uuid.UUID
     job_id: uuid.UUID
     agent_id: uuid.UUID
@@ -144,6 +146,7 @@ async def _seed_postgres(session: AsyncSession) -> Setup:
     )
     return Setup(
         tasks=SQLTaskRepository(session),
+        jobs=SQLJobRepository(session),
         owner_id=owner.id,
         job_id=job.id,
         agent_id=agent.id,
@@ -160,10 +163,13 @@ async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
     """Provide each task repository implementation with a ready job to attach to."""
     if request.param == "fake":
         jobs = FakeJobRepository()
+        tasks = FakeTaskRepository()
+        tasks.jobs = jobs
         owner_id = uuid.uuid4()
         job = await create_job(jobs, owner_id)
         yield Setup(
-            tasks=FakeTaskRepository(),
+            tasks=tasks,
+            jobs=jobs,
             owner_id=owner_id,
             job_id=job.id,
             agent_id=uuid.uuid4(),
@@ -530,6 +536,32 @@ async def test_stamp_heartbeats_writes_only_the_heartbeat_column(
     assert reloaded_completed.heartbeat_at != now
     assert reloaded_completed.status is TaskStatus.COMPLETED
     assert reloaded_completed.result == [{"name": "exact_match", "score": 1.0}]
+
+
+async def test_stamp_heartbeats_falls_back_to_the_jobs_cancel_request(
+    setup: Setup,
+) -> None:
+    """Report a job-level cancel request the task row does not carry yet."""
+    start = datetime.now(UTC)
+    task = _agent_task(setup)
+    task.claim(setup.worker_id, start)
+    task.start(start)
+    stored = await setup.tasks.create(task)
+    assert stored.cancel_requested_at is None
+
+    now = datetime.now(UTC)
+    assert await setup.tasks.stamp_heartbeats([stored.id], setup.worker_id, now) == {
+        stored.id: None
+    }
+
+    job = await setup.jobs.get(setup.job_id)
+    job.request_cancel(now)
+    await setup.jobs.update(job)
+
+    stamped = await setup.tasks.stamp_heartbeats([stored.id], setup.worker_id, now)
+    assert stamped == {stored.id: job.cancel_requested_at}
+    # The stamp is read through, not written onto the task row.
+    assert (await setup.tasks.get(stored.id)).cancel_requested_at is None
 
 
 async def test_claim_pending_skip_locked_never_double_claims() -> None:

--- a/tests/server/test_task_repository.py
+++ b/tests/server/test_task_repository.py
@@ -448,7 +448,7 @@ async def test_stamp_cancel_requested_skips_terminal_tasks(setup: Setup) -> None
     stored_completed = await setup.tasks.create(completed)
 
     now = datetime.now(UTC)
-    await setup.tasks.stamp_cancel_requested(setup.job_id, now)
+    await setup.tasks.stamp_cancel_requested([setup.job_id], now)
 
     reloaded_pending = await setup.tasks.get(pending.id)
     assert reloaded_pending.cancel_requested_at == now

--- a/tests/server/test_task_repository.py
+++ b/tests/server/test_task_repository.py
@@ -32,8 +32,8 @@ from conftest import (
 )
 from kitaru.api_models.v1.filter import FilterOp
 from kitaru.api_models.v1.job import JobKind
-from kitaru.api_models.v1.task import LabelSelector, TaskKind, TaskStatus, WorkerScope
-from kitaru.api_models.v1.worker import WorkerRuntime
+from kitaru.api_models.v1.task import TaskKind, TaskStatus
+from kitaru.api_models.v1.worker import LabelSelector, WorkerRuntime, WorkerScope
 from kitaru.server.adapters.db.repositories.account_repository import (
     SQLAccountRepository,
 )

--- a/tests/server/test_task_service.py
+++ b/tests/server/test_task_service.py
@@ -349,6 +349,39 @@ async def test_backstop_stamps_live_siblings_and_cancels_pending_ones(
     assert await services.task_service.list_unpropagated_cancel_job_ids() == []
 
 
+async def test_heartbeat_stops_a_sibling_before_the_backstop_runs(
+    services: JobAndTaskServices,
+) -> None:
+    """An aborting failure reaches a live sibling on its next heartbeat."""
+    job_id = await _pending_job(services)
+    failing = await _claimable_agent_task(
+        services, job_id, on_failure=TaskOnFailure.ABORT
+    )
+    sibling = await _claimable_agent_task(services, job_id)
+    worker = await create_worker(services.workers, ACTOR.account.id)
+    worker_actor = build_worker_actor(ACTOR.account, worker.id)
+    await services.task_service.claim_tasks(10, actor=worker_actor)
+
+    assert (
+        await services.task_service.heartbeat_worker(
+            worker.id, [sibling.id], actor=worker_actor
+        )
+        == []
+    )
+
+    await services.task_service.update_task(
+        failing.id,
+        TaskUpdate(status=TaskStatus.FAILED, error="boom"),
+        actor=build_task_actor(ACTOR.account, failing.id, 1, worker.id),
+    )
+
+    # The sibling's own row is still unstamped, the job carries the request.
+    assert (await services.tasks.get(sibling.id)).cancel_requested_at is None
+    assert await services.task_service.heartbeat_worker(
+        worker.id, [sibling.id], actor=worker_actor
+    ) == [sibling.id]
+
+
 async def test_backstop_settles_the_job_once_it_drains(
     services: JobAndTaskServices,
 ) -> None:

--- a/tests/server/test_task_service.py
+++ b/tests/server/test_task_service.py
@@ -44,10 +44,12 @@ from kitaru.analytics.events import AnalyticsEvent
 from kitaru.api_models.v1.job import JobStatus
 from kitaru.api_models.v1.session import SessionStatus
 from kitaru.api_models.v1.task import (
-    LabelSelector,
     TaskKind,
     TaskOnFailure,
     TaskStatus,
+)
+from kitaru.api_models.v1.worker import (
+    LabelSelector,
     WorkerScope,
 )
 from kitaru.server.application.events import EventDispatcher

--- a/tests/server/test_task_service.py
+++ b/tests/server/test_task_service.py
@@ -41,8 +41,15 @@ from conftest import (
     create_worker,
 )
 from kitaru.analytics.events import AnalyticsEvent
+from kitaru.api_models.v1.job import JobStatus
 from kitaru.api_models.v1.session import SessionStatus
-from kitaru.api_models.v1.task import LabelSelector, TaskKind, TaskStatus, WorkerScope
+from kitaru.api_models.v1.task import (
+    LabelSelector,
+    TaskKind,
+    TaskOnFailure,
+    TaskStatus,
+    WorkerScope,
+)
 from kitaru.server.application.events import EventDispatcher
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.models.task import TaskFilter, TaskPolicy, TaskUpdate
@@ -71,6 +78,13 @@ ACTOR = AuthContext(account=Account(id=uuid.uuid4(), name="ann"))
 def services() -> JobAndTaskServices:
     """Provide fake-backed job and task services."""
     return build_job_and_task_services()
+
+
+async def _sweep_stale(services: JobAndTaskServices) -> None:
+    """Run the sweeper's stale rescue over every candidate task."""
+    now = datetime.now(UTC)
+    for task_id in await services.task_service.list_stale_task_ids(now):
+        await services.task_service.sweep_stale_task(task_id, now)
 
 
 async def _pending_job(services: JobAndTaskServices) -> uuid.UUID:
@@ -250,8 +264,10 @@ async def test_claim_scope_non_required_selector_matches_unlabeled(
     assert {item.task.id for item in claimed} == {matching.id, unlabeled.id}
 
 
-async def test_claim_sweeps_stale_tasks_first(services: JobAndTaskServices) -> None:
-    """A stale claimed task requeues before the claim query runs."""
+async def test_sweep_requeues_a_stale_task_for_a_later_claim(
+    services: JobAndTaskServices,
+) -> None:
+    """A stale claimed task requeues on the sweep and the next claim picks it up."""
     job_id = await _pending_job(services)
     stale = await _claimable_agent_task(services, job_id)
     stuck_worker = await create_worker(services.workers, ACTOR.account.id, name="stuck")
@@ -263,6 +279,7 @@ async def test_claim_sweeps_stale_tasks_first(services: JobAndTaskServices) -> N
     stored = await services.tasks.get(stale.id)
     stored.claimed_at = datetime.now(UTC) - timedelta(hours=1)
     await services.tasks.update(stored)
+    await _sweep_stale(services)
 
     other_worker = await create_worker(services.workers, ACTOR.account.id, name="other")
     reclaimed = await services.task_service.claim_tasks(
@@ -287,12 +304,103 @@ async def test_sweep_abandons_at_the_retry_cap(services: JobAndTaskServices) -> 
         stored = await services.tasks.get(task.id)
         stored.claimed_at = datetime.now(UTC) - timedelta(hours=1)
         await services.tasks.update(stored)
+        await _sweep_stale(services)
 
+    stored = await services.tasks.get(task.id)
+    assert stored.status is TaskStatus.ABANDONED
+
+
+async def test_backstop_stamps_live_siblings_and_cancels_pending_ones(
+    services: JobAndTaskServices,
+) -> None:
+    """An aborting failure stamps only the job, the backstop reaches its siblings."""
+    job_id = await _pending_job(services)
+    failing = await _claimable_agent_task(
+        services, job_id, on_failure=TaskOnFailure.ABORT
+    )
+    running_sibling = await _claimable_agent_task(services, job_id)
+    worker = await create_worker(services.workers, ACTOR.account.id)
+    claimed = await services.task_service.claim_tasks(
+        10, actor=build_worker_actor(ACTOR.account, worker.id)
+    )
+    assert {item.task.id for item in claimed} == {failing.id, running_sibling.id}
+    pending_sibling = await _claimable_agent_task(services, job_id)
+
+    await services.task_service.update_task(
+        failing.id,
+        TaskUpdate(status=TaskStatus.FAILED, error="boom"),
+        actor=build_task_actor(ACTOR.account, failing.id, 1, worker.id),
+    )
+
+    job = await services.jobs.get(job_id)
+    assert job.cancel_requested_at is not None
+    assert (await services.tasks.get(running_sibling.id)).cancel_requested_at is None
+    assert (await services.tasks.get(pending_sibling.id)).status is TaskStatus.PENDING
+
+    assert await services.task_service.list_unpropagated_cancel_job_ids() == [job_id]
+    await services.task_service.propagate_job_cancel(job_id)
+
+    stamped = await services.tasks.get(running_sibling.id)
+    assert stamped.status is TaskStatus.CLAIMED
+    assert stamped.cancel_requested_at is not None
+    assert (await services.tasks.get(pending_sibling.id)).status is TaskStatus.CANCELED
+    # The claimed sibling is still live, so the job stays unsettled.
+    assert (await services.jobs.get(job_id)).status is JobStatus.RUNNING
+    assert await services.task_service.list_unpropagated_cancel_job_ids() == []
+
+
+async def test_backstop_settles_the_job_once_it_drains(
+    services: JobAndTaskServices,
+) -> None:
+    """Canceling the last pending sibling drains the job and settles it failed."""
+    job_id = await _pending_job(services)
+    failing = await _claimable_agent_task(
+        services, job_id, on_failure=TaskOnFailure.ABORT
+    )
+    worker = await create_worker(services.workers, ACTOR.account.id)
     await services.task_service.claim_tasks(
         10, actor=build_worker_actor(ACTOR.account, worker.id)
     )
+    await _claimable_agent_task(services, job_id)
+
+    await services.task_service.update_task(
+        failing.id,
+        TaskUpdate(status=TaskStatus.FAILED, error="boom"),
+        actor=build_task_actor(ACTOR.account, failing.id, 1, worker.id),
+    )
+    assert (await services.jobs.get(job_id)).status is JobStatus.RUNNING
+
+    await services.task_service.propagate_job_cancel(job_id)
+
+    job = await services.jobs.get(job_id)
+    assert job.status is JobStatus.FAILED
+    assert job.error == "boom"
+
+
+async def test_abandoned_aborting_task_stamps_its_job(
+    services: JobAndTaskServices,
+) -> None:
+    """A stale aborting task abandoned by the sweep leaves its job cancel-requested."""
+    services = build_job_and_task_services(policy=TaskPolicy(retry_limit=1))
+    job_id = await _pending_job(services)
+    task = await _claimable_agent_task(services, job_id, on_failure=TaskOnFailure.ABORT)
+    sibling = await _claimable_agent_task(services, job_id)
+    worker = await create_worker(services.workers, ACTOR.account.id)
+    await services.task_service.claim_tasks(
+        10, actor=build_worker_actor(ACTOR.account, worker.id)
+    )
+
     stored = await services.tasks.get(task.id)
-    assert stored.status is TaskStatus.ABANDONED
+    stored.claimed_at = datetime.now(UTC) - timedelta(hours=1)
+    await services.tasks.update(stored)
+    await _sweep_stale(services)
+
+    assert (await services.tasks.get(task.id)).status is TaskStatus.ABANDONED
+    assert (await services.jobs.get(job_id)).cancel_requested_at is not None
+    assert (await services.tasks.get(sibling.id)).cancel_requested_at is None
+
+    await services.task_service.propagate_job_cancel(job_id)
+    assert (await services.tasks.get(sibling.id)).cancel_requested_at is not None
 
 
 async def test_sweep_cancels_a_cancel_requested_stale_task(
@@ -311,10 +419,7 @@ async def test_sweep_cancels_a_cancel_requested_stale_task(
     stored.cancel_requested_at = datetime.now(UTC)
     await services.tasks.update(stored)
 
-    other_worker = await create_worker(services.workers, ACTOR.account.id, name="other")
-    await services.task_service.claim_tasks(
-        10, actor=build_worker_actor(ACTOR.account, other_worker.id)
-    )
+    await _sweep_stale(services)
     stored = await services.tasks.get(task.id)
     assert stored.status is TaskStatus.CANCELED
 
@@ -339,10 +444,7 @@ async def test_sweep_requeue_unlinks_the_result_session(
     stored.claimed_at = datetime.now(UTC) - timedelta(hours=1)
     await services.tasks.update(stored)
 
-    other_worker = await create_worker(services.workers, ACTOR.account.id, name="other")
-    await services.task_service.claim_tasks(
-        10, actor=build_worker_actor(ACTOR.account, other_worker.id)
-    )
+    await _sweep_stale(services)
 
     reloaded_task = await services.tasks.get(task.id)
     assert isinstance(reloaded_task, AgentTask)
@@ -351,13 +453,8 @@ async def test_sweep_requeue_unlinks_the_result_session(
     assert reloaded_session.task_id is None
 
 
-async def test_sweep_stale_tasks_works_outside_the_claim_path() -> None:
-    """sweep_stale_tasks abandons a stale task and settles its job, called directly.
-
-    claim_tasks calls the same method, this proves it also works standalone
-    so a caller outside the claim path, such as a background sweep loop, can
-    reuse it without duplicating the sweep logic.
-    """
+async def test_sweep_stale_task_abandons_and_settles() -> None:
+    """The sweep unit abandons a task past its retry limit and settles its job."""
     services = build_job_and_task_services(policy=TaskPolicy(retry_limit=1))
     job_id = await _pending_job(services)
     task = await _claimable_agent_task(services, job_id)
@@ -370,7 +467,9 @@ async def test_sweep_stale_tasks_works_outside_the_claim_path() -> None:
     stored.claimed_at = datetime.now(UTC) - timedelta(hours=1)
     await services.tasks.update(stored)
 
-    await services.task_service.sweep_stale_tasks(datetime.now(UTC))
+    now = datetime.now(UTC)
+    assert await services.task_service.list_stale_task_ids(now) == [task.id]
+    await services.task_service.sweep_stale_task(task.id, now)
 
     stored = await services.tasks.get(task.id)
     assert stored.status is TaskStatus.ABANDONED

--- a/tests/server/test_task_sweeper.py
+++ b/tests/server/test_task_sweeper.py
@@ -86,6 +86,44 @@ def _stub_sweeper_wiring(monkeypatch: pytest.MonkeyPatch, service: TaskService) 
     monkeypatch.setattr(task_sweeper, "get_task_service", lambda *args: service)
 
 
+async def test_sweep_once_propagates_before_rescuing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every cancel propagation runs before the first stale rescue.
+
+    Rescuing first would requeue a stale task of a canceling job, because the
+    rescue reads the task's own cancel stamp, which the propagation has not
+    written yet.
+    """
+    services = build_job_and_task_services()
+    task_id, job_id = uuid.uuid4(), uuid.uuid4()
+    calls: list[str] = []
+
+    async def record_sweep(
+        self: TaskService, task_id: uuid.UUID, now: datetime
+    ) -> None:
+        calls.append("rescue")
+
+    async def record_propagate(self: TaskService, job_id: uuid.UUID) -> None:
+        calls.append("propagate")
+
+    async def candidates(*args: Any) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+        return [task_id], [job_id]
+
+    monkeypatch.setattr(TaskService, "sweep_stale_task", record_sweep)
+    monkeypatch.setattr(TaskService, "propagate_job_cancel", record_propagate)
+    monkeypatch.setattr(task_sweeper, "_read_candidates", candidates)
+    _stub_sweeper_wiring(monkeypatch, services.task_service)
+
+    await task_sweeper.sweep_once(
+        cast(DatabaseService, _StubDatabase()),
+        local_settings(),
+        AnalyticsClient(enabled=False),
+    )
+
+    assert calls == ["propagate", "rescue"]
+
+
 async def test_sweep_once_continues_after_a_failing_item(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/test_task_sweeper.py
+++ b/tests/server/test_task_sweeper.py
@@ -14,14 +14,142 @@
 """Tests for the background stale-task sweep loop."""
 
 import asyncio
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import datetime
+from typing import Any, cast
 
 import pytest
+from asyncpg.exceptions import LockNotAvailableError
+from sqlalchemy.exc import DBAPIError
 
-from conftest import local_settings
+from conftest import build_job_and_task_services, local_settings
 from kitaru.analytics.client import AnalyticsClient
 from kitaru.server.api import task_sweeper
 from kitaru.server.api.config import APISettings
+from kitaru.server.application.services.task_service import TaskService
 from kitaru.server.database.service import DatabaseService
+
+
+def _lock_not_available_error() -> DBAPIError:
+    """Build a database error chained like a driver-reported NOWAIT failure."""
+    adapter_error = Exception("adapter error")
+    adapter_error.__cause__ = LockNotAvailableError("could not obtain lock")
+    return DBAPIError("SELECT task", None, adapter_error)
+
+
+class _RecordingSession:
+    """Session double recording the commits and rollbacks a sweep unit drives."""
+
+    def __init__(self) -> None:
+        """Initialize the counters."""
+        self.commits = 0
+        self.rollbacks = 0
+
+    async def commit(self) -> None:
+        """Record a commit."""
+        self.commits += 1
+
+    async def rollback(self) -> None:
+        """Record a rollback."""
+        self.rollbacks += 1
+
+
+class _StubDatabase:
+    """Database service double yielding one recording session per call."""
+
+    def __init__(self) -> None:
+        """Initialize the session log."""
+        self.sessions: list[_RecordingSession] = []
+
+    async def get_async_session(self) -> AsyncGenerator[Any, None]:
+        """Yield a fresh recording session.
+
+        Yields:
+            Recording session double.
+        """
+        session = _RecordingSession()
+        self.sessions.append(session)
+        yield session
+
+
+def _stub_sweeper_wiring(monkeypatch: pytest.MonkeyPatch, service: TaskService) -> None:
+    """Bind the sweeper's per-transaction service build to one fake-backed service.
+
+    Args:
+        monkeypatch: Patcher for the sweeper module.
+        service: Service every sweep unit runs against.
+    """
+    monkeypatch.setattr(
+        task_sweeper, "get_server_analytics", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(task_sweeper, "get_task_service", lambda *args: service)
+
+
+async def test_sweep_once_continues_after_a_failing_item(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An item that raises is rolled back and the remaining items still run."""
+    services = build_job_and_task_services()
+    first, second = uuid.uuid4(), uuid.uuid4()
+    swept: list[uuid.UUID] = []
+
+    async def failing_sweep(
+        self: TaskService, task_id: uuid.UUID, now: datetime
+    ) -> None:
+        swept.append(task_id)
+        if task_id == first:
+            raise RuntimeError("boom")
+
+    async def candidates(*args: Any) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+        return [first, second], []
+
+    monkeypatch.setattr(TaskService, "sweep_stale_task", failing_sweep)
+    monkeypatch.setattr(task_sweeper, "_read_candidates", candidates)
+    _stub_sweeper_wiring(monkeypatch, services.task_service)
+    database = _StubDatabase()
+
+    await task_sweeper.sweep_once(
+        cast(DatabaseService, database),
+        local_settings(),
+        AnalyticsClient(enabled=False),
+    )
+
+    assert swept == [first, second]
+    assert [session.rollbacks for session in database.sessions] == [1, 0]
+    assert [session.commits for session in database.sessions] == [0, 1]
+
+
+async def test_sweep_once_skips_a_job_whose_task_rows_are_held(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A contended NOWAIT acquisition rolls back that job alone."""
+    services = build_job_and_task_services()
+    held, free = uuid.uuid4(), uuid.uuid4()
+    propagated: list[uuid.UUID] = []
+
+    async def failing_propagate(self: TaskService, job_id: uuid.UUID) -> None:
+        propagated.append(job_id)
+        if job_id == held:
+            raise _lock_not_available_error()
+
+    async def candidates(*args: Any) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+        return [], [held, free]
+
+    monkeypatch.setattr(TaskService, "propagate_job_cancel", failing_propagate)
+    monkeypatch.setattr(task_sweeper, "_read_candidates", candidates)
+    _stub_sweeper_wiring(monkeypatch, services.task_service)
+    database = _StubDatabase()
+
+    await task_sweeper.sweep_once(
+        cast(DatabaseService, database),
+        local_settings(),
+        AnalyticsClient(enabled=False),
+    )
+
+    assert propagated == [held, free]
+    assert [session.rollbacks for session in database.sessions] == [1, 0]
+    assert [session.commits for session in database.sessions] == [0, 1]
 
 
 async def test_start_task_sweeper_returns_none_when_interval_is_zero() -> None:

--- a/tests/server/test_task_sweeper_pg.py
+++ b/tests/server/test_task_sweeper_pg.py
@@ -113,7 +113,7 @@ async def test_background_sweep_reaches_replay_settlement_subscribers(
     """A replay's job settling through the sweep still settles the replay.
 
     The sweep abandons the stale agent task exactly like the claim path
-    would, and the resulting JobSettled event must still reach the same
+    would, and the resulting JobsSettled event must still reach the same
     replay-settlement subscriber a request wires, proving the background
     tick shares the request's event dispatcher composition rather than
     running the transition without it.

--- a/tests/server/test_worker_repository.py
+++ b/tests/server/test_worker_repository.py
@@ -21,8 +21,7 @@ import pytest
 
 from conftest import FakeWorkerRepository, pg_session, postgres_available
 from kitaru.api_models.v1.filter import FilterOp
-from kitaru.api_models.v1.task import LabelSelector, WorkerScope
-from kitaru.api_models.v1.worker import WorkerRuntime
+from kitaru.api_models.v1.worker import LabelSelector, WorkerRuntime, WorkerScope
 from kitaru.server.adapters.db.repositories.account_repository import (
     SQLAccountRepository,
 )

--- a/tests/server/test_worker_service.py
+++ b/tests/server/test_worker_service.py
@@ -20,8 +20,7 @@ import pytest
 
 from conftest import FakeWorkerRepository, create_worker
 from kitaru.api_models.v1.filter import FilterOp
-from kitaru.api_models.v1.task import LabelSelector, WorkerScope
-from kitaru.api_models.v1.worker import WorkerRuntime
+from kitaru.api_models.v1.worker import LabelSelector, WorkerRuntime, WorkerScope
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.models.worker import WorkerFilter
 from kitaru.server.application.services.worker_service import WorkerService

--- a/tests/task/task_fixtures.py
+++ b/tests/task/task_fixtures.py
@@ -78,7 +78,9 @@ async def build_task_app() -> AsyncGenerator[TaskAppFixture, None]:
     """Build an API client routed to the app with fake-backed services."""
     services = build_job_and_task_services()
     node_service = SessionNodeService(
-        repository=FakeSessionNodeRepository(), session_repository=services.sessions
+        repository=FakeSessionNodeRepository(),
+        session_repository=services.sessions,
+        task_repository=services.tasks,
     )
     session_service = SessionService(
         repository=services.sessions,

--- a/tests/worker/fakes.py
+++ b/tests/worker/fakes.py
@@ -35,13 +35,13 @@ from kitaru.api_models.v1.task import (
     TaskSpecResponse,
     TaskStatus,
     TaskWithSpec,
-    WorkerScope,
 )
 from kitaru.api_models.v1.worker import (
     WorkerHeartbeatResponse,
     WorkerRegistrationResponse,
     WorkerResponse,
     WorkerRuntime,
+    WorkerScope,
 )
 from kitaru.client.api_client import KitaruAPIClient
 

--- a/tests/worker/test_config.py
+++ b/tests/worker/test_config.py
@@ -17,7 +17,8 @@ import uuid
 
 import pytest
 
-from kitaru.api_models.v1.task import LabelSelector, TaskKind, WorkerScope
+from kitaru.api_models.v1.task import TaskKind
+from kitaru.api_models.v1.worker import LabelSelector, WorkerScope
 from kitaru.worker.config import WorkerConfig
 from kitaru.worker.worker import default_worker_name
 

--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -33,6 +33,8 @@ from kitaru.api_models.v1.task import (
     TaskClaimResponse,
     TaskKind,
     TaskStatus,
+)
+from kitaru.api_models.v1.worker import (
     WorkerScope,
 )
 from kitaru.client.exceptions import APIError, NotFoundError

--- a/tests/worker/test_worker_auth.py
+++ b/tests/worker/test_worker_auth.py
@@ -23,8 +23,7 @@ from conftest import (
     asgi_api_client,
     local_settings,
 )
-from kitaru.api_models.v1.task import WorkerScope
-from kitaru.api_models.v1.worker import WorkerCreateRequest, WorkerRuntime
+from kitaru.api_models.v1.worker import WorkerCreateRequest, WorkerRuntime, WorkerScope
 from kitaru.server.adapters.auth.auth_service import AuthService
 from kitaru.server.adapters.rest.dependencies import (
     get_auth_service,


### PR DESCRIPTION
Fixes for a set of lock ordering and locking gaps found while stress testing the branch.

- **Job cancellation deadlocked against task reporting and silently lost the cancel.** Cancel took the job row lock and then the task row locks, while reporting and claiming take task then job. Cancelling now takes every task lock before the job lock. The deadlock rolled the whole request back, so the cancel never persisted and the job ran to completion.
- **A superseded task attempt kept full write access to the current attempt's session.** Attempt fencing was applied only on `PATCH /tasks/{id}`. Every other task-token path authorized on the task id, which is stable across attempts, so a reclaimed worker could still read the task spec, write nodes into the replacement's session, and finalize it. Node ingestion, session update, and spec read now check the token's attempt against the stored task.
- **Concurrent ingestion of the same node index returned 500.** Node ids were minted from an unlocked read, so two batches for one index both inserted and collided on the `(session, index)` key. The session row is now locked for the read.
- **Concurrent cohort membership deltas silently lost one another.** The delta was applied to an unlocked read of the latest version's members, so two concurrent versions each carried only their own change. The cohort row is now locked before the read.
- **Deleting a cohort version while a run naming it started returned 500.** The version was read unlocked and the referencing run row was inserted later, so a delete landing in between produced an unmapped foreign key violation. The version is now read locked, and the race resolves as a 404 or a 409 depending on which side wins.
- **Experiment run cancellation deadlocked against replay settlement and was silently lost.** Cancelling held the run row lock across every task and job lock, while reporting reaches the run row last through settlement. Cancellation now runs in two transactions: the run is marked canceling and committed on its own, then every unsettled job is cancelled in a single transaction that locks all task rows in one id-ordered statement before any job, replay, or run lock. Locking task rows job by job also deadlocks, against the heartbeat stamp locking a worker's task rows across jobs in id order. Re-marking an already canceling run is a no-op, so a partial failure is finished by calling cancel again.
- **Cancellation row work and settlement are batched.** Pending tasks are cancelled in one bulk update and drained jobs settle in one bulk read and write, which takes cancelling a 1000-replay run from ~6.5s to ~3.2s. `JobSettled` and `ReplaySettled` are replaced by `JobsSettled` and `ReplaysSettled`, dispatched with a batch of one on the single-job paths, so every settlement path flows through the same two events.

`ExperimentRunService.cancel_run` is replaced by `mark_run_canceling` and `cancel_run_jobs`, orchestrated by `kitaru.server.api.run_cancellation`.
