### PR TITLE
Add API key rotation

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -711,6 +711,19 @@
             "title": "Key",
             "type": "string"
           },
+          "last_rotated": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Time of the last rotation.",
+            "title": "Last Rotated"
+          },
           "last_used": {
             "anyOf": [
               {
@@ -750,6 +763,7 @@
           "name",
           "active",
           "last_used",
+          "last_rotated",
           "key"
         ],
         "title": "ApiKeyIssuedResponse",
@@ -774,6 +788,19 @@
             "format": "uuid",
             "title": "Id",
             "type": "string"
+          },
+          "last_rotated": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Time of the last rotation.",
+            "title": "Last Rotated"
           },
           "last_used": {
             "anyOf": [
@@ -813,9 +840,25 @@
           "id",
           "name",
           "active",
-          "last_used"
+          "last_used",
+          "last_rotated"
         ],
         "title": "ApiKeyResponse",
+        "type": "object"
+      },
+      "ApiKeyRotateRequest": {
+        "additionalProperties": false,
+        "description": "API key rotate request.",
+        "properties": {
+          "retain_period_minutes": {
+            "default": 0,
+            "description": "Number of minutes the previous key remains valid after rotation.",
+            "minimum": 0.0,
+            "title": "Retain Period Minutes",
+            "type": "integer"
+          }
+        },
+        "title": "ApiKeyRotateRequest",
         "type": "object"
       },
       "ApiKeyUpdateRequest": {
@@ -8484,6 +8527,60 @@
           }
         },
         "summary": "Update Api Key",
+        "tags": [
+          "api-keys"
+        ]
+      }
+    },
+    "/v1/api-keys/{api_key_id}/rotate": {
+      "post": {
+        "description": "Rotate an API key.\n\nClients observe HTTP 200 on success, 404 when the caller owns no API key\nwith this id, and 422 on invalid input. The response carries the new\nplaintext key exactly once.\n\nArgs:\n    api_key_id: Id of the API key.\n    body: API key rotate request.\n    service: API key service.\n    actor: Caller context.\n\nReturns:\n    Rotated API key including the new plaintext key.",
+        "operationId": "rotate_api_key_v1_api_keys__api_key_id__rotate_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "api_key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Api Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApiKeyRotateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiKeyIssuedResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Rotate Api Key",
         "tags": [
           "api-keys"
         ]

--- a/src/kitaru/api_models/v1/api_key.py
+++ b/src/kitaru/api_models/v1/api_key.py
@@ -34,6 +34,16 @@ class ApiKeyUpdateRequest(RequestModel):
     active: bool = Field(description="New active state.")
 
 
+class ApiKeyRotateRequest(RequestModel):
+    """API key rotate request."""
+
+    retain_period_minutes: int = Field(
+        default=0,
+        ge=0,
+        description="Number of minutes the previous key remains valid after rotation.",
+    )
+
+
 class ApiKeyListParams(FilterableListParams):
     """API key list params."""
 
@@ -47,6 +57,7 @@ class ApiKeyResponse(OwnedResponseModel):
     last_used: datetime | None = Field(
         description="Time of the last use for authentication."
     )
+    last_rotated: datetime | None = Field(description="Time of the last rotation.")
 
 
 class ApiKeyIssuedResponse(ApiKeyResponse):

--- a/src/kitaru/client/resources/api_keys.py
+++ b/src/kitaru/client/resources/api_keys.py
@@ -22,6 +22,7 @@ from kitaru.api_models.v1.api_key import (
     ApiKeyIssuedResponse,
     ApiKeyListParams,
     ApiKeyResponse,
+    ApiKeyRotateRequest,
     ApiKeyUpdateRequest,
 )
 from kitaru.api_models.v1.base import Page
@@ -140,6 +141,31 @@ class ApiKeysResource:
             json=request.model_dump(mode="json", exclude_unset=True),
         )
         return ApiKeyResponse.model_validate(response.json())
+
+    async def rotate(
+        self, api_key_id: uuid.UUID, request: ApiKeyRotateRequest | None = None
+    ) -> ApiKeyIssuedResponse:
+        """Rotate an API key.
+
+        The response carries the new plaintext key exactly once.
+
+        Args:
+            api_key_id: Id of the API key.
+            request: API key rotate request.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing API key.
+
+        Returns:
+            Rotated API key including the new plaintext key.
+        """
+        request = request or ApiKeyRotateRequest()
+        response = await self._client.request(
+            "POST",
+            f"/v1/api-keys/{api_key_id}/rotate",
+            json=request.model_dump(mode="json", exclude_unset=True),
+        )
+        return ApiKeyIssuedResponse.model_validate(response.json())
 
     async def delete(self, api_key_id: uuid.UUID) -> None:
         """Delete an API key.

--- a/src/kitaru/server/adapters/auth/auth_service.py
+++ b/src/kitaru/server/adapters/auth/auth_service.py
@@ -407,7 +407,11 @@ class AuthService:
             api_key = await self._api_key_repository.get(key_id)
         except ApiKeyNotFound as exc:
             raise AuthenticationError("Invalid API key.") from exc
-        if not verify_secret(secret, api_key.key_hash):
+        if not verify_secret(secret, api_key.key_hash) and (
+            api_key.previous_key_hash is None
+            or not api_key.is_previous_key_valid(datetime.now(UTC))
+            or not verify_secret(secret, api_key.previous_key_hash)
+        ):
             raise AuthenticationError("Invalid API key.")
         if not api_key.active:
             raise AuthenticationError("Invalid API key.")

--- a/src/kitaru/server/adapters/db/orm/api_key.py
+++ b/src/kitaru/server/adapters/db/orm/api_key.py
@@ -58,8 +58,11 @@ class ApiKeyORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     owner_id: Mapped[uuid.UUID]
     name: Mapped[str] = mapped_column(String(MAX_NAME_LENGTH))
     key_hash: Mapped[str] = mapped_column(String(128))
+    previous_key_hash: Mapped[str | None] = mapped_column(String(128))
+    retain_period_minutes: Mapped[int]
     active: Mapped[bool]
     last_used: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    last_rotated: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
     @classmethod
     def from_domain(cls, api_key: ApiKey) -> "ApiKeyORM":
@@ -76,8 +79,11 @@ class ApiKeyORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             owner_id=api_key.owner_id,
             name=api_key.name,
             key_hash=api_key.key_hash,
+            previous_key_hash=api_key.previous_key_hash,
+            retain_period_minutes=api_key.retain_period_minutes,
             active=api_key.active,
             last_used=api_key.last_used,
+            last_rotated=api_key.last_rotated,
         )
 
     def to_domain(self) -> ApiKey:
@@ -91,8 +97,11 @@ class ApiKeyORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             owner_id=self.owner_id,
             name=self.name,
             key_hash=self.key_hash,
+            previous_key_hash=self.previous_key_hash,
+            retain_period_minutes=self.retain_period_minutes,
             active=self.active,
             last_used=self.last_used,
+            last_rotated=self.last_rotated,
             created=self.created,
             updated=self.updated,
         )

--- a/src/kitaru/server/adapters/db/repositories/api_key_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/api_key_repository.py
@@ -73,11 +73,13 @@ class SQLApiKeyRepository(BaseSQLRepository[ApiKeyORM]):
         )
         return row.to_domain()
 
-    async def get(self, api_key_id: uuid.UUID) -> ApiKey:
+    async def get(self, api_key_id: uuid.UUID, exclusive: bool = False) -> ApiKey:
         """Load an API key by id.
 
         Args:
             api_key_id: Id of the API key.
+            exclusive: Whether to lock the row for the duration of the
+                transaction.
 
         Raises:
             ApiKeyNotFound: No API key has this id.
@@ -85,7 +87,7 @@ class SQLApiKeyRepository(BaseSQLRepository[ApiKeyORM]):
         Returns:
             Stored API key.
         """
-        row = await self._get_row(api_key_id)
+        row = await self._get_row(api_key_id, exclusive=exclusive)
         return row.to_domain()
 
     async def query(
@@ -133,8 +135,11 @@ class SQLApiKeyRepository(BaseSQLRepository[ApiKeyORM]):
         row.owner_id = api_key.owner_id
         row.name = api_key.name
         row.key_hash = api_key.key_hash
+        row.previous_key_hash = api_key.previous_key_hash
+        row.retain_period_minutes = api_key.retain_period_minutes
         row.active = api_key.active
         row.last_used = api_key.last_used
+        row.last_rotated = api_key.last_rotated
         await self._flush(
             {API_KEY_NAME_UNIQUE_CONSTRAINT: lambda: DuplicateApiKeyName(api_key.name)}
         )

--- a/src/kitaru/server/adapters/rest/mapping/api_keys.py
+++ b/src/kitaru/server/adapters/rest/mapping/api_keys.py
@@ -40,6 +40,7 @@ def api_key_to_response(api_key: ApiKey) -> ApiKeyResponse:
         name=api_key.name,
         active=api_key.active,
         last_used=api_key.last_used,
+        last_rotated=api_key.last_rotated,
         created=api_key.created,
         updated=api_key.updated,
     )
@@ -64,6 +65,7 @@ def api_key_to_issued_response(api_key: ApiKey, key: str) -> ApiKeyIssuedRespons
         active=api_key.active,
         key=key,
         last_used=api_key.last_used,
+        last_rotated=api_key.last_rotated,
         created=api_key.created,
         updated=api_key.updated,
     )

--- a/src/kitaru/server/adapters/rest/routers/api_keys.py
+++ b/src/kitaru/server/adapters/rest/routers/api_keys.py
@@ -23,6 +23,7 @@ from kitaru.api_models.v1.api_key import (
     ApiKeyIssuedResponse,
     ApiKeyListParams,
     ApiKeyResponse,
+    ApiKeyRotateRequest,
     ApiKeyUpdateRequest,
 )
 from kitaru.api_models.v1.base import Page
@@ -139,6 +140,34 @@ async def update_api_key(
     """
     api_key = await service.update_api_key(api_key_id, active=body.active, actor=actor)
     return api_key_to_response(api_key)
+
+
+@router.post("/{api_key_id}/rotate")
+async def rotate_api_key(
+    api_key_id: uuid.UUID,
+    body: ApiKeyRotateRequest,
+    service: Annotated[ApiKeyService, Depends(get_api_key_service)],
+    actor: Annotated[AuthContext, Depends(authorize)],
+) -> ApiKeyIssuedResponse:
+    """Rotate an API key.
+
+    Clients observe HTTP 200 on success, 404 when the caller owns no API key
+    with this id, and 422 on invalid input. The response carries the new
+    plaintext key exactly once.
+
+    Args:
+        api_key_id: Id of the API key.
+        body: API key rotate request.
+        service: API key service.
+        actor: Caller context.
+
+    Returns:
+        Rotated API key including the new plaintext key.
+    """
+    api_key, key = await service.rotate_api_key(
+        api_key_id, retain_period_minutes=body.retain_period_minutes, actor=actor
+    )
+    return api_key_to_issued_response(api_key, key)
 
 
 @router.delete("/{api_key_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/src/kitaru/server/application/interfaces/api_key_repository.py
+++ b/src/kitaru/server/application/interfaces/api_key_repository.py
@@ -37,11 +37,13 @@ class ApiKeyRepository(Protocol):
         """
         ...
 
-    async def get(self, api_key_id: uuid.UUID) -> ApiKey:
+    async def get(self, api_key_id: uuid.UUID, exclusive: bool = False) -> ApiKey:
         """Load an API key by id.
 
         Args:
             api_key_id: Id of the API key.
+            exclusive: Whether to lock the row for the duration of the
+                transaction.
 
         Raises:
             ApiKeyNotFound: No API key has this id.

--- a/src/kitaru/server/application/services/api_key_service.py
+++ b/src/kitaru/server/application/services/api_key_service.py
@@ -14,6 +14,7 @@
 """API key use cases."""
 
 import uuid
+from datetime import UTC, datetime
 
 from kitaru.server.application.interfaces.api_key_repository import (
     ApiKeyRepository,
@@ -112,6 +113,33 @@ class ApiKeyService:
         api_key = await self.get_api_key(api_key_id, actor=actor)
         api_key.update_active(active)
         return await self._repository.update(api_key)
+
+    async def rotate_api_key(
+        self, api_key_id: uuid.UUID, retain_period_minutes: int, actor: AuthContext
+    ) -> tuple[ApiKey, str]:
+        """Rotate an API key owned by the caller.
+
+        Args:
+            api_key_id: Id of the API key.
+            retain_period_minutes: Minutes the previous key remains valid.
+            actor: Caller context.
+
+        Raises:
+            ApiKeyNotFound: No API key of the caller has this id.
+
+        Returns:
+            Rotated API key and the encoded plaintext key.
+        """
+        owner_id = actor.account.id
+        api_key = await self._repository.get(api_key_id, exclusive=True)
+        if api_key.owner_id != owner_id:
+            raise ApiKeyNotFound(api_key_id)
+        secret = generate_secret()
+        api_key.rotate(
+            hash_secret(secret), retain_period_minutes, when=datetime.now(UTC)
+        )
+        stored = await self._repository.update(api_key)
+        return stored, encode_api_key(stored.id, secret)
 
     async def delete_api_key(self, api_key_id: uuid.UUID, actor: AuthContext) -> None:
         """Delete an API key owned by the caller.

--- a/src/kitaru/server/database/migrations/versions/001_initial.py
+++ b/src/kitaru/server/database/migrations/versions/001_initial.py
@@ -61,8 +61,11 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.Uuid(), nullable=False),
         sa.Column("name", sa.String(length=255), nullable=False),
         sa.Column("key_hash", sa.String(length=128), nullable=False),
+        sa.Column("previous_key_hash", sa.String(length=128), nullable=True),
+        sa.Column("retain_period_minutes", sa.Integer(), nullable=False),
         sa.Column("active", sa.Boolean(), nullable=False),
         sa.Column("last_used", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_rotated", sa.DateTime(timezone=True), nullable=True),
         sa.ForeignKeyConstraint(
             ["owner_id"], ["account.id"], name="fk_api_key_owner_id"
         ),

--- a/src/kitaru/server/domain/api_key.py
+++ b/src/kitaru/server/domain/api_key.py
@@ -16,7 +16,7 @@
 import base64
 import json
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from pydantic import Field
 
@@ -66,8 +66,11 @@ class ApiKey(DomainModel):
     owner_id: uuid.UUID
     name: Name
     key_hash: str
+    previous_key_hash: str | None = None
+    retain_period_minutes: int = 0
     active: bool = True
     last_used: datetime | None = None
+    last_rotated: datetime | None = None
     created: datetime | None = None
     updated: datetime | None = None
 
@@ -86,6 +89,36 @@ class ApiKey(DomainModel):
             when: Time of use.
         """
         self.last_used = when
+
+    def rotate(
+        self, new_key_hash: str, retain_period_minutes: int, when: datetime
+    ) -> None:
+        """Replace the key hash, retaining the previous one for the retain period.
+
+        Args:
+            new_key_hash: Hash of the newly generated secret.
+            retain_period_minutes: Minutes the previous key remains valid.
+            when: Time of rotation.
+        """
+        self.previous_key_hash = self.key_hash
+        self.key_hash = new_key_hash
+        self.retain_period_minutes = retain_period_minutes
+        self.last_rotated = when
+
+    def is_previous_key_valid(self, now: datetime) -> bool:
+        """Check whether the previous key is still within its retain period.
+
+        Args:
+            now: Current time.
+
+        Returns:
+            Whether the previous key hash still authenticates.
+        """
+        if self.previous_key_hash is None or self.last_rotated is None:
+            return False
+        if self.retain_period_minutes <= 0:
+            return False
+        return now - self.last_rotated < timedelta(minutes=self.retain_period_minutes)
 
 
 def encode_api_key(key_id: uuid.UUID, secret: str) -> str:

--- a/tests/client/test_api_keys.py
+++ b/tests/client/test_api_keys.py
@@ -24,6 +24,7 @@ from kitaru.api_models.v1.api_key import (
     ApiKeyIssuedResponse,
     ApiKeyListParams,
     ApiKeyResponse,
+    ApiKeyRotateRequest,
     ApiKeyUpdateRequest,
 )
 from kitaru.api_models.v1.filter import FilterCondition, FilterOp
@@ -147,6 +148,32 @@ async def test_update(api_client: KitaruAPIClient) -> None:
         created.id, ApiKeyUpdateRequest(active=True)
     )
     assert updated.active is True
+
+
+async def test_rotate(api_client: KitaruAPIClient) -> None:
+    """Rotate an API key through the SDK."""
+    created = await api_client.api_keys.create(ApiKeyCreateRequest(name="ci"))
+    rotated = await api_client.api_keys.rotate(
+        created.id, ApiKeyRotateRequest(retain_period_minutes=5)
+    )
+    assert isinstance(rotated, ApiKeyIssuedResponse)
+    assert rotated.id == created.id
+    assert rotated.key.startswith(API_KEY_PREFIX)
+    assert rotated.key != created.key
+    assert rotated.last_rotated is not None
+
+
+async def test_rotate_without_request(api_client: KitaruAPIClient) -> None:
+    """Rotate an API key without a request body."""
+    created = await api_client.api_keys.create(ApiKeyCreateRequest(name="ci"))
+    rotated = await api_client.api_keys.rotate(created.id)
+    assert rotated.key != created.key
+
+
+async def test_rotate_not_found(api_client: KitaruAPIClient) -> None:
+    """Surface HTTP 404 as a typed error."""
+    with pytest.raises(NotFoundError):
+        await api_client.api_keys.rotate(uuid.uuid4())
 
 
 async def test_delete(api_client: KitaruAPIClient) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -884,11 +884,13 @@ class FakeApiKeyRepository:
         self._api_keys[stored.id] = stored
         return stored.model_copy()
 
-    async def get(self, api_key_id: uuid.UUID) -> ApiKey:
+    async def get(self, api_key_id: uuid.UUID, exclusive: bool = False) -> ApiKey:
         """Load an API key by id.
 
         Args:
             api_key_id: Id of the API key.
+            exclusive: Ignored, the fake has no concurrent callers to lock
+                against.
 
         Raises:
             ApiKeyNotFound: No API key has this id.
@@ -896,6 +898,7 @@ class FakeApiKeyRepository:
         Returns:
             Stored API key.
         """
+        _ = exclusive
         api_key = self._api_keys.get(api_key_id)
         if api_key is None:
             raise ApiKeyNotFound(api_key_id)

--- a/tests/server/test_api_key_repository.py
+++ b/tests/server/test_api_key_repository.py
@@ -115,6 +115,33 @@ async def test_get_not_found(setup: Setup) -> None:
         await repository.get(missing_id)
 
 
+async def test_get_exclusive(setup: Setup) -> None:
+    """Load an API key with a row lock, a no-op difference for the fake backend."""
+    repository, owner_id, _ = setup
+    created = await repository.create(
+        ApiKey(owner_id=owner_id, name="ci", key_hash="hash")
+    )
+    loaded = await repository.get(created.id, exclusive=True)
+    assert loaded == created
+
+
+async def test_rotation_fields_round_trip(setup: Setup) -> None:
+    """Persist the previous hash, retain period, and rotation timestamp."""
+    repository, owner_id, _ = setup
+    created = await repository.create(
+        ApiKey(owner_id=owner_id, name="ci", key_hash="hash")
+    )
+    last_rotated = datetime.now(UTC)
+    created.rotate("new-hash", retain_period_minutes=5, when=last_rotated)
+    updated = await repository.update(created)
+    assert updated.key_hash == "new-hash"
+    assert updated.previous_key_hash == "hash"
+    assert updated.retain_period_minutes == 5
+    assert updated.last_rotated == last_rotated
+    loaded = await repository.get(created.id)
+    assert loaded == updated
+
+
 async def test_query(setup: Setup) -> None:
     """Query API keys newest-first with filters."""
     repository, owner_id, other_owner_id = setup

--- a/tests/server/test_api_key_service.py
+++ b/tests/server/test_api_key_service.py
@@ -14,6 +14,7 @@
 """Tests for API key use cases."""
 
 import uuid
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -25,11 +26,12 @@ from kitaru.server.application.services.api_key_service import ApiKeyService
 from kitaru.server.domain.account import Account
 from kitaru.server.domain.api_key import (
     API_KEY_PREFIX,
+    ApiKey,
     ApiKeyNotFound,
     DuplicateApiKeyName,
     decode_api_key,
 )
-from kitaru.server.domain.keys import hash_secret
+from kitaru.server.domain.keys import hash_secret, verify_secret
 from kitaru.server.filtering import FilterCondition
 
 ACTOR = AuthContext(account=Account(id=uuid.uuid4(), name="ann"))
@@ -195,3 +197,80 @@ async def test_delete_api_key_foreign_owner(service: ApiKeyService) -> None:
         await service.delete_api_key(created.id, actor=FOREIGN_ACTOR)
     loaded = await service.get_api_key(created.id, actor=ACTOR)
     assert loaded == created
+
+
+async def test_rotate_api_key(service: ApiKeyService) -> None:
+    """Rotate an API key, retaining the previous hash."""
+    created, _ = await service.create_api_key(name="ci", actor=ACTOR)
+    rotated, key = await service.rotate_api_key(
+        created.id, retain_period_minutes=5, actor=ACTOR
+    )
+    assert key.startswith(API_KEY_PREFIX)
+    key_id, secret = decode_api_key(key)
+    assert key_id == rotated.id
+    assert verify_secret(secret, rotated.key_hash)
+    assert rotated.previous_key_hash == created.key_hash
+    assert rotated.retain_period_minutes == 5
+    assert rotated.last_rotated is not None
+
+
+async def test_rotate_api_key_not_found(service: ApiKeyService) -> None:
+    """Raise for an unknown API key id."""
+    with pytest.raises(ApiKeyNotFound):
+        await service.rotate_api_key(uuid.uuid4(), retain_period_minutes=0, actor=ACTOR)
+
+
+async def test_rotate_api_key_foreign_owner(service: ApiKeyService) -> None:
+    """Raise not found for a key owned by another account."""
+    created, _ = await service.create_api_key(name="ci", actor=ACTOR)
+    with pytest.raises(ApiKeyNotFound):
+        await service.rotate_api_key(
+            created.id, retain_period_minutes=0, actor=FOREIGN_ACTOR
+        )
+    loaded = await service.get_api_key(created.id, actor=ACTOR)
+    assert loaded == created
+
+
+async def test_rotate_api_key_twice_overwrites_previous_hash(
+    service: ApiKeyService,
+) -> None:
+    """Overwrite the previous hash with the most recently rotated hash."""
+    created, _ = await service.create_api_key(name="ci", actor=ACTOR)
+    first_rotation, _ = await service.rotate_api_key(
+        created.id, retain_period_minutes=5, actor=ACTOR
+    )
+    second_rotation, _ = await service.rotate_api_key(
+        created.id, retain_period_minutes=5, actor=ACTOR
+    )
+    assert second_rotation.previous_key_hash == first_rotation.key_hash
+    assert second_rotation.previous_key_hash != created.key_hash
+
+
+async def test_is_previous_key_valid_no_previous_hash() -> None:
+    """Reject a check when no previous hash has ever been stored."""
+    api_key = ApiKey(owner_id=ACTOR.account.id, name="ci", key_hash="hash")
+    assert api_key.is_previous_key_valid(datetime.now(UTC)) is False
+
+
+async def test_is_previous_key_valid_zero_retain_period() -> None:
+    """Reject a check when the retain period is zero."""
+    api_key = ApiKey(owner_id=ACTOR.account.id, name="ci", key_hash="hash")
+    now = datetime.now(UTC)
+    api_key.rotate("new-hash", retain_period_minutes=0, when=now)
+    assert api_key.is_previous_key_valid(now) is False
+
+
+async def test_is_previous_key_valid_inside_window() -> None:
+    """Accept a check inside the retain window."""
+    api_key = ApiKey(owner_id=ACTOR.account.id, name="ci", key_hash="hash")
+    now = datetime.now(UTC)
+    api_key.rotate("new-hash", retain_period_minutes=5, when=now)
+    assert api_key.is_previous_key_valid(now + timedelta(minutes=4)) is True
+
+
+async def test_is_previous_key_valid_after_window() -> None:
+    """Reject a check once the retain window has passed."""
+    api_key = ApiKey(owner_id=ACTOR.account.id, name="ci", key_hash="hash")
+    now = datetime.now(UTC)
+    api_key.rotate("new-hash", retain_period_minutes=5, when=now)
+    assert api_key.is_previous_key_valid(now + timedelta(minutes=5)) is False

--- a/tests/server/test_api_keys_api.py
+++ b/tests/server/test_api_keys_api.py
@@ -60,6 +60,7 @@ async def test_create_api_key(client: httpx.AsyncClient) -> None:
     assert body["active"] is True
     assert body["key"].startswith(API_KEY_PREFIX)
     assert body["last_used"] is None
+    assert body["last_rotated"] is None
     assert body["created"] is not None
     assert body["updated"] is not None
     assert uuid.UUID(body["id"])
@@ -76,6 +77,7 @@ async def test_create_api_key_response_has_no_hash(client: httpx.AsyncClient) ->
         "active",
         "key",
         "last_used",
+        "last_rotated",
         "created",
         "updated",
     }
@@ -197,6 +199,55 @@ async def test_update_api_key_not_found(client: httpx.AsyncClient) -> None:
         f"/v1/api-keys/{uuid.uuid4()}", json={"active": False}
     )
     assert response.status_code == 404
+
+
+async def test_rotate_api_key(client: httpx.AsyncClient) -> None:
+    """Rotate an API key and observe the issued response shape."""
+    created = (await client.post("/v1/api-keys", json={"name": "ci"})).json()
+    response = await client.post(
+        f"/v1/api-keys/{created['id']}/rotate", json={"retain_period_minutes": 5}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body) == {
+        "id",
+        "owner_id",
+        "name",
+        "active",
+        "key",
+        "last_used",
+        "last_rotated",
+        "created",
+        "updated",
+    }
+    assert body["id"] == created["id"]
+    assert body["key"].startswith(API_KEY_PREFIX)
+    assert body["key"] != created["key"]
+    assert body["last_rotated"] is not None
+
+
+async def test_rotate_api_key_default_retain_period(client: httpx.AsyncClient) -> None:
+    """Default retain_period_minutes to zero for an empty rotate body."""
+    created = (await client.post("/v1/api-keys", json={"name": "ci"})).json()
+    response = await client.post(f"/v1/api-keys/{created['id']}/rotate", json={})
+    assert response.status_code == 200
+
+
+async def test_rotate_api_key_not_found(client: httpx.AsyncClient) -> None:
+    """Observe HTTP 404 for an unknown API key id."""
+    response = await client.post(
+        f"/v1/api-keys/{uuid.uuid4()}/rotate", json={"retain_period_minutes": 5}
+    )
+    assert response.status_code == 404
+
+
+async def test_rotate_api_key_negative_retain_period(client: httpx.AsyncClient) -> None:
+    """Observe HTTP 422 for a negative retain_period_minutes."""
+    created = (await client.post("/v1/api-keys", json={"name": "ci"})).json()
+    response = await client.post(
+        f"/v1/api-keys/{created['id']}/rotate", json={"retain_period_minutes": -1}
+    )
+    assert response.status_code == 422
 
 
 async def test_delete_api_key(client: httpx.AsyncClient) -> None:

--- a/tests/server/test_api_keys_api_pg.py
+++ b/tests/server/test_api_keys_api_pg.py
@@ -74,6 +74,22 @@ async def test_update_persists_across_requests(client: httpx.AsyncClient) -> Non
     assert body["updated"] > created["updated"]
 
 
+async def test_rotate_persists_across_requests(client: httpx.AsyncClient) -> None:
+    """Persist a rotation across requests."""
+    created = (await client.post("/v1/api-keys", json={"name": "ci"})).json()
+    response = await client.post(
+        f"/v1/api-keys/{created['id']}/rotate", json={"retain_period_minutes": 5}
+    )
+    assert response.status_code == 200
+    rotated = response.json()
+    assert rotated["key"] != created["key"]
+
+    response = await client.get(f"/v1/api-keys/{created['id']}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["last_rotated"] == rotated["last_rotated"]
+
+
 async def test_delete_persists_across_requests(client: httpx.AsyncClient) -> None:
     """Persist a deletion across requests."""
     created = (await client.post("/v1/api-keys", json={"name": "ci"})).json()

--- a/tests/server/test_auth_service.py
+++ b/tests/server/test_auth_service.py
@@ -40,7 +40,7 @@ from kitaru.server.application.models.auth import (
 )
 from kitaru.server.domain.account import Account
 from kitaru.server.domain.api_key import encode_api_key
-from kitaru.server.domain.keys import generate_secret
+from kitaru.server.domain.keys import generate_secret, hash_secret
 
 
 @pytest.fixture
@@ -188,6 +188,85 @@ async def test_api_key_auth_malformed(service: AuthService, credential: str) -> 
     """Reject malformed API key strings."""
     with pytest.raises(AuthenticationError, match="Invalid API key"):
         await service.resolve(credential)
+
+
+async def test_api_key_auth_old_key_valid_within_retain_window(
+    service: AuthService,
+    account_repository: FakeAccountRepository,
+    api_key_repository: FakeApiKeyRepository,
+) -> None:
+    """Accept the previous key while it is within its retain window."""
+    account = await create_account(account_repository)
+    api_key, old_key = await create_api_key(api_key_repository, account.id)
+
+    stored = await api_key_repository.get(api_key.id)
+    stored.rotate(
+        hash_secret(generate_secret()), retain_period_minutes=5, when=datetime.now(UTC)
+    )
+    await api_key_repository.update(stored)
+
+    context = await service.resolve(old_key)
+    assert context.account.id == account.id
+
+
+async def test_api_key_auth_old_key_rejected_with_zero_retain(
+    service: AuthService,
+    account_repository: FakeAccountRepository,
+    api_key_repository: FakeApiKeyRepository,
+) -> None:
+    """Reject the previous key when rotated with a zero retain period."""
+    account = await create_account(account_repository)
+    api_key, old_key = await create_api_key(api_key_repository, account.id)
+
+    stored = await api_key_repository.get(api_key.id)
+    stored.rotate(
+        hash_secret(generate_secret()), retain_period_minutes=0, when=datetime.now(UTC)
+    )
+    await api_key_repository.update(stored)
+
+    with pytest.raises(AuthenticationError, match="Invalid API key"):
+        await service.resolve(old_key)
+
+
+async def test_api_key_auth_old_key_rejected_after_retain_window(
+    service: AuthService,
+    account_repository: FakeAccountRepository,
+    api_key_repository: FakeApiKeyRepository,
+) -> None:
+    """Reject the previous key once its retain window has passed."""
+    account = await create_account(account_repository)
+    api_key, old_key = await create_api_key(api_key_repository, account.id)
+
+    stored = await api_key_repository.get(api_key.id)
+    stale_rotation = datetime.now(UTC) - timedelta(minutes=10)
+    stored.rotate(
+        hash_secret(generate_secret()), retain_period_minutes=5, when=stale_rotation
+    )
+    await api_key_repository.update(stored)
+
+    with pytest.raises(AuthenticationError, match="Invalid API key"):
+        await service.resolve(old_key)
+
+
+async def test_api_key_auth_new_key_immediately_after_rotation(
+    service: AuthService,
+    account_repository: FakeAccountRepository,
+    api_key_repository: FakeApiKeyRepository,
+) -> None:
+    """Accept the new key right after rotation."""
+    account = await create_account(account_repository)
+    api_key, _ = await create_api_key(api_key_repository, account.id)
+
+    new_secret = generate_secret()
+    stored = await api_key_repository.get(api_key.id)
+    stored.rotate(
+        hash_secret(new_secret), retain_period_minutes=5, when=datetime.now(UTC)
+    )
+    await api_key_repository.update(stored)
+    new_key = encode_api_key(api_key.id, new_secret)
+
+    context = await service.resolve(new_key)
+    assert context.account.id == account.id
 
 
 async def test_login_with_password(

--- a/tests/server/test_route_manifest.py
+++ b/tests/server/test_route_manifest.py
@@ -40,6 +40,7 @@ def test_route_manifest_is_registered() -> None:
         "/v1/agents/{agent_id}/versions",
         "/v1/api-keys",
         "/v1/api-keys/{api_key_id}",
+        "/v1/api-keys/{api_key_id}/rotate",
         "/v1/blobs",
         "/v1/blobs/{blob_id}",
         "/v1/blobs/{blob_id}/content",


### PR DESCRIPTION
Rotate an API key with POST /v1/api-keys/{api_key_id}/rotate or client.api_keys.rotate(...), returning the new key exactly once.
The previous key optionally stays valid for retain_period_minutes after rotation, and each rotation retains only the latest previous key.