### PR TITLE
Add permission layer and account admin flag

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -60,6 +60,11 @@
             "title": "Id",
             "type": "string"
           },
+          "is_admin": {
+            "description": "Whether the account has admin rights.",
+            "title": "Is Admin",
+            "type": "boolean"
+          },
           "is_service_account": {
             "description": "Whether this is a service account.",
             "title": "Is Service Account",
@@ -90,6 +95,7 @@
           "name",
           "email",
           "is_service_account",
+          "is_admin",
           "active",
           "metadata",
           "activation_token"
@@ -112,6 +118,12 @@
             ],
             "description": "Contact email.",
             "title": "Email"
+          },
+          "is_admin": {
+            "default": false,
+            "description": "Whether the account has admin rights.",
+            "title": "Is Admin",
+            "type": "boolean"
           },
           "name": {
             "description": "Account name.",
@@ -169,6 +181,11 @@
             "title": "Id",
             "type": "string"
           },
+          "is_admin": {
+            "description": "Whether the account has admin rights.",
+            "title": "Is Admin",
+            "type": "boolean"
+          },
           "is_service_account": {
             "description": "Whether this is a service account.",
             "title": "Is Service Account",
@@ -199,6 +216,7 @@
           "name",
           "email",
           "is_service_account",
+          "is_admin",
           "active",
           "metadata"
         ],
@@ -209,6 +227,18 @@
         "additionalProperties": false,
         "description": "Account update request.",
         "properties": {
+          "is_admin": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New admin rights state.",
+            "title": "Is Admin"
+          },
           "metadata": {
             "anyOf": [
               {
@@ -7529,7 +7559,7 @@
         ]
       },
       "patch": {
-        "description": "Partially update an account.\n\nA password write carries the current password in ``old_password``.\n\nClients observe HTTP 200 on success, 403 when writing a password outside\nthe ``local`` auth scheme, when writing another account's password or\nmetadata, and when the supplied current password is missing or wrong, 404\nwhen the account does not exist, and 422 on invalid input.\n\nArgs:\n    account_id: Id of the account.\n    body: Account update request.\n    service: Account service.\n    actor: Caller context.\n    settings: API settings for this process.\n\nRaises:\n    HTTPException: The caller is not the account whose password or\n        metadata it writes.\n\nReturns:\n    Updated account.",
+        "description": "Partially update an account.\n\nA password write carries the current password in ``old_password``.\n\nClients observe HTTP 200 on success, 403 when writing a password or the\nadmin flag outside the ``local`` auth scheme, when writing another\naccount's password or metadata, when changing the calling account's own\nadmin flag, when making a service account an admin, and when the\nsupplied current password is missing or wrong, 404 when the account does\nnot exist, and 422 on invalid input.\n\nArgs:\n    account_id: Id of the account.\n    body: Account update request.\n    service: Account service.\n    actor: Caller context.\n    settings: API settings for this process.\n\nRaises:\n    HTTPException: The caller is not the account whose password or\n        metadata it writes, or is changing its own admin flag.\n\nReturns:\n    Updated account.",
         "operationId": "update_account_v1_accounts__account_id__patch",
         "parameters": [
           {

--- a/src/kitaru/api_models/v1/account.py
+++ b/src/kitaru/api_models/v1/account.py
@@ -31,6 +31,9 @@ class AccountCreateRequest(RequestModel):
     name: str = Field(description="Account name.")
     email: str | None = Field(default=None, description="Contact email.")
     password: str | None = Field(default=None, description="Login password.")
+    is_admin: bool = Field(
+        default=False, description="Whether the account has admin rights."
+    )
 
 
 class AccountUpdateRequest(RequestModel):
@@ -43,6 +46,7 @@ class AccountUpdateRequest(RequestModel):
     metadata: dict[str, JsonValue] | None = Field(
         default=None, description="New metadata."
     )
+    is_admin: bool | None = Field(default=None, description="New admin rights state.")
 
 
 class AccountActivateRequest(RequestModel):
@@ -63,6 +67,7 @@ class AccountResponse(TimestampedResponseModel):
     name: str = Field(description="Account name.")
     email: str | None = Field(description="Contact email.")
     is_service_account: bool = Field(description="Whether this is a service account.")
+    is_admin: bool = Field(description="Whether the account has admin rights.")
     active: bool = Field(description="Whether the account can authenticate.")
     metadata: dict[str, JsonValue] = Field(description="Arbitrary metadata.")
 

--- a/src/kitaru/server/adapters/db/orm/account.py
+++ b/src/kitaru/server/adapters/db/orm/account.py
@@ -51,6 +51,7 @@ class AccountORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     is_service_account: Mapped[bool]
+    is_admin: Mapped[bool]
     external_id: Mapped[uuid.UUID | None]
     name: Mapped[str] = mapped_column(String(MAX_NAME_LENGTH))
     email: Mapped[str | None] = mapped_column(String(255))
@@ -72,6 +73,7 @@ class AccountORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         return cls(
             id=account.id,
             is_service_account=account.is_service_account,
+            is_admin=account.is_admin,
             external_id=account.external_id,
             name=account.name,
             email=account.email,
@@ -90,6 +92,7 @@ class AccountORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         return Account(
             id=self.id,
             is_service_account=self.is_service_account,
+            is_admin=self.is_admin,
             external_id=self.external_id,
             name=self.name,
             email=self.email,

--- a/src/kitaru/server/adapters/permissions/__init__.py
+++ b/src/kitaru/server/adapters/permissions/__init__.py
@@ -1,0 +1,14 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Permission adapters."""

--- a/src/kitaru/server/adapters/permissions/admin_flag.py
+++ b/src/kitaru/server/adapters/permissions/admin_flag.py
@@ -1,0 +1,76 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Admin flag permission provider."""
+
+import uuid
+
+from kitaru.server.application.models.permissions import (
+    ALL_IDS,
+    Action,
+    AllowedIds,
+    ResourceType,
+)
+from kitaru.server.domain.account import Account
+
+ADMIN_ONLY_PERMISSIONS: frozenset[tuple[ResourceType, Action]] = frozenset(
+    {
+        (ResourceType.ACCOUNT, Action.CREATE),
+        (ResourceType.ACCOUNT, Action.DEACTIVATE),
+        (ResourceType.ACCOUNT, Action.SET_ADMIN),
+    }
+)
+
+
+class AdminFlagPermissionProvider:
+    """Admin flag permission provider."""
+
+    async def has_permission(
+        self,
+        account: Account,
+        resource_type: ResourceType,
+        action: Action,
+        resource_id: uuid.UUID | None = None,
+    ) -> bool:
+        """Check whether an account may perform an action.
+
+        Args:
+            account: Account to check.
+            resource_type: Resource type the action applies to.
+            action: Action to check.
+            resource_id: Id of the specific resource, checked broadly when
+                ``None``.
+
+        Returns:
+            Whether the account may perform the action.
+        """
+        _ = resource_id
+        if account.is_admin:
+            return True
+        return (resource_type, action) not in ADMIN_ONLY_PERMISSIONS
+
+    async def get_allowed_ids(
+        self, account: Account, resource_type: ResourceType, action: Action
+    ) -> AllowedIds:
+        """List the resource ids an account may perform an action on.
+
+        Args:
+            account: Account to check.
+            resource_type: Resource type the action applies to.
+            action: Action to check.
+
+        Returns:
+            Allowed resource ids, or every id when unrestricted.
+        """
+        _ = account, resource_type, action
+        return ALL_IDS

--- a/src/kitaru/server/adapters/permissions/allow_all.py
+++ b/src/kitaru/server/adapters/permissions/allow_all.py
@@ -1,0 +1,66 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Allow-all permission provider."""
+
+import uuid
+
+from kitaru.server.application.models.permissions import (
+    ALL_IDS,
+    Action,
+    AllowedIds,
+    ResourceType,
+)
+from kitaru.server.domain.account import Account
+
+
+class AllowAllPermissionProvider:
+    """Permission provider that allows everything."""
+
+    async def has_permission(
+        self,
+        account: Account,
+        resource_type: ResourceType,
+        action: Action,
+        resource_id: uuid.UUID | None = None,
+    ) -> bool:
+        """Check whether an account may perform an action.
+
+        Args:
+            account: Account to check.
+            resource_type: Resource type the action applies to.
+            action: Action to check.
+            resource_id: Id of the specific resource, checked broadly when
+                ``None``.
+
+        Returns:
+            Whether the account may perform the action.
+        """
+        _ = account, resource_type, action, resource_id
+        return True
+
+    async def get_allowed_ids(
+        self, account: Account, resource_type: ResourceType, action: Action
+    ) -> AllowedIds:
+        """List the resource ids an account may perform an action on.
+
+        Args:
+            account: Account to check.
+            resource_type: Resource type the action applies to.
+            action: Action to check.
+
+        Returns:
+            Allowed resource ids, or every id when unrestricted.
+        """
+        _ = account, resource_type, action
+        return ALL_IDS

--- a/src/kitaru/server/adapters/rest/dependencies.py
+++ b/src/kitaru/server/adapters/rest/dependencies.py
@@ -84,6 +84,8 @@ from kitaru.server.adapters.db.repositories.task_repository import SQLTaskReposi
 from kitaru.server.adapters.db.repositories.worker_repository import (
     SQLWorkerRepository,
 )
+from kitaru.server.adapters.permissions.admin_flag import AdminFlagPermissionProvider
+from kitaru.server.adapters.permissions.allow_all import AllowAllPermissionProvider
 from kitaru.server.adapters.rest.commit_route import attach_request_session
 from kitaru.server.api.composition import build_event_dispatcher
 from kitaru.server.api.config import UNSET_SERVER_ID, APISettings
@@ -114,6 +116,7 @@ from kitaru.server.application.services.experiment_run_service import (
 )
 from kitaru.server.application.services.experiment_service import ExperimentService
 from kitaru.server.application.services.job_service import JobService
+from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.application.services.plugin_service import PluginService
 from kitaru.server.application.services.replay_service import ReplayService
 from kitaru.server.application.services.secret_service import SecretService
@@ -209,13 +212,31 @@ def get_server_analytics(
     )
 
 
+def get_permission_service(
+    settings: Annotated[APISettings, Depends(get_app_settings)],
+) -> PermissionService:
+    """Return a permission service for the current request.
+
+    Args:
+        settings: API settings for this process.
+
+    Returns:
+        Permission service bound to the auth scheme's provider.
+    """
+    if settings.AUTH_SCHEME is AuthScheme.CONTROL_PLANE:
+        return PermissionService(AllowAllPermissionProvider())
+    return PermissionService(AdminFlagPermissionProvider())
+
+
 def get_account_service(
     session: Annotated[AsyncSession, Depends(get_session)],
+    permission_service: Annotated[PermissionService, Depends(get_permission_service)],
 ) -> AccountService:
     """Return an account service for the current request.
 
     Args:
         session: Request-scoped database session.
+        permission_service: Permission service for the current request.
 
     Returns:
         Account service bound to the SQL repository.
@@ -223,6 +244,7 @@ def get_account_service(
     return AccountService(
         repository=SQLAccountRepository(session),
         password_hasher=BcryptPasswordHasher(),
+        permission_service=permission_service,
     )
 
 

--- a/src/kitaru/server/adapters/rest/mapping/accounts.py
+++ b/src/kitaru/server/adapters/rest/mapping/accounts.py
@@ -39,6 +39,7 @@ def account_to_response(account: Account) -> AccountResponse:
         name=account.name,
         email=account.email,
         is_service_account=account.is_service_account,
+        is_admin=account.is_admin,
         active=account.active,
         metadata=account.metadata,
         created=account.created,

--- a/src/kitaru/server/adapters/rest/routers/accounts.py
+++ b/src/kitaru/server/adapters/rest/routers/accounts.py
@@ -16,7 +16,7 @@
 import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query, status
 
 from kitaru.api_models.v1.account import (
     AccountActivateRequest,
@@ -76,6 +76,7 @@ async def create_account(
         name=body.name,
         email=body.email,
         password=body.password,
+        is_admin=body.is_admin,
         actor=actor,
     )
     if activation_token is not None:
@@ -145,10 +146,12 @@ async def update_account(
 
     A password write carries the current password in ``old_password``.
 
-    Clients observe HTTP 200 on success, 403 when writing a password outside
-    the ``local`` auth scheme, when writing another account's password or
-    metadata, and when the supplied current password is missing or wrong, 404
-    when the account does not exist, and 422 on invalid input.
+    Clients observe HTTP 200 on success, 403 when writing a password or the
+    admin flag outside the ``local`` auth scheme, when writing another
+    account's password or metadata, when changing the calling account's own
+    admin flag, when making a service account an admin, and when the
+    supplied current password is missing or wrong, 404 when the account does
+    not exist, and 422 on invalid input.
 
     Args:
         account_id: Id of the account.
@@ -157,31 +160,17 @@ async def update_account(
         actor: Caller context.
         settings: API settings for this process.
 
-    Raises:
-        HTTPException: The caller is not the account whose password or
-            metadata it writes.
-
     Returns:
         Updated account.
     """
-    if body.password is not None:
+    if body.password is not None or body.is_admin is not None:
         require_local_account_management(settings)
-    if account_id != actor.account.id:
-        if body.password is not None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Accounts cannot change the password of other accounts.",
-            )
-        if body.metadata is not None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Accounts can only update their own metadata.",
-            )
     account = await service.update_account(
         account_id,
         password=body.password,
         old_password=body.old_password,
         metadata=body.metadata,
+        is_admin=body.is_admin,
         actor=actor,
     )
     return account_to_response(account)
@@ -207,17 +196,9 @@ async def deactivate_account(
         service: Account service.
         actor: Caller context.
 
-    Raises:
-        HTTPException: The caller is deactivating itself.
-
     Returns:
         Deactivated account carrying its activation token.
     """
-    if account_id == actor.account.id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Accounts cannot deactivate themselves.",
-        )
     account, activation_token = await service.deactivate_account(
         account_id, actor=actor
     )

--- a/src/kitaru/server/api/app.py
+++ b/src/kitaru/server/api/app.py
@@ -36,6 +36,7 @@ from kitaru.server.adapters.db.errors import is_deadlock
 from kitaru.server.adapters.db.repositories.account_repository import (
     SQLAccountRepository,
 )
+from kitaru.server.adapters.permissions.admin_flag import AdminFlagPermissionProvider
 from kitaru.server.adapters.rest.routers import (
     accounts,
     agent_versions,
@@ -68,6 +69,7 @@ from kitaru.server.api.config import APISettings
 from kitaru.server.api.otel import configure_otel, instrument_engine, shutdown_otel
 from kitaru.server.api.task_sweeper import start_task_sweeper, stop_task_sweeper
 from kitaru.server.application.services.account_service import AccountService
+from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.database.service import DatabaseService
 from kitaru.server.domain.base import (
     ConflictError,
@@ -215,6 +217,7 @@ def create_app(settings: APISettings) -> FastAPI:
                 account_service = AccountService(
                     repository=SQLAccountRepository(session),
                     password_hasher=BcryptPasswordHasher(),
+                    permission_service=PermissionService(AdminFlagPermissionProvider()),
                 )
                 await account_service.ensure_account(
                     settings.DEFAULT_ACCOUNT_NAME, settings.DEFAULT_ACCOUNT_PASSWORD

--- a/src/kitaru/server/application/interfaces/permissions.py
+++ b/src/kitaru/server/application/interfaces/permissions.py
@@ -1,0 +1,64 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Permission provider interface."""
+
+import uuid
+from typing import Protocol
+
+from kitaru.server.application.models.permissions import (
+    Action,
+    AllowedIds,
+    ResourceType,
+)
+from kitaru.server.domain.account import Account
+
+
+class PermissionProvider(Protocol):
+    """Permission provider."""
+
+    async def has_permission(
+        self,
+        account: Account,
+        resource_type: ResourceType,
+        action: Action,
+        resource_id: uuid.UUID | None = None,
+    ) -> bool:
+        """Check whether an account may perform an action.
+
+        Args:
+            account: Account to check.
+            resource_type: Resource type the action applies to.
+            action: Action to check.
+            resource_id: Id of the specific resource, checked broadly when
+                ``None``.
+
+        Returns:
+            Whether the account may perform the action.
+        """
+        ...
+
+    async def get_allowed_ids(
+        self, account: Account, resource_type: ResourceType, action: Action
+    ) -> AllowedIds:
+        """List the resource ids an account may perform an action on.
+
+        Args:
+            account: Account to check.
+            resource_type: Resource type the action applies to.
+            action: Action to check.
+
+        Returns:
+            Allowed resource ids, or every id when unrestricted.
+        """
+        ...

--- a/src/kitaru/server/application/models/permissions.py
+++ b/src/kitaru/server/application/models/permissions.py
@@ -1,0 +1,41 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Permission models."""
+
+import uuid
+from enum import StrEnum
+
+
+class ResourceType(StrEnum):
+    """Resource type."""
+
+    ACCOUNT = "account"
+
+
+class Action(StrEnum):
+    """Action."""
+
+    CREATE = "create"
+    DEACTIVATE = "deactivate"
+    SET_ADMIN = "set_admin"
+
+
+class AllIds:
+    """Sentinel for every id being allowed."""
+
+
+# Sentinel meaning every id is allowed.
+ALL_IDS = AllIds()
+
+AllowedIds = frozenset[uuid.UUID] | AllIds

--- a/src/kitaru/server/application/services/account_service.py
+++ b/src/kitaru/server/application/services/account_service.py
@@ -24,6 +24,8 @@ from kitaru.server.application.interfaces.account_repository import (
 from kitaru.server.application.interfaces.password_hasher import PasswordHasher
 from kitaru.server.application.models.account import AccountFilter
 from kitaru.server.application.models.auth import AuthContext
+from kitaru.server.application.models.permissions import Action, ResourceType
+from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.domain.account import (
     Account,
     AccountNotFound,
@@ -37,22 +39,28 @@ class AccountService:
     """Account use cases."""
 
     def __init__(
-        self, repository: AccountRepository, password_hasher: PasswordHasher
+        self,
+        repository: AccountRepository,
+        password_hasher: PasswordHasher,
+        permission_service: PermissionService,
     ) -> None:
         """Initialize the service.
 
         Args:
             repository: Account repository.
             password_hasher: Password hasher for login credentials.
+            permission_service: Permission service for authorization checks.
         """
         self._repository = repository
         self._password_hasher = password_hasher
+        self._permission_service = permission_service
 
     async def create_account(
         self,
         name: str,
         email: str | None,
         password: str | None,
+        is_admin: bool,
         actor: AuthContext,
     ) -> tuple[Account, str | None]:
         """Create an account, active with a password or pending activation.
@@ -61,20 +69,24 @@ class AccountService:
             name: Account name.
             email: Contact email.
             password: Login password, hashed before storage.
+            is_admin: Whether the account has admin rights.
             actor: Caller context.
 
         Raises:
+            ForbiddenError: The caller may not create accounts.
             DuplicateAccountName: The account name is already registered.
 
         Returns:
             Created account and its activation token when one was generated.
         """
-        _ = actor
+        await self._permission_service.check(actor, ResourceType.ACCOUNT, Action.CREATE)
         if password is not None:
             password_hash = await to_thread.run_sync(
                 self._password_hasher.hash, password
             )
-            account = Account(name=name, email=email, password_hash=password_hash)
+            account = Account(
+                name=name, email=email, password_hash=password_hash, is_admin=is_admin
+            )
             return await self._repository.create(account), None
         activation_token = generate_secret()
         account = Account(
@@ -82,6 +94,7 @@ class AccountService:
             email=email,
             active=False,
             activation_token_hash=hash_secret(activation_token),
+            is_admin=is_admin,
         )
         return await self._repository.create(account), activation_token
 
@@ -96,9 +109,14 @@ class AccountService:
             Stored account.
         """
         try:
-            return await self._repository.get_by_name(name)
+            account = await self._repository.get_by_name(name)
         except AccountNotFound:
-            pass
+            account = None
+        if account is not None:
+            if account.is_admin:
+                return account
+            account.update_is_admin(True)
+            return await self._repository.update(account)
         password_hash = None
         if password is not None:
             password_hash = await to_thread.run_sync(
@@ -106,7 +124,7 @@ class AccountService:
             )
         try:
             return await self._repository.create(
-                Account(name=name, password_hash=password_hash)
+                Account(name=name, password_hash=password_hash, is_admin=True)
             )
         except DuplicateAccountName:
             return await self._repository.get_by_name(name)
@@ -148,6 +166,7 @@ class AccountService:
         password: str | None,
         old_password: str | None,
         metadata: dict[str, Any] | None,
+        is_admin: bool | None,
         actor: AuthContext,
     ) -> Account:
         """Partially update an account.
@@ -157,19 +176,38 @@ class AccountService:
             password: New login password, unchanged when ``None``.
             old_password: Current login password, required to set a new one.
             metadata: New metadata, unchanged when ``None``.
+            is_admin: New admin rights state, unchanged when ``None``.
             actor: Caller context.
 
         Raises:
             AccountNotFound: No account has this id.
-            ForbiddenError: The current password is missing or does not match.
+            ForbiddenError: The caller may not set admin rights, writes its
+                own admin flag or another account's password or metadata,
+                the current password is missing or does not match, or the
+                target account is a service account.
 
         Returns:
             Updated account.
         """
-        _ = actor
         account = await self._repository.get(account_id)
+        if account_id != actor.account.id:
+            if password is not None:
+                raise ForbiddenError(
+                    "Accounts cannot change the password of other accounts"
+                )
+            if metadata is not None:
+                raise ForbiddenError("Accounts can only update their own metadata")
         if metadata is not None:
             account.update_metadata(metadata)
+        if is_admin is not None:
+            await self._permission_service.check(
+                actor, ResourceType.ACCOUNT, Action.SET_ADMIN, resource_id=account_id
+            )
+            if account_id == actor.account.id:
+                raise ForbiddenError("Accounts cannot change their own admin flag")
+            if account.is_service_account:
+                raise ForbiddenError("Service accounts cannot be admins")
+            account.update_is_admin(is_admin)
         if password is not None:
             if old_password is None:
                 raise ForbiddenError(
@@ -198,11 +236,17 @@ class AccountService:
 
         Raises:
             AccountNotFound: No account has this id.
+            ForbiddenError: The caller may not deactivate this account or is
+                deactivating itself.
 
         Returns:
             Deactivated account and its activation token.
         """
-        _ = actor
+        await self._permission_service.check(
+            actor, ResourceType.ACCOUNT, Action.DEACTIVATE, resource_id=account_id
+        )
+        if account_id == actor.account.id:
+            raise ForbiddenError("Accounts cannot deactivate themselves")
         account = await self._repository.get(account_id)
         activation_token = generate_secret()
         account.update_active(False)

--- a/src/kitaru/server/application/services/permission_service.py
+++ b/src/kitaru/server/application/services/permission_service.py
@@ -1,0 +1,89 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Permission checks."""
+
+import uuid
+
+from kitaru.server.application.interfaces.permissions import PermissionProvider
+from kitaru.server.application.models.auth import AccountPrincipal, AuthContext
+from kitaru.server.application.models.permissions import (
+    ALL_IDS,
+    Action,
+    AllowedIds,
+    ResourceType,
+)
+from kitaru.server.domain.base import ForbiddenError
+
+
+class PermissionService:
+    """Permission checks."""
+
+    def __init__(self, provider: PermissionProvider) -> None:
+        """Initialize the service.
+
+        Args:
+            provider: Permission provider.
+        """
+        self._provider = provider
+
+    async def check(
+        self,
+        actor: AuthContext,
+        resource_type: ResourceType,
+        action: Action,
+        resource_id: uuid.UUID | None = None,
+    ) -> None:
+        """Require an account principal to be permitted an action.
+
+        Worker and task principals pass through, since they are covered by
+        the grant checks in ``resource_access.py``.
+
+        Args:
+            actor: Caller context.
+            resource_type: Resource type the action applies to.
+            action: Action to check.
+            resource_id: Id of the specific resource, checked broadly when
+                ``None``.
+
+        Raises:
+            ForbiddenError: The account is not permitted the action.
+        """
+        if not isinstance(actor.principal, AccountPrincipal):
+            return
+        allowed = await self._provider.has_permission(
+            actor.account, resource_type, action, resource_id
+        )
+        if not allowed:
+            raise ForbiddenError(
+                f"Insufficient permissions for {resource_type.value}:{action.value}"
+            )
+
+    async def get_allowed_ids(
+        self, actor: AuthContext, resource_type: ResourceType, action: Action
+    ) -> AllowedIds:
+        """List the resource ids an actor may perform an action on.
+
+        Args:
+            actor: Caller context.
+            resource_type: Resource type the action applies to.
+            action: Action to check.
+
+        Returns:
+            Allowed resource ids, or every id when unrestricted.
+        """
+        if not isinstance(actor.principal, AccountPrincipal):
+            return ALL_IDS
+        return await self._provider.get_allowed_ids(
+            actor.account, resource_type, action
+        )

--- a/src/kitaru/server/database/migrations/versions/001_initial.py
+++ b/src/kitaru/server/database/migrations/versions/001_initial.py
@@ -38,6 +38,7 @@ def upgrade() -> None:
         sa.Column("updated", sa.DateTime(timezone=True), nullable=False),
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("is_service_account", sa.Boolean(), nullable=False),
+        sa.Column("is_admin", sa.Boolean(), nullable=False),
         sa.Column("name", sa.String(length=255), nullable=False),
         sa.Column("email", sa.String(length=255), nullable=True),
         sa.Column("password_hash", sa.String(length=128), nullable=True),

--- a/src/kitaru/server/domain/account.py
+++ b/src/kitaru/server/domain/account.py
@@ -53,6 +53,7 @@ class Account(DomainModel):
 
     id: uuid.UUID = Field(default_factory=uuid7)
     is_service_account: bool = False
+    is_admin: bool = False
     external_id: uuid.UUID | None = None
     name: AccountName
     email: str | None = None
@@ -70,6 +71,14 @@ class Account(DomainModel):
             active: New active state.
         """
         self.active = active
+
+    def update_is_admin(self, is_admin: bool) -> None:
+        """Set whether the account has admin rights.
+
+        Args:
+            is_admin: New admin state.
+        """
+        self.is_admin = is_admin
 
     def update_identity(self, name: str, email: str | None) -> None:
         """Set the account name and contact email.

--- a/tests/client/test_accounts.py
+++ b/tests/client/test_accounts.py
@@ -32,13 +32,15 @@ from kitaru.api_models.v1.account import (
 from kitaru.api_models.v1.filter import FilterCondition, FilterOp
 from kitaru.client.api_client import KitaruAPIClient
 from kitaru.client.exceptions import APIError, NotFoundError
+from kitaru.server.adapters.permissions.admin_flag import AdminFlagPermissionProvider
 from kitaru.server.adapters.rest.dependencies import authorize, get_account_service
 from kitaru.server.api.app import create_app
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.services.account_service import AccountService
+from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.domain.account import Account
 
-ACTOR = AuthContext(account=Account(id=uuid.uuid4(), name="admin"))
+ACTOR = AuthContext(account=Account(id=uuid.uuid4(), name="admin", is_admin=True))
 
 
 @pytest.fixture
@@ -48,6 +50,7 @@ async def api_client() -> AsyncGenerator[KitaruAPIClient, None]:
     service = AccountService(
         repository=FakeAccountRepository(),
         password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
     )
     app.dependency_overrides[get_account_service] = lambda: service
     app.dependency_overrides[authorize] = lambda: ACTOR

--- a/tests/server/test_account_service.py
+++ b/tests/server/test_account_service.py
@@ -19,9 +19,11 @@ import pytest
 
 from conftest import FakeAccountRepository, FakePasswordHasher
 from kitaru.api_models.v1.filter import FilterOp
+from kitaru.server.adapters.permissions.admin_flag import AdminFlagPermissionProvider
 from kitaru.server.application.models.account import AccountFilter
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.services.account_service import AccountService
+from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.domain.account import (
     Account,
     AccountNotFound,
@@ -31,7 +33,10 @@ from kitaru.server.domain.base import ForbiddenError
 from kitaru.server.domain.keys import hash_secret
 from kitaru.server.filtering import FilterCondition
 
-ACTOR = AuthContext(account=Account(id=uuid.uuid4(), name="admin"))
+ACTOR = AuthContext(account=Account(id=uuid.uuid4(), name="admin", is_admin=True))
+NON_ADMIN_ACTOR = AuthContext(
+    account=Account(id=uuid.uuid4(), name="alice", is_admin=False)
+)
 
 
 @pytest.fixture
@@ -40,13 +45,30 @@ def service() -> AccountService:
     return AccountService(
         repository=FakeAccountRepository(),
         password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
     )
+
+
+@pytest.fixture
+def service_and_repository() -> tuple[AccountService, FakeAccountRepository]:
+    """Provide an account service and its backing repository."""
+    repository = FakeAccountRepository()
+    service = AccountService(
+        repository=repository,
+        password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
+    )
+    return service, repository
 
 
 async def test_create_account(service: AccountService) -> None:
     """Create an account with all fields."""
     account, _ = await service.create_account(
-        name="alice", email="alice@example.com", password="secret", actor=ACTOR
+        name="alice",
+        email="alice@example.com",
+        password="secret",
+        is_admin=False,
+        actor=ACTOR,
     )
     assert account.name == "alice"
     assert account.email == "alice@example.com"
@@ -62,7 +84,7 @@ async def test_create_account_without_password_pends_activation(
 ) -> None:
     """Start a password-less account inactive with an activation token."""
     account, activation_token = await service.create_account(
-        name="alice", email=None, password=None, actor=ACTOR
+        name="alice", email=None, password=None, is_admin=False, actor=ACTOR
     )
     assert account.password_hash is None
     assert account.active is False
@@ -73,7 +95,7 @@ async def test_create_account_without_password_pends_activation(
 async def test_activate_account(service: AccountService) -> None:
     """Activate a pending account and clear its token."""
     created, activation_token = await service.create_account(
-        name="alice", email=None, password=None, actor=ACTOR
+        name="alice", email=None, password=None, is_admin=False, actor=ACTOR
     )
     assert activation_token is not None
     activated = await service.activate_account(
@@ -87,7 +109,7 @@ async def test_activate_account(service: AccountService) -> None:
 async def test_activate_account_wrong_token(service: AccountService) -> None:
     """Reject activation with a token that does not match."""
     created, _ = await service.create_account(
-        name="alice", email=None, password=None, actor=ACTOR
+        name="alice", email=None, password=None, is_admin=False, actor=ACTOR
     )
     with pytest.raises(ForbiddenError):
         await service.activate_account(
@@ -100,7 +122,7 @@ async def test_activate_account_without_pending_token(
 ) -> None:
     """Reject activation of an account that has no pending token."""
     created, _ = await service.create_account(
-        name="alice", email=None, password="secret", actor=ACTOR
+        name="alice", email=None, password="secret", is_admin=False, actor=ACTOR
     )
     with pytest.raises(ForbiddenError):
         await service.activate_account(
@@ -113,7 +135,7 @@ async def test_deactivate_account_mints_activation_token(
 ) -> None:
     """Mint a fresh activation token when an account is deactivated."""
     created, _ = await service.create_account(
-        name="alice", email=None, password="secret", actor=ACTOR
+        name="alice", email=None, password="secret", is_admin=False, actor=ACTOR
     )
     updated, activation_token = await service.deactivate_account(
         created.id, actor=ACTOR
@@ -125,26 +147,28 @@ async def test_deactivate_account_mints_activation_token(
 async def test_create_account_hashes_password(service: AccountService) -> None:
     """Store the hash of a given password, never the plaintext."""
     account, _ = await service.create_account(
-        name="alice", email=None, password="secret", actor=ACTOR
+        name="alice", email=None, password="secret", is_admin=False, actor=ACTOR
     )
     assert account.password_hash == "hashed:secret"
 
 
 async def test_create_account_duplicate_name(service: AccountService) -> None:
     """Reject a second account with the same name."""
-    await service.create_account(name="alice", email=None, password=None, actor=ACTOR)
+    await service.create_account(
+        name="alice", email=None, password=None, is_admin=False, actor=ACTOR
+    )
     with pytest.raises(
         DuplicateAccountName, match="Account name 'alice' is already registered"
     ):
         await service.create_account(
-            name="alice", email=None, password=None, actor=ACTOR
+            name="alice", email=None, password=None, is_admin=False, actor=ACTOR
         )
 
 
 async def test_get_account(service: AccountService) -> None:
     """Load a stored account by id."""
     created, _ = await service.create_account(
-        name="alice", email=None, password=None, actor=ACTOR
+        name="alice", email=None, password=None, is_admin=False, actor=ACTOR
     )
     loaded = await service.get_account(created.id, actor=ACTOR)
     assert loaded == created
@@ -160,7 +184,9 @@ async def test_get_account_not_found(service: AccountService) -> None:
 async def test_list_accounts(service: AccountService) -> None:
     """List accounts newest-first with filters."""
     for name in ["alice", "bob", "carol"]:
-        await service.create_account(name=name, email=None, password=None, actor=ACTOR)
+        await service.create_account(
+            name=name, email=None, password=None, is_admin=False, actor=ACTOR
+        )
 
     accounts, next_cursor = await service.list_accounts(AccountFilter(), actor=ACTOR)
     assert next_cursor is None
@@ -179,7 +205,9 @@ async def test_list_accounts(service: AccountService) -> None:
 async def test_list_accounts_walks_pages(service: AccountService) -> None:
     """Walk every page of accounts via next_cursor."""
     for name in ["alice", "bob", "carol"]:
-        await service.create_account(name=name, email=None, password=None, actor=ACTOR)
+        await service.create_account(
+            name=name, email=None, password=None, is_admin=False, actor=ACTOR
+        )
 
     collected: list[str] = []
     cursor = None
@@ -198,7 +226,7 @@ async def test_list_accounts_walks_pages(service: AccountService) -> None:
 async def test_deactivate_then_activate_account(service: AccountService) -> None:
     """Deactivate an account and bring it back with its fresh token."""
     created, _ = await service.create_account(
-        name="alice", email=None, password="secret", actor=ACTOR
+        name="alice", email=None, password="secret", is_admin=False, actor=ACTOR
     )
     deactivated, activation_token = await service.deactivate_account(
         created.id, actor=ACTOR
@@ -216,14 +244,15 @@ async def test_deactivate_then_activate_account(service: AccountService) -> None
 async def test_update_account_password(service: AccountService) -> None:
     """Replace the stored password hash."""
     created, _ = await service.create_account(
-        name="alice", email=None, password="old", actor=ACTOR
+        name="alice", email=None, password="old", is_admin=False, actor=ACTOR
     )
     updated = await service.update_account(
         created.id,
         password="new",
         old_password="old",
         metadata=None,
-        actor=ACTOR,
+        is_admin=None,
+        actor=AuthContext(account=created),
     )
     assert updated.password_hash == "hashed:new"
     assert updated.active is True
@@ -237,6 +266,7 @@ async def test_update_account_not_found(service: AccountService) -> None:
             password=None,
             old_password=None,
             metadata=None,
+            is_admin=None,
             actor=ACTOR,
         )
 
@@ -244,7 +274,7 @@ async def test_update_account_not_found(service: AccountService) -> None:
 async def test_update_account_metadata(service: AccountService) -> None:
     """Replace account metadata whole."""
     created, _ = await service.create_account(
-        name="alice", email=None, password=None, actor=ACTOR
+        name="alice", email=None, password=None, is_admin=False, actor=ACTOR
     )
     assert created.metadata == {}
     updated = await service.update_account(
@@ -252,7 +282,8 @@ async def test_update_account_metadata(service: AccountService) -> None:
         password=None,
         old_password=None,
         metadata={"theme": "dark"},
-        actor=ACTOR,
+        is_admin=None,
+        actor=AuthContext(account=created),
     )
     assert updated.metadata == {"theme": "dark"}
     updated = await service.update_account(
@@ -260,7 +291,8 @@ async def test_update_account_metadata(service: AccountService) -> None:
         password=None,
         old_password=None,
         metadata={"locale": "de"},
-        actor=ACTOR,
+        is_admin=None,
+        actor=AuthContext(account=created),
     )
     assert updated.metadata == {"locale": "de"}
 
@@ -270,7 +302,7 @@ async def test_update_account_password_without_old_password(
 ) -> None:
     """Reject a password change that omits the current password."""
     created, _ = await service.create_account(
-        name="alice", email=None, password="old", actor=ACTOR
+        name="alice", email=None, password="old", is_admin=False, actor=ACTOR
     )
     with pytest.raises(ForbiddenError):
         await service.update_account(
@@ -278,7 +310,8 @@ async def test_update_account_password_without_old_password(
             password="new",
             old_password=None,
             metadata=None,
-            actor=ACTOR,
+            is_admin=None,
+            actor=AuthContext(account=created),
         )
 
 
@@ -287,7 +320,7 @@ async def test_update_account_password_wrong_old_password(
 ) -> None:
     """Reject a password change whose current password does not match."""
     created, _ = await service.create_account(
-        name="alice", email=None, password="old", actor=ACTOR
+        name="alice", email=None, password="old", is_admin=False, actor=ACTOR
     )
     with pytest.raises(ForbiddenError):
         await service.update_account(
@@ -295,7 +328,8 @@ async def test_update_account_password_wrong_old_password(
             password="new",
             old_password="wrong",
             metadata=None,
-            actor=ACTOR,
+            is_admin=None,
+            actor=AuthContext(account=created),
         )
 
 
@@ -304,7 +338,7 @@ async def test_update_account_password_without_stored_password(
 ) -> None:
     """Reject a password change on an account that has no password set."""
     created, _ = await service.create_account(
-        name="alice", email=None, password=None, actor=ACTOR
+        name="alice", email=None, password=None, is_admin=False, actor=ACTOR
     )
     with pytest.raises(ForbiddenError):
         await service.update_account(
@@ -312,5 +346,115 @@ async def test_update_account_password_without_stored_password(
             password="new",
             old_password="anything",
             metadata=None,
+            is_admin=None,
+            actor=AuthContext(account=created),
+        )
+
+
+async def test_create_account_forbidden_for_non_admin(service: AccountService) -> None:
+    """Reject account creation by a non-admin actor."""
+    with pytest.raises(ForbiddenError):
+        await service.create_account(
+            name="alice",
+            email=None,
+            password=None,
+            is_admin=False,
+            actor=NON_ADMIN_ACTOR,
+        )
+
+
+async def test_create_account_with_is_admin_true(service: AccountService) -> None:
+    """Create an account with admin rights."""
+    account, _ = await service.create_account(
+        name="alice", email=None, password="secret", is_admin=True, actor=ACTOR
+    )
+    assert account.is_admin is True
+
+
+async def test_deactivate_account_forbidden_for_non_admin(
+    service: AccountService,
+) -> None:
+    """Reject account deactivation by a non-admin actor."""
+    created, _ = await service.create_account(
+        name="alice", email=None, password="secret", is_admin=False, actor=ACTOR
+    )
+    with pytest.raises(ForbiddenError):
+        await service.deactivate_account(created.id, actor=NON_ADMIN_ACTOR)
+
+
+async def test_update_account_is_admin_forbidden_for_non_admin(
+    service: AccountService,
+) -> None:
+    """Reject setting the admin flag by a non-admin actor."""
+    created, _ = await service.create_account(
+        name="alice", email=None, password=None, is_admin=False, actor=ACTOR
+    )
+    with pytest.raises(ForbiddenError):
+        await service.update_account(
+            created.id,
+            password=None,
+            old_password=None,
+            metadata=None,
+            is_admin=True,
+            actor=NON_ADMIN_ACTOR,
+        )
+
+
+async def test_update_account_is_admin_promote_and_demote(
+    service: AccountService,
+) -> None:
+    """Set and clear the admin flag on an account."""
+    created, _ = await service.create_account(
+        name="alice", email=None, password=None, is_admin=False, actor=ACTOR
+    )
+    promoted = await service.update_account(
+        created.id,
+        password=None,
+        old_password=None,
+        metadata=None,
+        is_admin=True,
+        actor=ACTOR,
+    )
+    assert promoted.is_admin is True
+    demoted = await service.update_account(
+        created.id,
+        password=None,
+        old_password=None,
+        metadata=None,
+        is_admin=False,
+        actor=ACTOR,
+    )
+    assert demoted.is_admin is False
+
+
+async def test_update_account_is_admin_forbidden_for_service_account(
+    service_and_repository: tuple[AccountService, FakeAccountRepository],
+) -> None:
+    """Reject making a service account an admin."""
+    service, repository = service_and_repository
+    created = await repository.create(Account(name="svc", is_service_account=True))
+    with pytest.raises(ForbiddenError):
+        await service.update_account(
+            created.id,
+            password=None,
+            old_password=None,
+            metadata=None,
+            is_admin=True,
             actor=ACTOR,
         )
+
+
+async def test_ensure_account_creates_default_admin(service: AccountService) -> None:
+    """Create the default account as an admin."""
+    account = await service.ensure_account("admin", "secret")
+    assert account.is_admin is True
+
+
+async def test_ensure_account_promotes_existing_non_admin(
+    service_and_repository: tuple[AccountService, FakeAccountRepository],
+) -> None:
+    """Promote an existing non-admin account of the same name."""
+    service, repository = service_and_repository
+    await repository.create(Account(name="admin", is_admin=False))
+    account = await service.ensure_account("admin", "secret")
+    assert account.is_admin is True

--- a/tests/server/test_accounts_api.py
+++ b/tests/server/test_accounts_api.py
@@ -21,13 +21,18 @@ import httpx
 import pytest
 
 from conftest import FakeAccountRepository, FakePasswordHasher, local_settings
+from kitaru.server.adapters.permissions.admin_flag import AdminFlagPermissionProvider
 from kitaru.server.adapters.rest.dependencies import authorize, get_account_service
 from kitaru.server.api.app import create_app
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.services.account_service import AccountService
+from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.domain.account import Account
 
-ACTOR = AuthContext(account=Account(id=uuid.uuid4(), name="admin"))
+ACTOR = AuthContext(account=Account(id=uuid.uuid4(), name="admin", is_admin=True))
+NON_ADMIN_ACTOR = AuthContext(
+    account=Account(id=uuid.uuid4(), name="alice", is_admin=False)
+)
 
 
 @pytest.fixture
@@ -37,12 +42,49 @@ async def client() -> AsyncGenerator[httpx.AsyncClient, None]:
     service = AccountService(
         repository=FakeAccountRepository(),
         password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
     )
     app.dependency_overrides[get_account_service] = lambda: service
     app.dependency_overrides[authorize] = lambda: ACTOR
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         yield client
+
+
+@pytest.fixture
+async def non_admin_client() -> AsyncGenerator[httpx.AsyncClient, None]:
+    """Provide an HTTP client for the app authorized as a non-admin account."""
+    app = create_app(local_settings())
+    service = AccountService(
+        repository=FakeAccountRepository(),
+        password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
+    )
+    app.dependency_overrides[get_account_service] = lambda: service
+    app.dependency_overrides[authorize] = lambda: NON_ADMIN_ACTOR
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
+@pytest.fixture
+async def non_admin_client_with_target() -> AsyncGenerator[
+    tuple[httpx.AsyncClient, uuid.UUID], None
+]:
+    """Provide a non-admin-authorized client plus a pre-seeded target account id."""
+    app = create_app(local_settings())
+    repository = FakeAccountRepository()
+    target = await repository.create(Account(name="bob"))
+    service = AccountService(
+        repository=repository,
+        password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
+    )
+    app.dependency_overrides[get_account_service] = lambda: service
+    app.dependency_overrides[authorize] = lambda: NON_ADMIN_ACTOR
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, target.id
 
 
 async def test_create_account(client: httpx.AsyncClient) -> None:
@@ -75,6 +117,7 @@ async def test_create_account_response_has_no_password(
         "name",
         "email",
         "is_service_account",
+        "is_admin",
         "active",
         "metadata",
         "created",
@@ -277,6 +320,7 @@ async def self_client() -> AsyncGenerator[httpx.AsyncClient, None]:
     service = AccountService(
         repository=repository,
         password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
     )
     app.dependency_overrides[get_account_service] = lambda: service
     app.dependency_overrides[authorize] = lambda: ACTOR
@@ -330,7 +374,7 @@ async def test_update_other_account_metadata_forbidden(
         f"/v1/accounts/{created['id']}", json={"metadata": {"theme": "dark"}}
     )
     assert response.status_code == 403
-    assert response.json() == {"detail": "Accounts can only update their own metadata."}
+    assert response.json() == {"detail": "Accounts can only update their own metadata"}
 
 
 async def test_update_own_account_password(self_client: httpx.AsyncClient) -> None:
@@ -377,7 +421,7 @@ async def test_update_other_account_password_forbidden(
     )
     assert response.status_code == 403
     assert response.json() == {
-        "detail": "Accounts cannot change the password of other accounts."
+        "detail": "Accounts cannot change the password of other accounts"
     }
 
 
@@ -465,7 +509,7 @@ async def test_deactivate_own_account_forbidden(
     """Observe HTTP 403 when an account deactivates itself."""
     response = await self_client.post(f"/v1/accounts/{ACTOR.account.id}/deactivate")
     assert response.status_code == 403
-    assert response.json() == {"detail": "Accounts cannot deactivate themselves."}
+    assert response.json() == {"detail": "Accounts cannot deactivate themselves"}
 
 
 async def test_activate_account_is_unauthenticated(
@@ -478,3 +522,50 @@ async def test_activate_account_is_unauthenticated(
         json={"activation_token": created["activation_token"], "password": "secret"},
     )
     assert response.status_code == 200
+
+
+async def test_create_account_forbidden_for_non_admin(
+    non_admin_client: httpx.AsyncClient,
+) -> None:
+    """Observe HTTP 403 when a non-admin actor creates an account."""
+    response = await non_admin_client.post("/v1/accounts", json={"name": "alice"})
+    assert response.status_code == 403
+
+
+async def test_deactivate_account_forbidden_for_non_admin(
+    non_admin_client_with_target: tuple[httpx.AsyncClient, uuid.UUID],
+) -> None:
+    """Observe HTTP 403 when a non-admin actor deactivates another account."""
+    client, target_id = non_admin_client_with_target
+    response = await client.post(f"/v1/accounts/{target_id}/deactivate")
+    assert response.status_code == 403
+
+
+async def test_update_own_account_is_admin_forbidden(
+    self_client: httpx.AsyncClient,
+) -> None:
+    """Observe HTTP 403 when an account changes its own admin flag."""
+    response = await self_client.patch(
+        f"/v1/accounts/{ACTOR.account.id}", json={"is_admin": False}
+    )
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Accounts cannot change their own admin flag"}
+
+
+async def test_update_account_is_admin_forbidden_for_non_admin(
+    non_admin_client_with_target: tuple[httpx.AsyncClient, uuid.UUID],
+) -> None:
+    """Observe HTTP 403 when a non-admin actor sets another account's admin flag."""
+    client, target_id = non_admin_client_with_target
+    response = await client.patch(f"/v1/accounts/{target_id}", json={"is_admin": True})
+    assert response.status_code == 403
+
+
+async def test_update_account_is_admin(client: httpx.AsyncClient) -> None:
+    """Set another account's admin flag as an admin actor."""
+    created = (await client.post("/v1/accounts", json={"name": "alice"})).json()
+    response = await client.patch(
+        f"/v1/accounts/{created['id']}", json={"is_admin": True}
+    )
+    assert response.status_code == 200
+    assert response.json()["is_admin"] is True

--- a/tests/server/test_auth_api.py
+++ b/tests/server/test_auth_api.py
@@ -27,6 +27,7 @@ from conftest import (
     local_settings,
 )
 from kitaru.server.adapters.auth.auth_service import AuthService
+from kitaru.server.adapters.permissions.admin_flag import AdminFlagPermissionProvider
 from kitaru.server.adapters.rest.dependencies import (
     get_account_service,
     get_api_key_service,
@@ -36,6 +37,7 @@ from kitaru.server.api.app import create_app
 from kitaru.server.api.config import APISettings
 from kitaru.server.application.services.account_service import AccountService
 from kitaru.server.application.services.api_key_service import ApiKeyService
+from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.domain.account import Account
 
 COOKIE_NAME = "kitaru_session"
@@ -265,7 +267,9 @@ async def test_none_scheme_requires_bootstrap(
         api_key_repository,
     )
     account_service = AccountService(
-        repository=account_repository, password_hasher=FakePasswordHasher()
+        repository=account_repository,
+        password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
     )
     app.dependency_overrides[get_account_service] = lambda: account_service
     transport = httpx.ASGITransport(app=app)

--- a/tests/server/test_control_plane_auth_api.py
+++ b/tests/server/test_control_plane_auth_api.py
@@ -35,6 +35,7 @@ from kitaru.server.adapters.auth.control_plane import (
     ControlPlaneError,
     ControlPlaneUser,
 )
+from kitaru.server.adapters.permissions.admin_flag import AdminFlagPermissionProvider
 from kitaru.server.adapters.rest.dependencies import (
     get_account_service,
     get_api_key_service,
@@ -45,6 +46,7 @@ from kitaru.server.api.config import APISettings
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.services.account_service import AccountService
 from kitaru.server.application.services.api_key_service import ApiKeyService
+from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.domain.account import Account
 
 
@@ -107,7 +109,9 @@ def build_app(
     api_key_service = ApiKeyService(repository=api_key_repository)
     app.dependency_overrides[get_api_key_service] = lambda: api_key_service
     account_service = AccountService(
-        repository=account_repository, password_hasher=FakePasswordHasher()
+        repository=account_repository,
+        password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
     )
     app.dependency_overrides[get_account_service] = lambda: account_service
     return app
@@ -309,6 +313,22 @@ async def test_update_account_forbidden(
     response = await client.patch(
         f"/v1/accounts/{uuid.uuid4()}",
         json={"password": "new", "old_password": "old"},
+        headers={"Authorization": f"Bearer {CONTROL_PLANE_API_KEY_PREFIX}abc123"},
+    )
+    assert response.status_code == 403
+
+
+async def test_update_account_is_admin_forbidden(
+    client: httpx.AsyncClient,
+    control_plane_client: FakeControlPlaneClient,
+    settings: APISettings,
+) -> None:
+    """Observe HTTP 403 when setting the admin flag under the control plane scheme."""
+    authenticate(control_plane_client, settings)
+
+    response = await client.patch(
+        f"/v1/accounts/{uuid.uuid4()}",
+        json={"is_admin": True},
         headers={"Authorization": f"Bearer {CONTROL_PLANE_API_KEY_PREFIX}abc123"},
     )
     assert response.status_code == 403

--- a/tests/server/test_permission_service.py
+++ b/tests/server/test_permission_service.py
@@ -1,0 +1,167 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for permission providers and the permission service."""
+
+import uuid
+
+import pytest
+
+from kitaru.server.adapters.permissions.admin_flag import (
+    ADMIN_ONLY_PERMISSIONS,
+    AdminFlagPermissionProvider,
+)
+from kitaru.server.adapters.permissions.allow_all import AllowAllPermissionProvider
+from kitaru.server.application.models.auth import (
+    AuthContext,
+    TaskPrincipal,
+    WorkerPrincipal,
+)
+from kitaru.server.application.models.permissions import (
+    ALL_IDS,
+    Action,
+    AllowedIds,
+    ResourceType,
+)
+from kitaru.server.application.services.permission_service import PermissionService
+from kitaru.server.domain.account import Account
+from kitaru.server.domain.base import ForbiddenError
+
+ADMIN_ACCOUNT = Account(id=uuid.uuid4(), name="admin", is_admin=True)
+NON_ADMIN_ACCOUNT = Account(id=uuid.uuid4(), name="alice", is_admin=False)
+
+
+class DenyAllPermissionProvider:
+    """Permission provider that denies everything."""
+
+    async def has_permission(
+        self,
+        account: Account,
+        resource_type: ResourceType,
+        action: Action,
+        resource_id: uuid.UUID | None = None,
+    ) -> bool:
+        """Check whether an account may perform an action.
+
+        Args:
+            account: Account to check.
+            resource_type: Resource type the action applies to.
+            action: Action to check.
+            resource_id: Id of the specific resource, checked broadly when
+                ``None``.
+
+        Returns:
+            Whether the account may perform the action.
+        """
+        _ = account, resource_type, action, resource_id
+        return False
+
+    async def get_allowed_ids(
+        self, account: Account, resource_type: ResourceType, action: Action
+    ) -> AllowedIds:
+        """List the resource ids an account may perform an action on.
+
+        Args:
+            account: Account to check.
+            resource_type: Resource type the action applies to.
+            action: Action to check.
+
+        Returns:
+            Allowed resource ids, or every id when unrestricted.
+        """
+        _ = account, resource_type, action
+        return frozenset()
+
+
+def task_principal() -> TaskPrincipal:
+    """Build a task principal for tests.
+
+    Returns:
+        Task principal with fresh ids.
+    """
+    return TaskPrincipal(
+        task_id=uuid.uuid4(), attempt=1, worker_id=uuid.uuid4(), job_id=uuid.uuid4()
+    )
+
+
+@pytest.mark.parametrize("resource_type,action", sorted(ADMIN_ONLY_PERMISSIONS))
+async def test_admin_flag_provider_allows_admin(
+    resource_type: ResourceType, action: Action
+) -> None:
+    """Allow an admin account on every admin-only pair."""
+    provider = AdminFlagPermissionProvider()
+    assert await provider.has_permission(ADMIN_ACCOUNT, resource_type, action) is True
+
+
+@pytest.mark.parametrize("resource_type,action", sorted(ADMIN_ONLY_PERMISSIONS))
+async def test_admin_flag_provider_denies_non_admin(
+    resource_type: ResourceType, action: Action
+) -> None:
+    """Deny a non-admin account on every admin-only pair."""
+    provider = AdminFlagPermissionProvider()
+    assert (
+        await provider.has_permission(NON_ADMIN_ACCOUNT, resource_type, action) is False
+    )
+
+
+async def test_admin_flag_provider_get_allowed_ids_returns_all_ids() -> None:
+    """Return every id for both admin and non-admin accounts."""
+    provider = AdminFlagPermissionProvider()
+    for account in (ADMIN_ACCOUNT, NON_ADMIN_ACCOUNT):
+        assert (
+            await provider.get_allowed_ids(account, ResourceType.ACCOUNT, Action.CREATE)
+            is ALL_IDS
+        )
+
+
+async def test_allow_all_provider_allows_admin_only_pair_for_non_admin() -> None:
+    """Allow a non-admin account on an admin-only pair."""
+    provider = AllowAllPermissionProvider()
+    assert (
+        await provider.has_permission(
+            NON_ADMIN_ACCOUNT, ResourceType.ACCOUNT, Action.SET_ADMIN
+        )
+        is True
+    )
+
+
+async def test_check_denial_raises_forbidden_error() -> None:
+    """Raise ForbiddenError when the provider denies the account."""
+    service = PermissionService(DenyAllPermissionProvider())
+    actor = AuthContext(account=NON_ADMIN_ACCOUNT)
+    with pytest.raises(ForbiddenError):
+        await service.check(actor, ResourceType.ACCOUNT, Action.CREATE)
+
+
+async def test_check_worker_principal_bypasses_provider() -> None:
+    """Pass a worker principal through without consulting the provider."""
+    service = PermissionService(DenyAllPermissionProvider())
+    actor = AuthContext(
+        account=NON_ADMIN_ACCOUNT, principal=WorkerPrincipal(worker_id=uuid.uuid4())
+    )
+    await service.check(actor, ResourceType.ACCOUNT, Action.CREATE)
+
+
+async def test_check_task_principal_bypasses_provider() -> None:
+    """Pass a task principal through without consulting the provider."""
+    service = PermissionService(DenyAllPermissionProvider())
+    actor = AuthContext(account=NON_ADMIN_ACCOUNT, principal=task_principal())
+    await service.check(actor, ResourceType.ACCOUNT, Action.CREATE)
+
+
+async def test_get_allowed_ids_task_principal_returns_all_ids() -> None:
+    """Return every id for a task principal even with a restrictive provider."""
+    service = PermissionService(DenyAllPermissionProvider())
+    actor = AuthContext(account=NON_ADMIN_ACCOUNT, principal=task_principal())
+    result = await service.get_allowed_ids(actor, ResourceType.ACCOUNT, Action.CREATE)
+    assert result is ALL_IDS


### PR DESCRIPTION
Adds a `PermissionService` behind a `PermissionProvider` port, with an admin-flag provider for the local and none auth schemes and a noop provider for the control plane.
Accounts gain an `is_admin` flag (the default account is bootstrapped as admin) that gates account create, deactivate, and admin changes.
The flag is only settable under the local auth scheme, for non-service accounts, and never on the caller's own account.