### PR TITLE
Refresh Kitaru v2 agent guidance

### DIFF
--- a/.agents/skills/kitaru-dev/SKILL.md
+++ b/.agents/skills/kitaru-dev/SKILL.md
@@ -5,21 +5,20 @@ description: Use for Kitaru commands, CLI, analytics, PRs.
 
 # Kitaru Development, CLI, and PR Workflow
 
-Use this when you need the command catalog beyond the daily loop in the root
-`AGENTS.md`, or when adding CLI commands, analytics events, or PR descriptions.
+Use this when you need the command catalog beyond the daily loop in the root `AGENTS.md`, or when adding CLI commands, analytics events, or PR descriptions.
 
 ## Python Workflows
 
-- `uv sync`: install and sync dependencies
+- `uv sync`: install the base SDK and development dependencies
+- `uv sync --extra cli`: include the optional CLI
 - `uv sync --extra mcp`: include the optional native MCP server
-- `uv sync --extra local`: install with local ZenML runtime components
-- `uv run kitaru init`: required in a fresh `git worktree`; it creates the
-  `.kitaru/` project marker that ZenML's dynamic pipeline resolver needs to
-  re-import example modules by dotted path
-- `just check`: all checks: format, lint, typecheck, typos, YAML, actions lint, links
+- `uv sync --extra server`: include server components
+- `uv sync --extra worker`: include worker components
+- `uv sync --extra otel`: include OpenTelemetry integrations
+- `just check`: run formatting, lint, typecheck, typos, YAML, actions lint, and links
 - `just fix`: auto-fix formatting, lint issues, and YAML
-- `just test`: full pytest suite
-- `just test tests/test_file.py::test_name`: one targeted test
+- `just test`: run the full pytest suite
+- `just test tests/test_file.py::test_name`: run one targeted test
 - `just lint`: lint only
 - `just typecheck`: type check only
 - `just typos`: typo check only
@@ -28,95 +27,62 @@ Use this when you need the command catalog beyond the daily loop in the root
 - `just actions-lint`: lint GitHub Actions workflows; requires `actionlint`
 - `just zizmor`: audit GitHub Actions workflow security with `zizmor`
 - `just audit`: audit Python dependencies with `pip-audit` and the documented ignore list
-- `just links`: check markdown links offline; requires `lychee`
+- `just links`: check Markdown links offline; requires `lychee`
 - `just links-external`: check links including external URLs; slow
-- `just example-coverage-audit`: validate `examples/example-coverage.yaml`
-  against public example docs, referenced tests/smoke/provider metadata, and
-  explicit waivers for `missing`, `planned`, or `manual_only` coverage
+- `just example-coverage-audit`: validate `examples/example-coverage.yaml` metadata and waivers
 - `just build`: build wheel and sdist locally
-- `just mcp-schema-check`: verify the public MCP registry budgets and committed snapshots
-- `just mcp-wheel-smoke`: verify clean base and `[mcp]` installs from the single wheel under `dist/`
+- `just cli-artifact-smoke`: verify clean CLI wheel and source installations
+- `just mcp-schema-check`: verify public MCP registry budgets and committed snapshots
+- `just mcp-wheel-smoke`: verify clean base and `[mcp]` installs from the wheel under `dist/`
+- `just migration-check`: compare Alembic migrations with the ORM schema; requires PostgreSQL
 
-When merging `develop` into a feature branch and resolving `pyproject.toml` or
-`uv.lock`, do not assume a broad `uv lock` preserves recent dependency-security
-fixes. Check recent commits touching `uv.lock` or `.github/pip-audit-ignored.txt`,
-use targeted commands such as `uv lock --upgrade-package <package>` when a
-package was intentionally bumped, and run `just audit` before pushing.
+There is no v2 `kitaru init` command or `local` extra. Do not carry the v1 `.kitaru/` project-marker setup into v2 instructions or tests.
+
+When merging the v2 base into a feature branch and resolving `pyproject.toml` or `uv.lock`, check recent dependency-security changes before regenerating the lockfile broadly. Use targeted upgrades when a package was intentionally bumped and run `just audit` before pushing.
 
 ## Docs Workflows
 
 These require Node 22+ and pnpm.
 
-- `just generate-docs`: generate changelog and SDK reference docs
 - `just docs`: preview docs locally at `localhost:3000`
-- `just docs-build`: build docs static export
-- `just docs-validate`: validate the static export as served under `/docs`
+- `just docs-build`: build the static docs export
+- `just docs-validate`: validate the export as served under `/docs`
+
+The v2 checkout currently lacks `scripts/generate_sdk_docs.py`, so `just generate-docs` and the SDK-reference generation step in docs CI are blocked. Do not advertise them as healthy or restore the deleted v1 generator without reviewing the v2 public SDK surface. CLI contracts remain available offline through `kitaru schema`; CLI reference publishing is deferred.
 
 ## Native MCP Server
 
-The native v2 server is installed with `kitaru[mcp]` and started with `kitaru-mcp`. It defaults to `read-only` mode with 2 tools; `standard` advertises 5 and `destructive` advertises 7. Treat a mode change or schema snapshot change as a public API and security review.
+The native v2 server is installed with `kitaru[mcp]` and started with `kitaru-mcp`. It defaults to `read-only`; `standard` and `destructive` expose progressively broader capabilities.
 
-Run `uv run --extra mcp python scripts/report_mcp_schema.py --check` after changing MCP models, registry declarations, descriptions, annotations, or SDK versions. Build the wheel and run `just mcp-wheel-smoke` after entrypoint, packaging, or optional-import changes.
+Treat `tests/mcp/snapshots/metrics.json` and `src/kitaru/mcp/registry.py` as the inventory authorities. Do not copy tool counts into prose. Run `just mcp-schema-check` after changing MCP models, registry declarations, descriptions, annotations, or SDK versions. Build the wheel and run `just mcp-wheel-smoke` after entrypoint, packaging, lifecycle, or optional-import changes.
 
 ## CLI Structure
 
-The `kitaru` console script is defined in `pyproject.toml` under `[project.scripts]`. `src/kitaru/cli/__init__.py` is the lazy entry point, and command implementations live in ordinary modules under `src/kitaru/cli/`.
+The `kitaru` console script is defined in `pyproject.toml` under `[project.scripts]`. `src/kitaru/cli/__init__.py` is the lazy entry point, `src/kitaru/cli/app.py` registers the shared Cyclopts applications, and command implementations live under `src/kitaru/cli/`.
 
-Add new subcommands in the appropriate `src/kitaru/cli/*.py` module and register them on the shared Cyclopts app. When testing CLI commands, always pass an explicit argument list to `main([...])`; successful invocations return exit code 0.
+Register new leaf commands through the `_spec(...)` and `_register(...)` metadata in `src/kitaru/cli/app.py`. Tests should call `main([...])` with an explicit argument list and assert the returned integer exit code.
 
-## JSON Output Contract
+## Structured Output Contract
 
-Agent-facing commands use the version-1 structured contract. Success documents include `schema_version`, `command`, `ok`, `warnings`, `links`, and `next_actions`, plus `item` for one result or `items`, `count`, and `page` for a list. Structured errors are one JSON object on stderr with a stable error kind and exit code.
+Agent-facing commands use the version-1 structured contract. Success documents include `schema_version`, `command`, `ok`, `warnings`, `links`, and `next_actions`, plus `item` for one result or `items`, `count`, and `page` for a list. Streaming commands emit JSONL events. Structured errors are one JSON object on stderr with a stable error kind and exit code.
+
+For agent-facing use, prefer `--output json --machine --non-interactive --no-browser`. A deliberate dashboard or device-login handoff is the exception.
 
 Document login consistently: `kitaru login SERVER` targets the full managed or self-hosted instance URL, while `kitaru login --local` targets an already-running server at `http://localhost:8000`; it never starts a local server.
 
-## Diagnostics and Cleanup
-
-`kitaru status` shows the selected server, provenance, credential state, compatibility, and live-worker count. `kitaru info` adds local package, Python, and platform details. `kitaru doctor` runs independent local, server, authentication, and tooling checks without stopping after the first failure. These commands never print secret values.
+`kitaru status` shows the selected server, provenance, credential state, compatibility, and live-worker count. `kitaru info` adds local package, Python, platform, and server details. `kitaru doctor` runs independent local, server, authentication, and tooling checks without stopping after the first failure. These commands never print secret values.
 
 ## Analytics
 
-Kitaru collects anonymous usage analytics for opted-in users. When adding new
-features, discuss analytics coverage with the core team to decide what should
-be tracked.
+Analytics events live in `src/kitaru/analytics/events.py`; source attribution lives in `src/kitaru/analytics/source.py`. Server-side feature events are emitted through the application analytics service. MCP attribution is set once for the MCP lifecycle through `AnalyticsSource.MCP`.
 
-- Add every event name to the `AnalyticsEvent` enum in `src/kitaru/analytics.py`.
-- Track only non-sensitive metadata: event names, boolean flags, enum values,
-  and counts.
-- Never include user content, file paths, prompts, or secret values.
-- CLI feature events use `track()` in subcommand handlers under `src/kitaru/cli/`.
-- Native MCP calls are attributed through `AnalyticsSource.MCP` on the shared API client; do not add argument/body telemetry or a separate tool event without a reviewed privacy contract.
-- Core SDK lifecycle events use `track(AnalyticsEvent.X, {...})` in the relevant module.
-- All `track()` calls must fail silently.
-
-If a CLI command is multi-word, such as `clean project`, add it to
-`_MULTI_TOKEN_COMMANDS` in `cli.py`.
+- Add event names to `AnalyticsEvent` in `src/kitaru/analytics/events.py`.
+- Track only reviewed, non-sensitive metadata such as event names, boolean flags, enum values, and counts.
+- Never include user content, file paths, prompts, credentials, or secret values.
+- Keep analytics failures non-fatal.
 
 ## Pull Requests
 
-Use a clear human-readable title. Never include a `[Codex] ` prefix. Include:
+Use a clear human-readable title without a `[Codex]` prefix. Include what changed, why it was needed, important implementation decisions, and reviewer focus areas. Link related issues when applicable.
 
-- what changed
-- why it was needed
-- key implementation decisions
-- reviewer focus areas
-
-Link related issues when applicable.
-
-Every PR description should include a `Reviewer Notes` H2 or H3 section. Treat
-that section as a narrative guide for a human reviewer, not a file-by-file
-checklist:
-
-- Start with the story of the change: where important behavior now happens,
-  what used to go wrong, and what would break if the implementation is wrong.
-- Point reviewers toward genuinely tricky or high-risk areas. Mention files
-  only when the file name helps the story, and explain what to inspect there.
-- Include a concrete `Reproduction` subsection either inside Reviewer Notes or
-  immediately after it.
-- Prefer an example, CLI flow, or UI path that proves the behavior end to end.
-- Do not use a standalone `Verification` section as a substitute for
-  reproduction when it only says `just check`, `just test`, or `/simplify`.
-  Those commands are useful local hygiene, but they do not show the reviewer
-  how to see the feature or bug fix.
-- If local hygiene commands are worth mentioning, keep them as a short `Local
-  checks run` note after the reproduction steps.
+Every PR description should include a `Reviewer Notes` H2 or H3 section that explains the story and risks of the change, plus a concrete `Reproduction` subsection. Keep local hygiene commands as a short note after reproduction rather than using them as a substitute for reviewer guidance.

--- a/.agents/skills/kitaru-docs/SKILL.md
+++ b/.agents/skills/kitaru-docs/SKILL.md
@@ -5,72 +5,41 @@ description: Use for Kitaru docs.
 
 # Kitaru Documentation Workflow
 
-Use this when editing or reviewing Kitaru documentation, examples, generated
-reference docs, docs redirects, or docs CI behavior.
+Use this when editing or reviewing Kitaru documentation, examples, generated reference docs, docs redirects, or docs CI behavior.
 
 ## Documentation Surfaces
 
 Kitaru docs live on three surfaces:
 
-1. Hand-written docs are plain Markdown in `docs/book/`, published to
-   `docs.zenml.io/kitaru` via GitBook Git Sync. Edit these `.md` files directly.
-   Navigation is `docs/book/toc.md`, config is `docs/book/.gitbook.yaml`, and
-   authoring conventions live in `docs/book/AGENTS.md`.
-2. Generated SDK reference docs live in the FumaDocs app under `docs/`.
-   Generated output is `docs/content/docs/reference/python/`, served from
-   `sdkdocs.kitaru.ai`.
-3. `kitaru.ai/docs/*` redirects are handled by `docs/worker/redirect.mjs` and
-   `wrangler.redirect.toml`.
+1. Hand-written docs are plain Markdown in `docs/book/`, published to `docs.zenml.io/kitaru` through GitBook Git Sync. Navigation is `docs/book/toc.md`, configuration is `docs/book/.gitbook.yaml`, and authoring conventions live in `docs/book/AGENTS.md`.
+2. Generated SDK reference docs are intended to live in the FumaDocs app under `docs/`, with output under `docs/content/docs/reference/python/` served from `sdkdocs.kitaru.ai`. The v2 Python generator is currently absent, so reference generation and deployment are blocked. CLI reference publishing is deferred.
+3. `kitaru.ai/docs/*` redirects are handled by `docs/worker/redirect.mjs` and `wrangler.redirect.toml`.
 
-Do not add hand-written pages to the FumaDocs app under `docs/content/docs/`.
-The public changelog is owned by the changelog repo at `docs.zenml.io/changelog`.
-This repo may generate a gitignored `docs/content/docs/changelog.mdx` for local
-reference builds, but agents should not hand-edit or commit it.
+Do not add hand-written pages to `docs/content/docs/`. The public changelog is owned by the changelog repository at `docs.zenml.io/changelog`. This repository may generate a gitignored `docs/content/docs/changelog.mdx` for local reference builds, but agents should not hand-edit or commit it.
 
-The public marketing/runtime site for Kitaru lives in `zenml-io-v2`. If a task
-involves Astro pages, public site assets, marketing Cloudflare Pages deployment,
-or runtime web APIs such as waitlist/get-started/newsletter endpoints, switch
-to that repository instead of adding that code here.
+The public marketing/runtime site lives in `zenml-io-v2`. If a task involves Astro pages, public site assets, marketing Cloudflare deployment, or runtime website APIs, switch to that repository instead of adding the code here.
 
 ## Docs Content Rules
 
 - Only document shipped features; do not add "Coming Soon" sections.
-- Keep ZenML invisible to users. Use Kitaru terminology such as workflow,
-  checkpoint, stack, deployment, and storage. Avoid ZenML terms such as
-  orchestrator, artifact store, pipeline, and step in user docs.
-- Inside `docs/book/`, link to sibling pages with relative `.md` paths, such as
-  `../concepts/checkpoints.md` or `flows.md#runtime-options`.
+- Inside `docs/book/`, link to sibling pages with relative `.md` paths.
 - Link to SDK reference with `https://sdkdocs.kitaru.ai`.
 - Link to other ZenML docs with absolute `https://docs.zenml.io/...` URLs.
-- Link to diagrams with
-  `https://assets.kitaru.ai/docs/diagrams/<slug>.png`.
-- Do not commit temporary planning/review files such as `docs/plans/*`,
-  `docs/reviews/*`, or prompt exports unless the user explicitly asks for a
-  durable tracked document.
-- Only `kitaru.llm()` auto-resolves alias-linked secrets today. If documenting
-  non-LLM secret access, label it as the current low-level pattern instead of
-  implying there is a dedicated Kitaru secret getter.
-- CLI command contracts live under `src/kitaru/cli/` and are available offline through `kitaru schema`; CLI reference publishing is deferred.
-- Native MCP documentation must match `tests/mcp/snapshots/metrics.json`: 2 read-only tools, 5 standard tools, and 7 destructive tools. Keep third-party/provider MCP documentation separate and intact.
-- Current shipped stack-create types on the CLI are `local`, `kubernetes`, `vertex`, `sagemaker`, and `azureml`. The native v2 MCP server does not expose stack management.
-- Advanced CLI stack creation supports `--extra` plus the remote-only `--async` convenience flag.
-- Public Python SDK `kitaru.create_stack(...)` remains local-only; keep that
-  distinction explicit.
-- Document `KITARU_*` env vars as the public surface. Mention `ZENML_*` only as
-  a compatibility note when necessary for migration or interop.
-- `kitaru model register` still writes aliases to local config, but
-  submitted/replayed runs automatically receive a transported registry snapshot
-  via `KITARU_MODEL_REGISTRY`.
-- Describe `kitaru model list` as listing aliases available in the current
-  environment, not only aliases stored locally.
+- Link to diagrams with `https://assets.kitaru.ai/docs/diagrams/<slug>.png`.
+- Do not commit temporary planning/review files or prompt exports unless the user explicitly asks for a durable tracked document.
+- Treat `KITARU_*` variables as the public configuration surface.
+- CLI contracts live in `src/kitaru/cli/app.py` and are available offline through `kitaru schema`.
+- The generated OpenAPI document and `src/kitaru/api_models/` are the API contract authorities.
+- Native MCP documentation must match `src/kitaru/mcp/registry.py` and `tests/mcp/snapshots/metrics.json`. Run `just mcp-schema-check`; do not copy tool counts into prose.
+- The native v2 MCP server does not expose stack or model-alias management.
+- Do not document v1 runtime surfaces such as `kitaru init`, `kitaru stack`, `kitaru model`, `kitaru executions`, `kitaru.llm()`, or `kitaru.create_stack()` unless they are reintroduced in v2 source and tests.
+- Agent-facing CLI docs should preserve the structured JSON/JSONL, `--machine`, `--non-interactive`, and `--no-browser` contracts.
 - Every `.mdx` page needs `title` and `description` frontmatter.
+
+Do not run or advertise `just generate-docs` as healthy until `scripts/generate_sdk_docs.py` is restored for the v2 public SDK and the docs workflow passes.
 
 ## Example READMEs
 
-Example READMEs are user-facing. They should teach new users what Kitaru does
-and walk them through the specific example.
+Example READMEs are user-facing. They should teach new users what Kitaru does and walk them through the specific example.
 
-Do not add maintainer-oriented sections such as "Testing", CI-only credential
-setup, or notes about stubbed/mocked test runs. If a section would not help a
-first-time user understand Kitaru, it belongs in tests, contributor docs, or PR
-descriptions instead.
+Do not add maintainer-oriented sections such as "Testing", CI-only credential setup, or notes about stubbed or mocked runs. If a section would not help a first-time user understand Kitaru, it belongs in tests, contributor docs, or PR descriptions instead.

--- a/.agents/skills/kitaru-tests-release/SKILL.md
+++ b/.agents/skills/kitaru-tests-release/SKILL.md
@@ -5,195 +5,107 @@ description: Use for Kitaru tests, CI, releases.
 
 # Kitaru Tests, CI, and Release Workflow
 
-Use this when adding, moving, or debugging tests beyond the basic commands and
-safety rules in `tests/AGENTS.md`, or when changing CI/release behavior.
-
-## `primed_zenml`
-
-`primed_zenml` eagerly initializes the ZenML store. Use it only when the test:
-
-- actually runs a flow
-- uses `KitaruClient` against real local state
-- spawns threads or code paths that touch the ZenML runtime lazily
-
-Do not add `primed_zenml` to lightweight unit tests, parser tests, serializer
-tests, or simple CLI rendering tests.
+Use this when adding, moving, or debugging tests beyond the basic commands and safety rules in `tests/AGENTS.md`, or when changing CI/release behavior.
 
 ## Unit and Contract Tests
 
-- Build small stubs or `SimpleNamespace` objects instead of booting full runtime state.
-- Assert on one behavior or contract at a time.
+- Build small typed stubs or `SimpleNamespace` objects instead of booting unrelated runtime state.
+- Assert one behavior or contract at a time.
 - Include regression coverage for bug fixes.
+- Keep tests independent of working-directory state unless the test creates that state explicitly.
+- Avoid shared mutable module-level state and wall-clock ordering assumptions.
+
+V2 has no `primed_zenml` fixture or `test_phase*` example suite. Do not copy those v1 patterns into new tests.
 
 ## CLI Tests
 
-- Always call the Cyclopts app with an explicit arg list, such as `app(["--help"])`.
-- Successful invocations raise `SystemExit(0)`; assert on that explicitly.
-- Use `capsys` and assert on stable plain-text substrings.
-- Prefer lightweight stubs/mocks for execution objects instead of full backend setup.
+- Install the surface with `uv sync --extra cli --extra worker`.
+- Call `src/kitaru/cli/app.py::main` with an explicit argument list.
+- Assert the returned integer exit code, such as `main(["--help"]) == 0`; successful calls do not raise `SystemExit(0)`.
+- Use `capsys` and assert stable structured or plain-text contracts.
+- Prefer lightweight stubs for remote resources instead of starting the full server.
+- Exercise offline help, version, schema, and scaffold commands without reading local configuration.
+- Run `just cli-artifact-smoke` after optional-dependency, entrypoint, or packaging changes.
 
-Keep CLI tests focused on argument parsing, command dispatch, and rendered
-output, not unrelated runtime bootstrapping.
+Keep CLI tests focused on argument parsing, command dispatch, output contracts, and the specific resource interaction under test.
 
-## Example-Driven Tests
+## Server and SDK Tests
 
-`tests/test_phase*.py` tests are close to executable documentation. They prove
-that examples in `examples/` still work end to end.
+Follow the four server-resource surfaces in `tests/AGENTS.md`: service tests, ASGI REST tests, shared repository contracts, and PostgreSQL end-to-end tests. Add SDK round-trip coverage under `tests/client/` when a public resource changes.
 
-When adding or updating one:
+Use the PostgreSQL-backed tests for transaction, locking, migration, or cross-request behavior that an in-memory fake cannot prove. Run `docker compose up -d db` before those tests and `just migration-check` after schema changes.
 
-- import and call the example entrypoint directly
-- use `monkeypatch` to provide fake credentials or mock-response env vars
-- request `primed_zenml` when the flow genuinely executes
-- assert on persisted execution state, metadata, checkpoints, or artifacts, not
-  only a return value
+## Task and Worker Tests
 
-Good pattern: `tests/test_phase12_llm_example.py` registers a model alias,
-injects fake API credentials, runs the example flow, and inspects recorded
-metadata in ZenML.
-
-## Live Provider Tests
-
-Live provider tests live under `tests/live/` and are off by default. They are
-for trusted manual or scheduled runs, not normal PR CI.
-
-- Mark every live provider test with `@pytest.mark.live_llm` plus the provider
-  marker: `live_openai`, `live_anthropic`, or `live_gemini`.
-- `live_llm` by itself is invalid because it bypasses the deterministic
-  provider-call guard but is not selected by provider workflows.
-- Put slower or higher-cost checks under `@pytest.mark.provider_extended`.
-- Skip cleanly when the required key is absent.
-- The shared guard skips `live_openai` without `OPENAI_API_KEY`,
-  `live_anthropic` without `ANTHROPIC_API_KEY`, and `live_gemini` without
-  `GEMINI_API_KEY` or `GOOGLE_API_KEY`.
-- Keep prompts tiny and bounded.
-- Set max-turns or equivalent limits explicitly.
-- Do not add live provider tests to fork PR workflows.
-- Do not bypass the provider guard in deterministic tests; fake the provider or
-  patch Kitaru's local call point instead.
+- Task subprocess contracts live under `tests/task/`.
+- Worker lifecycle and handler contracts live under `tests/worker/`.
+- Keep subprocess tests bounded and assert structured receipts, exit behavior, and redaction.
+- Use the existing worker fakes rather than starting unrelated services.
 
 ## MCP Tests
 
 - Synchronize with `uv sync --frozen --extra mcp` and run `just test tests/mcp`.
 - Keep handler tests typed and bounded; use resource-shaped fake `KitaruAPIClient` objects unless a protocol or real-server contract requires deeper integration.
-- Test capability filtering through `MCPServer.list_tools()`, not by calling decorated functions alone. The exact inventories are 2 tools in `read-only`, 5 in `standard`, and 7 in `destructive`.
+- Test capability filtering through `MCPServer.list_tools()`, not by calling decorated functions alone.
+- Treat `tests/mcp/snapshots/metrics.json` and `src/kitaru/mcp/registry.py` as the tool-inventory authorities. Do not hardcode copied inventory counts in instructions.
 - Run `just mcp-schema-check` after any input/output model, registry, annotation, description, or MCP SDK change. Snapshot changes require explicit MCP API review.
-- Build the wheel and run `just mcp-wheel-smoke` after launcher, packaging, lifecycle, or optional-import changes. The smoke installs the same wheel once without extras and once with `[mcp]`, then negotiates stdio and exercises all modes.
-- Protected workflow tests must prove stable request-ID forwarding and older-server refusal. Import tests must preserve the four bounded preflight reads. Receipts cannot report stored versus replayed because typed resources discard response headers.
-
-## Parallel Safety and Fixtures
-
-- no hidden dependence on cwd unless the test sets it up itself
-- no shared mutable module-level state
-- no assumptions about another test having already created config, stores, or env vars
-- no reliance on wall-clock ordering between tests
-
-Put fixtures in `tests/conftest.py` when many files need them, in
-`tests/mcp/conftest.py` when only MCP tests need them, and locally when only one
-file needs them.
+- Build the wheel and run `just mcp-wheel-smoke` after launcher, packaging, lifecycle, or optional-import changes.
+- Preserve stable request-ID forwarding, mixed-version refusal, bounded preflight reads, and text/structured response parity where the existing contracts require them.
 
 ## Bug Fix Workflow
 
-Every bug fix should come with a regression test that would have caught the
-original problem:
+Every bug fix should include a regression test that would have caught the original problem:
 
 1. Write or update the test so it captures the broken behavior.
-2. Make the code change.
-3. Rerun the targeted test.
-4. Rerun the broader relevant suite.
+2. Run it and observe the expected failure when practical.
+3. Make the code change.
+4. Rerun the targeted test.
+5. Rerun the broader relevant suite.
 
-If you change code after running tests, run the tests again. Do not assume the
-earlier green run still counts.
+If code changes after a successful test run, run the affected tests again.
 
 ## Feature Completion Checklist
 
-When adding a new CLI command, MCP tool, or SDK feature:
+When adding a new CLI command, MCP tool, SDK resource, task, or worker capability:
 
-- Add a non-destructive invocation to `scripts/smoke-test.sh`, such as
-  `kitaru <command> --dry-run` or `kitaru <command> --help`.
-- When adding, removing, renaming, or publicly documenting an example under
-  `examples/`, update `examples/example-coverage.yaml` and run
-  `just example-coverage-audit`.
-- Check whether analytics coverage is needed. Add the event to
-  `AnalyticsEvent` and wire it into the appropriate surface.
-- If the CLI command is multi-word, add it to `_MULTI_TOKEN_COMMANDS` in `cli.py`.
+- Add or update focused tests for the changed surface.
+- Update offline CLI registration metadata for CLI commands.
+- Update `examples/example-coverage.yaml` and run `just example-coverage-audit` when examples are added, removed, renamed, or publicly documented.
+- Review analytics coverage and add events only through the current v2 analytics paths.
+- Run the relevant CLI artifact, MCP schema, MCP wheel, migration, OpenAPI, or package-build checks for the changed contract.
 
 ## Python CI
 
-`.github/workflows/ci.yml` runs on push/PR to `develop`. Base lanes cover Python 3.11–3.14 without resolving MCP. MCP lanes cover Python 3.11–3.14 with `kitaru[mcp]` plus shared connection/client contracts. A Python 3.12 installed-wheel lane builds one artifact, verifies base imports and missing-extra startup in a clean environment, then negotiates stdio, lists the 2/5/7 registries, calls a stubbed read, checks text/structured parity, and shuts down from a clean `[mcp]` install.
+`.github/workflows/ci.yml` runs on pushes to `develop` and on pull requests. It includes separate base, CLI, and MCP matrices across Python 3.11 through 3.14, plus installed CLI-artifact and MCP-wheel contracts. Push-only jobs cover Docker server smoke and UI wheel packaging because those paths may require trusted UI release credentials.
 
-Push jobs also run Docker server smoke and UI wheel-packaging checks because those paths may need trusted UI release credentials. The release workflow reruns the schema, source-suite, and clean installed-wheel contracts against the artifact it publishes.
-
-When changing Kitaru UI bundling, frontend smoke testing, Docker dashboard
-packaging, or release UI selection, read `FRONTEND-TESTING.md` first.
+Do not describe the inherited `llm-integration.yml` provider markers or absent `tests/live/` suite as v2 release evidence. V2 currently has no tracked `live_llm`, `live_openai`, `live_anthropic`, or `live_gemini` test surface.
 
 ## Docs CI
 
-`.github/workflows/docs.yml` runs on manual dispatch, `main` pushes, and PRs
-touching docs/reference-related inputs such as `docs/**`, docs generation
-scripts, SDK source, `CHANGELOG.md`, `pyproject.toml`, `uv.lock`, or Wrangler
-config.
+`.github/workflows/docs.yml` runs on manual dispatch, `main` pushes, and selected docs/reference pull-request paths. It is configured to regenerate SDK reference docs and build the FumaDocs export, but the v2 checkout currently lacks `scripts/generate_sdk_docs.py`; treat that workflow as blocked until a v2 generator is restored. Deployment conditions remain `main` push or manual dispatch, and hand-written docs publish separately through GitBook Git Sync.
 
-It regenerates SDK reference docs and builds the FumaDocs static export on
-all runs. It deploys `sdkdocs.kitaru.ai` and the `kitaru.ai/docs` redirect
-worker only on `main` push or manual dispatch. PRs build only and do not create
-preview Workers. Hand-written docs publish separately through GitBook Git Sync.
-Marketing site deployment is handled from `zenml-io-v2`.
+## Release Workflow
 
-## Other Workflows
+The authoritative release procedure is `.github/workflows/release.yml`. A normal dispatch checks out `develop`; a recovery dispatch may reuse an existing release tag. Therefore a v2 feature branch cannot be released through the normal dispatch until the intended v2 history is present on the release source branch.
 
-- `release.yml`: release automation for version bump, PyPI publish, Docker
-  image publish, and GitHub Release. Do not add live provider calls here.
-- `llm-integration.yml`: trusted weekly/manual live OpenAI/Anthropic provider
-  checks. It has only `schedule` and `workflow_dispatch` triggers, runs paid
-  tests outside PR CI, can target an exact ref/SHA, uploads logs/results only,
-  and sends compact Discord failure alerts via `DISCORD_WEBHOOK_SRE`. Exact
-  validation evidence is the tested SHA plus run ID and attempt in
-  `llm-integration.provenance.json`. Run it again after environment-policy
-  changes. Before removing required reviewers, cancel stale waiting runs. Never
-  create a paid failure solely to test notifications.
-- `spellcheck.yml`: typo/spell checking on `develop` pushes and non-draft PRs.
-- `image-optimiser.yml`: PR-only compression for changed JPG/JPEG/PNG/WebP
-  files in same-repo non-draft PRs.
-- `zizmor.yml`: GitHub Actions security analysis for workflow/dependabot changes,
-  plus weekly and manual runs.
+Before dispatching:
+
+1. Fetch `develop`, `main`, and tags.
+2. Confirm the intended release commits are on `develop` and identify the last immutable release tag.
+3. Review the `[Unreleased]` changelog and version classification.
+4. Confirm no other release run is active.
+5. Run `just check`, the relevant base/CLI/MCP tests, `just mcp-schema-check`, `just cli-artifact-smoke`, `just migration-check`, and `just build` as applicable. Run `just mcp-wheel-smoke` only after `just build`; it consumes the wheel under `dist/`.
+6. Use the workflow's `dry-run` input when a non-publishing rehearsal is needed.
+
+The release workflow itself installs the CLI, MCP, and worker extras; checks lint, types, MCP schemas, base/CLI/MCP tests, clean CLI artifacts, migrations, UI wheel contents, and the installed MCP wheel contract; then handles versioning, tagging, PyPI, GitHub Release, public and managed images, Helm packaging, release branches, and `main` advancement.
+
+Do not use the removed `scripts/smoke-test.sh`, provider-area flags, remote-stack smoke, v1 adapters, or local ZenML flow runs as v2 release gates.
 
 ## Branching and Releases
 
 - Default branch is `develop`.
-- All PRs target `develop`.
+- Pull requests normally target `develop`; v2 feature work may target its explicit integration branch until that migration lands.
 - `main` tracks the latest released version only; do not push directly.
-- Releases are cut via the Release workflow: `workflow_dispatch` on `develop`
-  or `v*` tag push.
-- Release branches (`release/X.Y.Z`) and tags (`vX.Y.Z`) are created automatically.
-- Version is maintained in `pyproject.toml` and bumped by the release workflow.
-  Never hardcode it; use `importlib.metadata.version("kitaru")`.
-- Update `CHANGELOG.md` under `[Unreleased]` when making user-facing changes.
-
-Before release dispatch, check `.github/workflows/llm-integration.yml`. A weekly
-green run on `develop` is a canary, not exact release evidence. If OpenAI or
-Anthropic adapter/example behavior changed, trigger a manual
-`llm-integration.yml` run for the exact release ref or SHA and require it to
-pass, or record an explicit waiver in the release conversation. Gemini remains
-local release-smoke evidence or waiver for v1.
-
-## Release Smoke
-
-Before releasing, run release-grade smoke with structured output:
-
-```bash
-./scripts/smoke-test.sh --release --json-out smoke-results.json
-```
-
-Add repeatable `--required-provider-area <area>` flags for changed
-provider-backed behavior: `openai`, `anthropic`, `gemini-model`,
-`gemini-antigravity`, `google-adk`, or `research-bot`.
-
-For normal runtime releases, also opt into remote-stack smoke with
-operator-provided private config: `--remote-stack-smoke` or
-`KITARU_REMOTE_SMOKE=1`. Docs-only or no-runtime releases may record an explicit
-waiver instead.
-
-Bare `./scripts/smoke-test.sh` remains useful for local development, but it is
-not enough release evidence for provider- or remote-stack-relevant changes.
-Use `-s` to skip reinstall and `-k` to keep the server running afterward.
+- Releases are cut through `.github/workflows/release.yml` by dispatch or `v*` tag push.
+- The workflow maintains the version in `pyproject.toml`; application code should use `importlib.metadata.version("kitaru")` rather than hardcoding it.
+- Update `CHANGELOG.md` under `[Unreleased]` for user-facing changes.

--- a/.claude/skills/kitaru-dev-commands/SKILL.md
+++ b/.claude/skills/kitaru-dev-commands/SKILL.md
@@ -1,103 +1,109 @@
 ---
 name: kitaru-dev-commands
-description: Full reference for Kitaru's just recipes, test/lint/typecheck invocations, docs generation, UI bundle scripts, Docker image builds, and the CI/CD workflow table. Use when you need a command beyond `just check` / `just fix` / `just test`, when a CI workflow fails and you need to know what it runs, or when working on docs generation, the Kitaru UI bundle, or Docker images.
+description: Full reference for Kitaru v2 development commands, tests, docs generation, packaging, Docker builds, and CI workflows. Use when a task needs commands beyond just check, just fix, or just test.
 ---
 
-# Kitaru development commands
+# Kitaru v2 development commands
 
-This project uses [just](https://github.com/casey/just) as a command stack. Run `just --list` to see all recipes.
+Run `just --list` for the recipe inventory, then verify that a recipe's backing files exist before using it on v2. Treat `pyproject.toml`, source, tests, and existing scripts as authoritative when inherited recipes or workflows disagree.
 
-## Core workflow (the three commands you'll use most)
-
-| Command | What it does | When to run |
-|---|---|---|
-| **`just check`** | Runs *all* checks: format, lint, typecheck, typos, yaml, actions lint, links | After every chunk of work and before committing/pushing |
-| **`just fix`** | Auto-fixes formatting, lint issues, and yaml | When `just check` reports fixable issues — handles most linting problems automatically |
-| **`just test`** | Runs the full pytest suite | After code changes and before committing/pushing |
-
-**Typical loop:** write code → `just fix` (auto-fix what it can) → `just check` (verify everything passes) → `just test` (make sure nothing is broken) → commit.
-
-**Worktree setup gotcha:** In a fresh `git worktree`, the `test_phase*_example::*_runs_end_to_end` tests (~14 of them) fail with `RuntimeError: Unable to resolve dynamic pipeline source. Make sure your pipeline is defined at the top level of your module.` This is because ZenML's dynamic pipeline resolver uses `get_source_root()` to locate the project root before re-importing the pipeline module by dotted path, and that root comes from the `.kitaru/` marker. Worktrees don't inherit `.kitaru/` from the main checkout, so the resolver can't find `examples.features.basic_flow....` on `sys.path`. **Fix:** run `uv run kitaru init` once in the new worktree after `uv sync`. The unit test suite passes without this — only the end-to-end example tests need it.
+## Environment setup
 
 ```bash
-# Setup
-uv sync                              # Install dependencies
-uv sync --extra local                # Include local ZenML runtime components
-uv run kitaru init                   # Required in a fresh git worktree — see note above
-
-# Common Python workflows
-just check                            # Run all checks (format, lint, typecheck, typos, yaml, actions lint, links)
-just test                             # Run all tests
-just test tests/test_foo.py           # Run a single test file
-just test tests/test_foo.py::test_bar # Run a single test
-just test -x                          # Stop on first failure
-uv run pytest -m live_openai          # Explicit live OpenAI checks (requires key)
-uv run pytest -m live_anthropic       # Explicit live Anthropic checks (requires key)
-just fix                              # Auto-fix formatting, lint, and yaml
-
-# Default pytest excludes live provider tests with -m 'not live_llm'.
-# Tests under tests/live/ are paid/external checks and must be selected
-# explicitly with provider credentials available.
-
-# Agent tip: the full suite takes ~4 minutes. When running it through a
-# pager/truncated stream that may drop the failure list, pipe through
-# grep so the failure names survive:
-#   just test 2>&1 | grep -E "FAILED|ERROR|passed|failed" | tail -20
-# That keeps the PASS/FAIL summary and every FAILED line without
-# forcing a rerun just to recover the list.
-
-# Individual checks
-just lint                             # Lint only
-just typecheck                        # Type check only
-just typos                            # Typo check only
-just format-check                     # Check formatting without modifying
-just yaml-check                       # Check YAML formatting
-just actions-lint                     # Lint GitHub Actions workflows (requires actionlint)
-just zizmor                           # Audit GitHub Actions workflow security
-just audit                            # Audit Python dependencies with pip-audit
-just links                            # Check markdown links offline (requires lychee)
-just example-coverage-audit           # Validate example metadata and required waivers; audit-only, no provider calls
-just build                            # Build wheel + sdist locally
-just mcp-schema-check                 # Verify MCP 2/5/7 schema snapshots and budgets
-just mcp-wheel-smoke                  # Verify clean base and [mcp] wheel installs
-
-# Docs workflows (require Node 22+ and pnpm)
-just generate-docs                    # Generate changelog + SDK reference docs
-just docs                             # Preview docs dev server (localhost:3000)
-just docs-build                       # Build docs static export
-just docs-validate                    # Validate the static export as served under /docs
-
-# Kitaru UI bundle testing
-# Read FRONTEND-TESTING.md before changing UI bundle, frontend smoke, Docker dashboard, or release UI workflows.
-just ui-bundle                                # Download latest stable/full kitaru-ui-v* bundle
-just UI_TAG=kitaru-ui-v0.2.0 ui-bundle        # Download a specific stable UI bundle
-just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease  # Explicit prerelease opt-in
-just ui-login                                 # Start local Kitaru with prepared bundle
-just ui-smoke                                 # Smoke test prepared bundle and keep server running
-
-# Docker
-just server-image                              # Build production server image (bundles latest stable UI first)
-just DOCKER_TAG=v0.2.0 server-image            # Build with specific image tag
-just UI_TAG=kitaru-ui-v0.2.0 server-image      # Build with specific stable Kitaru UI release
-just server-image-push                         # Build + push to Docker Hub
-just server-dev-image                          # Build dev server image (requires docker/kitaru-ui-dist/)
-
-# Public website deploys are owned by the sibling zenml-io-v2 repository.
+uv sync                              # Base SDK and development dependencies
+uv sync --extra cli                  # Optional CLI
+uv sync --extra mcp                  # Optional native MCP server
+uv sync --extra server               # FastAPI server and database dependencies
+uv sync --extra worker               # Worker runtime
+uv sync --extra otel                 # OpenTelemetry integrations
 ```
 
-Note: `zizmor` is not part of `just check`. `just check` runs `actionlint` (a syntax linter); `zizmor` is a separate security scanner with its own recipe and a path-filtered workflow. Run `just zizmor` locally before pushing workflow changes.
+There is no v2 `local` extra, `kitaru init` command, or `.kitaru/` project-marker setup.
 
-When working with Python, invoke the relevant `/astral:<skill>` for uv, ty, and ruff to ensure best practices are followed.
+## Core workflow
+
+```bash
+just fix                              # Auto-fix formatting, lint, and YAML
+just check                            # Format, lint, types, typos, YAML, actions, links
+just test                             # Full pytest suite
+just test tests/cli                   # One test surface
+just test tests/cli/test_app.py::test_help_version_schema_and_scaffold_skip_bootstrap
+```
+
+The full suite can be summarized without losing failure names:
+
+```bash
+just test 2>&1 | grep -E "FAILED|ERROR|passed|failed" | tail -20
+```
+
+## Focused checks
+
+```bash
+just format-check
+just lint
+just typecheck
+just typos
+just yaml-check
+just actions-lint
+just zizmor
+just audit
+just links
+just links-external
+just example-coverage-audit
+just migration-check                    # Requires docker compose up -d db
+just build
+```
+
+## CLI and MCP contracts
+
+```bash
+just cli-artifact-smoke                  # Clean CLI wheel and source installs
+just mcp-schema-check                    # Registry schemas, budgets, snapshots
+just mcp-wheel-smoke                     # Clean base and [mcp] wheel installs
+uv run --extra cli kitaru schema         # Offline CLI command catalog
+```
+
+Do not copy MCP tool counts into this skill. Read `tests/mcp/snapshots/metrics.json` and run `just mcp-schema-check`.
+
+CLI tests call `src/kitaru/cli/app.py::main` with explicit arguments and assert its returned integer code. They do not expect `SystemExit(0)`.
+
+## Docs workflows
+
+These require Node 22+ and pnpm.
+
+```bash
+just docs                                # Preview at localhost:3000
+just docs-build                          # Static export
+just docs-validate                       # Validate export under /docs
+```
+
+`scripts/generate_sdk_docs.py` is absent from v2, so `just generate-docs` and the SDK-reference generation step in docs CI are blocked. Do not restore the deleted v1 generator without reviewing the v2 public SDK. CLI reference publishing is deferred; `kitaru schema` is the current offline CLI contract.
+
+## UI and Docker
+
+Read `FRONTEND-TESTING.md` before changing UI bundle, frontend smoke, Docker dashboard, or release UI behavior.
+
+```bash
+just ui-bundle                           # Download latest stable UI bundle
+just UI_TAG=kitaru-ui-v0.2.0 ui-bundle  # Pin a stable UI bundle
+just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease
+```
+
+The inherited `just ui-login` recipe calls `kitaru login` without the required `SERVER` argument or `--local`, so do not advertise it as a working v2 command. After preparing a bundle, set the printed `KITARU_UI_DIST_PATH` and use `uv run kitaru login SERVER` or `uv run kitaru login --local` against an already-running server.
+
+Do not advertise `just ui-smoke` or `just release-smoke` as working v2 checks while they still call the removed `scripts/smoke-test.sh`.
+
+The v2 Dockerfiles are `docker/dev-client.Dockerfile`, `docker/dev-server.Dockerfile`, `docker/release-client.Dockerfile`, and `docker/release-server.Dockerfile`. Follow `docker/CLAUDE.md`; do not use inherited v1 `server-image` recipes as v2 release evidence.
 
 ## CI/CD workflows
 
-| Workflow | Trigger | Purpose |
-|---|---|---|
-| `ci.yml` | Push/PR to `develop` | PRs run Python checks plus base and `kitaru[mcp]` matrices on 3.11–3.14, schema snapshots, and a Python 3.12 clean installed-wheel MCP contract. Pushes also run Docker server smoke and UI wheel packaging because those jobs may need trusted UI release credentials. |
-| `docs.yml` | Manual dispatch; push to `main`; selected docs/script/source PR paths | Regenerate the SDK reference and build the static docs app on every run. Deploy the SDK reference site (`sdkdocs.kitaru.ai`, worker `kitaru-sdkdocs`) plus the `kitaru.ai/docs` redirect worker (`kitaru-site`) only on `main` push or manual dispatch. PRs build only and do not create preview Workers. Hand-written docs (`docs/book/`) publish separately via GitBook Git Sync. |
-| `release.yml` | Workflow dispatch or `v*` tag | Stable Kitaru UI bundling, version/changelog/lock handling for dispatch releases, PyPI publish, Docker image publish, Helm OCI chart publish, release branch/main update, GitHub Release. No live provider calls. |
-| `llm-integration.yml` | Weekly schedule; manual dispatch | Trusted live OpenAI/Anthropic provider checks outside PR CI. Manual runs can target an exact Kitaru ref/SHA and select `provider-core`, `provider-extended`, OpenAI, Anthropic, and the opt-in research bot. Uploads logs/results only and sends Discord failure alerts. Secret-bearing jobs use the GitHub Environment `live-provider-tests`; put `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `DISCORD_WEBHOOK_SRE` in that Environment with `kitaru-admins` approval/restrictions. |
-| `ui-prerelease-smoke.yml` | Manual dispatch | Tests an explicit prerelease Kitaru UI bundle against a Kitaru ref without publishing PyPI, Docker, Helm, tags, or releases |
-| `spellcheck.yml` | Manual/reusable runs, push to `develop`, non-draft PRs | Separate typo/spell checking |
-| `image-optimiser.yml` | PRs changing JPG/JPEG/PNG/WebP files | Image compression for same-repo non-draft PRs |
-| `zizmor.yml` | Workflow/dependabot changes, weekly schedule, manual runs | GitHub Actions security analysis |
+| Workflow | Current v2 role |
+|---|---|
+| `ci.yml` | Pushes to `develop` and pull requests. Base, CLI, and MCP test matrices cover Python 3.11-3.14; separate jobs validate CLI artifacts, installed MCP wheels, migrations, Docker server startup, and UI wheel packaging. |
+| `docs.yml` | Intended SDK reference build/deploy workflow. It is currently blocked because the v2 Python SDK generator is absent; deployment conditions remain `main` push or manual dispatch. |
+| `release.yml` | Validates source and built artifacts, then performs versioning, PyPI, GitHub Release, Docker/ECR, Helm, release-branch, and `main` updates. Normal dispatch releases `develop`, not the current feature branch. |
+| `spellcheck.yml` | Separate typo/spell checking. |
+| `image-optimiser.yml` | Compresses changed images on eligible pull requests. |
+| `zizmor.yml` | Audits GitHub Actions security. |
+
+The inherited `llm-integration.yml` still references absent v1 provider tests. Do not use it or the missing `tests/live/` marker suite as proof of v2 behavior.

--- a/.claude/skills/kitaru-release/SKILL.md
+++ b/.claude/skills/kitaru-release/SKILL.md
@@ -1,678 +1,176 @@
 ---
 name: kitaru-release
-description: >-
-  Guide the Kitaru release process end-to-end — diff develop against the
-  last tag, classify commits (src / docs content / docs infra / release infra),
-  filter docs-infra-only PRs out of the Python library CHANGELOG, remember that
-  marketing-site work now lives in sibling zenml-io-v2, check
-  zenml-io/zenml-frontend-monorepo for the latest stable kitaru-ui-v*
-  release that will be bundled into the Python package and then copied
-  into the Docker image, suggest a version bump, update CHANGELOG.md, run the
-  smoke test, trigger the release workflow via gh, and rewrite the
-  auto-generated GitHub Release notes into structured Highlights / Added /
-  Changed / Fixed / Infrastructure sections. Interactive — pauses for user
-  confirmation at version choice, CHANGELOG diff, smoke-test result,
-  and release-notes draft. Use when the user invokes
-  /kitaru-release, or says "cut a release", "make a release",
-  "release kitaru", "new kitaru version", "ship a release",
-  "prepare a release", "what would be in the next release",
-  "bump kitaru version".
+description: Guide a Kitaru v2 release from branch and changelog review through the current GitHub release workflow, artifact verification, and recovery. Use only for release preparation or execution.
 ---
 
-# Kitaru Release
+# Kitaru v2 release
 
-End-to-end runbook for cutting a new Kitaru release. Every step has exact commands; never substitute or invent alternatives.
+The authoritative implementation is `.github/workflows/release.yml`. Read it before every release because publishing targets, validation gates, inputs, and recovery behavior can change.
 
-## Interaction contract
+This workflow publishes packages and images and advances protected branches. Never dispatch a non-dry-run release or approve a publishing environment without explicit user confirmation.
 
-This workflow is **interactive with mandatory pauses**. Do not run multiple phases back-to-back without user confirmation. The four pauses are marked ★ in the checklist. Never skip them — releases publish to PyPI + Docker Hub + ECR and force-push `main`, so silent errors compound.
+## Release boundary
 
-There is also a **fifth pause enforced by GitHub itself**: the `pypi` environment has required reviewers (`kitaru-admins` team), so the release job pauses at that environment gate until a `kitaru-admins` member approves the deployment. The gate is real and will wait indefinitely if nobody approves. But the *pending window can be very short*: when the triggering user is in `kitaru-admins`, they can approve immediately via the web UI, and the deployment clears in seconds. In the v0.17.0 release (2026-06-19) the `pypi` deployment moved from `waiting` to `queued` in about 7 seconds because the user approved it in the browser, so agent-side polling (every ~15-20s) missed the `pending_deployment` entirely and saw the run already past the gate. **Lesson: if you do not catch a `pending_deployment`, do not conclude there is no gate.** It may already have been approved (possibly by the user in the web UI). Confirm by reading the deployment status history (Step 9), not by assuming. Coordinate with the user, who may be approving in the browser while you watch.
+A normal `workflow_dispatch` release checks out `develop`, regardless of the branch from which the workflow is dispatched. A v2 feature or integration branch is not releasable through the normal path until its intended history is present on `develop`. An existing `v<VERSION>` tag activates recovery mode and checks out that immutable tag.
 
-## Checklist
+If the requested v2 commit is not on the workflow's release source, stop and report the branch mismatch. Do not work around it by pushing directly to `develop` or `main`.
 
-Copy and track progress in your todo / task list:
-
-```
-- [ ] Step 1: Fetch + gather state
-- [ ] Step 2: Classify commits by scope and release-confidence area
-- [ ] Step 3: Check monorepo Kitaru UI stable releases since last Kitaru release
-- [ ] Step 4: ★ Pause — show summary, suggest version, await user confirmation
-- [ ] Step 5: Update CHANGELOG [Unreleased] block
-- [ ] Step 6: ★ Pause — show CHANGELOG diff, await confirmation, then commit + push
-- [ ] Step 7: Run smoke test
-- [ ] Step 7b (optional): Offer directed ad-hoc testing of the release's headline changes (large merge windows / flagship features)
-- [ ] Step 8: ★ Pause — verify smoke test and live-provider evidence, await confirmation to trigger release
-- [ ] Step 9: Trigger release workflow via gh, watch to completion
-- [ ] Step 10: Draft structured release notes
-- [ ] Step 11: ★ Pause — show drafted notes, await confirmation
-- [ ] Step 12: Apply notes via gh release edit
-- [ ] Step 13: Final summary with all URLs
-```
-
----
-
-## Step 1: Fetch + gather state
-
-Always fetch first — `main` gets force-pushed during releases and stale local refs produce the wrong diff.
+## 1. Refresh and establish the release range
 
 ```bash
-git fetch origin main develop --tags --prune
-git checkout develop
-git pull --ff-only
+git fetch origin develop main --tags --prune
+git status --short
+git log -1 --oneline origin/develop
+git describe --tags --abbrev=0 origin/main
 ```
 
-Identify the last release tag (do NOT use `origin/main` as a base — always use the tag, since tags are immutable and main is force-pushed):
+Use the last immutable release tag as the comparison base. Do not use a potentially force-updated `origin/main` commit as the release range boundary.
 
 ```bash
 LAST_TAG=$(git describe --tags --abbrev=0 origin/main)
-echo "Last release: $LAST_TAG"
-```
-
-List commits since last release:
-
-```bash
 git log "$LAST_TAG"..origin/develop --oneline
-git diff "$LAST_TAG"..origin/develop --stat | tail -30
+git diff "$LAST_TAG"..origin/develop --stat
 ```
 
-## Step 2: Classify commits by scope
+Stop if the working tree contains changes that are not part of release preparation, another release run is active, or `develop` does not contain the intended release work.
 
-For each commit between `$LAST_TAG` and `origin/develop`, determine its scope from the file paths it touched:
+## 2. Review version and changelog
 
-| Scope | Paths | CHANGELOG? |
-|---|---|---|
-| **Library** | `src/kitaru/**` | Yes |
-| **Docs content** | `docs/book/**.md` hand-written GitBook docs; generated `docs/content/**` only when source generation changes | Yes when user-visible |
-| **Scripts / build** | `scripts/**`, `pyproject.toml` version-adjacent | Sometimes (judgement call) |
-| **Docs site infra** | `docs/app/**`, `docs/scripts/**`, `docs/package.json`, `wrangler.toml` | No (unless user-visible) |
-| **Marketing site** | Lives in sibling `zenml-io-v2`, not this repo | No — handle in that repo |
-| **CI / dependabot** | `.github/workflows/**`, dependabot bumps | No |
-| **Release infra** | `docker/**`, `helm/**` | No unless user-facing |
+Read the current version from `pyproject.toml`; the workflow updates it during a dispatch release. Review `CHANGELOG.md` under `[Unreleased]` against the commits in the release range.
 
-Per-commit inspection:
+Use semantic versioning:
+
+- patch: compatible fixes and maintenance
+- minor: new backward-compatible public capability
+- major: intentional breaking public contract
+
+Check every issue or PR reference against the actual release range. Exclude changes that belong only to the sibling marketing repository or that do not affect the released Kitaru package, docs, images, or operational contract.
+
+If the changelog needs editing, make that a focused pull request into the release source branch. Do not silently commit or push release-preparation edits.
+
+## 3. Select relevant validation
+
+Run the smallest complete set that matches the changed surfaces. The release workflow will rerun its authoritative gates against the release checkout and built artifact.
+
+### General source checks
 
 ```bash
-git show --stat <sha> | head -30
+just check
+just test
+just build
 ```
 
-Treat no-op pairs (add X / revert X in same unreleased window) as excluded — they net to nothing.
-
-Then answer this release-confidence question for every user-facing change:
-
-> What executes this changed behavior?
-
-Classify each changed behavior into one or more areas:
-
-| Area | Typical paths | Evidence to record |
-|---|---|---|
-| CLI | `src/kitaru/cli/**` | Deterministic pytest, local smoke command, or manual waiver |
-| MCP | `src/kitaru/mcp/**`, `tests/mcp/**` | `tests/mcp`, `just mcp-schema-check`, and clean installed-wheel `just mcp-wheel-smoke` |
-| SDK primitives | `src/kitaru/**` core runtime/client/checkpoint/wait/replay code | Deterministic pytest plus local smoke flow if available |
-| Provider adapters | `src/kitaru/adapters/**`, provider examples | Provider area below, deterministic fake test if available, live/local provider check if required. OpenAI/Anthropic changes need exact-ref `llm-integration.yml` evidence or an explicit waiver; weekly-green `develop` is only a canary. |
-| Public examples | `examples/**` | Example pytest, local smoke command, help/import contract, or waiver |
-| Docs-listed examples | `docs/book/getting-started/examples.md`, `examples/README.md` | Confirm docs do not promise an untested or unshipped path |
-| UI/release machinery | `scripts/download-ui.sh`, `docker/**`, `.github/workflows/release.yml`, UI bundle paths | Dry-run release or UI smoke evidence |
-
-For each changed behavior, record four facts in your release notes to the user before smoke:
-
-1. **Deterministic pytest:** the exact test file or marker that runs without provider credentials, or `none`.
-2. **Local smoke:** the smoke check that executes it, or `none`.
-3. **Live/provider check:** the provider run required, if any.
-4. **Manual verification / waiver:** what a human must check if neither pytest nor smoke executes it.
-
-Run `just example-coverage-audit` when example coverage is part of the release evidence. It validates paths, metadata, and explicit waivers for `missing`, `planned`, or `manual_only` entries. It does not run examples or providers, so a green audit means the manifest is honest, not that every example executed.
-
-Translate changed provider behavior into smoke flags. Use this vocabulary only:
-
-| Changed behavior | Smoke flag |
-|---|---|
-| OpenAI adapter, OpenAI-backed LangGraph/PydanticAI path, OpenAI LLM flow/model alias behavior | `--required-provider-area openai` |
-| Claude Agent SDK / Anthropic behavior | `--required-provider-area anthropic` |
-| Gemini raw model response behavior | `--required-provider-area gemini-model` |
-| Gemini Antigravity managed-agent behavior | `--required-provider-area gemini-antigravity` |
-| Google ADK/Gemini adapter behavior | `--required-provider-area google-adk` |
-| OpenAI research bot web-search behavior | `--required-provider-area research-bot` |
-
-Do **not** let the smoke script infer this from git history. The release skill/operator decides which areas changed and passes the flags explicitly.
-
-## Step 3: Check monorepo Kitaru UI stable releases
-
-Official Kitaru releases bundle a Kitaru UI release from `zenml-io/zenml-frontend-monorepo` into the Python package. The Docker image then copies that already-packaged UI from the installed `kitaru` package. Docker does **not** download UI assets or choose a UI tag itself.
-
-Before changing UI bundle selection, frontend smoke testing, Docker dashboard packaging, or release UI workflow behavior, read `FRONTEND-TESTING.md`. It is the canonical runbook for stable/prerelease `kitaru-ui-v*` testing and token/trusted-event boundaries.
-
-The release workflow's `kitaru-ui-tag` input accepts only `kitaru-ui-v<semver>` tags. If the input is empty, `scripts/download-ui.sh` selects the highest stable/full `kitaru-ui-v*` release. Drafts and prereleases are excluded. Prerelease UI tags are only for local testing and `.github/workflows/ui-prerelease-smoke.yml`.
-
-Fetch the last Kitaru release timestamp and the monorepo releases:
+### CLI changes
 
 ```bash
-LAST_KITARU_TS=$(gh release view "$LAST_TAG" -R zenml-io/kitaru --json publishedAt --jq .publishedAt)
-gh release list -R zenml-io/zenml-frontend-monorepo --limit 50 \
-  --json tagName,publishedAt,isDraft,isPrerelease \
-  --jq '[.[] | select(.tagName | startswith("kitaru-ui-v"))]'
+uv sync --frozen --extra cli --extra worker
+just test tests/cli
+just cli-artifact-smoke
 ```
 
-From the JSON, find the highest/version-latest non-draft, non-prerelease `kitaru-ui-v*` release and compare its `publishedAt` to `$LAST_KITARU_TS`:
-
-- If UI `publishedAt > $LAST_KITARU_TS` → a new UI will ship. **Remember the UI tag name** for release notes step 10.
-- If UI `publishedAt <= $LAST_KITARU_TS` → same UI as last release. Don't mention it.
-- If there is no full/non-prerelease `kitaru-ui-v*` release → stop and tell the user the official Kitaru release is blocked until frontend maintainers promote one.
-
-Do **not** fetch or summarize what's in the UI release — just note the tag if it's newer.
-
-## Step 4: ★ Pause — summary + version suggestion
-
-Present a summary table to the user covering:
-
-1. Commits since last release with scope classification
-2. Whether a new Kitaru UI bundle ships (tag only, no contents)
-3. File-level diff stats
-4. Version bump suggestion with reasoning
-5. If the window is large or ships a flagship feature, note that you can run
-   optional directed ad-hoc verification of the headline changes after smoke
-   (Step 7b), and ask whether the user wants it.
-
-Version semantics:
-
-| Bump | When |
-|---|---|
-| **Major** (`X.0.0`) | Breaking public API change, primitive removed, config file format breaks |
-| **Minor** (`0.X.0`) | New user-facing SDK primitive, new CLI command group, new public surface |
-| **Patch** (`0.0.X`) | Bug fix, doc improvement, internal refactor, small-surface CLI tweak |
-
-Default to patch unless the diff clearly warrants minor. A single new CLI flag is usually patch. A whole new command group (e.g. `kitaru auth`) is minor.
-
-**Wait for user to confirm or override the version.** Do not proceed until they've agreed on a version number.
-
-## Step 5: Update CHANGELOG [Unreleased] block
-
-Read `CHANGELOG.md` and locate the `## [Unreleased]` heading. Under it, organize entries into:
-
-```markdown
-## [Unreleased]
-
-### Added
-- [new user-facing capabilities]
-
-### Changed
-- [modifications to existing behavior]
-
-### Fixed
-- [bug fixes]
-
-### Infrastructure
-- [release process, CI, packaging, smoke, or test infrastructure changes]
-```
-
-Rules:
-
-- **One bullet per logical change**, not one bullet per commit.
-- **Always verify PR references** — cross-check every `(#N)` in existing `[Unreleased]` bullets against `git log --oneline $LAST_TAG..origin/develop`. A common failure mode: the bullet is written with a draft PR number that changed when rebased. Correct any mismatches.
-- **Include** library changes (`src/`) and docs content changes (`docs/content/**.mdx`) that materially help readers.
-- **Exclude** site-only PRs, dependabot action bumps, docs-infra PRs (sitemap, llms.txt, redirects), and no-op revert pairs.
-- Each bullet should be scannable. Lead with the effect (what users see), then mechanism if non-obvious.
-- If a change touches the CLI, use backticks for command names and flags: `` `kitaru executions list --size 20` ``.
-
-## Step 6: ★ Pause — show diff + commit
+### MCP changes
 
 ```bash
-git diff CHANGELOG.md
+uv sync --frozen --extra mcp
+just test tests/mcp
+just mcp-schema-check
+just build
+just mcp-wheel-smoke
 ```
 
-Show the diff to the user. **Wait for confirmation.** Only then:
+Treat any change to the MCP registry, schemas, descriptions, annotations, capability modes, or committed snapshots as public API and security review work. Read the current inventory from `tests/mcp/snapshots/metrics.json`; do not rely on copied tool counts.
+
+### Server, database, task, or worker changes
 
 ```bash
-git add CHANGELOG.md
-git commit -m "$(cat <<'EOF'
-Update CHANGELOG for upcoming release
-
-[1-2 sentences summarising what was added to the Unreleased block
- and what was intentionally excluded]
-EOF
-)"
+docker compose up -d db
+uv sync --frozen --extra server --extra worker --extra otel
+just migration-check
+just test tests/server tests/task tests/worker
 ```
 
-Ask the user to confirm the push:
+### Docs changes
 
 ```bash
-git push origin develop
+just docs-build
+just docs-validate
 ```
 
-Never push without that explicit confirmation — the release workflow reads `CHANGELOG.md` from `develop` at runtime, so this push is load-bearing for the release step.
+The v2 checkout currently lacks `scripts/generate_sdk_docs.py`, so SDK-reference generation and docs CI are blocked until a reviewed v2 generator lands. Do not use the deleted v1 generator as release evidence.
 
-## Step 7: Run smoke test
+### UI packaging or Docker changes
 
-```bash
-./scripts/smoke-test.sh --release --json-out smoke-results.json \
-  [--required-provider-area openai] \
-  [--required-provider-area anthropic] \
-  [--required-provider-area gemini-model] \
-  [--required-provider-area gemini-antigravity] \
-  [--required-provider-area google-adk] \
-  [--required-provider-area research-bot]
-```
+Read `FRONTEND-TESTING.md` and `docker/CLAUDE.md`. Use the current CI and release workflow steps as the validation recipe. Do not use `scripts/smoke-test.sh`, `just ui-smoke`, or `just release-smoke`; the script was removed from v2.
 
-Expected runtime: 3-5 minutes for local smoke. Remote-stack smoke adds remote execution time and depends on the operator's configured infrastructure. The script:
+V2 has no tracked `tests/live/` provider suite or `live_llm` marker contract. Do not use inherited v1 adapters, provider-area flags, local ZenML flows, or remote-stack smoke as release evidence.
 
-- Does a full `uv sync --python 3.12 --extra local --extra llm --extra mcp` plus the adapter extras (`pydantic-ai`, `openai-agents`, `claude-agent-sdk`, `gemini`, `langgraph`)
-- Optionally, when `--remote-stack-smoke` / `KITARU_REMOTE_SMOKE=1` is set, logs into an operator-provided remote server, inspects the configured remote stacks, submits the private importable smoke flow, waits for success, reads execution/artifact/log evidence, and then continues into the normal local smoke path
-- Starts a local Kitaru server on `http://127.0.0.1:8383`
-- Exercises CLI, SDK flows (including replay), the adapter examples (PydanticAI, LangGraph, OpenAI Agents, Claude Agent SDK, Gemini Interactions, and isolated Google ADK checks), and an end-to-end LLM flow; native MCP release evidence comes from the separate schema and installed-wheel contracts
-- Tears down the server
-- Writes structured results to `smoke-results.json`, including skipped checks and skip reasons
-- In `--release` mode, fails if `timeout`/`gtimeout` is unavailable
-- In `--release` mode, fails when an explicitly required provider area skips
+## 4. Review the workflow plan
 
-Only pass `--required-provider-area ...` for provider areas classified in Step 2 as changed/release-relevant. If no provider-backed behavior changed, run `--release --json-out smoke-results.json` without required-provider flags; provider skips are still reported, but they do not block the release.
+Before dispatch, summarize:
 
-**Remote-stack smoke is expected before every normal runtime release.** It remains opt-in at the command level so local development stays fast and private infrastructure is never required by default, but a normal Kitaru release should prove both remote stack shapes unless the release is explicitly docs-only/no-runtime or the release conversation records a waiver. Stack/server/image values are operator-provided config: source them from shell env or an untracked local file, never from committed files. Prerequisites are a reachable remote Kitaru server, an existing Kubernetes-backed stack, an existing local-runner stack with remote artifact storage, any needed cloud integrations installed locally, and a pushed flow image for the Kubernetes run. Build the image with `just dev-image REPO=<operator-image-repo>`, then pass the pushed image reference.
+- proposed version and release type
+- last release tag and exact `origin/develop` SHA
+- important user-facing changes
+- validation run and results
+- any skipped gate and the reason
+- whether the stable UI tag should be automatic or explicitly pinned
+- whether this is a dry run, normal release, or recovery of an existing tag
 
-Example remote opt-in shape, with placeholder values only:
+Ask for explicit confirmation before any push of release-preparation changes and again before a non-dry-run dispatch.
 
-```bash
-export KITARU_REMOTE_SMOKE=1
-export KITARU_REMOTE_SMOKE_SERVER_URL=<remote-kitaru-server-url>
-export KITARU_REMOTE_SMOKE_KUBERNETES_STACK=<existing-kubernetes-stack>
-export KITARU_REMOTE_SMOKE_LOCAL_REMOTE_ARTIFACT_STACK=<existing-local-runner-remote-artifact-stack>
-export KITARU_REMOTE_SMOKE_FLOW_IMAGE=<pushed-dev-flow-image>
-./scripts/smoke-test.sh --release --json-out smoke-results.json --remote-stack-smoke
-```
+## 5. Dispatch
 
-Remote smoke failures block the release when policy requires remote evidence or when the operator opted in, unless the release conversation records an explicit waiver. The structured JSON records safe evidence such as execution IDs, statuses, artifact counts, and log-readback success; it must not contain private server URLs, stack names, buckets, registries, account IDs, or credential names. Before publishing, run the manual privacy scan with local private patterns if you have them: `KITARU_REMOTE_SMOKE_PRIVATE_VALUE_PATTERNS="<pattern1>:<pattern2>" uv run pytest tests/test_remote_stack_smoke.py -k private`.
-
-**Set credentials before running, or most provider work is SKIPPED.** The five adapter examples are always present, but only the ones with a credential actually exercise a real model call — without keys they degrade to a `--help`/import smoke or are skipped outright. For a full provider run, export the relevant credentials first:
-
-```bash
-export OPENAI_API_KEY=...        # OpenAI Agents real run, LangGraph `calls`, research bot
-export ANTHROPIC_API_KEY=...     # Claude Agent SDK real run (or CLAUDE_CODE_USE_BEDROCK=1 / _VERTEX=1)
-export GEMINI_API_KEY=...        # Gemini Interactions raw `--mode model` real run (GOOGLE_API_KEY also works)
-export KITARU_SMOKE_RESEARCH_BOT=1     # opt in to the real web-search research-bot test
-export KITARU_SMOKE_GEMINI_ANTIGRAVITY=1  # opt in to the Gemini `--mode antigravity` managed-agent run
-./scripts/smoke-test.sh --release --json-out smoke-results.json \
-  --required-provider-area openai \
-  --required-provider-area anthropic
-```
-
-**If you are running the smoke through Claude Code (or a similar agent harness), `ANTHROPIC_API_KEY` is scrubbed from spawned shells.** Claude Code uses `ANTHROPIC_API_KEY` for its own auth and strips it from the environment of the subprocesses it launches, so even when the operator's `~/.zshrc` exports it, a bare smoke run starts *without* it and the Claude Agent SDK real run silently skips. A non-interactive shell may also not source `~/.zshrc` at all, so other keys (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `KITARU_UI_RELEASE_TOKEN`) can be missing too. The fix is to source the operator profile *inside* the smoke command and clear any stale venv: prefix the run with `source ~/.zshrc >/dev/null 2>&1; unset VIRTUAL_ENV;`. Verify presence without printing secrets first, e.g. `source ~/.zshrc; for v in OPENAI_API_KEY ANTHROPIC_API_KEY GEMINI_API_KEY; do val="${(P)v}"; [ -n "$val" ] && echo "$v SET (${#val})" || echo "$v unset"; done` (zsh indirect expansion is `${(P)v}`, not `${!v}`). Apply the same `source ~/.zshrc; unset VIRTUAL_ENV` prefix to any subagents you spawn for Step 7b, or they inherit the same scrubbed/empty environment.
-
-**A Gemini `--mode model` failure with `BadRequestError: 400 ... API_KEY_INVALID` is an expired-credential failure, not a code regression.** The traceback dives through `gemini/_runner.py` → `interaction_resource.create()` → google-genai, which reads like an adapter bug, but the bottom line is Google's server rejecting the key at the auth boundary (the `--help`/`--dry-run` Gemini checks still pass). Treat it like the `VIRTUAL_ENV` noise: rule it out as environmental. If the release's Gemini change is local cost/metadata logic covered by deterministic mocked tests (not a change to the Gemini request path), this is a valid waiver candidate per Step 8, the same as any other Gemini smoke skip.
-
-**Gemini has two credential paths and they unlock different tests** — this is easy to get wrong. The smoke test checks for `GEMINI_API_KEY`/`GOOGLE_API_KEY` (the direct API path) *separately* from Vertex ADC config (`GOOGLE_GENAI_USE_VERTEXAI=true` + `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION`):
-
-| Gemini test | Direct API key (`GEMINI_API_KEY`/`GOOGLE_API_KEY`) | Vertex ADC (`GOOGLE_GENAI_USE_VERTEXAI` + project + location) |
-|---|---|---|
-| `--mode model` (raw response) | ✅ runs a real call automatically | ❌ **skipped** — Vertex ADC is *not* accepted on this path |
-| `--mode antigravity` (managed-agent preset) | ✅ runs, but only with `KITARU_SMOKE_GEMINI_ANTIGRAVITY=1` | ✅ runs, but only with `KITARU_SMOKE_GEMINI_ANTIGRAVITY=1` |
-
-So if the release machine authenticates Gemini through **Vertex** (common for `zenml-core`-style setups), `--mode model` will skip no matter what, and the *only* way to get a real Gemini round-trip is to set `KITARU_SMOKE_GEMINI_ANTIGRAVITY=1` so the antigravity test runs against Vertex ADC. Don't report "Gemini covered" off a Vertex run unless you opted into antigravity. (Vertex ADC must actually be available, via `gcloud auth application-default login` or `GOOGLE_APPLICATION_CREDENTIALS`, or the antigravity test will fail rather than skip.)
-
-**On Vertex, the antigravity managed-agent path requires `GOOGLE_CLOUD_LOCATION=global`, not a regional value.** A regional endpoint (`europe-north1`, `us-central1`, etc.) rejects the managed-agent resource creation with a misleading `400 BadRequestError: "Resource setup has just started. Please try again shortly."` raised from `google.genai._interactions ... interaction_resource.create()`. It fails *instantly*, not after a wait, so it is NOT a transient retry case; switching the location to `global` is the fix. A working Vertex env for the antigravity smoke (project `zenml-core`):
-
-```bash
-export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.keys/google/zenml/gcp_credentials.json
-export GOOGLE_GENAI_USE_VERTEXAI=true
-export GOOGLE_CLOUD_PROJECT=zenml-core
-export GOOGLE_CLOUD_LOCATION=global
-export KITARU_SMOKE_GEMINI_ANTIGRAVITY=1
-```
-
-Parse the final summary and `smoke-results.json`. **Tell the user exactly which checks were SKIPPED and why** (which key or opt-in was unset), which provider areas were required, and whether any release-relevant skips occurred. A bare run with no keys is a weak provider gate — flag that explicitly rather than reporting "all passed" when half the adapter suite was skipped.
-
-**Watch for stale `VIRTUAL_ENV` contamination.** If the shell has a leftover `VIRTUAL_ENV` from a different worktree/venv, `uv` prints a "does not match the project environment path" warning **to stderr**, and the few smoke checks that capture `... 2>&1` and parse JSON (e.g. `analytics disabled in smoke test`, `executions get <latest>`) will choke on the warning glued to the front of the JSON and report a spurious `<parse error>` failure/skip. This is environment noise, not a regression — confirm by re-running the affected command with `unset VIRTUAL_ENV` before treating it as a release blocker.
-
-The script uses `set -uo pipefail` **without `-e`** deliberately — it continues past failures to collect all results and prints a final `Passed: N  Failed: M  Skipped: K` summary.
-
-Prefer running in the background with `run_in_background: true` and tail the log afterwards — the full output is verbose and not useful in conversation context.
-
-**Verify the bundled UI too (recommended pre-release check).** The Python smoke test above does not exercise the dashboard. To click through the exact UI release that will ship, bundle it and run the UI smoke against it:
-
-```bash
-export KITARU_UI_RELEASE_TOKEN=<token-with-contents-read>  # the private monorepo needs auth
-just UI_TAG=kitaru-ui-v<X.Y.Z> ui-bundle    # use the tag from Step 3; or bare `just ui-bundle` for highest stable
-just UI_TAG=kitaru-ui-v<X.Y.Z> ui-smoke     # runs the smoke test with that UI and keeps the server up
-```
-
-`ui-smoke` runs `KITARU_UI_DIST_PATH=<prepared-dist> ./scripts/smoke-test.sh --keep-server`, so after it passes the server stays up and prints a dashboard URL for manual click-through. This UI helper is not the same as release-grade smoke; run the `--release --json-out ...` command above separately for the release gate. `KITARU_UI_RELEASE_TOKEN` is required because `ui-bundle` downloads from the **private** `zenml-io/zenml-frontend-monorepo`; without it you get a `curl: (22) ... 404`. Read **`FRONTEND-TESTING.md`** (repo root) for the full stable/prerelease bundle runbook.
-
-**If running from a git worktree:** a fresh worktree may not have `src/kitaru/_ui/dist/` populated yet. The same `just ui-bundle` / `just ui-smoke` path above prepares it, or run `bash scripts/download-ui.sh` before `./scripts/smoke-test.sh`. The direct override path is `KITARU_UI_DIST_PATH=/path/to/dist ./scripts/smoke-test.sh --keep-server`.
-
-## Step 7b (optional): Directed ad-hoc testing of the release's headline changes
-
-The smoke test proves the surfaces still respond; it does **not** prove a big
-new feature is *correct*. When a release window merged a lot (many PRs since the
-last tag) or shipped a flagship feature, **offer the user directed ad-hoc
-verification** beyond smoke. This is opt-in: ask first, and only run it if the
-user agrees (it costs time and, for provider-backed features, real API calls).
-
-When to offer it (use judgement, surface the offer at the Step 4 pause and again
-here):
-
-- Many PRs since the last tag, or a diff that touches a lot of `src/kitaru/**`.
-- A new or substantially changed user-facing feature (new SDK surface, new CLI
-  command, new MCP tool, new cross-cutting behavior like usage/cost tracking).
-- A feature whose **correctness** matters and is not covered by deterministic
-  pytest in an obvious way (aggregations, math, replay/resume semantics,
-  cross-surface consistency between SDK / CLI / MCP).
-
-How to run it (the pattern that worked well; adapt to the feature):
-
-1. **Generate a controlled dataset inline first** (do this yourself, not in a
-   subagent, so it is reliable and you capture exact IDs). Define a
-   uniquely-named flow so its executions do not mix with smoke runs, run it a few
-   times, and exercise any special path (e.g. replay) you want to verify. Capture
-   the execution IDs.
-2. **Fan out verification with a workflow** (this is a legitimate `ultracode`
-   use; only run a workflow when the user has opted into multi-agent
-   orchestration). Pass the dataset IDs as `args`. Good shape:
-   - One verifier per applicable surface runs an equivalent bounded query and returns structured results. Drive the native MCP server with the locked `mcp` v2 client over stdio; do not use the deleted v1 `fastmcp` smoke command. Start in read-only mode unless the verification explicitly needs a reviewed standard or destructive operation.
-   - A barrier, then adversarial verifiers in parallel: cross-surface
-     consistency (do SDK/CLI/MCP agree exactly?), aggregation math (hand-sum the
-     per-execution metadata and compare to the endpoint's SUM), replay/resume
-     semantics (incurred vs reused, no double-count), and edge cases / error
-     handling (empty filter returns clean zero; malformed input returns a clean
-     error, not a traceback).
-3. **Triage findings.** A correctness failure on the core path blocks the
-   release; a narrow, safe edge-case inconsistency does not. For anything real
-   but non-blocking, **file a follow-up GitHub issue** (`gh issue create`) and
-   proceed. Tell the user the verdict and the issue link.
-4. **Clean up** any temporary generator files and scratch JSON you created, and
-   note if a `--keep-server` smoke left a local server running (offer
-   `uv run kitaru logout`).
-
-This step does not gate the release on its own, but a confirmed core-path
-correctness failure found here should stop the release the same as a smoke
-failure.
-
-## Step 8: ★ Pause — verify smoke test and live-provider evidence
-
-Parse the final summary and `smoke-results.json`. **Any non-zero `Failed:` count = STOP and investigate — do not auto-proceed.** Also stop if `release_relevant_skipped` is nonzero in the JSON counts or if the terminal summary lists `RELEASE-RELEVANT SKIPS`.
-
-- Surface the failing check names to the user
-- Surface skipped check names and reasons to the user
-- Surface the provider attestation: required provider areas, credentials detected, and each required area's passed/failed/skipped counts
-- Surface whether remote-stack smoke ran, whether both remote stack shapes passed, or why remote evidence was waived/skipped
-- Do NOT proceed to the release trigger on an unexplained failure
-- If a required provider area skipped, ask the user to either rerun with the needed credentials/opt-in or explicitly record a waiver in the release conversation
-- Offer to investigate individual failures
-
-Before treating a failure as a hard blocker, **rule out spurious environment noise** — most commonly the stale `VIRTUAL_ENV` contamination described in Step 7. If a failing check captures `2>&1` and parses JSON, re-run that exact command with `unset VIRTUAL_ENV` (and from a clean shell, not a worktree with a different venv). If it then passes cleanly, the failure is an environment artifact, not a regression: say so explicitly, show the clean re-run as evidence, and you may proceed once the user confirms. A genuine `Failed:` with no environmental explanation still blocks the release.
-
-Only when every failure is either `Failed: 0` or provably spurious, every required provider area has either run or has an explicit waiver, and the user confirms, proceed to live-provider workflow evidence.
-
-### Live-provider workflow evidence before release dispatch
-
-Do **not** use `.github/workflows/release.yml` as the provider-validation path. The publishing workflow must stay focused on release artifacts. Provider calls belong in local release smoke and the trusted `.github/workflows/llm-integration.yml` workflow.
-
-There are two evidence levels:
-
-1. **Weekly-green `develop` canary** — useful if the release only changed docs, local CLI behavior, packaging, or other code that does not affect provider adapters/examples. It says “the provider paths were healthy recently on `develop`.”
-2. **Manual exact-ref evidence** — required when OpenAI or Anthropic/Claude adapter/example behavior changed. It says “this exact release ref/SHA ran the live provider checks.”
-
-Check recent live runs:
-
-```bash
-gh run list --workflow=llm-integration.yml --limit 10 \
-  --json databaseId,displayTitle,event,status,conclusion,createdAt,url,headSha
-```
-
-For a candidate run, inspect the tested ref/SHA and downloaded summary artifact:
-
-```bash
-gh run view <RUN_ID> --json databaseId,displayTitle,status,conclusion,url,createdAt,headSha
-rm -rf /tmp/kitaru-llm-integration
-mkdir -p /tmp/kitaru-llm-integration
-gh run download <RUN_ID> -n llm-integration-results -D /tmp/kitaru-llm-integration
-cat /tmp/kitaru-llm-integration/llm-integration.summary.md
-cat /tmp/kitaru-llm-integration/llm-integration.provenance.json
-```
-
-Exact provider evidence is the tested SHA, workflow run ID, and run attempt recorded in `llm-integration.provenance.json`. The workflow run's own `headSha` is the trusted workflow ref, not necessarily the Kitaru ref under test, so do not rely on `headSha` alone.
-
-The `live-provider-tests` environment is restricted to `develop` and has no required reviewers, allowing scheduled and manual runs to proceed unattended. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, and `DISCORD_WEBHOOK_SRE` are repository secrets, not environment secrets. If correcting an environment that required approval, cancel stale waiting runs before removing the reviewer requirement, then rerun the canary after the policy change.
-
-If exact-ref evidence is needed and missing, trigger it manually from trusted workflow code while testing the release ref/SHA:
-
-```bash
-gh workflow run llm-integration.yml --ref develop \
-  -f kitaru_ref=<RELEASE_REF_OR_SHA> \
-  -f suite=provider-core \
-  -f include_openai=true \
-  -f include_anthropic=true \
-  -f include_research_bot=false
-sleep 5
-gh run list --workflow=llm-integration.yml --limit 3 \
-  --json databaseId,displayTitle,event,status,conclusion,createdAt,url
-```
-
-Capture the new `databaseId`, then watch it:
-
-```bash
-gh run watch <RUN_ID> --exit-status
-```
-
-If it fails, inspect logs and stop:
-
-```bash
-gh run view <RUN_ID> --log-failed
-```
-
-Rerun the canary after any environment or approval-policy change. Never cause a paid provider failure solely to test notification delivery.
-
-Release evidence table to report to the user before Step 9:
-
-```text
-Normal CI: passed / missing / failed
-Local release smoke: passed / failed / skipped relevant checks
-OpenAI live workflow: passed / missing / failed / waived
-Anthropic live workflow: passed / missing / failed / waived
-Gemini local smoke: passed / skipped / waived
-```
-
-Rules:
-
-- If OpenAI adapter/example behavior changed, require a successful OpenAI live workflow check for the exact release ref/SHA or an explicit waiver.
-- If Anthropic/Claude adapter/example behavior changed, require a successful Anthropic live workflow check for the exact release ref/SHA or an explicit waiver.
-- If Gemini behavior changed, require local Gemini release-smoke evidence or an explicit waiver. Gemini is not part of GitHub live checks in v1.
-- If the OpenAI research bot changed, run `llm-integration.yml` manually with `-f suite=provider-extended -f include_openai=true -f include_anthropic=false -f include_research_bot=true`, or record a waiver.
-- If only docs or local CLI behavior changed, live checks are recommended but not required; weekly-green `develop` is enough canary evidence if recent and relevant.
-- Do not proceed to Step 9 on a missing required exact-ref live workflow result unless the user explicitly approves a waiver.
-
-Only when smoke evidence and required live-provider evidence are green or explicitly waived, and the user confirms, proceed.
-
-## Step 9: Trigger release workflow
-
-**Dry-run first when the release machinery itself changed.** A dry-run (`-f dry-run=true`) builds the wheel, downloads + bundles the UI, and builds the Docker image, but skips every publish/push/tag and the `pypi` approval gate — so it surfaces workflow bugs *before* any irreversible step. Strongly prefer a dry-run first whenever `release.yml`, `scripts/download-ui.sh`, the Docker/Helm packaging, or the UI-bundling path has changed since the last release, or when a new secret/credential is involved. (This is exactly what caught the missing `KITARU_UI_RELEASE_TOKEN` and the PyPI-verify bug before they could half-publish a release.) For a routine release with no machinery changes, a dry-run is optional but cheap.
+Dry run:
 
 ```bash
 gh workflow run release.yml --ref develop \
-  -f version=<AGREED_VERSION> \
-  [-f kitaru-ui-tag=kitaru-ui-v<X.Y.Z>]  # only if pinning a specific stable/full UI version
-  [-f dry-run=true]                      # do a dry-run pass first; re-run without it after it's green
+  -f version=<VERSION> \
+  -f dry-run=true
 ```
 
-Confirm the trigger succeeded:
+Normal release, only after explicit confirmation:
 
 ```bash
-sleep 5
-gh run list --workflow=release.yml --limit 1 \
-  --json databaseId,status,conclusion,displayTitle,createdAt
+gh workflow run release.yml --ref develop \
+  -f version=<VERSION> \
+  -f dry-run=false
 ```
 
-Capture the `databaseId` and watch:
+Add `-f kitaru-ui-tag=<TAG>` only when an exact stable UI release was explicitly selected. Otherwise let the workflow resolve its documented stable default.
+
+Capture the run ID immediately and monitor the exact run rather than whichever release run happens to be latest:
 
 ```bash
-gh run watch <RUN_ID> --exit-status
+gh run list --workflow=release.yml --limit 5
+gh run view <RUN_ID>
+gh run view <RUN_ID> --log-failed
 ```
 
-Run this in the background (`run_in_background: true`) with a generous timeout (600000ms / 10min). Typical runtime is 4-8 minutes for success paths (plus a few seconds for the approval gate — see below).
+The workflow validates source, CLI, MCP, migrations, package artifacts, the bundled UI wheel, and installed-wheel contracts before publishing. A real release may pause at its configured GitHub environment approval gate. Leave that approval to the user unless they explicitly ask you to perform it.
 
-### Approving the pypi deployment gate
+## 6. Verify published state
 
-For **non-dry-run** releases, the `release` job uses `environment: pypi`, which has required reviewers (`kitaru-admins`), so it pauses here until someone approves. The pending window can be brief: the triggering user (if in `kitaru-admins`) can approve immediately in the web UI. In the v0.17.0 release the user clicked approve in the browser and the deployment cleared in ~7 seconds, so agent polling never caught a `pending_deployment`. If your `pending_deployments` check comes back empty, do not assume there was no gate; check the deployment status history (below) to see whether it was already approved, and ask the user whether they approved it in the browser. The user triggering the run can approve their own deployment (`prevent_self_review: false` is set on the environment).
+After success, verify the exact version across the surfaces the workflow publishes:
 
-Check for pending approvals:
+- Git tag and GitHub Release
+- PyPI metadata and attached wheel/sdist assets
+- public client and server container tags
+- managed image result reported by the workflow
+- Helm chart publication
+- `release/<VERSION>`, `main`, and `develop` state described by the workflow summary
+- SDK docs deployment when the `main` update triggers it
 
-```bash
-gh api repos/zenml-io/kitaru/actions/runs/<RUN_ID>/pending_deployments \
-  --jq '.[] | {env: .environment.name, state: .current_user_can_approve}'
-```
+Use the workflow run and attempt as provenance. Do not infer success for one surface from another surface being available.
 
-**Option A — approve in the web UI (recommended for one-off):** Open the Actions run page, click "Review deployments", tick the `pypi` box, click "Approve and deploy".
+## Recovery
 
-**Option B — approve via CLI:**
+The workflow is designed to recover from an existing matching `v<VERSION>` tag. A recovery dispatch must reproduce that tagged commit and skips version/changelog/lockfile mutation.
 
-```bash
-# Look up the pypi environment ID dynamically (it's stable but better not to hard-code)
-ENV_ID=$(gh api repos/zenml-io/kitaru/environments/pypi --jq .id)
-gh api -X POST repos/zenml-io/kitaru/actions/runs/<RUN_ID>/pending_deployments \
-  -F "environment_ids[]=$ENV_ID" \
-  -f state=approved \
-  -f comment='Approved via kitaru-release skill'
-```
+Before retrying:
 
-Dry-runs (`-f dry-run=true`) use the `dry-run` GitHub environment and skip the `pypi` approval gate entirely.
+1. Read the failed step and determine which side effects already completed.
+2. Confirm the existing tag and published artifacts match the workflow's recorded release SHA.
+3. Fix the workflow on a reviewed branch when the workflow itself is defective; do not advance `develop` casually during a partial-release recovery.
+4. Re-dispatch only after explaining the recovery path and receiving explicit approval.
 
-Never approve a release on someone else's behalf without their confirmation. If the user triggering the release is not a `kitaru-admins` member, ask them to ping an admin to approve, or pause the skill until an admin has done so.
-
-### After approval (or immediately for dry-run)
-
-On completion, verify release artifact exists:
-
-```bash
-gh release view v<VERSION> --json name,tagName,isDraft,url,publishedAt
-```
-
-For non-dry-run releases, the workflow also validates `CLOUD_PLUGINS_REPO_PAT` early, pins the current `zenml-io/zenml-cloud-plugins` `main` SHA, checks that `refs/tags/kitaru-<VERSION>` is either missing or already points at that SHA, then creates the tag after the Kitaru Helm chart has been pushed. That tag is the downstream trigger for the Kitaru Pro server image build; dry-runs skip it and should say so in the workflow summary.
-
-If `isDraft: false` and `publishedAt` is populated, the release succeeded. If the workflow failed, inspect job logs with `gh run view <RUN_ID> --log-failed` and stop — do not attempt the notes-editing step.
-
-## Step 10: Draft release notes
-
-Fetch the auto-generated notes so you can see what to strip:
-
-```bash
-gh release view v<VERSION> --json body --jq .body
-```
-
-Auto-notes list every merged PR including site-only ones. Rewrite into:
-
-```markdown
-## Highlights
-
-[1-2 sentence summary framed relative to the previous release. For a patch, say "A small maintenance release on top of v<prev>". For a minor with a flagship feature, foreground that feature. Mention the new kitaru-ui only if step 3 found a newer one: "This release also bundles the latest Kitaru UI (<ui-tag>)." Do not describe UI changes. Keep each paragraph on one physical line (no hard wrapping) and use no em-dashes (see Formatting rules below).]
-
-## Added
-- [if any new user-facing capability — use bullet text from CHANGELOG]
-
-## Changed
-- [use bullet text from CHANGELOG, expand where helpful for non-experts]
-
-## Fixed
-- [use bullet text from CHANGELOG]
-
-## Infrastructure
-- [use Infrastructure bullet text from CHANGELOG]
-
-**Full Changelog**: https://github.com/zenml-io/kitaru/compare/v<prev>...v<VERSION>
-```
-
-Rules:
-
-- **Skip empty sections.** If there's nothing Fixed, omit the Fixed heading entirely.
-- **Keep it proportional.** Patch releases get a short Highlights paragraph; minor/major releases can have richer Highlights with subsections + code samples (see the `v0.4.0` release for the flagship-feature pattern).
-- **Do not include** site-only PRs (launch blog, lightbox, redirects, sitemap), dependabot action bumps, or no-op revert pairs. These were already filtered from CHANGELOG; the release notes should follow the same filter.
-- **UI release line placement**: if mentioning the new UI, put it as the last sentence of the Highlights paragraph, not a separate section and not in a PR list.
-
-### Formatting rules (GitHub renders the notes as Markdown)
-
-These exist because hard-wrapped notes render with awkward mid-sentence breaks
-and em-dashes read as AI-generated text. Follow them exactly when composing the
-`gh release edit` body.
-
-- **One physical line per bullet and per paragraph. Do NOT hard-wrap at ~72/80 columns.** When you write the heredoc body, keep each bullet on a single long line and each Highlights paragraph on a single line. A newline inside a sentence becomes a stray soft break on the rendered page, which is the "weird line breaks" failure mode. Only put a newline between distinct bullets, between paragraphs, and around headings/code fences.
-- **No em-dashes (`—`) anywhere in the notes.** Rewrite with a comma, colon, or a restructured sentence. (Em-dashes are a known AI-text tell and are banned in user-facing Kitaru copy.) After applying, verify with `gh release view v<VERSION> --json body --jq .body | grep -c '—'` and expect `0`.
-- **Avoid en-dashes (`–`) too**; use a hyphen or "to" (e.g. "1 to 10000", not "1–10000").
-- Code identifiers (commands, flags, methods, env vars, file paths) go in backticks, as in the CHANGELOG.
-
-## Step 11: ★ Pause — show drafted notes
-
-Present the full drafted notes as a fenced code block to the user. **Wait for confirmation** before applying.
-
-## Step 12: Apply notes
-
-```bash
-gh release edit v<VERSION> --notes "$(cat <<'EOF'
-[drafted notes from step 10]
-EOF
-)"
-```
-
-Verify:
-
-```bash
-gh release view v<VERSION> --json body --jq .body | head -20
-```
-
-## Step 13: Final summary
-
-Print a completion table with every artifact URL:
-
-| Artifact | Link |
-|---|---|
-| GitHub Release | `https://github.com/zenml-io/kitaru/releases/tag/v<VERSION>` |
-| PyPI | `https://pypi.org/project/kitaru/<VERSION>/` |
-| Docker Hub | `zenmldocker/kitaru:<VERSION>` + `:latest` |
-| Cloud plugins trigger | `https://github.com/zenml-io/zenml-cloud-plugins/tree/kitaru-<VERSION>` |
-| CHANGELOG on main | `https://github.com/zenml-io/kitaru/blob/main/CHANGELOG.md` |
-
-Mark any post-release follow-ups (social posts, docs sync) as user-driven. The skill is done at this point.
-
----
-
-## Known gotchas
-
-- **Main is force-pushed.** Always diff against the last tag, never against `origin/main`. `git fetch --tags` is mandatory before every invocation.
-- **CHANGELOG PR references drift.** Draft PR numbers get renumbered at merge. Cross-check every `(#N)` against `git log`.
-- **Marketing vs library changelog.** Marketing-site changes now live in `zenml-io-v2`, not this repo. Docs infra changes usually do not belong in the Python library CHANGELOG unless they change user-visible docs behavior.
-- **UI tag default.** The release workflow defaults `kitaru-ui-tag` to the highest stable/full `kitaru-ui-v*` release from `zenml-io/zenml-frontend-monorepo`. Only pass `-f kitaru-ui-tag=kitaru-ui-v<X.Y.Z>` if the user explicitly wants to pin to a specific stable UI. Official releases reject prerelease UI tags. Read `FRONTEND-TESTING.md` before touching this path.
-- **Prerelease UI smoke.** To validate a prerelease UI, use Actions → `UI prerelease smoke` with a required `ui-tag` such as `kitaru-ui-v0.3.0-rc.1`. That workflow sets `KITARU_UI_ALLOW_PRERELEASE=true`, builds/verifies locally, and publishes nothing.
-- **Concurrency group.** `release.yml` has `concurrency: group: release, cancel-in-progress: false` — a second release trigger queues rather than cancels. If something goes wrong mid-release, do not trigger a second run; wait for the first to finish, then reset from the resulting state.
-- **Dry-run environment.** Real publishes use the `pypi` GitHub environment (requires secrets + manual approval); dry-runs use the `dry-run` GitHub environment and skip the `pypi` approval gate. If the user wants a dry-run first, pass `-f dry-run=true` and loop back through Step 9 again for the real run after they approve.
-- **PyPI approval gate (window can be short).** The `pypi` environment has required reviewers (`kitaru-admins` team, `prevent_self_review: false`), so a non-dry-run release pauses at this gate awaiting approval, and will sit in `waiting` indefinitely if nobody approves. But the pending window can be very brief when the triggering user is in `kitaru-admins` and approves immediately in the web UI: in the v0.17.0 release the deployment cleared from `waiting` to `queued` in about 7 seconds, so polling `pending_deployments` every 15-20s never caught it and the publish proceeded. Practical guidance: after dispatch, check `pending_deployments` quickly and repeatedly, but if it comes back empty do NOT conclude there was no gate — read the deployment status history (`gh api repos/zenml-io/kitaru/deployments?environment=pypi`) to confirm it was approved, and ask the user whether they clicked approve in the browser. Only if it genuinely stays `waiting` do you need to drive the approval yourself.
-- **Non-dry-run releases require `RELEASE_GIT_TOKEN` for protected branch pushes.** `release.yml` now fails early if `secrets.RELEASE_GIT_TOKEN` is missing on a real release, before any PyPI/Docker/Helm side effects. The secret is only used for the protected branch pushes to `develop`, `main`, and `release/*`; checkout, GitHub API reads, and the Kitaru repo tag push still use the default `GITHUB_TOKEN`. If a later push step still gets a 403/permission error, check that the token's identity is actually allowed to bypass the `develop`/`main` rulesets and create `release/*` branches. Dry-runs do not require this secret.
-- **Non-dry-run releases require `CLOUD_PLUGINS_REPO_PAT` for the downstream Kitaru Pro trigger.** `release.yml` validates this secret before expensive publish work, pins the current `zenml-io/zenml-cloud-plugins` `main` SHA, and fails early if `refs/tags/kitaru-$VERSION` already exists somewhere else. After Docker and Helm have been published, the workflow creates that tag at the pinned SHA. The secret needs read access to `zenml-cloud-plugins/main` and permission to create Git tags in `zenml-io/zenml-cloud-plugins`. Existing matching tags are treated as recovery-safe and skipped; existing divergent tags fail the release and require manual investigation. Dry-runs do not require this secret and do not create the downstream tag.
-- **All releases require `KITARU_UI_RELEASE_TOKEN` to fetch the UI.** The "Download stable Kitaru UI" step (`scripts/download-ui.sh`) pulls the bundle from the **private** `zenml-io/zenml-frontend-monorepo`, and only sends an auth header when the token is set. A missing/empty secret resolves to an empty string (not a hard error), so the request goes out unauthenticated and the private repo answers `404` → `curl: (22)` → the step dies *before* any publish. The token is a fine-grained PAT with **Contents: read** on the monorepo — and fine-grained PATs **expire**, so a release that worked months ago can fail here later. If you see the 404 at "Download stable Kitaru UI", check the secret exists (`gh secret list -R zenml-io/kitaru`) and that the PAT hasn't expired or hit org pending-approval. This step runs on dry-runs too, so a dry-run catches a missing/expired token safely.
-- **Recovery dispatch skips file mutations.** When `v$VERSION` already exists on origin, the workflow detects this pre-checkout, checks out the tag itself, and skips the "Bump version" / "Update CHANGELOG" / "Update lockfile" / "Commit release changes" steps. This is intentional: `uv lock` is not stable across time (it regenerates `exclude-newer` timestamps and may re-resolve transitive deps if newer versions have been released between the original tag push and the recovery dispatch), so running it would create a commit on top of the tagged SHA and fail the consistency check. Do not re-enable those steps for recovery — the tag is the authoritative identity anchor.
-- **Recovering when the fix is in `release.yml` itself.** If a release fails partway (e.g. after PyPI publish + tag push but before Docker/Helm/main/GitHub-Release) and the fix lives in the workflow file, do **not** commit the fix to `develop`. The "Push release commit to develop" step does a *plain, non-force* push of the bump commit and only succeeds as a fast-forward; advancing `develop` breaks that and the recovery fails one step later. Instead: `git checkout -b fix-branch v$VERSION` (off the tag), commit the workflow fix, push the branch, and dispatch `gh workflow run release.yml --ref fix-branch -f version=$VERSION`. GitHub runs the workflow YAML from the dispatched ref (so it gets your fix) while the recovery logic still checks out the *tag* for the build (so `develop` stays put and the bump commit fast-forwards). All downstream ref/publish steps are idempotent (skip-existing / fast-forward-only / create-or-match), so the recovery picks up exactly where it died. Afterwards, open a normal PR from `fix-branch` into `develop` so the fix lands for future releases.
-- **Editing `release.yml` triggers `zizmor`.** Any change under `.github/workflows/**` fires the path-filtered `zizmor.yml` security scan, which runs `uvx zizmor` **unpinned** (latest). Because it drifts stricter over time and only re-scans on workflow edits, a recovery/fix PR can inherit a *pre-existing* finding it didn't cause (e.g. a floating `# v7` action comment that now needs the exact `# v7.1.0`). Run `just zizmor` locally before pushing any workflow change — `just check` does **not** include zizmor (it runs actionlint, a different tool).
-- **The `prompt-exports/` directory** is commonly untracked in the working tree — ignore it when staging CHANGELOG commits.
-
-## Inputs and outputs reference
-
-Release workflow inputs (`release.yml`):
-
-| Input | Required | Default | Notes |
-|---|---|---|---|
-| `version` | yes | — | Semver without `v` prefix, e.g. `0.4.1` |
-| `kitaru-ui-tag` | no | latest stable/full `kitaru-ui-v*` | Optional stable UI pin, e.g. `kitaru-ui-v0.2.0`; prereleases are rejected |
-| `dry-run` | no | `false` | Skips PyPI/Docker/tag pushes |
-
-Useful state-inspection commands:
-
-```bash
-# What's on develop not yet released
-git log "$(git describe --tags --abbrev=0 origin/main)"..origin/develop --oneline
-
-# Current [Unreleased] CHANGELOG block
-sed -n '/## \[Unreleased\]/,/## \[/p' CHANGELOG.md | head -50
-
-# Active release workflow runs
-gh run list --workflow=release.yml --limit 5 \
-  --json databaseId,status,conclusion,displayTitle,createdAt
-
-# Latest Kitaru UI releases in the frontend monorepo
-gh release list -R zenml-io/zenml-frontend-monorepo --limit 50 \
-  --json tagName,publishedAt,isDraft,isPrerelease \
-  --jq '[.[] | select(.tagName | startswith("kitaru-ui-v"))]'
-```
+Never delete or move a published release tag, overwrite a divergent release branch, or retry a partially published version as though no side effects occurred.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ Only document shipped features.
 
 ## Git, Commits, and PRs
 
-- Default branch is `develop`; all PRs target `develop`.
+- Default branch is `develop`; PRs normally target `develop`. During the v2 migration, v2 feature work may target its explicitly named integration branch.
 - `main` tracks the latest released version only; do not push directly.
 - Use short, imperative commit subjects such as `Add ...` or `Update ...`.
 - Keep commit titles concise, around 50 characters when practical.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ src/kitaru/           # Python package (src layout) — see src/kitaru/AGENTS.md
   server/             # FastAPI server (API, application, domain, adapters layers)
 tests/                # pytest tests — see tests/AGENTS.md
 examples/             # Runnable SDK examples
-docs/                 # Two docs surfaces — see "Documentation surfaces" below
+docs/                 # Three docs surfaces — see "Documentation surfaces" below
   book/               # GitBook source for docs.zenml.io/kitaru (hand-written .md)
   content/docs/       # FumaDocs SDK reference content (generated)
   scripts/            # Node-side doc generation (convert-sdk-docs.mjs)
@@ -77,7 +77,7 @@ durable tracked document.
 
 ## Branching strategy
 
-- **`develop`** is the default branch and the target for all PRs.
+- **`develop`** is the default branch and the normal target for PRs. During the v2 migration, v2 feature work may target its explicitly named integration branch.
 - **`main`** contains only released versions. Updated by force-pushing during releases. Never push directly to `main`.
 - **`release/X.Y.Z`** branches are archival snapshots created during the release process.
 - **Tags** follow `vX.Y.Z` (e.g. `v0.1.0`).
@@ -129,7 +129,7 @@ The server follows a layered architecture (API, application, domain, infrastruct
 ## Commits and PRs
 
 - **Run CI checks locally before committing/pushing.** Always run `just check` and `just test` before pushing to `develop`. All checks must pass locally — do not rely on CI to catch failures. This includes format, lint, typecheck, typos, yaml, actions lint, links, and tests.
-- **Fix pre-existing failures too.** If `just check` or `just test` surfaces failures that predate your changes, fix them rather than ignoring them. Other people may be working in the same repo, so not every failure is yours — but don't default to "not my problem." Ask the user if unsure whether a failure should be addressed in this commit.
+- **Keep pre-existing failures separate.** If `just check` or `just test` surfaces a failure unrelated to the requested change, diagnose and report it. Fix it only when it blocks the scoped change or the user explicitly approves expanding the task; do not absorb another contributor's work into the current commit by default.
 - **Commits:** Imperative mood, concise summary (50 chars or less): "Add feature" not "Added feature". Explain *why* in the body (blank line after summary), reference issues when applicable (`Fixes #1234`).
 - **Bug fixes:** Always add a regression test that would have caught the bug. Understand root cause before implementing the fix.
 - **PRs:** Human-readable titles (no "feat:"/"doc:" prefixes). Write comprehensive descriptions: what the changes do, why they're needed, key implementation decisions, and areas needing reviewer attention.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -39,11 +39,9 @@ Python tooling except for the generated reference content. The static export in
 
 ## Deploying sdkdocs.kitaru.ai
 
-**Automatic (the normal path):** the `SDK Reference Docs` workflow
-(`.github/workflows/docs.yml`) regenerates the SDK reference, builds the
-static export, and tests the redirect worker on every run. It `wrangler deploy`s
-the reference site to `kitaru-sdkdocs`, then deploys the `kitaru-site` redirect
-worker, only on:
+**Intended automatic path:** the `SDK Reference Docs` workflow (`.github/workflows/docs.yml`) is configured to regenerate the SDK reference, build the static export, and test the redirect worker. At this v2 baseline, `scripts/generate_sdk_docs.py` has not been restored, so the workflow cannot complete its reference-generation step. Treat SDK reference deployment as blocked until a v2 generator lands; do not copy the deleted v1 generator without reviewing the v2 public SDK surface.
+
+Once that blocker is resolved, deployment is limited to:
 
 - **push to `main`** (i.e. at release time), and
 - **manual `workflow_dispatch`** (Actions → "SDK Reference Docs" → Run workflow)
@@ -51,13 +49,10 @@ worker, only on:
 
 PRs build and test only; they do not deploy or create preview Workers. The workflow does not run `scripts/generate_changelog_docs.py`; public changelog traffic is handled by the redirect worker.
 
-**Manual (from a clone, needs Cloudflare creds via `wrangler login`):**
+**Manual redirect-only deployment** requires Cloudflare credentials through `wrangler login`. Do not deploy the SDK reference app manually while the v2 generator is absent.
 
 ```bash
-# from repo root — regenerate reference, build, deploy
-uv run python scripts/generate_sdk_docs.py
-cd docs && node scripts/convert-sdk-docs.mjs && pnpm run build && cd ..
-npx wrangler deploy                                   # SDK site -> sdkdocs.kitaru.ai
+# from repo root
 npx wrangler deploy --config wrangler.redirect.toml   # kitaru.ai/docs redirect worker
 ```
 
@@ -68,25 +63,14 @@ changes when redirect rules in `docs/worker/redirect.mjs` change.
 
 - **Never add Node.js tooling to the repo root.** No root `package.json`,
   no root `node_modules`, no workspace config.
-- **Never hand-edit generated files:** `content/docs/changelog.mdx` and
-  `content/docs/reference/` are created by
-  generation scripts and gitignored. The public changelog is hosted at
-  `docs.zenml.io/changelog`; the local `changelog.mdx` is only generated for
-  local/reference builds. SDK reference uses a two-step pipeline:
-  `scripts/generate_sdk_docs.py` (Python extraction) + `docs/scripts/convert-sdk-docs.mjs`
-  (Node MDX conversion via fumadocs-python).
+- **Never hand-edit generated files:** `content/docs/changelog.mdx` and `content/docs/reference/` are generated and gitignored. The public changelog is hosted at `docs.zenml.io/changelog`; the local `changelog.mdx` is only for local/reference builds. The Node conversion remains in `docs/scripts/convert-sdk-docs.mjs`, but its v2 Python input generator is currently absent. Do not present `just generate-docs` or docs CI as healthy until that generator is restored and verified against the v2 SDK.
 - **CLI contracts remain offline:** command metadata lives under `src/kitaru/cli/` and is exposed through `kitaru schema`; user-facing CLI reference publishing is deferred.
 - **Respect static export constraints:** No server-side features (middleware,
   rewrites, cookies, ISR). All content must be buildable at build time.
 - **Only document shipped features.** No "Coming Soon" sections for unimplemented
   features. Every page must describe something a user can actually use today.
-- **ZenML invisibility:** Users should never need to know Kitaru is built on
-  ZenML underneath. Never say "orchestrator", "artifact store", or "pipeline"
-  in user-facing docs — use Kitaru terminology (workflow, checkpoint, storage).
-- **Secret docs must stay honest:** only `kitaru.llm()` auto-resolves
-  alias-linked secrets today. If you need to document non-LLM secret access,
-  keep it in a clearly marked advanced or low-level note instead of implying a
-  first-class Kitaru helper exists.
+- **Use v2 product terminology:** describe sessions, nodes, agents, cohorts, experiments, evaluations, jobs, tasks, workers, and replays as the current source and API models define them. Do not import v1 flow, checkpoint, stack, model-alias, or ZenML runtime terminology into v2 docs.
+- **Secret docs must stay honest:** derive secret behavior from the current v2 API models, client resource, routes, and authorization tests. Do not imply that a v1 model-alias or LLM helper exists in v2.
 - **Frontmatter required:** Every `.mdx` page needs `title` and `description`.
 
 ## Content Structure
@@ -115,7 +99,6 @@ These are registered globally in `mdx-components.tsx`:
 
 ```bash
 # From repo root:
-just generate-docs  # Generate changelog + SDK reference docs (run first on fresh clone)
 just docs           # Start dev server at localhost:3000
 just docs-build     # Full static build
 just docs-validate  # Validate the static export as served under /docs
@@ -128,13 +111,7 @@ pnpm run lint       # Biome lint
 pnpm run format     # Biome format
 ```
 
-**Important:** Generated content (the local/reference changelog page and SDK reference) is gitignored.
-On a fresh clone, run `just generate-docs` before `just docs` or `just docs-build`,
-otherwise generated pages will be missing from the sidebar. The deployed public
-changelog still lives at `docs.zenml.io/changelog`; the generated
-`changelog.mdx` here is not the public changelog source. SDK reference
-generation requires `fumapy` — `just generate-docs` auto-installs it from
-`docs/node_modules/fumadocs-python` (requires `pnpm install` in `docs/` first).
+**Important:** Generated content (the local/reference changelog page and SDK reference) is gitignored. Fresh clones cannot currently generate the SDK reference because the v2 Python generator is absent. `just docs`, `just docs-build`, and `just docs-validate` can operate on the available app content, but the full reference sidebar and deployment remain blocked until a reviewed v2 generator lands. The deployed public changelog still lives at `docs.zenml.io/changelog`; the generated `changelog.mdx` here is not the public changelog source.
 
 ## File Responsibilities
 
@@ -156,13 +133,12 @@ this FumaDocs reference app, and generated output).
 - Hand-written docs are **GitBook Markdown under `docs/book/`** (not MDX). Edit those `.md` files directly and add new pages to `docs/book/toc.md`. GitBook conventions live in `docs/book/AGENTS.md`.
 - Links **within the GitBook space** use relative `.md` paths (e.g. `../concepts/checkpoints.md`, `flows.md#runtime-options`). Link to the **SDK reference** with `https://sdkdocs.kitaru.ai` (the separate reference site, not in the GitBook space). Link to **other ZenML docs** with absolute `https://docs.zenml.io/...`. Diagrams are static PNG images hosted on Cloudflare R2 and referenced as `https://assets.kitaru.ai/docs/diagrams/<slug>.png` (regenerate via the diagram pipeline, not committed to the repo).
 - Do not commit temporary agent planning/review files such as `docs/plans/*`, `docs/reviews/*`, or prompt exports unless the user explicitly asks for a durable tracked document. Treat them as coordination scratchpads, not product docs.
-- Generated reference output should still come from the existing generation scripts rather than manual edits.
+- Generated reference output must come from reviewed generation scripts rather than manual edits. The v2 Python generator is currently absent, so do not claim that fresh SDK reference output can be generated yet.
 
 ### Accuracy rules for what we describe
 
 - Treat `KITARU_*` environment variables as the public configuration surface in docs and examples. Mention `ZENML_*` only as a compatibility note when needed.
-- `kitaru model register` still writes aliases to local config, but submitted/replayed runs automatically receive a transported registry snapshot via `KITARU_MODEL_REGISTRY`. Describe `kitaru model list` as listing aliases available in the current environment, not just aliases stored locally.
 - Agent-facing CLI docs should describe the version-1 structured contract: success documents include `schema_version`, `command`, `ok`, `warnings`, `links`, and `next_actions`, plus `item` or `items`, `count`, and `page`; streaming commands emit JSONL events.
 - Login docs/guidance should treat `kitaru login SERVER` as managed or self-hosted login and `kitaru login --local` as targeting an already-running server at `http://localhost:8000`; login never starts a server.
-- Only `kitaru.llm()` auto-resolves alias-linked secrets today. If you need to document non-LLM secret access, present it as the current low-level pattern rather than implying a public Kitaru helper already exists.
-- Current shipped stack-create types on the CLI/MCP surface are `local`, `kubernetes`, `vertex`, `sagemaker`, and `azureml`. Advanced CLI/MCP stack creation also supports `--extra` / structured `extra` plus the remote-only `--async` / `async_mode` convenience flag. The public Python SDK `kitaru.create_stack(...)` still provisions local stacks only, so docs should keep that distinction explicit.
+- Treat `src/kitaru/cli/app.py`, the offline `kitaru schema` output, and the generated OpenAPI document as the command and API authorities. Do not document v1 runtime commands such as `kitaru init`, `kitaru stack`, `kitaru model`, or `kitaru executions` unless they are reintroduced in v2 source and tests.
+- Native MCP documentation must match `tests/mcp/snapshots/metrics.json` and `src/kitaru/mcp/registry.py`. Do not copy tool counts into prose; run `just mcp-schema-check` and describe the tools present in the current snapshot. The native v2 MCP server does not expose stack or model-alias management.

--- a/docs/book/AGENTS.md
+++ b/docs/book/AGENTS.md
@@ -6,7 +6,7 @@ Edit these `.md` files directly — they are the source of truth for hand-writte
 docs.
 
 Do **not** put hand-written docs in `docs/content/docs/` — that is the
-reference-only FumaDocs app (generated CLI + SDK reference, served at
+reference-only FumaDocs app (generated SDK reference, served at
 `sdkdocs.kitaru.ai`).
 
 ## Adding & editing pages
@@ -33,7 +33,7 @@ reference-only FumaDocs app (generated CLI + SDK reference, served at
 
 - **Within this space:** relative `.md` paths — `../concepts/checkpoints.md`,
   `flows.md#runtime-options`. Section index → `../concepts/README.md`.
-- **SDK / CLI reference:** `https://sdkdocs.kitaru.ai` — the separate reference
+- **SDK reference:** `https://sdkdocs.kitaru.ai` — the separate reference
   site, not part of this GitBook space.
 - **Other ZenML docs:** absolute `https://docs.zenml.io/...`.
 - **Changelog:** `https://docs.zenml.io/changelog` (owned by the changelog repo).
@@ -64,6 +64,5 @@ regenerate.
 
 ## Style
 
-- Keep **Kitaru product terminology** (flow, checkpoint, stack, deployment) — do
-  not rewrite into ZenML internals (pipeline, step, orchestrator).
+- Keep **current Kitaru v2 terminology** (session, node, agent version, cohort, experiment, evaluation, job, task, worker, replay). Do not copy v1 flow, checkpoint, stack, deployment, or ZenML runtime terminology into new pages.
 - US English. Only document shipped features.

--- a/src/kitaru/AGENTS.md
+++ b/src/kitaru/AGENTS.md
@@ -1,16 +1,19 @@
 # Kitaru package rules
 
-The package has five independent top-level parts. `client` and `server` never
-import each other and both sit on `api_models`, `analytics`, and `transport`.
-import-linter enforces this, along with the server layering (adapters above
-application above domain).
+The import-linter contract covers five shared/runtime parts. `client` and `server` never import each other and both sit on `api_models`, `analytics`, and `transport`. Import-linter enforces this, along with the server layering (adapters above application above domain).
 
 - `analytics/`: Async analytics client and event source tracking.
 - `api_models/`: Versioned request and response DTOs shared by server and SDK.
 - `transport.py`: Retrying HTTP transport shared by every outbound client.
 - `client/`: Async SDK making REST calls.
-- `server/`: FastAPI server in layers (API, application, domain,
-  infrastructure adapters).
+- `server/`: FastAPI server in layers (API, application, domain, infrastructure adapters).
+
+The package also has four first-class delivery surfaces outside that five-part contract:
+
+- `cli/`: Optional Cyclopts CLI and structured output rendering.
+- `mcp/`: Optional native MCP server and capability-filtered tool registry.
+- `task/`: Importer and evaluator task subprocess entrypoints.
+- `worker/`: Worker lifecycle, task dispatch, and task handlers.
 
 Module naming: modules that define per-entity types are singular
 (`domain/order.py`, `orm/order.py`, `application/models/order.py`,


### PR DESCRIPTION
## What changed?

Kitaru's always-loaded repository instructions and repo-local skills now describe the shipped v2 CLI, MCP, SDK, documentation, test, and release surfaces. They no longer direct agents to removed v1 setup, stack, model-alias, live-provider, or release-smoke workflows.

The guidance now points agents to `kitaru schema`, the MCP registry and snapshot, current source paths, and current workflow files as live authorities. It also records the missing SDK reference generator and inherited broken Justfile/workflow recipes as blockers instead of presenting them as healthy commands.

## Why?

The old guidance mixed v2 behavior with v1 commands such as `kitaru init`, nonexistent extras such as `local`, obsolete test markers, and removed release scripts. Agents following it could fail during setup, write incorrect CLI tests, document unshipped APIs, or treat broken release checks as evidence.

## Reviewer Notes

Start with the five files under `.agents/skills/` and `.claude/skills/`. They contain the main behavior change for future agents. `AGENTS.md`, `CLAUDE.md`, `docs/CLAUDE.md`, `docs/book/AGENTS.md`, and `src/kitaru/AGENTS.md` align the always-loaded instruction chain with those skills.

The important boundary is that this PR fixes guidance only. It does not repair the inherited `llm-integration.yml`, missing `scripts/generate_sdk_docs.py`, or dead Justfile recipes that still reference removed v1 files. The refreshed guidance names those gaps explicitly so later work does not mistake them for working v2 paths.

## Reproduction

1. Run `uv run --extra cli kitaru schema --output json --machine --non-interactive --no-browser` and compare the command inventory with the refreshed CLI guidance.
2. Run `just mcp-schema-check` and confirm the refreshed MCP guidance relies on the registry and committed snapshot instead of copied tool counts.
3. Search the changed instruction files for `kitaru init`, `--extra local`, `live_llm`, `scripts/smoke-test.sh`, and `scripts/generate_sdk_docs.py`. Each remaining match should explicitly identify removed or blocked v1 behavior, not prescribe it.

## Local checks run

- `just check`
- `just test` (2,559 passed, 503 skipped)
- `just mcp-schema-check`
- `uv run --extra cli kitaru schema --output json --machine --non-interactive --no-browser`
- Repo skill validation for all five changed `SKILL.md` files
- Independent correctness, project-standards, agent-native, and fix-validation reviews
- `git diff --check`

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this PR changes only repository guidance. After merge, the owner should watch the first agent-driven development or release task for attempts to use a command marked removed or blocked; any such attempt means the instruction chain still contains stale advice and the guidance should be corrected or the underlying recipe repaired.
