### PR TITLE
Reduce database lock contention on the task execution path

### DIFF
--- a/src/kitaru/server/adapters/db/orm/agent_version.py
+++ b/src/kitaru/server/adapters/db/orm/agent_version.py
@@ -40,7 +40,6 @@ AGENT_VERSION_AGENT_ID_VERSION_UNIQUE_CONSTRAINT = unique_constraint_name(
 )
 AGENT_VERSION_AGENT_ID_FOREIGN_KEY = foreign_key_name("agent_version", ["agent_id"])
 AGENT_VERSION_OWNER_ID_FOREIGN_KEY = foreign_key_name("agent_version", ["owner_id"])
-AGENT_VERSION_AGENT_ID_INDEX = index_name("agent_version", ["agent_id"])
 AGENT_VERSION_OWNER_ID_INDEX = index_name("agent_version", ["owner_id"])
 
 
@@ -58,7 +57,6 @@ class AgentVersionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         ForeignKeyConstraint(
             ["owner_id"], ["account.id"], name=AGENT_VERSION_OWNER_ID_FOREIGN_KEY
         ),
-        Index(AGENT_VERSION_AGENT_ID_INDEX, "agent_id"),
         Index(AGENT_VERSION_OWNER_ID_INDEX, "owner_id"),
     )
 

--- a/src/kitaru/server/adapters/db/orm/annotation.py
+++ b/src/kitaru/server/adapters/db/orm/annotation.py
@@ -44,9 +44,6 @@ ANNOTATION_INVESTIGATION_SESSION_ID_QUESTION_KEY_UNIQUE_CONSTRAINT = (
 )
 ANNOTATION_OWNER_ID_INDEX = index_name("annotation", ["owner_id"])
 ANNOTATION_SESSION_ID_INDEX = index_name("annotation", ["session_id"])
-ANNOTATION_INVESTIGATION_SESSION_ID_INDEX = index_name(
-    "annotation", ["investigation_session_id"]
-)
 
 
 class AnnotationORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -76,7 +73,6 @@ class AnnotationORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         ),
         Index(ANNOTATION_OWNER_ID_INDEX, "owner_id"),
         Index(ANNOTATION_SESSION_ID_INDEX, "session_id"),
-        Index(ANNOTATION_INVESTIGATION_SESSION_ID_INDEX, "investigation_session_id"),
     )
 
     owner_id: Mapped[uuid.UUID]

--- a/src/kitaru/server/adapters/db/repositories/task_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/task_repository.py
@@ -329,14 +329,19 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
 
     async def stamp_heartbeats(
         self, task_ids: Sequence[uuid.UUID], worker_id: uuid.UUID, now: datetime
-    ) -> dict[uuid.UUID, datetime | None]:
+    ) -> tuple[dict[uuid.UUID, datetime | None], set[uuid.UUID]]:
         """Stamp heartbeat_at on the worker's in-flight tasks among the ids.
 
         Writes only the heartbeat column, so a stamp cannot overwrite fields
         concurrent writers committed since the caller last read the tasks.
-        Task rows are locked in id order. The owning job row is joined for
-        its own cancel request, which reaches a task before the sweep stamps
-        it, and joining leaves that row unlocked.
+        Candidates are read unlocked first, then locked in id order with
+        ``SKIP LOCKED``, so a row a settlement transaction is mid-mutation on
+        is left unstamped for this tick rather than waited on. The candidate
+        filter is re-applied on the locked row, so a row that turns terminal
+        in the gap between the two reads lands in neither set rather than
+        being wrongly stamped. The owning job row is joined for its own
+        cancel request, which reaches a task before the sweep stamps it, and
+        joining leaves that row unlocked.
 
         Args:
             task_ids: Candidate task ids.
@@ -345,19 +350,31 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
 
         Returns:
             Cancel request time of the task, falling back to its job's, by id
-            for every stamped task.
+            for every stamped task, and the owned in-flight candidates whose
+            lock was held elsewhere and so were left unstamped.
         """
         if not task_ids:
-            return {}
+            return {}, set()
+        candidate_filter = (
+            TaskORM.worker_id == worker_id,
+            TaskORM.status.in_(IN_FLIGHT_STATUS_VALUES),
+        )
+        candidate_ids = set(
+            (
+                await self._session.scalars(
+                    select(TaskORM.id).where(
+                        TaskORM.id.in_(list(task_ids)), *candidate_filter
+                    )
+                )
+            ).all()
+        )
+        if not candidate_ids:
+            return {}, set()
         locked = (
             select(TaskORM.id)
-            .where(
-                TaskORM.id.in_(list(task_ids)),
-                TaskORM.worker_id == worker_id,
-                TaskORM.status.in_(IN_FLIGHT_STATUS_VALUES),
-            )
+            .where(TaskORM.id.in_(candidate_ids), *candidate_filter)
             .order_by(TaskORM.id.asc())
-            .with_for_update()
+            .with_for_update(skip_locked=True)
         )
         statement = (
             update(TaskORM)
@@ -371,7 +388,10 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         )
         rows = (await self._session.execute(statement)).all()
         await self._session.flush()
-        return {task_id: cancel_requested_at for task_id, cancel_requested_at in rows}
+        stamped = {
+            task_id: cancel_requested_at for task_id, cancel_requested_at in rows
+        }
+        return stamped, candidate_ids - stamped.keys()
 
     async def lock_by_jobs(
         self, job_ids: Sequence[uuid.UUID], nowait: bool = False

--- a/src/kitaru/server/api/app.py
+++ b/src/kitaru/server/api/app.py
@@ -21,6 +21,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
 from kitaru.analytics.client import AnalyticsClient
 from kitaru.analytics.source import (
@@ -152,6 +153,26 @@ def _register_deadlock_exception_handler(app: FastAPI) -> None:
         return JSONResponse(status_code=503, content={"detail": "Deadlock detected"})
 
 
+def _register_pool_timeout_exception_handler(app: FastAPI) -> None:
+    """Register the JSON error response for an exhausted connection pool.
+
+    Clients receive HTTP 503 with the usual ``detail`` message.
+
+    Args:
+        app: FastAPI application that will serve the v1 API.
+    """
+
+    @app.exception_handler(SQLAlchemyTimeoutError)
+    async def pool_timeout(
+        request: Request, exc: SQLAlchemyTimeoutError
+    ) -> JSONResponse:
+        _ = request
+        _ = exc
+        return JSONResponse(
+            status_code=503, content={"detail": "Database connection pool exhausted"}
+        )
+
+
 def _register_token_grant_exception_handler(app: FastAPI) -> None:
     """Register the OAuth 2.0 error response for a failed token grant.
 
@@ -258,6 +279,7 @@ def create_app(settings: APISettings) -> FastAPI:
     app.state.control_plane_client = None
     _register_domain_exception_handlers(app)
     _register_deadlock_exception_handler(app)
+    _register_pool_timeout_exception_handler(app)
     _register_token_grant_exception_handler(app)
     app.middleware("http")(_set_analytics_source)
     # FastAPIInstrumentor registers its middleware last, which makes the

--- a/src/kitaru/server/api/composition.py
+++ b/src/kitaru/server/api/composition.py
@@ -97,7 +97,6 @@ def register_subscribers(
             replay_pipeline.append_result_evaluations,
             replay_repository=replay_repository,
             experiment_repository=experiment_repository,
-            job_repository=job_repository,
             task_repository=task_repository,
         ),
     )

--- a/src/kitaru/server/application/interfaces/task_repository.py
+++ b/src/kitaru/server/application/interfaces/task_repository.py
@@ -183,11 +183,13 @@ class TaskRepository(Protocol):
 
     async def stamp_heartbeats(
         self, task_ids: Sequence[uuid.UUID], worker_id: uuid.UUID, now: datetime
-    ) -> dict[uuid.UUID, datetime | None]:
+    ) -> tuple[dict[uuid.UUID, datetime | None], set[uuid.UUID]]:
         """Stamp heartbeat_at on the worker's in-flight tasks among the ids.
 
         Writes only the heartbeat column, so a stamp cannot overwrite fields
-        concurrent writers committed since the caller last read the tasks.
+        concurrent writers committed since the caller last read the tasks. A
+        row locked by another open transaction is left unstamped rather than
+        waited on.
 
         Args:
             task_ids: Candidate task ids.
@@ -196,7 +198,8 @@ class TaskRepository(Protocol):
 
         Returns:
             Cancel request time of the task, falling back to its job's, by id
-            for every stamped task.
+            for every stamped task, and the owned in-flight candidates whose
+            lock was held elsewhere and so were left unstamped.
         """
         ...
 

--- a/src/kitaru/server/application/services/job_service.py
+++ b/src/kitaru/server/application/services/job_service.py
@@ -53,13 +53,40 @@ AGENT_VERSION_LABEL = "agent_version"
 SESSION_NAME_ENV = "KITARU_SESSION_NAME"
 
 
+async def add_tasks(
+    tasks: list[Task], repository: JobRepository, task_repository: TaskRepository
+) -> list[Task]:
+    """Append many tasks to an unsettled job under one job row lock.
+
+    Shared with the replay pipeline, which appends tasks to a replay's job
+    from outside the request that created it. Every task must belong to the
+    same job, so the settled check taken under the one lock covers all of
+    them.
+
+    Args:
+        tasks: Tasks to append, every one belonging to the same job.
+        repository: Job repository.
+        task_repository: Task repository.
+
+    Raises:
+        JobNotFound: No job has the tasks' job id.
+        JobAlreadySettled: The job already reached a terminal status.
+
+    Returns:
+        Created tasks, in the given order.
+    """
+    if not tasks:
+        return []
+    job = await repository.get(tasks[0].job_id, exclusive=True)
+    if job.settled:
+        raise JobAlreadySettled(job.id)
+    return [await task_repository.create(task) for task in tasks]
+
+
 async def add_task(
     task: Task, repository: JobRepository, task_repository: TaskRepository
 ) -> Task:
     """Append a task to an unsettled job.
-
-    Shared with the replay pipeline, which appends tasks to a replay's job
-    from outside the request that created it.
 
     Args:
         task: Task to append.
@@ -73,10 +100,8 @@ async def add_task(
     Returns:
         Created task.
     """
-    job = await repository.get(task.job_id, exclusive=True)
-    if job.settled:
-        raise JobAlreadySettled(job.id)
-    return await task_repository.create(task)
+    created = await add_tasks([task], repository, task_repository)
+    return created[0]
 
 
 class JobService:

--- a/src/kitaru/server/application/services/replay_pipeline.py
+++ b/src/kitaru/server/application/services/replay_pipeline.py
@@ -31,7 +31,6 @@ from kitaru.server.application.interfaces.job_repository import JobRepository
 from kitaru.server.application.interfaces.replay_repository import ReplayRepository
 from kitaru.server.application.interfaces.task_repository import TaskRepository
 from kitaru.server.application.models.auth import AuthContext
-from kitaru.server.application.services.job_service import add_tasks
 from kitaru.server.domain.job import Job
 from kitaru.server.domain.replay import Replay
 from kitaru.server.domain.replay_config import ReplayConfig, effective_inputs
@@ -129,21 +128,21 @@ async def append_result_evaluations(
     event: TaskTerminal,
     replay_repository: ReplayRepository,
     experiment_repository: ExperimentRepository,
-    job_repository: JobRepository,
     task_repository: TaskRepository,
 ) -> None:
     """Append the replay's result evaluator tasks when its agent task completes.
 
     A no-op when the terminal task is not an agent task, did not complete, or
-    does not belong to a replay's job. The evaluator tasks are built before
-    the job row is locked, so the lock only spans the settled check and the
-    inserts it guards.
+    does not belong to a replay's job. Inserts the evaluator tasks without
+    locking the job row. The completing task's own transition settles the
+    job afterward, in the same transaction, and its drained scan reads every
+    task including these, so the job can never be judged drained before they
+    exist.
 
     Args:
         event: TaskTerminal event.
         replay_repository: Replay repository.
         experiment_repository: Experiment repository, for the replay config.
-        job_repository: Job repository.
         task_repository: Task repository.
     """
     task = event.task
@@ -165,7 +164,7 @@ async def append_result_evaluations(
         for evaluator in config.evaluators
     ]
     if evaluator_tasks:
-        await add_tasks(evaluator_tasks, job_repository, task_repository)
+        await task_repository.create_many(evaluator_tasks)
     replay.start_evaluating()
     await replay_repository.update(replay)
 

--- a/src/kitaru/server/application/services/replay_pipeline.py
+++ b/src/kitaru/server/application/services/replay_pipeline.py
@@ -31,7 +31,7 @@ from kitaru.server.application.interfaces.job_repository import JobRepository
 from kitaru.server.application.interfaces.replay_repository import ReplayRepository
 from kitaru.server.application.interfaces.task_repository import TaskRepository
 from kitaru.server.application.models.auth import AuthContext
-from kitaru.server.application.services.job_service import add_task
+from kitaru.server.application.services.job_service import add_tasks
 from kitaru.server.domain.job import Job
 from kitaru.server.domain.replay import Replay
 from kitaru.server.domain.replay_config import ReplayConfig, effective_inputs
@@ -135,7 +135,9 @@ async def append_result_evaluations(
     """Append the replay's result evaluator tasks when its agent task completes.
 
     A no-op when the terminal task is not an agent task, did not complete, or
-    does not belong to a replay's job.
+    does not belong to a replay's job. The evaluator tasks are built before
+    the job row is locked, so the lock only spans the settled check and the
+    inserts it guards.
 
     Args:
         event: TaskTerminal event.
@@ -152,18 +154,18 @@ async def append_result_evaluations(
         return
     config = await experiment_repository.get_replay_config(replay.replay_config_id)
     assert task.result_session_id is not None
-    for evaluator in config.evaluators:
-        await add_task(
-            EvaluationTask(
-                job_id=task.job_id,
-                plugin_version_id=evaluator.evaluator_version_id,
-                input_session_id=task.result_session_id,
-                params=evaluator.params,
-                on_failure=TaskOnFailure.ABORT,
-            ),
-            job_repository,
-            task_repository,
+    evaluator_tasks: list[Task] = [
+        EvaluationTask(
+            job_id=task.job_id,
+            plugin_version_id=evaluator.evaluator_version_id,
+            input_session_id=task.result_session_id,
+            params=evaluator.params,
+            on_failure=TaskOnFailure.ABORT,
         )
+        for evaluator in config.evaluators
+    ]
+    if evaluator_tasks:
+        await add_tasks(evaluator_tasks, job_repository, task_repository)
     replay.start_evaluating()
     await replay_repository.update(replay)
 

--- a/src/kitaru/server/application/services/task_service.py
+++ b/src/kitaru/server/application/services/task_service.py
@@ -140,7 +140,9 @@ class TaskService:
 
         A reported task the caller no longer owns, that no longer exists, that
         already reached a terminal status, or whose cancellation was requested
-        on the task or on its job comes back for the worker to stop.
+        on the task or on its job comes back for the worker to stop. A task
+        the caller owns and is in flight but whose row a settlement
+        transaction holds locked keeps running, unstamped for this tick.
 
         Args:
             worker_id: Id of the reporting worker.
@@ -162,9 +164,13 @@ class TaskService:
             raise WorkerAccessDenied(worker_id)
         now = datetime.now(UTC)
         await self._workers.update_last_seen_at(worker_id, now)
-        stamped = await self._repository.stamp_heartbeats(task_ids, worker_id, now)
+        stamped, skipped = await self._repository.stamp_heartbeats(
+            task_ids, worker_id, now
+        )
         cancel_task_ids: list[uuid.UUID] = []
         for task_id in task_ids:
+            if task_id in skipped:
+                continue
             if task_id not in stamped or stamped[task_id] is not None:
                 cancel_task_ids.append(task_id)
         return cancel_task_ids

--- a/src/kitaru/server/application/services/task_transitions.py
+++ b/src/kitaru/server/application/services/task_transitions.py
@@ -82,7 +82,10 @@ class TaskTransitions:
         The ordered sequence runs inside the caller's transaction: the
         transition is persisted, a terminal status publishes ``TaskTerminal``
         so subscribers can append work before the job is checked, and the job
-        advances afterward, publishing ``JobsSettled`` when it settles.
+        advances afterward, publishing ``JobsSettled`` when it settles. A
+        non-terminal transition (running, requeued) never drains the job and
+        never trips its abort-on-hard-failure check, so it skips the job row
+        lock entirely.
 
         Args:
             task: Task to transition.
@@ -96,9 +99,10 @@ class TaskTransitions:
             Stored task carrying its new status.
         """
         stored = await self._write_transition(task, transition)
+        if not stored.terminal:
+            return stored
         job = await self.advance_job(stored.job_id)
-        if stored.terminal:
-            self._track_task_terminal(stored, job)
+        self._track_task_terminal(stored, job)
         return stored
 
     async def _write_transition(

--- a/src/kitaru/server/database/migrations/versions/001_initial.py
+++ b/src/kitaru/server/database/migrations/versions/001_initial.py
@@ -296,7 +296,6 @@ def upgrade() -> None:
         ),
     )
     with op.batch_alter_table("agent_version", schema=None) as batch_op:
-        batch_op.create_index("ix_agent_version_agent_id", ["agent_id"], unique=False)
         batch_op.create_index("ix_agent_version_owner_id", ["owner_id"], unique=False)
 
     op.create_table(
@@ -973,11 +972,6 @@ def upgrade() -> None:
         ),
     )
     with op.batch_alter_table("annotation", schema=None) as batch_op:
-        batch_op.create_index(
-            "ix_annotation_investigation_session_id",
-            ["investigation_session_id"],
-            unique=False,
-        )
         batch_op.create_index("ix_annotation_owner_id", ["owner_id"], unique=False)
         batch_op.create_index("ix_annotation_session_id", ["session_id"], unique=False)
 
@@ -987,7 +981,6 @@ def downgrade() -> None:
     with op.batch_alter_table("annotation", schema=None) as batch_op:
         batch_op.drop_index("ix_annotation_session_id")
         batch_op.drop_index("ix_annotation_owner_id")
-        batch_op.drop_index("ix_annotation_investigation_session_id")
 
     op.drop_table("annotation")
     with op.batch_alter_table("investigation_session", schema=None) as batch_op:
@@ -1068,7 +1061,6 @@ def downgrade() -> None:
     op.drop_table("cohort")
     with op.batch_alter_table("agent_version", schema=None) as batch_op:
         batch_op.drop_index("ix_agent_version_owner_id")
-        batch_op.drop_index("ix_agent_version_agent_id")
 
     op.drop_table("agent_version")
     with op.batch_alter_table("worker", schema=None) as batch_op:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4982,8 +4982,11 @@ class FakeTaskRepository:
 
     async def stamp_heartbeats(
         self, task_ids: Sequence[uuid.UUID], worker_id: uuid.UUID, now: datetime
-    ) -> dict[uuid.UUID, datetime | None]:
+    ) -> tuple[dict[uuid.UUID, datetime | None], set[uuid.UUID]]:
         """Stamp heartbeat_at on the worker's in-flight tasks among the ids.
+
+        Row locking has no in-memory counterpart, so no candidate is ever
+        reported skipped.
 
         Args:
             task_ids: Candidate task ids.
@@ -4992,7 +4995,8 @@ class FakeTaskRepository:
 
         Returns:
             Cancel request time of the task, falling back to its job's, by id
-            for every stamped task.
+            for every stamped task, and the owned in-flight candidates whose
+            lock was held elsewhere and so were left unstamped.
         """
         stamped: dict[uuid.UUID, datetime | None] = {}
         for task_id in task_ids:
@@ -5014,7 +5018,7 @@ class FakeTaskRepository:
                 owner = (await self.jobs.get_many([task.job_id])).get(task.job_id)
                 if owner is not None:
                     stamped[task_id] = owner.cancel_requested_at
-        return stamped
+        return stamped, set()
 
     async def lock_by_jobs(
         self, job_ids: Sequence[uuid.UUID], nowait: bool = False

--- a/tests/server/test_pool_timeout_handler.py
+++ b/tests/server/test_pool_timeout_handler.py
@@ -1,0 +1,59 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for the pool timeout exception handler."""
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+
+from conftest import local_settings
+from kitaru.server.api.app import create_app
+
+
+def create_app_with_error_probes() -> FastAPI:
+    """Create the app with extra routes raising database errors."""
+    app = create_app(local_settings())
+
+    @app.get("/probe-pool-timeout")
+    async def raise_pool_timeout() -> None:
+        """Raise a database error caused by an exhausted connection pool."""
+        raise SQLAlchemyTimeoutError(
+            "QueuePool limit of size 5 overflow 10 reached, connection timed out"
+        )
+
+    @app.get("/probe-sqlalchemy-error")
+    async def raise_sqlalchemy_error() -> None:
+        """Raise a database error unrelated to pool exhaustion."""
+        raise SQLAlchemyError("generic database error")
+
+    return app
+
+
+async def test_pool_timeout_maps_to_503() -> None:
+    """Turn an exhausted connection pool into HTTP 503."""
+    transport = httpx.ASGITransport(app=create_app_with_error_probes())
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/probe-pool-timeout")
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Database connection pool exhausted"}
+
+
+async def test_other_sqlalchemy_errors_propagate() -> None:
+    """Leave a database error without a pool timeout cause unhandled."""
+    transport = httpx.ASGITransport(app=create_app_with_error_probes())
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        with pytest.raises(SQLAlchemyError):
+            await client.get("/probe-sqlalchemy-error")

--- a/tests/server/test_task_repository.py
+++ b/tests/server/test_task_repository.py
@@ -20,6 +20,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, NamedTuple
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from conftest import (
@@ -33,6 +34,7 @@ from kitaru.api_models.v1.filter import FilterOp
 from kitaru.api_models.v1.job import JobKind
 from kitaru.api_models.v1.task import TaskKind, TaskStatus
 from kitaru.api_models.v1.worker import LabelSelector, WorkerRuntime, WorkerScope
+from kitaru.server.adapters.db.orm.task import TaskORM
 from kitaru.server.adapters.db.repositories.account_repository import (
     SQLAccountRepository,
 )
@@ -514,7 +516,7 @@ async def test_stamp_heartbeats_writes_only_the_heartbeat_column(
     stored_completed = await setup.tasks.create(completed)
 
     now = datetime.now(UTC)
-    stamped = await setup.tasks.stamp_heartbeats(
+    stamped, skipped = await setup.tasks.stamp_heartbeats(
         [stored_held.id, stored_canceling.id, stored_completed.id],
         setup.worker_id,
         now,
@@ -523,7 +525,11 @@ async def test_stamp_heartbeats_writes_only_the_heartbeat_column(
         stored_held.id: None,
         stored_canceling.id: stored_canceling.cancel_requested_at,
     }
-    assert await setup.tasks.stamp_heartbeats([stored_held.id], uuid.uuid4(), now) == {}
+    assert skipped == set()
+    assert await setup.tasks.stamp_heartbeats([stored_held.id], uuid.uuid4(), now) == (
+        {},
+        set(),
+    )
 
     reloaded_held = await setup.tasks.get(stored_held.id)
     assert isinstance(reloaded_held, AgentTask)
@@ -549,16 +555,20 @@ async def test_stamp_heartbeats_falls_back_to_the_jobs_cancel_request(
     assert stored.cancel_requested_at is None
 
     now = datetime.now(UTC)
-    assert await setup.tasks.stamp_heartbeats([stored.id], setup.worker_id, now) == {
-        stored.id: None
-    }
+    assert await setup.tasks.stamp_heartbeats([stored.id], setup.worker_id, now) == (
+        {stored.id: None},
+        set(),
+    )
 
     job = await setup.jobs.get(setup.job_id)
     job.request_cancel(now)
     await setup.jobs.update(job)
 
-    stamped = await setup.tasks.stamp_heartbeats([stored.id], setup.worker_id, now)
+    stamped, skipped = await setup.tasks.stamp_heartbeats(
+        [stored.id], setup.worker_id, now
+    )
     assert stamped == {stored.id: job.cancel_requested_at}
+    assert skipped == set()
     # The stamp is read through, not written onto the task row.
     assert (await setup.tasks.get(stored.id)).cancel_requested_at is None
 
@@ -592,3 +602,58 @@ async def test_claim_pending_skip_locked_never_double_claims() -> None:
         assert len(claimed_ids) == len(tasks)
         assert len(set(claimed_ids)) == len(tasks)
         assert set(claimed_ids) == {task.id for task in tasks}
+
+
+async def test_stamp_heartbeats_skips_a_task_row_locked_elsewhere() -> None:
+    """A heartbeat on a task locked by another transaction returns promptly.
+
+    The locked task comes back neither stamped nor cancelable, and a sibling
+    task in the same request still gets stamped.
+    """
+    if not await postgres_available():
+        pytest.skip("PostgreSQL is not reachable")
+    async with pg_session_with_engine() as (seed_session, engine):
+        setup = await _seed_postgres(seed_session, engine)
+        start = datetime.now(UTC)
+        locked_task = _agent_task(setup)
+        locked_task.claim(setup.worker_id, start)
+        locked_task.start(start)
+        stored_locked = await SQLTaskRepository(seed_session).create(locked_task)
+
+        free_task = _agent_task(setup)
+        free_task.claim(setup.worker_id, start)
+        free_task.start(start)
+        stored_free = await SQLTaskRepository(seed_session).create(free_task)
+        await seed_session.commit()
+
+        session_factory = async_sessionmaker(
+            bind=engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async with session_factory() as holder_session:
+            await holder_session.execute(
+                select(TaskORM).where(TaskORM.id == stored_locked.id).with_for_update()
+            )
+
+            async with session_factory() as heartbeat_session:
+                now = datetime.now(UTC)
+                stamped, skipped = await asyncio.wait_for(
+                    SQLTaskRepository(heartbeat_session).stamp_heartbeats(
+                        [stored_locked.id, stored_free.id], setup.worker_id, now
+                    ),
+                    timeout=5,
+                )
+                await heartbeat_session.commit()
+                reloaded_locked = await SQLTaskRepository(heartbeat_session).get(
+                    stored_locked.id
+                )
+                reloaded_free = await SQLTaskRepository(heartbeat_session).get(
+                    stored_free.id
+                )
+
+            await holder_session.rollback()
+
+        assert skipped == {stored_locked.id}
+        assert stamped == {stored_free.id: None}
+        assert reloaded_locked.heartbeat_at is None
+        assert reloaded_free.heartbeat_at == now

--- a/tests/server/test_task_service.py
+++ b/tests/server/test_task_service.py
@@ -980,6 +980,27 @@ async def test_advance_job_settlement_tracks_job_completed() -> None:
     assert tracked_properties["task_kinds"] == ["evaluator", "importer"]
 
 
+async def test_second_of_two_sibling_tasks_settles_the_job() -> None:
+    """The job stays unsettled after one sibling completes and settles after the other.
+
+    Exactly one of the two completions elects itself the settler, the one
+    whose scan finds every task of the job terminal.
+    """
+    transitions, tasks, jobs = _build_transitions(None)
+    job = await create_job(jobs, ACTOR.account.id)
+    first = await create_import_task(tasks, job.id)
+    second = await create_evaluation_task(tasks, job.id)
+
+    await _complete_task(transitions, first, result={"created": 1})
+    assert not (await jobs.get(job.id)).settled
+
+    await _complete_task(
+        transitions, second, result=[{"name": "quality", "score": 1.0}]
+    )
+    settled = await jobs.get(job.id)
+    assert settled.status is JobStatus.COMPLETED
+
+
 async def test_apply_status_non_terminal_writes_track_nothing() -> None:
     """Skip tracking when a transition leaves the task non-terminal."""
     analytics = _RecordingAnalytics()


### PR DESCRIPTION
- Worker heartbeats skip task rows locked by in-flight settlement instead of queueing behind them. Skipped tasks are reported as still owned, not cancelable.
- The job settlement lock is taken only on terminal task transitions and only as the last step of the transaction, after all handler reads and inserts.
- Follow-up evaluator tasks are inserted without locking the job row.
- Database connection pool exhaustion now returns 503 instead of 500.
- Drops two single-column indexes that were exact prefixes of unique constraints on the same tables.
- Under a stress workload (5000 tasks, 8 workers), locked job-row reads drop by roughly half and heartbeat lock waits disappear from pg_stat_statements entirely.