### PR TITLE
Register default plugins at server startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- The server registers a set of built-in default plugins at startup, under the reserved `kitaru/` name prefix: the `kitaru/langfuse` importer and the `kitaru/cost`, `kitaru/latency`, and `kitaru/tool-call-patterns` evaluators. Registration is idempotent and creates a new version only when the declared plugin version is bumped.
+- The `kitaru/` plugin name prefix is reserved for built-in default plugins, which are registered at server startup without an owner. Creating a plugin whose name starts with `kitaru/` via the API is rejected.
 - Sessions carry a per-agent sequential `number`, assigned at creation and returned in session responses. Numbers may skip when a create fails after its number was allocated.
 - CLI investigation and annotation commands, plus MCP commands for review workflows, evaluator registration, and starting bounded evaluations or experiment runs. The new operations use existing API and SDK resources, require exact IDs and evaluator versions, and return submitted workflows without polling.
 - Investigations and annotations, managed via `/v1/investigations` and `/v1/annotations`. An investigation asks a set of questions about a set of sessions, each optionally carrying a curated view, and answers are stored as annotations. Annotations also attach directly to a session, targeting the whole session or a part of it through a selector.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- The server registers a set of built-in default plugins at startup, under the reserved `kitaru/` name prefix: the `kitaru/langfuse` importer and the `kitaru/cost`, `kitaru/latency`, and `kitaru/tool-call-patterns` evaluators. Registration is idempotent and creates a new version only when the packaged source changes.
+- The server registers a set of built-in default plugins at startup, under the reserved `kitaru/` name prefix: the `kitaru/langfuse` importer and the `kitaru/cost`, `kitaru/latency`, and `kitaru/tool-call-patterns` evaluators. Registration is idempotent and creates a new version only when the declared plugin version is bumped.
 - Sessions carry a per-agent sequential `number`, assigned at creation and returned in session responses. Numbers may skip when a create fails after its number was allocated.
 - CLI investigation and annotation commands, plus MCP commands for review workflows, evaluator registration, and starting bounded evaluations or experiment runs. The new operations use existing API and SDK resources, require exact IDs and evaluator versions, and return submitted workflows without polling.
 - Investigations and annotations, managed via `/v1/investigations` and `/v1/annotations`. An investigation asks a set of questions about a set of sessions, each optionally carrying a curated view, and answers are stored as annotations. Annotations also attach directly to a session, targeting the whole session or a part of it through a selector.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- The server registers a set of built-in default plugins at startup, under the reserved `kitaru/` name prefix: the `kitaru/langfuse` importer and the `kitaru/cost`, `kitaru/latency`, and `kitaru/tool-call-patterns` evaluators. Registration is idempotent and creates a new version only when the packaged source changes.
 - Sessions carry a per-agent sequential `number`, assigned at creation and returned in session responses. Numbers may skip when a create fails after its number was allocated.
 - CLI investigation and annotation commands, plus MCP commands for review workflows, evaluator registration, and starting bounded evaluations or experiment runs. The new operations use existing API and SDK resources, require exact IDs and evaluator versions, and return submitted workflows without polling.
 - Investigations and annotations, managed via `/v1/investigations` and `/v1/annotations`. An investigation asks a set of questions about a set of sessions, each optionally carrying a curated view, and answers are stored as annotations. Annotations also attach directly to a session, targeting the whole session or a part of it through a selector.

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2262,10 +2262,17 @@
             "type": "string"
           },
           "owner_id": {
-            "description": "Id of the owning account.",
-            "format": "uuid",
-            "title": "Owner Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Id of the owning account, null for a default plugin.",
+            "title": "Owner Id"
           },
           "updated": {
             "description": "Last modification time.",
@@ -3184,10 +3191,17 @@
             "type": "string"
           },
           "owner_id": {
-            "description": "Id of the owning account.",
-            "format": "uuid",
-            "title": "Owner Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Id of the owning account, null for a default plugin.",
+            "title": "Owner Id"
           },
           "provider": {
             "anyOf": [

--- a/src/kitaru/api_models/v1/evaluator.py
+++ b/src/kitaru/api_models/v1/evaluator.py
@@ -19,7 +19,6 @@ from pydantic import Field
 
 from kitaru.api_models.v1.base import (
     JsonValue,
-    OwnedResponseModel,
     RequestModel,
     TimestampedResponseModel,
 )
@@ -52,9 +51,12 @@ class EvaluatorListParams(FilterableListParams):
     """Evaluator list params."""
 
 
-class EvaluatorResponse(OwnedResponseModel):
+class EvaluatorResponse(TimestampedResponseModel):
     """Evaluator response."""
 
+    owner_id: uuid.UUID | None = Field(
+        description="Id of the owning account, null for a default plugin."
+    )
     id: uuid.UUID = Field(description="Evaluator id.")
     name: str = Field(description="Evaluator name.")
     description: str | None = Field(description="Evaluator description.")

--- a/src/kitaru/api_models/v1/importer.py
+++ b/src/kitaru/api_models/v1/importer.py
@@ -19,7 +19,6 @@ from pydantic import Field
 
 from kitaru.api_models.v1.base import (
     JsonValue,
-    OwnedResponseModel,
     RequestModel,
     TimestampedResponseModel,
 )
@@ -55,9 +54,12 @@ class ImporterListParams(FilterableListParams):
     """Importer list params."""
 
 
-class ImporterResponse(OwnedResponseModel):
+class ImporterResponse(TimestampedResponseModel):
     """Importer response."""
 
+    owner_id: uuid.UUID | None = Field(
+        description="Id of the owning account, null for a default plugin."
+    )
     id: uuid.UUID = Field(description="Importer id.")
     name: str = Field(description="Importer name.")
     description: str | None = Field(description="Importer description.")

--- a/src/kitaru/server/adapters/db/orm/blob.py
+++ b/src/kitaru/server/adapters/db/orm/blob.py
@@ -56,7 +56,7 @@ class BlobORM(UUIDPrimaryKeyMixin, Base):
     created: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC), sort_order=-2
     )
-    owner_id: Mapped[uuid.UUID]
+    owner_id: Mapped[uuid.UUID | None]
     sha256: Mapped[str] = mapped_column(String(64))
     size: Mapped[int]
     media_type: Mapped[str] = mapped_column(String(255))

--- a/src/kitaru/server/adapters/db/orm/plugin.py
+++ b/src/kitaru/server/adapters/db/orm/plugin.py
@@ -68,7 +68,7 @@ class PluginORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         Index(PLUGIN_KIND_PROVIDER_INDEX, "kind", "provider"),
     )
 
-    owner_id: Mapped[uuid.UUID]
+    owner_id: Mapped[uuid.UUID | None]
     kind: Mapped[str] = mapped_column(String(32))
     name: Mapped[str] = mapped_column(String(MAX_NAME_LENGTH))
     description: Mapped[str | None] = mapped_column(Text)

--- a/src/kitaru/server/adapters/db/repositories/blob_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/blob_repository.py
@@ -66,7 +66,9 @@ class SQLBlobRepository(BaseSQLRepository[BlobORM]):
         return row.to_domain(), True
 
     @staticmethod
-    def _select_metadata() -> Select[tuple[uuid.UUID, uuid.UUID, str, int, str, Any]]:
+    def _select_metadata() -> Select[
+        tuple[uuid.UUID, uuid.UUID | None, str, int, str, Any]
+    ]:
         """Build the select over every blob column except the content.
 
         Returns:
@@ -82,7 +84,9 @@ class SQLBlobRepository(BaseSQLRepository[BlobORM]):
         )
 
     @staticmethod
-    def _to_metadata(row: Row[tuple[uuid.UUID, uuid.UUID, str, int, str, Any]]) -> Blob:
+    def _to_metadata(
+        row: Row[tuple[uuid.UUID, uuid.UUID | None, str, int, str, Any]],
+    ) -> Blob:
         """Build a domain blob from a metadata row.
 
         Args:

--- a/src/kitaru/server/adapters/rest/mapping/plugins.py
+++ b/src/kitaru/server/adapters/rest/mapping/plugins.py
@@ -21,11 +21,7 @@ instead of duplicating them.
 
 from typing import Any, TypeVar
 
-from kitaru.api_models.v1.base import (
-    ListParams,
-    OwnedResponseModel,
-    TimestampedResponseModel,
-)
+from kitaru.api_models.v1.base import ListParams, TimestampedResponseModel
 from kitaru.api_models.v1.evaluator import (
     EvaluatorUpdateRequest,
     EvaluatorVersionResponse,
@@ -51,7 +47,7 @@ from kitaru.server.domain.plugin import (
     ScriptPluginSource as DomainScriptPluginSource,
 )
 
-PluginResponseT = TypeVar("PluginResponseT", bound=OwnedResponseModel)
+PluginResponseT = TypeVar("PluginResponseT", bound=TimestampedResponseModel)
 PluginVersionResponseT = TypeVar(
     "PluginVersionResponseT", bound=TimestampedResponseModel
 )

--- a/src/kitaru/server/adapters/rest/routers/plugins.py
+++ b/src/kitaru/server/adapters/rest/routers/plugins.py
@@ -22,12 +22,7 @@ instead of duplicating them.
 import uuid
 from typing import TypeVar
 
-from kitaru.api_models.v1.base import (
-    ListParams,
-    OwnedResponseModel,
-    Page,
-    TimestampedResponseModel,
-)
+from kitaru.api_models.v1.base import ListParams, Page, TimestampedResponseModel
 from kitaru.api_models.v1.evaluator import (
     EvaluatorCreateRequest,
     EvaluatorUpdateRequest,
@@ -46,7 +41,7 @@ from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.models.plugin import PluginVersionFilter
 from kitaru.server.application.services.plugin_service import PluginService
 
-PluginResponseT = TypeVar("PluginResponseT", bound=OwnedResponseModel)
+PluginResponseT = TypeVar("PluginResponseT", bound=TimestampedResponseModel)
 PluginVersionResponseT = TypeVar(
     "PluginVersionResponseT", bound=TimestampedResponseModel
 )

--- a/src/kitaru/server/api/app.py
+++ b/src/kitaru/server/api/app.py
@@ -37,6 +37,10 @@ from kitaru.server.adapters.db.errors import is_deadlock
 from kitaru.server.adapters.db.repositories.account_repository import (
     SQLAccountRepository,
 )
+from kitaru.server.adapters.db.repositories.blob_repository import SQLBlobRepository
+from kitaru.server.adapters.db.repositories.plugin_repository import (
+    SQLPluginRepository,
+)
 from kitaru.server.adapters.permissions.admin_flag import AdminFlagPermissionProvider
 from kitaru.server.adapters.rest.routers import (
     accounts,
@@ -72,6 +76,9 @@ from kitaru.server.api.config import APISettings
 from kitaru.server.api.otel import configure_otel, instrument_engine, shutdown_otel
 from kitaru.server.api.task_sweeper import start_task_sweeper, stop_task_sweeper
 from kitaru.server.application.services.account_service import AccountService
+from kitaru.server.application.services.default_plugins import (
+    register_default_plugins,
+)
 from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.database.service import DatabaseService
 from kitaru.server.domain.base import (
@@ -246,6 +253,11 @@ def create_app(settings: APISettings) -> FastAPI:
                     settings.DEFAULT_ACCOUNT_NAME, settings.DEFAULT_ACCOUNT_PASSWORD
                 )
                 await session.commit()
+        async for session in database.get_async_session():
+            await register_default_plugins(
+                SQLPluginRepository(session), SQLBlobRepository(session)
+            )
+            await session.commit()
         sweep_task = start_task_sweeper(database, settings, analytics)
         try:
             yield

--- a/src/kitaru/server/api/app.py
+++ b/src/kitaru/server/api/app.py
@@ -32,7 +32,6 @@ from kitaru.analytics.source import (
 )
 from kitaru.api_models.v1.info import AuthScheme
 from kitaru.server.adapters.auth.control_plane import ControlPlaneClient
-from kitaru.server.adapters.auth.passwords import BcryptPasswordHasher
 from kitaru.server.adapters.db.errors import is_deadlock
 from kitaru.server.adapters.db.repositories.account_repository import (
     SQLAccountRepository,
@@ -41,7 +40,6 @@ from kitaru.server.adapters.db.repositories.blob_repository import SQLBlobReposi
 from kitaru.server.adapters.db.repositories.plugin_repository import (
     SQLPluginRepository,
 )
-from kitaru.server.adapters.permissions.admin_flag import AdminFlagPermissionProvider
 from kitaru.server.adapters.rest.routers import (
     accounts,
     agent_versions,
@@ -72,14 +70,13 @@ from kitaru.server.adapters.rest.routers import (
 )
 from kitaru.server.adapters.rest.routers.auth import TokenGrantError
 from kitaru.server.api import health
+from kitaru.server.api.bootstrap import (
+    ensure_default_account,
+    register_default_plugins,
+)
 from kitaru.server.api.config import APISettings
 from kitaru.server.api.otel import configure_otel, instrument_engine, shutdown_otel
 from kitaru.server.api.task_sweeper import start_task_sweeper, stop_task_sweeper
-from kitaru.server.application.services.account_service import AccountService
-from kitaru.server.application.services.default_plugins import (
-    register_default_plugins,
-)
-from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.database.service import DatabaseService
 from kitaru.server.domain.base import (
     ConflictError,
@@ -244,13 +241,10 @@ def create_app(settings: APISettings) -> FastAPI:
         # is no local default account to fall back on.
         if settings.AUTH_SCHEME is not AuthScheme.CONTROL_PLANE:
             async for session in database.get_async_session():
-                account_service = AccountService(
-                    repository=SQLAccountRepository(session),
-                    password_hasher=BcryptPasswordHasher(),
-                    permission_service=PermissionService(AdminFlagPermissionProvider()),
-                )
-                await account_service.ensure_account(
-                    settings.DEFAULT_ACCOUNT_NAME, settings.DEFAULT_ACCOUNT_PASSWORD
+                await ensure_default_account(
+                    SQLAccountRepository(session),
+                    settings.DEFAULT_ACCOUNT_NAME,
+                    settings.DEFAULT_ACCOUNT_PASSWORD,
                 )
                 await session.commit()
         async for session in database.get_async_session():

--- a/src/kitaru/server/api/bootstrap.py
+++ b/src/kitaru/server/api/bootstrap.py
@@ -16,7 +16,6 @@
 import hashlib
 import logging
 from importlib.metadata import version
-from pathlib import Path
 
 from kitaru.base import FrozenModel
 from kitaru.server.adapters.auth.passwords import BcryptPasswordHasher
@@ -27,7 +26,6 @@ from kitaru.server.application.interfaces.plugin_repository import PluginReposit
 from kitaru.server.application.services.account_service import AccountService
 from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.domain.blob import Blob
-from kitaru.server.domain.names import RESERVED_PLUGIN_NAME_PREFIX
 from kitaru.server.domain.plugin import (
     DuplicatePluginName,
     DuplicatePluginVersion,
@@ -37,7 +35,6 @@ from kitaru.server.domain.plugin import (
     ScriptPluginSource,
 )
 
-_PLUGINS_ROOT = Path(__file__).resolve().parents[4] / "plugins"
 _SOURCE_MEDIA_TYPE = "text/x-python"
 
 logger = logging.getLogger(__name__)
@@ -69,60 +66,11 @@ class DefaultPluginDefinition(FrozenModel):
     description: str
     provider: str | None
     entrypoint: str
-    source_file: str
+    content: bytes
     version: int
 
 
-DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = (
-    DefaultPluginDefinition(
-        kind=PluginKind.IMPORTER,
-        name=f"{RESERVED_PLUGIN_NAME_PREFIX}langfuse",
-        description="Import Langfuse JSON and JSONL trace exports.",
-        provider="langfuse",
-        entrypoint="parse",
-        source_file="importers/langfuse.py",
-        version=1,
-    ),
-    DefaultPluginDefinition(
-        kind=PluginKind.EVALUATOR,
-        name=f"{RESERVED_PLUGIN_NAME_PREFIX}cost",
-        description="Report the total recorded session cost.",
-        provider=None,
-        entrypoint="cost",
-        source_file="evaluators/basic.py",
-        version=1,
-    ),
-    DefaultPluginDefinition(
-        kind=PluginKind.EVALUATOR,
-        name=f"{RESERVED_PLUGIN_NAME_PREFIX}latency",
-        description="Measure session wall-clock duration.",
-        provider=None,
-        entrypoint="latency",
-        source_file="evaluators/basic.py",
-        version=1,
-    ),
-    DefaultPluginDefinition(
-        kind=PluginKind.EVALUATOR,
-        name=f"{RESERVED_PLUGIN_NAME_PREFIX}tool-call-patterns",
-        description="Count repeated calls to the same tool.",
-        provider=None,
-        entrypoint="tool_call_patterns",
-        source_file="evaluators/basic.py",
-        version=1,
-    ),
-)
-
-
-def _read_source(source_file: str) -> bytes:
-    """Read one default plugin source file.
-
-    Args:
-        source_file: File path relative to the repository plugins directory.
-
-    Returns:
-        Source file content.
-    """
-    return (_PLUGINS_ROOT / source_file).read_bytes()
+DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = ()
 
 
 async def _get_or_create_plugin(
@@ -173,14 +121,13 @@ async def register_default_plugins(
         if plugin.latest_version >= definition.version:
             logger.debug("Default plugin %s is already current.", definition.name)
             continue
-        content = _read_source(definition.source_file)
         blob, _ = await blob_repository.create(
             Blob(
                 owner_id=None,
-                sha256=hashlib.sha256(content).hexdigest(),
-                size=len(content),
+                sha256=hashlib.sha256(definition.content).hexdigest(),
+                size=len(definition.content),
                 media_type=_SOURCE_MEDIA_TYPE,
-                data=content,
+                data=definition.content,
             )
         )
         try:

--- a/src/kitaru/server/api/bootstrap.py
+++ b/src/kitaru/server/api/bootstrap.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Default plugin registration at server startup."""
+"""Default account and default plugin bootstrap at server startup."""
 
 import hashlib
 import logging
@@ -19,8 +19,13 @@ from importlib.metadata import version
 from pathlib import Path
 
 from kitaru.base import FrozenModel
+from kitaru.server.adapters.auth.passwords import BcryptPasswordHasher
+from kitaru.server.adapters.permissions.admin_flag import AdminFlagPermissionProvider
+from kitaru.server.application.interfaces.account_repository import AccountRepository
 from kitaru.server.application.interfaces.blob_repository import BlobRepository
 from kitaru.server.application.interfaces.plugin_repository import PluginRepository
+from kitaru.server.application.services.account_service import AccountService
+from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.domain.blob import Blob
 from kitaru.server.domain.names import RESERVED_PLUGIN_NAME_PREFIX
 from kitaru.server.domain.plugin import (
@@ -32,10 +37,28 @@ from kitaru.server.domain.plugin import (
     ScriptPluginSource,
 )
 
-_PLUGINS_ROOT = Path(__file__).resolve().parents[5] / "plugins"
+_PLUGINS_ROOT = Path(__file__).resolve().parents[4] / "plugins"
 _SOURCE_MEDIA_TYPE = "text/x-python"
 
 logger = logging.getLogger(__name__)
+
+
+async def ensure_default_account(
+    repository: AccountRepository, name: str, password: str | None
+) -> None:
+    """Create the default account when it does not exist.
+
+    Args:
+        repository: Account repository.
+        name: Account name.
+        password: Login password, hashed before storage.
+    """
+    account_service = AccountService(
+        repository=repository,
+        password_hasher=BcryptPasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
+    )
+    await account_service.ensure_account(name, password)
 
 
 class DefaultPluginDefinition(FrozenModel):

--- a/src/kitaru/server/api/bootstrap.py
+++ b/src/kitaru/server/api/bootstrap.py
@@ -70,6 +70,7 @@ class DefaultPluginDefinition(FrozenModel):
     provider: str | None
     entrypoint: str
     source_file: str
+    version: int
 
 
 DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = (
@@ -80,6 +81,7 @@ DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = (
         provider="langfuse",
         entrypoint="parse",
         source_file="importers/langfuse.py",
+        version=1,
     ),
     DefaultPluginDefinition(
         kind=PluginKind.EVALUATOR,
@@ -88,6 +90,7 @@ DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = (
         provider=None,
         entrypoint="cost",
         source_file="evaluators/basic.py",
+        version=1,
     ),
     DefaultPluginDefinition(
         kind=PluginKind.EVALUATOR,
@@ -96,6 +99,7 @@ DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = (
         provider=None,
         entrypoint="latency",
         source_file="evaluators/basic.py",
+        version=1,
     ),
     DefaultPluginDefinition(
         kind=PluginKind.EVALUATOR,
@@ -104,6 +108,7 @@ DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = (
         provider=None,
         entrypoint="tool_call_patterns",
         source_file="evaluators/basic.py",
+        version=1,
     ),
 )
 
@@ -153,38 +158,10 @@ async def _get_or_create_plugin(
         return await repository.get_by_name(definition.kind, definition.name)
 
 
-async def _version_is_current(
-    repository: PluginRepository,
-    blob_repository: BlobRepository,
-    plugin: Plugin,
-    definition: DefaultPluginDefinition,
-    digest: str,
-) -> bool:
-    """Return whether a plugin's latest version already matches its packaged source.
-
-    Args:
-        repository: Plugin repository.
-        blob_repository: Blob repository.
-        plugin: Plugin the candidate version belongs to.
-        definition: Default plugin definition.
-        digest: sha256 digest of the packaged source.
-
-    Returns:
-        Whether the latest version's source and entrypoint already match.
-    """
-    if plugin.latest_version < 1:
-        return False
-    latest = await repository.get_version(plugin.id, plugin.latest_version)
-    if not isinstance(latest.source, ScriptPluginSource):
-        return False
-    blob = await blob_repository.get_metadata(latest.source.blob_id)
-    return blob.sha256 == digest and latest.source.entrypoint == definition.entrypoint
-
-
 async def register_default_plugins(
     repository: PluginRepository, blob_repository: BlobRepository
 ) -> None:
-    """Create or update the built-in default plugins for the installed version.
+    """Create the built-in default plugins and their declared versions.
 
     Args:
         repository: Plugin repository.
@@ -192,18 +169,15 @@ async def register_default_plugins(
     """
     installed_version = version("kitaru")
     for definition in DEFAULT_PLUGIN_DEFINITIONS:
-        content = _read_source(definition.source_file)
-        digest = hashlib.sha256(content).hexdigest()
         plugin = await _get_or_create_plugin(repository, definition)
-        if await _version_is_current(
-            repository, blob_repository, plugin, definition, digest
-        ):
+        if plugin.latest_version >= definition.version:
             logger.debug("Default plugin %s is already current.", definition.name)
             continue
+        content = _read_source(definition.source_file)
         blob, _ = await blob_repository.create(
             Blob(
                 owner_id=None,
-                sha256=digest,
+                sha256=hashlib.sha256(content).hexdigest(),
                 size=len(content),
                 media_type=_SOURCE_MEDIA_TYPE,
                 data=content,

--- a/src/kitaru/server/application/services/default_plugins.py
+++ b/src/kitaru/server/application/services/default_plugins.py
@@ -1,0 +1,197 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Default plugin registration at server startup."""
+
+import hashlib
+import logging
+from importlib.metadata import version
+from pathlib import Path
+
+from kitaru.base import FrozenModel
+from kitaru.server.application.interfaces.blob_repository import BlobRepository
+from kitaru.server.application.interfaces.plugin_repository import PluginRepository
+from kitaru.server.domain.blob import Blob
+from kitaru.server.domain.names import RESERVED_PLUGIN_NAME_PREFIX
+from kitaru.server.domain.plugin import (
+    DuplicatePluginName,
+    DuplicatePluginVersion,
+    Plugin,
+    PluginKind,
+    PluginNotFound,
+    ScriptPluginSource,
+)
+
+_PLUGINS_ROOT = Path(__file__).resolve().parents[5] / "plugins"
+_SOURCE_MEDIA_TYPE = "text/x-python"
+
+logger = logging.getLogger(__name__)
+
+
+class DefaultPluginDefinition(FrozenModel):
+    """Default plugin definition."""
+
+    kind: PluginKind
+    name: str
+    description: str
+    provider: str | None
+    entrypoint: str
+    source_file: str
+
+
+DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = (
+    DefaultPluginDefinition(
+        kind=PluginKind.IMPORTER,
+        name=f"{RESERVED_PLUGIN_NAME_PREFIX}langfuse",
+        description="Import Langfuse JSON and JSONL trace exports.",
+        provider="langfuse",
+        entrypoint="parse",
+        source_file="importers/langfuse.py",
+    ),
+    DefaultPluginDefinition(
+        kind=PluginKind.EVALUATOR,
+        name=f"{RESERVED_PLUGIN_NAME_PREFIX}cost",
+        description="Report the total recorded session cost.",
+        provider=None,
+        entrypoint="cost",
+        source_file="evaluators/basic.py",
+    ),
+    DefaultPluginDefinition(
+        kind=PluginKind.EVALUATOR,
+        name=f"{RESERVED_PLUGIN_NAME_PREFIX}latency",
+        description="Measure session wall-clock duration.",
+        provider=None,
+        entrypoint="latency",
+        source_file="evaluators/basic.py",
+    ),
+    DefaultPluginDefinition(
+        kind=PluginKind.EVALUATOR,
+        name=f"{RESERVED_PLUGIN_NAME_PREFIX}tool-call-patterns",
+        description="Count repeated calls to the same tool.",
+        provider=None,
+        entrypoint="tool_call_patterns",
+        source_file="evaluators/basic.py",
+    ),
+)
+
+
+def _read_source(source_file: str) -> bytes:
+    """Read one default plugin source file.
+
+    Args:
+        source_file: File path relative to the repository plugins directory.
+
+    Returns:
+        Source file content.
+    """
+    return (_PLUGINS_ROOT / source_file).read_bytes()
+
+
+async def _get_or_create_plugin(
+    repository: PluginRepository, definition: DefaultPluginDefinition
+) -> Plugin:
+    """Load a default plugin, creating it ownerless on first startup.
+
+    Args:
+        repository: Plugin repository.
+        definition: Default plugin definition.
+
+    Returns:
+        Stored plugin.
+    """
+    try:
+        return await repository.get_by_name(definition.kind, definition.name)
+    except PluginNotFound:
+        pass
+    try:
+        plugin = await repository.create(
+            Plugin(
+                owner_id=None,
+                kind=definition.kind,
+                name=definition.name,
+                description=definition.description,
+                provider=definition.provider,
+                metadata={},
+            )
+        )
+        logger.info("Created default plugin %s.", definition.name)
+        return plugin
+    except DuplicatePluginName:
+        return await repository.get_by_name(definition.kind, definition.name)
+
+
+async def _version_is_current(
+    repository: PluginRepository,
+    blob_repository: BlobRepository,
+    plugin: Plugin,
+    definition: DefaultPluginDefinition,
+    digest: str,
+) -> bool:
+    """Return whether a plugin's latest version already matches its packaged source.
+
+    Args:
+        repository: Plugin repository.
+        blob_repository: Blob repository.
+        plugin: Plugin the candidate version belongs to.
+        definition: Default plugin definition.
+        digest: sha256 digest of the packaged source.
+
+    Returns:
+        Whether the latest version's source and entrypoint already match.
+    """
+    if plugin.latest_version < 1:
+        return False
+    latest = await repository.get_version(plugin.id, plugin.latest_version)
+    if not isinstance(latest.source, ScriptPluginSource):
+        return False
+    blob = await blob_repository.get_metadata(latest.source.blob_id)
+    return blob.sha256 == digest and latest.source.entrypoint == definition.entrypoint
+
+
+async def register_default_plugins(
+    repository: PluginRepository, blob_repository: BlobRepository
+) -> None:
+    """Create or update the built-in default plugins for the installed version.
+
+    Args:
+        repository: Plugin repository.
+        blob_repository: Blob repository.
+    """
+    installed_version = version("kitaru")
+    for definition in DEFAULT_PLUGIN_DEFINITIONS:
+        content = _read_source(definition.source_file)
+        digest = hashlib.sha256(content).hexdigest()
+        plugin = await _get_or_create_plugin(repository, definition)
+        if await _version_is_current(
+            repository, blob_repository, plugin, definition, digest
+        ):
+            logger.debug("Default plugin %s is already current.", definition.name)
+            continue
+        blob, _ = await blob_repository.create(
+            Blob(
+                owner_id=None,
+                sha256=digest,
+                size=len(content),
+                media_type=_SOURCE_MEDIA_TYPE,
+                data=content,
+            )
+        )
+        try:
+            await repository.create_version(
+                plugin.id,
+                ScriptPluginSource(blob_id=blob.id, entrypoint=definition.entrypoint),
+                installed_version,
+            )
+            logger.info("Created a new version for default plugin %s.", definition.name)
+        except DuplicatePluginVersion:
+            continue

--- a/src/kitaru/server/application/services/plugin_service.py
+++ b/src/kitaru/server/application/services/plugin_service.py
@@ -27,11 +27,13 @@ from kitaru.server.application.models.plugin import (
 )
 from kitaru.server.application.services import analytics_events
 from kitaru.server.application.services.server_analytics import ServerAnalytics
+from kitaru.server.domain.names import RESERVED_PLUGIN_NAME_PREFIX
 from kitaru.server.domain.plugin import (
     Plugin,
     PluginKind,
     PluginSource,
     PluginVersion,
+    ReservedPluginName,
     ScriptPluginSource,
 )
 
@@ -79,10 +81,14 @@ class PluginService:
         Raises:
             DuplicatePluginName: The (kind, name) pair is already registered.
             InvalidPluginProvider: The kind is evaluator and provider is set.
+            ReservedPluginName: ``name`` starts with the reserved default-plugin
+                prefix.
 
         Returns:
             Created plugin.
         """
+        if name.startswith(RESERVED_PLUGIN_NAME_PREFIX):
+            raise ReservedPluginName(name)
         plugin = Plugin(
             owner_id=actor.account.id,
             kind=self.kind,

--- a/src/kitaru/server/database/migrations/versions/001_initial.py
+++ b/src/kitaru/server/database/migrations/versions/001_initial.py
@@ -188,7 +188,7 @@ def upgrade() -> None:
         sa.Column("created", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated", sa.DateTime(timezone=True), nullable=False),
         sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("owner_id", sa.Uuid(), nullable=False),
+        sa.Column("owner_id", sa.Uuid(), nullable=True),
         sa.Column("kind", sa.String(length=32), nullable=False),
         sa.Column("name", sa.String(length=255), nullable=False),
         sa.Column("description", sa.Text(), nullable=True),

--- a/src/kitaru/server/database/migrations/versions/001_initial.py
+++ b/src/kitaru/server/database/migrations/versions/001_initial.py
@@ -146,7 +146,7 @@ def upgrade() -> None:
         "blob",
         sa.Column("created", sa.DateTime(timezone=True), nullable=False),
         sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column("owner_id", sa.Uuid(), nullable=False),
+        sa.Column("owner_id", sa.Uuid(), nullable=True),
         sa.Column("sha256", sa.String(length=64), nullable=False),
         sa.Column("size", sa.Integer(), nullable=False),
         sa.Column("media_type", sa.String(length=255), nullable=False),

--- a/src/kitaru/server/domain/blob.py
+++ b/src/kitaru/server/domain/blob.py
@@ -80,7 +80,7 @@ class Blob(DomainModel):
     """Blob."""
 
     id: uuid.UUID = Field(default_factory=uuid7)
-    owner_id: uuid.UUID
+    owner_id: uuid.UUID | None
     sha256: str
     size: int
     media_type: str

--- a/src/kitaru/server/domain/names.py
+++ b/src/kitaru/server/domain/names.py
@@ -38,6 +38,10 @@ EVALUATION_ALLOWED_SEPARATORS = frozenset({"-", "_", "."})
 # separators alongside the default set.
 VERSION_ALLOWED_SEPARATORS = frozenset({"-", "_", ".", "+", "/"})
 
+# Default plugins ship under this prefix, reserved so no user-created plugin
+# can collide with one.
+RESERVED_PLUGIN_NAME_PREFIX = "kitaru/"
+
 MAX_NAME_LENGTH = 255
 
 
@@ -121,6 +125,30 @@ def validate_version_name(value: str, max_length: int = MAX_NAME_LENGTH) -> str:
     return _validate(value, VERSION_ALLOWED_SEPARATORS, max_length)
 
 
+def validate_plugin_name(value: str, max_length: int = MAX_NAME_LENGTH) -> str:
+    """Validate a plugin name, which allows the reserved default-plugin prefix.
+
+    Args:
+        value: Name to validate.
+        max_length: Maximum name length.
+
+    Raises:
+        InvalidName: ``value`` violates the name rules.
+
+    Returns:
+        Validated name.
+    """
+    if value.startswith(RESERVED_PLUGIN_NAME_PREFIX):
+        remainder = value[len(RESERVED_PLUGIN_NAME_PREFIX) :]
+        _validate(
+            remainder,
+            DEFAULT_ALLOWED_SEPARATORS,
+            max_length - len(RESERVED_PLUGIN_NAME_PREFIX),
+        )
+        return value
+    return _validate(value, DEFAULT_ALLOWED_SEPARATORS, max_length)
+
+
 def _validate(value: str, allowed_separators: frozenset[str], max_length: int) -> str:
     """Check a name against a character set.
 
@@ -154,3 +182,4 @@ Name = Annotated[str, AfterValidator(validate_name)]
 AccountName = Annotated[str, AfterValidator(validate_account_name)]
 EvaluationName = Annotated[str, AfterValidator(validate_evaluation_name)]
 VersionName = Annotated[str, AfterValidator(validate_version_name)]
+PluginName = Annotated[str, AfterValidator(validate_plugin_name)]

--- a/src/kitaru/server/domain/plugin.py
+++ b/src/kitaru/server/domain/plugin.py
@@ -29,7 +29,11 @@ from kitaru.server.domain.base import (
     ValidationError,
 )
 from kitaru.server.domain.ids import uuid7
-from kitaru.server.domain.names import Name, VersionName
+from kitaru.server.domain.names import (
+    RESERVED_PLUGIN_NAME_PREFIX,
+    PluginName,
+    VersionName,
+)
 from kitaru.source_refs import parse_source_ref
 
 MAX_REQUIREMENT_LENGTH = 255
@@ -66,6 +70,21 @@ class DuplicatePluginName(ConflictError):
         """
         super().__init__(
             f"{kind.value.capitalize()} name '{name}' is already registered"
+        )
+
+
+class ReservedPluginName(ValidationError):
+    """Raised when a plugin name uses the reserved default-plugin prefix."""
+
+    def __init__(self, name: str) -> None:
+        """Initialize the error.
+
+        Args:
+            name: Name that uses the reserved prefix.
+        """
+        super().__init__(
+            f"Plugin name '{name}' uses the reserved prefix "
+            f"'{RESERVED_PLUGIN_NAME_PREFIX}'"
         )
 
 
@@ -253,9 +272,9 @@ class Plugin(DomainModel):
     """Plugin."""
 
     id: uuid.UUID = Field(default_factory=uuid7)
-    owner_id: uuid.UUID
+    owner_id: uuid.UUID | None
     kind: PluginKind
-    name: Name
+    name: PluginName
     description: str | None = None
     provider: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3212,7 +3212,7 @@ class FakeBlobRepository:
 
 async def create_blob(
     repository: FakeBlobRepository,
-    owner_id: uuid.UUID,
+    owner_id: uuid.UUID | None,
     content: bytes = b"blob-content",
     media_type: str = "application/octet-stream",
 ) -> Blob:

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -824,10 +824,17 @@
               "type": "string"
             },
             "owner_id": {
-              "description": "Id of the owning account.",
-              "format": "uuid",
-              "title": "Owner Id",
-              "type": "string"
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the owning account, null for a default plugin.",
+              "title": "Owner Id"
             },
             "updated": {
               "description": "Last modification time.",
@@ -1087,10 +1094,17 @@
               "type": "string"
             },
             "owner_id": {
-              "description": "Id of the owning account.",
-              "format": "uuid",
-              "title": "Owner Id",
-              "type": "string"
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the owning account, null for a default plugin.",
+              "title": "Owner Id"
             },
             "provider": {
               "anyOf": [
@@ -9245,10 +9259,17 @@
               "type": "string"
             },
             "owner_id": {
-              "description": "Id of the owning account.",
-              "format": "uuid",
-              "title": "Owner Id",
-              "type": "string"
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the owning account, null for a default plugin.",
+              "title": "Owner Id"
             },
             "updated": {
               "description": "Last modification time.",

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,7 +6,7 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 140918,
+      "discovery_response_bytes": 141083,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
@@ -32,10 +32,10 @@
         },
         "kitaru_evaluators_manage": {
           "$defs_count": 11,
-          "combined_bytes": 8253,
+          "combined_bytes": 8308,
           "input_bytes": 3958,
           "maximum_nesting_depth": 7,
-          "output_bytes": 4295
+          "output_bytes": 4350
         },
         "kitaru_experiments_manage": {
           "$defs_count": 26,
@@ -46,10 +46,10 @@
         },
         "kitaru_registry_read": {
           "$defs_count": 37,
-          "combined_bytes": 25133,
+          "combined_bytes": 25243,
           "input_bytes": 4989,
           "maximum_nesting_depth": 8,
-          "output_bytes": 20144
+          "output_bytes": 20254
         },
         "kitaru_review_manage": {
           "$defs_count": 25,
@@ -89,7 +89,7 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 71883,
+      "discovery_response_bytes": 71993,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
@@ -101,10 +101,10 @@
         },
         "kitaru_registry_read": {
           "$defs_count": 37,
-          "combined_bytes": 25133,
+          "combined_bytes": 25243,
           "input_bytes": 4989,
           "maximum_nesting_depth": 8,
-          "output_bytes": 20144
+          "output_bytes": 20254
         },
         "kitaru_review_read": {
           "$defs_count": 22,
@@ -116,7 +116,7 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 131456,
+      "discovery_response_bytes": 131621,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
@@ -135,10 +135,10 @@
         },
         "kitaru_evaluators_manage": {
           "$defs_count": 11,
-          "combined_bytes": 8253,
+          "combined_bytes": 8308,
           "input_bytes": 3958,
           "maximum_nesting_depth": 7,
-          "output_bytes": 4295
+          "output_bytes": 4350
         },
         "kitaru_experiments_manage": {
           "$defs_count": 26,
@@ -149,10 +149,10 @@
         },
         "kitaru_registry_read": {
           "$defs_count": 37,
-          "combined_bytes": 25133,
+          "combined_bytes": 25243,
           "input_bytes": 4989,
           "maximum_nesting_depth": 8,
-          "output_bytes": 20144
+          "output_bytes": 20254
         },
         "kitaru_review_manage": {
           "$defs_count": 25,

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -824,10 +824,17 @@
               "type": "string"
             },
             "owner_id": {
-              "description": "Id of the owning account.",
-              "format": "uuid",
-              "title": "Owner Id",
-              "type": "string"
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the owning account, null for a default plugin.",
+              "title": "Owner Id"
             },
             "updated": {
               "description": "Last modification time.",
@@ -1087,10 +1094,17 @@
               "type": "string"
             },
             "owner_id": {
-              "description": "Id of the owning account.",
-              "format": "uuid",
-              "title": "Owner Id",
-              "type": "string"
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the owning account, null for a default plugin.",
+              "title": "Owner Id"
             },
             "provider": {
               "anyOf": [

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -824,10 +824,17 @@
               "type": "string"
             },
             "owner_id": {
-              "description": "Id of the owning account.",
-              "format": "uuid",
-              "title": "Owner Id",
-              "type": "string"
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the owning account, null for a default plugin.",
+              "title": "Owner Id"
             },
             "updated": {
               "description": "Last modification time.",
@@ -1087,10 +1094,17 @@
               "type": "string"
             },
             "owner_id": {
-              "description": "Id of the owning account.",
-              "format": "uuid",
-              "title": "Owner Id",
-              "type": "string"
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the owning account, null for a default plugin.",
+              "title": "Owner Id"
             },
             "provider": {
               "anyOf": [
@@ -9245,10 +9259,17 @@
               "type": "string"
             },
             "owner_id": {
-              "description": "Id of the owning account.",
-              "format": "uuid",
-              "title": "Owner Id",
-              "type": "string"
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the owning account, null for a default plugin.",
+              "title": "Owner Id"
             },
             "updated": {
               "description": "Last modification time.",

--- a/tests/server/test_blob_repository.py
+++ b/tests/server/test_blob_repository.py
@@ -39,7 +39,7 @@ from kitaru.server.domain.plugin import (
 Setup = tuple[BlobRepository, uuid.UUID]
 
 
-def _blob(owner_id: uuid.UUID, content: bytes = b"content") -> Blob:
+def _blob(owner_id: uuid.UUID | None, content: bytes = b"content") -> Blob:
     return Blob(
         owner_id=owner_id,
         sha256=hashlib.sha256(content).hexdigest(),
@@ -72,6 +72,15 @@ async def test_create_sets_timestamp(setup: Setup) -> None:
     assert blob.media_type == "text/plain"
     assert blob.data == b"content"
     assert blob.created is not None
+
+
+async def test_create_and_round_trip_without_owner(setup: Setup) -> None:
+    """Store and reload a default plugin blob with no owner."""
+    repository, _ = setup
+    created, _ = await repository.create(_blob(None))
+    assert created.owner_id is None
+    loaded = await repository.get(created.id)
+    assert loaded.owner_id is None
 
 
 async def test_create_dedup(setup: Setup) -> None:

--- a/tests/server/test_control_plane_auth_api.py
+++ b/tests/server/test_control_plane_auth_api.py
@@ -27,6 +27,7 @@ from conftest import (
     FakePasswordHasher,
     control_plane_settings,
     create_api_key,
+    lifespan_client,
 )
 from kitaru.api_models.v1.auth import CONTROL_PLANE_API_KEY_PREFIX
 from kitaru.server.adapters.auth.auth_service import AuthService
@@ -349,12 +350,23 @@ async def test_list_accounts_allowed(
     assert response.status_code == 200
 
 
-async def test_control_plane_scheme_skips_default_account_bootstrap() -> None:
+async def test_control_plane_scheme_skips_default_account_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Skip the default-account bootstrap at startup under the control plane scheme."""
-    settings = control_plane_settings(SKIP_DB_MIGRATION=True, DB_PORT=1)
-    app = create_app(settings)
-    async with app.router.lifespan_context(app):
+    called = False
+
+    async def _record_call(
+        self: AccountService, name: str, password: str | None
+    ) -> None:
+        _ = self, name, password
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(AccountService, "ensure_account", _record_call)
+    async with lifespan_client(control_plane_settings(use_db=True)):
         pass
+    assert called is False
 
 
 async def test_update_own_account_metadata_allowed(

--- a/tests/server/test_default_plugins.py
+++ b/tests/server/test_default_plugins.py
@@ -18,8 +18,8 @@ from collections.abc import Callable
 import pytest
 
 from conftest import FakeBlobRepository, FakePluginRepository
-from kitaru.server.application.services import default_plugins
-from kitaru.server.application.services.default_plugins import (
+from kitaru.server.api import bootstrap
+from kitaru.server.api.bootstrap import (
     DEFAULT_PLUGIN_DEFINITIONS,
     register_default_plugins,
 )
@@ -54,7 +54,7 @@ async def test_register_creates_default_plugins(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Create every default plugin ownerless with one version on first startup."""
-    monkeypatch.setattr(default_plugins, "_read_source", _source_reader())
+    monkeypatch.setattr(bootstrap, "_read_source", _source_reader())
 
     await register_default_plugins(repository, blob_repository)
 
@@ -75,7 +75,7 @@ async def test_register_is_idempotent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Leave version numbers unchanged when nothing about the source changed."""
-    monkeypatch.setattr(default_plugins, "_read_source", _source_reader())
+    monkeypatch.setattr(bootstrap, "_read_source", _source_reader())
     await register_default_plugins(repository, blob_repository)
 
     await register_default_plugins(repository, blob_repository)
@@ -91,11 +91,11 @@ async def test_register_creates_new_version_on_content_change(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Create version 2 only for plugins whose source file changed."""
-    monkeypatch.setattr(default_plugins, "_read_source", _source_reader())
+    monkeypatch.setattr(bootstrap, "_read_source", _source_reader())
     await register_default_plugins(repository, blob_repository)
 
     monkeypatch.setattr(
-        default_plugins,
+        bootstrap,
         "_read_source",
         _source_reader({"evaluators/basic.py": b"changed"}),
     )

--- a/tests/server/test_default_plugins.py
+++ b/tests/server/test_default_plugins.py
@@ -13,27 +13,37 @@
 #  permissions and limitations under the License.
 """Tests for default plugin registration."""
 
-from collections.abc import Callable
-
 import pytest
 
 from conftest import FakeBlobRepository, FakePluginRepository
 from kitaru.server.api import bootstrap
 from kitaru.server.api.bootstrap import (
-    DEFAULT_PLUGIN_DEFINITIONS,
+    DefaultPluginDefinition,
     register_default_plugins,
 )
-from kitaru.server.domain.plugin import ScriptPluginSource
+from kitaru.server.domain.names import RESERVED_PLUGIN_NAME_PREFIX
+from kitaru.server.domain.plugin import PluginKind, ScriptPluginSource
 
-
-def _source_reader(
-    overrides: dict[str, bytes] | None = None,
-) -> Callable[[str], bytes]:
-    """Build a deterministic stand-in for reading plugin source files."""
-    overrides = overrides or {}
-    return lambda source_file: overrides.get(
-        source_file, f"content-of-{source_file}".encode()
-    )
+DEFINITIONS = (
+    DefaultPluginDefinition(
+        kind=PluginKind.IMPORTER,
+        name=f"{RESERVED_PLUGIN_NAME_PREFIX}importer",
+        description="Test importer.",
+        provider="langfuse",
+        entrypoint="parse",
+        content=b"def parse(): ...",
+        version=1,
+    ),
+    DefaultPluginDefinition(
+        kind=PluginKind.EVALUATOR,
+        name=f"{RESERVED_PLUGIN_NAME_PREFIX}evaluator",
+        description="Test evaluator.",
+        provider=None,
+        entrypoint="evaluate",
+        content=b"def evaluate(): ...",
+        version=1,
+    ),
+)
 
 
 @pytest.fixture
@@ -54,11 +64,11 @@ async def test_register_creates_default_plugins(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Create every default plugin ownerless with one version on first startup."""
-    monkeypatch.setattr(bootstrap, "_read_source", _source_reader())
+    monkeypatch.setattr(bootstrap, "DEFAULT_PLUGIN_DEFINITIONS", DEFINITIONS)
 
     await register_default_plugins(repository, blob_repository)
 
-    for definition in DEFAULT_PLUGIN_DEFINITIONS:
+    for definition in DEFINITIONS:
         plugin = await repository.get_by_name(definition.kind, definition.name)
         assert plugin.owner_id is None
         assert plugin.description == definition.description
@@ -67,6 +77,9 @@ async def test_register_creates_default_plugins(
         version = await repository.get_version(plugin.id, 1)
         assert isinstance(version.source, ScriptPluginSource)
         assert version.source.entrypoint == definition.entrypoint
+        blob = await blob_repository.get(version.source.blob_id)
+        assert blob.owner_id is None
+        assert blob.data == definition.content
 
 
 async def test_register_is_idempotent(
@@ -75,12 +88,12 @@ async def test_register_is_idempotent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Leave version numbers unchanged when the declared versions are unchanged."""
-    monkeypatch.setattr(bootstrap, "_read_source", _source_reader())
+    monkeypatch.setattr(bootstrap, "DEFAULT_PLUGIN_DEFINITIONS", DEFINITIONS)
     await register_default_plugins(repository, blob_repository)
 
     await register_default_plugins(repository, blob_repository)
 
-    for definition in DEFAULT_PLUGIN_DEFINITIONS:
+    for definition in DEFINITIONS:
         plugin = await repository.get_by_name(definition.kind, definition.name)
         assert plugin.latest_version == 1
 
@@ -91,24 +104,20 @@ async def test_register_creates_new_version_on_version_bump(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Create version 2 only for plugins whose declared version was bumped."""
-    monkeypatch.setattr(bootstrap, "_read_source", _source_reader())
+    monkeypatch.setattr(bootstrap, "DEFAULT_PLUGIN_DEFINITIONS", DEFINITIONS)
     await register_default_plugins(repository, blob_repository)
 
-    bumped_names = {
-        definition.name
-        for definition in DEFAULT_PLUGIN_DEFINITIONS
-        if definition.source_file == "evaluators/basic.py"
-    }
+    bumped_name = DEFINITIONS[0].name
     bumped = tuple(
         definition.model_copy(update={"version": 2})
-        if definition.name in bumped_names
+        if definition.name == bumped_name
         else definition
-        for definition in DEFAULT_PLUGIN_DEFINITIONS
+        for definition in DEFINITIONS
     )
     monkeypatch.setattr(bootstrap, "DEFAULT_PLUGIN_DEFINITIONS", bumped)
     await register_default_plugins(repository, blob_repository)
 
-    for definition in DEFAULT_PLUGIN_DEFINITIONS:
+    for definition in DEFINITIONS:
         plugin = await repository.get_by_name(definition.kind, definition.name)
-        expected_version = 2 if definition.name in bumped_names else 1
+        expected_version = 2 if definition.name == bumped_name else 1
         assert plugin.latest_version == expected_version

--- a/tests/server/test_default_plugins.py
+++ b/tests/server/test_default_plugins.py
@@ -1,0 +1,112 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for default plugin registration."""
+
+from collections.abc import Callable
+
+import pytest
+
+from conftest import FakeBlobRepository, FakePluginRepository
+from kitaru.server.application.services import default_plugins
+from kitaru.server.application.services.default_plugins import (
+    DEFAULT_PLUGIN_DEFINITIONS,
+    register_default_plugins,
+)
+from kitaru.server.domain.plugin import ScriptPluginSource
+
+
+def _source_reader(
+    overrides: dict[str, bytes] | None = None,
+) -> Callable[[str], bytes]:
+    """Build a deterministic stand-in for reading plugin source files."""
+    overrides = overrides or {}
+    return lambda source_file: overrides.get(
+        source_file, f"content-of-{source_file}".encode()
+    )
+
+
+@pytest.fixture
+def blob_repository() -> FakeBlobRepository:
+    """Provide a fake blob repository."""
+    return FakeBlobRepository()
+
+
+@pytest.fixture
+def repository(blob_repository: FakeBlobRepository) -> FakePluginRepository:
+    """Provide a fake plugin repository wired to the fake blob repository."""
+    return FakePluginRepository(blob_repository=blob_repository)
+
+
+async def test_register_creates_default_plugins(
+    repository: FakePluginRepository,
+    blob_repository: FakeBlobRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Create every default plugin ownerless with one version on first startup."""
+    monkeypatch.setattr(default_plugins, "_read_source", _source_reader())
+
+    await register_default_plugins(repository, blob_repository)
+
+    for definition in DEFAULT_PLUGIN_DEFINITIONS:
+        plugin = await repository.get_by_name(definition.kind, definition.name)
+        assert plugin.owner_id is None
+        assert plugin.description == definition.description
+        assert plugin.provider == definition.provider
+        assert plugin.latest_version == 1
+        version = await repository.get_version(plugin.id, 1)
+        assert isinstance(version.source, ScriptPluginSource)
+        assert version.source.entrypoint == definition.entrypoint
+
+
+async def test_register_is_idempotent(
+    repository: FakePluginRepository,
+    blob_repository: FakeBlobRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Leave version numbers unchanged when nothing about the source changed."""
+    monkeypatch.setattr(default_plugins, "_read_source", _source_reader())
+    await register_default_plugins(repository, blob_repository)
+
+    await register_default_plugins(repository, blob_repository)
+
+    for definition in DEFAULT_PLUGIN_DEFINITIONS:
+        plugin = await repository.get_by_name(definition.kind, definition.name)
+        assert plugin.latest_version == 1
+
+
+async def test_register_creates_new_version_on_content_change(
+    repository: FakePluginRepository,
+    blob_repository: FakeBlobRepository,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Create version 2 only for plugins whose source file changed."""
+    monkeypatch.setattr(default_plugins, "_read_source", _source_reader())
+    await register_default_plugins(repository, blob_repository)
+
+    monkeypatch.setattr(
+        default_plugins,
+        "_read_source",
+        _source_reader({"evaluators/basic.py": b"changed"}),
+    )
+    await register_default_plugins(repository, blob_repository)
+
+    changed_names = {
+        definition.name
+        for definition in DEFAULT_PLUGIN_DEFINITIONS
+        if definition.source_file == "evaluators/basic.py"
+    }
+    for definition in DEFAULT_PLUGIN_DEFINITIONS:
+        plugin = await repository.get_by_name(definition.kind, definition.name)
+        expected_version = 2 if definition.name in changed_names else 1
+        assert plugin.latest_version == expected_version

--- a/tests/server/test_default_plugins.py
+++ b/tests/server/test_default_plugins.py
@@ -74,7 +74,7 @@ async def test_register_is_idempotent(
     blob_repository: FakeBlobRepository,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Leave version numbers unchanged when nothing about the source changed."""
+    """Leave version numbers unchanged when the declared versions are unchanged."""
     monkeypatch.setattr(bootstrap, "_read_source", _source_reader())
     await register_default_plugins(repository, blob_repository)
 
@@ -85,28 +85,30 @@ async def test_register_is_idempotent(
         assert plugin.latest_version == 1
 
 
-async def test_register_creates_new_version_on_content_change(
+async def test_register_creates_new_version_on_version_bump(
     repository: FakePluginRepository,
     blob_repository: FakeBlobRepository,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Create version 2 only for plugins whose source file changed."""
+    """Create version 2 only for plugins whose declared version was bumped."""
     monkeypatch.setattr(bootstrap, "_read_source", _source_reader())
     await register_default_plugins(repository, blob_repository)
 
-    monkeypatch.setattr(
-        bootstrap,
-        "_read_source",
-        _source_reader({"evaluators/basic.py": b"changed"}),
-    )
-    await register_default_plugins(repository, blob_repository)
-
-    changed_names = {
+    bumped_names = {
         definition.name
         for definition in DEFAULT_PLUGIN_DEFINITIONS
         if definition.source_file == "evaluators/basic.py"
     }
+    bumped = tuple(
+        definition.model_copy(update={"version": 2})
+        if definition.name in bumped_names
+        else definition
+        for definition in DEFAULT_PLUGIN_DEFINITIONS
+    )
+    monkeypatch.setattr(bootstrap, "DEFAULT_PLUGIN_DEFINITIONS", bumped)
+    await register_default_plugins(repository, blob_repository)
+
     for definition in DEFAULT_PLUGIN_DEFINITIONS:
         plugin = await repository.get_by_name(definition.kind, definition.name)
-        expected_version = 2 if definition.name in changed_names else 1
+        expected_version = 2 if definition.name in bumped_names else 1
         assert plugin.latest_version == expected_version

--- a/tests/server/test_default_plugins_api_pg.py
+++ b/tests/server/test_default_plugins_api_pg.py
@@ -13,37 +13,33 @@
 #  permissions and limitations under the License.
 """End-to-end default plugin registration tests against PostgreSQL."""
 
-from collections.abc import AsyncGenerator
-
-import httpx
 import pytest
 
 from conftest import db_settings, lifespan_client
+from kitaru.server.api import bootstrap
+from kitaru.server.api.bootstrap import DefaultPluginDefinition
 from kitaru.server.domain.names import RESERVED_PLUGIN_NAME_PREFIX
-
-
-@pytest.fixture
-async def client() -> AsyncGenerator[httpx.AsyncClient, None]:
-    """Provide an HTTP client for the app running its full lifespan."""
-    async with lifespan_client(db_settings()) as client:
-        yield client
+from kitaru.server.domain.plugin import PluginKind
 
 
 async def test_default_plugins_are_registered_at_startup(
-    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """List the packaged default plugins with a null owner after startup."""
-    evaluators = (await client.get("/v1/evaluators")).json()["items"]
-    importers = (await client.get("/v1/importers")).json()["items"]
-
-    evaluator_names = {item["name"] for item in evaluators}
-    importer_names = {item["name"] for item in importers}
-    assert f"{RESERVED_PLUGIN_NAME_PREFIX}cost" in evaluator_names
-    assert f"{RESERVED_PLUGIN_NAME_PREFIX}latency" in evaluator_names
-    assert f"{RESERVED_PLUGIN_NAME_PREFIX}tool-call-patterns" in evaluator_names
-    assert f"{RESERVED_PLUGIN_NAME_PREFIX}langfuse" in importer_names
-    assert all(
-        item["owner_id"] is None
-        for item in evaluators + importers
-        if item["name"].startswith(RESERVED_PLUGIN_NAME_PREFIX)
+    """List a catalog-declared default plugin with a null owner after startup."""
+    definition = DefaultPluginDefinition(
+        kind=PluginKind.EVALUATOR,
+        name=f"{RESERVED_PLUGIN_NAME_PREFIX}evaluator",
+        description="Test evaluator.",
+        provider=None,
+        entrypoint="evaluate",
+        content=b"def evaluate(): ...",
+        version=1,
     )
+    monkeypatch.setattr(bootstrap, "DEFAULT_PLUGIN_DEFINITIONS", (definition,))
+
+    async with lifespan_client(db_settings()) as client:
+        evaluators = (await client.get("/v1/evaluators")).json()["items"]
+
+    matches = [item for item in evaluators if item["name"] == definition.name]
+    assert len(matches) == 1
+    assert matches[0]["owner_id"] is None

--- a/tests/server/test_default_plugins_api_pg.py
+++ b/tests/server/test_default_plugins_api_pg.py
@@ -1,0 +1,49 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""End-to-end default plugin registration tests against PostgreSQL."""
+
+from collections.abc import AsyncGenerator
+
+import httpx
+import pytest
+
+from conftest import db_settings, lifespan_client
+from kitaru.server.domain.names import RESERVED_PLUGIN_NAME_PREFIX
+
+
+@pytest.fixture
+async def client() -> AsyncGenerator[httpx.AsyncClient, None]:
+    """Provide an HTTP client for the app running its full lifespan."""
+    async with lifespan_client(db_settings()) as client:
+        yield client
+
+
+async def test_default_plugins_are_registered_at_startup(
+    client: httpx.AsyncClient,
+) -> None:
+    """List the packaged default plugins with a null owner after startup."""
+    evaluators = (await client.get("/v1/evaluators")).json()["items"]
+    importers = (await client.get("/v1/importers")).json()["items"]
+
+    evaluator_names = {item["name"] for item in evaluators}
+    importer_names = {item["name"] for item in importers}
+    assert f"{RESERVED_PLUGIN_NAME_PREFIX}cost" in evaluator_names
+    assert f"{RESERVED_PLUGIN_NAME_PREFIX}latency" in evaluator_names
+    assert f"{RESERVED_PLUGIN_NAME_PREFIX}tool-call-patterns" in evaluator_names
+    assert f"{RESERVED_PLUGIN_NAME_PREFIX}langfuse" in importer_names
+    assert all(
+        item["owner_id"] is None
+        for item in evaluators + importers
+        if item["name"].startswith(RESERVED_PLUGIN_NAME_PREFIX)
+    )

--- a/tests/server/test_evaluators_api.py
+++ b/tests/server/test_evaluators_api.py
@@ -99,6 +99,12 @@ async def test_create_evaluator_duplicate_name(client: httpx.AsyncClient) -> Non
     }
 
 
+async def test_create_evaluator_reserved_name(client: httpx.AsyncClient) -> None:
+    """Observe HTTP 422 for a name using the reserved default-plugin prefix."""
+    response = await client.post("/v1/evaluators", json={"name": "kitaru/accuracy"})
+    assert response.status_code == 422
+
+
 async def test_create_evaluator_rejects_provider(client: httpx.AsyncClient) -> None:
     """Observe HTTP 422 when the request carries a provider field."""
     response = await client.post(

--- a/tests/server/test_importers_api.py
+++ b/tests/server/test_importers_api.py
@@ -89,6 +89,14 @@ async def test_create_importer_duplicate_name(client: httpx.AsyncClient) -> None
     }
 
 
+async def test_create_importer_reserved_name(client: httpx.AsyncClient) -> None:
+    """Observe HTTP 422 for a name using the reserved default-plugin prefix."""
+    response = await client.post(
+        "/v1/importers", json={"name": "kitaru/langfuse-import"}
+    )
+    assert response.status_code == 422
+
+
 async def test_list_importers_filter_by_provider(client: httpx.AsyncClient) -> None:
     """List importers filtered by provider."""
     await client.post(

--- a/tests/server/test_names.py
+++ b/tests/server/test_names.py
@@ -21,6 +21,7 @@ from kitaru.server.domain.names import (
     validate_account_name,
     validate_evaluation_name,
     validate_name,
+    validate_plugin_name,
     validate_version_name,
 )
 
@@ -121,3 +122,41 @@ def test_invalid_version_names_rejected(name: str) -> None:
     """Reject names that are empty, boundary separated, or outside the set."""
     with pytest.raises(InvalidName):
         validate_version_name(name)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["accuracy", "accuracy-v2", "kitaru/langfuse"],
+)
+def test_valid_plugin_names_pass(name: str) -> None:
+    """Accept ordinary names and names under the reserved default-plugin prefix."""
+    assert validate_plugin_name(name) == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "foo/bar",
+        "kitaru/foo/bar",
+        "kitaru/",
+        "Kitaru/foo",
+        "a b",
+        "a.b",
+        "a:b",
+        "a@b",
+        "ä",
+    ],
+)
+def test_invalid_plugin_names_rejected(name: str) -> None:
+    """Reject names outside the default set and misuses of the reserved prefix."""
+    with pytest.raises(InvalidName):
+        validate_plugin_name(name)
+
+
+def test_plugin_name_length_limit() -> None:
+    """Reject a reserved-prefix name whose remainder exceeds the maximum length."""
+    assert validate_plugin_name("kitaru/" + "a" * 248)
+    with pytest.raises(InvalidName):
+        validate_plugin_name("kitaru/" + "a" * 249)
+    with pytest.raises(InvalidName):
+        validate_plugin_name("abc", max_length=2)

--- a/tests/server/test_plugin_repository.py
+++ b/tests/server/test_plugin_repository.py
@@ -67,7 +67,7 @@ async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
 
 
 def _plugin(
-    owner_id: uuid.UUID,
+    owner_id: uuid.UUID | None,
     kind: PluginKind = PluginKind.EVALUATOR,
     name: str = "accuracy",
     provider: str | None = None,
@@ -84,6 +84,15 @@ async def test_create_sets_timestamps(setup: Setup) -> None:
     assert plugin.latest_version == 0
     assert plugin.created is not None
     assert plugin.updated is not None
+
+
+async def test_create_and_round_trip_without_owner(setup: Setup) -> None:
+    """Store and reload a default plugin with no owner."""
+    repository, _ = setup
+    created = await repository.create(_plugin(None, name="kitaru/accuracy"))
+    assert created.owner_id is None
+    loaded = await repository.get(created.id)
+    assert loaded.owner_id is None
 
 
 async def test_create_duplicate_name_same_kind(setup: Setup) -> None:

--- a/tests/server/test_plugin_service.py
+++ b/tests/server/test_plugin_service.py
@@ -37,6 +37,7 @@ from kitaru.server.domain.plugin import (
     PluginKind,
     PluginNotFound,
     PluginVersionNotFound,
+    ReservedPluginName,
     ScriptPluginSource,
 )
 
@@ -130,6 +131,25 @@ async def test_create_plugin_duplicate_name(evaluator_service: PluginService) ->
         await evaluator_service.create_plugin(
             name="accuracy", description=None, provider=None, metadata={}, actor=ACTOR
         )
+
+
+async def test_create_plugin_reserved_name(evaluator_service: PluginService) -> None:
+    """Reject a name that uses the reserved default-plugin prefix."""
+    with pytest.raises(
+        ReservedPluginName,
+        match="Plugin name 'kitaru/accuracy' uses the reserved prefix 'kitaru/'",
+    ):
+        await evaluator_service.create_plugin(
+            name="kitaru/accuracy",
+            description=None,
+            provider=None,
+            metadata={},
+            actor=ACTOR,
+        )
+    plugins, _ = await evaluator_service.list_plugins(
+        PluginFilter(kind=PluginKind.EVALUATOR), actor=ACTOR
+    )
+    assert plugins == []
 
 
 async def test_create_plugin_evaluator_rejects_provider(


### PR DESCRIPTION
This PR adds a startup bootstrap harness that registers built-in default plugins from a declared catalog. Each catalog entry carries the plugin source content and a pinned version, and a new version is created only when the declared version is bumped. The catalog currently ships empty.

- The `kitaru/` name prefix is reserved for default plugins: creating a plugin with it via the API returns 422.
- Default plugins and their blobs have no owner, so plugin and blob `owner_id` are now nullable. API creation still sets the caller as owner.