### PR TITLE
Fix plugin `model_provider` drift and blob cache test on Python 3.14

### DIFF
--- a/examples/integrations/pydantic_ai_v2/__main__.py
+++ b/examples/integrations/pydantic_ai_v2/__main__.py
@@ -6,9 +6,8 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-from pydantic_ai import Agent
-
 from kitaru_pydantic_ai import KitaruAgent
+from pydantic_ai import Agent
 
 PROMPT = """
 Call both available tools exactly once:

--- a/plugins/packages/braintrust-importer/src/kitaru_braintrust_importer/importer.py
+++ b/plugins/packages/braintrust-importer/src/kitaru_braintrust_importer/importer.py
@@ -794,7 +794,7 @@ class BraintrustProjectLogImporter:
                             or metadata.get("model"),
                             model=metadata.get("gen_ai.response.model")
                             or metadata.get("model"),
-                            provider=metadata.get("gen_ai.provider.name")
+                            model_provider=metadata.get("gen_ai.provider.name")
                             or metadata.get("provider"),
                             tokens=_token_usage(row),
                             cost=_decimal(_metrics(row).get("estimated_cost")),

--- a/plugins/packages/evaluator/src/kitaru_evaluator/deterministic.py
+++ b/plugins/packages/evaluator/src/kitaru_evaluator/deterministic.py
@@ -153,7 +153,7 @@ def _input_envelope(view: SessionView) -> dict[str, Any]:
             "outputs": node.outputs,
             "parent_id": node.parent_id,
             "parent_index": node.parent_index,
-            "provider": node.provider,
+            "provider": node.model_provider,
             "requested_model": node.requested_model,
             "secondary_parent_ids": node.secondary_parent_ids,
             "secondary_parent_indexes": node.secondary_parent_indexes,
@@ -1409,7 +1409,7 @@ def llm_call_signals(session: SessionView) -> list[EvaluationResult]:
                 {
                     "complete_model": sum(node.model is not None for node in calls),
                     "complete_provider": sum(
-                        node.provider is not None for node in calls
+                        node.model_provider is not None for node in calls
                     ),
                     "complete_requested_model": sum(
                         node.requested_model is not None for node in calls
@@ -1470,11 +1470,11 @@ def model_policy(
         )
     if providers is not None:
         violations = [
-            {"index": node.index, "provider": node.provider}
+            {"index": node.index, "provider": node.model_provider}
             for node in calls
-            if node.provider is not None and node.provider not in providers
+            if node.model_provider is not None and node.model_provider not in providers
         ]
-        complete = can_pass and all(node.provider is not None for node in calls)
+        complete = can_pass and all(node.model_provider is not None for node in calls)
         results.append(
             _json_result(
                 "allowed_providers",

--- a/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
+++ b/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
@@ -1049,7 +1049,7 @@ class LangfuseJSONLImporter:
                             or _first_nonempty(record, "model", "modelId", "model_id")
                             or _metadata_value(record, "gen_ai.request.model")
                         ),
-                        provider=(
+                        model_provider=(
                             _first_nonempty(record, "modelProvider", "model_provider")
                             or _metadata_value(
                                 record,

--- a/plugins/packages/langsmith-importer/src/kitaru_langsmith_importer/importer.py
+++ b/plugins/packages/langsmith-importer/src/kitaru_langsmith_importer/importer.py
@@ -875,7 +875,7 @@ class LangSmithRunImporter:
                             outputs=_decode_json(record.get("outputs")),
                             requested_model=requested_model,
                             model=model,
-                            provider=provider,
+                            model_provider=provider,
                             tokens=_tokens(record),
                             cost=_decimal(record.get("total_cost")),
                             model_params=_invocation(record) or None,

--- a/plugins/packages/opentelemetry-importer/src/kitaru_opentelemetry_importer/importer.py
+++ b/plugins/packages/opentelemetry-importer/src/kitaru_opentelemetry_importer/importer.py
@@ -1180,7 +1180,7 @@ def _parse_session(
                             )
                             else None
                         ),
-                        provider=(
+                        model_provider=(
                             str(value)
                             if (
                                 value := _attribute(

--- a/plugins/tests/evaluators/test_deterministic.py
+++ b/plugins/tests/evaluators/test_deterministic.py
@@ -48,7 +48,7 @@ def _node(
     tool_name: str | None = None,
     requested_model: str | None = None,
     model: str | None = None,
-    provider: str | None = None,
+    model_provider: str | None = None,
     tokens: TokenUsage | None = None,
     cost: Decimal | None = None,
 ) -> SessionNodeResponse:
@@ -73,7 +73,7 @@ def _node(
         outputs=outputs,
         requested_model=requested_model,
         model=model,
-        provider=provider,
+        model_provider=model_provider,
         tokens=tokens,
         cost=cost,
         tool_name=tool_name,
@@ -634,7 +634,7 @@ def test_resource_budget_reconciles_rollups_and_uses_inclusive_ceilings() -> Non
         ),
         cost=Decimal("1.25"),
         model="m",
-        provider="p",
+        model_provider="p",
     )
     view = _view(
         [llm], cost=Decimal("1.25"), tokens=TokenUsage(input_tokens=2, output_tokens=3)
@@ -783,7 +783,7 @@ def test_llm_signals_and_model_policy_use_recorded_metadata() -> None:
             outputs="",
             requested_model="requested",
             model="served",
-            provider="acme",
+            model_provider="acme",
             tokens=TokenUsage(input_tokens=1, output_tokens=0),
         ),
         _node(
@@ -793,7 +793,7 @@ def test_llm_signals_and_model_policy_use_recorded_metadata() -> None:
             outputs=None,
             requested_model="served",
             model="served",
-            provider=None,
+            model_provider=None,
             tokens=None,
         ),
     ]

--- a/plugins/tests/importers/test_braintrust.py
+++ b/plugins/tests/importers/test_braintrust.py
@@ -343,7 +343,7 @@ def test_maps_otel_conversation_model_provider_and_cost() -> None:
     )
     assert node.requested_model == "requested-model"
     assert node.model == "resolved-model"
-    assert node.provider == "openai"
+    assert node.model_provider == "openai"
     assert node.cost == Decimal("0.00125")
     assert node.tokens is not None
     assert node.tokens.input_tokens == 5

--- a/plugins/tests/importers/test_langfuse.py
+++ b/plugins/tests/importers/test_langfuse.py
@@ -366,7 +366,7 @@ def test_surfaces_flattened_model_metadata_and_terminal_output() -> None:
     assert session.outputs == {"role": "assistant", "content": "hi"}
     assert generation.requested_model == "requested-model"
     assert generation.model == "resolved-model"
-    assert generation.provider == "openai"
+    assert generation.model_provider == "openai"
 
 
 def test_imports_legacy_ingestion_events() -> None:
@@ -528,7 +528,7 @@ def test_maps_openai_agents_function_span_as_tool() -> None:
     tool = nodes["trace-1:function"]
     assert tool.node_type is NodeType.TOOL_CALL
     assert tool.tool_name == "get_weather"
-    assert tool.provider == "openai"
+    assert tool.model_provider == "openai"
     assert tool.metadata == {
         "langfuse.gen_ai.system": "openai",
         "langfuse.name": "get_weather",
@@ -562,7 +562,7 @@ def test_maps_flattened_openai_agents_function_span_as_tool() -> None:
     tool = nodes["trace-1:function"]
     assert tool.node_type is NodeType.TOOL_CALL
     assert tool.tool_name == "get_weather"
-    assert tool.provider == "openai"
+    assert tool.model_provider == "openai"
 
 
 def test_maps_model_provider_cost_and_bounded_metadata() -> None:
@@ -593,7 +593,7 @@ def test_maps_model_provider_cost_and_bounded_metadata() -> None:
     node = session.nodes[0]
     assert node.requested_model == "requested-model"
     assert node.model == "resolved-model"
-    assert node.provider == "openai"
+    assert node.model_provider == "openai"
     assert node.cost == Decimal("0.0125")
     assert "response" not in node.metadata
     assert node.metadata["langfuse.gen_ai.provider.name"] == "openai"

--- a/plugins/tests/importers/test_langsmith.py
+++ b/plugins/tests/importers/test_langsmith.py
@@ -167,7 +167,7 @@ def test_groups_thread_traces_into_ordered_turns_and_nodes() -> None:
     assert session.metadata["langsmith.join_paths"] == ["extra.metadata.thread_id"]
     nodes = {node.external_id: node for node in flatten(session.nodes)}
     assert nodes["trace-2:llm-2"].node_type is NodeType.LLM_CALL
-    assert nodes["trace-2:llm-2"].provider == "openai"
+    assert nodes["trace-2:llm-2"].model_provider == "openai"
     assert nodes["trace-2:llm-2"].model == "gpt-5-mini"
     assert nodes["trace-2:llm-2"].tokens is not None
     assert nodes["trace-2:llm-2"].tokens.input_tokens == 12

--- a/plugins/tests/importers/test_otlp.py
+++ b/plugins/tests/importers/test_otlp.py
@@ -206,7 +206,7 @@ def test_imports_span_graph_and_genai_fields() -> None:
     assert child.node_type is NodeType.LLM_CALL
     assert child.requested_model == "gpt-5-mini"
     assert child.model == "gpt-5-mini-2026-06-01"
-    assert child.provider == "openai"
+    assert child.model_provider == "openai"
     assert child.input_text_selector == "/0/content"
     assert child.output_text_selector == "/0/content"
     assert child.tokens and child.tokens.input_tokens == 120

--- a/tests/worker/test_blob_cache.py
+++ b/tests/worker/test_blob_cache.py
@@ -159,16 +159,14 @@ async def test_eviction_skips_an_entry_removed_by_another_process(
     path_b = await cache.put(digest_b, content_b)
 
     real_stat = Path.stat
-    path_a_stat_calls = 0
 
     def flaky_stat(self: Path, *args: Any, **kwargs: Any) -> os.stat_result:
-        # The first stat passes the is_file check, then the entry vanishes
-        # before the size stat.
-        nonlocal path_a_stat_calls
+        # The entry vanishes before the size stat. Raise on every intercepted
+        # call: since Python 3.13 is_file() takes an os.path fast path that
+        # bypasses Path.stat, so counting calls to skip the is_file check
+        # would leave the size stat unpatched.
         if self == path_a:
-            path_a_stat_calls += 1
-            if path_a_stat_calls > 1:
-                raise FileNotFoundError(errno.ENOENT, "No such file", str(self))
+            raise FileNotFoundError(errno.ENOENT, "No such file", str(self))
         return real_stat(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "stat", flaky_stat)


### PR DESCRIPTION
## What this does

Fixes the three failures that `just check`, `just test`, and the plugins test suite report on a clean checkout of `v2-spec-consolidated`:

1. **`provider` → `model_provider` drift in the plugins workspace.** The core `ImportedNode` and `SessionNodeResponse` models renamed `provider` to `model_provider` (completed in the #659 merge), but the plugins workspace never followed. All four importers (Langfuse, Braintrust, LangSmith, OpenTelemetry) still passed `provider=` to `ImportedNode`, which has `extra="forbid"`, so every imported node raised an `extra_forbidden` validation error. The deterministic evaluators likewise read the removed `.provider` attribute. 84 of 177 plugin tests failed.
2. **`tests/worker/test_blob_cache.py::test_eviction_skips_an_entry_removed_by_another_process`** failed on Python 3.14 (already noted in #701's description). The test monkeypatches `Path.stat` and counted on `is_file()` consuming the first call, but since Python 3.13 `is_file()` takes an `os.path` fast path that bypasses `Path.stat`. The fake "file vanished" error never fired, the entry stayed in the eviction budget, and the cache genuinely evicted it. The fake now raises on every intercepted call, which lands the error exactly at the explicit `entry.stat()` in `_evict_to_fit`.
3. A ruff `I001` import-sort error in `examples/integrations/pydantic_ai_v2/__main__.py` that failed `just check`.

## Reviewer Notes

The risky part is the rename's edge: in `plugins/packages/evaluator/src/kitaru_evaluator/deterministic.py`, only the *attribute reads* changed to `.model_provider`. The `"provider"` dict keys in the shared-hash payload and in evaluator report output are kept on purpose — renaming them would silently change stored digests (or force an `_ENCODING_REVISION` bump) and alter report shapes, which is behavior change beyond a drift fix. If you'd rather migrate the key and bump the revision, that should be its own PR.

The importer changes are one-keyword renames at each `ImportedNode(...)` construction site, and the plugin test changes mirror them (`.provider ==` assertions and the `_node()` fixture kwarg in `test_deterministic.py`).

For the blob cache test, the thing to check is that the reworked patch still exercises the intended branch: `_evict_to_fit` in `src/kitaru/worker/blob_cache.py` must hit the `except OSError: continue` on the size stat, excluding the vanished entry from the budget so nothing else gets evicted. On Python ≤3.12, where `is_file()` still routes through `Path.stat`, the always-raise fake makes `is_file()` return False instead — the entry is skipped one line earlier and the assertions still hold.

### Reproduction

On clean `v2-spec-consolidated`:

```bash
just check                    # fails: ruff I001 in examples/integrations/pydantic_ai_v2/__main__.py
just test                     # fails: tests/worker/test_blob_cache.py eviction race test
cd plugins && uv run pytest   # 84 failed, 93 passed — all extra_forbidden / missing .provider
```

On this branch all three are green. To see the importer path work end to end, any Langfuse export parse now produces nodes instead of raising, e.g. `uv run pytest plugins/tests/importers/test_langfuse.py -k model_provider`.

Local checks run: `just check`, `just test` (3175 passed, 1 skipped), `cd plugins && uv run pytest` (177 passed), plus ruff format/lint and `ty check` inside `plugins/`.