### PR TITLE
Replace investigation session status with an optional verdict

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -3370,7 +3370,7 @@
             "type": "string"
           },
           "completed_sessions": {
-            "description": "Number of linked sessions marked completed or skipped.",
+            "description": "Number of linked sessions with a verdict.",
             "title": "Completed Sessions",
             "type": "integer"
           },
@@ -3541,14 +3541,22 @@
             "title": "Session Id",
             "type": "string"
           },
-          "status": {
-            "$ref": "#/components/schemas/InvestigationSessionStatus"
-          },
           "updated": {
             "description": "Last modification time.",
             "format": "date-time",
             "title": "Updated",
             "type": "string"
+          },
+          "verdict": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InvestigationSessionVerdict"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Investigation session verdict."
           },
           "view": {
             "anyOf": [
@@ -3569,36 +3577,43 @@
           "investigation_id",
           "session_id",
           "position",
-          "status",
+          "verdict",
           "view"
         ],
         "title": "InvestigationSessionResponse",
         "type": "object"
       },
-      "InvestigationSessionStatus": {
-        "description": "Investigation session status.",
-        "enum": [
-          "pending",
-          "completed",
-          "skipped"
-        ],
-        "title": "InvestigationSessionStatus",
-        "type": "string"
-      },
       "InvestigationSessionUpdateRequest": {
         "additionalProperties": false,
         "description": "Investigation session update request.",
         "properties": {
-          "status": {
-            "$ref": "#/components/schemas/InvestigationSessionStatus",
-            "description": "New investigation session status."
+          "verdict": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InvestigationSessionVerdict"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New investigation session verdict, None clears it."
           }
         },
         "required": [
-          "status"
+          "verdict"
         ],
         "title": "InvestigationSessionUpdateRequest",
         "type": "object"
+      },
+      "InvestigationSessionVerdict": {
+        "description": "Investigation session verdict.",
+        "enum": [
+          "acceptable",
+          "problematic",
+          "uncertain"
+        ],
+        "title": "InvestigationSessionVerdict",
+        "type": "string"
       },
       "InvestigationSessionView": {
         "additionalProperties": false,
@@ -3697,6 +3712,17 @@
             ],
             "description": "New investigation name.",
             "title": "Name"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InvestigationStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "New investigation status."
           }
         },
         "title": "InvestigationUpdateRequest",
@@ -7770,7 +7796,7 @@
         "type": "object"
       },
       "UserActivationTokenResponse": {
-        "description": "Account response carrying a newly minted activation token.",
+        "description": "User response carrying a newly minted activation token.",
         "properties": {
           "activation_token": {
             "description": "Plaintext token, shown once.",
@@ -13034,7 +13060,7 @@
         ]
       },
       "patch": {
-        "description": "Update an investigation's name and description.\n\nClients observe HTTP 200 on success, 404 when no investigation has this\nid, and 422 when the update clears the investigation name.\n\nArgs:\n    investigation_id: Id of the investigation.\n    body: Investigation update request.\n    service: Investigation service.\n    actor: Caller context.\n\nReturns:\n    Updated investigation.",
+        "description": "Update an investigation's name, description, and status.\n\nClients observe HTTP 200 on success, 404 when no investigation has this\nid, 409 when the update moves the status backwards, and 422 when the\nupdate clears the investigation name or status.\n\nArgs:\n    investigation_id: Id of the investigation.\n    body: Investigation update request.\n    service: Investigation service.\n    actor: Caller context.\n\nReturns:\n    Updated investigation.",
         "operationId": "update_investigation_v1_investigations__investigation_id__patch",
         "parameters": [
           {
@@ -13164,8 +13190,8 @@
     },
     "/v1/investigations/{investigation_id}/sessions/{session_id}": {
       "patch": {
-        "description": "Mark a linked session completed or skipped.\n\nCompletes the investigation once no linked session is left pending.\nClients observe HTTP 200 on success, 404 when no investigation has this\nid or no investigation session links this investigation and session, and\n409 when the linked session is not pending.\n\nArgs:\n    investigation_id: Id of the investigation.\n    session_id: Id of the linked session.\n    body: Investigation session update request.\n    service: Investigation service.\n    actor: Caller context.\n\nReturns:\n    Updated investigation session.",
-        "operationId": "update_investigation_session_status_v1_investigations__investigation_id__sessions__session_id__patch",
+        "description": "Set or clear a linked session's verdict.\n\nClients observe HTTP 200 on success and 404 when no investigation has\nthis id or no investigation session links this investigation and\nsession.\n\nArgs:\n    investigation_id: Id of the investigation.\n    session_id: Id of the linked session.\n    body: Investigation session update request.\n    service: Investigation service.\n    actor: Caller context.\n\nReturns:\n    Updated investigation session.",
+        "operationId": "update_investigation_session_verdict_v1_investigations__investigation_id__sessions__session_id__patch",
         "parameters": [
           {
             "in": "path",
@@ -13220,7 +13246,7 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Update Investigation Session Status",
+        "summary": "Update Investigation Session Verdict",
         "tags": [
           "investigations"
         ]

--- a/src/kitaru/api_models/v1/investigation.py
+++ b/src/kitaru/api_models/v1/investigation.py
@@ -38,12 +38,12 @@ class InvestigationStatus(StrEnum):
     COMPLETED = "completed"
 
 
-class InvestigationSessionStatus(StrEnum):
-    """Investigation session status."""
+class InvestigationSessionVerdict(StrEnum):
+    """Investigation session verdict."""
 
-    PENDING = "pending"
-    COMPLETED = "completed"
-    SKIPPED = "skipped"
+    ACCEPTABLE = "acceptable"
+    PROBLEMATIC = "problematic"
+    UNCERTAIN = "uncertain"
 
 
 class QuestionItem(RequestModel):
@@ -122,6 +122,9 @@ class InvestigationUpdateRequest(RequestModel):
 
     name: str | None = Field(default=None, description="New investigation name.")
     description: str | None = Field(default=None, description="New curator rationale.")
+    status: InvestigationStatus | None = Field(
+        default=None, description="New investigation status."
+    )
 
 
 class InvestigationListParams(FilterableListParams):
@@ -150,7 +153,7 @@ class InvestigationResponse(OwnedResponseModel):
     metadata: dict[str, JsonValue] = Field(description="Arbitrary metadata.")
     total_sessions: int = Field(description="Number of linked sessions.")
     completed_sessions: int = Field(
-        description="Number of linked sessions marked completed or skipped."
+        description="Number of linked sessions with a verdict."
     )
 
 
@@ -161,8 +164,8 @@ class InvestigationSessionsListParams(CursorParams):
 class InvestigationSessionUpdateRequest(RequestModel):
     """Investigation session update request."""
 
-    status: InvestigationSessionStatus = Field(
-        description="New investigation session status."
+    verdict: InvestigationSessionVerdict | None = Field(
+        description="New investigation session verdict, None clears it."
     )
 
 
@@ -175,7 +178,7 @@ class InvestigationSessionResponse(TimestampedResponseModel):
     )
     session_id: uuid.UUID = Field(description="Session being investigated.")
     position: int = Field(description="Presentation order within the investigation.")
-    status: InvestigationSessionStatus = Field(
-        description="Investigation session status."
+    verdict: InvestigationSessionVerdict | None = Field(
+        description="Investigation session verdict."
     )
     view: InvestigationSessionView | None = Field(description="Curated session view.")

--- a/src/kitaru/cli/app.py
+++ b/src/kitaru/cli/app.py
@@ -31,7 +31,10 @@ from cyclopts import App, Parameter
 from cyclopts.exceptions import CycloptsError
 from pydantic import ValidationError as PydanticValidationError
 
-from kitaru.api_models.v1.investigation import InvestigationSessionStatus
+from kitaru.api_models.v1.investigation import (
+    InvestigationSessionVerdict,
+    InvestigationStatus,
+)
 from kitaru.api_models.v1.session import SessionOrigin, SessionStatus
 from kitaru.api_models.v1.task import TaskKind
 from kitaru.cli import (
@@ -1031,7 +1034,7 @@ _LIST_PARAMETERS = (
 )
 _CURSOR_PARAMETERS = _LIST_PARAMETERS[:2]
 _VERSION_LIST_PARAMETERS = _LIST_PARAMETERS[:-1]
-_INVESTIGATION_SESSION_STATUS_PARAMETERS = (
+_INVESTIGATION_SESSION_VERDICT_PARAMETERS = (
     ParameterSpec("INVESTIGATION", "UUID", "argument", True, "Investigation ID."),
     ParameterSpec(
         "SESSION",
@@ -1039,6 +1042,13 @@ _INVESTIGATION_SESSION_STATUS_PARAMETERS = (
         "argument",
         True,
         "Session ID linked to the investigation.",
+    ),
+    ParameterSpec(
+        "VERDICT",
+        "acceptable|problematic|uncertain",
+        "argument",
+        True,
+        "Verdict for the investigation session.",
     ),
 )
 _WAIT_PARAMETERS = (
@@ -1917,6 +1927,13 @@ async def investigation_get(investigation: uuid.UUID, /) -> CommandResult:
                 False,
                 "Clear the curator rationale.",
             ),
+            ParameterSpec(
+                "--status",
+                "in_progress|completed",
+                "option",
+                False,
+                "New investigation status.",
+            ),
         ),
         read_only=False,
         side_effects=("mutates_remote_state",),
@@ -1931,6 +1948,7 @@ async def investigation_update(
     name: str | None = None,
     description: str | None = None,
     clear_description: bool = False,
+    status: InvestigationStatus | None = None,
 ) -> CommandResult:
     """Update selected fields on one investigation."""
     async with _open_asset_client() as client:
@@ -1940,6 +1958,7 @@ async def investigation_update(
             name=name,
             description=description,
             clear_description=clear_description,
+            status=status,
         )
 
 
@@ -2007,50 +2026,28 @@ async def investigation_session_list(
 @_register(
     investigation_session_app,
     _spec(
-        ("investigation", "session", "complete"),
-        "Mark a pending investigation session completed.",
-        parameters=_INVESTIGATION_SESSION_STATUS_PARAMETERS,
+        ("investigation", "session", "verdict"),
+        "Set an investigation session verdict.",
+        parameters=_INVESTIGATION_SESSION_VERDICT_PARAMETERS,
         read_only=False,
         side_effects=("mutates_remote_state",),
-        idempotency="server_rejects_settled_sessions",
+        idempotency="idempotent",
         errors=_ASSET_WRITE_ERRORS,
     ),
 )
-async def investigation_session_complete(
-    investigation: uuid.UUID, session: uuid.UUID, /
+async def investigation_session_verdict(
+    investigation: uuid.UUID,
+    session: uuid.UUID,
+    verdict: InvestigationSessionVerdict,
+    /,
 ) -> CommandResult:
-    """Mark one pending investigation session completed."""
+    """Set one investigation session's verdict."""
     async with _open_asset_client() as client:
-        return await investigations.update_investigation_session_status(
+        return await investigations.update_investigation_session_verdict(
             client,
             investigation,
             session,
-            status=InvestigationSessionStatus.COMPLETED,
-        )
-
-
-@_register(
-    investigation_session_app,
-    _spec(
-        ("investigation", "session", "skip"),
-        "Mark a pending investigation session skipped.",
-        parameters=_INVESTIGATION_SESSION_STATUS_PARAMETERS,
-        read_only=False,
-        side_effects=("mutates_remote_state",),
-        idempotency="server_rejects_settled_sessions",
-        errors=_ASSET_WRITE_ERRORS,
-    ),
-)
-async def investigation_session_skip(
-    investigation: uuid.UUID, session: uuid.UUID, /
-) -> CommandResult:
-    """Mark one pending investigation session skipped."""
-    async with _open_asset_client() as client:
-        return await investigations.update_investigation_session_status(
-            client,
-            investigation,
-            session,
-            status=InvestigationSessionStatus.SKIPPED,
+            verdict=verdict,
         )
 
 

--- a/src/kitaru/cli/investigations.py
+++ b/src/kitaru/cli/investigations.py
@@ -20,9 +20,10 @@ from kitaru.api_models.v1.investigation import (
     InvestigationCreateRequest,
     InvestigationSessionInput,
     InvestigationSessionsListParams,
-    InvestigationSessionStatus,
     InvestigationSessionUpdateRequest,
+    InvestigationSessionVerdict,
     InvestigationSessionView,
+    InvestigationStatus,
     InvestigationUpdateRequest,
     QuestionItem,
 )
@@ -161,6 +162,7 @@ async def update_investigation(
     name: str | None,
     description: str | None,
     clear_description: bool,
+    status: InvestigationStatus | None,
 ) -> CommandResult:
     """Update only explicitly selected investigation fields."""
     if description is not None and clear_description:
@@ -175,6 +177,8 @@ async def update_investigation(
         fields["description"] = description
     elif clear_description:
         fields["description"] = None
+    if status is not None:
+        fields["status"] = status
     if not fields:
         raise CLIError("invalid_arguments", "Select at least one investigation update.")
     investigation = await client.investigations.update(
@@ -210,18 +214,18 @@ async def list_investigation_sessions(
     return page_result(page, size=size)
 
 
-async def update_investigation_session_status(
+async def update_investigation_session_verdict(
     client: Any,
     investigation_id: uuid.UUID,
     session_id: uuid.UUID,
     *,
-    status: InvestigationSessionStatus,
+    verdict: InvestigationSessionVerdict,
 ) -> CommandResult:
-    """Set one pending investigation session to a terminal status."""
+    """Set one investigation session's verdict."""
     session = await client.investigations.update_session(
         investigation_id,
         session_id,
-        InvestigationSessionUpdateRequest(status=status),
+        InvestigationSessionUpdateRequest(verdict=verdict),
     )
     return CommandResult(
         item=session.model_dump(mode="json"),

--- a/src/kitaru/client/resources/investigations.py
+++ b/src/kitaru/client/resources/investigations.py
@@ -128,7 +128,7 @@ class InvestigationsResource:
     async def update(
         self, investigation_id: uuid.UUID, request: InvestigationUpdateRequest
     ) -> InvestigationResponse:
-        """Update an investigation's name and description.
+        """Update an investigation's name, description, and status.
 
         Args:
             investigation_id: Id of the investigation.
@@ -218,7 +218,7 @@ class InvestigationsResource:
         session_id: uuid.UUID,
         request: InvestigationSessionUpdateRequest,
     ) -> InvestigationSessionResponse:
-        """Mark an investigation session completed or skipped.
+        """Set or clear an investigation session's verdict.
 
         Args:
             investigation_id: Id of the investigation.

--- a/src/kitaru/mcp/models/review.py
+++ b/src/kitaru/mcp/models/review.py
@@ -13,6 +13,7 @@ from kitaru.api_models.v1.base import JsonValue
 from kitaru.api_models.v1.filter import Filter
 from kitaru.api_models.v1.investigation import (
     InvestigationSessionInput,
+    InvestigationSessionVerdict,
     QuestionItem,
 )
 from kitaru.mcp.models.common import MCPModel, PageOptions
@@ -80,6 +81,7 @@ class InvestigationUpdate(MCPModel):
     name: str | None = None
     description: str | None = None
     clear_description: bool = False
+    status: Literal["in_progress", "completed"] | None = None
 
     @model_validator(mode="after")
     def _validate_update(self) -> "InvestigationUpdate":
@@ -93,20 +95,22 @@ class InvestigationUpdate(MCPModel):
             raise ValueError("description cannot be null without clear_description")
         if self.description is not None and self.clear_description:
             raise ValueError("description and clear_description conflict")
-        if not ({"name", "description"} & self.model_fields_set) and not (
+        if "status" in self.model_fields_set and self.status is None:
+            raise ValueError("status cannot be null")
+        if not ({"name", "description", "status"} & self.model_fields_set) and not (
             self.clear_description
         ):
             raise ValueError("investigation update must change at least one field")
         return self
 
 
-class SetInvestigationSessionStatus(MCPModel):
-    """Set one linked session to a terminal status."""
+class SetInvestigationSessionVerdict(MCPModel):
+    """Set or clear one linked session's verdict."""
 
-    operation: Literal["set_session_status"]
+    operation: Literal["set_session_verdict"]
     investigation_id: uuid.UUID
     session_id: uuid.UUID
-    status: Literal["completed", "skipped"]
+    verdict: InvestigationSessionVerdict | None
 
 
 class ManualAnnotationCreate(MCPModel):
@@ -139,7 +143,7 @@ class AnnotationUpdate(MCPModel):
 ReviewManageRequest = Annotated[
     InvestigationCreate
     | InvestigationUpdate
-    | SetInvestigationSessionStatus
+    | SetInvestigationSessionVerdict
     | ManualAnnotationCreate
     | InvestigationAnswerCreate
     | AnnotationUpdate,

--- a/src/kitaru/mcp/tools/review.py
+++ b/src/kitaru/mcp/tools/review.py
@@ -28,7 +28,7 @@ from kitaru.mcp.models.review import (
     ReviewListSessions,
     ReviewManageRequest,
     ReviewReadRequest,
-    SetInvestigationSessionStatus,
+    SetInvestigationSessionVerdict,
 )
 from kitaru.mcp.tools.registry import build_page_data
 
@@ -78,18 +78,20 @@ async def handle_review_manage(
         )
         return await state.client.investigations.create(dto)
     if isinstance(request, InvestigationUpdate):
-        values = request.model_dump(include={"name", "description"}, exclude_unset=True)
+        values = request.model_dump(
+            include={"name", "description", "status"}, exclude_unset=True
+        )
         if request.clear_description:
             values["description"] = None
         return await state.client.investigations.update(
             request.investigation_id,
             InvestigationUpdateRequest.model_validate(values),
         )
-    if isinstance(request, SetInvestigationSessionStatus):
+    if isinstance(request, SetInvestigationSessionVerdict):
         return await state.client.investigations.update_session(
             request.investigation_id,
             request.session_id,
-            InvestigationSessionUpdateRequest(status=request.status),
+            InvestigationSessionUpdateRequest(verdict=request.verdict),
         )
     if isinstance(request, ManualAnnotationCreate):
         return await state.client.annotations.create(

--- a/src/kitaru/server/adapters/db/orm/investigation_session.py
+++ b/src/kitaru/server/adapters/db/orm/investigation_session.py
@@ -21,7 +21,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from kitaru.api_models.v1.investigation import (
-    InvestigationSessionStatus,
+    InvestigationSessionVerdict,
     InvestigationSessionView,
 )
 from kitaru.server.adapters.db.orm.base import (
@@ -49,7 +49,7 @@ INVESTIGATION_SESSION_SESSION_ID_INDEX = index_name(
     "investigation_session", ["session_id"]
 )
 
-STATUS_LENGTH = 32
+VERDICT_LENGTH = 32
 
 
 class InvestigationSessionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -80,7 +80,7 @@ class InvestigationSessionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     investigation_id: Mapped[uuid.UUID]
     session_id: Mapped[uuid.UUID]
     position: Mapped[int]
-    status: Mapped[str] = mapped_column(String(STATUS_LENGTH))
+    verdict: Mapped[str | None] = mapped_column(String(VERDICT_LENGTH))
     view: Mapped[Any | None] = mapped_column(JSONB(none_as_null=True))
 
     @classmethod
@@ -98,7 +98,7 @@ class InvestigationSessionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             investigation_id=session.investigation_id,
             session_id=session.session_id,
             position=session.position,
-            status=session.status.value,
+            verdict=session.verdict.value if session.verdict is not None else None,
             view=(
                 session.view.model_dump(mode="json")
                 if session.view is not None
@@ -117,7 +117,11 @@ class InvestigationSessionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             investigation_id=self.investigation_id,
             session_id=self.session_id,
             position=self.position,
-            status=InvestigationSessionStatus(self.status),
+            verdict=(
+                InvestigationSessionVerdict(self.verdict)
+                if self.verdict is not None
+                else None
+            ),
             view=(
                 InvestigationSessionView.model_validate(self.view)
                 if self.view is not None

--- a/src/kitaru/server/adapters/db/repositories/investigation_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/investigation_repository.py
@@ -18,7 +18,6 @@ from collections.abc import Mapping, Sequence
 
 from sqlalchemy import func, select
 
-from kitaru.api_models.v1.investigation import InvestigationSessionStatus
 from kitaru.server.adapters.db.filtering import FilterBinding, compile_filter_expression
 from kitaru.server.adapters.db.orm.investigation import InvestigationORM
 from kitaru.server.adapters.db.orm.investigation_session import InvestigationSessionORM
@@ -42,7 +41,7 @@ INVESTIGATION_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
 }
 
 INVESTIGATION_SESSION_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
-    "status": InvestigationSessionORM.status,
+    "verdict": InvestigationSessionORM.verdict,
 }
 
 SessionCounts = tuple[int, int]
@@ -67,39 +66,30 @@ class SQLInvestigationRepository(BaseSQLRepository[InvestigationORM]):
     async def _load_session_counts(
         self, investigation_ids: Sequence[uuid.UUID]
     ) -> dict[uuid.UUID, SessionCounts]:
-        """Bulk-count linked and completed or skipped sessions per investigation.
+        """Bulk-count linked sessions and non-null verdicts per investigation.
 
         Args:
             investigation_ids: Ids of the investigations.
 
         Returns:
-            Total and completed or skipped session counts keyed by
-            investigation id, missing ids omitted.
+            Session and verdict counts keyed by investigation id, missing
+            ids omitted.
         """
         if not investigation_ids:
             return {}
         statement = (
             select(
                 InvestigationSessionORM.investigation_id,
-                InvestigationSessionORM.status,
                 func.count(InvestigationSessionORM.id),
+                func.count(InvestigationSessionORM.verdict),
             )
             .where(InvestigationSessionORM.investigation_id.in_(investigation_ids))
-            .group_by(
-                InvestigationSessionORM.investigation_id, InvestigationSessionORM.status
-            )
+            .group_by(InvestigationSessionORM.investigation_id)
         )
         rows = (await self._session.execute(statement)).all()
-        tallies: dict[uuid.UUID, dict[str, int]] = {}
-        for investigation_id, status, count in rows:
-            tallies.setdefault(investigation_id, {})[status] = count
         return {
-            investigation_id: (
-                sum(tally.values()),
-                sum(tally.values())
-                - tally.get(InvestigationSessionStatus.PENDING.value, 0),
-            )
-            for investigation_id, tally in tallies.items()
+            investigation_id: (total, completed)
+            for investigation_id, total, completed in rows
         }
 
     async def _to_domain(self, row: InvestigationORM) -> Investigation:
@@ -156,11 +146,7 @@ class SQLInvestigationRepository(BaseSQLRepository[InvestigationORM]):
             [InvestigationSessionORM.from_domain(session) for session in sessions]
         )
         await self._flush()
-        completed = sum(
-            1
-            for session in sessions
-            if session.status is not InvestigationSessionStatus.PENDING
-        )
+        completed = sum(1 for session in sessions if session.verdict is not None)
         return row.to_domain(len(sessions), completed)
 
     async def get(
@@ -337,6 +323,6 @@ class SQLInvestigationRepository(BaseSQLRepository[InvestigationORM]):
             Stored investigation session with the updated timestamp renewed.
         """
         row = await self._get_session_row(session.id)
-        row.status = session.status.value
+        row.verdict = session.verdict.value if session.verdict is not None else None
         await self._flush()
         return row.to_domain()

--- a/src/kitaru/server/adapters/rest/mapping/investigations.py
+++ b/src/kitaru/server/adapters/rest/mapping/investigations.py
@@ -158,7 +158,7 @@ def investigation_session_to_response(
         investigation_id=session.investigation_id,
         session_id=session.session_id,
         position=session.position,
-        status=session.status,
+        verdict=session.verdict,
         view=session.view,
         created=session.created,
         updated=session.updated,

--- a/src/kitaru/server/adapters/rest/routers/investigations.py
+++ b/src/kitaru/server/adapters/rest/routers/investigations.py
@@ -133,10 +133,11 @@ async def update_investigation(
     service: Annotated[InvestigationService, Depends(get_investigation_service)],
     actor: Annotated[AuthContext, Depends(authorize)],
 ) -> InvestigationResponse:
-    """Update an investigation's name and description.
+    """Update an investigation's name, description, and status.
 
     Clients observe HTTP 200 on success, 404 when no investigation has this
-    id, and 422 when the update clears the investigation name.
+    id, 409 when the update moves the status backwards, and 422 when the
+    update clears the investigation name or status.
 
     Args:
         investigation_id: Id of the investigation.
@@ -207,19 +208,18 @@ async def list_investigation_sessions(
 
 
 @router.patch("/{investigation_id}/sessions/{session_id}")
-async def update_investigation_session_status(
+async def update_investigation_session_verdict(
     investigation_id: uuid.UUID,
     session_id: uuid.UUID,
     body: InvestigationSessionUpdateRequest,
     service: Annotated[InvestigationService, Depends(get_investigation_service)],
     actor: Annotated[AuthContext, Depends(authorize)],
 ) -> InvestigationSessionResponse:
-    """Mark a linked session completed or skipped.
+    """Set or clear a linked session's verdict.
 
-    Completes the investigation once no linked session is left pending.
-    Clients observe HTTP 200 on success, 404 when no investigation has this
-    id or no investigation session links this investigation and session, and
-    409 when the linked session is not pending.
+    Clients observe HTTP 200 on success and 404 when no investigation has
+    this id or no investigation session links this investigation and
+    session.
 
     Args:
         investigation_id: Id of the investigation.
@@ -231,7 +231,7 @@ async def update_investigation_session_status(
     Returns:
         Updated investigation session.
     """
-    session = await service.update_investigation_session_status(
-        investigation_id, session_id, body.status, actor=actor
+    session = await service.update_investigation_session_verdict(
+        investigation_id, session_id, body.verdict, actor=actor
     )
     return investigation_session_to_response(session)

--- a/src/kitaru/server/application/models/investigation.py
+++ b/src/kitaru/server/application/models/investigation.py
@@ -18,14 +18,14 @@ from collections.abc import Mapping
 from typing import ClassVar
 
 from kitaru.api_models.v1.investigation import (
-    InvestigationSessionStatus,
+    InvestigationSessionVerdict,
     InvestigationSessionView,
     InvestigationStatus,
     QuestionItem,
 )
 from kitaru.base import FrozenModel
 from kitaru.server.base import ListFilter
-from kitaru.server.filtering import EQUALITY_OPS, FilterField
+from kitaru.server.filtering import EQUALITY_OPS, NULLABLE_OPS, FilterField
 
 
 class InvestigationFilter(ListFilter):
@@ -46,7 +46,9 @@ class InvestigationSessionFilter(ListFilter):
 
     sortable_fields: ClassVar[frozenset[str]] = frozenset({"position"})
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
-        "status": FilterField(value_type=InvestigationSessionStatus, ops=EQUALITY_OPS),
+        "verdict": FilterField(
+            value_type=InvestigationSessionVerdict, ops=EQUALITY_OPS | NULLABLE_OPS
+        ),
     }
 
     investigation_id: uuid.UUID
@@ -75,3 +77,4 @@ class InvestigationUpdate(FrozenModel):
 
     name: str | None = None
     description: str | None = None
+    status: InvestigationStatus | None = None

--- a/src/kitaru/server/application/services/investigation_service.py
+++ b/src/kitaru/server/application/services/investigation_service.py
@@ -18,8 +18,7 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 
 from kitaru.analytics.events import AnalyticsEvent
-from kitaru.api_models.v1.filter import FilterOp
-from kitaru.api_models.v1.investigation import InvestigationSessionStatus
+from kitaru.api_models.v1.investigation import InvestigationSessionVerdict
 from kitaru.server.application.interfaces.agent_repository import AgentRepository
 from kitaru.server.application.interfaces.investigation_repository import (
     InvestigationRepository,
@@ -38,7 +37,6 @@ from kitaru.server.application.services.analytics_events import (
 from kitaru.server.application.services.server_analytics import ServerAnalytics
 from kitaru.server.domain.base import ValidationError
 from kitaru.server.domain.investigation import Investigation, InvestigationSession
-from kitaru.server.filtering import FilterCondition
 
 
 class InvestigationService:
@@ -180,7 +178,7 @@ class InvestigationService:
         command: InvestigationUpdate,
         actor: AuthContext,
     ) -> Investigation:
-        """Partially update an investigation's name and description.
+        """Partially update an investigation's name, description, and status.
 
         Args:
             investigation_id: Id of the investigation.
@@ -189,7 +187,10 @@ class InvestigationService:
 
         Raises:
             InvestigationNotFound: No investigation has this id.
-            ValidationError: The command clears the investigation name.
+            IllegalInvestigationStatusTransition: The command moves the
+                status backwards.
+            ValidationError: The command clears the investigation name or
+                status.
 
         Returns:
             Updated investigation.
@@ -203,6 +204,10 @@ class InvestigationService:
             investigation.update_name(command.name)
         if "description" in fields:
             investigation.update_description(command.description)
+        if "status" in fields:
+            if command.status is None:
+                raise ValidationError("Investigation status cannot be cleared")
+            investigation.update_status(command.status, datetime.now(UTC))
         return await self._repository.update(investigation)
 
     async def delete_investigation(
@@ -242,62 +247,33 @@ class InvestigationService:
         await self._repository.get(session_filter.investigation_id)
         return await self._repository.query_sessions(session_filter)
 
-    async def update_investigation_session_status(
+    async def update_investigation_session_verdict(
         self,
         investigation_id: uuid.UUID,
         session_id: uuid.UUID,
-        status: InvestigationSessionStatus,
+        verdict: InvestigationSessionVerdict | None,
         actor: AuthContext,
     ) -> InvestigationSession:
-        """Mark a linked session completed or skipped.
-
-        Completes the investigation once no linked session is left pending.
+        """Set or clear a linked session's verdict.
 
         Args:
             investigation_id: Id of the investigation.
             session_id: Id of the linked session.
-            status: Target status, completed or skipped.
+            verdict: New verdict, None clears it.
             actor: Caller context.
 
         Raises:
             InvestigationNotFound: No investigation has this id.
             InvestigationSessionNotFound: No investigation session links this
                 investigation and session.
-            IllegalInvestigationSessionStatusTransition: The linked session
-                is not pending.
-            ValidationError: The target status is neither completed nor
-                skipped.
 
         Returns:
             Updated investigation session.
         """
         _ = actor
-        # The investigation row is locked before the session transition, so a
-        # racing status update on another linked session cannot also observe
-        # zero sessions left pending and complete the investigation twice.
-        investigation = await self._repository.get(investigation_id, exclusive=True)
+        await self._repository.get(investigation_id)
         session = await self._repository.get_session_by_session_id(
-            investigation_id, session_id, exclusive=True
+            investigation_id, session_id
         )
-        if status is InvestigationSessionStatus.COMPLETED:
-            session.complete()
-        elif status is InvestigationSessionStatus.SKIPPED:
-            session.skip()
-        else:
-            raise ValidationError(
-                f"Investigation session status cannot be set to '{status}'"
-            )
-        session = await self._repository.update_session(session)
-
-        pending = FilterCondition(
-            field="status", op=FilterOp.EQ, value=InvestigationSessionStatus.PENDING
-        )
-        remaining, _ = await self._repository.query_sessions(
-            InvestigationSessionFilter(
-                investigation_id=investigation_id, expression=pending, size=1
-            )
-        )
-        if not remaining:
-            investigation.complete(datetime.now(UTC))
-            await self._repository.update(investigation)
-        return session
+        session.update_verdict(verdict)
+        return await self._repository.update_session(session)

--- a/src/kitaru/server/database/migrations/versions/001_initial.py
+++ b/src/kitaru/server/database/migrations/versions/001_initial.py
@@ -921,7 +921,7 @@ def upgrade() -> None:
         sa.Column("investigation_id", sa.Uuid(), nullable=False),
         sa.Column("session_id", sa.Uuid(), nullable=False),
         sa.Column("position", sa.Integer(), nullable=False),
-        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("verdict", sa.String(length=32), nullable=True),
         sa.Column(
             "view",
             postgresql.JSONB(none_as_null=True, astext_type=sa.Text()),

--- a/src/kitaru/server/domain/investigation.py
+++ b/src/kitaru/server/domain/investigation.py
@@ -20,7 +20,7 @@ from typing import Any
 from pydantic import Field, field_validator
 
 from kitaru.api_models.v1.investigation import (
-    InvestigationSessionStatus,
+    InvestigationSessionVerdict,
     InvestigationSessionView,
     InvestigationStatus,
     QuestionItem,
@@ -110,28 +110,6 @@ class InvestigationSessionNotFound(NotFoundError):
         )
 
 
-class IllegalInvestigationSessionStatusTransition(ConflictError):
-    """Raised when an investigation session status transition is not allowed."""
-
-    def __init__(
-        self,
-        investigation_session_id: uuid.UUID,
-        current: InvestigationSessionStatus,
-        target: InvestigationSessionStatus,
-    ) -> None:
-        """Initialize the error.
-
-        Args:
-            investigation_session_id: Id of the investigation session.
-            current: Current investigation session status.
-            target: Target investigation session status.
-        """
-        super().__init__(
-            f"Investigation session {investigation_session_id} cannot "
-            f"transition from {current} to {target}"
-        )
-
-
 class Investigation(DomainModel):
     """Investigation."""
 
@@ -199,6 +177,25 @@ class Investigation(DomainModel):
         """
         self.description = description
 
+    def update_status(self, status: InvestigationStatus, now: datetime) -> None:
+        """Set a new investigation status.
+
+        Args:
+            status: New status.
+            now: Current time.
+
+        Raises:
+            IllegalInvestigationStatusTransition: The status moves backwards.
+        """
+        if status is self.status:
+            return
+        if status is InvestigationStatus.IN_PROGRESS:
+            self.start(now)
+        elif status is InvestigationStatus.COMPLETED:
+            self.complete(now)
+        else:
+            raise IllegalInvestigationStatusTransition(self.id, self.status, status)
+
     def start(self, now: datetime) -> None:
         """Move a pending investigation to in_progress on its first answer.
 
@@ -241,33 +238,15 @@ class InvestigationSession(DomainModel):
     investigation_id: uuid.UUID
     session_id: uuid.UUID
     position: int
-    status: InvestigationSessionStatus = InvestigationSessionStatus.PENDING
+    verdict: InvestigationSessionVerdict | None = None
     view: InvestigationSessionView | None = None
     created: datetime | None = None
     updated: datetime | None = None
 
-    def complete(self) -> None:
-        """Mark the session completed once its questions are answered.
+    def update_verdict(self, verdict: InvestigationSessionVerdict | None) -> None:
+        """Set a new session verdict.
 
-        Raises:
-            IllegalInvestigationSessionStatusTransition: The session is not
-                pending.
+        Args:
+            verdict: New verdict, None clears it.
         """
-        if self.status is not InvestigationSessionStatus.PENDING:
-            raise IllegalInvestigationSessionStatusTransition(
-                self.id, self.status, InvestigationSessionStatus.COMPLETED
-            )
-        self.status = InvestigationSessionStatus.COMPLETED
-
-    def skip(self) -> None:
-        """Mark the session skipped, abandoning its remaining questions.
-
-        Raises:
-            IllegalInvestigationSessionStatusTransition: The session is not
-                pending.
-        """
-        if self.status is not InvestigationSessionStatus.PENDING:
-            raise IllegalInvestigationSessionStatusTransition(
-                self.id, self.status, InvestigationSessionStatus.SKIPPED
-            )
-        self.status = InvestigationSessionStatus.SKIPPED
+        self.verdict = verdict

--- a/tests/cli/test_investigations.py
+++ b/tests/cli/test_investigations.py
@@ -26,8 +26,9 @@ from kitaru.api_models.v1.investigation import (
     InvestigationCreateRequest,
     InvestigationListParams,
     InvestigationSessionsListParams,
-    InvestigationSessionStatus,
     InvestigationSessionUpdateRequest,
+    InvestigationSessionVerdict,
+    InvestigationStatus,
     InvestigationUpdateRequest,
 )
 from kitaru.cli import app as app_module
@@ -289,11 +290,25 @@ async def test_crud_and_session_status_commands_map_to_sdk() -> None:
         name="renamed",
         description=None,
         clear_description=True,
+        status=None,
     )
     _, request = client.update_calls[-1]
     assert request.model_dump(mode="json", exclude_unset=True) == {
         "name": "renamed",
         "description": None,
+    }
+
+    await investigations.update_investigation(
+        client,
+        investigation_id,
+        name=None,
+        description=None,
+        clear_description=False,
+        status=InvestigationStatus.COMPLETED,
+    )
+    _, request = client.update_calls[-1]
+    assert request.model_dump(mode="json", exclude_unset=True) == {
+        "status": "completed",
     }
 
     sessions = await investigations.list_investigation_sessions(
@@ -308,17 +323,17 @@ async def test_crud_and_session_status_commands_map_to_sdk() -> None:
     assert sessions.page["next_cursor"] == "next-session"
 
     for target in (
-        InvestigationSessionStatus.COMPLETED,
-        InvestigationSessionStatus.SKIPPED,
+        InvestigationSessionVerdict.ACCEPTABLE,
+        InvestigationSessionVerdict.PROBLEMATIC,
     ):
-        await investigations.update_investigation_session_status(
+        await investigations.update_investigation_session_verdict(
             client,
             investigation_id,
             client.session_ids[0],
-            status=target,
+            verdict=target,
         )
         _, _, request = client.session_update_calls[-1]
-        assert request.status is target
+        assert request.verdict is target
 
     with pytest.raises(CLIError, match="requires --force"):
         await investigations.delete_investigation(client, investigation_id, force=False)
@@ -340,6 +355,7 @@ async def test_sparse_update_rejects_conflicts_and_empty_changes() -> None:
             name=None,
             description="set",
             clear_description=True,
+            status=None,
         )
     with pytest.raises(CLIError, match="Select at least one"):
         await investigations.update_investigation(
@@ -348,6 +364,7 @@ async def test_sparse_update_rejects_conflicts_and_empty_changes() -> None:
             name=None,
             description=None,
             clear_description=False,
+            status=None,
         )
     assert client.update_calls == []
 
@@ -386,12 +403,15 @@ def test_public_argv_and_schema_cover_investigation_lifecycle(
             "session.list",
         ),
         (
-            ["investigation", "session", "complete", investigation_id, session_id],
-            "session.complete",
-        ),
-        (
-            ["investigation", "session", "skip", investigation_id, session_id],
-            "session.skip",
+            [
+                "investigation",
+                "session",
+                "verdict",
+                investigation_id,
+                session_id,
+                "acceptable",
+            ],
+            "session.verdict",
         ),
         (["investigation", "delete", investigation_id, "--force"], "delete"),
     ]
@@ -406,10 +426,9 @@ def test_public_argv_and_schema_cover_investigation_lifecycle(
         "investigation.delete",
         "investigation.get",
         "investigation.list",
-        "investigation.session.complete",
         "investigation.session.list",
-        "investigation.session.skip",
+        "investigation.session.verdict",
         "investigation.update",
     }
     assert specs["investigation.delete"]["side_effects"]["deletes_remote_state"]
-    assert specs["investigation.session.complete"]["mutating"] is True
+    assert specs["investigation.session.verdict"]["mutating"] is True

--- a/tests/client/test_investigations.py
+++ b/tests/client/test_investigations.py
@@ -35,15 +35,15 @@ from kitaru.api_models.v1.investigation import (
     InvestigationSessionInput,
     InvestigationSessionResponse,
     InvestigationSessionsListParams,
-    InvestigationSessionStatus,
     InvestigationSessionUpdateRequest,
+    InvestigationSessionVerdict,
     InvestigationStatus,
     InvestigationUpdateRequest,
     QuestionItem,
 )
 from kitaru.api_models.v1.session import SessionCreateRequest, SessionOrigin
 from kitaru.client.api_client import KitaruAPIClient
-from kitaru.client.exceptions import APIError, NotFoundError
+from kitaru.client.exceptions import NotFoundError
 from kitaru.server.adapters.rest.dependencies import (
     authorize,
     authorize_with_task,
@@ -205,6 +205,12 @@ async def test_update(api_client: KitaruAPIClient) -> None:
     )
     assert updated.description == "new"
 
+    updated = await api_client.investigations.update(
+        created.id, InvestigationUpdateRequest(status=InvestigationStatus.COMPLETED)
+    )
+    assert updated.status is InvestigationStatus.COMPLETED
+    assert updated.ended_at is not None
+
 
 async def test_delete(api_client: KitaruAPIClient) -> None:
     """Delete an investigation through the SDK."""
@@ -249,7 +255,7 @@ async def test_list_sessions_and_iter_sessions(api_client: KitaruAPIClient) -> N
 
 
 async def test_update_session(api_client: KitaruAPIClient) -> None:
-    """Mark an investigation session completed through the SDK."""
+    """Set an investigation session verdict through the SDK."""
     agent_id = await _make_agent(api_client)
     session_id = await _make_session(api_client, agent_id)
     created = await api_client.investigations.create(
@@ -263,17 +269,19 @@ async def test_update_session(api_client: KitaruAPIClient) -> None:
     updated = await api_client.investigations.update_session(
         created.id,
         session_id,
-        InvestigationSessionUpdateRequest(status=InvestigationSessionStatus.COMPLETED),
+        InvestigationSessionUpdateRequest(
+            verdict=InvestigationSessionVerdict.ACCEPTABLE
+        ),
     )
-    assert updated.status is InvestigationSessionStatus.COMPLETED
+    assert updated.verdict is InvestigationSessionVerdict.ACCEPTABLE
 
     reloaded = await api_client.investigations.get(created.id)
-    assert reloaded.status is InvestigationStatus.COMPLETED
+    assert reloaded.status is InvestigationStatus.PENDING
     assert reloaded.completed_sessions == 1
 
 
-async def test_update_session_illegal_transition(api_client: KitaruAPIClient) -> None:
-    """Surface HTTP 409 as a typed error for a settled session."""
+async def test_update_session_clears_verdict(api_client: KitaruAPIClient) -> None:
+    """Clear an investigation session verdict through the SDK."""
     agent_id = await _make_agent(api_client)
     session_id = await _make_session(api_client, agent_id)
     created = await api_client.investigations.create(
@@ -287,14 +295,16 @@ async def test_update_session_illegal_transition(api_client: KitaruAPIClient) ->
     await api_client.investigations.update_session(
         created.id,
         session_id,
-        InvestigationSessionUpdateRequest(status=InvestigationSessionStatus.COMPLETED),
+        InvestigationSessionUpdateRequest(
+            verdict=InvestigationSessionVerdict.PROBLEMATIC
+        ),
     )
-    with pytest.raises(APIError) as exc_info:
-        await api_client.investigations.update_session(
-            created.id,
-            session_id,
-            InvestigationSessionUpdateRequest(
-                status=InvestigationSessionStatus.SKIPPED
-            ),
-        )
-    assert exc_info.value.status_code == 409
+    updated = await api_client.investigations.update_session(
+        created.id,
+        session_id,
+        InvestigationSessionUpdateRequest(verdict=None),
+    )
+    assert updated.verdict is None
+
+    reloaded = await api_client.investigations.get(created.id)
+    assert reloaded.completed_sessions == 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,6 @@ from kitaru.api_models.v1.evaluation import EvaluationDataType
 from kitaru.api_models.v1.experiment_run import ExperimentRunStatus
 from kitaru.api_models.v1.filter import FilterOp
 from kitaru.api_models.v1.info import AuthScheme
-from kitaru.api_models.v1.investigation import InvestigationSessionStatus
 from kitaru.api_models.v1.job import JobKind, JobStatus
 from kitaru.api_models.v1.replay import ReplayStatus
 from kitaru.api_models.v1.session import SessionOrigin, TokenUsage
@@ -5791,24 +5790,20 @@ class FakeInvestigationRepository:
         self._annotations: FakeAnnotationRepository | None = None
 
     def _counts(self, investigation_id: uuid.UUID) -> tuple[int, int]:
-        """Count an investigation's linked and completed or skipped sessions.
+        """Count an investigation's linked sessions and non-null verdicts.
 
         Args:
             investigation_id: Id of the investigation.
 
         Returns:
-            Total and completed or skipped linked session counts.
+            Total and verdict-set linked session counts.
         """
         links = [
             session
             for session in self._sessions.values()
             if session.investigation_id == investigation_id
         ]
-        completed = sum(
-            1
-            for session in links
-            if session.status is not InvestigationSessionStatus.PENDING
-        )
+        completed = sum(1 for session in links if session.verdict is not None)
         return len(links), completed
 
     def _with_counts(self, investigation: Investigation) -> Investigation:

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -4884,7 +4884,7 @@
               "type": "string"
             },
             "completed_sessions": {
-              "description": "Number of linked sessions marked completed or skipped.",
+              "description": "Number of linked sessions with a verdict.",
               "title": "Completed Sessions",
               "type": "integer"
             },
@@ -5029,14 +5029,22 @@
               "title": "Session Id",
               "type": "string"
             },
-            "status": {
-              "$ref": "#/$defs/InvestigationSessionStatus"
-            },
             "updated": {
               "description": "Last modification time.",
               "format": "date-time",
               "title": "Updated",
               "type": "string"
+            },
+            "verdict": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/InvestigationSessionVerdict"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Investigation session verdict."
             },
             "view": {
               "anyOf": [
@@ -5057,20 +5065,20 @@
             "investigation_id",
             "session_id",
             "position",
-            "status",
+            "verdict",
             "view"
           ],
           "title": "InvestigationSessionResponse",
           "type": "object"
         },
-        "InvestigationSessionStatus": {
-          "description": "Investigation session status.",
+        "InvestigationSessionVerdict": {
+          "description": "Investigation session verdict.",
           "enum": [
-            "pending",
-            "completed",
-            "skipped"
+            "acceptable",
+            "problematic",
+            "uncertain"
           ],
-          "title": "InvestigationSessionStatus",
+          "title": "InvestigationSessionVerdict",
           "type": "string"
         },
         "InvestigationSessionView": {
@@ -7479,6 +7487,16 @@
           "title": "InvestigationSessionInput",
           "type": "object"
         },
+        "InvestigationSessionVerdict": {
+          "description": "Investigation session verdict.",
+          "enum": [
+            "acceptable",
+            "problematic",
+            "uncertain"
+          ],
+          "title": "InvestigationSessionVerdict",
+          "type": "string"
+        },
         "InvestigationSessionView": {
           "additionalProperties": false,
           "description": "Investigation session view.",
@@ -7581,6 +7599,22 @@
               "const": "update_investigation",
               "title": "Operation",
               "type": "string"
+            },
+            "status": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "in_progress",
+                    "completed"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Status"
             }
           },
           "required": [
@@ -7649,9 +7683,9 @@
           "title": "QuestionItem",
           "type": "object"
         },
-        "SetInvestigationSessionStatus": {
+        "SetInvestigationSessionVerdict": {
           "additionalProperties": false,
-          "description": "Set one linked session to a terminal status.",
+          "description": "Set or clear one linked session's verdict.",
           "properties": {
             "investigation_id": {
               "format": "uuid",
@@ -7659,7 +7693,7 @@
               "type": "string"
             },
             "operation": {
-              "const": "set_session_status",
+              "const": "set_session_verdict",
               "title": "Operation",
               "type": "string"
             },
@@ -7668,22 +7702,24 @@
               "title": "Session Id",
               "type": "string"
             },
-            "status": {
-              "enum": [
-                "completed",
-                "skipped"
-              ],
-              "title": "Status",
-              "type": "string"
+            "verdict": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/InvestigationSessionVerdict"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "required": [
             "operation",
             "investigation_id",
             "session_id",
-            "status"
+            "verdict"
           ],
-          "title": "SetInvestigationSessionStatus",
+          "title": "SetInvestigationSessionVerdict",
           "type": "object"
         }
       },
@@ -7694,7 +7730,7 @@
               "answer_question": "#/$defs/InvestigationAnswerCreate",
               "create_annotation": "#/$defs/ManualAnnotationCreate",
               "create_investigation": "#/$defs/InvestigationCreate",
-              "set_session_status": "#/$defs/SetInvestigationSessionStatus",
+              "set_session_verdict": "#/$defs/SetInvestigationSessionVerdict",
               "update_annotation": "#/$defs/AnnotationUpdate",
               "update_investigation": "#/$defs/InvestigationUpdate"
             },
@@ -7708,7 +7744,7 @@
               "$ref": "#/$defs/InvestigationUpdate"
             },
             {
-              "$ref": "#/$defs/SetInvestigationSessionStatus"
+              "$ref": "#/$defs/SetInvestigationSessionVerdict"
             },
             {
               "$ref": "#/$defs/ManualAnnotationCreate"
@@ -7899,7 +7935,7 @@
               "type": "string"
             },
             "completed_sessions": {
-              "description": "Number of linked sessions marked completed or skipped.",
+              "description": "Number of linked sessions with a verdict.",
               "title": "Completed Sessions",
               "type": "integer"
             },
@@ -8044,14 +8080,22 @@
               "title": "Session Id",
               "type": "string"
             },
-            "status": {
-              "$ref": "#/$defs/InvestigationSessionStatus"
-            },
             "updated": {
               "description": "Last modification time.",
               "format": "date-time",
               "title": "Updated",
               "type": "string"
+            },
+            "verdict": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/InvestigationSessionVerdict"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Investigation session verdict."
             },
             "view": {
               "anyOf": [
@@ -8072,20 +8116,20 @@
             "investigation_id",
             "session_id",
             "position",
-            "status",
+            "verdict",
             "view"
           ],
           "title": "InvestigationSessionResponse",
           "type": "object"
         },
-        "InvestigationSessionStatus": {
-          "description": "Investigation session status.",
+        "InvestigationSessionVerdict": {
+          "description": "Investigation session verdict.",
           "enum": [
-            "pending",
-            "completed",
-            "skipped"
+            "acceptable",
+            "problematic",
+            "uncertain"
           ],
-          "title": "InvestigationSessionStatus",
+          "title": "InvestigationSessionVerdict",
           "type": "string"
         },
         "InvestigationSessionView": {

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,7 +6,7 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 141559,
+      "discovery_response_bytes": 142027,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
@@ -52,18 +52,18 @@
           "output_bytes": 20629
         },
         "kitaru_review_manage": {
-          "$defs_count": 23,
-          "combined_bytes": 15119,
-          "input_bytes": 7035,
-          "maximum_nesting_depth": 7,
-          "output_bytes": 8084
+          "$defs_count": 24,
+          "combined_bytes": 15512,
+          "input_bytes": 7353,
+          "maximum_nesting_depth": 8,
+          "output_bytes": 8159
         },
         "kitaru_review_read": {
           "$defs_count": 21,
-          "combined_bytes": 12832,
+          "combined_bytes": 12907,
           "input_bytes": 3775,
           "maximum_nesting_depth": 8,
-          "output_bytes": 9057
+          "output_bytes": 9132
         },
         "kitaru_session_import": {
           "$defs_count": 6,
@@ -89,7 +89,7 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 72751,
+      "discovery_response_bytes": 72826,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
@@ -108,15 +108,15 @@
         },
         "kitaru_review_read": {
           "$defs_count": 21,
-          "combined_bytes": 12832,
+          "combined_bytes": 12907,
           "input_bytes": 3775,
           "maximum_nesting_depth": 8,
-          "output_bytes": 9057
+          "output_bytes": 9132
         }
       }
     },
     "standard": {
-      "discovery_response_bytes": 132097,
+      "discovery_response_bytes": 132565,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
@@ -155,18 +155,18 @@
           "output_bytes": 20629
         },
         "kitaru_review_manage": {
-          "$defs_count": 23,
-          "combined_bytes": 15119,
-          "input_bytes": 7035,
-          "maximum_nesting_depth": 7,
-          "output_bytes": 8084
+          "$defs_count": 24,
+          "combined_bytes": 15512,
+          "input_bytes": 7353,
+          "maximum_nesting_depth": 8,
+          "output_bytes": 8159
         },
         "kitaru_review_read": {
           "$defs_count": 21,
-          "combined_bytes": 12832,
+          "combined_bytes": 12907,
           "input_bytes": 3775,
           "maximum_nesting_depth": 8,
-          "output_bytes": 9057
+          "output_bytes": 9132
         },
         "kitaru_session_import": {
           "$defs_count": 6,

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -4884,7 +4884,7 @@
               "type": "string"
             },
             "completed_sessions": {
-              "description": "Number of linked sessions marked completed or skipped.",
+              "description": "Number of linked sessions with a verdict.",
               "title": "Completed Sessions",
               "type": "integer"
             },
@@ -5029,14 +5029,22 @@
               "title": "Session Id",
               "type": "string"
             },
-            "status": {
-              "$ref": "#/$defs/InvestigationSessionStatus"
-            },
             "updated": {
               "description": "Last modification time.",
               "format": "date-time",
               "title": "Updated",
               "type": "string"
+            },
+            "verdict": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/InvestigationSessionVerdict"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Investigation session verdict."
             },
             "view": {
               "anyOf": [
@@ -5057,20 +5065,20 @@
             "investigation_id",
             "session_id",
             "position",
-            "status",
+            "verdict",
             "view"
           ],
           "title": "InvestigationSessionResponse",
           "type": "object"
         },
-        "InvestigationSessionStatus": {
-          "description": "Investigation session status.",
+        "InvestigationSessionVerdict": {
+          "description": "Investigation session verdict.",
           "enum": [
-            "pending",
-            "completed",
-            "skipped"
+            "acceptable",
+            "problematic",
+            "uncertain"
           ],
-          "title": "InvestigationSessionStatus",
+          "title": "InvestigationSessionVerdict",
           "type": "string"
         },
         "InvestigationSessionView": {

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -4884,7 +4884,7 @@
               "type": "string"
             },
             "completed_sessions": {
-              "description": "Number of linked sessions marked completed or skipped.",
+              "description": "Number of linked sessions with a verdict.",
               "title": "Completed Sessions",
               "type": "integer"
             },
@@ -5029,14 +5029,22 @@
               "title": "Session Id",
               "type": "string"
             },
-            "status": {
-              "$ref": "#/$defs/InvestigationSessionStatus"
-            },
             "updated": {
               "description": "Last modification time.",
               "format": "date-time",
               "title": "Updated",
               "type": "string"
+            },
+            "verdict": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/InvestigationSessionVerdict"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Investigation session verdict."
             },
             "view": {
               "anyOf": [
@@ -5057,20 +5065,20 @@
             "investigation_id",
             "session_id",
             "position",
-            "status",
+            "verdict",
             "view"
           ],
           "title": "InvestigationSessionResponse",
           "type": "object"
         },
-        "InvestigationSessionStatus": {
-          "description": "Investigation session status.",
+        "InvestigationSessionVerdict": {
+          "description": "Investigation session verdict.",
           "enum": [
-            "pending",
-            "completed",
-            "skipped"
+            "acceptable",
+            "problematic",
+            "uncertain"
           ],
-          "title": "InvestigationSessionStatus",
+          "title": "InvestigationSessionVerdict",
           "type": "string"
         },
         "InvestigationSessionView": {
@@ -7479,6 +7487,16 @@
           "title": "InvestigationSessionInput",
           "type": "object"
         },
+        "InvestigationSessionVerdict": {
+          "description": "Investigation session verdict.",
+          "enum": [
+            "acceptable",
+            "problematic",
+            "uncertain"
+          ],
+          "title": "InvestigationSessionVerdict",
+          "type": "string"
+        },
         "InvestigationSessionView": {
           "additionalProperties": false,
           "description": "Investigation session view.",
@@ -7581,6 +7599,22 @@
               "const": "update_investigation",
               "title": "Operation",
               "type": "string"
+            },
+            "status": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "in_progress",
+                    "completed"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Status"
             }
           },
           "required": [
@@ -7649,9 +7683,9 @@
           "title": "QuestionItem",
           "type": "object"
         },
-        "SetInvestigationSessionStatus": {
+        "SetInvestigationSessionVerdict": {
           "additionalProperties": false,
-          "description": "Set one linked session to a terminal status.",
+          "description": "Set or clear one linked session's verdict.",
           "properties": {
             "investigation_id": {
               "format": "uuid",
@@ -7659,7 +7693,7 @@
               "type": "string"
             },
             "operation": {
-              "const": "set_session_status",
+              "const": "set_session_verdict",
               "title": "Operation",
               "type": "string"
             },
@@ -7668,22 +7702,24 @@
               "title": "Session Id",
               "type": "string"
             },
-            "status": {
-              "enum": [
-                "completed",
-                "skipped"
-              ],
-              "title": "Status",
-              "type": "string"
+            "verdict": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/InvestigationSessionVerdict"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "required": [
             "operation",
             "investigation_id",
             "session_id",
-            "status"
+            "verdict"
           ],
-          "title": "SetInvestigationSessionStatus",
+          "title": "SetInvestigationSessionVerdict",
           "type": "object"
         }
       },
@@ -7694,7 +7730,7 @@
               "answer_question": "#/$defs/InvestigationAnswerCreate",
               "create_annotation": "#/$defs/ManualAnnotationCreate",
               "create_investigation": "#/$defs/InvestigationCreate",
-              "set_session_status": "#/$defs/SetInvestigationSessionStatus",
+              "set_session_verdict": "#/$defs/SetInvestigationSessionVerdict",
               "update_annotation": "#/$defs/AnnotationUpdate",
               "update_investigation": "#/$defs/InvestigationUpdate"
             },
@@ -7708,7 +7744,7 @@
               "$ref": "#/$defs/InvestigationUpdate"
             },
             {
-              "$ref": "#/$defs/SetInvestigationSessionStatus"
+              "$ref": "#/$defs/SetInvestigationSessionVerdict"
             },
             {
               "$ref": "#/$defs/ManualAnnotationCreate"
@@ -7899,7 +7935,7 @@
               "type": "string"
             },
             "completed_sessions": {
-              "description": "Number of linked sessions marked completed or skipped.",
+              "description": "Number of linked sessions with a verdict.",
               "title": "Completed Sessions",
               "type": "integer"
             },
@@ -8044,14 +8080,22 @@
               "title": "Session Id",
               "type": "string"
             },
-            "status": {
-              "$ref": "#/$defs/InvestigationSessionStatus"
-            },
             "updated": {
               "description": "Last modification time.",
               "format": "date-time",
               "title": "Updated",
               "type": "string"
+            },
+            "verdict": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/InvestigationSessionVerdict"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Investigation session verdict."
             },
             "view": {
               "anyOf": [
@@ -8072,20 +8116,20 @@
             "investigation_id",
             "session_id",
             "position",
-            "status",
+            "verdict",
             "view"
           ],
           "title": "InvestigationSessionResponse",
           "type": "object"
         },
-        "InvestigationSessionStatus": {
-          "description": "Investigation session status.",
+        "InvestigationSessionVerdict": {
+          "description": "Investigation session verdict.",
           "enum": [
-            "pending",
-            "completed",
-            "skipped"
+            "acceptable",
+            "problematic",
+            "uncertain"
           ],
-          "title": "InvestigationSessionStatus",
+          "title": "InvestigationSessionVerdict",
           "type": "string"
         },
         "InvestigationSessionView": {

--- a/tests/mcp/test_handlers_protocol.py
+++ b/tests/mcp/test_handlers_protocol.py
@@ -145,7 +145,7 @@ def _get_investigation_session() -> InvestigationSessionResponse:
         investigation_id=uuid.uuid4(),
         session_id=uuid.uuid4(),
         position=0,
-        status="pending",
+        verdict=None,
         view=None,
         created=now,
         updated=now,

--- a/tests/mcp/test_review_workflows.py
+++ b/tests/mcp/test_review_workflows.py
@@ -19,6 +19,7 @@ from kitaru.api_models.v1.evaluator import (
     EvaluatorResponse,
     EvaluatorVersionResponse,
 )
+from kitaru.api_models.v1.investigation import InvestigationSessionVerdict
 from kitaru.api_models.v1.job import JobResponse
 from kitaru.api_models.v1.plugin import PackagePluginSource
 from kitaru.mcp.errors import MCPToolError
@@ -41,7 +42,7 @@ from kitaru.mcp.models.review import (
     ReviewList,
     ReviewListSessions,
     ReviewManageRequest,
-    SetInvestigationSessionStatus,
+    SetInvestigationSessionVerdict,
 )
 from kitaru.mcp.models.workflows import (
     DeleteRequest,
@@ -97,7 +98,7 @@ async def test_review_read_protocol_has_typed_structured_text_parity() -> None:
     }
 
 
-async def test_review_manage_protocol_rejects_pending_before_handler() -> None:
+async def test_review_manage_protocol_rejects_unknown_verdict_before_handler() -> None:
     calls: list[object] = []
 
     async def update_session(*args: object) -> object:
@@ -113,10 +114,10 @@ async def test_review_manage_protocol_rejects_pending_before_handler() -> None:
             "kitaru_review_manage",
             {
                 "request": {
-                    "operation": "set_session_status",
+                    "operation": "set_session_verdict",
                     "investigation_id": str(uuid.uuid4()),
                     "session_id": str(uuid.uuid4()),
-                    "status": "pending",
+                    "verdict": "pending",
                 }
             },
             context,
@@ -206,7 +207,7 @@ async def test_review_annotation_list_routes_to_annotations() -> None:
     assert result.page.size == 3
 
 
-def test_review_management_rejects_noop_and_pending_status() -> None:
+def test_review_management_rejects_noop_and_unknown_verdict() -> None:
     with pytest.raises(ValidationError, match="change at least one"):
         InvestigationUpdate(
             operation="update_investigation", investigation_id=uuid.uuid4()
@@ -215,10 +216,10 @@ def test_review_management_rejects_noop_and_pending_status() -> None:
     with pytest.raises(ValidationError):
         adapter.validate_python(
             {
-                "operation": "set_session_status",
+                "operation": "set_session_verdict",
                 "investigation_id": uuid.uuid4(),
                 "session_id": uuid.uuid4(),
-                "status": "pending",
+                "verdict": "pending",
             }
         )
 
@@ -235,7 +236,7 @@ def test_investigation_create_preserves_empty_sdk_lists() -> None:
     assert request.sessions == []
 
 
-async def test_review_clear_and_status_forward_typed_sparse_dtos() -> None:
+async def test_review_clear_and_verdict_forward_typed_sparse_dtos() -> None:
     updates: list[object] = []
     session_updates: list[object] = []
 
@@ -263,16 +264,27 @@ async def test_review_clear_and_status_forward_typed_sparse_dtos() -> None:
     )
     await handle_review_manage(
         _get_state(client),
-        SetInvestigationSessionStatus(
-            operation="set_session_status",
+        InvestigationUpdate(
+            operation="update_investigation",
             investigation_id=uuid.uuid4(),
-            session_id=uuid.uuid4(),
             status="completed",
         ),
     )
+    await handle_review_manage(
+        _get_state(client),
+        SetInvestigationSessionVerdict(
+            operation="set_session_verdict",
+            investigation_id=uuid.uuid4(),
+            session_id=uuid.uuid4(),
+            verdict=InvestigationSessionVerdict.ACCEPTABLE,
+        ),
+    )
     assert cast(Any, updates[0]).model_dump(exclude_unset=True) == {"description": None}
-    assert cast(Any, session_updates[0]).model_dump(mode="json") == {
+    assert cast(Any, updates[1]).model_dump(exclude_unset=True) == {
         "status": "completed"
+    }
+    assert cast(Any, session_updates[0]).model_dump(mode="json") == {
+        "verdict": "acceptable"
     }
 
 

--- a/tests/server/test_investigation_repository.py
+++ b/tests/server/test_investigation_repository.py
@@ -29,7 +29,7 @@ from conftest import (
 )
 from kitaru.api_models.v1.filter import FilterOp
 from kitaru.api_models.v1.investigation import (
-    InvestigationSessionStatus,
+    InvestigationSessionVerdict,
     InvestigationStatus,
     QuestionItem,
 )
@@ -201,7 +201,7 @@ async def test_create_sets_timestamps_and_counts(setup: Setup) -> None:
 
 
 async def test_create_with_linked_sessions_counts_total(setup: Setup) -> None:
-    """Count every linked session as total_sessions regardless of status."""
+    """Count every linked session as total_sessions regardless of verdict."""
     repository, owner_id, agent_id, make_session_id, _ = setup
     session_ids = [await make_session_id(), await make_session_id()]
     investigation = Investigation(
@@ -407,8 +407,8 @@ async def test_delete_cascades_sessions(setup: Setup) -> None:
         await repository.get_session(linked.id)
 
 
-async def test_progress_counts_track_completed_or_skipped_links(setup: Setup) -> None:
-    """Count completed and skipped links together, apart from pending ones."""
+async def test_progress_counts_track_links_with_verdicts(setup: Setup) -> None:
+    """Count links with a verdict, apart from links without one."""
     repository, owner_id, agent_id, make_session_id, _ = setup
     session_ids = [
         await make_session_id(),
@@ -432,10 +432,10 @@ async def test_progress_counts_track_completed_or_skipped_links(setup: Setup) ->
         ],
     )
     first = await repository.get_session_by_session_id(created.id, session_ids[0])
-    first.complete()
+    first.update_verdict(InvestigationSessionVerdict.ACCEPTABLE)
     await repository.update_session(first)
     second = await repository.get_session_by_session_id(created.id, session_ids[1])
-    second.skip()
+    second.update_verdict(InvestigationSessionVerdict.PROBLEMATIC)
     await repository.update_session(second)
 
     loaded = await repository.get(created.id)
@@ -509,8 +509,8 @@ async def test_query_sessions_scoped_to_investigation(setup: Setup) -> None:
     assert [session.session_id for session in sessions] == [session_id]
 
 
-async def test_query_sessions_filters_by_status(setup: Setup) -> None:
-    """Filter an investigation's sessions by status."""
+async def test_query_sessions_filters_by_verdict(setup: Setup) -> None:
+    """Filter an investigation's sessions by verdict."""
     repository, owner_id, agent_id, make_session_id, _ = setup
     session_ids = [await make_session_id(), await make_session_id()]
     investigation = Investigation(
@@ -529,20 +529,28 @@ async def test_query_sessions_filters_by_status(setup: Setup) -> None:
         ],
     )
     target = await repository.get_session_by_session_id(created.id, session_ids[0])
-    target.complete()
+    target.update_verdict(InvestigationSessionVerdict.ACCEPTABLE)
     await repository.update_session(target)
 
     sessions, _ = await repository.query_sessions(
         InvestigationSessionFilter(
             investigation_id=created.id,
             expression=FilterCondition(
-                field="status",
+                field="verdict",
                 op=FilterOp.EQ,
-                value=InvestigationSessionStatus.COMPLETED,
+                value=InvestigationSessionVerdict.ACCEPTABLE,
             ),
         )
     )
     assert [session.session_id for session in sessions] == [session_ids[0]]
+
+    sessions, _ = await repository.query_sessions(
+        InvestigationSessionFilter(
+            investigation_id=created.id,
+            expression=FilterCondition(field="verdict", op=FilterOp.IS_NULL),
+        )
+    )
+    assert [session.session_id for session in sessions] == [session_ids[1]]
 
 
 async def test_query_sessions_walks_pages(setup: Setup) -> None:
@@ -623,7 +631,7 @@ async def test_get_session_by_session_id_not_found(setup: Setup) -> None:
 
 
 async def test_update_session(setup: Setup) -> None:
-    """Persist a status transition and renew the updated timestamp."""
+    """Persist a verdict change and renew the updated timestamp."""
     repository, owner_id, agent_id, make_session_id, _ = setup
     session_id = await make_session_id()
     investigation = Investigation(
@@ -638,9 +646,9 @@ async def test_update_session(setup: Setup) -> None:
         investigation, [_link(investigation.id, session_id, 0)]
     )
     linked = await repository.get_session_by_session_id(created.id, session_id)
-    linked.complete()
+    linked.update_verdict(InvestigationSessionVerdict.UNCERTAIN)
     updated = await repository.update_session(linked)
-    assert updated.status is InvestigationSessionStatus.COMPLETED
+    assert updated.verdict is InvestigationSessionVerdict.UNCERTAIN
     assert updated.created == linked.created
     assert updated.updated is not None
     loaded = await repository.get_session(linked.id)

--- a/tests/server/test_investigation_service.py
+++ b/tests/server/test_investigation_service.py
@@ -28,7 +28,7 @@ from conftest import (
 from kitaru.analytics.events import AnalyticsEvent
 from kitaru.api_models.v1.filter import FilterOp
 from kitaru.api_models.v1.investigation import (
-    InvestigationSessionStatus,
+    InvestigationSessionVerdict,
     InvestigationStatus,
     QuestionItem,
 )
@@ -49,7 +49,7 @@ from kitaru.server.domain.agent import AgentNotFound
 from kitaru.server.domain.base import ValidationError
 from kitaru.server.domain.investigation import (
     DuplicateQuestionKey,
-    IllegalInvestigationSessionStatusTransition,
+    IllegalInvestigationStatusTransition,
     InvestigationNotFound,
     InvestigationSessionNotFound,
 )
@@ -411,6 +411,72 @@ async def test_update_investigation_omitted_fields_unchanged(
     assert updated.description == "old"
 
 
+async def test_update_investigation_status(
+    service: InvestigationService, agent_id: uuid.UUID
+) -> None:
+    """Move an investigation through in_progress to completed."""
+    created = await service.create_investigation(
+        InvestigationCreate(
+            agent_id=agent_id, name="investigation", questions=[], sessions=[]
+        ),
+        actor=ACTOR,
+    )
+    updated = await service.update_investigation(
+        created.id,
+        InvestigationUpdate(status=InvestigationStatus.IN_PROGRESS),
+        actor=ACTOR,
+    )
+    assert updated.status is InvestigationStatus.IN_PROGRESS
+    assert updated.started_at is not None
+    assert updated.ended_at is None
+    updated = await service.update_investigation(
+        created.id,
+        InvestigationUpdate(status=InvestigationStatus.COMPLETED),
+        actor=ACTOR,
+    )
+    assert updated.status is InvestigationStatus.COMPLETED
+    assert updated.ended_at is not None
+
+
+async def test_update_investigation_status_illegal_transition(
+    service: InvestigationService, agent_id: uuid.UUID
+) -> None:
+    """Reject moving a completed investigation backwards."""
+    created = await service.create_investigation(
+        InvestigationCreate(
+            agent_id=agent_id, name="investigation", questions=[], sessions=[]
+        ),
+        actor=ACTOR,
+    )
+    await service.update_investigation(
+        created.id,
+        InvestigationUpdate(status=InvestigationStatus.COMPLETED),
+        actor=ACTOR,
+    )
+    with pytest.raises(IllegalInvestigationStatusTransition):
+        await service.update_investigation(
+            created.id,
+            InvestigationUpdate(status=InvestigationStatus.IN_PROGRESS),
+            actor=ACTOR,
+        )
+
+
+async def test_update_investigation_cannot_clear_status(
+    service: InvestigationService, agent_id: uuid.UUID
+) -> None:
+    """Reject clearing the investigation status with an explicit null."""
+    created = await service.create_investigation(
+        InvestigationCreate(
+            agent_id=agent_id, name="investigation", questions=[], sessions=[]
+        ),
+        actor=ACTOR,
+    )
+    with pytest.raises(ValidationError, match="Investigation status cannot be cleared"):
+        await service.update_investigation(
+            created.id, InvestigationUpdate(status=None), actor=ACTOR
+        )
+
+
 async def test_update_investigation_cannot_clear_name(
     service: InvestigationService, agent_id: uuid.UUID
 ) -> None:
@@ -470,10 +536,10 @@ async def test_list_investigation_sessions_not_found(
         )
 
 
-async def test_update_investigation_session_status_completed(
+async def test_update_investigation_session_verdict(
     service: InvestigationService, agent_id: uuid.UUID, session_ids: list[uuid.UUID]
 ) -> None:
-    """Mark a linked session completed without completing the investigation."""
+    """Set a linked session's verdict without completing the investigation."""
     investigation = await service.create_investigation(
         InvestigationCreate(
             agent_id=agent_id,
@@ -486,23 +552,23 @@ async def test_update_investigation_session_status_completed(
         ),
         actor=ACTOR,
     )
-    session = await service.update_investigation_session_status(
+    session = await service.update_investigation_session_verdict(
         investigation.id,
         session_ids[0],
-        InvestigationSessionStatus.COMPLETED,
+        InvestigationSessionVerdict.ACCEPTABLE,
         actor=ACTOR,
     )
-    assert session.status is InvestigationSessionStatus.COMPLETED
+    assert session.verdict is InvestigationSessionVerdict.ACCEPTABLE
     reloaded = await service.get_investigation(investigation.id, actor=ACTOR)
     assert reloaded.status is InvestigationStatus.PENDING
     assert reloaded.completed_sessions == 1
     assert reloaded.ended_at is None
 
 
-async def test_update_investigation_session_status_skipped(
+async def test_update_investigation_session_verdict_replaces_earlier_verdict(
     service: InvestigationService, agent_id: uuid.UUID, session_ids: list[uuid.UUID]
 ) -> None:
-    """Mark a linked session skipped and count it toward completed_sessions."""
+    """Replace a linked session's earlier verdict."""
     investigation = await service.create_investigation(
         InvestigationCreate(
             agent_id=agent_id,
@@ -515,21 +581,27 @@ async def test_update_investigation_session_status_skipped(
         ),
         actor=ACTOR,
     )
-    session = await service.update_investigation_session_status(
+    await service.update_investigation_session_verdict(
         investigation.id,
         session_ids[0],
-        InvestigationSessionStatus.SKIPPED,
+        InvestigationSessionVerdict.UNCERTAIN,
         actor=ACTOR,
     )
-    assert session.status is InvestigationSessionStatus.SKIPPED
+    session = await service.update_investigation_session_verdict(
+        investigation.id,
+        session_ids[0],
+        InvestigationSessionVerdict.PROBLEMATIC,
+        actor=ACTOR,
+    )
+    assert session.verdict is InvestigationSessionVerdict.PROBLEMATIC
     reloaded = await service.get_investigation(investigation.id, actor=ACTOR)
     assert reloaded.completed_sessions == 1
 
 
-async def test_update_investigation_session_status_completes_investigation(
+async def test_update_investigation_session_verdict_clear(
     service: InvestigationService, agent_id: uuid.UUID, session_ids: list[uuid.UUID]
 ) -> None:
-    """Flip the investigation to completed once the last pending link settles."""
+    """Clear a linked session's verdict."""
     investigation = await service.create_investigation(
         InvestigationCreate(
             agent_id=agent_id,
@@ -542,91 +614,68 @@ async def test_update_investigation_session_status_completes_investigation(
         ),
         actor=ACTOR,
     )
-    await service.update_investigation_session_status(
+    await service.update_investigation_session_verdict(
         investigation.id,
         session_ids[0],
-        InvestigationSessionStatus.COMPLETED,
+        InvestigationSessionVerdict.ACCEPTABLE,
         actor=ACTOR,
     )
-    await service.update_investigation_session_status(
+    session = await service.update_investigation_session_verdict(
+        investigation.id, session_ids[0], None, actor=ACTOR
+    )
+    assert session.verdict is None
+    reloaded = await service.get_investigation(investigation.id, actor=ACTOR)
+    assert reloaded.completed_sessions == 0
+
+
+async def test_update_investigation_session_verdict_does_not_complete_investigation(
+    service: InvestigationService, agent_id: uuid.UUID, session_ids: list[uuid.UUID]
+) -> None:
+    """Leave the investigation status untouched once every link has a verdict."""
+    investigation = await service.create_investigation(
+        InvestigationCreate(
+            agent_id=agent_id,
+            name="investigation",
+            questions=[],
+            sessions=[
+                InvestigationSessionInput(session_id=session_ids[0]),
+                InvestigationSessionInput(session_id=session_ids[1]),
+            ],
+        ),
+        actor=ACTOR,
+    )
+    await service.update_investigation_session_verdict(
+        investigation.id,
+        session_ids[0],
+        InvestigationSessionVerdict.ACCEPTABLE,
+        actor=ACTOR,
+    )
+    await service.update_investigation_session_verdict(
         investigation.id,
         session_ids[1],
-        InvestigationSessionStatus.SKIPPED,
+        InvestigationSessionVerdict.PROBLEMATIC,
         actor=ACTOR,
     )
     reloaded = await service.get_investigation(investigation.id, actor=ACTOR)
-    assert reloaded.status is InvestigationStatus.COMPLETED
+    assert reloaded.status is InvestigationStatus.PENDING
     assert reloaded.completed_sessions == 2
-    assert reloaded.ended_at is not None
+    assert reloaded.ended_at is None
 
 
-async def test_update_investigation_session_status_illegal_transition(
-    service: InvestigationService, agent_id: uuid.UUID, session_ids: list[uuid.UUID]
-) -> None:
-    """Reject settling a session that already settled."""
-    investigation = await service.create_investigation(
-        InvestigationCreate(
-            agent_id=agent_id,
-            name="investigation",
-            questions=[],
-            sessions=[InvestigationSessionInput(session_id=session_ids[0])],
-        ),
-        actor=ACTOR,
-    )
-    await service.update_investigation_session_status(
-        investigation.id,
-        session_ids[0],
-        InvestigationSessionStatus.COMPLETED,
-        actor=ACTOR,
-    )
-    with pytest.raises(IllegalInvestigationSessionStatusTransition):
-        await service.update_investigation_session_status(
-            investigation.id,
-            session_ids[0],
-            InvestigationSessionStatus.SKIPPED,
-            actor=ACTOR,
-        )
-
-
-async def test_update_investigation_session_status_invalid_target(
-    service: InvestigationService, agent_id: uuid.UUID, session_ids: list[uuid.UUID]
-) -> None:
-    """Reject setting a linked session's status back to pending."""
-    investigation = await service.create_investigation(
-        InvestigationCreate(
-            agent_id=agent_id,
-            name="investigation",
-            questions=[],
-            sessions=[InvestigationSessionInput(session_id=session_ids[0])],
-        ),
-        actor=ACTOR,
-    )
-    with pytest.raises(
-        ValidationError,
-        match="Investigation session status cannot be set to 'pending'",
-    ):
-        await service.update_investigation_session_status(
-            investigation.id,
-            session_ids[0],
-            InvestigationSessionStatus.PENDING,
-            actor=ACTOR,
-        )
-
-
-async def test_update_investigation_session_status_investigation_not_found(
+async def test_update_investigation_session_verdict_investigation_not_found(
     service: InvestigationService,
 ) -> None:
     """Raise for an unknown investigation id."""
     with pytest.raises(InvestigationNotFound):
-        await service.update_investigation_session_status(
+        await service.update_investigation_session_verdict(
             uuid.uuid4(),
             uuid.uuid4(),
-            InvestigationSessionStatus.COMPLETED,
+            InvestigationSessionVerdict.ACCEPTABLE,
             actor=ACTOR,
         )
 
 
-async def test_update_investigation_session_status_session_not_found(
+async def test_update_investigation_session_verdict_session_not_found(
     service: InvestigationService, agent_id: uuid.UUID
 ) -> None:
     """Raise when no linked session matches the investigation and session pair."""
@@ -637,10 +686,10 @@ async def test_update_investigation_session_status_session_not_found(
         actor=ACTOR,
     )
     with pytest.raises(InvestigationSessionNotFound):
-        await service.update_investigation_session_status(
+        await service.update_investigation_session_verdict(
             investigation.id,
             uuid.uuid4(),
-            InvestigationSessionStatus.COMPLETED,
+            InvestigationSessionVerdict.ACCEPTABLE,
             actor=ACTOR,
         )
 

--- a/tests/server/test_investigations_api.py
+++ b/tests/server/test_investigations_api.py
@@ -316,6 +316,75 @@ async def test_update_investigation(client: httpx.AsyncClient, agent_id: str) ->
     assert body["description"] == "new"
 
 
+async def test_update_investigation_status(
+    client: httpx.AsyncClient, agent_id: str
+) -> None:
+    """Complete an investigation through the update endpoint."""
+    created = (
+        await client.post(
+            "/v1/investigations",
+            json={
+                "agent_id": agent_id,
+                "name": "investigation",
+                "questions": [],
+                "sessions": [],
+            },
+        )
+    ).json()
+    response = await client.patch(
+        f"/v1/investigations/{created['id']}", json={"status": "completed"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "completed"
+    assert body["ended_at"] is not None
+
+
+async def test_update_investigation_status_illegal_transition(
+    client: httpx.AsyncClient, agent_id: str
+) -> None:
+    """Observe HTTP 409 when moving a completed investigation backwards."""
+    created = (
+        await client.post(
+            "/v1/investigations",
+            json={
+                "agent_id": agent_id,
+                "name": "investigation",
+                "questions": [],
+                "sessions": [],
+            },
+        )
+    ).json()
+    await client.patch(
+        f"/v1/investigations/{created['id']}", json={"status": "completed"}
+    )
+    response = await client.patch(
+        f"/v1/investigations/{created['id']}", json={"status": "in_progress"}
+    )
+    assert response.status_code == 409
+
+
+async def test_update_investigation_cannot_clear_status(
+    client: httpx.AsyncClient, agent_id: str
+) -> None:
+    """Observe HTTP 422 when clearing the investigation status."""
+    created = (
+        await client.post(
+            "/v1/investigations",
+            json={
+                "agent_id": agent_id,
+                "name": "investigation",
+                "questions": [],
+                "sessions": [],
+            },
+        )
+    ).json()
+    response = await client.patch(
+        f"/v1/investigations/{created['id']}", json={"status": None}
+    )
+    assert response.status_code == 422
+
+
 async def test_update_investigation_cannot_clear_name(
     client: httpx.AsyncClient, agent_id: str
 ) -> None:
@@ -397,7 +466,7 @@ async def test_list_investigation_sessions_ordered_by_position(
         session_ids[0],
     ]
     assert [item["position"] for item in body["items"]] == [0, 1]
-    assert body["items"][0]["status"] == "pending"
+    assert body["items"][0]["verdict"] is None
 
 
 async def test_list_investigation_sessions_walks_pages(
@@ -447,10 +516,10 @@ async def test_list_investigation_sessions_not_found(client: httpx.AsyncClient) 
     assert response.status_code == 404
 
 
-async def test_update_investigation_session_status(
+async def test_update_investigation_session_verdict(
     client: httpx.AsyncClient, agent_id: str, session_ids: list[str]
 ) -> None:
-    """Mark a linked session completed."""
+    """Set a linked session's verdict."""
     created = (
         await client.post(
             "/v1/investigations",
@@ -464,29 +533,59 @@ async def test_update_investigation_session_status(
     ).json()
     response = await client.patch(
         f"/v1/investigations/{created['id']}/sessions/{session_ids[0]}",
-        json={"status": "completed"},
+        json={"verdict": "acceptable"},
     )
     assert response.status_code == 200
     body = response.json()
-    assert body["status"] == "completed"
+    assert body["verdict"] == "acceptable"
 
     investigation = (await client.get(f"/v1/investigations/{created['id']}")).json()
-    assert investigation["status"] == "completed"
+    assert investigation["status"] == "pending"
     assert investigation["completed_sessions"] == 1
 
 
-async def test_update_investigation_session_status_investigation_not_found(
+async def test_update_investigation_session_verdict_clear(
+    client: httpx.AsyncClient, agent_id: str, session_ids: list[str]
+) -> None:
+    """Clear a linked session's verdict."""
+    created = (
+        await client.post(
+            "/v1/investigations",
+            json={
+                "agent_id": agent_id,
+                "name": "investigation",
+                "questions": [],
+                "sessions": [{"session_id": session_ids[0]}],
+            },
+        )
+    ).json()
+    await client.patch(
+        f"/v1/investigations/{created['id']}/sessions/{session_ids[0]}",
+        json={"verdict": "problematic"},
+    )
+    response = await client.patch(
+        f"/v1/investigations/{created['id']}/sessions/{session_ids[0]}",
+        json={"verdict": None},
+    )
+    assert response.status_code == 200
+    assert response.json()["verdict"] is None
+
+    investigation = (await client.get(f"/v1/investigations/{created['id']}")).json()
+    assert investigation["completed_sessions"] == 0
+
+
+async def test_update_investigation_session_verdict_investigation_not_found(
     client: httpx.AsyncClient,
 ) -> None:
     """Observe HTTP 404 when no investigation has this id."""
     response = await client.patch(
         f"/v1/investigations/{uuid.uuid4()}/sessions/{uuid.uuid4()}",
-        json={"status": "completed"},
+        json={"verdict": "acceptable"},
     )
     assert response.status_code == 404
 
 
-async def test_update_investigation_session_status_session_not_found(
+async def test_update_investigation_session_verdict_session_not_found(
     client: httpx.AsyncClient, agent_id: str
 ) -> None:
     """Observe HTTP 404 when no investigation session links this pair."""
@@ -503,32 +602,6 @@ async def test_update_investigation_session_status_session_not_found(
     ).json()
     response = await client.patch(
         f"/v1/investigations/{created['id']}/sessions/{uuid.uuid4()}",
-        json={"status": "completed"},
+        json={"verdict": "acceptable"},
     )
     assert response.status_code == 404
-
-
-async def test_update_investigation_session_status_illegal_transition(
-    client: httpx.AsyncClient, agent_id: str, session_ids: list[str]
-) -> None:
-    """Observe HTTP 409 when the linked session already settled."""
-    created = (
-        await client.post(
-            "/v1/investigations",
-            json={
-                "agent_id": agent_id,
-                "name": "investigation",
-                "questions": [],
-                "sessions": [{"session_id": session_ids[0]}],
-            },
-        )
-    ).json()
-    await client.patch(
-        f"/v1/investigations/{created['id']}/sessions/{session_ids[0]}",
-        json={"status": "completed"},
-    )
-    response = await client.patch(
-        f"/v1/investigations/{created['id']}/sessions/{session_ids[0]}",
-        json={"status": "skipped"},
-    )
-    assert response.status_code == 409

--- a/tests/server/test_investigations_api_pg.py
+++ b/tests/server/test_investigations_api_pg.py
@@ -147,35 +147,41 @@ async def test_list_sessions_ordered_by_position(
     items = body["items"]
     assert [item["session_id"] for item in items] == session_ids
     assert [item["position"] for item in items] == [0, 1]
-    assert [item["status"] for item in items] == ["pending", "pending"]
+    assert [item["verdict"] for item in items] == [None, None]
     assert items[0]["view"]["summary"] == "Retry loop without backoff"
     assert items[1]["view"] is None
 
 
-async def test_investigation_completes_once_no_session_pending(
+async def test_manual_completion_after_verdicts(
     client: httpx.AsyncClient, agent_id: str
 ) -> None:
-    """Flip the investigation to completed once every linked session settles."""
+    """Complete the investigation manually after every session got a verdict."""
     session_ids = [await _create_session(client, agent_id) for _ in range(2)]
     created = await _create_investigation(client, agent_id, session_ids)
 
     response = await client.patch(
         f"/v1/investigations/{created['id']}/sessions/{session_ids[0]}",
-        json={"status": "completed"},
+        json={"verdict": "acceptable"},
     )
     assert response.status_code == 200
-    assert response.json()["status"] == "completed"
-
-    # The investigation stays open while a linked session is still pending.
-    response = await client.get(f"/v1/investigations/{created['id']}")
-    assert response.json()["status"] == "pending"
+    assert response.json()["verdict"] == "acceptable"
 
     response = await client.patch(
         f"/v1/investigations/{created['id']}/sessions/{session_ids[1]}",
-        json={"status": "skipped"},
+        json={"verdict": "problematic"},
     )
     assert response.status_code == 200
-    assert response.json()["status"] == "skipped"
+    assert response.json()["verdict"] == "problematic"
+
+    # Verdicts alone never complete the investigation.
+    response = await client.get(f"/v1/investigations/{created['id']}")
+    assert response.json()["status"] == "pending"
+    assert response.json()["completed_sessions"] == 2
+
+    response = await client.patch(
+        f"/v1/investigations/{created['id']}", json={"status": "completed"}
+    )
+    assert response.status_code == 200
 
     response = await client.get(f"/v1/investigations/{created['id']}")
     assert response.status_code == 200


### PR DESCRIPTION
This PR replaces the investigation session status with an optional verdict (`acceptable`, `problematic`, `uncertain`).

- Set or clear a session's verdict with `PATCH /v1/investigations/{id}/sessions/{session_id}`. Verdicts can be changed at any time.
- Investigations no longer complete automatically once every session settles. Complete them by setting `status` on `PATCH /v1/investigations/{id}`. Backward transitions are rejected, and pending to in_progress on the first answer stays automatic.
- `completed_sessions` now counts linked sessions with a verdict.
- The CLI replaces `investigation session complete/skip` with `investigation session verdict`, and the MCP review operation `set_session_status` becomes `set_session_verdict`.