### PR TITLE
Gate the CSRF check on the session token contents

### DIFF
--- a/src/kitaru/server/adapters/auth/auth_service.py
+++ b/src/kitaru/server/adapters/auth/auth_service.py
@@ -116,14 +116,12 @@ class AuthService:
         self,
         credential: str,
         csrf_token: str | None = None,
-        from_cookie: bool = False,
     ) -> AuthContext:
         """Authenticate a bearer credential for API route handling.
 
         Args:
             credential: Bearer token supplied by the caller.
             csrf_token: CSRF token supplied alongside the bearer token.
-            from_cookie: Whether the credential arrived in the auth cookie.
 
         Raises:
             AuthenticationError: The credential cannot be validated.
@@ -137,11 +135,10 @@ class AuthService:
             context = await self._authenticate_api_key(credential)
         else:
             context = await self._resolve_session_token(credential)
-        # Only a cookie rides along on a cross-site request, so only a cookie
-        # needs the caller to prove it can read the login response.
-        if from_cookie and (
-            context.csrf_token is None
-            or not secrets.compare_digest(csrf_token or "", context.csrf_token)
+        # A token issued to a cookie session carries a CSRF token, so the
+        # caller must echo it to prove it can read the login response.
+        if context.csrf_token is not None and not secrets.compare_digest(
+            csrf_token or "", context.csrf_token
         ):
             raise AuthenticationError("Missing or invalid CSRF token.")
         return context

--- a/src/kitaru/server/adapters/rest/dependencies.py
+++ b/src/kitaru/server/adapters/rest/dependencies.py
@@ -154,7 +154,6 @@ class RequestCredential(NamedTuple):
 
     token: str
     csrf_token: str | None
-    from_cookie: bool
 
 
 async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
@@ -868,17 +867,17 @@ def get_optional_bearer_credential(
         settings: API settings for this process.
 
     Returns:
-        Credential without the ``Bearer`` prefix, the CSRF token, and where
-        the credential came from, or ``None``.
+        Credential without the ``Bearer`` prefix and the CSRF token, or
+        ``None``.
     """
     credential = get_bearer_credential(request)
     csrf_token = request.headers.get(CSRF_HEADER)
     if credential is not None:
-        return RequestCredential(credential, csrf_token, from_cookie=False)
+        return RequestCredential(credential, csrf_token)
     if settings.AUTH_COOKIE_NAME:
         cookie = request.cookies.get(settings.AUTH_COOKIE_NAME)
         if cookie:
-            return RequestCredential(cookie, csrf_token, from_cookie=True)
+            return RequestCredential(cookie, csrf_token)
     return None
 
 
@@ -977,7 +976,6 @@ async def _authenticate(
         return await auth_service.resolve(
             credential=credential.token,
             csrf_token=credential.csrf_token,
-            from_cookie=credential.from_cookie,
         )
     except AuthenticationError as exc:
         raise HTTPException(

--- a/tests/server/test_auth_service.py
+++ b/tests/server/test_auth_service.py
@@ -325,7 +325,7 @@ async def test_csrf_token(
     account_repository: FakeAccountRepository,
     api_key_repository: FakeApiKeyRepository,
 ) -> None:
-    """Enforce the CSRF token on cookie credentials only."""
+    """Enforce the CSRF token on session tokens that carry one."""
     settings = local_settings(AUTH_COOKIE_NAME="kitaru_session")
     service = AuthService(
         settings=settings,
@@ -338,19 +338,19 @@ async def test_csrf_token(
     issued = await service.login_with_password("alice", "secret")
     assert issued.csrf_token is not None
 
-    await service.resolve(issued.token, csrf_token=issued.csrf_token, from_cookie=True)
+    await service.resolve(issued.token, csrf_token=issued.csrf_token)
 
     with pytest.raises(AuthenticationError, match="Missing or invalid CSRF token"):
-        await service.resolve(issued.token, from_cookie=True)
+        await service.resolve(issued.token)
     with pytest.raises(AuthenticationError, match="Missing or invalid CSRF token"):
-        await service.resolve(issued.token, csrf_token="wrong", from_cookie=True)
+        await service.resolve(issued.token, csrf_token="wrong")
 
 
-async def test_csrf_token_not_required_for_header_credentials(
+async def test_csrf_token_not_required_without_encoded_token(
     account_repository: FakeAccountRepository,
     api_key_repository: FakeApiKeyRepository,
 ) -> None:
-    """Accept a session token from the authorization header without a CSRF token."""
+    """Accept a session token that carries no CSRF token without one."""
     settings = local_settings(AUTH_COOKIE_NAME="kitaru_session")
     service = AuthService(
         settings=settings,
@@ -358,11 +358,13 @@ async def test_csrf_token_not_required_for_header_credentials(
         api_key_repository=api_key_repository,
         password_hasher=FakePasswordHasher(),
     )
-    await create_account(account_repository)
+    account = await create_account(account_repository)
+    _, key = await create_api_key(api_key_repository, account.id)
 
-    token = (await service.login_with_password("alice", "secret")).token
+    issued = await service.login_with_api_key(key)
+    assert issued.csrf_token is None
 
-    context = await service.resolve(token)
+    context = await service.resolve(issued.token)
     assert context.account.name == "alice"
 
 


### PR DESCRIPTION
This PR requires the CSRF token whenever the resolved session token carries one, instead of whenever the credential arrives in the auth cookie.

- Tokens issued to cookie sessions now require the `X-CSRF-Token` header regardless of how the credential is sent.
- Tokens without an embedded CSRF token, such as those from the API key or device grants, never require one.