### PR TITLE
Skip the CSRF check for header credentials

### DIFF
--- a/src/kitaru/server/adapters/auth/auth_service.py
+++ b/src/kitaru/server/adapters/auth/auth_service.py
@@ -116,12 +116,14 @@ class AuthService:
         self,
         credential: str,
         csrf_token: str | None = None,
+        from_cookie: bool = False,
     ) -> AuthContext:
         """Authenticate a bearer credential for API route handling.
 
         Args:
             credential: Bearer token supplied by the caller.
             csrf_token: CSRF token supplied alongside the bearer token.
+            from_cookie: Whether the credential arrived in the auth cookie.
 
         Raises:
             AuthenticationError: The credential cannot be validated.
@@ -135,10 +137,13 @@ class AuthService:
             context = await self._authenticate_api_key(credential)
         else:
             context = await self._resolve_session_token(credential)
-        # A token issued to a cookie session carries a CSRF token, so the
-        # caller must echo it to prove it can read the login response.
-        if context.csrf_token is not None and not secrets.compare_digest(
-            csrf_token or "", context.csrf_token
+        # Only a cookie rides along on a cross-site request. A header
+        # credential is attached by the caller itself, so a token that
+        # carries a CSRF token still resolves without one there.
+        if (
+            from_cookie
+            and context.csrf_token is not None
+            and not secrets.compare_digest(csrf_token or "", context.csrf_token)
         ):
             raise AuthenticationError("Missing or invalid CSRF token.")
         return context

--- a/src/kitaru/server/adapters/rest/dependencies.py
+++ b/src/kitaru/server/adapters/rest/dependencies.py
@@ -154,6 +154,7 @@ class RequestCredential(NamedTuple):
 
     token: str
     csrf_token: str | None
+    from_cookie: bool
 
 
 async def get_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
@@ -867,17 +868,17 @@ def get_optional_bearer_credential(
         settings: API settings for this process.
 
     Returns:
-        Credential without the ``Bearer`` prefix and the CSRF token, or
-        ``None``.
+        Credential without the ``Bearer`` prefix, the CSRF token, and where
+        the credential came from, or ``None``.
     """
     credential = get_bearer_credential(request)
     csrf_token = request.headers.get(CSRF_HEADER)
     if credential is not None:
-        return RequestCredential(credential, csrf_token)
+        return RequestCredential(credential, csrf_token, from_cookie=False)
     if settings.AUTH_COOKIE_NAME:
         cookie = request.cookies.get(settings.AUTH_COOKIE_NAME)
         if cookie:
-            return RequestCredential(cookie, csrf_token)
+            return RequestCredential(cookie, csrf_token, from_cookie=True)
     return None
 
 
@@ -976,6 +977,7 @@ async def _authenticate(
         return await auth_service.resolve(
             credential=credential.token,
             csrf_token=credential.csrf_token,
+            from_cookie=credential.from_cookie,
         )
     except AuthenticationError as exc:
         raise HTTPException(

--- a/tests/server/test_auth_api.py
+++ b/tests/server/test_auth_api.py
@@ -366,3 +366,31 @@ async def test_cookie_login_and_logout(
         response = await client.post("/v1/logout")
         assert response.status_code == 204
         assert COOKIE_NAME not in client.cookies
+
+
+async def test_header_credential_skips_csrf_check(
+    account_repository: FakeAccountRepository,
+    api_key_repository: FakeApiKeyRepository,
+    account: Account,
+) -> None:
+    """Accept a CSRF-carrying token from the authorization header without one."""
+    _ = account
+    app = build_app(
+        local_settings(AUTH_COOKIE_NAME=COOKIE_NAME),
+        account_repository,
+        api_key_repository,
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/login", data={"username": "alice", "password": "secret"}
+        )
+        assert response.status_code == 200
+        assert response.json()["csrf_token"] is not None
+        token = response.json()["access_token"]
+
+        client.cookies.clear()
+        response = await client.get(
+            "/v1/api-keys", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert response.status_code == 200

--- a/tests/server/test_auth_service.py
+++ b/tests/server/test_auth_service.py
@@ -325,7 +325,7 @@ async def test_csrf_token(
     account_repository: FakeAccountRepository,
     api_key_repository: FakeApiKeyRepository,
 ) -> None:
-    """Enforce the CSRF token on session tokens that carry one."""
+    """Enforce the CSRF token on cookie credentials that carry one."""
     settings = local_settings(AUTH_COOKIE_NAME="kitaru_session")
     service = AuthService(
         settings=settings,
@@ -338,19 +338,40 @@ async def test_csrf_token(
     issued = await service.login_with_password("alice", "secret")
     assert issued.csrf_token is not None
 
-    await service.resolve(issued.token, csrf_token=issued.csrf_token)
+    await service.resolve(issued.token, csrf_token=issued.csrf_token, from_cookie=True)
 
     with pytest.raises(AuthenticationError, match="Missing or invalid CSRF token"):
-        await service.resolve(issued.token)
+        await service.resolve(issued.token, from_cookie=True)
     with pytest.raises(AuthenticationError, match="Missing or invalid CSRF token"):
-        await service.resolve(issued.token, csrf_token="wrong")
+        await service.resolve(issued.token, csrf_token="wrong", from_cookie=True)
+
+
+async def test_csrf_token_not_required_for_header_credentials(
+    account_repository: FakeAccountRepository,
+    api_key_repository: FakeApiKeyRepository,
+) -> None:
+    """Accept a header credential that carries a CSRF token without one."""
+    settings = local_settings(AUTH_COOKIE_NAME="kitaru_session")
+    service = AuthService(
+        settings=settings,
+        account_repository=account_repository,
+        api_key_repository=api_key_repository,
+        password_hasher=FakePasswordHasher(),
+    )
+    await create_account(account_repository)
+
+    issued = await service.login_with_password("alice", "secret")
+    assert issued.csrf_token is not None
+
+    context = await service.resolve(issued.token)
+    assert context.account.name == "alice"
 
 
 async def test_csrf_token_not_required_without_encoded_token(
     account_repository: FakeAccountRepository,
     api_key_repository: FakeApiKeyRepository,
 ) -> None:
-    """Accept a session token that carries no CSRF token without one."""
+    """Accept a cookie credential that carries no CSRF token without one."""
     settings = local_settings(AUTH_COOKIE_NAME="kitaru_session")
     service = AuthService(
         settings=settings,
@@ -364,7 +385,7 @@ async def test_csrf_token_not_required_without_encoded_token(
     issued = await service.login_with_api_key(key)
     assert issued.csrf_token is None
 
-    context = await service.resolve(issued.token)
+    context = await service.resolve(issued.token, from_cookie=True)
     assert context.account.name == "alice"
 
 


### PR DESCRIPTION
This PR requires the CSRF token only for cookie credentials whose session token carries one, so a CSRF-carrying token sent via the authorization header, such as a CLI control plane login token, resolves without it.