### PR TITLE
Track user enriched event on finished onboarding survey

### DIFF
--- a/src/kitaru/analytics/events.py
+++ b/src/kitaru/analytics/events.py
@@ -15,6 +15,8 @@
 
 from enum import StrEnum
 
+FINISHED_ONBOARDING_SURVEY_KEY = "finished_onboarding_survey"
+
 
 class AnalyticsEvent(StrEnum):
     """Analytics event."""
@@ -33,6 +35,7 @@ class AnalyticsEvent(StrEnum):
     ANNOTATION_CREATED = "Annotation Created"
     JOB_COMPLETED = "Job Completed"
     PLUGIN_VERSION_REGISTERED = "Plugin Version Registered"
+    USER_ENRICHED = "User Enriched"
 
 
 class AccountOrigin(StrEnum):

--- a/src/kitaru/server/application/services/account_service.py
+++ b/src/kitaru/server/application/services/account_service.py
@@ -18,7 +18,11 @@ from typing import Any
 
 from anyio import to_thread
 
-from kitaru.analytics.events import AccountOrigin
+from kitaru.analytics.events import (
+    FINISHED_ONBOARDING_SURVEY_KEY,
+    AccountOrigin,
+    AnalyticsEvent,
+)
 from kitaru.server.application.interfaces.account_repository import (
     AccountRepository,
 )
@@ -26,7 +30,10 @@ from kitaru.server.application.interfaces.password_hasher import PasswordHasher
 from kitaru.server.application.models.account import AccountFilter
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.models.permissions import Action, ResourceType
-from kitaru.server.application.services.analytics_events import build_account_traits
+from kitaru.server.application.services.analytics_events import (
+    build_account_traits,
+    build_user_enriched_properties,
+)
 from kitaru.server.application.services.permission_service import PermissionService
 from kitaru.server.application.services.server_analytics import ServerAnalytics
 from kitaru.server.domain.account import (
@@ -242,6 +249,7 @@ class AccountService:
                 )
             if metadata is not None:
                 raise ForbiddenError("Accounts can only update their own metadata")
+        survey_finished_before = FINISHED_ONBOARDING_SURVEY_KEY in account.metadata
         if metadata is not None:
             account.update_metadata(metadata)
         if is_admin is not None:
@@ -266,7 +274,18 @@ class AccountService:
                 self._password_hasher.hash, password
             )
             account.update_password_hash(password_hash)
-        return await self._repository.update(account)
+        account = await self._repository.update(account)
+        if (
+            self._analytics is not None
+            and not survey_finished_before
+            and FINISHED_ONBOARDING_SURVEY_KEY in account.metadata
+        ):
+            self._analytics.track(
+                account.id,
+                AnalyticsEvent.USER_ENRICHED,
+                build_user_enriched_properties(account),
+            )
+        return account
 
     async def update_service_account(
         self,

--- a/src/kitaru/server/application/services/analytics_events.py
+++ b/src/kitaru/server/application/services/analytics_events.py
@@ -65,6 +65,21 @@ def build_account_traits(account: Account, origin: AccountOrigin) -> dict[str, A
     return traits
 
 
+def build_user_enriched_properties(account: Account) -> dict[str, Any]:
+    """Build the properties of a user finishing the onboarding survey.
+
+    Args:
+        account: Account that finished the survey.
+
+    Returns:
+        Event properties.
+    """
+    properties: dict[str, Any] = {**account.metadata, "name": account.name}
+    if account.email is not None:
+        properties["email"] = account.email
+    return properties
+
+
 def build_session_completed_properties(session: Session) -> dict[str, Any]:
     """Build the properties of a session's transition to a terminal status.
 

--- a/tests/server/test_account_service.py
+++ b/tests/server/test_account_service.py
@@ -19,6 +19,7 @@ from typing import Any
 import pytest
 
 from conftest import FakeAccountRepository, FakePasswordHasher
+from kitaru.analytics.events import FINISHED_ONBOARDING_SURVEY_KEY, AnalyticsEvent
 from kitaru.api_models.v1.filter import FilterOp
 from kitaru.server.adapters.permissions.admin_flag import AdminFlagPermissionProvider
 from kitaru.server.application.models.account import AccountFilter
@@ -47,6 +48,7 @@ class _RecordingAnalytics(ServerAnalytics):
     def __init__(self) -> None:
         """Initialize the tracker."""
         self.identified: list[tuple[uuid.UUID, dict[str, Any]]] = []
+        self.tracked: list[tuple[uuid.UUID, str, dict[str, Any]]] = []
 
     def identify(
         self, user_id: uuid.UUID, traits: dict[str, Any] | None = None
@@ -58,6 +60,21 @@ class _RecordingAnalytics(ServerAnalytics):
             traits: User traits.
         """
         self.identified.append((user_id, traits or {}))
+
+    def track(
+        self,
+        user_id: uuid.UUID,
+        event: AnalyticsEvent | str,
+        properties: dict[str, Any] | None = None,
+    ) -> None:
+        """Record a track call instead of buffering it.
+
+        Args:
+            user_id: User id.
+            event: Event name.
+            properties: Event properties.
+        """
+        self.tracked.append((user_id, event, properties or {}))
 
 
 @pytest.fixture
@@ -801,3 +818,100 @@ async def test_create_user_without_analytics_tracker(
         actor=ACTOR,
     )
     assert account.name == "alice"
+
+
+async def test_update_user_tracks_the_finished_survey() -> None:
+    """Track the user enriched event when the survey is first finished."""
+    analytics = _RecordingAnalytics()
+    service = AccountService(
+        repository=FakeAccountRepository(),
+        password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
+        analytics=analytics,
+    )
+    created, _ = await service.create_user(
+        name="alice",
+        email="alice@example.com",
+        password=None,
+        is_admin=False,
+        actor=ACTOR,
+    )
+
+    await service.update_user(
+        created.id,
+        password=None,
+        old_password=None,
+        metadata={FINISHED_ONBOARDING_SURVEY_KEY: True, "usage_reason": "work"},
+        is_admin=None,
+        actor=AuthContext(account=created),
+    )
+
+    assert len(analytics.tracked) == 1
+    user_id, event, properties = analytics.tracked[0]
+    assert user_id == created.id
+    assert event == AnalyticsEvent.USER_ENRICHED
+    assert properties == {
+        FINISHED_ONBOARDING_SURVEY_KEY: True,
+        "usage_reason": "work",
+        "name": "alice",
+        "email": "alice@example.com",
+    }
+
+
+async def test_update_user_tracks_the_finished_survey_once() -> None:
+    """Skip the user enriched event when the survey was already finished."""
+    analytics = _RecordingAnalytics()
+    service = AccountService(
+        repository=FakeAccountRepository(),
+        password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
+        analytics=analytics,
+    )
+    created, _ = await service.create_user(
+        name="alice",
+        email=None,
+        password=None,
+        is_admin=False,
+        actor=ACTOR,
+    )
+
+    for _ in range(2):
+        await service.update_user(
+            created.id,
+            password=None,
+            old_password=None,
+            metadata={FINISHED_ONBOARDING_SURVEY_KEY: True},
+            is_admin=None,
+            actor=AuthContext(account=created),
+        )
+
+    assert len(analytics.tracked) == 1
+
+
+async def test_update_user_without_finished_survey_skips_the_event() -> None:
+    """Skip the user enriched event when the survey key is not set."""
+    analytics = _RecordingAnalytics()
+    service = AccountService(
+        repository=FakeAccountRepository(),
+        password_hasher=FakePasswordHasher(),
+        permission_service=PermissionService(AdminFlagPermissionProvider()),
+        analytics=analytics,
+    )
+    created, _ = await service.create_user(
+        name="alice",
+        email=None,
+        password=None,
+        is_admin=False,
+        actor=ACTOR,
+    )
+
+    await service.update_user(
+        created.id,
+        password=None,
+        old_password=None,
+        metadata={"theme": "dark"},
+        is_admin=None,
+        actor=AuthContext(account=created),
+    )
+
+    assert analytics.tracked == []


### PR DESCRIPTION
Track the "User Enriched" analytics event when a user first finishes the onboarding survey, keyed on the same `finished_onboarding_survey` metadata key as ZenML.