### PR TITLE
Add Python package and bundle releases

### DIFF
--- a/.github/actions/publish-managed-image/action.yml
+++ b/.github/actions/publish-managed-image/action.yml
@@ -2,8 +2,11 @@
 name: Publish managed Kitaru image
 description: Build and publish the managed Kitaru image to Amazon ECR.
 inputs:
-  version:
-    description: Kitaru release version.
+  package-version:
+    description: Published Kitaru Python package version.
+    required: true
+  image-tag:
+    description: Managed image tag.
     required: true
   dry-run:
     description: Validate the Dockerfile without publishing an image.
@@ -40,12 +43,12 @@ runs:
         target: server
         push: true
         build-args: |
-          KITARU_VERSION=${{ inputs.version }}
-        tags: 715803424590.dkr.ecr.eu-central-1.amazonaws.com/kitaru-pro-server:${{ inputs.version }}
+          KITARU_VERSION=${{ inputs.package-version }}
+        tags: 715803424590.dkr.ecr.eu-central-1.amazonaws.com/kitaru-pro-server:${{ inputs.image-tag }}
         labels: |-
           org.opencontainers.image.title=kitaru
           org.opencontainers.image.description=Kitaru server
-          org.opencontainers.image.version=${{ inputs.version }}
+          org.opencontainers.image.version=${{ inputs.image-tag }}
           org.opencontainers.image.source=https://github.com/zenml-io/kitaru
           org.opencontainers.image.revision=${{ github.sha }}
           org.opencontainers.image.licenses=Apache-2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,9 +311,9 @@ jobs:
         with:
           python-version: '3.12'
       - name: Test installed package artifact
-        run: >-
-          uv run --no-project python scripts/smoke_plugin_artifacts.py
-          --package "${{ matrix.path }}"
+        env:
+          PACKAGE_PATH: ${{ matrix.path }}
+        run: uv run --no-project python scripts/smoke_plugin_artifacts.py --package "$PACKAGE_PATH"
   mcp-wheel-contract:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,23 @@ jobs:
           jobSummary: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release-units:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    outputs:
+      plugin-matrix: ${{ steps.inventory.outputs.plugin-matrix }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        with:
+          python-version: '3.12'
+      - name: Validate release units and build plugin matrix
+        id: inventory
+        run: |
+          plugin_matrix=$(uv run --no-project --with packaging==26.2 python scripts/release_units.py matrix)
+          printf 'plugin-matrix=%s\n' "$plugin_matrix" >> "$GITHUB_OUTPUT"
   docker-smoke:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
@@ -280,20 +297,11 @@ jobs:
           assert DEFAULT_PLUGIN_DEFINITIONS"
   plugin-package:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    needs: release-units
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        package:
-          - braintrust-importer
-          - evaluator
-          - jsonl-importer
-          - langfuse-importer
-          - langgraph
-          - langsmith-importer
-          - openai-agents
-          - opentelemetry-importer
-          - pydantic-ai
+      matrix: ${{ fromJSON(needs.release-units.outputs.plugin-matrix).matrix }}
     name: plugin package (${{ matrix.package }})
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -305,7 +313,7 @@ jobs:
       - name: Test installed package artifact
         run: >-
           uv run --no-project python scripts/smoke_plugin_artifacts.py
-          --package "plugins/packages/${{ matrix.package }}"
+          --package "${{ matrix.path }}"
   mcp-wheel-contract:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,8 @@ jobs:
       - name: Test installed package artifact
         env:
           PACKAGE_PATH: ${{ matrix.path }}
-        run: uv run --no-project python scripts/smoke_plugin_artifacts.py --package "$PACKAGE_PATH"
+        run: uv run --no-project python scripts/smoke_plugin_artifacts.py --package
+          "$PACKAGE_PATH"
   mcp-wheel-contract:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -1,43 +1,18 @@
 ---
-name: Release plugin
+name: Release Python package
 on:
   workflow_dispatch:
     inputs:
-      package:
-        description: Plugin package directory under plugins/packages.
-        required: true
-        type: choice
-        options:
-          - braintrust-importer
-          - evaluator
-          - jsonl-importer
-          - langfuse-importer
-          - langgraph
-          - langsmith-importer
-          - openai-agents
-          - opentelemetry-importer
-          - pydantic-ai
-      version:
-        description: Package version already committed in its pyproject.toml.
+      package-tag:
+        description: Namespaced package tag to rehearse, such as python/kitaru/v0.22.0rc1.
         required: true
         type: string
   push:
     tags:
-      - braintrust-importer-v*
-      - evaluator-v*
-      - jsonl-importer-v*
-      - langfuse-importer-v*
-      - langgraph-v*
-      - langsmith-importer-v*
-      - openai-agents-v*
-      - opentelemetry-importer-v*
-      - pydantic-ai-v*
+      - python/**
 permissions: {}
 concurrency:
-  group: >-
-    release-plugin-${{
-      github.event_name == 'push' && github.ref_name || inputs.package
-    }}
+  group: release-python-${{ github.ref_name }}
   cancel-in-progress: false
 jobs:
   build:
@@ -45,9 +20,10 @@ jobs:
     permissions:
       contents: read
     outputs:
-      package_name: ${{ steps.metadata.outputs.package_name }}
-      package_tag: ${{ steps.metadata.outputs.package_tag }}
-      package_version: ${{ steps.metadata.outputs.package_version }}
+      distribution: ${{ steps.metadata.outputs.distribution }}
+      is-prerelease: ${{ steps.metadata.outputs.is-prerelease }}
+      package-tag: ${{ steps.metadata.outputs.package-tag }}
+      version: ${{ steps.metadata.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -57,122 +33,99 @@ jobs:
         with:
           python-version: '3.12'
           enable-cache: false
-      - name: Resolve package metadata
+      - name: Resolve package from the release inventory
         id: metadata
         env:
+          DISPATCH_TAG: ${{ inputs.package-tag }}
           EVENT_NAME: ${{ github.event_name }}
-          INPUT_PACKAGE: ${{ inputs.package }}
-          INPUT_VERSION: ${{ inputs.version }}
-          TAG_NAME: ${{ github.ref_name }}
+          PUSH_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = push ]; then
-            PACKAGE_TAG="$TAG_NAME"
-            case "$PACKAGE_TAG" in
-              braintrust-importer-v*)
-                REQUESTED_PACKAGE=braintrust-importer
-                REQUESTED_VERSION=${PACKAGE_TAG#braintrust-importer-v}
-                ;;
-              evaluator-v*)
-                REQUESTED_PACKAGE=evaluator
-                REQUESTED_VERSION=${PACKAGE_TAG#evaluator-v}
-                ;;
-              jsonl-importer-v*)
-                REQUESTED_PACKAGE=jsonl-importer
-                REQUESTED_VERSION=${PACKAGE_TAG#jsonl-importer-v}
-                ;;
-              langfuse-importer-v*)
-                REQUESTED_PACKAGE=langfuse-importer
-                REQUESTED_VERSION=${PACKAGE_TAG#langfuse-importer-v}
-                ;;
-              langgraph-v*)
-                REQUESTED_PACKAGE=langgraph
-                REQUESTED_VERSION=${PACKAGE_TAG#langgraph-v}
-                ;;
-              langsmith-importer-v*)
-                REQUESTED_PACKAGE=langsmith-importer
-                REQUESTED_VERSION=${PACKAGE_TAG#langsmith-importer-v}
-                ;;
-              openai-agents-v*)
-                REQUESTED_PACKAGE=openai-agents
-                REQUESTED_VERSION=${PACKAGE_TAG#openai-agents-v}
-                ;;
-              opentelemetry-importer-v*)
-                REQUESTED_PACKAGE=opentelemetry-importer
-                REQUESTED_VERSION=${PACKAGE_TAG#opentelemetry-importer-v}
-                ;;
-              pydantic-ai-v*)
-                REQUESTED_PACKAGE=pydantic-ai
-                REQUESTED_VERSION=${PACKAGE_TAG#pydantic-ai-v}
-                ;;
-              *)
-                echo "::error::Unsupported plugin tag: $PACKAGE_TAG"
-                exit 1
-                ;;
-            esac
+            package_tag="$PUSH_TAG"
           else
-            REQUESTED_PACKAGE="$INPUT_PACKAGE"
-            REQUESTED_VERSION="$INPUT_VERSION"
-            PACKAGE_TAG="$REQUESTED_PACKAGE-v$REQUESTED_VERSION"
+            package_tag="$DISPATCH_TAG"
           fi
-          PROJECT_DIR="plugins/packages/$REQUESTED_PACKAGE"
-          PACKAGE_VERSION=$(uv version --project "$PROJECT_DIR" --short)
-          PACKAGE_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' "$PROJECT_DIR/pyproject.toml")
-          test -n "$PACKAGE_NAME"
-          test "$PACKAGE_VERSION" = "$REQUESTED_VERSION"
-          test "$PACKAGE_TAG" = "$REQUESTED_PACKAGE-v$PACKAGE_VERSION"
+          unit=$(uv run --no-project --with packaging==26.2 python scripts/release_units.py resolve --tag "$package_tag" --format json)
+          distribution=$(jq -r '.unit.distribution' <<<"$unit")
+          project_dir=$(jq -r '.unit.path' <<<"$unit")
+          version=$(jq -r '.unit.version' <<<"$unit")
+          is_prerelease=false
+          if [[ "$version" =~ (a|b|rc|dev)[0-9]+ ]]; then
+            is_prerelease=true
+          fi
           {
-            printf 'PROJECT_DIR=%s\n' "$PROJECT_DIR"
-            printf 'PACKAGE_NAME=%s\n' "$PACKAGE_NAME"
-            printf 'PACKAGE_VERSION=%s\n' "$PACKAGE_VERSION"
-            printf 'PACKAGE_TAG=%s\n' "$PACKAGE_TAG"
+            printf 'DISTRIBUTION=%s\n' "$distribution"
+            printf 'IS_PRERELEASE=%s\n' "$is_prerelease"
+            printf 'PACKAGE_TAG=%s\n' "$package_tag"
+            printf 'PROJECT_DIR=%s\n' "$project_dir"
+            printf 'VERSION=%s\n' "$version"
           } >> "$GITHUB_ENV"
           {
-            printf 'package_name=%s\n' "$PACKAGE_NAME"
-            printf 'package_version=%s\n' "$PACKAGE_VERSION"
-            printf 'package_tag=%s\n' "$PACKAGE_TAG"
+            printf 'distribution=%s\n' "$distribution"
+            printf 'is-prerelease=%s\n' "$is_prerelease"
+            printf 'package-tag=%s\n' "$package_tag"
+            printf 'version=%s\n' "$version"
           } >> "$GITHUB_OUTPUT"
-      - name: Validate tagged commit is on main
-        if: github.event_name == 'push'
+      - name: Validate release source
         run: |
           set -euo pipefail
-          git fetch origin main
-          RELEASE_SHA=$(git rev-parse HEAD)
-          if ! git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
-            echo "::error::Tag $PACKAGE_TAG points to $RELEASE_SHA, which is not on main."
+          git fetch origin develop
+          release_sha=$(git rev-parse HEAD)
+          if ! git merge-base --is-ancestor "$release_sha" origin/develop; then
+            echo "::error::$PACKAGE_TAG points to $release_sha, which is not on develop."
             exit 1
           fi
-      - name: Validate release is new
-        if: github.event_name == 'push'
+      - name: Resolve exact frontend artifact
+        if: env.DISTRIBUTION == 'kitaru'
         run: |
           set -euo pipefail
-          STATUS=$(curl -sS -o /dev/null -w '%{http_code}' \
-            "https://pypi.org/pypi/$PACKAGE_NAME/$PACKAGE_VERSION/json")
-          if [ "$STATUS" = 200 ]; then
-            echo "::error::$PACKAGE_NAME $PACKAGE_VERSION is already published."
-            exit 1
-          fi
-          if [ "$STATUS" != 404 ]; then
-            echo "::error::PyPI returned HTTP $STATUS."
-            exit 1
-          fi
-      - name: Test package and catalog integration
+          ui=$(uv run --no-project python scripts/release_ui.py --version "$VERSION")
+          {
+            printf 'KITARU_UI_ALLOW_PRERELEASE=%s\n' "$(jq -r '.allow_prerelease' <<<"$ui")"
+            printf 'KITARU_UI_EXPECTED_SHA256=%s\n' "$(jq -r '.sha256' <<<"$ui")"
+            printf 'KITARU_UI_RELEASE_REPO=%s\n' "$(jq -r '.repository' <<<"$ui")"
+            printf 'KITARU_UI_TAG=%s\n' "$(jq -r '.tag' <<<"$ui")"
+          } >> "$GITHUB_ENV"
+      - name: Download exact frontend artifact
+        if: env.DISTRIBUTION == 'kitaru'
+        env:
+          KITARU_UI_RELEASE_TOKEN: ${{ secrets.KITARU_UI_RELEASE_TOKEN }}
+        run: bash scripts/download-ui.sh
+      - name: Build Kitaru
+        if: env.DISTRIBUTION == 'kitaru'
         run: |
-          uv sync --project plugins --frozen --all-packages
-          uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests tests/server/test_default_plugins.py
-          uv run --project plugins python -c "from kitaru.server.api.bootstrap import DEFAULT_PLUGIN_DEFINITIONS; assert DEFAULT_PLUGIN_DEFINITIONS"
-      - name: Test installed package artifact
-        run: >-
-          uv run --no-sync python scripts/smoke_plugin_artifacts.py
-          --package "$PROJECT_DIR"
-      - name: Build package
-        run: uv build --project "$PROJECT_DIR" --out-dir "plugins/dist/$PACKAGE_NAME"
-      - name: Upload package artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+          uv build --out-dir package-dist
+          wheel=$(find package-dist -maxdepth 1 -name '*.whl' -print -quit)
+          test -n "$wheel"
+          uv run --no-project scripts/verify-ui-wheel.py "$wheel"
+      - name: Build plugin
+        if: env.DISTRIBUTION != 'kitaru'
+        run: uv build --project "$PROJECT_DIR" --out-dir package-dist
+      - name: Test installed distribution
+        run: |
+          set -euo pipefail
+          wheel=$(find package-dist -maxdepth 1 -name '*.whl' -print -quit)
+          test -n "$wheel"
+          DIST_FILE="$wheel" uv run --no-project --with "$wheel" python - <<'PY'
+          import importlib.metadata
+          import os
+
+          assert importlib.metadata.version(os.environ["DISTRIBUTION"]) == os.environ["VERSION"]
+          PY
+      - name: Record artifact checksums
+        run: |
+          mkdir evidence
+          sha256sum -- package-dist/*.whl package-dist/*.tar.gz > evidence/SHA256SUMS
+          cat evidence/SHA256SUMS
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: plugin-distribution
-          path: plugins/dist/${{ steps.metadata.outputs.package_name }}/*
+          name: python-distribution
+          path: |
+            package-dist/*
+            evidence/*
           if-no-files-found: error
+          retention-days: 90
   publish:
     if: github.event_name == 'push'
     needs: build
@@ -182,24 +135,29 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - name: Download package artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: plugin-distribution
-          path: plugins/dist
-      - name: Publish package
+          name: python-distribution
+          path: .
+      - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
-          packages-dir: plugins/dist
-      - name: Create GitHub Release
+          packages-dir: package-dist
+      - name: Create package GitHub Release
         env:
+          DISTRIBUTION: ${{ needs.build.outputs.distribution }}
           GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          PACKAGE_NAME: ${{ needs.build.outputs.package_name }}
-          PACKAGE_TAG: ${{ needs.build.outputs.package_tag }}
-          PACKAGE_VERSION: ${{ needs.build.outputs.package_version }}
-        run: >-
-          gh release create "$PACKAGE_TAG" plugins/dist/*
-          --verify-tag
-          --title "$PACKAGE_NAME $PACKAGE_VERSION"
-          --generate-notes
+          IS_PRERELEASE: ${{ needs.build.outputs.is-prerelease }}
+          PACKAGE_TAG: ${{ needs.build.outputs.package-tag }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          prerelease=()
+          if [ "$IS_PRERELEASE" = true ]; then
+            prerelease+=(--prerelease)
+          fi
+          gh release create "$PACKAGE_TAG" package-dist/* evidence/* \
+            "${prerelease[@]}" \
+            --verify-tag \
+            --latest=false \
+            --title "$DISTRIBUTION $VERSION" \
+            --generate-notes

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -8,8 +8,7 @@ on:
         required: true
         type: string
   push:
-    tags:
-      - python/**
+    tags: [python/**]
 permissions: {}
 concurrency:
   group: release-python-${{ github.ref_name }}
@@ -110,7 +109,6 @@ jobs:
           DIST_FILE="$wheel" uv run --no-project --with "$wheel" python - <<'PY'
           import importlib.metadata
           import os
-
           assert importlib.metadata.version(os.environ["DISTRIBUTION"]) == os.environ["VERSION"]
           PY
       - name: Record artifact checksums
@@ -150,7 +148,7 @@ jobs:
           IS_PRERELEASE: ${{ needs.build.outputs.is-prerelease }}
           PACKAGE_TAG: ${{ needs.build.outputs.package-tag }}
           VERSION: ${{ needs.build.outputs.version }}
-        run: |
+        run: |-
           prerelease=()
           if [ "$IS_PRERELEASE" = true ]; then
             prerelease+=(--prerelease)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,700 +1,231 @@
 ---
-name: Release
+name: Release Kitaru bundle
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to release (e.g. 0.22.0 or 0.22.0rc1)
+        description: Bundle version to rehearse, such as 0.22.0-rc.1.
         required: true
         type: string
-      kitaru-ui-tag:
-        description: Kitaru UI release tag (e.g. kitaru-ui-v0.1.0). Defaults to the
-          highest stable kitaru-ui-v* release.
-        required: false
-        type: string
-        default: ''
-      dry-run:
-        description: Dry run (build and test but do not publish or push)
-        required: false
-        type: boolean
-        default: false
   push:
-    tags: [v*]
+    tags:
+      - bundle/kitaru/v*
 permissions: {}
 concurrency:
-  group: release
+  group: release-bundle-${{ github.ref_name }}
   cancel-in-progress: false
-env:
-  KITARU_ANALYTICS_OPT_IN: false
-  ZENML_ANALYTICS_OPT_IN: false
 jobs:
-  release:
+  prepare:
     runs-on: ubuntu-latest
-    environment: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true' && 'dry-run' || 'pypi' }}
     permissions:
-      contents: write
-      id-token: write
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_PASSWORD: password
-        ports: [5433:5432]
-        options: --health-cmd pg_isready --health-interval 5s --health-timeout 5s
-          --health-retries 10
+      contents: read
+    outputs:
+      bundle-version: ${{ steps.metadata.outputs.bundle-version }}
+      is-prerelease: ${{ steps.metadata.outputs.is-prerelease }}
+      kitaru-version: ${{ steps.metadata.outputs.kitaru-version }}
     steps:
-      # --- Determine version and trigger mode ---
-      - name: Determine and validate version
-        env:
-          DISPATCH_VERSION: ${{ github.event.inputs.version }}
-        run: |
-          set -euo pipefail
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            VERSION_CANDIDATE="$DISPATCH_VERSION"
-          else
-            VERSION_CANDIDATE="${GITHUB_REF_NAME#v}"
-          fi
-          if ! printf '%s' "$VERSION_CANDIDATE" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$'; then
-            echo "::error::Invalid version format: $VERSION_CANDIDATE (expected canonical PEP 440 like 1.2.3 or 1.2.3rc1)"
-            exit 1
-          fi
-          printf 'VERSION=%s\n' "$VERSION_CANDIDATE" >> "$GITHUB_ENV"
-          HELM_VERSION="$VERSION_CANDIDATE"
-          if [[ "$VERSION_CANDIDATE" =~ ^([0-9]+\.[0-9]+\.[0-9]+)(a|b|rc)([0-9]+)$ ]]; then
-            HELM_VERSION="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
-          fi
-          printf 'HELM_VERSION=%s\n' "$HELM_VERSION" >> "$GITHUB_ENV"
-      # --- Determine checkout ref (dispatch only) ---
-      # Normally checks out `develop`. If v$VERSION already exists on origin,
-      # this is a partial-recovery dispatch and we must check out that tag so
-      # the rest of the workflow runs against the canonical release commit —
-      # otherwise the SHA consistency check would fail, and the error message
-      # telling operators to "check out $TAG_SHA and retry" wouldn't be
-      # actionable from workflow_dispatch. Uses the full repo URL because
-      # `origin` isn't configured until after actions/checkout runs.
-      - name: Determine checkout ref (dispatch only)
-        if: github.event_name == 'workflow_dispatch'
-        id: ref
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/v$VERSION" --silent 2>/dev/null; then
-            echo "Tag v$VERSION exists — recovery mode, checking out tag"
-            printf 'ref=refs/tags/v%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
-            printf 'TAG_EXISTS_AT_START=true\n' >> "$GITHUB_ENV"
-          else
-            echo "No existing tag — normal release flow, checking out develop"
-            printf 'ref=develop\n' >> "$GITHUB_OUTPUT"
-            printf 'TAG_EXISTS_AT_START=false\n' >> "$GITHUB_ENV"
-          fi
-
-      # --- Checkout ---
-      - name: Checkout (dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-        with:
-          ref: ${{ steps.ref.outputs.ref }}
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persist-credentials: false
-      - name: Checkout tagged commit (tag push)
-        if: github.event_name == 'push'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      # --- Configure git ---
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Validate protected-branch push token
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
-        env:
-          RELEASE_GIT_TOKEN: ${{ secrets.RELEASE_GIT_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -z "$RELEASE_GIT_TOKEN" ]; then
-            echo "::error::secrets.RELEASE_GIT_TOKEN is required for non-dry-run releases."
-            echo "::error::This workflow uses it for protected branch pushes to develop, main, and release/* after publishing."
-            echo "::error::Configure the secret or rerun with dry-run=true."
-            exit 1
-          fi
-      # --- Install uv (needed before version bump to regenerate lockfile) ---
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
         with:
           python-version: '3.12'
           enable-cache: false
-      - name: Validate default plugin packages are published
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+      - name: Resolve bundle metadata
+        id: metadata
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_TAG: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = push ]; then
+            bundle_version=${PUSH_TAG#bundle/kitaru/v}
+          else
+            bundle_version="$DISPATCH_VERSION"
+          fi
+          if [[ "$bundle_version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-rc\.([0-9]+)$ ]]; then
+            kitaru_version="${BASH_REMATCH[1]}rc${BASH_REMATCH[2]}"
+            is_prerelease=true
+          elif [[ "$bundle_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            kitaru_version="$bundle_version"
+            is_prerelease=false
+          else
+            echo "::error::Expected X.Y.Z or X.Y.Z-rc.N, got $bundle_version"
+            exit 1
+          fi
+          manifest_version=$(uv version --short)
+          if [ "$manifest_version" != "$kitaru_version" ]; then
+            echo "::error::Bundle $bundle_version requires kitaru $kitaru_version, but pyproject.toml contains $manifest_version."
+            exit 1
+          fi
+          {
+            printf 'BUNDLE_VERSION=%s\n' "$bundle_version"
+            printf 'IS_PRERELEASE=%s\n' "$is_prerelease"
+            printf 'KITARU_VERSION=%s\n' "$kitaru_version"
+          } >> "$GITHUB_ENV"
+          {
+            printf 'bundle-version=%s\n' "$bundle_version"
+            printf 'is-prerelease=%s\n' "$is_prerelease"
+            printf 'kitaru-version=%s\n' "$kitaru_version"
+          } >> "$GITHUB_OUTPUT"
+      - name: Validate bundle source
+        run: |
+          set -euo pipefail
+          git fetch origin develop
+          release_sha=$(git rev-parse HEAD)
+          if ! git merge-base --is-ancestor "$release_sha" origin/develop; then
+            echo "::error::Bundle source $release_sha is not on develop."
+            exit 1
+          fi
+      - name: Confirm Python packages exist on PyPI
+        run: |
+          set -euo pipefail
+          curl -fsS "https://pypi.org/pypi/kitaru/$KITARU_VERSION/json" >/dev/null
           while read -r requirement; do
+            test -z "$requirement" && continue
             package=${requirement%%==*}
             version=${requirement#*==}
             curl -fsS "https://pypi.org/pypi/$package/$version/json" >/dev/null
           done < plugins/default-requirements.txt
-
-      # --- Bump version (dispatch only, skip in recovery mode) ---
-      # In recovery mode (tag already exists) we checked out the tag itself,
-      # so these mutating steps must be skipped. Otherwise `uv lock` can
-      # re-resolve transitive deps to newer versions and create a commit on
-      # top of the tag, making HEAD diverge from the tag SHA — which the
-      # consistency check will then (correctly) reject.
-      - name: Bump version in pyproject.toml
-        if: github.event_name == 'workflow_dispatch' && env.TAG_EXISTS_AT_START !=
-          'true'
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+      - name: Build and test client image
         run: |
-          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
-          echo "Updated pyproject.toml to version $VERSION"
-          grep '^version' pyproject.toml
-      - name: Update CHANGELOG.md
-        if: github.event_name == 'workflow_dispatch' && env.TAG_EXISTS_AT_START !=
-          'true'
+          docker build --load -f docker/release-client.Dockerfile \
+            --target client --build-arg KITARU_VERSION="$KITARU_VERSION" \
+            -t kitaru-bundle-client:test .
+          docker run --rm kitaru-bundle-client:test python -c "import kitaru"
+      - name: Build and test server image
         run: |
-          DATE=$(date +%Y-%m-%d)
-          if grep -q "^## \[$VERSION\] - " CHANGELOG.md; then
-            echo "CHANGELOG.md already has a section for $VERSION — skipping"
-          else
-            sed -i "s/^## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $DATE/" CHANGELOG.md
-            echo "Updated CHANGELOG.md for $VERSION ($DATE)"
-          fi
-      - name: Update lockfile
-        if: github.event_name == 'workflow_dispatch' && env.TAG_EXISTS_AT_START !=
-          'true'
-        run: uv lock
-      - name: Commit release changes
-        if: github.event_name == 'workflow_dispatch' && env.TAG_EXISTS_AT_START !=
-          'true'
+          docker build --load -f docker/release-server.Dockerfile \
+            --target server --build-arg KITARU_VERSION="$KITARU_VERSION" \
+            -t kitaru-bundle-server:test .
+          docker run --rm kitaru-bundle-server:test python -c "import kitaru"
+      - name: Build and test worker image
         run: |
-          git add pyproject.toml CHANGELOG.md uv.lock
-          if git diff --cached --quiet; then
-            echo "No release changes to commit"
-          else
-            git commit -m "Release $VERSION"
-          fi
-
-      # --- Capture authoritative RELEASE_SHA for this release ---
-      # The v$VERSION tag, if it exists, is the immutable source of truth for
-      # which commit owns this version. A recovery dispatch must run on the
-      # exact same commit; otherwise PyPI, Docker, Helm, and the tag would
-      # diverge (split-brain release).
-      - name: Verify release SHA consistency
-        run: |
-          RELEASE_SHA=$(git rev-parse HEAD)
-          # Dispatch trigger pre-populates $TAG_EXISTS_AT_START. Tag-push trigger
-          # skipped the dispatch-only probe, but by definition the tag exists.
-          if [ -z "${TAG_EXISTS_AT_START:-}" ]; then
-            TAG_EXISTS_AT_START=true
-          fi
-          if [ "$TAG_EXISTS_AT_START" = "true" ]; then
-            git fetch origin "refs/tags/v$VERSION:refs/tags/v$VERSION" --force
-            TAG_SHA=$(git rev-list -n 1 "v$VERSION")
-            if [ "$TAG_SHA" != "$RELEASE_SHA" ]; then
-              echo "::error::Tag v$VERSION pins SHA $TAG_SHA but workflow HEAD is $RELEASE_SHA."
-              echo "::error::The workflow must run on the same commit the tag points to."
-              echo "::error::Dispatch a different version, or check out $TAG_SHA and retry."
-              exit 1
-            fi
-            echo "Tag v$VERSION matches HEAD ($RELEASE_SHA) — recovery-safe"
-          else
-            echo "No existing tag for v$VERSION — normal release flow"
-          fi
-          if ! grep -q "^## \[$VERSION\] - " CHANGELOG.md; then
-            echo "::error::CHANGELOG.md is missing a '## [$VERSION] - YYYY-MM-DD' section."
-            echo "::error::The release commit is incomplete — add the changelog entry before retrying."
-            exit 1
-          fi
-          printf 'RELEASE_SHA=%s\n' "$RELEASE_SHA" >> "$GITHUB_ENV"
-
-      # --- Verify version matches (tag push only) ---
-      - name: Verify tag matches pyproject.toml version
-        if: github.event_name == 'push'
-        run: |
-          TOML_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
-          if [ "$TOML_VERSION" != "$VERSION" ]; then
-            echo "::error::Tag version ($VERSION) does not match pyproject.toml ($TOML_VERSION)"
-            exit 1
-          fi
-
-      # --- Run CI checks ---
-      - name: Install dependencies
-        run: >-
-          uv sync --frozen
-          --extra server
-          --extra otel
-          --extra cli
-          --extra mcp
-          --extra worker
-      - name: Install canonical example adapter
-        run: uv pip install --no-deps --editable plugins/packages/pydantic-ai
-      - name: Check typos
-        uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14  # v1.48.0
-      - name: Lint
-        run: |
-          uv run ruff check .
-          uv run ruff format --check .
-      - name: Type check
-        run: uv run ty check
-      - name: Check MCP schemas
-        run: uv run python scripts/report_mcp_schema.py --check
-      - name: Test base, CLI, and MCP suites
-        run: |
-          uv run pytest --ignore=tests/cli --ignore=tests/mcp
-          uv run pytest tests/cli
-          uv run pytest tests/mcp
-      - name: Test clean CLI wheel and source installations
-        run: uv run --no-sync python scripts/smoke_cli_artifacts.py
-      - name: Check migration consistency
-        run: |
-          uv sync --frozen --extra server --extra otel
-          uv run python scripts/check_migrations.py
-
-      # --- Bundle Kitaru UI ---
-      - name: Download stable Kitaru UI
-        run: bash scripts/download-ui.sh
-        env:
-          TAG: ${{ github.event.inputs.kitaru-ui-tag || '' }}
-          KITARU_UI_RELEASE_TOKEN: ${{ secrets.KITARU_UI_RELEASE_TOKEN }}
-      - name: Record Kitaru UI bundle identity
-        run: |
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-          manifest = json.loads(Path("src/kitaru/_ui/bundle_manifest.json").read_text())
-          values = {
-              "KITARU_UI_REPO": manifest["repo"],
-              "KITARU_UI_TAG": manifest["tag"],
-              "KITARU_UI_CHECKSUM": manifest["checksum"],
-          }
-          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
-              for key, value in values.items():
-                  env_file.write(f"{key}={value}\n")
-          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
-              summary.write("## Kitaru UI bundle\n")
-              summary.write(f"Repo: `{values['KITARU_UI_REPO']}`\n\n")
-              summary.write(f"Tag: `{values['KITARU_UI_TAG']}`\n\n")
-              summary.write(f"Checksum: `{values['KITARU_UI_CHECKSUM']}`\n\n")
-          PY
-
-      # --- Build ---
-      - name: Build package
-        run: uv build
-      - name: Verify Kitaru UI in wheel
-        run: |
-          WHEEL=$(ls dist/*.whl)
-          uv run --no-project scripts/verify-ui-wheel.py "$WHEEL"
-      - name: Build and test candidate plugin wheels
-        run: >-
-          uv run --no-sync python scripts/smoke_plugin_artifacts.py
-          --kitaru-wheel dist
-          --candidate-dir plugins/candidate-wheels
-      - name: Test clean base and MCP wheel installations
-        run: KITARU_TEST_WHEEL=dist uv run pytest tests/mcp/test_installed_contract.py
-      - name: List build artifacts
-        run: ls -lh dist/
-
-      # --- Tag (dispatch only, skip on dry-run) ---
-      # Push the tag BEFORE PyPI so that any later failure leaves a durable
-      # anchor: a subsequent recovery dispatch will find the tag, check out
-      # its SHA, and pass the consistency check. Without this, a mid-workflow
-      # failure after PyPI upload but before tag push would leave PyPI with
-      # artifacts from one commit and no immutable ref to anchor the next run
-      # to the same commit (split-brain release risk).
-      - name: Create and push tag
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run != 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          AUTHENTICATED_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          if [ "$TAG_EXISTS_AT_START" = "true" ]; then
-            echo "Tag v$VERSION already exists at RELEASE_SHA $RELEASE_SHA — skipping"
-          else
-            git tag "v$VERSION" "$RELEASE_SHA"
-            git push "$AUTHENTICATED_REMOTE" "v$VERSION"
-          fi
-
-      # --- Publish (skip on dry-run) ---
-      - name: Publish to PyPI
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+          docker build --load -f docker/release-worker.Dockerfile \
+            --target worker --build-arg KITARU_VERSION="$KITARU_VERSION" \
+            -t kitaru-bundle-worker:test .
+          docker run --rm kitaru-bundle-worker:test python -c "import kitaru"
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
         with:
-          skip-existing: true
-      - name: Wait for PyPI availability
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+          version: v3.9.2
+      - name: Build Helm chart
         run: |
-          echo "Waiting for kitaru==$VERSION to appear on PyPI..."
-          for i in $(seq 1 30); do
-            if curl -fsS "https://pypi.org/pypi/kitaru/$VERSION/json" >/dev/null 2>&1; then
-              echo "kitaru==$VERSION is available on PyPI (attempt $i)"
-              exit 0
-            fi
-            echo "Attempt $i/30: not yet available, waiting 10s..."
-            sleep 10
-          done
-          echo "::error::kitaru==$VERSION did not appear on PyPI within 5 minutes"
-          exit 1
-      - name: Verify PyPI artifacts match local build
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
-        run: |
-          python - <<'PY'
-          import hashlib
-          import json
-          import os
-          import sys
-          import urllib.request
-          from pathlib import Path
-          version = os.environ["VERSION"]
-          metadata_url = f"https://pypi.org/pypi/kitaru/{version}/json"
-          with urllib.request.urlopen(metadata_url, timeout=30) as response:
-              metadata = json.load(response)
-          remote_files = {
-              item["filename"]: item["digests"]["sha256"]
-              for item in metadata.get("urls", [])
-              if "filename" in item and "digests" in item and "sha256" in item["digests"]
-          }
-          # PyPI only lists built distributions (sdist + wheels). The local
-          # dist/ directory also holds files PyPI never serves as separate
-          # downloads: uv writes a dist/.gitignore, and the publish step drops
-          # PEP 740 *.publish.attestation sidecars next to each artifact. Those
-          # must not be treated as missing from PyPI.
-          dist_artifacts = [
-              path
-              for path in sorted(Path("dist").iterdir())
-              if path.is_file() and path.name.endswith((".whl", ".tar.gz"))
-          ]
-          if not dist_artifacts:
-              print("::error::No .whl or .tar.gz artifacts found in dist/ to verify")
-              sys.exit(1)
-          failures = []
-          for artifact in dist_artifacts:
-              expected = remote_files.get(artifact.name)
-              if expected is None:
-                  failures.append(f"{artifact.name} is missing from PyPI metadata")
-                  continue
-              actual = hashlib.sha256(artifact.read_bytes()).hexdigest()
-              if actual != expected:
-                  failures.append(
-                      f"{artifact.name} hash mismatch: local={actual} pypi={expected}"
-                  )
-          if failures:
-              for failure in failures:
-                  print(f"::error::{failure}")
-              print(
-                  "::error::Local dist artifacts differ from PyPI. This prevents "
-                  "a recovery run from publishing GitHub/Docker/Helm artifacts "
-                  "built with a different UI bundle than the already-published package."
-              )
-              sys.exit(1)
-          print("PyPI artifacts match local dist/ build outputs.")
-          PY
-
-      # --- Push release commit to develop (dispatch only, skip on dry-run) ---
-      - name: Push release commit to develop
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run != 'true' }}
-        env:
-          RELEASE_GIT_TOKEN: ${{ secrets.RELEASE_GIT_TOKEN }}
-        run: |
-          set -euo pipefail
-          AUTHENTICATED_REMOTE="https://x-access-token:${RELEASE_GIT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          REMOTE_DEVELOP=$(git ls-remote origin refs/heads/develop | awk '{print $1}')
-          if [ "$REMOTE_DEVELOP" = "$RELEASE_SHA" ]; then
-            echo "origin/develop is at RELEASE_SHA $RELEASE_SHA — skipping push"
-          else
-            # Distinguish "not ancestor" (exit 1) from fatal git errors (exit 128).
-            set +e
-            git merge-base --is-ancestor "$RELEASE_SHA" "$REMOTE_DEVELOP"
-            ancestor_status=$?
-            set -e
-            case "$ancestor_status" in
-              0)
-                echo "origin/develop ($REMOTE_DEVELOP) already contains RELEASE_SHA $RELEASE_SHA — skipping push"
-                ;;
-              1)
-                git push "$AUTHENTICATED_REMOTE" "$RELEASE_SHA:refs/heads/develop"
-                ;;
-              *)
-                echo "::error::Ancestry check failed (exit $ancestor_status) for origin/develop ($REMOTE_DEVELOP) vs RELEASE_SHA $RELEASE_SHA"
-                exit 1
-                ;;
-            esac
-          fi
-
-      # --- Create release branch and update main (skip on dry-run) ---
-      # Both guards are identity-based: we only touch refs if they're missing
-      # or already at RELEASE_SHA. Divergent state triggers a hard error rather
-      # than silently overwriting an archival branch or rewinding main.
-      - name: Create release branch
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
-        env:
-          RELEASE_GIT_TOKEN: ${{ secrets.RELEASE_GIT_TOKEN }}
-        run: |
-          set -euo pipefail
-          AUTHENTICATED_REMOTE="https://x-access-token:${RELEASE_GIT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          REMOTE_SHA=$(git ls-remote --heads origin "refs/heads/release/$VERSION" | awk '{print $1}')
-          if [ -z "$REMOTE_SHA" ]; then
-            git push "$AUTHENTICATED_REMOTE" "$RELEASE_SHA:refs/heads/release/$VERSION"
-            echo "Created release/$VERSION at $RELEASE_SHA"
-          elif [ "$REMOTE_SHA" = "$RELEASE_SHA" ]; then
-            echo "release/$VERSION is already at RELEASE_SHA $RELEASE_SHA — skipping"
-          else
-            echo "::error::release/$VERSION exists at $REMOTE_SHA but expected $RELEASE_SHA."
-            echo "::error::Archival release branches are immutable; manual intervention required."
-            exit 1
-          fi
-      - name: Update main to release
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
-        env:
-          RELEASE_GIT_TOKEN: ${{ secrets.RELEASE_GIT_TOKEN }}
-        run: |
-          set -euo pipefail
-          AUTHENTICATED_REMOTE="https://x-access-token:${RELEASE_GIT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          REMOTE_MAIN=$(git ls-remote origin refs/heads/main | awk '{print $1}')
-          if [ "$REMOTE_MAIN" = "$RELEASE_SHA" ]; then
-            echo "origin/main is already at RELEASE_SHA $RELEASE_SHA — skipping"
-          else
-            set +e
-            git merge-base --is-ancestor "$REMOTE_MAIN" "$RELEASE_SHA"
-            ancestor_status=$?
-            set -e
-            case "$ancestor_status" in
-              0)
-                git push --force-with-lease=refs/heads/main:"$REMOTE_MAIN" "$AUTHENTICATED_REMOTE" "$RELEASE_SHA:refs/heads/main"
-                echo "Fast-forwarded main to $RELEASE_SHA"
-                ;;
-              1)
-                echo "::error::origin/main ($REMOTE_MAIN) is not an ancestor of RELEASE_SHA $RELEASE_SHA."
-                echo "::error::Force-pushing would rewind main to an older release. Manual intervention required."
-                exit 1
-                ;;
-              *)
-                echo "::error::Ancestry check failed (exit $ancestor_status) for origin/main ($REMOTE_MAIN) vs RELEASE_SHA $RELEASE_SHA"
-                exit 1
-                ;;
-            esac
-          fi
-
-      # --- GitHub Release (skip on dry-run) ---
-      # If the release already exists, verify it's attached to v$VERSION, then
-      # check each expected dist/* asset. Reproducible assets (wheel, sdist) are
-      # SHA256-compared against the local build; matching assets are skipped,
-      # mismatched assets fail loudly (never silently overwrite), and missing
-      # assets get uploaded. Signature/attestation assets are regenerated on
-      # every publish run and are never byte-identical, so they are uploaded when
-      # missing and left as-is otherwise rather than SHA256-compared.
-      - name: Create GitHub Release
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          release_json=$(gh release view "v$VERSION" --json tagName,assets 2>/dev/null) || release_json=""
-          if [ -z "$release_json" ]; then
-            gh release create "v$VERSION" dist/* \
-              --title "v$VERSION" \
-              --generate-notes
-            exit 0
-          fi
-          existing_tag=$(echo "$release_json" | jq -r '.tagName')
-          if [ "$existing_tag" != "v$VERSION" ]; then
-            echo "::error::Release v$VERSION is attached to tag $existing_tag, expected v$VERSION"
-            exit 1
-          fi
-          echo "Release v$VERSION exists — reconciling dist/* assets by SHA256"
-          mkdir -p existing-assets
-          existing_assets=$(echo "$release_json" | jq -r '.assets[].name')
-          for f in dist/*; do
-            name=$(basename "$f")
-            case "$name" in
-              *.attestation|*.sigstore|*.sig|*.asc)
-                # Signatures/attestations are regenerated on every publish run and
-                # are never byte-identical, so they cannot be SHA256-reconciled.
-                # Upload if the release is missing one; otherwise keep the existing
-                # signature. A signature is verified by validating it against the
-                # artifact, never by expecting two signatures to match byte-for-byte.
-                if echo "$existing_assets" | grep -Fxq "$name"; then
-                  echo "  keeping existing signature asset (not reproducible): $name"
-                else
-                  echo "  uploading missing signature asset: $name"
-                  gh release upload "v$VERSION" "$f"
-                fi
-                continue
-                ;;
-            esac
-            if echo "$existing_assets" | grep -Fxq "$name"; then
-              gh release download "v$VERSION" --pattern "$name" --dir existing-assets --clobber
-              local_hash=$(sha256sum "$f" | awk '{print $1}')
-              remote_hash=$(sha256sum "existing-assets/$name" | awk '{print $1}')
-              if [ "$local_hash" = "$remote_hash" ]; then
-                echo "  asset matches local build: $name"
-              else
-                echo "::error::Release asset $name hash mismatch (remote=$remote_hash local=$local_hash)."
-                echo "::error::The existing asset was built from a different commit. Manual intervention required."
-                exit 1
-              fi
-            else
-              echo "  uploading missing asset: $name"
-              gh release upload "v$VERSION" "$f"
-            fi
-          done
-
-      # --- Docker image ---
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
-      - name: Log in to Docker Hub
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
+          sed -i "s/^version: .*/version: \"$BUNDLE_VERSION\"/" helm/Chart.yaml
+          helm lint ./helm
+          mkdir bundle-dist
+          helm package ./helm --destination bundle-dist
+          sha256sum -- bundle-dist/* > bundle-dist/SHA256SUMS
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: bundle-candidate
+          path: bundle-dist/
+          if-no-files-found: error
+          retention-days: 90
+  publish:
+    if: github.event_name == 'push'
+    needs: prepare
+    runs-on: ubuntu-latest
+    environment: bundle-publish
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: bundle-candidate
+          path: bundle-dist
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build candidate Docker images from local wheels (dry run)
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true' }}
-        run: |
-          docker build \
-            -f plugins/candidate.Dockerfile \
-            --target client \
-            --build-arg KITARU_VERSION="$VERSION" \
-            -t kitaru-candidate-client .
-          docker build \
-            -f plugins/candidate.Dockerfile \
-            --target server \
-            --build-arg KITARU_VERSION="$VERSION" \
-            --build-arg "KITARU_EXTRAS=--extra server --extra otel" \
-            -t kitaru-candidate-server .
-          docker build \
-            -f plugins/candidate.Dockerfile \
-            --target worker \
-            --build-arg KITARU_VERSION="$VERSION" \
-            --build-arg "KITARU_EXTRAS=--extra worker" \
-            -t kitaru-candidate-worker .
-          docker run --rm kitaru-candidate-client \
-            python -c "import kitaru"
-          docker run --rm kitaru-candidate-server \
-            python -c "from kitaru.server.api.bootstrap import DEFAULT_PLUGIN_DEFINITIONS; assert DEFAULT_PLUGIN_DEFINITIONS"
-          docker run --rm kitaru-candidate-worker \
-            python -c "import kitaru"
-      - name: Build and publish public client Docker image
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+      - name: Publish client image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           file: docker/release-client.Dockerfile
           target: client
           push: true
-          build-args: |
-            KITARU_VERSION=${{ env.VERSION }}
-          tags: |
-            zenmldocker/kitaru:${{ env.VERSION }}
-            zenmldocker/kitaru:latest
-          labels: |
-            org.opencontainers.image.title=kitaru
-            org.opencontainers.image.description=Kitaru client
-            org.opencontainers.image.version=${{ env.VERSION }}
-            org.opencontainers.image.source=https://github.com/zenml-io/kitaru
-            org.opencontainers.image.licenses=Apache-2.0
-      - name: Build and publish public worker Docker image
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+          build-args: KITARU_VERSION=${{ needs.prepare.outputs.kitaru-version }}
+          tags: zenmldocker/kitaru:${{ needs.prepare.outputs.bundle-version }}
+      - name: Publish worker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           file: docker/release-worker.Dockerfile
           target: worker
           push: true
-          build-args: |
-            KITARU_VERSION=${{ env.VERSION }}
-          tags: |
-            zenmldocker/kitaru-worker:${{ env.VERSION }}
-            zenmldocker/kitaru-worker:latest
-          labels: |
-            org.opencontainers.image.title=kitaru-worker
-            org.opencontainers.image.description=Kitaru worker
-            org.opencontainers.image.version=${{ env.VERSION }}
-            org.opencontainers.image.source=https://github.com/zenml-io/kitaru
-            org.opencontainers.image.licenses=Apache-2.0
-      - name: Build and publish public server Docker image
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+          build-args: KITARU_VERSION=${{ needs.prepare.outputs.kitaru-version }}
+          tags: zenmldocker/kitaru-worker:${{ needs.prepare.outputs.bundle-version }}
+      - name: Publish server image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           file: docker/release-server.Dockerfile
           target: server
           push: true
-          build-args: |
-            KITARU_VERSION=${{ env.VERSION }}
-          tags: |
-            zenmldocker/kitaru-server:${{ env.VERSION }}
-            zenmldocker/kitaru-server:latest
-          labels: |
-            org.opencontainers.image.title=kitaru-server
-            org.opencontainers.image.description=Kitaru server
-            org.opencontainers.image.version=${{ env.VERSION }}
-            org.opencontainers.image.source=https://github.com/zenml-io/kitaru
-            org.opencontainers.image.licenses=Apache-2.0
-      - name: Build and publish managed ECR image
+          build-args: KITARU_VERSION=${{ needs.prepare.outputs.kitaru-version }}
+          tags: zenmldocker/kitaru-server:${{ needs.prepare.outputs.bundle-version }}
+      - name: Publish managed image
         uses: ./.github/actions/publish-managed-image
         with:
-          version: ${{ env.VERSION }}
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true' }}
+          package-version: ${{ needs.prepare.outputs.kitaru-version }}
+          image-tag: ${{ needs.prepare.outputs.bundle-version }}
           aws-role-arn: ${{ vars.KITARU_ECR_ROLE_ARN }}
-
-      # --- Helm chart ---
-      - name: Install Helm
-        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
-        with:
-          version: v3.9.2
-      - name: Set Chart.yaml version
-        run: |
-          sed -i "s/^version: .*/version: \"$HELM_VERSION\"/" helm/Chart.yaml
-          grep -E '^version:' helm/Chart.yaml
-      - name: Helm lint
-        run: helm lint ./helm
-      - name: Configure AWS credentials (Helm / ECR)
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+      - name: Configure AWS credentials for Helm
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:
           role-to-assume: arn:aws:iam::715803424590:role/gh-action-role-zenml-helm
           aws-region: us-east-1
-      - name: Login to Amazon ECR Public (Helm)
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+      - name: Login to Amazon ECR Public
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64  # v2.1.6
         with:
           mask-password: 'true'
           registry-type: public
-      - name: Package Helm chart
-        run: helm package ./helm
-      - name: Push Helm chart to Amazon ECR Public
-        if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true') }}
+      - name: Publish Helm chart
         env:
+          BUNDLE_VERSION: ${{ needs.prepare.outputs.bundle-version }}
           REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
-          REGISTRY_ALIAS: zenml
-          REPOSITORY: kitaru
-        run: |-
-          helm push "${REPOSITORY}-${HELM_VERSION}.tgz" \
-            "oci://${REGISTRY}/${REGISTRY_ALIAS}"
-
-      # --- Dry-run summary ---
-      - name: Dry-run summary
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true' }}
-        run: |-
-          {
-            echo "## Dry-run complete"
-            echo "Version: $VERSION"
-            echo ""
-            echo "### Python package"
-            ls dist/
-            echo ""
-            echo "### Docker image"
-            echo "Built from local wheels: kitaru-candidate-client"
-            echo "Built from local wheels: kitaru-candidate-server"
-            echo "Built from local wheels: kitaru-candidate-worker"
-            echo "Kitaru UI bundle: $KITARU_UI_REPO@$KITARU_UI_TAG"
-            echo "Kitaru UI checksum: $KITARU_UI_CHECKSUM"
-            echo ""
-            echo "### Helm chart"
-            echo "Built (not pushed): kitaru-${HELM_VERSION}.tgz"
-            echo ""
-            echo "No changes were pushed, published, or tagged."
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: helm push "bundle-dist/kitaru-$BUNDLE_VERSION.tgz" "oci://$REGISTRY/zenml"
+      - name: Create bundle GitHub Release
+        env:
+          BUNDLE_VERSION: ${{ needs.prepare.outputs.bundle-version }}
+          GH_TOKEN: ${{ github.token }}
+          IS_PRERELEASE: ${{ needs.prepare.outputs.is-prerelease }}
+        run: |
+          prerelease=()
+          if [ "$IS_PRERELEASE" = true ]; then
+            prerelease+=(--prerelease)
+          fi
+          gh release create "$GITHUB_REF_NAME" bundle-dist/* \
+            "${prerelease[@]}" \
+            --verify-tag \
+            --latest=false \
+            --title "Kitaru $BUNDLE_VERSION" \
+            --generate-notes
+  promote-latest:
+    if: github.event_name == 'push' && needs.prepare.outputs.is-prerelease == 'false'
+    needs: [prepare, publish]
+    runs-on: ubuntu-latest
+    environment: bundle-promotion
+    permissions: {}
+    steps:
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Move Docker latest aliases
+        env:
+          BUNDLE_VERSION: ${{ needs.prepare.outputs.bundle-version }}
+        run: |
+          docker buildx imagetools create --tag zenmldocker/kitaru:latest "zenmldocker/kitaru:$BUNDLE_VERSION"
+          docker buildx imagetools create --tag zenmldocker/kitaru-worker:latest "zenmldocker/kitaru-worker:$BUNDLE_VERSION"
+          docker buildx imagetools create --tag zenmldocker/kitaru-server:latest "zenmldocker/kitaru-server:$BUNDLE_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,7 @@ on:
         required: true
         type: string
   push:
-    tags:
-      - bundle/kitaru/v*
+    tags: [bundle/kitaru/v*]
 permissions: {}
 concurrency:
   group: release-bundle-${{ github.ref_name }}
@@ -225,7 +224,7 @@ jobs:
       - name: Move Docker latest aliases
         env:
           BUNDLE_VERSION: ${{ needs.prepare.outputs.bundle-version }}
-        run: |
+        run: |-
           docker buildx imagetools create --tag zenmldocker/kitaru:latest "zenmldocker/kitaru:$BUNDLE_VERSION"
           docker buildx imagetools create --tag zenmldocker/kitaru-worker:latest "zenmldocker/kitaru-worker:$BUNDLE_VERSION"
           docker buildx imagetools create --tag zenmldocker/kitaru-server:latest "zenmldocker/kitaru-server:$BUNDLE_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to release (e.g. 0.2.0)
+        description: Version to release (e.g. 0.22.0 or 0.22.0rc1)
         required: true
         type: string
       kitaru-ui-tag:
@@ -54,11 +54,16 @@ jobs:
           else
             VERSION_CANDIDATE="${GITHUB_REF_NAME#v}"
           fi
-          if ! printf '%s' "$VERSION_CANDIDATE" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
-            echo "::error::Invalid version format: $VERSION_CANDIDATE (expected semver like 1.2.3 or 1.2.3-rc.1)"
+          if ! printf '%s' "$VERSION_CANDIDATE" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$'; then
+            echo "::error::Invalid version format: $VERSION_CANDIDATE (expected canonical PEP 440 like 1.2.3 or 1.2.3rc1)"
             exit 1
           fi
           printf 'VERSION=%s\n' "$VERSION_CANDIDATE" >> "$GITHUB_ENV"
+          HELM_VERSION="$VERSION_CANDIDATE"
+          if [[ "$VERSION_CANDIDATE" =~ ^([0-9]+\.[0-9]+\.[0-9]+)(a|b|rc)([0-9]+)$ ]]; then
+            HELM_VERSION="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
+          fi
+          printf 'HELM_VERSION=%s\n' "$HELM_VERSION" >> "$GITHUB_ENV"
       # --- Determine checkout ref (dispatch only) ---
       # Normally checks out `develop`. If v$VERSION already exists on origin,
       # this is a partial-recovery dispatch and we must check out that tag so
@@ -641,7 +646,7 @@ jobs:
           version: v3.9.2
       - name: Set Chart.yaml version
         run: |
-          sed -i "s/^version: .*/version: \"$VERSION\"/" helm/Chart.yaml
+          sed -i "s/^version: .*/version: \"$HELM_VERSION\"/" helm/Chart.yaml
           grep -E '^version:' helm/Chart.yaml
       - name: Helm lint
         run: helm lint ./helm
@@ -667,7 +672,7 @@ jobs:
           REGISTRY_ALIAS: zenml
           REPOSITORY: kitaru
         run: |-
-          helm push "${REPOSITORY}-${VERSION}.tgz" \
+          helm push "${REPOSITORY}-${HELM_VERSION}.tgz" \
             "oci://${REGISTRY}/${REGISTRY_ALIAS}"
 
       # --- Dry-run summary ---
@@ -689,7 +694,7 @@ jobs:
             echo "Kitaru UI checksum: $KITARU_UI_CHECKSUM"
             echo ""
             echo "### Helm chart"
-            echo "Built (not pushed): kitaru-${VERSION}.tgz"
+            echo "Built (not pushed): kitaru-${HELM_VERSION}.tgz"
             echo ""
             echo "No changes were pushed, published, or tagged."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/release/release-units.toml
+++ b/release/release-units.toml
@@ -1,0 +1,129 @@
+schema-version = 1
+
+[release-checks]
+common = [
+    "release-units",
+    "lint",
+    "client-import",
+    "typos",
+    "typecheck",
+    "audit",
+    "Canonical example end to end",
+    "docker-smoke",
+    "plugin-tests",
+    "test (py311-base)",
+    "test (py312-base)",
+    "test (py313-base)",
+    "test (py314-base)",
+]
+
+[[units]]
+slug = "kitaru"
+path = "."
+distribution = "kitaru"
+registry = "pypi"
+version-source = "pyproject.toml"
+default-catalog = false
+tag-prefix = "python/kitaru/v"
+checks = [
+    "cli-artifact-contract",
+    "mcp-wheel-contract",
+    "test (py311-cli)",
+    "test (py312-cli)",
+    "test (py313-cli)",
+    "test (py314-cli)",
+    "test (py311-mcp)",
+    "test (py312-mcp)",
+    "test (py313-mcp)",
+    "test (py314-mcp)",
+]
+
+[[units]]
+slug = "braintrust-importer"
+path = "plugins/packages/braintrust-importer"
+distribution = "kitaru-braintrust-importer"
+registry = "pypi"
+version-source = "plugins/packages/braintrust-importer/pyproject.toml"
+default-catalog = true
+tag-prefix = "python/kitaru-braintrust-importer/v"
+checks = ["plugin package (braintrust-importer)"]
+
+[[units]]
+slug = "evaluator"
+path = "plugins/packages/evaluator"
+distribution = "kitaru-evaluator"
+registry = "pypi"
+version-source = "plugins/packages/evaluator/pyproject.toml"
+default-catalog = true
+tag-prefix = "python/kitaru-evaluator/v"
+checks = ["plugin package (evaluator)"]
+
+[[units]]
+slug = "jsonl-importer"
+path = "plugins/packages/jsonl-importer"
+distribution = "kitaru-jsonl-importer"
+registry = "pypi"
+version-source = "plugins/packages/jsonl-importer/pyproject.toml"
+default-catalog = true
+tag-prefix = "python/kitaru-jsonl-importer/v"
+checks = ["plugin package (jsonl-importer)"]
+
+[[units]]
+slug = "langfuse-importer"
+path = "plugins/packages/langfuse-importer"
+distribution = "kitaru-langfuse-importer"
+registry = "pypi"
+version-source = "plugins/packages/langfuse-importer/pyproject.toml"
+default-catalog = true
+tag-prefix = "python/kitaru-langfuse-importer/v"
+checks = ["plugin package (langfuse-importer)"]
+
+[[units]]
+slug = "langgraph"
+path = "plugins/packages/langgraph"
+distribution = "kitaru-langgraph"
+registry = "pypi"
+version-source = "plugins/packages/langgraph/pyproject.toml"
+default-catalog = false
+tag-prefix = "python/kitaru-langgraph/v"
+checks = ["plugin package (langgraph)"]
+
+[[units]]
+slug = "langsmith-importer"
+path = "plugins/packages/langsmith-importer"
+distribution = "kitaru-langsmith-importer"
+registry = "pypi"
+version-source = "plugins/packages/langsmith-importer/pyproject.toml"
+default-catalog = true
+tag-prefix = "python/kitaru-langsmith-importer/v"
+checks = ["plugin package (langsmith-importer)"]
+
+[[units]]
+slug = "openai-agents"
+path = "plugins/packages/openai-agents"
+distribution = "kitaru-openai-agents"
+registry = "pypi"
+version-source = "plugins/packages/openai-agents/pyproject.toml"
+default-catalog = false
+tag-prefix = "python/kitaru-openai-agents/v"
+checks = ["plugin package (openai-agents)"]
+
+[[units]]
+slug = "opentelemetry-importer"
+path = "plugins/packages/opentelemetry-importer"
+distribution = "kitaru-opentelemetry-importer"
+registry = "pypi"
+version-source = "plugins/packages/opentelemetry-importer/pyproject.toml"
+default-catalog = true
+tag-prefix = "python/kitaru-opentelemetry-importer/v"
+checks = ["plugin package (opentelemetry-importer)"]
+
+[[units]]
+slug = "pydantic-ai"
+path = "plugins/packages/pydantic-ai"
+distribution = "kitaru-pydantic-ai"
+registry = "pypi"
+version-source = "plugins/packages/pydantic-ai/pyproject.toml"
+default-catalog = false
+tag-prefix = "python/kitaru-pydantic-ai/v"
+checks = ["plugin package (pydantic-ai)"]

--- a/releases/python/kitaru/README.md
+++ b/releases/python/kitaru/README.md
@@ -1,0 +1,15 @@
+# Kitaru frontend declarations
+
+Add one `<kitaru-version>.toml` file before you create a `python/kitaru/v<kitaru-version>` tag.
+
+```toml
+schema-version = 1
+kitaru-version = "0.22.0rc1"
+ui-repository = "zenml-io/zenml-frontend-monorepo"
+ui-tag = "kitaru-ui-v0.3.0-rc.1"
+ui-archive = "kitaru-ui.tar.gz"
+ui-sha256 = "<64 lowercase hexadecimal characters>"
+allow-prerelease = true
+```
+
+The Python release workflow downloads this exact archive and rejects a different checksum. Stable Kitaru versions must select a stable frontend tag and set `allow-prerelease = false`.

--- a/scripts/download-ui.sh
+++ b/scripts/download-ui.sh
@@ -9,6 +9,7 @@
 #   TAG                         — explicit release tag (kitaru-ui-v<semver>)
 #   KITARU_UI_TAG               — alias for TAG (used by release workflows)
 #   KITARU_UI_ALLOW_PRERELEASE  — set to "true" to allow prerelease tags
+#   KITARU_UI_EXPECTED_SHA256    — optional exact archive checksum requirement
 #   KITARU_UI_RELEASE_TOKEN     — GitHub token with Contents: read access
 #   KITARU_UI_INSTALL_DIR       — destination parent dir (default: src/kitaru/_ui)
 #   VERIFY_CHECKSUM             — set to "false" to skip checksum verification
@@ -33,6 +34,7 @@ DIST_DIR="$INSTALL_DIR/dist"
 MANIFEST_FILE="$INSTALL_DIR/bundle_manifest.json"
 VERIFY_CHECKSUM="${VERIFY_CHECKSUM:-true}"
 ALLOW_PRERELEASE="${KITARU_UI_ALLOW_PRERELEASE:-false}"
+EXPECTED_SHA256="${KITARU_UI_EXPECTED_SHA256:-}"
 TAG_PATTERN='^kitaru-ui-v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?(\+[0-9A-Za-z][0-9A-Za-z.-]*)?$'
 
 find_python() {
@@ -320,6 +322,12 @@ main() {
 
     local bundle_sha256
     bundle_sha256=$(compute_sha256 "$archive")
+    if [ -n "$EXPECTED_SHA256" ] && [ "$bundle_sha256" != "$EXPECTED_SHA256" ]; then
+        echo "Error: archive SHA256 does not match the release declaration" >&2
+        echo "  expected: $EXPECTED_SHA256" >&2
+        echo "  actual:   $bundle_sha256" >&2
+        exit 1
+    fi
 
     # Clean and extract.
     rm -rf "$DIST_DIR"

--- a/scripts/release_ui.py
+++ b/scripts/release_ui.py
@@ -1,0 +1,104 @@
+"""Validate the exact frontend artifact selected for a Kitaru release."""
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+UI_REPOSITORY = "zenml-io/zenml-frontend-monorepo"
+UI_ARCHIVE = "kitaru-ui.tar.gz"
+UI_TAG_PATTERN = re.compile(r"kitaru-ui-v\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?")
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+
+
+class UIReleaseError(ValueError):
+    """Raised when the selected frontend release is incomplete or invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class UIRelease:
+    """One exact frontend artifact selected for a Kitaru package release."""
+
+    kitaru_version: str
+    repository: str
+    tag: str
+    archive: str
+    sha256: str
+    allow_prerelease: bool
+
+    def to_json(self) -> str:
+        """Serialize the declaration for workflow consumption."""
+        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+
+
+def _get_string(document: dict[str, object], key: str) -> str:
+    value = document.get(key)
+    if not isinstance(value, str) or not value:
+        raise UIReleaseError(f"{key} must be a non-empty string")
+    return value
+
+
+def load_ui_release(version: str, repo_root: Path = REPO_ROOT) -> UIRelease:
+    """Load the committed frontend declaration for one Kitaru version."""
+    path = repo_root / "releases" / "python" / "kitaru" / f"{version}.toml"
+    try:
+        document = tomllib.loads(path.read_text())
+    except FileNotFoundError as error:
+        raise UIReleaseError(f"missing frontend declaration: {path}") from error
+    except tomllib.TOMLDecodeError as error:
+        raise UIReleaseError(f"invalid frontend declaration {path}: {error}") from error
+
+    if document.get("schema-version") != 1:
+        raise UIReleaseError("schema-version must be 1")
+    declared_version = _get_string(document, "kitaru-version")
+    if declared_version != version:
+        raise UIReleaseError(
+            f"kitaru-version {declared_version} does not match {version}"
+        )
+    repository = _get_string(document, "ui-repository")
+    if repository != UI_REPOSITORY:
+        raise UIReleaseError(f"ui-repository must be {UI_REPOSITORY}")
+    tag = _get_string(document, "ui-tag")
+    if UI_TAG_PATTERN.fullmatch(tag) is None:
+        raise UIReleaseError(f"invalid ui-tag: {tag}")
+    archive = _get_string(document, "ui-archive")
+    if archive != UI_ARCHIVE:
+        raise UIReleaseError(f"ui-archive must be {UI_ARCHIVE}")
+    sha256 = _get_string(document, "ui-sha256")
+    if SHA256_PATTERN.fullmatch(sha256) is None:
+        raise UIReleaseError("ui-sha256 must be 64 lowercase hexadecimal characters")
+    allow_prerelease = document.get("allow-prerelease")
+    if not isinstance(allow_prerelease, bool):
+        raise UIReleaseError("allow-prerelease must be true or false")
+    if "-" in tag and not allow_prerelease:
+        raise UIReleaseError("a frontend prerelease requires allow-prerelease = true")
+
+    return UIRelease(
+        kitaru_version=version,
+        repository=repository,
+        tag=tag,
+        archive=archive,
+        sha256=sha256,
+        allow_prerelease=allow_prerelease,
+    )
+
+
+def main() -> int:
+    """Print one validated frontend declaration as JSON."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+    try:
+        print(load_ui_release(args.version).to_json())
+    except UIReleaseError as error:
+        print(f"release_ui_error: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_units.py
+++ b/scripts/release_units.py
@@ -1,0 +1,544 @@
+"""Validate and query Kitaru's Python release-unit inventory."""
+
+import argparse
+import ast
+import json
+import re
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_TAG_PATTERN = re.compile(
+    r"python/(?P<distribution>[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?)/v(?P<version>[^/]+)"
+)
+SLUG_PATTERN = re.compile(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
+
+
+class ReleaseInventoryError(ValueError):
+    """Raised when release-unit metadata is invalid or inconsistent."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseUnit:
+    """One independently versioned Python distribution."""
+
+    slug: str
+    path: str
+    distribution: str
+    registry: str
+    version_source: str
+    version: str
+    default_catalog: bool
+    tag_prefix: str
+    required_checks: frozenset[str]
+
+    @property
+    def tag(self) -> str:
+        """Build the immutable package tag for the current manifest version."""
+        return f"{self.tag_prefix}{self.version}"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the unit using the stable public field names."""
+        return {
+            "slug": self.slug,
+            "path": self.path,
+            "distribution": self.distribution,
+            "registry": self.registry,
+            "version_source": self.version_source,
+            "version": self.version,
+            "default_catalog": self.default_catalog,
+            "tag_prefix": self.tag_prefix,
+            "tag": self.tag,
+            "required_checks": sorted(self.required_checks),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseInventory:
+    """Validated release-unit metadata for the repository."""
+
+    schema_version: int
+    common_checks: frozenset[str]
+    units: tuple[ReleaseUnit, ...]
+
+    @property
+    def plugin_units(self) -> tuple[ReleaseUnit, ...]:
+        """Return the independently packaged plugin units."""
+        return tuple(unit for unit in self.units if unit.slug != "kitaru")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the inventory as a versioned automation contract."""
+        return {
+            "schema_version": self.schema_version,
+            "common_checks": sorted(self.common_checks),
+            "units": [unit.to_dict() for unit in self.units],
+        }
+
+    def to_json(self) -> str:
+        """Serialize the inventory as deterministic compact JSON."""
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def validate_version(value: str) -> str:
+    """Validate and return a canonical PEP 440 public version."""
+    try:
+        version = Version(value)
+    except InvalidVersion as error:
+        raise ReleaseInventoryError(
+            f"version must be canonical PEP 440: {value}"
+        ) from error
+    canonical = str(version)
+    if canonical != value:
+        raise ReleaseInventoryError(
+            f"version must be canonical PEP 440: {value} normalizes to {canonical}"
+        )
+    return canonical
+
+
+def _read_toml(path: Path) -> dict[str, Any]:
+    try:
+        return tomllib.loads(path.read_text())
+    except FileNotFoundError as error:
+        raise ReleaseInventoryError(f"missing TOML file: {path}") from error
+    except tomllib.TOMLDecodeError as error:
+        raise ReleaseInventoryError(f"invalid TOML file {path}: {error}") from error
+
+
+def _get_string(document: dict[str, Any], key: str, context: str) -> str:
+    value = document.get(key)
+    if not isinstance(value, str) or not value:
+        raise ReleaseInventoryError(f"{context}: {key} must be a non-empty string")
+    return value
+
+
+def _get_string_list(document: dict[str, Any], key: str, context: str) -> list[str]:
+    value = document.get(key)
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) and item for item in value
+    ):
+        raise ReleaseInventoryError(f"{context}: {key} must be a list of strings")
+    if len(value) != len(set(value)):
+        raise ReleaseInventoryError(f"{context}: {key} contains duplicates")
+    return value
+
+
+def _resolve_repo_path(repo_root: Path, value: str, context: str) -> Path:
+    relative_path = Path(value)
+    if relative_path.is_absolute():
+        raise ReleaseInventoryError(f"{context}: path must be repository-relative")
+    root = repo_root.resolve()
+    resolved = (root / relative_path).resolve()
+    if not resolved.is_relative_to(root):
+        raise ReleaseInventoryError(f"{context}: path escapes the repository")
+    return resolved
+
+
+def _parse_manifest(
+    repo_root: Path, project_path: Path, version_source: str, context: str
+) -> tuple[str, str]:
+    manifest_path = _resolve_repo_path(repo_root, version_source, context)
+    if not manifest_path.is_relative_to(project_path):
+        raise ReleaseInventoryError(f"{context}: version source is outside the project")
+    manifest = _read_toml(manifest_path)
+    project = manifest.get("project")
+    if not isinstance(project, dict):
+        raise ReleaseInventoryError(f"{context}: version source has no [project] table")
+    name = _get_string(project, "name", context)
+    version = validate_version(_get_string(project, "version", context))
+    return name, version
+
+
+def _parse_requirement(value: str, context: str) -> Requirement:
+    try:
+        return Requirement(value)
+    except InvalidRequirement as error:
+        raise ReleaseInventoryError(
+            f"{context}: invalid requirement {value}"
+        ) from error
+
+
+def _load_default_requirements(repo_root: Path) -> dict[str, str]:
+    requirements_path = repo_root / "plugins" / "default-requirements.txt"
+    requirements: dict[str, str] = {}
+    try:
+        lines = requirements_path.read_text().splitlines()
+    except FileNotFoundError as error:
+        raise ReleaseInventoryError(
+            "missing plugins/default-requirements.txt"
+        ) from error
+    for line in lines:
+        value = line.strip()
+        if not value or value.startswith("#"):
+            continue
+        requirement = _parse_requirement(value, "plugins/default-requirements.txt")
+        name = canonicalize_name(requirement.name)
+        if name in requirements:
+            raise ReleaseInventoryError(f"duplicate default requirement: {name}")
+        requirements[name] = str(requirement.specifier)
+    return requirements
+
+
+def _load_bootstrap_requirements(repo_root: Path) -> set[str]:
+    bootstrap_path = repo_root / "src" / "kitaru" / "server" / "api" / "bootstrap.py"
+    try:
+        module = ast.parse(bootstrap_path.read_text(), filename=str(bootstrap_path))
+    except FileNotFoundError as error:
+        raise ReleaseInventoryError("missing server plugin catalog") from error
+    except SyntaxError as error:
+        raise ReleaseInventoryError(
+            f"invalid server plugin catalog: {error}"
+        ) from error
+
+    requirements: set[str] = set()
+    for node in ast.walk(module):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "DefaultPluginDefinition"
+        ):
+            continue
+        requirement_keywords = [
+            keyword for keyword in node.keywords if keyword.arg == "requirement"
+        ]
+        if len(requirement_keywords) != 1:
+            raise ReleaseInventoryError(
+                "server plugin catalog entries must declare one requirement"
+            )
+        requirement_value = requirement_keywords[0].value
+        if not isinstance(requirement_value, ast.Constant) or not isinstance(
+            requirement_value.value, str
+        ):
+            raise ReleaseInventoryError(
+                "server plugin catalog requirements must be string literals"
+            )
+        requirement = _parse_requirement(
+            requirement_value.value, "server plugin catalog"
+        )
+        requirements.add(canonicalize_name(requirement.name))
+    return requirements
+
+
+def _validate_plugin_coverage(repo_root: Path, units: tuple[ReleaseUnit, ...]) -> None:
+    packages_root = repo_root / "plugins" / "packages"
+    actual = {
+        manifest.parent.name for manifest in packages_root.glob("*/pyproject.toml")
+    }
+    expected = {unit.slug for unit in units if unit.slug != "kitaru"}
+    unlisted = sorted(actual - expected)
+    missing = sorted(expected - actual)
+    if unlisted:
+        raise ReleaseInventoryError(f"unlisted plugin project: {unlisted[0]}")
+    if missing:
+        raise ReleaseInventoryError(
+            f"inventory plugin project is missing: {missing[0]}"
+        )
+
+
+def _validate_default_catalog(repo_root: Path, units: tuple[ReleaseUnit, ...]) -> None:
+    inventory_defaults = {
+        canonicalize_name(unit.distribution) for unit in units if unit.default_catalog
+    }
+    requirement_specs = _load_default_requirements(repo_root)
+    requirement_defaults = set(requirement_specs)
+    bootstrap_defaults = _load_bootstrap_requirements(repo_root)
+    if requirement_defaults != bootstrap_defaults:
+        raise ReleaseInventoryError(
+            "server default catalog does not match plugins/default-requirements.txt"
+        )
+    if inventory_defaults != requirement_defaults:
+        raise ReleaseInventoryError("default catalog does not match inventory")
+
+    units_by_name: dict[str, ReleaseUnit] = {
+        str(canonicalize_name(unit.distribution)): unit for unit in units
+    }
+    for name, specifier in requirement_specs.items():
+        expected = f"=={units_by_name[name].version}"
+        if specifier != expected:
+            raise ReleaseInventoryError(
+                f"{name}: default requirement {specifier} does not match {expected}"
+            )
+
+
+def load_inventory(
+    repo_root: Path = REPO_ROOT, inventory_path: Path | None = None
+) -> ReleaseInventory:
+    """Load and validate the repository's release-unit inventory."""
+    root = repo_root.resolve()
+    path = inventory_path or root / "release" / "release-units.toml"
+    document = _read_toml(path)
+    schema_version = document.get("schema-version")
+    if schema_version != 1:
+        raise ReleaseInventoryError(
+            f"unsupported release inventory schema version: {schema_version}"
+        )
+    checks_document = document.get("release-checks")
+    if not isinstance(checks_document, dict):
+        raise ReleaseInventoryError("release-checks must be a table")
+    common_checks = frozenset(
+        _get_string_list(checks_document, "common", "release-checks")
+    )
+
+    raw_units = document.get("units")
+    if not isinstance(raw_units, list) or not raw_units:
+        raise ReleaseInventoryError("units must be a non-empty array of tables")
+
+    units: list[ReleaseUnit] = []
+    seen_slugs: set[str] = set()
+    seen_distributions: set[str] = set()
+    seen_tag_prefixes: set[str] = set()
+    for raw_unit in raw_units:
+        if not isinstance(raw_unit, dict):
+            raise ReleaseInventoryError("each release unit must be a table")
+        slug = _get_string(raw_unit, "slug", "release unit")
+        if slug in seen_slugs:
+            raise ReleaseInventoryError(f"duplicate slug: {slug}")
+        seen_slugs.add(slug)
+        context = slug
+        if SLUG_PATTERN.fullmatch(slug) is None:
+            raise ReleaseInventoryError(f"{context}: invalid slug")
+
+        project_path = _get_string(raw_unit, "path", context)
+        expected_project_path = "." if slug == "kitaru" else f"plugins/packages/{slug}"
+        if project_path != expected_project_path:
+            raise ReleaseInventoryError(
+                f"{context}: project path must be {expected_project_path}"
+            )
+        resolved_project = _resolve_repo_path(root, project_path, context)
+        if not resolved_project.is_dir():
+            raise ReleaseInventoryError(f"{context}: project path does not exist")
+
+        distribution = _get_string(raw_unit, "distribution", context)
+        normalized_distribution = canonicalize_name(distribution)
+        if normalized_distribution in seen_distributions:
+            raise ReleaseInventoryError(f"duplicate distribution: {distribution}")
+        seen_distributions.add(normalized_distribution)
+
+        registry = _get_string(raw_unit, "registry", context)
+        if registry != "pypi":
+            raise ReleaseInventoryError(f"{context}: unsupported registry {registry}")
+        version_source = _get_string(raw_unit, "version-source", context)
+        manifest_name, version = _parse_manifest(
+            root, resolved_project, version_source, context
+        )
+        if manifest_name != distribution:
+            raise ReleaseInventoryError(
+                f"{context}: manifest name {manifest_name} does not match "
+                f"{distribution}"
+            )
+
+        default_catalog = raw_unit.get("default-catalog")
+        if not isinstance(default_catalog, bool):
+            raise ReleaseInventoryError(
+                f"{context}: default-catalog must be true or false"
+            )
+        tag_prefix = _get_string(raw_unit, "tag-prefix", context)
+        expected_tag_prefix = f"python/{distribution}/v"
+        if tag_prefix != expected_tag_prefix:
+            raise ReleaseInventoryError(
+                f"{context}: tag prefix must be {expected_tag_prefix}"
+            )
+        if tag_prefix in seen_tag_prefixes:
+            raise ReleaseInventoryError(f"duplicate tag prefix: {tag_prefix}")
+        seen_tag_prefixes.add(tag_prefix)
+
+        unit_checks = frozenset(_get_string_list(raw_unit, "checks", context))
+        units.append(
+            ReleaseUnit(
+                slug=slug,
+                path=project_path,
+                distribution=distribution,
+                registry=registry,
+                version_source=version_source,
+                version=version,
+                default_catalog=default_catalog,
+                tag_prefix=tag_prefix,
+                required_checks=common_checks | unit_checks,
+            )
+        )
+
+    resolved_units = tuple(units)
+    root_units = [unit for unit in resolved_units if unit.path == "."]
+    if len(root_units) != 1 or root_units[0].slug != "kitaru":
+        raise ReleaseInventoryError("inventory must contain one root kitaru unit")
+    _validate_plugin_coverage(root, resolved_units)
+    _validate_default_catalog(root, resolved_units)
+    return ReleaseInventory(
+        schema_version=schema_version,
+        common_checks=common_checks,
+        units=resolved_units,
+    )
+
+
+def _resolve_unit(selector: str, inventory: ReleaseInventory) -> ReleaseUnit:
+    for unit in inventory.units:
+        if unit.slug == selector:
+            return unit
+    raise ReleaseInventoryError(f"unknown release unit: {selector}")
+
+
+def parse_package_tag(tag: str, inventory: ReleaseInventory) -> ReleaseUnit:
+    """Resolve a namespaced package tag and verify its manifest version."""
+    match = PACKAGE_TAG_PATTERN.fullmatch(tag)
+    if match is None:
+        raise ReleaseInventoryError(f"invalid package tag: {tag}")
+    distribution = match.group("distribution")
+    version = validate_version(match.group("version"))
+    unit = next(
+        (unit for unit in inventory.units if unit.distribution == distribution), None
+    )
+    if unit is None:
+        raise ReleaseInventoryError(
+            f"unknown distribution in package tag: {distribution}"
+        )
+    if version != unit.version:
+        raise ReleaseInventoryError(
+            f"{tag}: version does not match manifest version {unit.version}"
+        )
+    return unit
+
+
+def build_plugin_matrix(
+    inventory: ReleaseInventory,
+) -> dict[str, list[dict[str, str]]]:
+    """Build the GitHub Actions matrix for independently packaged plugins."""
+    return {
+        "include": [
+            {
+                "package": unit.slug,
+                "path": unit.path,
+            }
+            for unit in inventory.plugin_units
+        ]
+    }
+
+
+def format_units(units: tuple[ReleaseUnit, ...]) -> str:
+    """Render concise deterministic release-unit rows for human operators."""
+    lines = ["SLUG\tDISTRIBUTION\tVERSION\tDEFAULT\tTAG"]
+    lines.extend(
+        "\t".join(
+            (
+                unit.slug,
+                unit.distribution,
+                unit.version,
+                "yes" if unit.default_catalog else "no",
+                unit.tag,
+            )
+        )
+        for unit in units
+    )
+    return "\n".join(lines)
+
+
+def format_inventory(inventory: ReleaseInventory) -> str:
+    """Render a concise deterministic inventory for human operators."""
+    return format_units(inventory.units)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate and query Kitaru Python release units."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list", help="List all release units.")
+    list_parser.add_argument("--format", choices=("text", "json"), default="text")
+
+    subparsers.add_parser("matrix", help="Print the plugin CI matrix as JSON.")
+
+    resolve_parser = subparsers.add_parser(
+        "resolve", help="Resolve one unit or package tag."
+    )
+    selector = resolve_parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--unit")
+    selector.add_argument("--tag")
+    resolve_parser.add_argument("--format", choices=("text", "json"), default="text")
+
+    validate_parser = subparsers.add_parser(
+        "validate", help="Validate the inventory and repository manifests."
+    )
+    validate_parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the release-unit query CLI."""
+    args = _parse_args()
+    try:
+        inventory = load_inventory()
+        if args.command == "list":
+            output = (
+                inventory.to_json()
+                if args.format == "json"
+                else format_inventory(inventory)
+            )
+        elif args.command == "matrix":
+            output = json.dumps(
+                {
+                    "schema_version": inventory.schema_version,
+                    "matrix": build_plugin_matrix(inventory),
+                },
+                separators=(",", ":"),
+            )
+        elif args.command == "resolve":
+            unit = (
+                parse_package_tag(args.tag, inventory)
+                if args.tag
+                else _resolve_unit(args.unit, inventory)
+            )
+            output = (
+                json.dumps(
+                    {
+                        "schema_version": inventory.schema_version,
+                        "unit": unit.to_dict(),
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+                if args.format == "json"
+                else format_units((unit,))
+            )
+        else:
+            output = (
+                json.dumps(
+                    {
+                        "schema_version": inventory.schema_version,
+                        "status": "valid",
+                        "unit_count": len(inventory.units),
+                    },
+                    separators=(",", ":"),
+                )
+                if args.format == "json"
+                else f"Validated {len(inventory.units)} release units."
+            )
+    except ReleaseInventoryError as error:
+        if getattr(args, "format", "text") == "json":
+            print(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "error": {
+                            "kind": "release_inventory_error",
+                            "message": str(error),
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+                file=sys.stderr,
+            )
+        else:
+            print(f"error: {error}", file=sys.stderr)
+        return 2
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_units.py
+++ b/scripts/release_units.py
@@ -94,6 +94,10 @@ def validate_version(value: str) -> str:
         raise ReleaseInventoryError(
             f"version must be canonical PEP 440: {value}"
         ) from error
+    if version.local is not None:
+        raise ReleaseInventoryError(
+            f"PyPI release versions must not contain a local segment: {value}"
+        )
     canonical = str(version)
     if canonical != value:
         raise ReleaseInventoryError(

--- a/tests/scripts/test_release_ui.py
+++ b/tests/scripts/test_release_ui.py
@@ -1,0 +1,79 @@
+import json
+from pathlib import Path
+
+import pytest
+from scripts.release_ui import UIReleaseError, load_ui_release
+
+
+def _write_declaration(root: Path, version: str, **changes: object) -> None:
+    values: dict[str, object] = {
+        "schema-version": 1,
+        "kitaru-version": version,
+        "ui-repository": "zenml-io/zenml-frontend-monorepo",
+        "ui-tag": "kitaru-ui-v0.3.0-rc.1",
+        "ui-archive": "kitaru-ui.tar.gz",
+        "ui-sha256": "a" * 64,
+        "allow-prerelease": True,
+    }
+    values.update(changes)
+    path = root / "releases" / "python" / "kitaru" / f"{version}.toml"
+    path.parent.mkdir(parents=True)
+    lines = []
+    for key, value in values.items():
+        if isinstance(value, bool):
+            rendered = str(value).lower()
+        elif isinstance(value, int):
+            rendered = str(value)
+        else:
+            rendered = json.dumps(value)
+        lines.append(f"{key} = {rendered}")
+    path.write_text("\n".join(lines) + "\n")
+
+
+def test_load_ui_release_accepts_an_exact_rc_artifact(tmp_path: Path) -> None:
+    _write_declaration(tmp_path, "0.22.0rc1")
+
+    release = load_ui_release("0.22.0rc1", tmp_path)
+
+    assert release.tag == "kitaru-ui-v0.3.0-rc.1"
+    assert release.sha256 == "a" * 64
+    assert json.loads(release.to_json())["allow_prerelease"] is True
+
+
+def test_load_ui_release_requires_the_requested_version(tmp_path: Path) -> None:
+    _write_declaration(
+        tmp_path,
+        "0.22.0rc1",
+        **{"kitaru-version": "0.22.0rc2"},
+    )
+
+    with pytest.raises(UIReleaseError, match="does not match"):
+        load_ui_release("0.22.0rc1", tmp_path)
+
+
+def test_load_ui_release_rejects_an_unapproved_prerelease(tmp_path: Path) -> None:
+    _write_declaration(
+        tmp_path,
+        "0.22.0rc1",
+        **{"allow-prerelease": False},
+    )
+
+    with pytest.raises(UIReleaseError, match="requires allow-prerelease"):
+        load_ui_release("0.22.0rc1", tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("ui-repository", "other/repository", "ui-repository"),
+        ("ui-archive", "ui.zip", "ui-archive"),
+        ("ui-sha256", "not-a-checksum", "ui-sha256"),
+    ],
+)
+def test_load_ui_release_rejects_untrusted_identity(
+    tmp_path: Path, field: str, value: str, message: str
+) -> None:
+    _write_declaration(tmp_path, "0.22.0rc1", **{field: value})
+
+    with pytest.raises(UIReleaseError, match=message):
+        load_ui_release("0.22.0rc1", tmp_path)

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -233,7 +233,8 @@ def test_ci_plugin_matrix_is_loaded_from_the_release_inventory() -> None:
         in workflow
     )
     assert "PACKAGE_PATH: ${{ matrix.path }}" in workflow
-    assert '--package "$PACKAGE_PATH"' in workflow
+    assert "--package" in workflow
+    assert '"$PACKAGE_PATH"' in workflow
     assert "          - braintrust-importer\n" not in workflow
 
 
@@ -249,6 +250,16 @@ def test_each_unit_exposes_its_exact_release_critical_checks() -> None:
             assert f"plugin package ({unit.slug})" in unit.required_checks
 
 
+def _run_cli(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "release_units.py"), *arguments],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
 @pytest.mark.parametrize(
     ("arguments", "expected_fragment"),
     [
@@ -260,13 +271,7 @@ def test_each_unit_exposes_its_exact_release_critical_checks() -> None:
 def test_cli_text_commands_succeed(
     arguments: list[str], expected_fragment: str
 ) -> None:
-    result = subprocess.run(
-        [sys.executable, str(REPO_ROOT / "scripts" / "release_units.py"), *arguments],
-        cwd=REPO_ROOT,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = _run_cli(*arguments)
 
     assert result.returncode == 0
     assert expected_fragment in result.stdout
@@ -283,13 +288,7 @@ def test_cli_text_commands_succeed(
     ],
 )
 def test_cli_json_commands_succeed(arguments: list[str], expected_key: str) -> None:
-    result = subprocess.run(
-        [sys.executable, str(REPO_ROOT / "scripts" / "release_units.py"), *arguments],
-        cwd=REPO_ROOT,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = _run_cli(*arguments)
 
     assert result.returncode == 0
     assert json.loads(result.stdout)[expected_key]
@@ -298,21 +297,7 @@ def test_cli_json_commands_succeed(arguments: list[str], expected_key: str) -> N
 
 def test_cli_resolves_the_current_package_tag() -> None:
     tag = load_inventory().units[0].tag
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(REPO_ROOT / "scripts" / "release_units.py"),
-            "resolve",
-            "--tag",
-            tag,
-            "--format",
-            "json",
-        ],
-        cwd=REPO_ROOT,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = _run_cli("resolve", "--tag", tag, "--format", "json")
 
     assert result.returncode == 0
     assert json.loads(result.stdout)["unit"]["tag"] == tag
@@ -320,21 +305,7 @@ def test_cli_resolves_the_current_package_tag() -> None:
 
 
 def test_cli_json_errors_are_structured() -> None:
-    result = subprocess.run(
-        [
-            sys.executable,
-            str(REPO_ROOT / "scripts" / "release_units.py"),
-            "resolve",
-            "--unit",
-            "unknown",
-            "--format",
-            "json",
-        ],
-        cwd=REPO_ROOT,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = _run_cli("resolve", "--unit", "unknown", "--format", "json")
 
     assert result.returncode == 2
     assert result.stdout == ""

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -98,6 +98,18 @@ def test_noncanonical_python_versions_are_rejected(version: str) -> None:
         validate_version(version)
 
 
+def test_local_python_versions_are_rejected_for_pypi() -> None:
+    with pytest.raises(ReleaseInventoryError, match="local segment"):
+        validate_version("1.0+build.1")
+
+
+def test_legacy_release_workflow_accepts_canonical_python_rc_versions() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
+
+    assert "1.2.3rc1" in workflow
+    assert "HELM_VERSION" in workflow
+
+
 @pytest.mark.parametrize(
     ("tag", "message"),
     [

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -1,0 +1,334 @@
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from scripts.release_units import (
+    ReleaseInventoryError,
+    build_plugin_matrix,
+    format_inventory,
+    load_inventory,
+    parse_package_tag,
+    validate_version,
+)
+
+REPO_ROOT = Path(__file__).parents[2]
+INVENTORY_PATH = REPO_ROOT / "release" / "release-units.toml"
+
+EXPECTED_UNITS = {
+    "kitaru": "kitaru",
+    "braintrust-importer": "kitaru-braintrust-importer",
+    "evaluator": "kitaru-evaluator",
+    "jsonl-importer": "kitaru-jsonl-importer",
+    "langfuse-importer": "kitaru-langfuse-importer",
+    "langgraph": "kitaru-langgraph",
+    "langsmith-importer": "kitaru-langsmith-importer",
+    "openai-agents": "kitaru-openai-agents",
+    "opentelemetry-importer": "kitaru-opentelemetry-importer",
+    "pydantic-ai": "kitaru-pydantic-ai",
+}
+
+EXPECTED_DEFAULT_DISTRIBUTIONS = {
+    "kitaru-braintrust-importer",
+    "kitaru-evaluator",
+    "kitaru-jsonl-importer",
+    "kitaru-langfuse-importer",
+    "kitaru-langsmith-importer",
+    "kitaru-opentelemetry-importer",
+}
+
+
+@pytest.fixture
+def release_repo(tmp_path: Path) -> Path:
+    for relative_path in (
+        "pyproject.toml",
+        "release/release-units.toml",
+        "plugins/default-requirements.txt",
+        "src/kitaru/server/api/bootstrap.py",
+    ):
+        source = REPO_ROOT / relative_path
+        destination = tmp_path / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
+
+    for manifest in (REPO_ROOT / "plugins" / "packages").glob("*/pyproject.toml"):
+        relative_path = manifest.relative_to(REPO_ROOT)
+        destination = tmp_path / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(manifest, destination)
+
+    return tmp_path
+
+
+def test_inventory_describes_exactly_the_ten_python_distributions() -> None:
+    inventory = load_inventory()
+
+    assert {unit.slug: unit.distribution for unit in inventory.units} == EXPECTED_UNITS
+    assert {
+        unit.distribution for unit in inventory.units if unit.default_catalog
+    } == EXPECTED_DEFAULT_DISTRIBUTIONS
+    assert all(unit.registry == "pypi" for unit in inventory.units)
+    assert all(unit.path != "docs" for unit in inventory.units)
+    assert all(not unit.path.startswith("packages/") for unit in inventory.units)
+
+
+def test_inventory_versions_and_tags_match_project_manifests() -> None:
+    inventory = load_inventory()
+
+    for unit in inventory.units:
+        resolved = parse_package_tag(unit.tag, inventory)
+        assert resolved == unit
+        assert unit.tag == f"python/{unit.distribution}/v{unit.version}"
+
+
+@pytest.mark.parametrize("version", ["0.22.0rc1", "0.22.0", "1.0.dev1"])
+def test_canonical_python_versions_are_accepted(version: str) -> None:
+    assert validate_version(version) == version
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["0.22.0-rc.1", "v0.22.0", "01.2.3", "not-a-version"],
+)
+def test_noncanonical_python_versions_are_rejected(version: str) -> None:
+    with pytest.raises(ReleaseInventoryError, match="canonical PEP 440"):
+        validate_version(version)
+
+
+@pytest.mark.parametrize(
+    ("tag", "message"),
+    [
+        ("kitaru-v0.21.0", "package tag"),
+        ("python/unknown/v0.1.0", "unknown distribution"),
+        ("python/kitaru/v0.22.0-rc.1", "canonical PEP 440"),
+        ("python/kitaru/v0.22.0", "does not match manifest version"),
+    ],
+)
+def test_invalid_or_mismatched_package_tags_are_rejected(
+    tag: str, message: str
+) -> None:
+    with pytest.raises(ReleaseInventoryError, match=message):
+        parse_package_tag(tag, load_inventory())
+
+
+def test_inventory_rejects_duplicate_unit_identity(release_repo: Path) -> None:
+    inventory_path = release_repo / "release" / "release-units.toml"
+    document = inventory_path.read_text()
+    inventory_path.write_text(
+        document.replace('slug = "evaluator"', 'slug = "braintrust-importer"', 1)
+    )
+
+    with pytest.raises(
+        ReleaseInventoryError, match="duplicate slug: braintrust-importer"
+    ):
+        load_inventory(release_repo)
+
+
+def test_inventory_rejects_an_unlisted_plugin_project(release_repo: Path) -> None:
+    manifest = release_repo / "plugins" / "packages" / "unlisted" / "pyproject.toml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text('[project]\nname = "kitaru-unlisted"\nversion = "0.1.0"\n')
+
+    with pytest.raises(
+        ReleaseInventoryError, match="unlisted plugin project: unlisted"
+    ):
+        load_inventory(release_repo)
+
+
+def test_inventory_rejects_a_missing_plugin_project(release_repo: Path) -> None:
+    shutil.rmtree(release_repo / "plugins" / "packages" / "langgraph")
+
+    with pytest.raises(
+        ReleaseInventoryError, match="langgraph: project path does not exist"
+    ):
+        load_inventory(release_repo)
+
+
+def test_inventory_rejects_an_adapter_in_the_default_catalog(
+    release_repo: Path,
+) -> None:
+    inventory_path = release_repo / "release" / "release-units.toml"
+    document = inventory_path.read_text()
+    langgraph = document.index('slug = "langgraph"')
+    next_unit = document.index("[[units]]", langgraph)
+    langgraph_block = document[langgraph:next_unit].replace(
+        "default-catalog = false", "default-catalog = true"
+    )
+    inventory_path.write_text(
+        f"{document[:langgraph]}{langgraph_block}{document[next_unit:]}"
+    )
+
+    with pytest.raises(
+        ReleaseInventoryError, match="default catalog does not match inventory"
+    ):
+        load_inventory(release_repo)
+
+
+def test_text_and_json_outputs_contain_the_same_unit_identities() -> None:
+    inventory = load_inventory()
+    text_output = format_inventory(inventory)
+    json_output = json.loads(inventory.to_json())
+
+    assert json_output["schema_version"] == 1
+    assert {unit["slug"] for unit in json_output["units"]} == {
+        unit.slug for unit in inventory.units
+    }
+    assert all(unit.distribution in text_output for unit in inventory.units)
+
+
+def test_plugin_matrix_is_generated_from_the_nine_plugin_units() -> None:
+    matrix = build_plugin_matrix(load_inventory())
+
+    assert matrix == {
+        "include": [
+            {
+                "package": slug,
+                "path": f"plugins/packages/{slug}",
+            }
+            for slug in EXPECTED_UNITS
+            if slug != "kitaru"
+        ]
+    }
+
+
+def test_legacy_plugin_workflow_choices_match_the_inventory() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release-plugins.yml").read_text()
+    match = re.search(
+        r"(?ms)^        options:\n(?P<options>(?:^          - [a-z0-9-]+\n)+)",
+        workflow,
+    )
+    assert match is not None
+    choices = {
+        line.removeprefix("          - ")
+        for line in match.group("options").splitlines()
+    }
+
+    assert choices == {unit.slug for unit in load_inventory().plugin_units}
+
+
+def test_ci_plugin_matrix_is_loaded_from_the_release_inventory() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+
+    assert (
+        "plugin_matrix=$(uv run --no-project --with packaging==26.2 python "
+        "scripts/release_units.py matrix)" in workflow
+    )
+    assert (
+        "matrix: ${{ fromJSON(needs.release-units.outputs.plugin-matrix).matrix }}"
+        in workflow
+    )
+    assert '--package "${{ matrix.path }}"' in workflow
+    assert "          - braintrust-importer\n" not in workflow
+
+
+def test_each_unit_exposes_its_exact_release_critical_checks() -> None:
+    inventory = load_inventory()
+
+    for unit in inventory.units:
+        assert inventory.common_checks <= unit.required_checks
+        if unit.slug == "kitaru":
+            assert "cli-artifact-contract" in unit.required_checks
+            assert "mcp-wheel-contract" in unit.required_checks
+        else:
+            assert f"plugin package ({unit.slug})" in unit.required_checks
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected_fragment"),
+    [
+        (["list"], "SLUG\tDISTRIBUTION\tVERSION\tDEFAULT\tTAG"),
+        (["resolve", "--unit", "kitaru"], "python/kitaru/v"),
+        (["validate"], "Validated 10 release units."),
+    ],
+)
+def test_cli_text_commands_succeed(
+    arguments: list[str], expected_fragment: str
+) -> None:
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "release_units.py"), *arguments],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert expected_fragment in result.stdout
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected_key"),
+    [
+        (["list", "--format", "json"], "units"),
+        (["matrix"], "matrix"),
+        (["resolve", "--unit", "kitaru", "--format", "json"], "unit"),
+        (["validate", "--format", "json"], "status"),
+    ],
+)
+def test_cli_json_commands_succeed(arguments: list[str], expected_key: str) -> None:
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "release_units.py"), *arguments],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout)[expected_key]
+    assert result.stderr == ""
+
+
+def test_cli_resolves_the_current_package_tag() -> None:
+    tag = load_inventory().units[0].tag
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "release_units.py"),
+            "resolve",
+            "--tag",
+            tag,
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout)["unit"]["tag"] == tag
+    assert result.stderr == ""
+
+
+def test_cli_json_errors_are_structured() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "release_units.py"),
+            "resolve",
+            "--unit",
+            "unknown",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert json.loads(result.stderr) == {
+        "schema_version": 1,
+        "error": {
+            "kind": "release_inventory_error",
+            "message": "unknown release unit: unknown",
+        },
+    }

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -232,7 +232,8 @@ def test_ci_plugin_matrix_is_loaded_from_the_release_inventory() -> None:
         "matrix: ${{ fromJSON(needs.release-units.outputs.plugin-matrix).matrix }}"
         in workflow
     )
-    assert '--package "${{ matrix.path }}"' in workflow
+    assert "PACKAGE_PATH: ${{ matrix.path }}" in workflow
+    assert '--package "$PACKAGE_PATH"' in workflow
     assert "          - braintrust-importer\n" not in workflow
 
 

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -1,5 +1,4 @@
 import json
-import re
 import shutil
 import subprocess
 import sys
@@ -103,11 +102,12 @@ def test_local_python_versions_are_rejected_for_pypi() -> None:
         validate_version("1.0+build.1")
 
 
-def test_legacy_release_workflow_accepts_canonical_python_rc_versions() -> None:
+def test_bundle_workflow_maps_semver_rc_to_python_rc() -> None:
     workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
 
-    assert "1.2.3rc1" in workflow
-    assert "HELM_VERSION" in workflow
+    assert "bundle/kitaru/v*" in workflow
+    assert 'kitaru_version="${BASH_REMATCH[1]}rc${BASH_REMATCH[2]}"' in workflow
+    assert "promote-latest:" in workflow
 
 
 @pytest.mark.parametrize(
@@ -206,19 +206,13 @@ def test_plugin_matrix_is_generated_from_the_nine_plugin_units() -> None:
     }
 
 
-def test_legacy_plugin_workflow_choices_match_the_inventory() -> None:
+def test_python_release_workflow_resolves_every_tag_from_the_inventory() -> None:
     workflow = (REPO_ROOT / ".github" / "workflows" / "release-plugins.yml").read_text()
-    match = re.search(
-        r"(?ms)^        options:\n(?P<options>(?:^          - [a-z0-9-]+\n)+)",
-        workflow,
-    )
-    assert match is not None
-    choices = {
-        line.removeprefix("          - ")
-        for line in match.group("options").splitlines()
-    }
 
-    assert choices == {unit.slug for unit in load_inventory().plugin_units}
+    assert "python/**" in workflow
+    assert "scripts/release_units.py resolve --tag" in workflow
+    assert "scripts/release_ui.py --version" in workflow
+    assert "uv version" not in workflow
 
 
 def test_ci_plugin_matrix_is_loaded_from_the_release_inventory() -> None:

--- a/tests/test_canonical_example.py
+++ b/tests/test_canonical_example.py
@@ -303,7 +303,8 @@ def test_readme_teaches_the_complete_returns_improvement_loop() -> None:
 
     assert "source .env" in readme
     assert "--env-file .env" not in readme
-    assert r"\"summary\":\"A \$280 refund exceeded" in readme
+    assert "$TICKET_004_SESSION_ID:outcome=" in readme
+    assert "--question-key outcome" in readme
     assert (
         "uv pip install --editable '../../plugins/packages/pydantic-ai[openai]'"
         in readme


### PR DESCRIPTION
## Summary

This PR adds the release inventory and the workflows needed to rehearse and publish Kitaru release candidates.

- Defines the root `kitaru` package and all nine plugin packages in one validated inventory.
- Publishes one selected Python distribution from `python/<distribution>/v<version>` tags.
- Requires core releases to commit an exact frontend tag and SHA-256 checksum.
- Publishes versioned Docker images and the Helm chart from `bundle/kitaru/v<version>` tags.
- Keeps Docker `latest` unchanged for release candidates.
- Moves Docker `latest` only after approval of a stable bundle.
- Keeps manual workflow dispatches read-only for release rehearsals.

Python versions use canonical PEP 440, such as `0.22.0rc1`. Bundle, Docker, and Helm versions use SemVer, such as `0.22.0-rc.1`.

## Validation

- `pytest -q tests/scripts/test_release_units.py tests/scripts/test_release_ui.py`: 39 passed
- Ruff check and format check passed
- Actionlint passed
- Zizmor reported no unsuppressed findings
- `bash -n scripts/download-ui.sh` passed
- `git diff --check` passed

## Deployment impact

Tag pushes can publish artifacts after the required GitHub environments and credentials are configured. Manual dispatches build and test without publishing.

## Reviewer Notes

Review the trust boundaries and tag rules first:

1. `release/release-units.toml` defines which package a Python tag can publish.
2. `releases/python/kitaru/<version>.toml` selects the exact frontend archive for a core release.
3. `.github/workflows/release-plugins.yml` publishes one Python package.
4. `.github/workflows/release.yml` publishes the versioned Docker and Helm bundle.
5. The `bundle-promotion` environment controls stable Docker `latest` aliases.
