### PR TITLE
Apply replay system prompt overrides independently of prompt overrides

### DIFF
--- a/src/kitaru/server/domain/replay_config.py
+++ b/src/kitaru/server/domain/replay_config.py
@@ -171,8 +171,7 @@ class ReplayConfig(DomainModel):
 def effective_inputs(inputs: Any, override: ReplayOverride | None) -> Any:
     """Apply a replay override's prompt fields to recorded inputs.
 
-    An override with no prompt leaves inputs unchanged, matching or system
-    prompt overrides applying only alongside a prompt override. Model and
+    The prompt and system prompt overrides apply independently. Model and
     model parameter overrides do not touch inputs, they apply at the adapter
     level.
 
@@ -181,15 +180,21 @@ def effective_inputs(inputs: Any, override: ReplayOverride | None) -> Any:
         override: Replay override, if any.
 
     Returns:
-        Inputs with the override's prompt applied, dict inputs keeping their
-        other keys.
+        Inputs with the override's prompt fields applied, dict inputs keeping
+        their other keys.
     """
-    if override is None or override.prompt is None:
+    if override is None or (override.prompt is None and override.system_prompt is None):
         return inputs
     if isinstance(inputs, dict):
         result = dict(inputs)
-        result["prompt"] = override.prompt
+        if override.prompt is not None:
+            result["prompt"] = override.prompt
         if override.system_prompt is not None:
             result["system_prompt"] = override.system_prompt
         return result
-    return override.prompt
+    if override.system_prompt is None:
+        return override.prompt
+    return {
+        "prompt": override.prompt if override.prompt is not None else inputs,
+        "system_prompt": override.system_prompt,
+    }

--- a/tests/server/test_replay_config.py
+++ b/tests/server/test_replay_config.py
@@ -43,10 +43,17 @@ def test_effective_inputs_no_override() -> None:
     assert effective_inputs({"prompt": "hi"}, None) == {"prompt": "hi"}
 
 
-def test_effective_inputs_no_prompt_override() -> None:
-    """Leave inputs unchanged when the override carries no prompt."""
-    override = ReplayOverride(system_prompt="be terse")
+def test_effective_inputs_no_prompt_fields() -> None:
+    """Leave inputs unchanged when the override carries no prompt fields."""
+    override = ReplayOverride(model="openai:gpt-5")
     assert effective_inputs({"prompt": "hi"}, override) == {"prompt": "hi"}
+
+
+def test_effective_inputs_dict_replaces_system_prompt_key() -> None:
+    """Replace a dict's system prompt key without a prompt override."""
+    override = ReplayOverride(system_prompt="be terse")
+    result = effective_inputs({"prompt": "hi", "system_prompt": "old"}, override)
+    assert result == {"prompt": "hi", "system_prompt": "be terse"}
 
 
 def test_effective_inputs_dict_replaces_prompt_key() -> None:
@@ -67,6 +74,20 @@ def test_effective_inputs_plain_value_replaced_by_prompt() -> None:
     """Replace a non-dict input wholesale with the override prompt."""
     override = ReplayOverride(prompt="new prompt")
     assert effective_inputs("hi", override) == "new prompt"
+
+
+def test_effective_inputs_plain_value_with_prompt_and_system_prompt() -> None:
+    """Wrap a non-dict input into a dict carrying both override fields."""
+    override = ReplayOverride(prompt="new prompt", system_prompt="new system")
+    result = effective_inputs("hi", override)
+    assert result == {"prompt": "new prompt", "system_prompt": "new system"}
+
+
+def test_effective_inputs_plain_value_with_system_prompt_only() -> None:
+    """Wrap a non-dict input into a dict, keeping it as the prompt."""
+    override = ReplayOverride(system_prompt="new system")
+    result = effective_inputs("hi", override)
+    assert result == {"prompt": "hi", "system_prompt": "new system"}
 
 
 def _config(tool_policy: ToolPolicy) -> ReplayConfig:


### PR DESCRIPTION
This PR fixes `effective_inputs` so a replay override's system prompt applies to the agent task inputs independently of a prompt override. Previously a system-prompt-only override was silently ignored, and non-dict inputs dropped the system prompt even alongside a prompt override. Non-dict inputs are now wrapped into a dict carrying `prompt` and `system_prompt` when a system prompt override is set.
