### PR TITLE
Investigation session question lists

### DIFF
--- a/examples/pydantic_ai_ticket_resolver/README.md
+++ b/examples/pydantic_ai_ticket_resolver/README.md
@@ -182,7 +182,7 @@ Choose the node that contains the accepted `issue_refund` result and store its I
 TICKET_004_REFUND_NODE_ID="YOUR_REFUND_NODE_UUID"
 ```
 
-Create a one-session investigation with a session question and a curated evidence view:
+Create a one-session investigation with a keyed session question:
 
 ```bash
 INVESTIGATION_ID="$(
@@ -190,8 +190,7 @@ INVESTIGATION_ID="$(
     --agent returns-resolver \
     --description "Review whether risky refunds require human approval." \
     --session "$TICKET_004_SESSION_ID" \
-    --session-question "$TICKET_004_SESSION_ID=Is this outcome acceptable, problematic, or uncertain, and what should the agent have done instead?" \
-    --session-view "$TICKET_004_SESSION_ID={\"summary\":\"A \$280 refund exceeded the automatic approval threshold.\",\"items\":[{\"label\":\"Accepted refund\",\"description\":\"The terminal action that needs review.\",\"selectors\":[{\"node_id\":\"$TICKET_004_REFUND_NODE_ID\",\"part\":\"output\"}]}]}" \
+    --session-question "$TICKET_004_SESSION_ID:outcome=Is this outcome acceptable, problematic, or uncertain, and what should the agent have done instead?" \
   | jq -r '.item.id'
 )"
 
@@ -208,11 +207,13 @@ Store the support lead's answers and anchor the outcome judgment to the refund n
 ```bash
 uv run kitaru annotation create \
   --investigation-session "$INVESTIGATION_SESSION_ID" \
+  --question-key outcome \
   --selector "{\"node_id\":\"$TICKET_004_REFUND_NODE_ID\",\"part\":\"output\"}" \
   --value '{"judgment":"problematic","reason":"The amount exceeds the automatic approval threshold."}'
 
 uv run kitaru annotation create \
   --investigation-session "$INVESTIGATION_SESSION_ID" \
+  --question-key outcome \
   --value '{"action":"escalate","reason":"Human approval is required before a refund."}'
 
 uv run kitaru investigation session complete \

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -529,6 +529,18 @@
             "title": "Owner Id",
             "type": "string"
           },
+          "question_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Key of the question being answered.",
+            "title": "Question Key"
+          },
           "selector": {
             "anyOf": [
               {
@@ -3405,6 +3417,11 @@
             "title": "Investigation Session Id",
             "type": "string"
           },
+          "question_key": {
+            "description": "Key of the question being answered.",
+            "title": "Question Key",
+            "type": "string"
+          },
           "selector": {
             "anyOf": [
               {
@@ -3423,6 +3440,7 @@
         },
         "required": [
           "investigation_session_id",
+          "question_key",
           "value"
         ],
         "title": "InvestigationAnswerCreateRequest",
@@ -3609,48 +3627,57 @@
         "additionalProperties": false,
         "description": "Investigation session input.",
         "properties": {
-          "highlights": {
-            "description": "Curated highlights for the session.",
+          "questions": {
+            "description": "Questions to answer about the session.",
             "items": {
-              "$ref": "#/components/schemas/InvestigationSessionHighlight"
+              "$ref": "#/components/schemas/InvestigationSessionQuestion"
             },
-            "title": "Highlights",
+            "minItems": 1,
+            "title": "Questions",
             "type": "array"
-          },
-          "question": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Question to answer about the session.",
-            "title": "Question"
           },
           "session_id": {
             "description": "Session to link.",
             "format": "uuid",
             "title": "Session Id",
             "type": "string"
-          },
-          "view": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/InvestigationSessionView"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Curated session view."
           }
         },
         "required": [
-          "session_id"
+          "session_id",
+          "questions"
         ],
         "title": "InvestigationSessionInput",
+        "type": "object"
+      },
+      "InvestigationSessionQuestion": {
+        "additionalProperties": false,
+        "description": "Investigation session question.",
+        "properties": {
+          "highlights": {
+            "description": "Curated highlights for the question.",
+            "items": {
+              "$ref": "#/components/schemas/InvestigationSessionHighlight"
+            },
+            "title": "Highlights",
+            "type": "array"
+          },
+          "key": {
+            "description": "Question key, unique within the session.",
+            "title": "Key",
+            "type": "string"
+          },
+          "question": {
+            "description": "Question to answer about the session.",
+            "title": "Question",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "question"
+        ],
+        "title": "InvestigationSessionQuestion",
         "type": "object"
       },
       "InvestigationSessionResponse": {
@@ -3661,14 +3688,6 @@
             "format": "date-time",
             "title": "Created",
             "type": "string"
-          },
-          "highlights": {
-            "description": "Curated highlights for the session.",
-            "items": {
-              "$ref": "#/components/schemas/InvestigationSessionHighlight"
-            },
-            "title": "Highlights",
-            "type": "array"
           },
           "id": {
             "description": "Investigation session id.",
@@ -3687,17 +3706,13 @@
             "title": "Position",
             "type": "integer"
           },
-          "question": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Question to answer about the session.",
-            "title": "Question"
+          "questions": {
+            "description": "Questions to answer about the session.",
+            "items": {
+              "$ref": "#/components/schemas/InvestigationSessionQuestion"
+            },
+            "title": "Questions",
+            "type": "array"
           },
           "session_id": {
             "description": "Session being investigated.",
@@ -3721,17 +3736,6 @@
               }
             ],
             "description": "Investigation session verdict."
-          },
-          "view": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/InvestigationSessionView"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Curated session view."
           }
         },
         "required": [
@@ -3741,10 +3745,8 @@
           "investigation_id",
           "session_id",
           "position",
-          "question",
-          "verdict",
-          "view",
-          "highlights"
+          "questions",
+          "verdict"
         ],
         "title": "InvestigationSessionResponse",
         "type": "object"
@@ -3780,66 +3782,6 @@
         ],
         "title": "InvestigationSessionVerdict",
         "type": "string"
-      },
-      "InvestigationSessionView": {
-        "additionalProperties": false,
-        "description": "Investigation session view.",
-        "properties": {
-          "items": {
-            "description": "Curated findings for the session.",
-            "items": {
-              "$ref": "#/components/schemas/InvestigationSessionViewItem"
-            },
-            "title": "Items",
-            "type": "array"
-          },
-          "summary": {
-            "description": "Summary shown above the trace.",
-            "title": "Summary",
-            "type": "string"
-          },
-          "version": {
-            "default": 1,
-            "description": "Format version.",
-            "title": "Version",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "summary"
-        ],
-        "title": "InvestigationSessionView",
-        "type": "object"
-      },
-      "InvestigationSessionViewItem": {
-        "additionalProperties": false,
-        "description": "Investigation session view item.",
-        "properties": {
-          "description": {
-            "description": "Prose explaining what the curator saw.",
-            "title": "Description",
-            "type": "string"
-          },
-          "label": {
-            "description": "Short title for the item.",
-            "title": "Label",
-            "type": "string"
-          },
-          "selectors": {
-            "description": "References the item covers.",
-            "items": {
-              "$ref": "#/components/schemas/AnnotationSelector"
-            },
-            "title": "Selectors",
-            "type": "array"
-          }
-        },
-        "required": [
-          "label",
-          "description"
-        ],
-        "title": "InvestigationSessionViewItem",
-        "type": "object"
       },
       "InvestigationStatus": {
         "description": "Investigation status.",

--- a/src/kitaru/api_models/v1/annotation.py
+++ b/src/kitaru/api_models/v1/annotation.py
@@ -73,6 +73,7 @@ class InvestigationAnswerCreateRequest(RequestModel):
     investigation_session_id: uuid.UUID = Field(
         description="Investigation session being answered."
     )
+    question_key: str = Field(description="Key of the question being answered.")
     selector: AnnotationSelector | None = Field(
         default=None, description="Part of the session being annotated."
     )
@@ -101,6 +102,9 @@ class AnnotationResponse(OwnedResponseModel):
     session_id: uuid.UUID = Field(description="Session being annotated.")
     investigation_session_id: uuid.UUID | None = Field(
         default=None, description="Investigation session being answered."
+    )
+    question_key: str | None = Field(
+        default=None, description="Key of the question being answered."
     )
     selector: AnnotationSelector | None = Field(
         default=None, description="Part of the session being annotated."

--- a/src/kitaru/api_models/v1/investigation.py
+++ b/src/kitaru/api_models/v1/investigation.py
@@ -16,8 +16,9 @@
 import uuid
 from datetime import datetime
 from enum import StrEnum
+from typing import Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from kitaru.api_models.v1.annotation import AnnotationSelector
 from kitaru.api_models.v1.base import (
@@ -46,26 +47,6 @@ class InvestigationSessionVerdict(StrEnum):
     UNCERTAIN = "uncertain"
 
 
-class InvestigationSessionViewItem(RequestModel):
-    """Investigation session view item."""
-
-    label: str = Field(description="Short title for the item.")
-    description: str = Field(description="Prose explaining what the curator saw.")
-    selectors: list[AnnotationSelector] = Field(
-        default_factory=list, description="References the item covers."
-    )
-
-
-class InvestigationSessionView(RequestModel):
-    """Investigation session view."""
-
-    version: int = Field(default=1, description="Format version.")
-    summary: str = Field(description="Summary shown above the trace.")
-    items: list[InvestigationSessionViewItem] = Field(
-        default_factory=list, description="Curated findings for the session."
-    )
-
-
 class InvestigationSessionHighlight(RequestModel):
     """Investigation session highlight."""
 
@@ -73,19 +54,38 @@ class InvestigationSessionHighlight(RequestModel):
     description: str = Field(description="Prose explaining what the highlight shows.")
 
 
+class InvestigationSessionQuestion(RequestModel):
+    """Investigation session question."""
+
+    key: str = Field(description="Question key, unique within the session.")
+    question: str = Field(description="Question to answer about the session.")
+    highlights: list[InvestigationSessionHighlight] = Field(
+        default_factory=list, description="Curated highlights for the question."
+    )
+
+
 class InvestigationSessionInput(RequestModel):
     """Investigation session input."""
 
     session_id: uuid.UUID = Field(description="Session to link.")
-    question: str | None = Field(
-        default=None, description="Question to answer about the session."
+    questions: list[InvestigationSessionQuestion] = Field(
+        min_length=1, description="Questions to answer about the session."
     )
-    view: InvestigationSessionView | None = Field(
-        default=None, description="Curated session view."
-    )
-    highlights: list[InvestigationSessionHighlight] = Field(
-        default_factory=list, description="Curated highlights for the session."
-    )
+
+    @model_validator(mode="after")
+    def _unique_question_keys(self) -> Self:
+        """Reject duplicate question keys.
+
+        Raises:
+            ValueError: A question key repeats.
+
+        Returns:
+            The validated input.
+        """
+        keys = [question.key for question in self.questions]
+        if len(keys) != len(set(keys)):
+            raise ValueError("question keys must be unique")
+        return self
 
 
 class InvestigationCreateRequest(RequestModel):
@@ -159,11 +159,9 @@ class InvestigationSessionResponse(TimestampedResponseModel):
     )
     session_id: uuid.UUID = Field(description="Session being investigated.")
     position: int = Field(description="Presentation order within the investigation.")
-    question: str | None = Field(description="Question to answer about the session.")
+    questions: list[InvestigationSessionQuestion] = Field(
+        description="Questions to answer about the session."
+    )
     verdict: InvestigationSessionVerdict | None = Field(
         description="Investigation session verdict."
-    )
-    view: InvestigationSessionView | None = Field(description="Curated session view.")
-    highlights: list[InvestigationSessionHighlight] = Field(
-        description="Curated highlights for the session."
     )

--- a/src/kitaru/cli/annotations.py
+++ b/src/kitaru/cli/annotations.py
@@ -43,6 +43,7 @@ async def create_annotation(
     value: str,
     session_id: uuid.UUID | None,
     investigation_session_id: uuid.UUID | None,
+    question_key: str | None,
     selector: str | None,
 ) -> CommandResult:
     """Create either a manual annotation or an investigation answer."""
@@ -51,6 +52,16 @@ async def create_annotation(
             "invalid_arguments",
             "Select exactly one annotation target: --session or "
             "--investigation-session.",
+        )
+    if investigation_session_id is None and question_key is not None:
+        raise CLIError(
+            "invalid_arguments",
+            "--question-key requires --investigation-session.",
+        )
+    if investigation_session_id is not None and question_key is None:
+        raise CLIError(
+            "invalid_arguments",
+            "--investigation-session requires --question-key.",
         )
     parsed_value = _parse_json_value(value, option="--value")
     parsed_selector = (
@@ -70,8 +81,10 @@ async def create_annotation(
         request = ManualAnnotationCreateRequest(**manual_fields)
     else:
         assert investigation_session_id is not None
+        assert question_key is not None
         answer_fields: dict[str, Any] = {
             "investigation_session_id": investigation_session_id,
+            "question_key": question_key,
             "value": parsed_value,
         }
         if parsed_selector is not None:

--- a/src/kitaru/cli/app.py
+++ b/src/kitaru/cli/app.py
@@ -1822,25 +1822,18 @@ async def cohort_version_delete(
                 "Ordered session UUID; repeat for each linked session.",
             ),
             ParameterSpec(
-                "--session-view",
-                "SESSION=JSON_OBJECT[]",
-                "option",
-                False,
-                "Curated view for a session selected with --session.",
-            ),
-            ParameterSpec(
                 "--session-question",
-                "SESSION=QUESTION[]",
+                "SESSION:KEY=QUESTION[]",
                 "option",
                 False,
-                "Question for a session selected with --session.",
+                "Keyed question for a session selected with --session.",
             ),
             ParameterSpec(
                 "--session-highlights",
-                "SESSION=JSON_ARRAY[]",
+                "SESSION:KEY=JSON_ARRAY[]",
                 "option",
                 False,
-                "Curated highlights for a session selected with --session.",
+                "Curated highlights for a question added with --session-question.",
             ),
         ),
         read_only=False,
@@ -1856,7 +1849,6 @@ async def investigation_create(
     agent: str,
     description: str | None = None,
     session: list[uuid.UUID] | None = None,
-    session_view: list[str] | None = None,
     session_question: list[str] | None = None,
     session_highlights: list[str] | None = None,
 ) -> CommandResult:
@@ -1868,7 +1860,6 @@ async def investigation_create(
             agent=agent,
             description=description,
             session_ids=session or [],
-            session_views=session_view or [],
             session_questions=session_question or [],
             session_highlights=session_highlights or [],
         )
@@ -2081,6 +2072,13 @@ async def investigation_session_verdict(
                 "Investigation-session ID for an answer.",
             ),
             ParameterSpec(
+                "--question-key",
+                "string",
+                "option",
+                False,
+                "Key of the question being answered.",
+            ),
+            ParameterSpec(
                 "--selector",
                 "JSON object",
                 "option",
@@ -2100,6 +2098,7 @@ async def annotation_create(
     value: str,
     session: uuid.UUID | None = None,
     investigation_session: uuid.UUID | None = None,
+    question_key: str | None = None,
     selector: str | None = None,
 ) -> CommandResult:
     """Create one manual annotation or investigation answer."""
@@ -2109,6 +2108,7 @@ async def annotation_create(
             value=value,
             session_id=session,
             investigation_session_id=investigation_session,
+            question_key=question_key,
             selector=selector,
         )
 

--- a/src/kitaru/cli/investigations.py
+++ b/src/kitaru/cli/investigations.py
@@ -21,93 +21,60 @@ from kitaru.api_models.v1.investigation import (
     InvestigationCreateRequest,
     InvestigationSessionHighlight,
     InvestigationSessionInput,
+    InvestigationSessionQuestion,
     InvestigationSessionsListParams,
     InvestigationSessionUpdateRequest,
     InvestigationSessionVerdict,
-    InvestigationSessionView,
     InvestigationStatus,
     InvestigationUpdateRequest,
 )
 from kitaru.cli.output import CLIError, CommandResult
-from kitaru.cli.registration import (
-    list_params,
-    page_result,
-    parse_json_object,
-    resolve_asset,
-)
+from kitaru.cli.registration import list_params, page_result, resolve_asset
+
+
+def _parse_session_key_token(token: str, *, option: str) -> tuple[uuid.UUID, str]:
+    """Parse a ``SESSION:KEY`` token into a session UUID and question key."""
+    session_token, separator, key = token.partition(":")
+    if not separator or not session_token or not key:
+        raise CLIError("invalid_arguments", f"{option} must start with SESSION:KEY.")
+    try:
+        session_id = uuid.UUID(session_token)
+    except ValueError as error:
+        raise CLIError(
+            "invalid_arguments", f"{option} must start with a valid session UUID."
+        ) from error
+    return session_id, key
 
 
 def _parse_session_questions(
     entries: list[str], selected_session_ids: list[uuid.UUID]
-) -> dict[uuid.UUID, str]:
-    """Parse ``SESSION=QUESTION`` questions for selected sessions."""
+) -> dict[uuid.UUID, dict[str, str]]:
+    """Parse ``SESSION:KEY=QUESTION`` questions for selected sessions."""
     selected = set(selected_session_ids)
-    questions: dict[uuid.UUID, str] = {}
+    questions: dict[uuid.UUID, dict[str, str]] = {}
     for entry in entries:
-        session_token, separator, question = entry.partition("=")
-        if not separator or not session_token:
+        token, separator, question = entry.partition("=")
+        if not separator:
             raise CLIError(
                 "invalid_arguments",
-                "--session-question must be SESSION=QUESTION.",
+                "--session-question must be SESSION:KEY=QUESTION.",
             )
-        try:
-            session_id = uuid.UUID(session_token)
-        except ValueError as error:
-            raise CLIError(
-                "invalid_arguments",
-                "--session-question must start with a valid session UUID.",
-            ) from error
+        session_id, key = _parse_session_key_token(token, option="--session-question")
         if session_id not in selected:
             raise CLIError(
                 "invalid_arguments",
                 f"Session {session_id} from --session-question must also be "
                 "selected with --session.",
             )
-        if session_id in questions:
+        session_questions = questions.setdefault(session_id, {})
+        if key in session_questions:
             raise CLIError(
                 "invalid_arguments",
-                f"Each --session-question session must be unique; repeated "
-                f"{session_id}.",
+                f"Each --session-question key must be unique per session; "
+                f"repeated {key} for session {session_id}.",
             )
-        questions[session_id] = question
+        session_questions[key] = question
     return questions
-
-
-def _parse_session_views(
-    entries: list[str], selected_session_ids: list[uuid.UUID]
-) -> dict[uuid.UUID, InvestigationSessionView]:
-    """Parse ``SESSION=JSON_OBJECT`` views for selected sessions."""
-    selected = set(selected_session_ids)
-    views: dict[uuid.UUID, InvestigationSessionView] = {}
-    for entry in entries:
-        session_token, separator, payload = entry.partition("=")
-        if not separator or not session_token:
-            raise CLIError(
-                "invalid_arguments",
-                "--session-view must be SESSION=JSON_OBJECT.",
-            )
-        try:
-            session_id = uuid.UUID(session_token)
-        except ValueError as error:
-            raise CLIError(
-                "invalid_arguments",
-                "--session-view must start with a valid session UUID.",
-            ) from error
-        if session_id not in selected:
-            raise CLIError(
-                "invalid_arguments",
-                f"Session {session_id} from --session-view must also be selected "
-                "with --session.",
-            )
-        if session_id in views:
-            raise CLIError(
-                "invalid_arguments",
-                f"Each --session-view session must be unique; repeated {session_id}.",
-            )
-        views[session_id] = InvestigationSessionView.model_validate(
-            parse_json_object(payload, option="--session-view")
-        )
-    return views
 
 
 def _parse_highlights(
@@ -127,37 +94,32 @@ def _parse_highlights(
 
 def _parse_session_highlights(
     entries: list[str], selected_session_ids: list[uuid.UUID]
-) -> dict[uuid.UUID, list[InvestigationSessionHighlight]]:
-    """Parse ``SESSION=JSON_ARRAY`` highlights for selected sessions."""
+) -> dict[uuid.UUID, dict[str, list[InvestigationSessionHighlight]]]:
+    """Parse ``SESSION:KEY=JSON_ARRAY`` highlights for selected sessions."""
     selected = set(selected_session_ids)
-    highlights: dict[uuid.UUID, list[InvestigationSessionHighlight]] = {}
+    highlights: dict[uuid.UUID, dict[str, list[InvestigationSessionHighlight]]] = {}
     for entry in entries:
-        session_token, separator, payload = entry.partition("=")
-        if not separator or not session_token:
+        token, separator, payload = entry.partition("=")
+        if not separator:
             raise CLIError(
                 "invalid_arguments",
-                "--session-highlights must be SESSION=JSON_ARRAY.",
+                "--session-highlights must be SESSION:KEY=JSON_ARRAY.",
             )
-        try:
-            session_id = uuid.UUID(session_token)
-        except ValueError as error:
-            raise CLIError(
-                "invalid_arguments",
-                "--session-highlights must start with a valid session UUID.",
-            ) from error
+        session_id, key = _parse_session_key_token(token, option="--session-highlights")
         if session_id not in selected:
             raise CLIError(
                 "invalid_arguments",
                 f"Session {session_id} from --session-highlights must also be "
                 "selected with --session.",
             )
-        if session_id in highlights:
+        session_highlights = highlights.setdefault(session_id, {})
+        if key in session_highlights:
             raise CLIError(
                 "invalid_arguments",
-                f"Each --session-highlights session must be unique; repeated "
-                f"{session_id}.",
+                f"Each --session-highlights key must be unique per session; "
+                f"repeated {key} for session {session_id}.",
             )
-        highlights[session_id] = _parse_highlights(
+        session_highlights[key] = _parse_highlights(
             payload, option="--session-highlights"
         )
     return highlights
@@ -170,27 +132,36 @@ async def create_investigation(
     agent: str,
     description: str | None,
     session_ids: list[uuid.UUID],
-    session_views: list[str],
     session_questions: list[str],
     session_highlights: list[str],
 ) -> CommandResult:
     """Create an investigation with linked sessions."""
     if len(set(session_ids)) != len(session_ids):
         raise CLIError("invalid_arguments", "Each --session value must be unique.")
-    parsed_views = _parse_session_views(session_views, session_ids)
     parsed_questions = _parse_session_questions(session_questions, session_ids)
     parsed_highlights = _parse_session_highlights(session_highlights, session_ids)
+    for session_id, keyed_highlights in parsed_highlights.items():
+        unmatched = set(keyed_highlights) - set(parsed_questions.get(session_id, {}))
+        if unmatched:
+            raise CLIError(
+                "invalid_arguments",
+                f"--session-highlights key {sorted(unmatched)[0]!r} for session "
+                f"{session_id} has no matching --session-question.",
+            )
     resolved_agent = await resolve_asset(client.agents, agent, "Agent")
     sessions = []
     for session_id in session_ids:
-        session_fields: dict[str, Any] = {"session_id": session_id}
-        if session_id in parsed_questions:
-            session_fields["question"] = parsed_questions[session_id]
-        if session_id in parsed_views:
-            session_fields["view"] = parsed_views[session_id]
-        if session_id in parsed_highlights:
-            session_fields["highlights"] = parsed_highlights[session_id]
-        sessions.append(InvestigationSessionInput(**session_fields))
+        keyed_questions = parsed_questions.get(session_id, {})
+        keyed_highlights = parsed_highlights.get(session_id, {})
+        questions = []
+        for key, question in keyed_questions.items():
+            question_fields: dict[str, Any] = {"key": key, "question": question}
+            if key in keyed_highlights:
+                question_fields["highlights"] = keyed_highlights[key]
+            questions.append(InvestigationSessionQuestion(**question_fields))
+        sessions.append(
+            InvestigationSessionInput(session_id=session_id, questions=questions)
+        )
     investigation = await client.investigations.create(
         InvestigationCreateRequest(
             agent_id=resolved_agent.id,

--- a/src/kitaru/cli/presentation.py
+++ b/src/kitaru/cli/presentation.py
@@ -108,8 +108,7 @@ _DESCRIPTION = HumanField("description", "Description")
 _METADATA = HumanField("metadata", "Metadata")
 _INVESTIGATION_SESSION_FIELDS = (
     HumanField("verdict", "Verdict"),
-    HumanField("question", "Question"),
-    HumanField("highlights", "Highlights", formatter=_format_count),
+    HumanField("questions", "Questions", formatter=_format_count),
     HumanField("session_id", "Session"),
     _ID,
 )
@@ -404,7 +403,7 @@ _VIEWS: dict[str, HumanView] = {
         (
             HumanField("position", "Position"),
             HumanField("verdict", "Verdict"),
-            HumanField("question", "Question"),
+            HumanField("questions", "Questions", formatter=_format_count),
             HumanField("session_id", "Session", no_wrap=True),
             _ID,
         ),

--- a/src/kitaru/mcp/models/review.py
+++ b/src/kitaru/mcp/models/review.py
@@ -122,6 +122,7 @@ class InvestigationAnswerCreate(MCPModel):
 
     operation: Literal["answer_question"]
     investigation_session_id: uuid.UUID
+    question_key: str
     selector: AnnotationSelector | None = None
     value: JsonValue = Field()
 

--- a/src/kitaru/mcp/tools/review.py
+++ b/src/kitaru/mcp/tools/review.py
@@ -104,6 +104,7 @@ async def handle_review_manage(
         return await state.client.annotations.create(
             InvestigationAnswerCreateRequest(
                 investigation_session_id=request.investigation_session_id,
+                question_key=request.question_key,
                 selector=request.selector,
                 value=request.value,
             )

--- a/src/kitaru/server/adapters/db/orm/annotation.py
+++ b/src/kitaru/server/adapters/db/orm/annotation.py
@@ -16,7 +16,7 @@
 import uuid
 from typing import Any
 
-from sqlalchemy import ForeignKeyConstraint, Index
+from sqlalchemy import ForeignKeyConstraint, Index, String
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -36,6 +36,8 @@ ANNOTATION_INVESTIGATION_SESSION_ID_FOREIGN_KEY = foreign_key_name(
 )
 ANNOTATION_OWNER_ID_INDEX = index_name("annotation", ["owner_id"])
 ANNOTATION_SESSION_ID_INDEX = index_name("annotation", ["session_id"])
+
+QUESTION_KEY_LENGTH = 64
 
 
 class AnnotationORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -65,6 +67,7 @@ class AnnotationORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     owner_id: Mapped[uuid.UUID]
     session_id: Mapped[uuid.UUID]
     investigation_session_id: Mapped[uuid.UUID | None]
+    question_key: Mapped[str | None] = mapped_column(String(QUESTION_KEY_LENGTH))
     selector: Mapped[Any | None] = mapped_column(JSONB(none_as_null=True))
     value: Mapped[Any] = mapped_column(JSONB)
 
@@ -83,6 +86,7 @@ class AnnotationORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             "owner_id": annotation.owner_id,
             "session_id": annotation.session_id,
             "investigation_session_id": annotation.investigation_session_id,
+            "question_key": annotation.question_key,
             "selector": (
                 annotation.selector.model_dump(mode="json")
                 if annotation.selector is not None
@@ -114,6 +118,7 @@ class AnnotationORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             owner_id=self.owner_id,
             session_id=self.session_id,
             investigation_session_id=self.investigation_session_id,
+            question_key=self.question_key,
             selector=(
                 AnnotationSelector.model_validate(self.selector)
                 if self.selector is not None

--- a/src/kitaru/server/adapters/db/orm/investigation_session.py
+++ b/src/kitaru/server/adapters/db/orm/investigation_session.py
@@ -16,14 +16,13 @@
 import uuid
 from typing import Any
 
-from sqlalchemy import ForeignKeyConstraint, Index, String, Text, UniqueConstraint
+from sqlalchemy import ForeignKeyConstraint, Index, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from kitaru.api_models.v1.investigation import (
-    InvestigationSessionHighlight,
+    InvestigationSessionQuestion,
     InvestigationSessionVerdict,
-    InvestigationSessionView,
 )
 from kitaru.server.adapters.db.orm.base import (
     Base,
@@ -81,10 +80,8 @@ class InvestigationSessionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     investigation_id: Mapped[uuid.UUID]
     session_id: Mapped[uuid.UUID]
     position: Mapped[int]
-    question: Mapped[str | None] = mapped_column(Text)
     verdict: Mapped[str | None] = mapped_column(String(VERDICT_LENGTH))
-    view: Mapped[Any | None] = mapped_column(JSONB(none_as_null=True))
-    highlights: Mapped[list[Any]] = mapped_column(JSONB)
+    questions: Mapped[list[Any]] = mapped_column(JSONB)
 
     @classmethod
     def from_domain(cls, session: InvestigationSession) -> "InvestigationSessionORM":
@@ -101,15 +98,9 @@ class InvestigationSessionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             investigation_id=session.investigation_id,
             session_id=session.session_id,
             position=session.position,
-            question=session.question,
             verdict=session.verdict.value if session.verdict is not None else None,
-            view=(
-                session.view.model_dump(mode="json")
-                if session.view is not None
-                else None
-            ),
-            highlights=[
-                highlight.model_dump(mode="json") for highlight in session.highlights
+            questions=[
+                question.model_dump(mode="json") for question in session.questions
             ],
         )
 
@@ -124,20 +115,14 @@ class InvestigationSessionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             investigation_id=self.investigation_id,
             session_id=self.session_id,
             position=self.position,
-            question=self.question,
             verdict=(
                 InvestigationSessionVerdict(self.verdict)
                 if self.verdict is not None
                 else None
             ),
-            view=(
-                InvestigationSessionView.model_validate(self.view)
-                if self.view is not None
-                else None
-            ),
-            highlights=[
-                InvestigationSessionHighlight.model_validate(highlight)
-                for highlight in self.highlights
+            questions=[
+                InvestigationSessionQuestion.model_validate(question)
+                for question in self.questions
             ],
             created=self.created,
             updated=self.updated,

--- a/src/kitaru/server/adapters/rest/mapping/annotations.py
+++ b/src/kitaru/server/adapters/rest/mapping/annotations.py
@@ -62,6 +62,7 @@ def investigation_answer_create_to_command(
     """
     return InvestigationAnswerCreate(
         investigation_session_id=body.investigation_session_id,
+        question_key=body.question_key,
         selector=body.selector,
         value=body.value,
     )
@@ -83,6 +84,7 @@ def annotation_to_response(annotation: Annotation) -> AnnotationResponse:
         owner_id=annotation.owner_id,
         session_id=annotation.session_id,
         investigation_session_id=annotation.investigation_session_id,
+        question_key=annotation.question_key,
         selector=annotation.selector,
         value=annotation.value,
         created=annotation.created,

--- a/src/kitaru/server/adapters/rest/mapping/investigations.py
+++ b/src/kitaru/server/adapters/rest/mapping/investigations.py
@@ -52,9 +52,7 @@ def investigation_create_to_command(
         sessions=[
             InvestigationSessionInput(
                 session_id=item.session_id,
-                question=item.question,
-                view=item.view,
-                highlights=item.highlights,
+                questions=item.questions,
             )
             for item in body.sessions
         ],
@@ -161,10 +159,8 @@ def investigation_session_to_response(
         investigation_id=session.investigation_id,
         session_id=session.session_id,
         position=session.position,
-        question=session.question,
+        questions=session.questions,
         verdict=session.verdict,
-        view=session.view,
-        highlights=session.highlights,
         created=session.created,
         updated=session.updated,
     )

--- a/src/kitaru/server/application/models/annotation.py
+++ b/src/kitaru/server/application/models/annotation.py
@@ -47,5 +47,6 @@ class InvestigationAnswerCreate(FrozenModel):
     """Investigation answer create command."""
 
     investigation_session_id: uuid.UUID
+    question_key: str
     selector: AnnotationSelector | None = None
     value: Any

--- a/src/kitaru/server/application/models/investigation.py
+++ b/src/kitaru/server/application/models/investigation.py
@@ -17,12 +17,9 @@ import uuid
 from collections.abc import Mapping
 from typing import ClassVar
 
-from pydantic import Field
-
 from kitaru.api_models.v1.investigation import (
-    InvestigationSessionHighlight,
+    InvestigationSessionQuestion,
     InvestigationSessionVerdict,
-    InvestigationSessionView,
     InvestigationStatus,
 )
 from kitaru.base import FrozenModel
@@ -61,9 +58,7 @@ class InvestigationSessionInput(FrozenModel):
     """Investigation session input."""
 
     session_id: uuid.UUID
-    question: str | None = None
-    view: InvestigationSessionView | None = None
-    highlights: list[InvestigationSessionHighlight] = Field(default_factory=list)
+    questions: list[InvestigationSessionQuestion]
 
 
 class InvestigationCreate(FrozenModel):

--- a/src/kitaru/server/application/services/annotation_service.py
+++ b/src/kitaru/server/application/services/annotation_service.py
@@ -153,12 +153,20 @@ class AnnotationService:
             InvestigationSessionNotFound: No investigation session has the
                 command's investigation session id.
             InvestigationNotFound: No investigation links the session.
-            ValidationError: The selector names a node outside the session.
+            ValidationError: The question key does not exist on the linked
+                investigation session, or the selector names a node outside
+                the session.
 
         Returns:
             Stored annotation.
         """
         link = await self._investigations.get_session(command.investigation_session_id)
+        question_keys = {question.key for question in link.questions}
+        if command.question_key not in question_keys:
+            raise ValidationError(
+                f"Question {command.question_key} does not exist on "
+                f"investigation session {link.id}"
+            )
         # Locked because a racing first answer on the same investigation
         # could otherwise both observe pending and both flip the status.
         investigation = await self._investigations.get(
@@ -172,6 +180,7 @@ class AnnotationService:
             owner_id=actor.account.id,
             session_id=link.session_id,
             investigation_session_id=link.id,
+            question_key=command.question_key,
             selector=command.selector,
             value=command.value,
         )

--- a/src/kitaru/server/application/services/investigation_service.py
+++ b/src/kitaru/server/application/services/investigation_service.py
@@ -124,9 +124,7 @@ class InvestigationService:
                 investigation_id=investigation.id,
                 session_id=item.session_id,
                 position=position,
-                question=item.question,
-                view=item.view,
-                highlights=item.highlights,
+                questions=item.questions,
             )
             for position, item in enumerate(command.sessions)
         ]

--- a/src/kitaru/server/database/migrations/versions/001_initial.py
+++ b/src/kitaru/server/database/migrations/versions/001_initial.py
@@ -920,16 +920,8 @@ def upgrade() -> None:
         sa.Column("investigation_id", sa.Uuid(), nullable=False),
         sa.Column("session_id", sa.Uuid(), nullable=False),
         sa.Column("position", sa.Integer(), nullable=False),
-        sa.Column("question", sa.Text(), nullable=True),
         sa.Column("verdict", sa.String(length=32), nullable=True),
-        sa.Column(
-            "view",
-            postgresql.JSONB(none_as_null=True, astext_type=sa.Text()),
-            nullable=True,
-        ),
-        sa.Column(
-            "highlights", postgresql.JSONB(astext_type=sa.Text()), nullable=False
-        ),
+        sa.Column("questions", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.ForeignKeyConstraint(
             ["investigation_id"],
             ["investigation.id"],
@@ -962,6 +954,7 @@ def upgrade() -> None:
         sa.Column("owner_id", sa.Uuid(), nullable=False),
         sa.Column("session_id", sa.Uuid(), nullable=False),
         sa.Column("investigation_session_id", sa.Uuid(), nullable=True),
+        sa.Column("question_key", sa.String(length=64), nullable=True),
         sa.Column(
             "selector",
             postgresql.JSONB(none_as_null=True, astext_type=sa.Text()),

--- a/src/kitaru/server/domain/annotation.py
+++ b/src/kitaru/server/domain/annotation.py
@@ -43,6 +43,7 @@ class Annotation(DomainModel):
     owner_id: uuid.UUID
     session_id: uuid.UUID
     investigation_session_id: uuid.UUID | None = None
+    question_key: str | None = None
     selector: AnnotationSelector | None = None
     value: Any
     created: datetime | None = None

--- a/src/kitaru/server/domain/investigation.py
+++ b/src/kitaru/server/domain/investigation.py
@@ -20,9 +20,8 @@ from typing import Any
 from pydantic import Field
 
 from kitaru.api_models.v1.investigation import (
-    InvestigationSessionHighlight,
+    InvestigationSessionQuestion,
     InvestigationSessionVerdict,
-    InvestigationSessionView,
     InvestigationStatus,
 )
 from kitaru.server.domain.base import ConflictError, DomainModel, NotFoundError
@@ -172,10 +171,8 @@ class InvestigationSession(DomainModel):
     investigation_id: uuid.UUID
     session_id: uuid.UUID
     position: int
-    question: str | None = None
+    questions: list[InvestigationSessionQuestion]
     verdict: InvestigationSessionVerdict | None = None
-    view: InvestigationSessionView | None = None
-    highlights: list[InvestigationSessionHighlight] = Field(default_factory=list)
     created: datetime | None = None
     updated: datetime | None = None
 

--- a/tests/cli/test_annotations.py
+++ b/tests/cli/test_annotations.py
@@ -111,6 +111,7 @@ async def test_create_supports_manual_annotations_and_investigation_answers() ->
         value='{"label":"failure","confidence":0.8}',
         session_id=session_id,
         investigation_session_id=None,
+        question_key=None,
         selector=json.dumps({"node_id": str(node_id), "path": "/message"}),
     )
     request = client.create_calls[-1]
@@ -131,26 +132,46 @@ async def test_create_supports_manual_annotations_and_investigation_answers() ->
         value='"yes"',
         session_id=None,
         investigation_session_id=investigation_session_id,
+        question_key="root-cause",
         selector=None,
     )
     request = client.create_calls[-1]
     assert isinstance(request, InvestigationAnswerCreateRequest)
     assert request.model_dump(mode="json", exclude_unset=True) == {
         "investigation_session_id": str(investigation_session_id),
+        "question_key": "root-cause",
         "value": "yes",
     }
 
 
 @pytest.mark.parametrize(
-    ("session_id", "investigation_session_id", "message"),
+    ("session_id", "investigation_session_id", "question_key", "message"),
     [
-        (None, None, "exactly one annotation target"),
-        (uuid.UUID(int=1), uuid.UUID(int=2), "exactly one annotation target"),
+        (None, None, None, "exactly one annotation target"),
+        (
+            uuid.UUID(int=1),
+            uuid.UUID(int=2),
+            "root-cause",
+            "exactly one annotation target",
+        ),
+        (
+            None,
+            uuid.UUID(int=2),
+            None,
+            "--investigation-session requires --question-key",
+        ),
+        (
+            uuid.UUID(int=1),
+            None,
+            "root-cause",
+            "--question-key requires --investigation-session",
+        ),
     ],
 )
 async def test_create_rejects_ambiguous_or_incomplete_targets(
     session_id: uuid.UUID | None,
     investigation_session_id: uuid.UUID | None,
+    question_key: str | None,
     message: str,
 ) -> None:
     """Target validation fails before any remote create request."""
@@ -162,6 +183,7 @@ async def test_create_rejects_ambiguous_or_incomplete_targets(
             value="true",
             session_id=session_id,
             investigation_session_id=investigation_session_id,
+            question_key=question_key,
             selector=None,
         )
 
@@ -178,6 +200,7 @@ async def test_value_and_selector_require_valid_json() -> None:
             value="not-json",
             session_id=uuid.uuid4(),
             investigation_session_id=None,
+            question_key=None,
             selector=None,
         )
     with pytest.raises(CLIError, match="--selector must contain a JSON object"):
@@ -186,6 +209,7 @@ async def test_value_and_selector_require_valid_json() -> None:
             value="null",
             session_id=uuid.uuid4(),
             investigation_session_id=None,
+            question_key=None,
             selector="[]",
         )
     assert client.create_calls == []
@@ -280,4 +304,5 @@ def test_public_argv_and_schema_cover_annotation_crud(
     }
     assert create_parameters["--session"]["required"] is False
     assert create_parameters["--investigation-session"]["required"] is False
+    assert create_parameters["--question-key"]["required"] is False
     assert specs["annotation.delete"]["side_effects"]["deletes_remote_state"]

--- a/tests/cli/test_investigations.py
+++ b/tests/cli/test_investigations.py
@@ -78,10 +78,14 @@ class StubInvestigationClient:
                 "investigation_id": str(self.investigation.id),
                 "session_id": str(self.session_ids[0]),
                 "position": 0,
-                "question": "What caused the failure?",
+                "questions": [
+                    {
+                        "key": "root-cause",
+                        "question": "What caused the failure?",
+                        "highlights": [],
+                    }
+                ],
                 "verdict": None,
-                "view": None,
-                "highlights": [],
             },
         )
         self.agent_lookups = 0
@@ -167,23 +171,10 @@ class StubInvestigationClient:
             return self.owner.investigation_session
 
 
-async def test_create_maps_sessions_views_questions_and_highlights_to_sdk() -> None:
-    """Create preserves session order and validates curated per-session fields."""
+async def test_create_maps_sessions_questions_and_highlights_to_sdk() -> None:
+    """Create groups keyed questions and highlights per session."""
     client = StubInvestigationClient()
-    node_id = uuid.uuid4()
     highlight_node_id = uuid.uuid4()
-    view = json.dumps(
-        {
-            "summary": "The failed tool call",
-            "items": [
-                {
-                    "label": "Failure",
-                    "description": "The tool returned an error.",
-                    "selectors": [{"node_id": str(node_id)}],
-                }
-            ],
-        }
-    )
     highlights = json.dumps(
         [{"selector": {"node_id": str(highlight_node_id)}, "description": "Odd retry."}]
     )
@@ -194,9 +185,12 @@ async def test_create_maps_sessions_views_questions_and_highlights_to_sdk() -> N
         agent="assistant",
         description="Review selected failures",
         session_ids=client.session_ids,
-        session_views=[f"{client.session_ids[1]}={view}"],
-        session_questions=[f"{client.session_ids[0]}=What caused it?"],
-        session_highlights=[f"{client.session_ids[1]}={highlights}"],
+        session_questions=[
+            f"{client.session_ids[0]}:root-cause=What caused it?",
+            f"{client.session_ids[1]}:root-cause=What caused it?",
+            f"{client.session_ids[1]}:retry=Was the retry appropriate?",
+        ],
+        session_highlights=[f"{client.session_ids[1]}:retry={highlights}"],
     )
 
     [request] = client.create_calls
@@ -207,29 +201,24 @@ async def test_create_maps_sessions_views_questions_and_highlights_to_sdk() -> N
         "sessions": [
             {
                 "session_id": str(client.session_ids[0]),
-                "question": "What caused it?",
+                "questions": [
+                    {"key": "root-cause", "question": "What caused it?"},
+                ],
             },
             {
                 "session_id": str(client.session_ids[1]),
-                "view": {
-                    "summary": "The failed tool call",
-                    "items": [
-                        {
-                            "label": "Failure",
-                            "description": "The tool returned an error.",
-                            "selectors": [
-                                {
-                                    "node_id": str(node_id),
-                                }
-                            ],
-                        }
-                    ],
-                },
-                "highlights": [
+                "questions": [
+                    {"key": "root-cause", "question": "What caused it?"},
                     {
-                        "selector": {"node_id": str(highlight_node_id)},
-                        "description": "Odd retry.",
-                    }
+                        "key": "retry",
+                        "question": "Was the retry appropriate?",
+                        "highlights": [
+                            {
+                                "selector": {"node_id": str(highlight_node_id)},
+                                "description": "Odd retry.",
+                            }
+                        ],
+                    },
                 ],
             },
         ],
@@ -238,70 +227,75 @@ async def test_create_maps_sessions_views_questions_and_highlights_to_sdk() -> N
 
 
 @pytest.mark.parametrize(
-    ("sessions", "views", "questions", "highlights", "message"),
+    ("sessions", "questions", "highlights", "message"),
     [
         (
             [uuid.UUID(int=1), uuid.UUID(int=1)],
             [],
             [],
-            [],
             "--session value must be unique",
         ),
-        ([], [f"{uuid.UUID(int=2)}={{}}"], [], [], "also be selected with --session"),
         (
-            [],
             [],
             ["missing-separator"],
             [],
-            "--session-question must be SESSION=QUESTION",
+            "--session-question must be SESSION:KEY=QUESTION",
         ),
         (
             [],
-            [],
             [f"{uuid.UUID(int=2)}=why?"],
+            [],
+            "--session-question must start with SESSION:KEY",
+        ),
+        (
+            [],
+            [f"{uuid.UUID(int=2)}:root-cause=why?"],
             [],
             "also be selected with --session",
         ),
         (
             [uuid.UUID(int=3)],
+            [
+                f"{uuid.UUID(int=3)}:root-cause=why?",
+                f"{uuid.UUID(int=3)}:root-cause=why not?",
+            ],
             [],
-            [f"{uuid.UUID(int=3)}=why?", f"{uuid.UUID(int=3)}=why not?"],
-            [],
-            "session must be unique",
+            "key must be unique per session",
         ),
         (
-            [],
             [],
             [],
             ["missing-separator"],
-            "--session-highlights must be SESSION=JSON_ARRAY",
+            "--session-highlights must be SESSION:KEY=JSON_ARRAY",
         ),
         (
             [],
             [],
-            [],
-            [f"{uuid.UUID(int=2)}=why?"],
+            [f"{uuid.UUID(int=2)}:root-cause=why?"],
             "also be selected with --session",
         ),
         (
             [uuid.UUID(int=4)],
             [],
-            [],
-            [f"{uuid.UUID(int=4)}=not-json"],
+            [f"{uuid.UUID(int=4)}:root-cause=not-json"],
             "--session-highlights is not valid JSON",
         ),
         (
             [uuid.UUID(int=4)],
             [],
-            [],
-            [f"{uuid.UUID(int=4)}={{}}"],
+            [f"{uuid.UUID(int=4)}:root-cause={{}}"],
             "--session-highlights must contain a JSON array",
+        ),
+        (
+            [uuid.UUID(int=5)],
+            [f"{uuid.UUID(int=5)}:root-cause=why?"],
+            [f"{uuid.UUID(int=5)}:retry=[]"],
+            "has no matching --session-question",
         ),
     ],
 )
 async def test_create_validation_precedes_agent_lookup(
     sessions: list[uuid.UUID],
-    views: list[str],
     questions: list[str],
     highlights: list[str],
     message: str,
@@ -316,7 +310,6 @@ async def test_create_validation_precedes_agent_lookup(
             agent="assistant",
             description=None,
             session_ids=sessions,
-            session_views=views,
             session_questions=questions,
             session_highlights=highlights,
         )

--- a/tests/client/test_annotations.py
+++ b/tests/client/test_annotations.py
@@ -40,6 +40,7 @@ from kitaru.api_models.v1.annotation import (
 from kitaru.api_models.v1.investigation import (
     InvestigationCreateRequest,
     InvestigationSessionInput,
+    InvestigationSessionQuestion,
 )
 from kitaru.api_models.v1.session import SessionCreateRequest, SessionOrigin
 from kitaru.client.api_client import KitaruAPIClient
@@ -64,6 +65,7 @@ from kitaru.server.application.services.session_service import SessionService
 from kitaru.server.domain.account import Account
 
 ACCOUNT = Account(id=uuid.uuid4(), name="ann")
+QUESTION_KEY = "cause"
 
 
 @pytest.fixture
@@ -138,7 +140,16 @@ async def _make_investigation_session(
         InvestigationCreateRequest(
             agent_id=agent_id,
             name="investigation",
-            sessions=[InvestigationSessionInput(session_id=session_id)],
+            sessions=[
+                InvestigationSessionInput(
+                    session_id=session_id,
+                    questions=[
+                        InvestigationSessionQuestion(
+                            key=QUESTION_KEY, question="What caused it?"
+                        )
+                    ],
+                )
+            ],
         )
     )
     page = await api_client.investigations.list_sessions(investigation.id)
@@ -180,11 +191,13 @@ async def test_create_investigation_answer(api_client: KitaruAPIClient) -> None:
     annotation = await api_client.annotations.create(
         InvestigationAnswerCreateRequest(
             investigation_session_id=investigation_session_id,
+            question_key=QUESTION_KEY,
             value="a retry loop",
         )
     )
     assert annotation.session_id == session_id
     assert annotation.investigation_session_id == investigation_session_id
+    assert annotation.question_key == QUESTION_KEY
 
 
 async def test_get(api_client: KitaruAPIClient) -> None:

--- a/tests/client/test_investigations.py
+++ b/tests/client/test_investigations.py
@@ -15,6 +15,7 @@
 
 import uuid
 from collections.abc import AsyncGenerator
+from typing import Any
 
 import pytest
 
@@ -35,6 +36,7 @@ from kitaru.api_models.v1.investigation import (
     InvestigationResponse,
     InvestigationSessionHighlight,
     InvestigationSessionInput,
+    InvestigationSessionQuestion,
     InvestigationSessionResponse,
     InvestigationSessionsListParams,
     InvestigationSessionUpdateRequest,
@@ -63,6 +65,20 @@ from kitaru.server.application.services.session_service import SessionService
 from kitaru.server.domain.account import Account
 
 ACCOUNT = Account(id=uuid.uuid4(), name="ann")
+
+
+def _question(**overrides: Any) -> InvestigationSessionQuestion:
+    """Build a minimal investigation session question.
+
+    Args:
+        **overrides: Additional question fields.
+
+    Returns:
+        Question ready to pass to InvestigationSessionInput.
+    """
+    values: dict[str, Any] = {"key": "cause", "question": "What caused it?"}
+    values.update(overrides)
+    return InvestigationSessionQuestion(**values)
 
 
 @pytest.fixture
@@ -129,7 +145,9 @@ async def test_create(api_client: KitaruAPIClient) -> None:
             name="investigation",
             description="curator rationale",
             sessions=[
-                InvestigationSessionInput(session_id=session_id)
+                InvestigationSessionInput(
+                    session_id=session_id, questions=[_question()]
+                )
                 for session_id in session_ids
             ],
         )
@@ -227,7 +245,9 @@ async def test_list_sessions_and_iter_sessions(api_client: KitaruAPIClient) -> N
             agent_id=agent_id,
             name="investigation",
             sessions=[
-                InvestigationSessionInput(session_id=session_id)
+                InvestigationSessionInput(
+                    session_id=session_id, questions=[_question()]
+                )
                 for session_id in session_ids
             ],
         )
@@ -254,7 +274,11 @@ async def test_update_session(api_client: KitaruAPIClient) -> None:
         InvestigationCreateRequest(
             agent_id=agent_id,
             name="investigation",
-            sessions=[InvestigationSessionInput(session_id=session_id)],
+            sessions=[
+                InvestigationSessionInput(
+                    session_id=session_id, questions=[_question()]
+                )
+            ],
         )
     )
     updated = await api_client.investigations.update_session(
@@ -279,7 +303,11 @@ async def test_update_session_clears_verdict(api_client: KitaruAPIClient) -> Non
         InvestigationCreateRequest(
             agent_id=agent_id,
             name="investigation",
-            sessions=[InvestigationSessionInput(session_id=session_id)],
+            sessions=[
+                InvestigationSessionInput(
+                    session_id=session_id, questions=[_question()]
+                )
+            ],
         )
     )
     await api_client.investigations.update_session(
@@ -310,18 +338,19 @@ async def test_create_session_with_question(api_client: KitaruAPIClient) -> None
             name="investigation",
             sessions=[
                 InvestigationSessionInput(
-                    session_id=session_id, question="What caused it?"
+                    session_id=session_id, questions=[_question()]
                 )
             ],
         )
     )
 
     page = await api_client.investigations.list_sessions(created.id)
-    assert page.items[0].question == "What caused it?"
+    assert page.items[0].questions[0].key == "cause"
+    assert page.items[0].questions[0].question == "What caused it?"
 
 
 async def test_create_session_with_highlights(api_client: KitaruAPIClient) -> None:
-    """Set highlights on a session input and read them back."""
+    """Set highlights on a session question and read them back."""
     agent_id = await _make_agent(api_client)
     session_id = await _make_session(api_client, agent_id)
     highlights = [
@@ -334,10 +363,12 @@ async def test_create_session_with_highlights(api_client: KitaruAPIClient) -> No
             agent_id=agent_id,
             name="investigation",
             sessions=[
-                InvestigationSessionInput(session_id=session_id, highlights=highlights)
+                InvestigationSessionInput(
+                    session_id=session_id, questions=[_question(highlights=highlights)]
+                )
             ],
         )
     )
 
     page = await api_client.investigations.list_sessions(created.id)
-    assert page.items[0].highlights == highlights
+    assert page.items[0].questions[0].highlights == highlights

--- a/tests/integration/test_canonical_example_e2e.py
+++ b/tests/integration/test_canonical_example_e2e.py
@@ -254,16 +254,6 @@ def test_canonical_example_completes_import_to_replay(tmp_path: Path) -> None:
                     node for node in nodes if node.get("tool_name") in terminal_tools
                 )
                 evidence_nodes[ticket_id] = evidence["id"]
-                view = {
-                    "summary": f"Review the terminal action for {ticket_id}.",
-                    "items": [
-                        {
-                            "label": "Terminal action",
-                            "description": "The accepted action used for the review.",
-                            "selectors": [{"node_id": evidence["id"]}],
-                        }
-                    ],
-                }
                 question = (
                     "Is this outcome acceptable, problematic, or uncertain, and "
                     "what should the agent have done in this case?"
@@ -272,10 +262,8 @@ def test_canonical_example_completes_import_to_replay(tmp_path: Path) -> None:
                     [
                         "--session",
                         session_id,
-                        "--session-view",
-                        f"{session_id}={json.dumps(view, separators=(',', ':'))}",
                         "--session-question",
-                        f"{session_id}={question}",
+                        f"{session_id}:outcome={question}",
                     ]
                 )
 
@@ -304,6 +292,8 @@ def test_canonical_example_completes_import_to_replay(tmp_path: Path) -> None:
                     "create",
                     "--investigation-session",
                     investigation_session_id,
+                    "--question-key",
+                    "outcome",
                     "--selector",
                     selector,
                     "--value",
@@ -320,6 +310,8 @@ def test_canonical_example_completes_import_to_replay(tmp_path: Path) -> None:
                     "create",
                     "--investigation-session",
                     investigation_session_id,
+                    "--question-key",
+                    "outcome",
                     "--value",
                     json.dumps({"action": expected_action}, separators=(",", ":")),
                 )

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -4752,6 +4752,19 @@
               "title": "Owner Id",
               "type": "string"
             },
+            "question_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Key of the question being answered.",
+              "title": "Question Key"
+            },
             "selector": {
               "anyOf": [
                 {
@@ -4996,6 +5009,36 @@
           "title": "InvestigationSessionHighlight",
           "type": "object"
         },
+        "InvestigationSessionQuestion": {
+          "additionalProperties": false,
+          "description": "Investigation session question.",
+          "properties": {
+            "highlights": {
+              "description": "Curated highlights for the question.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionHighlight"
+              },
+              "title": "Highlights",
+              "type": "array"
+            },
+            "key": {
+              "description": "Question key, unique within the session.",
+              "title": "Key",
+              "type": "string"
+            },
+            "question": {
+              "description": "Question to answer about the session.",
+              "title": "Question",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "question"
+          ],
+          "title": "InvestigationSessionQuestion",
+          "type": "object"
+        },
         "InvestigationSessionResponse": {
           "description": "Investigation session response.",
           "properties": {
@@ -5004,14 +5047,6 @@
               "format": "date-time",
               "title": "Created",
               "type": "string"
-            },
-            "highlights": {
-              "description": "Curated highlights for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionHighlight"
-              },
-              "title": "Highlights",
-              "type": "array"
             },
             "id": {
               "description": "Investigation session id.",
@@ -5030,17 +5065,13 @@
               "title": "Position",
               "type": "integer"
             },
-            "question": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Question to answer about the session.",
-              "title": "Question"
+            "questions": {
+              "description": "Questions to answer about the session.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionQuestion"
+              },
+              "title": "Questions",
+              "type": "array"
             },
             "session_id": {
               "description": "Session being investigated.",
@@ -5064,17 +5095,6 @@
                 }
               ],
               "description": "Investigation session verdict."
-            },
-            "view": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/InvestigationSessionView"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Curated session view."
             }
           },
           "required": [
@@ -5084,10 +5104,8 @@
             "investigation_id",
             "session_id",
             "position",
-            "question",
-            "verdict",
-            "view",
-            "highlights"
+            "questions",
+            "verdict"
           ],
           "title": "InvestigationSessionResponse",
           "type": "object"
@@ -5101,66 +5119,6 @@
           ],
           "title": "InvestigationSessionVerdict",
           "type": "string"
-        },
-        "InvestigationSessionView": {
-          "additionalProperties": false,
-          "description": "Investigation session view.",
-          "properties": {
-            "items": {
-              "description": "Curated findings for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionViewItem"
-              },
-              "title": "Items",
-              "type": "array"
-            },
-            "summary": {
-              "description": "Summary shown above the trace.",
-              "title": "Summary",
-              "type": "string"
-            },
-            "version": {
-              "default": 1,
-              "description": "Format version.",
-              "title": "Version",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "summary"
-          ],
-          "title": "InvestigationSessionView",
-          "type": "object"
-        },
-        "InvestigationSessionViewItem": {
-          "additionalProperties": false,
-          "description": "Investigation session view item.",
-          "properties": {
-            "description": {
-              "description": "Prose explaining what the curator saw.",
-              "title": "Description",
-              "type": "string"
-            },
-            "label": {
-              "description": "Short title for the item.",
-              "title": "Label",
-              "type": "string"
-            },
-            "selectors": {
-              "description": "References the item covers.",
-              "items": {
-                "$ref": "#/$defs/AnnotationSelector"
-              },
-              "title": "Selectors",
-              "type": "array"
-            }
-          },
-          "required": [
-            "label",
-            "description"
-          ],
-          "title": "InvestigationSessionViewItem",
-          "type": "object"
         },
         "InvestigationStatus": {
           "description": "Investigation status.",
@@ -7370,6 +7328,10 @@
               "title": "Operation",
               "type": "string"
             },
+            "question_key": {
+              "title": "Question Key",
+              "type": "string"
+            },
             "selector": {
               "anyOf": [
                 {
@@ -7388,6 +7350,7 @@
           "required": [
             "operation",
             "investigation_session_id",
+            "question_key",
             "value"
           ],
           "title": "InvestigationAnswerCreate",
@@ -7467,50 +7430,57 @@
           "additionalProperties": false,
           "description": "Investigation session input.",
           "properties": {
-            "highlights": {
-              "description": "Curated highlights for the session.",
+            "questions": {
+              "description": "Questions to answer about the session.",
               "items": {
-                "$ref": "#/$defs/InvestigationSessionHighlight"
+                "$ref": "#/$defs/InvestigationSessionQuestion"
               },
-              "title": "Highlights",
+              "minItems": 1,
+              "title": "Questions",
               "type": "array"
-            },
-            "question": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Question to answer about the session.",
-              "title": "Question"
             },
             "session_id": {
               "description": "Session to link.",
               "format": "uuid",
               "title": "Session Id",
               "type": "string"
-            },
-            "view": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/InvestigationSessionView"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Curated session view."
             }
           },
           "required": [
-            "session_id"
+            "session_id",
+            "questions"
           ],
           "title": "InvestigationSessionInput",
+          "type": "object"
+        },
+        "InvestigationSessionQuestion": {
+          "additionalProperties": false,
+          "description": "Investigation session question.",
+          "properties": {
+            "highlights": {
+              "description": "Curated highlights for the question.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionHighlight"
+              },
+              "title": "Highlights",
+              "type": "array"
+            },
+            "key": {
+              "description": "Question key, unique within the session.",
+              "title": "Key",
+              "type": "string"
+            },
+            "question": {
+              "description": "Question to answer about the session.",
+              "title": "Question",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "question"
+          ],
+          "title": "InvestigationSessionQuestion",
           "type": "object"
         },
         "InvestigationSessionVerdict": {
@@ -7522,66 +7492,6 @@
           ],
           "title": "InvestigationSessionVerdict",
           "type": "string"
-        },
-        "InvestigationSessionView": {
-          "additionalProperties": false,
-          "description": "Investigation session view.",
-          "properties": {
-            "items": {
-              "description": "Curated findings for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionViewItem"
-              },
-              "title": "Items",
-              "type": "array"
-            },
-            "summary": {
-              "description": "Summary shown above the trace.",
-              "title": "Summary",
-              "type": "string"
-            },
-            "version": {
-              "default": 1,
-              "description": "Format version.",
-              "title": "Version",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "summary"
-          ],
-          "title": "InvestigationSessionView",
-          "type": "object"
-        },
-        "InvestigationSessionViewItem": {
-          "additionalProperties": false,
-          "description": "Investigation session view item.",
-          "properties": {
-            "description": {
-              "description": "Prose explaining what the curator saw.",
-              "title": "Description",
-              "type": "string"
-            },
-            "label": {
-              "description": "Short title for the item.",
-              "title": "Label",
-              "type": "string"
-            },
-            "selectors": {
-              "description": "References the item covers.",
-              "items": {
-                "$ref": "#/$defs/AnnotationSelector"
-              },
-              "title": "Selectors",
-              "type": "array"
-            }
-          },
-          "required": [
-            "label",
-            "description"
-          ],
-          "title": "InvestigationSessionViewItem",
-          "type": "object"
         },
         "InvestigationUpdate": {
           "additionalProperties": false,
@@ -7806,6 +7716,19 @@
               "format": "uuid",
               "title": "Owner Id",
               "type": "string"
+            },
+            "question_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Key of the question being answered.",
+              "title": "Question Key"
             },
             "selector": {
               "anyOf": [
@@ -8051,6 +7974,36 @@
           "title": "InvestigationSessionHighlight",
           "type": "object"
         },
+        "InvestigationSessionQuestion": {
+          "additionalProperties": false,
+          "description": "Investigation session question.",
+          "properties": {
+            "highlights": {
+              "description": "Curated highlights for the question.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionHighlight"
+              },
+              "title": "Highlights",
+              "type": "array"
+            },
+            "key": {
+              "description": "Question key, unique within the session.",
+              "title": "Key",
+              "type": "string"
+            },
+            "question": {
+              "description": "Question to answer about the session.",
+              "title": "Question",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "question"
+          ],
+          "title": "InvestigationSessionQuestion",
+          "type": "object"
+        },
         "InvestigationSessionResponse": {
           "description": "Investigation session response.",
           "properties": {
@@ -8059,14 +8012,6 @@
               "format": "date-time",
               "title": "Created",
               "type": "string"
-            },
-            "highlights": {
-              "description": "Curated highlights for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionHighlight"
-              },
-              "title": "Highlights",
-              "type": "array"
             },
             "id": {
               "description": "Investigation session id.",
@@ -8085,17 +8030,13 @@
               "title": "Position",
               "type": "integer"
             },
-            "question": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Question to answer about the session.",
-              "title": "Question"
+            "questions": {
+              "description": "Questions to answer about the session.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionQuestion"
+              },
+              "title": "Questions",
+              "type": "array"
             },
             "session_id": {
               "description": "Session being investigated.",
@@ -8119,17 +8060,6 @@
                 }
               ],
               "description": "Investigation session verdict."
-            },
-            "view": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/InvestigationSessionView"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Curated session view."
             }
           },
           "required": [
@@ -8139,10 +8069,8 @@
             "investigation_id",
             "session_id",
             "position",
-            "question",
-            "verdict",
-            "view",
-            "highlights"
+            "questions",
+            "verdict"
           ],
           "title": "InvestigationSessionResponse",
           "type": "object"
@@ -8156,66 +8084,6 @@
           ],
           "title": "InvestigationSessionVerdict",
           "type": "string"
-        },
-        "InvestigationSessionView": {
-          "additionalProperties": false,
-          "description": "Investigation session view.",
-          "properties": {
-            "items": {
-              "description": "Curated findings for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionViewItem"
-              },
-              "title": "Items",
-              "type": "array"
-            },
-            "summary": {
-              "description": "Summary shown above the trace.",
-              "title": "Summary",
-              "type": "string"
-            },
-            "version": {
-              "default": 1,
-              "description": "Format version.",
-              "title": "Version",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "summary"
-          ],
-          "title": "InvestigationSessionView",
-          "type": "object"
-        },
-        "InvestigationSessionViewItem": {
-          "additionalProperties": false,
-          "description": "Investigation session view item.",
-          "properties": {
-            "description": {
-              "description": "Prose explaining what the curator saw.",
-              "title": "Description",
-              "type": "string"
-            },
-            "label": {
-              "description": "Short title for the item.",
-              "title": "Label",
-              "type": "string"
-            },
-            "selectors": {
-              "description": "References the item covers.",
-              "items": {
-                "$ref": "#/$defs/AnnotationSelector"
-              },
-              "title": "Selectors",
-              "type": "array"
-            }
-          },
-          "required": [
-            "label",
-            "description"
-          ],
-          "title": "InvestigationSessionViewItem",
-          "type": "object"
         },
         "InvestigationStatus": {
           "description": "Investigation status.",

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,7 +6,7 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 142400,
+      "discovery_response_bytes": 140483,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
@@ -52,18 +52,18 @@
           "output_bytes": 20629
         },
         "kitaru_review_manage": {
-          "$defs_count": 24,
-          "combined_bytes": 15792,
-          "input_bytes": 7540,
+          "$defs_count": 22,
+          "combined_bytes": 14492,
+          "input_bytes": 6857,
           "maximum_nesting_depth": 8,
-          "output_bytes": 8252
+          "output_bytes": 7635
         },
         "kitaru_review_read": {
-          "$defs_count": 21,
-          "combined_bytes": 13000,
+          "$defs_count": 20,
+          "combined_bytes": 12383,
           "input_bytes": 3775,
           "maximum_nesting_depth": 8,
-          "output_bytes": 9225
+          "output_bytes": 8608
         },
         "kitaru_session_import": {
           "$defs_count": 6,
@@ -89,7 +89,7 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 72919,
+      "discovery_response_bytes": 72302,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
@@ -107,16 +107,16 @@
           "output_bytes": 20629
         },
         "kitaru_review_read": {
-          "$defs_count": 21,
-          "combined_bytes": 13000,
+          "$defs_count": 20,
+          "combined_bytes": 12383,
           "input_bytes": 3775,
           "maximum_nesting_depth": 8,
-          "output_bytes": 9225
+          "output_bytes": 8608
         }
       }
     },
     "standard": {
-      "discovery_response_bytes": 132938,
+      "discovery_response_bytes": 131021,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
@@ -155,18 +155,18 @@
           "output_bytes": 20629
         },
         "kitaru_review_manage": {
-          "$defs_count": 24,
-          "combined_bytes": 15792,
-          "input_bytes": 7540,
+          "$defs_count": 22,
+          "combined_bytes": 14492,
+          "input_bytes": 6857,
           "maximum_nesting_depth": 8,
-          "output_bytes": 8252
+          "output_bytes": 7635
         },
         "kitaru_review_read": {
-          "$defs_count": 21,
-          "combined_bytes": 13000,
+          "$defs_count": 20,
+          "combined_bytes": 12383,
           "input_bytes": 3775,
           "maximum_nesting_depth": 8,
-          "output_bytes": 9225
+          "output_bytes": 8608
         },
         "kitaru_session_import": {
           "$defs_count": 6,

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -4752,6 +4752,19 @@
               "title": "Owner Id",
               "type": "string"
             },
+            "question_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Key of the question being answered.",
+              "title": "Question Key"
+            },
             "selector": {
               "anyOf": [
                 {
@@ -4996,6 +5009,36 @@
           "title": "InvestigationSessionHighlight",
           "type": "object"
         },
+        "InvestigationSessionQuestion": {
+          "additionalProperties": false,
+          "description": "Investigation session question.",
+          "properties": {
+            "highlights": {
+              "description": "Curated highlights for the question.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionHighlight"
+              },
+              "title": "Highlights",
+              "type": "array"
+            },
+            "key": {
+              "description": "Question key, unique within the session.",
+              "title": "Key",
+              "type": "string"
+            },
+            "question": {
+              "description": "Question to answer about the session.",
+              "title": "Question",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "question"
+          ],
+          "title": "InvestigationSessionQuestion",
+          "type": "object"
+        },
         "InvestigationSessionResponse": {
           "description": "Investigation session response.",
           "properties": {
@@ -5004,14 +5047,6 @@
               "format": "date-time",
               "title": "Created",
               "type": "string"
-            },
-            "highlights": {
-              "description": "Curated highlights for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionHighlight"
-              },
-              "title": "Highlights",
-              "type": "array"
             },
             "id": {
               "description": "Investigation session id.",
@@ -5030,17 +5065,13 @@
               "title": "Position",
               "type": "integer"
             },
-            "question": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Question to answer about the session.",
-              "title": "Question"
+            "questions": {
+              "description": "Questions to answer about the session.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionQuestion"
+              },
+              "title": "Questions",
+              "type": "array"
             },
             "session_id": {
               "description": "Session being investigated.",
@@ -5064,17 +5095,6 @@
                 }
               ],
               "description": "Investigation session verdict."
-            },
-            "view": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/InvestigationSessionView"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Curated session view."
             }
           },
           "required": [
@@ -5084,10 +5104,8 @@
             "investigation_id",
             "session_id",
             "position",
-            "question",
-            "verdict",
-            "view",
-            "highlights"
+            "questions",
+            "verdict"
           ],
           "title": "InvestigationSessionResponse",
           "type": "object"
@@ -5101,66 +5119,6 @@
           ],
           "title": "InvestigationSessionVerdict",
           "type": "string"
-        },
-        "InvestigationSessionView": {
-          "additionalProperties": false,
-          "description": "Investigation session view.",
-          "properties": {
-            "items": {
-              "description": "Curated findings for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionViewItem"
-              },
-              "title": "Items",
-              "type": "array"
-            },
-            "summary": {
-              "description": "Summary shown above the trace.",
-              "title": "Summary",
-              "type": "string"
-            },
-            "version": {
-              "default": 1,
-              "description": "Format version.",
-              "title": "Version",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "summary"
-          ],
-          "title": "InvestigationSessionView",
-          "type": "object"
-        },
-        "InvestigationSessionViewItem": {
-          "additionalProperties": false,
-          "description": "Investigation session view item.",
-          "properties": {
-            "description": {
-              "description": "Prose explaining what the curator saw.",
-              "title": "Description",
-              "type": "string"
-            },
-            "label": {
-              "description": "Short title for the item.",
-              "title": "Label",
-              "type": "string"
-            },
-            "selectors": {
-              "description": "References the item covers.",
-              "items": {
-                "$ref": "#/$defs/AnnotationSelector"
-              },
-              "title": "Selectors",
-              "type": "array"
-            }
-          },
-          "required": [
-            "label",
-            "description"
-          ],
-          "title": "InvestigationSessionViewItem",
-          "type": "object"
         },
         "InvestigationStatus": {
           "description": "Investigation status.",

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -4752,6 +4752,19 @@
               "title": "Owner Id",
               "type": "string"
             },
+            "question_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Key of the question being answered.",
+              "title": "Question Key"
+            },
             "selector": {
               "anyOf": [
                 {
@@ -4996,6 +5009,36 @@
           "title": "InvestigationSessionHighlight",
           "type": "object"
         },
+        "InvestigationSessionQuestion": {
+          "additionalProperties": false,
+          "description": "Investigation session question.",
+          "properties": {
+            "highlights": {
+              "description": "Curated highlights for the question.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionHighlight"
+              },
+              "title": "Highlights",
+              "type": "array"
+            },
+            "key": {
+              "description": "Question key, unique within the session.",
+              "title": "Key",
+              "type": "string"
+            },
+            "question": {
+              "description": "Question to answer about the session.",
+              "title": "Question",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "question"
+          ],
+          "title": "InvestigationSessionQuestion",
+          "type": "object"
+        },
         "InvestigationSessionResponse": {
           "description": "Investigation session response.",
           "properties": {
@@ -5004,14 +5047,6 @@
               "format": "date-time",
               "title": "Created",
               "type": "string"
-            },
-            "highlights": {
-              "description": "Curated highlights for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionHighlight"
-              },
-              "title": "Highlights",
-              "type": "array"
             },
             "id": {
               "description": "Investigation session id.",
@@ -5030,17 +5065,13 @@
               "title": "Position",
               "type": "integer"
             },
-            "question": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Question to answer about the session.",
-              "title": "Question"
+            "questions": {
+              "description": "Questions to answer about the session.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionQuestion"
+              },
+              "title": "Questions",
+              "type": "array"
             },
             "session_id": {
               "description": "Session being investigated.",
@@ -5064,17 +5095,6 @@
                 }
               ],
               "description": "Investigation session verdict."
-            },
-            "view": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/InvestigationSessionView"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Curated session view."
             }
           },
           "required": [
@@ -5084,10 +5104,8 @@
             "investigation_id",
             "session_id",
             "position",
-            "question",
-            "verdict",
-            "view",
-            "highlights"
+            "questions",
+            "verdict"
           ],
           "title": "InvestigationSessionResponse",
           "type": "object"
@@ -5101,66 +5119,6 @@
           ],
           "title": "InvestigationSessionVerdict",
           "type": "string"
-        },
-        "InvestigationSessionView": {
-          "additionalProperties": false,
-          "description": "Investigation session view.",
-          "properties": {
-            "items": {
-              "description": "Curated findings for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionViewItem"
-              },
-              "title": "Items",
-              "type": "array"
-            },
-            "summary": {
-              "description": "Summary shown above the trace.",
-              "title": "Summary",
-              "type": "string"
-            },
-            "version": {
-              "default": 1,
-              "description": "Format version.",
-              "title": "Version",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "summary"
-          ],
-          "title": "InvestigationSessionView",
-          "type": "object"
-        },
-        "InvestigationSessionViewItem": {
-          "additionalProperties": false,
-          "description": "Investigation session view item.",
-          "properties": {
-            "description": {
-              "description": "Prose explaining what the curator saw.",
-              "title": "Description",
-              "type": "string"
-            },
-            "label": {
-              "description": "Short title for the item.",
-              "title": "Label",
-              "type": "string"
-            },
-            "selectors": {
-              "description": "References the item covers.",
-              "items": {
-                "$ref": "#/$defs/AnnotationSelector"
-              },
-              "title": "Selectors",
-              "type": "array"
-            }
-          },
-          "required": [
-            "label",
-            "description"
-          ],
-          "title": "InvestigationSessionViewItem",
-          "type": "object"
         },
         "InvestigationStatus": {
           "description": "Investigation status.",
@@ -7370,6 +7328,10 @@
               "title": "Operation",
               "type": "string"
             },
+            "question_key": {
+              "title": "Question Key",
+              "type": "string"
+            },
             "selector": {
               "anyOf": [
                 {
@@ -7388,6 +7350,7 @@
           "required": [
             "operation",
             "investigation_session_id",
+            "question_key",
             "value"
           ],
           "title": "InvestigationAnswerCreate",
@@ -7467,50 +7430,57 @@
           "additionalProperties": false,
           "description": "Investigation session input.",
           "properties": {
-            "highlights": {
-              "description": "Curated highlights for the session.",
+            "questions": {
+              "description": "Questions to answer about the session.",
               "items": {
-                "$ref": "#/$defs/InvestigationSessionHighlight"
+                "$ref": "#/$defs/InvestigationSessionQuestion"
               },
-              "title": "Highlights",
+              "minItems": 1,
+              "title": "Questions",
               "type": "array"
-            },
-            "question": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Question to answer about the session.",
-              "title": "Question"
             },
             "session_id": {
               "description": "Session to link.",
               "format": "uuid",
               "title": "Session Id",
               "type": "string"
-            },
-            "view": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/InvestigationSessionView"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Curated session view."
             }
           },
           "required": [
-            "session_id"
+            "session_id",
+            "questions"
           ],
           "title": "InvestigationSessionInput",
+          "type": "object"
+        },
+        "InvestigationSessionQuestion": {
+          "additionalProperties": false,
+          "description": "Investigation session question.",
+          "properties": {
+            "highlights": {
+              "description": "Curated highlights for the question.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionHighlight"
+              },
+              "title": "Highlights",
+              "type": "array"
+            },
+            "key": {
+              "description": "Question key, unique within the session.",
+              "title": "Key",
+              "type": "string"
+            },
+            "question": {
+              "description": "Question to answer about the session.",
+              "title": "Question",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "question"
+          ],
+          "title": "InvestigationSessionQuestion",
           "type": "object"
         },
         "InvestigationSessionVerdict": {
@@ -7522,66 +7492,6 @@
           ],
           "title": "InvestigationSessionVerdict",
           "type": "string"
-        },
-        "InvestigationSessionView": {
-          "additionalProperties": false,
-          "description": "Investigation session view.",
-          "properties": {
-            "items": {
-              "description": "Curated findings for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionViewItem"
-              },
-              "title": "Items",
-              "type": "array"
-            },
-            "summary": {
-              "description": "Summary shown above the trace.",
-              "title": "Summary",
-              "type": "string"
-            },
-            "version": {
-              "default": 1,
-              "description": "Format version.",
-              "title": "Version",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "summary"
-          ],
-          "title": "InvestigationSessionView",
-          "type": "object"
-        },
-        "InvestigationSessionViewItem": {
-          "additionalProperties": false,
-          "description": "Investigation session view item.",
-          "properties": {
-            "description": {
-              "description": "Prose explaining what the curator saw.",
-              "title": "Description",
-              "type": "string"
-            },
-            "label": {
-              "description": "Short title for the item.",
-              "title": "Label",
-              "type": "string"
-            },
-            "selectors": {
-              "description": "References the item covers.",
-              "items": {
-                "$ref": "#/$defs/AnnotationSelector"
-              },
-              "title": "Selectors",
-              "type": "array"
-            }
-          },
-          "required": [
-            "label",
-            "description"
-          ],
-          "title": "InvestigationSessionViewItem",
-          "type": "object"
         },
         "InvestigationUpdate": {
           "additionalProperties": false,
@@ -7806,6 +7716,19 @@
               "format": "uuid",
               "title": "Owner Id",
               "type": "string"
+            },
+            "question_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Key of the question being answered.",
+              "title": "Question Key"
             },
             "selector": {
               "anyOf": [
@@ -8051,6 +7974,36 @@
           "title": "InvestigationSessionHighlight",
           "type": "object"
         },
+        "InvestigationSessionQuestion": {
+          "additionalProperties": false,
+          "description": "Investigation session question.",
+          "properties": {
+            "highlights": {
+              "description": "Curated highlights for the question.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionHighlight"
+              },
+              "title": "Highlights",
+              "type": "array"
+            },
+            "key": {
+              "description": "Question key, unique within the session.",
+              "title": "Key",
+              "type": "string"
+            },
+            "question": {
+              "description": "Question to answer about the session.",
+              "title": "Question",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "question"
+          ],
+          "title": "InvestigationSessionQuestion",
+          "type": "object"
+        },
         "InvestigationSessionResponse": {
           "description": "Investigation session response.",
           "properties": {
@@ -8059,14 +8012,6 @@
               "format": "date-time",
               "title": "Created",
               "type": "string"
-            },
-            "highlights": {
-              "description": "Curated highlights for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionHighlight"
-              },
-              "title": "Highlights",
-              "type": "array"
             },
             "id": {
               "description": "Investigation session id.",
@@ -8085,17 +8030,13 @@
               "title": "Position",
               "type": "integer"
             },
-            "question": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Question to answer about the session.",
-              "title": "Question"
+            "questions": {
+              "description": "Questions to answer about the session.",
+              "items": {
+                "$ref": "#/$defs/InvestigationSessionQuestion"
+              },
+              "title": "Questions",
+              "type": "array"
             },
             "session_id": {
               "description": "Session being investigated.",
@@ -8119,17 +8060,6 @@
                 }
               ],
               "description": "Investigation session verdict."
-            },
-            "view": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/InvestigationSessionView"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Curated session view."
             }
           },
           "required": [
@@ -8139,10 +8069,8 @@
             "investigation_id",
             "session_id",
             "position",
-            "question",
-            "verdict",
-            "view",
-            "highlights"
+            "questions",
+            "verdict"
           ],
           "title": "InvestigationSessionResponse",
           "type": "object"
@@ -8156,66 +8084,6 @@
           ],
           "title": "InvestigationSessionVerdict",
           "type": "string"
-        },
-        "InvestigationSessionView": {
-          "additionalProperties": false,
-          "description": "Investigation session view.",
-          "properties": {
-            "items": {
-              "description": "Curated findings for the session.",
-              "items": {
-                "$ref": "#/$defs/InvestigationSessionViewItem"
-              },
-              "title": "Items",
-              "type": "array"
-            },
-            "summary": {
-              "description": "Summary shown above the trace.",
-              "title": "Summary",
-              "type": "string"
-            },
-            "version": {
-              "default": 1,
-              "description": "Format version.",
-              "title": "Version",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "summary"
-          ],
-          "title": "InvestigationSessionView",
-          "type": "object"
-        },
-        "InvestigationSessionViewItem": {
-          "additionalProperties": false,
-          "description": "Investigation session view item.",
-          "properties": {
-            "description": {
-              "description": "Prose explaining what the curator saw.",
-              "title": "Description",
-              "type": "string"
-            },
-            "label": {
-              "description": "Short title for the item.",
-              "title": "Label",
-              "type": "string"
-            },
-            "selectors": {
-              "description": "References the item covers.",
-              "items": {
-                "$ref": "#/$defs/AnnotationSelector"
-              },
-              "title": "Selectors",
-              "type": "array"
-            }
-          },
-          "required": [
-            "label",
-            "description"
-          ],
-          "title": "InvestigationSessionViewItem",
-          "type": "object"
         },
         "InvestigationStatus": {
           "description": "Investigation status.",

--- a/tests/mcp/test_handlers_protocol.py
+++ b/tests/mcp/test_handlers_protocol.py
@@ -145,10 +145,8 @@ def _get_investigation_session() -> InvestigationSessionResponse:
         investigation_id=uuid.uuid4(),
         session_id=uuid.uuid4(),
         position=0,
-        question=None,
+        questions=[],
         verdict=None,
-        view=None,
-        highlights=[],
         created=now,
         updated=now,
     )

--- a/tests/mcp/test_review_workflows.py
+++ b/tests/mcp/test_review_workflows.py
@@ -316,7 +316,12 @@ async def test_review_creates_and_updates_forward_typed_sdk_dtos() -> None:
             operation="create_investigation",
             agent_id=uuid.uuid4(),
             name="failure review",
-            sessions=[{"session_id": session_id, "question": "Was it correct?"}],
+            sessions=[
+                {
+                    "session_id": session_id,
+                    "questions": [{"key": "root-cause", "question": "Was it correct?"}],
+                }
+            ],
         ),
     )
     await handle_review_manage(
@@ -332,6 +337,7 @@ async def test_review_creates_and_updates_forward_typed_sdk_dtos() -> None:
         InvestigationAnswerCreate(
             operation="answer_question",
             investigation_session_id=investigation_session_id,
+            question_key="root-cause",
             value=False,
         ),
     )
@@ -346,15 +352,19 @@ async def test_review_creates_and_updates_forward_typed_sdk_dtos() -> None:
     assert cast(Any, investigation_requests[0]).model_dump(mode="json")["sessions"] == [
         {
             "session_id": str(session_id),
-            "question": "Was it correct?",
-            "view": None,
-            "highlights": [],
+            "questions": [
+                {"key": "root-cause", "question": "Was it correct?", "highlights": []}
+            ],
         }
     ]
     assert cast(Any, annotation_creates[0]).model_dump(mode="json")["session_id"]
     assert cast(Any, annotation_creates[1]).model_dump(mode="json")[
         "investigation_session_id"
     ] == str(investigation_session_id)
+    assert (
+        cast(Any, annotation_creates[1]).model_dump(mode="json")["question_key"]
+        == "root-cause"
+    )
     assert cast(Any, annotation_updates[0]).model_dump(mode="json") == {"value": True}
 
 

--- a/tests/server/test_annotation_repository.py
+++ b/tests/server/test_annotation_repository.py
@@ -30,6 +30,7 @@ from conftest import (
 )
 from kitaru.api_models.v1.annotation import AnnotationSelector
 from kitaru.api_models.v1.filter import FilterOp
+from kitaru.api_models.v1.investigation import InvestigationSessionQuestion
 from kitaru.api_models.v1.session import SessionOrigin
 from kitaru.server.adapters.db.repositories.account_repository import (
     SQLAccountRepository,
@@ -57,6 +58,8 @@ from kitaru.server.domain.annotation import Annotation, AnnotationNotFound
 from kitaru.server.domain.investigation import Investigation, InvestigationSession
 from kitaru.server.domain.session import Session
 from kitaru.server.filtering import FilterCondition
+
+QUESTION_KEY = "cause"
 
 MakeInvestigationSession = Callable[[uuid.UUID], Awaitable[tuple[uuid.UUID, uuid.UUID]]]
 
@@ -97,7 +100,14 @@ async def _link_investigation_session(
         investigation,
         [
             InvestigationSession(
-                investigation_id=investigation.id, session_id=session_id, position=0
+                investigation_id=investigation.id,
+                session_id=session_id,
+                position=0,
+                questions=[
+                    InvestigationSessionQuestion(
+                        key=QUESTION_KEY, question="What caused it?"
+                    )
+                ],
             )
         ],
     )
@@ -196,6 +206,7 @@ def _answer(
         "owner_id": owner_id,
         "session_id": session_id,
         "investigation_session_id": investigation_session_id,
+        "question_key": QUESTION_KEY,
         "value": "answer",
     }
     values.update(overrides)
@@ -250,6 +261,7 @@ async def test_create_investigation_answer(setup: Setup) -> None:
     )
     assert created.session_id == session_id
     assert created.investigation_session_id == investigation_session_id
+    assert created.question_key == QUESTION_KEY
 
 
 async def test_create_investigation_answer_never_conflicts(setup: Setup) -> None:

--- a/tests/server/test_annotation_service.py
+++ b/tests/server/test_annotation_service.py
@@ -30,7 +30,10 @@ from conftest import (
 from kitaru.analytics.events import AnalyticsEvent
 from kitaru.api_models.v1.annotation import AnnotationSelector
 from kitaru.api_models.v1.filter import FilterOp
-from kitaru.api_models.v1.investigation import InvestigationStatus
+from kitaru.api_models.v1.investigation import (
+    InvestigationSessionQuestion,
+    InvestigationStatus,
+)
 from kitaru.api_models.v1.session_node import NodeStatus, NodeType
 from kitaru.server.application.models.annotation import (
     AnnotationFilter,
@@ -53,6 +56,7 @@ from kitaru.server.domain.session_node import SessionNode
 from kitaru.server.filtering import FilterCondition
 
 ACTOR = AuthContext(account=Account(id=uuid.uuid4(), name="ann"))
+QUESTION_KEY = "cause"
 
 
 class _RecordingAnalytics(ServerAnalytics):
@@ -172,7 +176,14 @@ async def _link_investigation_session(
         investigation,
         [
             InvestigationSession(
-                investigation_id=investigation.id, session_id=session_id, position=0
+                investigation_id=investigation.id,
+                session_id=session_id,
+                position=0,
+                questions=[
+                    InvestigationSessionQuestion(
+                        key=QUESTION_KEY, question="What caused it?"
+                    )
+                ],
             )
         ],
     )
@@ -355,12 +366,14 @@ async def test_create_investigation_answer(
     annotation = await service.create_investigation_answer(
         InvestigationAnswerCreate(
             investigation_session_id=investigation_session_id,
+            question_key=QUESTION_KEY,
             value="a retry loop",
         ),
         actor=ACTOR,
     )
     assert annotation.session_id == session_id
     assert annotation.investigation_session_id == investigation_session_id
+    assert annotation.question_key == QUESTION_KEY
 
     investigation = await investigation_repository.get(investigation_id)
     assert investigation.status is InvestigationStatus.IN_PROGRESS
@@ -375,6 +388,7 @@ async def test_create_investigation_answer_missing_link(
         await service.create_investigation_answer(
             InvestigationAnswerCreate(
                 investigation_session_id=uuid.uuid4(),
+                question_key=QUESTION_KEY,
                 value="x",
             ),
             actor=ACTOR,
@@ -398,7 +412,29 @@ async def test_create_investigation_answer_invalid_selector_node(
         await service.create_investigation_answer(
             InvestigationAnswerCreate(
                 investigation_session_id=investigation_session_id,
+                question_key=QUESTION_KEY,
                 selector=AnnotationSelector(node_id=node_id),
+                value="x",
+            ),
+            actor=ACTOR,
+        )
+
+
+async def test_create_investigation_answer_unknown_question_key(
+    service: AnnotationService,
+    investigation_repository: FakeInvestigationRepository,
+    agent_id: uuid.UUID,
+    session_id: uuid.UUID,
+) -> None:
+    """Reject a question key the linked investigation session does not have."""
+    _, investigation_session_id = await _link_investigation_session(
+        investigation_repository, agent_id, session_id
+    )
+    with pytest.raises(ValidationError):
+        await service.create_investigation_answer(
+            InvestigationAnswerCreate(
+                investigation_session_id=investigation_session_id,
+                question_key="unknown",
                 value="x",
             ),
             actor=ACTOR,
@@ -418,6 +454,7 @@ async def test_create_investigation_answer_never_conflicts(
     first = await service.create_investigation_answer(
         InvestigationAnswerCreate(
             investigation_session_id=investigation_session_id,
+            question_key=QUESTION_KEY,
             value="first answer",
         ),
         actor=ACTOR,
@@ -425,6 +462,7 @@ async def test_create_investigation_answer_never_conflicts(
     second = await service.create_investigation_answer(
         InvestigationAnswerCreate(
             investigation_session_id=investigation_session_id,
+            question_key=QUESTION_KEY,
             value="second answer",
         ),
         actor=ACTOR,
@@ -456,6 +494,7 @@ async def test_create_investigation_answer_second_answer_leaves_started_at(
     await service.create_investigation_answer(
         InvestigationAnswerCreate(
             investigation_session_id=investigation_session_id,
+            question_key=QUESTION_KEY,
             value="a retry loop",
         ),
         actor=ACTOR,
@@ -464,6 +503,7 @@ async def test_create_investigation_answer_second_answer_leaves_started_at(
     await service.create_investigation_answer(
         InvestigationAnswerCreate(
             investigation_session_id=investigation_session_id,
+            question_key=QUESTION_KEY,
             value=False,
         ),
         actor=ACTOR,
@@ -525,6 +565,7 @@ async def test_create_investigation_answer_tracks_annotation_created(
     await service.create_investigation_answer(
         InvestigationAnswerCreate(
             investigation_session_id=investigation_session_id,
+            question_key=QUESTION_KEY,
             value="a retry loop",
         ),
         actor=ACTOR,

--- a/tests/server/test_annotations_api.py
+++ b/tests/server/test_annotations_api.py
@@ -29,6 +29,7 @@ from conftest import (
     create_agent,
     create_session,
 )
+from kitaru.api_models.v1.investigation import InvestigationSessionQuestion
 from kitaru.server.adapters.rest.dependencies import (
     authorize,
     get_annotation_service,
@@ -45,6 +46,7 @@ from kitaru.server.domain.account import Account
 from kitaru.server.domain.investigation import Investigation, InvestigationSession
 
 ACCOUNT = Account(id=uuid.uuid4(), name="ann")
+QUESTION_KEY = "cause"
 
 
 @pytest.fixture
@@ -153,6 +155,11 @@ async def investigation_session_ids(
                 investigation_id=investigation.id,
                 session_id=uuid.UUID(session_id),
                 position=0,
+                questions=[
+                    InvestigationSessionQuestion(
+                        key=QUESTION_KEY, question="What caused it?"
+                    )
+                ],
             )
         ],
     )
@@ -220,12 +227,14 @@ async def test_create_investigation_answer(
         "/v1/annotations",
         json={
             "investigation_session_id": investigation_session_id,
+            "question_key": QUESTION_KEY,
             "value": "a retry loop",
         },
     )
     assert response.status_code == 201
     body = response.json()
     assert body["investigation_session_id"] == investigation_session_id
+    assert body["question_key"] == QUESTION_KEY
     assert body["value"] == "a retry loop"
 
 
@@ -239,6 +248,7 @@ async def test_create_investigation_answer_never_conflicts(
             "/v1/annotations",
             json={
                 "investigation_session_id": investigation_session_id,
+                "question_key": QUESTION_KEY,
                 "value": "first answer",
             },
         )
@@ -248,6 +258,7 @@ async def test_create_investigation_answer_never_conflicts(
             "/v1/annotations",
             json={
                 "investigation_session_id": investigation_session_id,
+                "question_key": QUESTION_KEY,
                 "value": "second answer",
             },
         )
@@ -264,6 +275,7 @@ async def test_create_investigation_answer_moves_investigation_in_progress(
         "/v1/annotations",
         json={
             "investigation_session_id": investigation_session_id,
+            "question_key": QUESTION_KEY,
             "value": "a retry loop",
         },
     )
@@ -280,10 +292,27 @@ async def test_create_investigation_answer_missing_link(
         "/v1/annotations",
         json={
             "investigation_session_id": str(uuid.uuid4()),
+            "question_key": QUESTION_KEY,
             "value": "x",
         },
     )
     assert response.status_code == 404
+
+
+async def test_create_investigation_answer_unknown_question_key(
+    client: httpx.AsyncClient, investigation_session_ids: tuple[str, str]
+) -> None:
+    """Observe HTTP 422 when the question key does not belong to the session."""
+    _, investigation_session_id = investigation_session_ids
+    response = await client.post(
+        "/v1/annotations",
+        json={
+            "investigation_session_id": investigation_session_id,
+            "question_key": "unknown",
+            "value": "x",
+        },
+    )
+    assert response.status_code == 422
 
 
 async def test_create_annotation_malformed_body(
@@ -295,6 +324,7 @@ async def test_create_annotation_malformed_body(
         json={
             "session_id": session_id,
             "investigation_session_id": str(uuid.uuid4()),
+            "question_key": QUESTION_KEY,
             "value": "x",
         },
     )
@@ -369,6 +399,7 @@ async def test_list_annotations_filters_by_investigation_id(
             "/v1/annotations",
             json={
                 "investigation_session_id": investigation_session_id,
+                "question_key": QUESTION_KEY,
                 "value": "a retry loop",
             },
         )

--- a/tests/server/test_annotations_api_pg.py
+++ b/tests/server/test_annotations_api_pg.py
@@ -74,6 +74,9 @@ async def _create_session_with_node(
     return session["id"], nodes[0]["id"]
 
 
+QUESTION_KEY = "cause"
+
+
 async def _create_investigation_with_link(
     client: httpx.AsyncClient, agent_id: str, session_id: str
 ) -> tuple[dict[str, object], dict[str, object]]:
@@ -84,7 +87,14 @@ async def _create_investigation_with_link(
             json={
                 "agent_id": agent_id,
                 "name": "payment-failures",
-                "sessions": [{"session_id": session_id}],
+                "sessions": [
+                    {
+                        "session_id": session_id,
+                        "questions": [
+                            {"key": QUESTION_KEY, "question": "What caused it?"}
+                        ],
+                    }
+                ],
             },
         )
     ).json()
@@ -190,6 +200,7 @@ async def test_investigation_answer_starts_investigation_and_never_conflicts(
         "/v1/annotations",
         json={
             "investigation_session_id": link["id"],
+            "question_key": QUESTION_KEY,
             "value": "Retry loop swallowed the error",
         },
     )
@@ -197,6 +208,7 @@ async def test_investigation_answer_starts_investigation_and_never_conflicts(
     answer = response.json()
     assert answer["session_id"] == session_id
     assert answer["investigation_session_id"] == link["id"]
+    assert answer["question_key"] == QUESTION_KEY
 
     response = await client.get(f"/v1/investigations/{investigation['id']}")
     assert response.status_code == 200
@@ -209,6 +221,7 @@ async def test_investigation_answer_starts_investigation_and_never_conflicts(
         "/v1/annotations",
         json={
             "investigation_session_id": link["id"],
+            "question_key": QUESTION_KEY,
             "value": "Actually a timeout, not a retry loop",
         },
     )
@@ -249,6 +262,7 @@ async def test_list_annotations_filtered_by_investigation_id(
             "/v1/annotations",
             json={
                 "investigation_session_id": link["id"],
+                "question_key": QUESTION_KEY,
                 "value": "answer",
             },
         )
@@ -289,6 +303,7 @@ async def test_delete_investigation_cascades_answers_but_keeps_manual(
             "/v1/annotations",
             json={
                 "investigation_session_id": link["id"],
+                "question_key": QUESTION_KEY,
                 "value": "answer",
             },
         )

--- a/tests/server/test_investigation_repository.py
+++ b/tests/server/test_investigation_repository.py
@@ -31,6 +31,7 @@ from kitaru.api_models.v1.annotation import AnnotationSelector
 from kitaru.api_models.v1.filter import FilterOp
 from kitaru.api_models.v1.investigation import (
     InvestigationSessionHighlight,
+    InvestigationSessionQuestion,
     InvestigationSessionVerdict,
     InvestigationStatus,
 )
@@ -146,6 +147,7 @@ def _link(
         "investigation_id": investigation_id,
         "session_id": session_id,
         "position": position,
+        "questions": [],
     }
     values.update(overrides)
     return InvestigationSession(**values)
@@ -590,8 +592,8 @@ async def test_get_session(setup: Setup) -> None:
     assert loaded == linked
 
 
-async def test_create_stores_session_question_and_highlights(setup: Setup) -> None:
-    """Persist a linked session's question and highlights, set at create."""
+async def test_create_stores_session_questions_and_highlights(setup: Setup) -> None:
+    """Persist a linked session's questions and highlights, set at create."""
     repository, owner_id, agent_id, make_session_id, _ = setup
     session_id = await make_session_id()
     other_session_id = await make_session_id()
@@ -607,27 +609,24 @@ async def test_create_stores_session_question_and_highlights(setup: Setup) -> No
             selector=AnnotationSelector(), description="Retried without backoff."
         )
     ]
+    questions = [
+        InvestigationSessionQuestion(
+            key="cause", question="What caused it?", highlights=highlights
+        )
+    ]
     created = await repository.create(
         investigation,
         [
-            _link(
-                investigation.id,
-                session_id,
-                0,
-                question="What caused it?",
-                highlights=highlights,
-            ),
+            _link(investigation.id, session_id, 0, questions=questions),
             _link(investigation.id, other_session_id, 1),
         ],
     )
     linked = await repository.get_session_by_session_id(created.id, session_id)
-    assert linked.question == "What caused it?"
-    assert linked.highlights == highlights
+    assert linked.questions == questions
     other_linked = await repository.get_session_by_session_id(
         created.id, other_session_id
     )
-    assert other_linked.question is None
-    assert other_linked.highlights == []
+    assert other_linked.questions == []
 
 
 async def test_get_session_not_found(setup: Setup) -> None:
@@ -674,8 +673,8 @@ async def test_update_session(setup: Setup) -> None:
     assert loaded == updated
 
 
-async def test_update_session_leaves_highlights_untouched(setup: Setup) -> None:
-    """Leave a linked session's highlights, set at create, untouched by the verdict."""
+async def test_update_session_leaves_questions_untouched(setup: Setup) -> None:
+    """Leave a linked session's questions, set at create, untouched by the verdict."""
     repository, owner_id, agent_id, make_session_id, _ = setup
     session_id = await make_session_id()
     investigation = Investigation(
@@ -690,15 +689,20 @@ async def test_update_session_leaves_highlights_untouched(setup: Setup) -> None:
             selector=AnnotationSelector(), description="Retried without backoff."
         )
     ]
+    questions = [
+        InvestigationSessionQuestion(
+            key="cause", question="What caused it?", highlights=highlights
+        )
+    ]
     created = await repository.create(
         investigation,
-        [_link(investigation.id, session_id, 0, highlights=highlights)],
+        [_link(investigation.id, session_id, 0, questions=questions)],
     )
     linked = await repository.get_session_by_session_id(created.id, session_id)
     linked.update_verdict(InvestigationSessionVerdict.UNCERTAIN)
     updated = await repository.update_session(linked)
     assert updated.verdict is InvestigationSessionVerdict.UNCERTAIN
-    assert updated.highlights == highlights
+    assert updated.questions == questions
     loaded = await repository.get_session(linked.id)
     assert loaded == updated
 
@@ -707,7 +711,7 @@ async def test_update_session_not_found(setup: Setup) -> None:
     """Raise for an unknown investigation session id."""
     repository, _, _, _, _ = setup
     session = InvestigationSession(
-        investigation_id=uuid.uuid4(), session_id=uuid.uuid4(), position=0
+        investigation_id=uuid.uuid4(), session_id=uuid.uuid4(), position=0, questions=[]
     )
     with pytest.raises(
         InvestigationSessionNotFound,

--- a/tests/server/test_investigation_service.py
+++ b/tests/server/test_investigation_service.py
@@ -30,6 +30,7 @@ from kitaru.api_models.v1.annotation import AnnotationSelector
 from kitaru.api_models.v1.filter import FilterOp
 from kitaru.api_models.v1.investigation import (
     InvestigationSessionHighlight,
+    InvestigationSessionQuestion,
     InvestigationSessionVerdict,
     InvestigationStatus,
 )
@@ -149,10 +150,22 @@ async def test_create_investigation(
             sessions=[
                 InvestigationSessionInput(
                     session_id=session_ids[0],
-                    question="What caused it?",
-                    highlights=highlights,
+                    questions=[
+                        InvestigationSessionQuestion(
+                            key="cause",
+                            question="What caused it?",
+                            highlights=highlights,
+                        )
+                    ],
                 ),
-                InvestigationSessionInput(session_id=session_ids[1]),
+                InvestigationSessionInput(
+                    session_id=session_ids[1],
+                    questions=[
+                        InvestigationSessionQuestion(
+                            key="cause", question="What caused it?"
+                        )
+                    ],
+                ),
             ],
         ),
         actor=ACTOR,
@@ -171,10 +184,8 @@ async def test_create_investigation(
     )
     assert [session.session_id for session in sessions] == session_ids
     assert [session.position for session in sessions] == [0, 1]
-    assert sessions[0].question == "What caused it?"
-    assert sessions[1].question is None
-    assert sessions[0].highlights == highlights
-    assert sessions[1].highlights == []
+    assert sessions[0].questions[0].highlights == highlights
+    assert sessions[1].questions[0].highlights == []
 
 
 async def test_create_investigation_missing_agent(
@@ -202,7 +213,11 @@ async def test_create_investigation_missing_session(
             InvestigationCreate(
                 agent_id=agent_id,
                 name="investigation",
-                sessions=[InvestigationSessionInput(session_id=missing_session_id)],
+                sessions=[
+                    InvestigationSessionInput(
+                        session_id=missing_session_id, questions=[]
+                    )
+                ],
             ),
             actor=ACTOR,
         )
@@ -227,7 +242,9 @@ async def test_create_investigation_session_wrong_agent(
             InvestigationCreate(
                 agent_id=agent_id,
                 name="investigation",
-                sessions=[InvestigationSessionInput(session_id=other_session.id)],
+                sessions=[
+                    InvestigationSessionInput(session_id=other_session.id, questions=[])
+                ],
             ),
             actor=ACTOR,
         )
@@ -245,8 +262,8 @@ async def test_create_investigation_duplicate_session_ids(
                 agent_id=agent_id,
                 name="investigation",
                 sessions=[
-                    InvestigationSessionInput(session_id=session_ids[0]),
-                    InvestigationSessionInput(session_id=session_ids[0]),
+                    InvestigationSessionInput(session_id=session_ids[0], questions=[]),
+                    InvestigationSessionInput(session_id=session_ids[0], questions=[]),
                 ],
             ),
             actor=ACTOR,
@@ -510,8 +527,8 @@ async def test_update_investigation_session_verdict(
             agent_id=agent_id,
             name="investigation",
             sessions=[
-                InvestigationSessionInput(session_id=session_ids[0]),
-                InvestigationSessionInput(session_id=session_ids[1]),
+                InvestigationSessionInput(session_id=session_ids[0], questions=[]),
+                InvestigationSessionInput(session_id=session_ids[1], questions=[]),
             ],
         ),
         actor=ACTOR,
@@ -538,8 +555,8 @@ async def test_update_investigation_session_verdict_replaces_earlier_verdict(
             agent_id=agent_id,
             name="investigation",
             sessions=[
-                InvestigationSessionInput(session_id=session_ids[0]),
-                InvestigationSessionInput(session_id=session_ids[1]),
+                InvestigationSessionInput(session_id=session_ids[0], questions=[]),
+                InvestigationSessionInput(session_id=session_ids[1], questions=[]),
             ],
         ),
         actor=ACTOR,
@@ -570,8 +587,8 @@ async def test_update_investigation_session_verdict_clear(
             agent_id=agent_id,
             name="investigation",
             sessions=[
-                InvestigationSessionInput(session_id=session_ids[0]),
-                InvestigationSessionInput(session_id=session_ids[1]),
+                InvestigationSessionInput(session_id=session_ids[0], questions=[]),
+                InvestigationSessionInput(session_id=session_ids[1], questions=[]),
             ],
         ),
         actor=ACTOR,
@@ -599,8 +616,8 @@ async def test_update_investigation_session_verdict_does_not_complete_investigat
             agent_id=agent_id,
             name="investigation",
             sessions=[
-                InvestigationSessionInput(session_id=session_ids[0]),
-                InvestigationSessionInput(session_id=session_ids[1]),
+                InvestigationSessionInput(session_id=session_ids[0], questions=[]),
+                InvestigationSessionInput(session_id=session_ids[1], questions=[]),
             ],
         ),
         actor=ACTOR,
@@ -653,13 +670,18 @@ async def test_update_investigation_session_verdict_session_not_found(
         )
 
 
-async def test_update_investigation_session_verdict_leaves_highlights_untouched(
+async def test_update_investigation_session_verdict_leaves_questions_untouched(
     service: InvestigationService, agent_id: uuid.UUID, session_ids: list[uuid.UUID]
 ) -> None:
-    """Leave a linked session's highlights, set at create, untouched by the verdict."""
+    """Leave a linked session's questions, set at create, untouched by the verdict."""
     highlights = [
         InvestigationSessionHighlight(
             selector=AnnotationSelector(), description="Retried without backoff."
+        )
+    ]
+    questions = [
+        InvestigationSessionQuestion(
+            key="cause", question="What caused it?", highlights=highlights
         )
     ]
     investigation = await service.create_investigation(
@@ -668,7 +690,7 @@ async def test_update_investigation_session_verdict_leaves_highlights_untouched(
             name="investigation",
             sessions=[
                 InvestigationSessionInput(
-                    session_id=session_ids[0], highlights=highlights
+                    session_id=session_ids[0], questions=questions
                 )
             ],
         ),
@@ -681,7 +703,7 @@ async def test_update_investigation_session_verdict_leaves_highlights_untouched(
         actor=ACTOR,
     )
     assert session.verdict is InvestigationSessionVerdict.ACCEPTABLE
-    assert session.highlights == highlights
+    assert session.questions == questions
 
 
 async def test_create_investigation_tracks_investigation_created(
@@ -705,7 +727,7 @@ async def test_create_investigation_tracks_investigation_created(
             agent_id=agent_id,
             name="investigation",
             sessions=[
-                InvestigationSessionInput(session_id=session_id)
+                InvestigationSessionInput(session_id=session_id, questions=[])
                 for session_id in session_ids
             ],
         ),

--- a/tests/server/test_investigations_api.py
+++ b/tests/server/test_investigations_api.py
@@ -40,6 +40,7 @@ from kitaru.server.application.services.investigation_service import (
 from kitaru.server.domain.account import Account
 
 ACCOUNT = Account(id=uuid.uuid4(), name="ann")
+DEFAULT_QUESTIONS = [{"key": "cause", "question": "What caused it?"}]
 
 
 @pytest.fixture
@@ -126,12 +127,17 @@ async def test_create_investigation(
             "sessions": [
                 {
                     "session_id": session_ids[0],
-                    "question": "What caused it?",
-                    "highlights": highlights,
+                    "questions": [
+                        {
+                            "key": "cause",
+                            "question": "What caused it?",
+                            "highlights": highlights,
+                        }
+                    ],
                 },
                 {
                     "session_id": session_ids[1],
-                    "view": {"summary": "Retry loop without backoff."},
+                    "questions": DEFAULT_QUESTIONS,
                 },
             ],
         },
@@ -151,10 +157,9 @@ async def test_create_investigation(
     sessions = (await client.get(f"/v1/investigations/{body['id']}/sessions")).json()[
         "items"
     ]
-    assert sessions[0]["question"] == "What caused it?"
-    assert sessions[0]["highlights"] == highlights
-    assert sessions[1]["question"] is None
-    assert sessions[1]["highlights"] == []
+    assert sessions[0]["questions"][0]["question"] == "What caused it?"
+    assert sessions[0]["questions"][0]["highlights"] == highlights
+    assert sessions[1]["questions"][0]["highlights"] == []
 
 
 async def test_create_investigation_missing_agent(client: httpx.AsyncClient) -> None:
@@ -179,7 +184,9 @@ async def test_create_investigation_missing_session(
         json={
             "agent_id": agent_id,
             "name": "investigation",
-            "sessions": [{"session_id": str(uuid.uuid4())}],
+            "sessions": [
+                {"session_id": str(uuid.uuid4()), "questions": DEFAULT_QUESTIONS}
+            ],
         },
     )
     assert response.status_code == 422
@@ -195,9 +202,47 @@ async def test_create_investigation_duplicate_session_ids(
             "agent_id": agent_id,
             "name": "investigation",
             "sessions": [
-                {"session_id": session_ids[0]},
-                {"session_id": session_ids[0]},
+                {"session_id": session_ids[0], "questions": DEFAULT_QUESTIONS},
+                {"session_id": session_ids[0], "questions": DEFAULT_QUESTIONS},
             ],
+        },
+    )
+    assert response.status_code == 422
+
+
+async def test_create_investigation_duplicate_question_keys(
+    client: httpx.AsyncClient, agent_id: str, session_ids: list[str]
+) -> None:
+    """Observe HTTP 422 when a session input repeats a question key."""
+    response = await client.post(
+        "/v1/investigations",
+        json={
+            "agent_id": agent_id,
+            "name": "investigation",
+            "sessions": [
+                {
+                    "session_id": session_ids[0],
+                    "questions": [
+                        {"key": "cause", "question": "What caused it?"},
+                        {"key": "cause", "question": "What else caused it?"},
+                    ],
+                }
+            ],
+        },
+    )
+    assert response.status_code == 422
+
+
+async def test_create_investigation_empty_questions(
+    client: httpx.AsyncClient, agent_id: str, session_ids: list[str]
+) -> None:
+    """Observe HTTP 422 when a session input carries no questions."""
+    response = await client.post(
+        "/v1/investigations",
+        json={
+            "agent_id": agent_id,
+            "name": "investigation",
+            "sessions": [{"session_id": session_ids[0], "questions": []}],
         },
     )
     assert response.status_code == 422
@@ -434,8 +479,8 @@ async def test_list_investigation_sessions_ordered_by_position(
                 "agent_id": agent_id,
                 "name": "investigation",
                 "sessions": [
-                    {"session_id": session_ids[1]},
-                    {"session_id": session_ids[0]},
+                    {"session_id": session_ids[1], "questions": DEFAULT_QUESTIONS},
+                    {"session_id": session_ids[0], "questions": DEFAULT_QUESTIONS},
                 ],
             },
         )
@@ -469,7 +514,10 @@ async def test_list_investigation_sessions_walks_pages(
             json={
                 "agent_id": agent_id,
                 "name": "investigation",
-                "sessions": [{"session_id": session_id} for session_id in session_ids],
+                "sessions": [
+                    {"session_id": session_id, "questions": DEFAULT_QUESTIONS}
+                    for session_id in session_ids
+                ],
             },
         )
     ).json()
@@ -508,7 +556,9 @@ async def test_update_investigation_session_verdict(
             json={
                 "agent_id": agent_id,
                 "name": "investigation",
-                "sessions": [{"session_id": session_ids[0]}],
+                "sessions": [
+                    {"session_id": session_ids[0], "questions": DEFAULT_QUESTIONS}
+                ],
             },
         )
     ).json()
@@ -535,7 +585,9 @@ async def test_update_investigation_session_verdict_clear(
             json={
                 "agent_id": agent_id,
                 "name": "investigation",
-                "sessions": [{"session_id": session_ids[0]}],
+                "sessions": [
+                    {"session_id": session_ids[0], "questions": DEFAULT_QUESTIONS}
+                ],
             },
         )
     ).json()
@@ -554,10 +606,10 @@ async def test_update_investigation_session_verdict_clear(
     assert investigation["completed_sessions"] == 0
 
 
-async def test_update_investigation_session_verdict_leaves_highlights_untouched(
+async def test_update_investigation_session_verdict_leaves_questions_untouched(
     client: httpx.AsyncClient, agent_id: str, session_ids: list[str]
 ) -> None:
-    """Leave a linked session's highlights, set at create, untouched by the PATCH."""
+    """Leave a linked session's questions, set at create, untouched by the PATCH."""
     highlights = [
         {
             "selector": {"node_id": None, "path": None, "span": None},
@@ -570,7 +622,18 @@ async def test_update_investigation_session_verdict_leaves_highlights_untouched(
             json={
                 "agent_id": agent_id,
                 "name": "investigation",
-                "sessions": [{"session_id": session_ids[0], "highlights": highlights}],
+                "sessions": [
+                    {
+                        "session_id": session_ids[0],
+                        "questions": [
+                            {
+                                "key": "cause",
+                                "question": "What caused it?",
+                                "highlights": highlights,
+                            }
+                        ],
+                    }
+                ],
             },
         )
     ).json()
@@ -581,7 +644,7 @@ async def test_update_investigation_session_verdict_leaves_highlights_untouched(
     assert response.status_code == 200
     body = response.json()
     assert body["verdict"] == "acceptable"
-    assert body["highlights"] == highlights
+    assert body["questions"][0]["highlights"] == highlights
 
 
 async def test_update_investigation_session_verdict_investigation_not_found(

--- a/tests/server/test_investigations_api_pg.py
+++ b/tests/server/test_investigations_api_pg.py
@@ -52,7 +52,7 @@ async def _create_session(client: httpx.AsyncClient, agent_id: str) -> str:
 
 
 def _highlights() -> list[dict[str, object]]:
-    """Build one highlight for a session create payload."""
+    """Build one highlight for a question payload."""
     return [
         {
             "selector": {"node_id": None, "path": None, "span": None},
@@ -66,7 +66,7 @@ async def _create_investigation(
 ) -> dict[str, object]:
     """Create an investigation linking the given sessions.
 
-    The first session carries a question, curated view, and highlights.
+    The first session carries a question with highlights.
     """
     response = await client.post(
         "/v1/investigations",
@@ -77,19 +77,23 @@ async def _create_investigation(
             "sessions": [
                 {
                     "session_id": session_ids[0],
-                    "question": "What caused the failure?",
-                    "highlights": _highlights(),
-                    "view": {
-                        "summary": "Retry loop without backoff",
-                        "items": [
-                            {
-                                "label": "Retry loop",
-                                "description": ("Retries three times without backoff."),
-                            }
-                        ],
-                    },
+                    "questions": [
+                        {
+                            "key": "cause",
+                            "question": "What caused the failure?",
+                            "highlights": _highlights(),
+                        }
+                    ],
                 },
-                *[{"session_id": session_id} for session_id in session_ids[1:]],
+                *[
+                    {
+                        "session_id": session_id,
+                        "questions": [
+                            {"key": "cause", "question": "What caused the failure?"}
+                        ],
+                    }
+                    for session_id in session_ids[1:]
+                ],
             ],
         },
     )
@@ -145,7 +149,7 @@ async def test_update_persists_across_requests(
 async def test_list_sessions_ordered_by_position(
     client: httpx.AsyncClient, agent_id: str
 ) -> None:
-    """List an investigation's sessions in position order, with the curated view."""
+    """List an investigation's sessions in position order, with their questions."""
     session_ids = [await _create_session(client, agent_id) for _ in range(2)]
     created = await _create_investigation(client, agent_id, session_ids)
 
@@ -156,18 +160,15 @@ async def test_list_sessions_ordered_by_position(
     assert [item["session_id"] for item in items] == session_ids
     assert [item["position"] for item in items] == [0, 1]
     assert [item["verdict"] for item in items] == [None, None]
-    assert items[0]["view"]["summary"] == "Retry loop without backoff"
-    assert items[1]["view"] is None
-    assert items[0]["question"] == "What caused the failure?"
-    assert items[1]["question"] is None
-    assert items[0]["highlights"] == _highlights()
-    assert items[1]["highlights"] == []
+    assert items[0]["questions"][0]["question"] == "What caused the failure?"
+    assert items[0]["questions"][0]["highlights"] == _highlights()
+    assert items[1]["questions"][0]["highlights"] == []
 
 
-async def test_verdict_update_leaves_highlights_untouched(
+async def test_verdict_update_leaves_questions_untouched(
     client: httpx.AsyncClient, agent_id: str
 ) -> None:
-    """Leave a session's highlights, set at create, untouched by a verdict PATCH."""
+    """Leave a session's questions, set at create, untouched by a verdict PATCH."""
     session_ids = [await _create_session(client, agent_id) for _ in range(1)]
     created = await _create_investigation(client, agent_id, session_ids)
 
@@ -178,13 +179,13 @@ async def test_verdict_update_leaves_highlights_untouched(
     assert response.status_code == 200
     body = response.json()
     assert body["verdict"] == "acceptable"
-    assert body["highlights"] == _highlights()
+    assert body["questions"][0]["highlights"] == _highlights()
 
     response = await client.get(f"/v1/investigations/{created['id']}/sessions")
     assert response.status_code == 200
     loaded = response.json()["items"][0]
     assert loaded["verdict"] == "acceptable"
-    assert loaded["highlights"] == _highlights()
+    assert loaded["questions"][0]["highlights"] == _highlights()
 
 
 async def test_manual_completion_after_verdicts(


### PR DESCRIPTION
- Investigation sessions now hold a list of keyed questions instead of a single question
- Each question carries its own highlights, session-level highlights are removed
- `InvestigationSessionView` is removed
- Investigation answers reference a question key, validated against the session's questions
- Question keys are unique per session and every session needs at least one question
- CLI: `--session-question "SESSION_ID:KEY=text"`, `--session-highlights "SESSION_ID:KEY=<json>"`, `--question-key` on annotation create, `--session-view` removed