### PR TITLE
Do not apply replay overrides to agent task inputs

### DIFF
--- a/src/kitaru/server/application/services/replay_pipeline.py
+++ b/src/kitaru/server/application/services/replay_pipeline.py
@@ -33,7 +33,7 @@ from kitaru.server.application.interfaces.task_repository import TaskRepository
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.domain.job import Job
 from kitaru.server.domain.replay import Replay
-from kitaru.server.domain.replay_config import ReplayConfig, effective_inputs
+from kitaru.server.domain.replay_config import ReplayConfig
 from kitaru.server.domain.session import Session
 from kitaru.server.domain.task import AgentTask, EvaluationTask, Task
 
@@ -53,10 +53,10 @@ async def create_replay_pipelines(
 ) -> list[Replay]:
     """Create many replays' jobs, initial tasks, and replay rows in three bulk writes.
 
-    Each agent task carries its baseline session's inputs with the config's
-    override applied and the agent version as a label. With
-    ``evaluate_baselines``, one baseline evaluator task is appended per
-    evaluator that has not already scored the baseline session.
+    Each agent task carries its baseline session's inputs and the agent
+    version as a label. With ``evaluate_baselines``, one baseline evaluator
+    task is appended per evaluator that has not already scored the baseline
+    session.
 
     Args:
         baselines: Sessions being replayed.
@@ -98,7 +98,7 @@ async def create_replay_pipelines(
             AgentTask(
                 job_id=job.id,
                 agent_version_id=agent_version_id,
-                inputs=effective_inputs(baseline.inputs, config.override),
+                inputs=baseline.inputs,
                 labels={AGENT_VERSION_LABEL: str(agent_version_id)},
                 on_failure=TaskOnFailure.ABORT,
             )

--- a/src/kitaru/server/domain/replay_config.py
+++ b/src/kitaru/server/domain/replay_config.py
@@ -166,35 +166,3 @@ class ReplayConfig(DomainModel):
                 raise ValidationError(
                     "A standalone replay cannot use cohort-version-scoped history"
                 )
-
-
-def effective_inputs(inputs: Any, override: ReplayOverride | None) -> Any:
-    """Apply a replay override's prompt fields to recorded inputs.
-
-    The prompt and system prompt overrides apply independently. Model and
-    model parameter overrides do not touch inputs, they apply at the adapter
-    level.
-
-    Args:
-        inputs: Recorded session inputs.
-        override: Replay override, if any.
-
-    Returns:
-        Inputs with the override's prompt fields applied, dict inputs keeping
-        their other keys.
-    """
-    if override is None or (override.prompt is None and override.system_prompt is None):
-        return inputs
-    if isinstance(inputs, dict):
-        result = dict(inputs)
-        if override.prompt is not None:
-            result["prompt"] = override.prompt
-        if override.system_prompt is not None:
-            result["system_prompt"] = override.system_prompt
-        return result
-    if override.system_prompt is None:
-        return override.prompt
-    return {
-        "prompt": override.prompt if override.prompt is not None else inputs,
-        "system_prompt": override.system_prompt,
-    }

--- a/tests/server/test_replay_config.py
+++ b/tests/server/test_replay_config.py
@@ -24,10 +24,8 @@ from kitaru.server.domain.replay_config import (
     HistoryConfig,
     PassthroughConfig,
     ReplayConfig,
-    ReplayOverride,
     ToolPolicy,
     default_tool_policy,
-    effective_inputs,
 )
 
 
@@ -36,58 +34,6 @@ def test_default_tool_policy_passes_every_tool_through() -> None:
     policy = default_tool_policy()
     assert policy.default == PassthroughConfig()
     assert policy.tools == {}
-
-
-def test_effective_inputs_no_override() -> None:
-    """Leave inputs unchanged with no override."""
-    assert effective_inputs({"prompt": "hi"}, None) == {"prompt": "hi"}
-
-
-def test_effective_inputs_no_prompt_fields() -> None:
-    """Leave inputs unchanged when the override carries no prompt fields."""
-    override = ReplayOverride(model="openai:gpt-5")
-    assert effective_inputs({"prompt": "hi"}, override) == {"prompt": "hi"}
-
-
-def test_effective_inputs_dict_replaces_system_prompt_key() -> None:
-    """Replace a dict's system prompt key without a prompt override."""
-    override = ReplayOverride(system_prompt="be terse")
-    result = effective_inputs({"prompt": "hi", "system_prompt": "old"}, override)
-    assert result == {"prompt": "hi", "system_prompt": "be terse"}
-
-
-def test_effective_inputs_dict_replaces_prompt_key() -> None:
-    """Replace a dict's prompt key, keeping the other keys."""
-    override = ReplayOverride(prompt="new prompt")
-    result = effective_inputs({"prompt": "hi", "temperature": 0.5}, override)
-    assert result == {"prompt": "new prompt", "temperature": 0.5}
-
-
-def test_effective_inputs_dict_replaces_prompt_and_system_prompt() -> None:
-    """Replace both the prompt and system prompt keys of a dict."""
-    override = ReplayOverride(prompt="new prompt", system_prompt="new system")
-    result = effective_inputs({"prompt": "hi", "system_prompt": "old"}, override)
-    assert result == {"prompt": "new prompt", "system_prompt": "new system"}
-
-
-def test_effective_inputs_plain_value_replaced_by_prompt() -> None:
-    """Replace a non-dict input wholesale with the override prompt."""
-    override = ReplayOverride(prompt="new prompt")
-    assert effective_inputs("hi", override) == "new prompt"
-
-
-def test_effective_inputs_plain_value_with_prompt_and_system_prompt() -> None:
-    """Wrap a non-dict input into a dict carrying both override fields."""
-    override = ReplayOverride(prompt="new prompt", system_prompt="new system")
-    result = effective_inputs("hi", override)
-    assert result == {"prompt": "new prompt", "system_prompt": "new system"}
-
-
-def test_effective_inputs_plain_value_with_system_prompt_only() -> None:
-    """Wrap a non-dict input into a dict, keeping it as the prompt."""
-    override = ReplayOverride(system_prompt="new system")
-    result = effective_inputs("hi", override)
-    assert result == {"prompt": "hi", "system_prompt": "new system"}
 
 
 def _config(tool_policy: ToolPolicy) -> ReplayConfig:


### PR DESCRIPTION
Agent tasks created for replays now carry the raw baseline session inputs, the prompt and system prompt overrides are no longer baked in at task creation.