### PR TITLE
Fix investigation annotation semantics

### DIFF
--- a/examples/pydantic_ai_ticket_resolver/README.md
+++ b/examples/pydantic_ai_ticket_resolver/README.md
@@ -202,26 +202,27 @@ INVESTIGATION_SESSION_ID="$(
 )"
 ```
 
-Store the support lead's answers and anchor the outcome judgment to the refund node:
+Store the support lead's rationale and expected action, then record the verdict on the investigation session:
 
 ```bash
 uv run kitaru annotation create \
   --investigation-session "$INVESTIGATION_SESSION_ID" \
   --question-key outcome \
-  --selector "{\"node_id\":\"$TICKET_004_REFUND_NODE_ID\",\"part\":\"output\"}" \
-  --value '{"judgment":"problematic","reason":"The amount exceeds the automatic approval threshold."}'
+  --selector "{\"node_id\":\"$TICKET_004_REFUND_NODE_ID\"}" \
+  --value '"The amount exceeds the automatic approval threshold."'
 
 uv run kitaru annotation create \
   --investigation-session "$INVESTIGATION_SESSION_ID" \
   --question-key outcome \
   --value '{"action":"escalate","reason":"Human approval is required before a refund."}'
 
-uv run kitaru investigation session complete \
+uv run kitaru investigation session verdict \
   "$INVESTIGATION_ID" \
-  "$TICKET_004_SESSION_ID"
+  "$TICKET_004_SESSION_ID" \
+  problematic
 ```
 
-Kitaru now stores the session question, review progress, answers, and exact trace evidence. The guided path repeats this review over a diverse set that it selects from the sessions.
+The investigation-session verdict is the classification. The annotations store the rationale, expected action, and exact trace evidence without duplicating that verdict. The guided path repeats this review over a diverse set that it selects from the sessions.
 
 ## Step 7: Decide what to improve
 

--- a/tests/integration/test_canonical_example_e2e.py
+++ b/tests/integration/test_canonical_example_e2e.py
@@ -281,7 +281,7 @@ def test_canonical_example_completes_import_to_replay(tmp_path: Path) -> None:
             links_by_session = {
                 item["session_id"]: item["id"] for item in linked_sessions
             }
-            for ticket_id, (judgment, expected_action) in reviewed_tickets.items():
+            for ticket_id, (verdict, expected_action) in reviewed_tickets.items():
                 session_id = sessions_by_ticket[ticket_id]
                 investigation_session_id = links_by_session[session_id]
                 selector = json.dumps(
@@ -297,13 +297,7 @@ def test_canonical_example_completes_import_to_replay(tmp_path: Path) -> None:
                     "--selector",
                     selector,
                     "--value",
-                    json.dumps(
-                        {
-                            "judgment": judgment,
-                            "reason": "Reviewed against the automatic refund policy.",
-                        },
-                        separators=(",", ":"),
-                    ),
+                    json.dumps("Reviewed against the automatic refund policy."),
                 )
                 _cli(
                     "annotation",
@@ -321,7 +315,7 @@ def test_canonical_example_completes_import_to_replay(tmp_path: Path) -> None:
                     "verdict",
                     investigation_id,
                     session_id,
-                    judgment,
+                    verdict,
                 )
 
             _cli("investigation", "update", investigation_id, "--status", "completed")
@@ -348,6 +342,11 @@ def test_canonical_example_completes_import_to_replay(tmp_path: Path) -> None:
             )
             assert len(annotations) == 10
             assert sum(item["selector"] is not None for item in annotations) == 5
+            assert sum(isinstance(item["value"], str) for item in annotations) == 5
+            assert all(
+                not (isinstance(item["value"], dict) and "judgment" in item["value"])
+                for item in annotations
+            )
 
             evaluator_path = tmp_path / "returns_policy.py"
             _write_documented_evaluator(evaluator_path)

--- a/tests/test_canonical_example.py
+++ b/tests/test_canonical_example.py
@@ -305,6 +305,10 @@ def test_readme_teaches_the_complete_returns_improvement_loop() -> None:
     assert "--env-file .env" not in readme
     assert "$TICKET_004_SESSION_ID:outcome=" in readme
     assert "--question-key outcome" in readme
+    assert '--selector "{\\"node_id\\":\\"$TICKET_004_REFUND_NODE_ID\\"}"' in readme
+    assert "kitaru investigation session verdict" in readme
+    assert '"judgment":"problematic"' not in readme
+    assert "The investigation-session verdict is the classification." in readme
     assert (
         "uv pip install --editable '../../plugins/packages/pydantic-ai[openai]'"
         in readme


### PR DESCRIPTION
## Summary

- Treat the investigation-session verdict as the sole acceptable, problematic, or uncertain classification.
- Store evidence annotations as rationale text without a duplicate judgment field.
- Keep expected-action annotations separate because they answer what the agent should do.
- Correct the README selector and verdict commands to match the current CLI.
- Add contract and end-to-end assertions that prevent judgment duplication from returning.

## Why

The canonical example stored the same classification in both the investigation-session verdict and an annotation value. This created competing sources of truth and rendered redundant data in investigation views. The documented selector also included an unsupported `part` field.

## Reviewer Notes

The main behavior change is in the investigation section of the canonical returns example. Reviewers should confirm that the verdict carries classification, the evidence annotation carries rationale, and the expected-action annotation remains a distinct answer.

### Reproduction

```bash
PYTHONPATH=. uv run pytest -q tests/test_canonical_example.py
uv run ruff format --check tests/test_canonical_example.py tests/integration/test_canonical_example_e2e.py
uv run ruff check tests/test_canonical_example.py tests/integration/test_canonical_example_e2e.py
```

The hosted workflow was also exercised against a staging Kitaru 0.21.0 backend. Rationale-only annotation values and investigation-session verdicts were accepted by the API.
