### PR TITLE
Add min and max to evaluation aggregates

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1927,6 +1927,30 @@
             "title": "Count",
             "type": "integer"
           },
+          "max": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Highest score of float and bool evaluations, null for other data types.",
+            "title": "Max"
+          },
+          "min": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Lowest score of float and bool evaluations, null for other data types.",
+            "title": "Min"
+          },
           "pass_rate": {
             "anyOf": [
               {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1910,18 +1910,6 @@
       "EvaluationStats": {
         "description": "Evaluation stats.",
         "properties": {
-          "average": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Mean score of float evaluations, share of true results of bool evaluations, null for other data types.",
-            "title": "Average"
-          },
           "count": {
             "description": "Number of aggregated evaluations.",
             "title": "Count",
@@ -1938,6 +1926,18 @@
             ],
             "description": "Highest score of float and bool evaluations, null for other data types.",
             "title": "Max"
+          },
+          "mean": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Mean score of float evaluations, share of true results of bool evaluations, null for other data types.",
+            "title": "Mean"
           },
           "min": {
             "anyOf": [

--- a/src/kitaru/api_models/v1/ui.py
+++ b/src/kitaru/api_models/v1/ui.py
@@ -48,7 +48,7 @@ class EvaluationStats(ResponseModel):
     """Evaluation stats."""
 
     count: int = Field(description="Number of aggregated evaluations.")
-    average: float | None = Field(
+    mean: float | None = Field(
         default=None,
         description="Mean score of float evaluations, share of true results of "
         "bool evaluations, null for other data types.",

--- a/src/kitaru/api_models/v1/ui.py
+++ b/src/kitaru/api_models/v1/ui.py
@@ -53,6 +53,16 @@ class EvaluationStats(ResponseModel):
         description="Mean score of float evaluations, share of true results of "
         "bool evaluations, null for other data types.",
     )
+    min: float | None = Field(
+        default=None,
+        description="Lowest score of float and bool evaluations, null for "
+        "other data types.",
+    )
+    max: float | None = Field(
+        default=None,
+        description="Highest score of float and bool evaluations, null for "
+        "other data types.",
+    )
     pass_rate: float | None = Field(
         default=None,
         description="Share of passed evaluations among those carrying a passed "

--- a/src/kitaru/server/adapters/rest/routers/ui.py
+++ b/src/kitaru/server/adapters/rest/routers/ui.py
@@ -125,7 +125,7 @@ def _evaluation_stats(
     scorable = data_type in (EvaluationDataType.FLOAT, EvaluationDataType.BOOL)
     return EvaluationStats(
         count=len(evaluations),
-        average=sum(scores) / len(scores) if scorable and scores else None,
+        mean=sum(scores) / len(scores) if scorable and scores else None,
         min=min(scores) if scorable and scores else None,
         max=max(scores) if scorable and scores else None,
         pass_rate=sum(flags) / len(flags) if flags else None,

--- a/src/kitaru/server/adapters/rest/routers/ui.py
+++ b/src/kitaru/server/adapters/rest/routers/ui.py
@@ -126,6 +126,8 @@ def _evaluation_stats(
     return EvaluationStats(
         count=len(evaluations),
         average=sum(scores) / len(scores) if scorable and scores else None,
+        min=min(scores) if scorable and scores else None,
+        max=max(scores) if scorable and scores else None,
         pass_rate=sum(flags) / len(flags) if flags else None,
         value_counts=dict(Counter(values))
         if data_type is EvaluationDataType.CATEGORICAL

--- a/tests/server/test_ui_experiment_runs_api.py
+++ b/tests/server/test_ui_experiment_runs_api.py
@@ -184,7 +184,7 @@ async def test_aggregates_float_evaluations(
             "data_type": "float",
             "baseline": {
                 "count": 1,
-                "average": 0.1,
+                "mean": 0.1,
                 "min": 0.1,
                 "max": 0.1,
                 "pass_rate": None,
@@ -192,7 +192,7 @@ async def test_aggregates_float_evaluations(
             },
             "result": {
                 "count": 2,
-                "average": 0.75,
+                "mean": 0.75,
                 "min": 0.5,
                 "max": 1.0,
                 "pass_rate": None,
@@ -250,14 +250,14 @@ async def test_aggregates_bool_and_pass_rate(
     assert aggregate["data_type"] == "bool"
     assert aggregate["baseline"] == {
         "count": 0,
-        "average": None,
+        "mean": None,
         "min": None,
         "max": None,
         "pass_rate": None,
         "value_counts": None,
     }
     assert aggregate["result"]["count"] == 3
-    assert aggregate["result"]["average"] == pytest.approx(2 / 3)
+    assert aggregate["result"]["mean"] == pytest.approx(2 / 3)
     assert aggregate["result"]["min"] == 0.0
     assert aggregate["result"]["max"] == 1.0
     assert aggregate["result"]["pass_rate"] == pytest.approx(2 / 3)
@@ -299,7 +299,7 @@ async def test_aggregates_categorical_value_counts(
     assert aggregate["data_type"] == "categorical"
     assert aggregate["baseline"] == {
         "count": 0,
-        "average": None,
+        "mean": None,
         "min": None,
         "max": None,
         "pass_rate": None,
@@ -307,7 +307,7 @@ async def test_aggregates_categorical_value_counts(
     }
     assert aggregate["result"] == {
         "count": 3,
-        "average": None,
+        "mean": None,
         "min": None,
         "max": None,
         "pass_rate": None,
@@ -346,7 +346,7 @@ async def test_aggregates_dedupes_shared_baseline_session(
     aggregate = body[0]
     assert aggregate["baseline"] == {
         "count": 1,
-        "average": 0.42,
+        "mean": 0.42,
         "min": 0.42,
         "max": 0.42,
         "pass_rate": None,
@@ -413,7 +413,7 @@ async def test_aggregates_include_baseline_only_names(
     assert aggregate["name"] == "baseline_only"
     assert aggregate["baseline"] == {
         "count": 1,
-        "average": 0.3,
+        "mean": 0.3,
         "min": 0.3,
         "max": 0.3,
         "pass_rate": None,
@@ -421,7 +421,7 @@ async def test_aggregates_include_baseline_only_names(
     }
     assert aggregate["result"] == {
         "count": 0,
-        "average": None,
+        "mean": None,
         "min": None,
         "max": None,
         "pass_rate": None,

--- a/tests/server/test_ui_experiment_runs_api.py
+++ b/tests/server/test_ui_experiment_runs_api.py
@@ -185,12 +185,16 @@ async def test_aggregates_float_evaluations(
             "baseline": {
                 "count": 1,
                 "average": 0.1,
+                "min": 0.1,
+                "max": 0.1,
                 "pass_rate": None,
                 "value_counts": None,
             },
             "result": {
                 "count": 2,
                 "average": 0.75,
+                "min": 0.5,
+                "max": 1.0,
                 "pass_rate": None,
                 "value_counts": None,
             },
@@ -247,11 +251,15 @@ async def test_aggregates_bool_and_pass_rate(
     assert aggregate["baseline"] == {
         "count": 0,
         "average": None,
+        "min": None,
+        "max": None,
         "pass_rate": None,
         "value_counts": None,
     }
     assert aggregate["result"]["count"] == 3
     assert aggregate["result"]["average"] == pytest.approx(2 / 3)
+    assert aggregate["result"]["min"] == 0.0
+    assert aggregate["result"]["max"] == 1.0
     assert aggregate["result"]["pass_rate"] == pytest.approx(2 / 3)
     assert aggregate["result"]["value_counts"] is None
 
@@ -292,12 +300,16 @@ async def test_aggregates_categorical_value_counts(
     assert aggregate["baseline"] == {
         "count": 0,
         "average": None,
+        "min": None,
+        "max": None,
         "pass_rate": None,
         "value_counts": {},
     }
     assert aggregate["result"] == {
         "count": 3,
         "average": None,
+        "min": None,
+        "max": None,
         "pass_rate": None,
         "value_counts": {"good": 2, "bad": 1},
     }
@@ -335,6 +347,8 @@ async def test_aggregates_dedupes_shared_baseline_session(
     assert aggregate["baseline"] == {
         "count": 1,
         "average": 0.42,
+        "min": 0.42,
+        "max": 0.42,
         "pass_rate": None,
         "value_counts": None,
     }
@@ -400,12 +414,16 @@ async def test_aggregates_include_baseline_only_names(
     assert aggregate["baseline"] == {
         "count": 1,
         "average": 0.3,
+        "min": 0.3,
+        "max": 0.3,
         "pass_rate": None,
         "value_counts": None,
     }
     assert aggregate["result"] == {
         "count": 0,
         "average": None,
+        "min": None,
+        "max": None,
         "pass_rate": None,
         "value_counts": None,
     }


### PR DESCRIPTION
Add min and max score stats to the experiment run evaluation aggregates UI endpoint and rename the existing average stat to mean.