### PR TITLE
Make Python package releases retry-safe

### DIFF
--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -140,21 +140,33 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: package-dist
+          skip-existing: true
       - name: Create package GitHub Release
         env:
           DISTRIBUTION: ${{ needs.build.outputs.distribution }}
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           IS_PRERELEASE: ${{ needs.build.outputs.is-prerelease }}
           PACKAGE_TAG: ${{ needs.build.outputs.package-tag }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |-
+          set -euo pipefail
           prerelease=()
           if [ "$IS_PRERELEASE" = true ]; then
             prerelease+=(--prerelease)
           fi
-          gh release create "$PACKAGE_TAG" package-dist/* evidence/* \
-            "${prerelease[@]}" \
-            --verify-tag \
-            --latest=false \
-            --title "$DISTRIBUTION $VERSION" \
-            --generate-notes
+          if gh release view "$PACKAGE_TAG" >/dev/null 2>&1; then
+            gh release upload "$PACKAGE_TAG" package-dist/* evidence/* --clobber
+            gh release edit "$PACKAGE_TAG" \
+              --latest=false \
+              --prerelease="$IS_PRERELEASE" \
+              --title "$DISTRIBUTION $VERSION" \
+              --verify-tag
+          else
+            gh release create "$PACKAGE_TAG" package-dist/* evidence/* \
+              "${prerelease[@]}" \
+              --verify-tag \
+              --latest=false \
+              --title "$DISTRIBUTION $VERSION" \
+              --generate-notes
+          fi

--- a/plugins/DEVELOPMENT.md
+++ b/plugins/DEVELOPMENT.md
@@ -365,7 +365,9 @@ git tag -a "$TAG" "$RELEASE_SHA" -m "$TAG"
 git push origin "$TAG"
 ```
 
-The tag push starts the `Release plugin` workflow. The workflow derives the package and version from the tag. It rejects a tag whose commit is not contained in `origin/main`. It also rejects an existing PyPI version. It then runs the tests, builds the selected distribution, publishes through PyPI Trusted Publishing, and creates a GitHub Release with the wheel and source distribution.
+The tag push starts the `Release Python package` workflow. The workflow derives the package and version from the tag. It rejects a tag whose commit is not contained in `origin/develop`. It then runs the tests, builds the selected distribution, publishes through PyPI Trusted Publishing, and creates a GitHub Release with the wheel, source distribution, and checksums.
+
+If publication stops after PyPI accepts one or more files, rerun the failed jobs from the same workflow run. The rerun downloads the original build artifact, skips files that PyPI already accepted, and creates or updates the GitHub Release. Do not move or recreate the release tag.
 
 Watch the run and require a successful conclusion:
 

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -215,6 +215,18 @@ def test_python_release_workflow_resolves_every_tag_from_the_inventory() -> None
     assert "uv version" not in workflow
 
 
+def test_python_release_workflow_can_resume_after_partial_publication() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release-plugins.yml").read_text()
+
+    assert "skip-existing: true" in workflow
+    assert "GH_REPO: ${{ github.repository }}" in workflow
+    assert 'gh release view "$PACKAGE_TAG"' in workflow
+    assert (
+        'gh release upload "$PACKAGE_TAG" package-dist/* evidence/* --clobber'
+        in workflow
+    )
+
+
 def test_ci_plugin_matrix_is_loaded_from_the_release_inventory() -> None:
     workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
 


### PR DESCRIPTION
## What changed

- let PyPI publishing skip distribution files already accepted during the same release
- make `gh` target `zenml-io/kitaru` without requiring a checkout in the publish job
- create a missing GitHub Release or reconcile an existing one by replacing its assets and release metadata
- document the failed-job retry procedure
- add a regression test for the workflow guarantees

## Root cause

The `python/kitaru/v0.22.0rc0` run published its wheel and source distribution to PyPI, then failed while creating the GitHub Release because the publish job had no Git checkout and `gh` could not infer the repository. Retrying the old workflow would then encounter the files already present on PyPI.

## Validation

- `uv run pytest -q tests/scripts/test_release_units.py` (34 passed)
- `uv run ruff check tests/scripts/test_release_units.py`
- `uv run ruff format --check tests/scripts/test_release_units.py`
- parsed `.github/workflows/release-plugins.yml` with PyYAML
- `git diff --check`

## Current RC0

Merging this PR protects future tagged runs. The existing RC0 run still uses the workflow stored at its tagged commit, so its missing GitHub Release must be created separately from run artifact `python-distribution`.