### PR TITLE
Add id filtering for entity lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed TypeScript replay and recording edge cases, aligned credential redaction and provider diagnostics across adapters, and made the adapter examples reproducible, rerunnable, and part of CI.
 
 ### Added
+- Every filterable entity list filters by `id`, including `in` over a list of ids.
 - TypeScript SDK packages for the core client and replay runtime, with Mastra and Vercel AI SDK adapters and runnable examples.
 - TypeScript release packaging for the core, Mastra, and Vercel AI SDK packages, with lockstep release-candidate versions, clean-consumer tarball checks, npm publishing, and GitHub release artifacts.
 - Session lists filter by `experiment_run_id`, returning the sessions produced as the results of the run's replays. Baseline sessions do not match.

--- a/src/kitaru/server/adapters/db/repositories/account_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/account_repository.py
@@ -34,6 +34,7 @@ from kitaru.server.domain.account import (
 from kitaru.server.domain.base import NotFoundError
 
 ACCOUNT_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": AccountORM.id,
     "name": AccountORM.name,
     "active": AccountORM.active,
     "is_service_account": AccountORM.is_service_account,

--- a/src/kitaru/server/adapters/db/repositories/agent_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/agent_repository.py
@@ -35,6 +35,7 @@ from kitaru.server.domain.agent import (
 from kitaru.server.domain.base import NotFoundError
 
 AGENT_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": AgentORM.id,
     "name": AgentORM.name,
 }
 

--- a/src/kitaru/server/adapters/db/repositories/agent_version_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/agent_version_repository.py
@@ -39,6 +39,7 @@ from kitaru.server.domain.agent_version import (
 from kitaru.server.domain.base import NotFoundError
 
 AGENT_VERSION_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": AgentVersionORM.id,
     "tag": build_tag_condition_binding(
         TagResourceType.AGENT_VERSION, AgentVersionORM.id
     ),

--- a/src/kitaru/server/adapters/db/repositories/annotation_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/annotation_repository.py
@@ -58,6 +58,7 @@ def _compile_investigation_id_condition(
 
 
 ANNOTATION_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": AnnotationORM.id,
     "session_id": AnnotationORM.session_id,
     "investigation_session_id": AnnotationORM.investigation_session_id,
     "investigation_id": _compile_investigation_id_condition,

--- a/src/kitaru/server/adapters/db/repositories/api_key_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/api_key_repository.py
@@ -34,6 +34,7 @@ from kitaru.server.domain.api_key import (
 from kitaru.server.domain.base import NotFoundError
 
 API_KEY_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": ApiKeyORM.id,
     "name": ApiKeyORM.name,
 }
 

--- a/src/kitaru/server/adapters/db/repositories/cohort_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/cohort_repository.py
@@ -35,6 +35,7 @@ from kitaru.server.domain.base import NotFoundError
 from kitaru.server.domain.cohort import Cohort, CohortNotFound, DuplicateCohortName
 
 COHORT_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": CohortORM.id,
     "agent_id": CohortORM.agent_id,
     "name": CohortORM.name,
     "tag": build_tag_condition_binding(TagResourceType.COHORT, CohortORM.id),

--- a/src/kitaru/server/adapters/db/repositories/cohort_version_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/cohort_version_repository.py
@@ -45,6 +45,7 @@ from kitaru.server.domain.cohort_version import (
 )
 
 COHORT_VERSION_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": CohortVersionORM.id,
     "tag": build_tag_condition_binding(
         TagResourceType.COHORT_VERSION, CohortVersionORM.id
     ),

--- a/src/kitaru/server/adapters/db/repositories/device_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/device_repository.py
@@ -29,6 +29,7 @@ from kitaru.server.domain.base import NotFoundError
 from kitaru.server.domain.device import Device, DeviceNotFound
 
 DEVICE_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": DeviceORM.id,
     "status": DeviceORM.status,
 }
 

--- a/src/kitaru/server/adapters/db/repositories/evaluation_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/evaluation_repository.py
@@ -108,6 +108,7 @@ def _compile_experiment_run_condition(
 
 
 EVALUATION_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": EvaluationORM.id,
     "session_id": EvaluationORM.session_id,
     "task_id": EvaluationORM.task_id,
     "evaluator_version_id": EvaluationORM.evaluator_version_id,

--- a/src/kitaru/server/adapters/db/repositories/experiment_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/experiment_repository.py
@@ -51,6 +51,7 @@ from kitaru.server.domain.replay_config import (
 )
 
 EXPERIMENT_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": ExperimentORM.id,
     "agent_id": ExperimentORM.agent_id,
     "name": ExperimentORM.name,
     "tag": build_tag_condition_binding(TagResourceType.EXPERIMENT, ExperimentORM.id),

--- a/src/kitaru/server/adapters/db/repositories/experiment_run_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/experiment_run_repository.py
@@ -42,6 +42,7 @@ from kitaru.server.domain.experiment_run import (
 )
 
 EXPERIMENT_RUN_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": ExperimentRunORM.id,
     "experiment_id": ExperimentRunORM.experiment_id,
     "cohort_version_id": ExperimentRunORM.cohort_version_id,
     # A run pins one cohort version, so a cohort-wide history spans every

--- a/src/kitaru/server/adapters/db/repositories/investigation_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/investigation_repository.py
@@ -36,6 +36,7 @@ from kitaru.server.domain.investigation import (
 )
 
 INVESTIGATION_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": InvestigationORM.id,
     "agent_id": InvestigationORM.agent_id,
     "status": InvestigationORM.status,
 }

--- a/src/kitaru/server/adapters/db/repositories/job_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/job_repository.py
@@ -29,6 +29,7 @@ from kitaru.server.domain.base import NotFoundError
 from kitaru.server.domain.job import TERMINAL_JOB_STATUSES, Job, JobNotFound
 
 JOB_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": JobORM.id,
     "kind": JobORM.kind,
     "status": JobORM.status,
 }

--- a/src/kitaru/server/adapters/db/repositories/plugin_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/plugin_repository.py
@@ -49,6 +49,7 @@ from kitaru.server.domain.plugin import (
 )
 
 PLUGIN_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": PluginORM.id,
     "name": PluginORM.name,
     "provider": PluginORM.provider,
 }

--- a/src/kitaru/server/adapters/db/repositories/replay_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/replay_repository.py
@@ -82,6 +82,7 @@ def _compile_result_session_condition(
 
 
 REPLAY_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": ReplayORM.id,
     "experiment_run_id": ReplayORM.experiment_run_id,
     "baseline_session_id": ReplayORM.baseline_session_id,
     "result_session_id": _compile_result_session_condition,

--- a/src/kitaru/server/adapters/db/repositories/secret_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/secret_repository.py
@@ -38,6 +38,7 @@ from kitaru.server.domain.secret import (
 )
 
 SECRET_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": SecretORM.id,
     "name": SecretORM.name,
 }
 

--- a/src/kitaru/server/adapters/db/repositories/session_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/session_repository.py
@@ -135,6 +135,7 @@ def _compile_has_evaluation_condition(
 
 
 SESSION_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": SessionORM.id,
     "agent_id": SessionORM.agent_id,
     "agent_version_id": SessionORM.agent_version_id,
     "task_id": SessionORM.task_id,

--- a/src/kitaru/server/adapters/db/repositories/tag_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/tag_repository.py
@@ -41,6 +41,7 @@ from kitaru.server.domain.tag import (
 )
 
 TAG_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": TagORM.id,
     "name": TagORM.name,
 }
 

--- a/src/kitaru/server/adapters/db/repositories/task_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/task_repository.py
@@ -43,6 +43,7 @@ IN_FLIGHT_STATUS_VALUES = [TaskStatus.CLAIMED.value, TaskStatus.RUNNING.value]
 _LAST_SEEN = func.coalesce(TaskORM.heartbeat_at, TaskORM.claimed_at)
 
 TASK_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": TaskORM.id,
     "job_id": TaskORM.job_id,
     "kind": TaskORM.kind,
     "status": TaskORM.status,

--- a/src/kitaru/server/adapters/db/repositories/worker_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/worker_repository.py
@@ -32,6 +32,7 @@ from kitaru.server.domain.base import NotFoundError
 from kitaru.server.domain.worker import Worker, WorkerNotFound
 
 WORKER_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
+    "id": WorkerORM.id,
     "name": WorkerORM.name,
 }
 

--- a/src/kitaru/server/application/models/account.py
+++ b/src/kitaru/server/application/models/account.py
@@ -13,17 +13,24 @@
 #  permissions and limitations under the License.
 """Account filter model."""
 
+import uuid
 from collections.abc import Mapping
 from typing import ClassVar
 
 from kitaru.server.base import ListFilter
-from kitaru.server.filtering import BOOLEAN_OPS, STRING_OPS, FilterField
+from kitaru.server.filtering import (
+    BOOLEAN_OPS,
+    EQUALITY_OPS,
+    STRING_OPS,
+    FilterField,
+)
 
 
 class AccountFilter(ListFilter):
     """Account list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "name": FilterField(value_type=str, ops=STRING_OPS),
         "active": FilterField(value_type=bool, ops=BOOLEAN_OPS),
         "is_service_account": FilterField(value_type=bool, ops=BOOLEAN_OPS),

--- a/src/kitaru/server/application/models/agent.py
+++ b/src/kitaru/server/application/models/agent.py
@@ -13,18 +13,20 @@
 #  permissions and limitations under the License.
 """Agent filter and command models."""
 
+import uuid
 from collections.abc import Mapping
 from typing import ClassVar
 
 from kitaru.base import FrozenModel
 from kitaru.server.base import ListFilter
-from kitaru.server.filtering import STRING_OPS, FilterField
+from kitaru.server.filtering import EQUALITY_OPS, STRING_OPS, FilterField
 
 
 class AgentFilter(ListFilter):
     """Agent list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "name": FilterField(value_type=str, ops=STRING_OPS),
     }
 

--- a/src/kitaru/server/application/models/agent_version.py
+++ b/src/kitaru/server/application/models/agent_version.py
@@ -21,13 +21,14 @@ from kitaru.api_models.v1.filter import FilterOp
 from kitaru.base import FrozenModel
 from kitaru.server.base import ListFilter
 from kitaru.server.domain.agent_version import AgentCapabilities, RunSpec
-from kitaru.server.filtering import FilterField
+from kitaru.server.filtering import EQUALITY_OPS, FilterField
 
 
 class AgentVersionFilter(ListFilter):
     """Agent version list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "tag": FilterField(value_type=str, ops=frozenset({FilterOp.EQ, FilterOp.IN})),
     }
 

--- a/src/kitaru/server/application/models/annotation.py
+++ b/src/kitaru/server/application/models/annotation.py
@@ -27,6 +27,7 @@ class AnnotationFilter(ListFilter):
     """Annotation list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "session_id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "investigation_session_id": FilterField(
             value_type=uuid.UUID, ops=EQUALITY_OPS | NULLABLE_OPS

--- a/src/kitaru/server/application/models/api_key.py
+++ b/src/kitaru/server/application/models/api_key.py
@@ -18,13 +18,14 @@ from collections.abc import Mapping
 from typing import ClassVar
 
 from kitaru.server.base import ListFilter
-from kitaru.server.filtering import STRING_OPS, FilterField
+from kitaru.server.filtering import EQUALITY_OPS, STRING_OPS, FilterField
 
 
 class ApiKeyFilter(ListFilter):
     """API key list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "name": FilterField(value_type=str, ops=STRING_OPS),
     }
 

--- a/src/kitaru/server/application/models/cohort.py
+++ b/src/kitaru/server/application/models/cohort.py
@@ -29,6 +29,7 @@ class CohortFilter(ListFilter):
     """Cohort list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "agent_id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "name": FilterField(value_type=str, ops=STRING_OPS),
         "tag": FilterField(value_type=str, ops=frozenset({FilterOp.EQ, FilterOp.IN})),
@@ -39,6 +40,7 @@ class CohortVersionFilter(ListFilter):
     """Cohort version list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "tag": FilterField(value_type=str, ops=frozenset({FilterOp.EQ, FilterOp.IN})),
     }
 

--- a/src/kitaru/server/application/models/device.py
+++ b/src/kitaru/server/application/models/device.py
@@ -26,6 +26,7 @@ class DeviceFilter(ListFilter):
     """Device list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "status": FilterField(value_type=DeviceStatus, ops=EQUALITY_OPS),
     }
 

--- a/src/kitaru/server/application/models/evaluation.py
+++ b/src/kitaru/server/application/models/evaluation.py
@@ -33,6 +33,7 @@ class EvaluationFilter(ListFilter):
     """Evaluation list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "session_id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "task_id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS | NULLABLE_OPS),
         "evaluator_version_id": FilterField(

--- a/src/kitaru/server/application/models/experiment.py
+++ b/src/kitaru/server/application/models/experiment.py
@@ -29,6 +29,7 @@ class ExperimentFilter(ListFilter):
     """Experiment list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "agent_id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "name": FilterField(value_type=str, ops=STRING_OPS),
         "tag": FilterField(value_type=str, ops=frozenset({FilterOp.EQ, FilterOp.IN})),

--- a/src/kitaru/server/application/models/experiment_run.py
+++ b/src/kitaru/server/application/models/experiment_run.py
@@ -29,6 +29,7 @@ class ExperimentRunFilter(ListFilter):
     """Experiment run list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "experiment_id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "cohort_version_id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "cohort_id": FilterField(value_type=uuid.UUID, ops=SCOPE_OPS),
@@ -43,6 +44,7 @@ class ExperimentRunJobsFilter(ListFilter):
     """Experiment run jobs list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "status": FilterField(value_type=JobStatus, ops=EQUALITY_OPS),
     }
 

--- a/src/kitaru/server/application/models/investigation.py
+++ b/src/kitaru/server/application/models/investigation.py
@@ -31,6 +31,7 @@ class InvestigationFilter(ListFilter):
     """Investigation list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "agent_id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "status": FilterField(value_type=InvestigationStatus, ops=EQUALITY_OPS),
     }

--- a/src/kitaru/server/application/models/job.py
+++ b/src/kitaru/server/application/models/job.py
@@ -30,6 +30,7 @@ class JobFilter(ListFilter):
     """Job list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "kind": FilterField(value_type=JobKind, ops=EQUALITY_OPS),
         "status": FilterField(value_type=JobStatus, ops=EQUALITY_OPS),
     }

--- a/src/kitaru/server/application/models/plugin.py
+++ b/src/kitaru/server/application/models/plugin.py
@@ -22,7 +22,12 @@ from pydantic import Field
 from kitaru.base import FrozenModel
 from kitaru.server.base import ListFilter
 from kitaru.server.domain.plugin import PluginKind
-from kitaru.server.filtering import NULLABLE_OPS, STRING_OPS, FilterField
+from kitaru.server.filtering import (
+    EQUALITY_OPS,
+    NULLABLE_OPS,
+    STRING_OPS,
+    FilterField,
+)
 
 
 class PluginFilter(ListFilter):
@@ -35,6 +40,7 @@ class EvaluatorFilter(PluginFilter):
     """Evaluator list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "name": FilterField(value_type=str, ops=STRING_OPS),
     }
 
@@ -43,6 +49,7 @@ class ImporterFilter(PluginFilter):
     """Importer list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "name": FilterField(value_type=str, ops=STRING_OPS),
         "provider": FilterField(value_type=str, ops=STRING_OPS | NULLABLE_OPS),
     }

--- a/src/kitaru/server/application/models/replay.py
+++ b/src/kitaru/server/application/models/replay.py
@@ -35,6 +35,7 @@ class ReplayFilter(ListFilter):
     """Replay list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "experiment_run_id": FilterField(
             value_type=uuid.UUID, ops=EQUALITY_OPS | NULLABLE_OPS
         ),

--- a/src/kitaru/server/application/models/secret.py
+++ b/src/kitaru/server/application/models/secret.py
@@ -18,13 +18,14 @@ from collections.abc import Mapping
 from typing import ClassVar
 
 from kitaru.server.base import ListFilter
-from kitaru.server.filtering import STRING_OPS, FilterField
+from kitaru.server.filtering import EQUALITY_OPS, STRING_OPS, FilterField
 
 
 class SecretFilter(ListFilter):
     """Secret list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "name": FilterField(value_type=str, ops=STRING_OPS),
     }
 

--- a/src/kitaru/server/application/models/session.py
+++ b/src/kitaru/server/application/models/session.py
@@ -40,6 +40,7 @@ class SessionFilter(ListFilter):
     """Session list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "agent_id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "agent_version_id": FilterField(
             value_type=uuid.UUID, ops=EQUALITY_OPS | NULLABLE_OPS

--- a/src/kitaru/server/application/models/tag.py
+++ b/src/kitaru/server/application/models/tag.py
@@ -13,16 +13,18 @@
 #  permissions and limitations under the License.
 """Tag filter model."""
 
+import uuid
 from collections.abc import Mapping
 from typing import ClassVar
 
 from kitaru.server.base import ListFilter
-from kitaru.server.filtering import STRING_OPS, FilterField
+from kitaru.server.filtering import EQUALITY_OPS, STRING_OPS, FilterField
 
 
 class TagFilter(ListFilter):
     """Tag list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "name": FilterField(value_type=str, ops=STRING_OPS),
     }

--- a/src/kitaru/server/application/models/task.py
+++ b/src/kitaru/server/application/models/task.py
@@ -38,6 +38,7 @@ class TaskFilter(ListFilter):
     """Task list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "job_id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "kind": FilterField(value_type=TaskKind, ops=EQUALITY_OPS),
         "status": FilterField(value_type=TaskStatus, ops=EQUALITY_OPS),
@@ -52,6 +53,7 @@ class JobTasksFilter(TaskFilter):
     """Job tasks list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": TaskFilter.filterable_fields["id"],
         "kind": TaskFilter.filterable_fields["kind"],
         "status": TaskFilter.filterable_fields["status"],
     }

--- a/src/kitaru/server/application/models/worker.py
+++ b/src/kitaru/server/application/models/worker.py
@@ -13,19 +13,21 @@
 #  permissions and limitations under the License.
 """Worker filter model."""
 
+import uuid
 from collections.abc import Mapping
 from typing import ClassVar
 
 from pydantic import AwareDatetime
 
 from kitaru.server.base import ListFilter
-from kitaru.server.filtering import STRING_OPS, FilterField
+from kitaru.server.filtering import EQUALITY_OPS, STRING_OPS, FilterField
 
 
 class WorkerFilter(ListFilter):
     """Worker list filter."""
 
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
+        "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "name": FilterField(value_type=str, ops=STRING_OPS),
     }
 


### PR DESCRIPTION
Every filterable entity list now filters by `id`, including `in` over a list of ids.