### PR TITLE
Allow fresh core releases in plugin checks

### DIFF
--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -105,7 +105,9 @@ jobs:
           set -euo pipefail
           wheel=$(find package-dist -maxdepth 1 -name '*.whl' -print -quit)
           test -n "$wheel"
-          DIST_FILE="$wheel" uv run --no-project --with "$wheel" python - <<'PY'
+          DIST_FILE="$wheel" uv run --no-project \
+            --exclude-newer-package "kitaru=0 days" \
+            --with "$wheel" python - <<'PY'
           import importlib.metadata
           import os
           assert importlib.metadata.version(os.environ["DISTRIBUTION"]) == os.environ["VERSION"]

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -227,6 +227,12 @@ def test_python_release_workflow_can_resume_after_partial_publication() -> None:
     )
 
 
+def test_python_release_workflow_can_install_a_new_core_release() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release-plugins.yml").read_text()
+
+    assert '--exclude-newer-package "kitaru=0 days"' in workflow
+
+
 def test_ci_plugin_matrix_is_loaded_from_the_release_inventory() -> None:
     workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
 


### PR DESCRIPTION
## What changed

- override the repository's three-day `exclude-newer` window for the `kitaru` package during the clean plugin installation check
- retain the cutoff for every other dependency
- add regression coverage for the release workflow setting

## Root cause

The plugin wheels depend on `kitaru>=0.22.0rc0,<0.23`. The repository config uses `exclude-newer = "3 days"`, so `uv` saw the newly published core RC on PyPI but filtered it out during the installation test.

## Validation

- resolved `kitaru 0.22.0rc0` with `--exclude-newer-package "kitaru=0 days"`
- `uv run pytest -q tests/scripts/test_release_units.py` (35 passed)
- `uv run ruff check tests/scripts/test_release_units.py`
- `uv run ruff format --check tests/scripts/test_release_units.py`
- parsed `.github/workflows/release-plugins.yml` with PyYAML
- `git diff --check`

## Release recovery

The failed plugin tags reference the previous workflow commit. Since neither plugin was published, delete those tags after this PR merges, recreate them on the new `develop` HEAD, and push them again.