### PR TITLE
Publish deployables after core releases

### DIFF
--- a/.agents/skills/kitaru-tests-release/SKILL.md
+++ b/.agents/skills/kitaru-tests-release/SKILL.md
@@ -97,20 +97,22 @@ Do not describe the inherited `llm-integration.yml` provider markers or absent `
 
 `.github/workflows/docs.yml` runs on manual dispatch, `main` pushes, and selected docs/reference pull-request paths. It is configured to regenerate SDK reference docs and build the FumaDocs export, but the v2 checkout currently lacks `scripts/generate_sdk_docs.py`; treat that workflow as blocked until a v2 generator is restored. Deployment conditions remain `main` push or manual dispatch, and hand-written docs publish separately through GitBook Git Sync.
 
-## Release Workflow
+## Release Workflows
 
-The authoritative release procedure is `.github/workflows/release.yml`. A normal dispatch checks out `develop`; a recovery dispatch may reuse an existing release tag. Therefore a v2 feature branch cannot be released through the normal dispatch until the intended v2 history is present on the release source branch.
+`.github/workflows/release-plugins.yml` publishes one Python distribution from an immutable namespaced tag. A core tag such as `python/kitaru/v0.22.0rc1` publishes Kitaru to PyPI and creates its GitHub Release. Plugin tags publish independently and do not gate the core release.
 
-Before dispatching:
+After a successful core Python workflow, `.github/workflows/release.yml` automatically publishes the matching client, server, worker, and managed images plus the Helm chart. It converts Python RC versions such as `0.22.0rc1` to deployable tags such as `0.22.0-rc.1`. No separate bundle tag is used. A manual dispatch with the existing core package tag is the recovery path.
+
+Before creating a core tag:
 
 1. Fetch `develop`, `main`, and tags.
 2. Confirm the intended release commits are on `develop` and identify the last immutable release tag.
-3. Review the `[Unreleased]` changelog and version classification.
+3. Review the changelog and version classification.
 4. Confirm no other release run is active.
 5. Run `just check`, the relevant base/CLI/MCP tests, `just mcp-schema-check`, `just cli-artifact-smoke`, `just plugin-artifact-smoke`, `just migration-check`, and `just build` as applicable. Run `just mcp-wheel-smoke` only after `just build`; it consumes the wheel under `dist/`.
-6. Use the workflow's `dry-run` input when a non-publishing rehearsal is needed.
+6. Dispatch `release-plugins.yml` with the proposed package tag when a non-publishing rehearsal is needed.
 
-The release workflow itself installs the CLI, MCP, and worker extras; checks lint, types, MCP schemas, base/CLI/MCP tests, clean CLI artifacts, migrations, UI wheel contents, and the installed MCP wheel contract; then handles versioning, tagging, PyPI, GitHub Release, public and managed images, Helm packaging, release branches, and `main` advancement.
+The core Python workflow builds and verifies the wheel, publishes it to PyPI, and creates the GitHub Release. The deployables workflow then verifies the core package, tests the release images, publishes the images and Helm chart, and attaches the chart to the core GitHub Release. Stable releases also move the Docker `latest` aliases.
 
 Do not use the removed `scripts/smoke-test.sh`, provider-area flags, remote-stack smoke, v1 adapters, or local ZenML flow runs as v2 release gates.
 
@@ -119,6 +121,7 @@ Do not use the removed `scripts/smoke-test.sh`, provider-area flags, remote-stac
 - Default branch is `develop`.
 - Pull requests normally target `develop`; v2 feature work may target its explicit integration branch until that migration lands.
 - `main` tracks the latest released version only; do not push directly.
-- Releases are cut through `.github/workflows/release.yml` by dispatch or `v*` tag push.
-- The workflow maintains the version in `pyproject.toml`; application code should use `importlib.metadata.version("kitaru")` rather than hardcoding it.
+- Python releases are cut with namespaced tags handled by `.github/workflows/release-plugins.yml`.
+- A successful core Python release automatically starts `.github/workflows/release.yml`; manual dispatch is reserved for recovery.
+- Release preparation maintains the version in `pyproject.toml`; application code should use `importlib.metadata.version("kitaru")` rather than hardcoding it.
 - Update `CHANGELOG.md` under `[Unreleased]` for user-facing changes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,25 @@
 ---
-name: Release Kitaru bundle
+name: Release Kitaru deployables
 on:
+  workflow_run:
+    workflows: [Release Python package]
+    types: [completed]
   workflow_dispatch:
     inputs:
-      version:
-        description: Bundle version to rehearse, such as 0.22.0-rc.1.
+      package-tag:
+        description: Existing core package tag to publish, such as python/kitaru/v0.22.0rc1.
         required: true
         type: string
-  push:
-    tags: [bundle/kitaru/v*]
 permissions: {}
 concurrency:
-  group: release-bundle-${{ github.ref_name }}
+  group: release-deployables-${{ github.event.workflow_run.head_branch || inputs.package-tag }}
   cancel-in-progress: false
 jobs:
   prepare:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'python/kitaru/v'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,9 +27,11 @@ jobs:
       bundle-version: ${{ steps.metadata.outputs.bundle-version }}
       is-prerelease: ${{ steps.metadata.outputs.is-prerelease }}
       kitaru-version: ${{ steps.metadata.outputs.kitaru-version }}
+      package-tag: ${{ steps.metadata.outputs.package-tag }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ github.event.workflow_run.head_sha || inputs.package-tag }}
           fetch-depth: 0
           persist-credentials: false
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
@@ -34,24 +41,26 @@ jobs:
       - name: Resolve bundle metadata
         id: metadata
         env:
-          DISPATCH_VERSION: ${{ inputs.version }}
+          DISPATCH_TAG: ${{ inputs.package-tag }}
           EVENT_NAME: ${{ github.event_name }}
-          PUSH_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = push ]; then
-            bundle_version=${PUSH_TAG#bundle/kitaru/v}
+          if [ "$EVENT_NAME" = workflow_run ]; then
+            package_tag="$RELEASE_TAG"
           else
-            bundle_version="$DISPATCH_VERSION"
+            package_tag="$DISPATCH_TAG"
           fi
-          if [[ "$bundle_version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-rc\.([0-9]+)$ ]]; then
+          if [[ "$package_tag" =~ ^python/kitaru/v([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)$ ]]; then
             kitaru_version="${BASH_REMATCH[1]}rc${BASH_REMATCH[2]}"
+            bundle_version="${BASH_REMATCH[1]}-rc.${BASH_REMATCH[2]}"
             is_prerelease=true
-          elif [[ "$bundle_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            kitaru_version="$bundle_version"
+          elif [[ "$package_tag" =~ ^python/kitaru/v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            kitaru_version="${BASH_REMATCH[1]}"
+            bundle_version="$kitaru_version"
             is_prerelease=false
           else
-            echo "::error::Expected X.Y.Z or X.Y.Z-rc.N, got $bundle_version"
+            echo "::error::Expected python/kitaru/vX.Y.Z or python/kitaru/vX.Y.ZrcN, got $package_tag"
             exit 1
           fi
           manifest_version=$(uv version --short)
@@ -63,11 +72,13 @@ jobs:
             printf 'BUNDLE_VERSION=%s\n' "$bundle_version"
             printf 'IS_PRERELEASE=%s\n' "$is_prerelease"
             printf 'KITARU_VERSION=%s\n' "$kitaru_version"
+            printf 'PACKAGE_TAG=%s\n' "$package_tag"
           } >> "$GITHUB_ENV"
           {
             printf 'bundle-version=%s\n' "$bundle_version"
             printf 'is-prerelease=%s\n' "$is_prerelease"
             printf 'kitaru-version=%s\n' "$kitaru_version"
+            printf 'package-tag=%s\n' "$package_tag"
           } >> "$GITHUB_OUTPUT"
       - name: Validate bundle source
         run: |
@@ -78,16 +89,8 @@ jobs:
             echo "::error::Bundle source $release_sha is not on develop."
             exit 1
           fi
-      - name: Confirm Python packages exist on PyPI
-        run: |
-          set -euo pipefail
-          curl -fsS "https://pypi.org/pypi/kitaru/$KITARU_VERSION/json" >/dev/null
-          while read -r requirement; do
-            test -z "$requirement" && continue
-            package=${requirement%%==*}
-            version=${requirement#*==}
-            curl -fsS "https://pypi.org/pypi/$package/$version/json" >/dev/null
-          done < plugins/default-requirements.txt
+      - name: Confirm Kitaru exists on PyPI
+        run: curl -fsS "https://pypi.org/pypi/kitaru/$KITARU_VERSION/json" >/dev/null
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
       - name: Build and test client image
         run: |
@@ -124,10 +127,8 @@ jobs:
           if-no-files-found: error
           retention-days: 90
   publish:
-    if: github.event_name == 'push'
     needs: prepare
     runs-on: ubuntu-latest
-    environment: bundle-publish
     permissions:
       contents: write
       id-token: write
@@ -193,27 +194,19 @@ jobs:
           BUNDLE_VERSION: ${{ needs.prepare.outputs.bundle-version }}
           REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
         run: helm push "bundle-dist/kitaru-$BUNDLE_VERSION.tgz" "oci://$REGISTRY/zenml"
-      - name: Create bundle GitHub Release
+      - name: Attach Helm chart to the core GitHub Release
         env:
-          BUNDLE_VERSION: ${{ needs.prepare.outputs.bundle-version }}
           GH_TOKEN: ${{ github.token }}
-          IS_PRERELEASE: ${{ needs.prepare.outputs.is-prerelease }}
+          GH_REPO: ${{ github.repository }}
+          PACKAGE_TAG: ${{ needs.prepare.outputs.package-tag }}
         run: |
-          prerelease=()
-          if [ "$IS_PRERELEASE" = true ]; then
-            prerelease+=(--prerelease)
-          fi
-          gh release create "$GITHUB_REF_NAME" bundle-dist/* \
-            "${prerelease[@]}" \
-            --verify-tag \
-            --latest=false \
-            --title "Kitaru $BUNDLE_VERSION" \
-            --generate-notes
+          set -euo pipefail
+          gh release view "$PACKAGE_TAG" >/dev/null
+          gh release upload "$PACKAGE_TAG" bundle-dist/* --clobber
   promote-latest:
-    if: github.event_name == 'push' && needs.prepare.outputs.is-prerelease == 'false'
+    if: needs.prepare.outputs.is-prerelease == 'false'
     needs: [prepare, publish]
     runs-on: ubuntu-latest
-    environment: bundle-promotion
     permissions: {}
     steps:
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0

--- a/docker/release-client.Dockerfile
+++ b/docker/release-client.Dockerfile
@@ -68,6 +68,7 @@ RUN test -n "$KITARU_VERSION" && \
   uv pip install \
     --no-deps \
     --only-binary=:all: \
+    --exclude-newer-package "kitaru=0 days" \
     "kitaru==$KITARU_VERSION" && \
   uv pip check && \
   python -c "import kitaru" && \

--- a/docker/release-server.Dockerfile
+++ b/docker/release-server.Dockerfile
@@ -73,6 +73,7 @@ RUN test -n "$KITARU_VERSION" && \
   uv pip install \
     --no-deps \
     --only-binary=:all: \
+    --exclude-newer-package "kitaru=0 days" \
     "kitaru==$KITARU_VERSION" && \
   uv pip check && \
   python -c \

--- a/docker/release-worker.Dockerfile
+++ b/docker/release-worker.Dockerfile
@@ -68,6 +68,7 @@ RUN test -n "$KITARU_VERSION" && \
   uv pip install \
     --no-deps \
     --only-binary=:all: \
+    --exclude-newer-package "kitaru=0 days" \
     "kitaru==$KITARU_VERSION" && \
   uv pip check && \
   python -c "import kitaru" && \

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -102,12 +102,29 @@ def test_local_python_versions_are_rejected_for_pypi() -> None:
         validate_version("1.0+build.1")
 
 
-def test_bundle_workflow_maps_semver_rc_to_python_rc() -> None:
+def test_core_release_publishes_deployables_without_waiting_for_plugins() -> None:
     workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
 
-    assert "bundle/kitaru/v*" in workflow
-    assert 'kitaru_version="${BASH_REMATCH[1]}rc${BASH_REMATCH[2]}"' in workflow
+    assert "workflows: [Release Python package]" in workflow
+    assert "bundle/kitaru/v*" not in workflow
+    assert (
+        "startsWith(github.event.workflow_run.head_branch, 'python/kitaru/v')"
+        in workflow
+    )
+    assert "plugins/default-requirements.txt" not in workflow
+    assert 'bundle_version="${BASH_REMATCH[1]}-rc.${BASH_REMATCH[2]}"' in workflow
+    assert 'gh release upload "$PACKAGE_TAG" bundle-dist/* --clobber' in workflow
     assert "promote-latest:" in workflow
+
+
+def test_release_images_can_install_a_new_core_release() -> None:
+    for dockerfile in (
+        "docker/release-client.Dockerfile",
+        "docker/release-server.Dockerfile",
+        "docker/release-worker.Dockerfile",
+    ):
+        content = (REPO_ROOT / dockerfile).read_text()
+        assert '--exclude-newer-package "kitaru=0 days"' in content
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- trigger deployable publication after a successful `Release Python package` run for a `python/kitaru/v*` tag
- derive deployable RC tags such as `0.22.0-rc.0` from Python versions such as `0.22.0rc0`
- remove the separate `bundle/kitaru/v*` trigger
- remove the gate requiring default plugin packages to exist before images are built
- attach the Helm chart to the existing core GitHub Release
- retain manual dispatch with a core package tag as the recovery path
- allow the three release Dockerfiles to install a core package published within the repository's three-day cutoff
- update the repository release skill and regression tests

## Release behavior

A core package tag publishes the wheel and GitHub Release through `release-plugins.yml`. When that workflow succeeds, `release.yml` publishes the client, server, worker, managed image, and Helm chart. Plugin tags remain independent. Stable core releases also move Docker `latest`; RC releases do not.

## Tradeoff

Default plugin package references may be unavailable for a short period while their independent release workflows finish. The deployable images themselves do not install those plugin packages.

## Validation

- `uv run pytest -q tests/scripts/test_release_units.py` (36 passed)
- `uv run ruff check tests/scripts/test_release_units.py`
- `uv run ruff format --check tests/scripts/test_release_units.py`
- parsed `.github/workflows/release.yml` with PyYAML
- `git diff --check`

## Recovering 0.22.0rc0

After this PR merges, manually dispatch `Release Kitaru deployables` with `python/kitaru/v0.22.0rc0`. Future core releases trigger it automatically.