### PR TITLE
Prepare Kitaru 0.22.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.22.0rc1]
+
+### Changed
+
+- Prepared the second Kitaru 0.22 release candidate with the frontend from RC0 and the current `develop` source.
+
 ## [0.22.0rc0]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.22.0rc0"
+version = "0.22.0rc1"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/releases/python/kitaru/0.22.0rc1.toml
+++ b/releases/python/kitaru/0.22.0rc1.toml
@@ -1,0 +1,3 @@
+schema-version = 1
+kitaru-version = "0.22.0rc1"
+ui-tag = "kitaru-ui-v0.2.0-rc.1"

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-10T10:10:44.774005Z"
+exclude-newer = "2026-08-10T12:16:02.367381Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.0rc0"
+version = "0.22.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What changed

- bump the core package version to `0.22.0rc1`
- update the root lockfile
- add the RC1 changelog entry
- declare `kitaru-ui-v0.2.0-rc.1` as the frontend artifact for RC1

## Release order

Merge #737 first so the RC1 core release automatically publishes Docker images, the managed image, and the Helm chart. Then merge this PR and tag the resulting `develop` HEAD with `python/kitaru/v0.22.0rc1`.

RC1 reuses the frontend tag that the completed RC0 build downloaded and verified.

## Validation

- `scripts/release_ui.py --version 0.22.0rc1` resolves the expected frontend contract
- `scripts/release_units.py resolve --tag python/kitaru/v0.22.0rc1` resolves the expected core release unit
- `uv lock --check`
- focused release tests: 38 passed
- Ruff check and format check passed
- `git diff --check`