### PR TITLE
Fix empty database TLS values in Helm chart

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -261,41 +261,44 @@ server:
     # NOTE: it is recommended to use the `server.certificates` option instead to
     # configure the CA certificate globally. This option only applies to the
     # PostgreSQL database.
-    sslCa:
-      # value: |
-      #   -----BEGIN CERTIFICATE-----
-      #   ...
-      #   -----END CERTIFICATE-----
-      #
-      # secretRef:
-      #   name: ca-certificate
-      #   key: ca.pem
+    # sslCa:
+    #   value: |
+    #     -----BEGIN CERTIFICATE-----
+    #     ...
+    #     -----END CERTIFICATE-----
+    #
+    #   secretRef:
+    #     name: ca-certificate
+    #     key: ca.pem
+    sslCa: {}
 
     # The PostgreSQL SSL client certificate. Required for SSL enabled authentication
     # if client certificates are used. Can be provided as an inline value or as
     # a Kubernetes secret reference.
-    sslCert:
-      # value: |
-      #   -----BEGIN CERTIFICATE-----
-      #   ...
-      #   -----END CERTIFICATE-----
-      #
-      # secretRef:
-      #   name: client-certificate
-      #   key: client-cert.pem
+    # sslCert:
+    #   value: |
+    #     -----BEGIN CERTIFICATE-----
+    #     ...
+    #     -----END CERTIFICATE-----
+    #
+    #   secretRef:
+    #     name: client-certificate
+    #     key: client-cert.pem
+    sslCert: {}
 
     # The PostgreSQL SSL client key. Required for SSL enabled authentication if
     # client certificates are used. Can be provided as an inline value or as
     # a Kubernetes secret reference.
-    sslKey:
-      # value: |
-      #   -----BEGIN PRIVATE KEY-----
-      #   ...
-      #   -----END PRIVATE KEY-----
-      #
-      # secretRef:
-      #   name: client-key
-      #   key: client-key.pem
+    # sslKey:
+    #   value: |
+    #     -----BEGIN PRIVATE KEY-----
+    #     ...
+    #     -----END PRIVATE KEY-----
+    #
+    #   secretRef:
+    #     name: client-key
+    #     key: client-key.pem
+    sslKey: {}
 
     # SQLAlchemy connection pool settings.
     poolSize: 5


### PR DESCRIPTION
## What changed

- define the default PostgreSQL TLS certificate settings as empty maps
- keep the inline and secret-reference examples in `values.yaml`

## Why

The Kitaru `0.22.0rc1` deployables workflow reached Helm lint after all three Docker images built. Helm parsed the empty `sslCa`, `sslCert`, and `sslKey` entries as null, so `database-cert-secret.yaml` failed when accessing their nested `value` properties.

## Validation

- `git diff --check`
- parsed `helm/values.yaml` and confirmed all three defaults are empty maps
- `docker run --rm -v /Users/alexej/Projects/kitaru:/work -w /work alpine/helm:3.9.2 lint ./helm`

The Helm 3.9.2 lint completed with 0 failed charts.