### PR TITLE
Use distinct PyPI environments per distribution

### DIFF
--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -129,7 +129,8 @@ jobs:
     if: github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
-    environment: pypi
+    environment:
+      name: pypi-${{ needs.build.outputs.distribution }}
     permissions:
       contents: write
       id-token: write

--- a/plugins/DEVELOPMENT.md
+++ b/plugins/DEVELOPMENT.md
@@ -313,11 +313,11 @@ Each distribution needs a PyPI Trusted Publisher. If the PyPI project does not e
 | GitHub owner | `zenml-io` |
 | GitHub repository | `kitaru` |
 | Workflow filename | `release-plugins.yml` |
-| Environment | `pypi` |
+| Environment | `pypi-<distribution>`; for example, `pypi-kitaru-langfuse-importer` |
 
 A pending publisher creates the PyPI project during its first successful upload. It does not reserve the project name before that upload.
 
-The GitHub `pypi` environment should restrict deployment approval to release maintainers. The workflow uses GitHub OIDC and does not require a stored PyPI API token.
+Create one GitHub environment named `pypi-<distribution>` for each distribution. The workflow selects that environment from the release inventory, which gives every PyPI project a distinct OIDC identity while retaining one workflow file. The workflow uses GitHub OIDC and does not require a stored PyPI API token.
 
 ## Run a release dry-run
 

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -230,6 +230,7 @@ def test_python_release_workflow_resolves_every_tag_from_the_inventory() -> None
     assert "scripts/release_units.py resolve --tag" in workflow
     assert "scripts/release_ui.py --version" in workflow
     assert "uv version" not in workflow
+    assert "name: pypi-${{ needs.build.outputs.distribution }}" in workflow
 
 
 def test_python_release_workflow_can_resume_after_partial_publication() -> None:


### PR DESCRIPTION
## What changed

- select `pypi-${distribution}` as the GitHub environment for each Python package publish job
- keep one release workflow while giving each PyPI project a distinct OIDC identity
- document the matching environment required for existing and pending PyPI publishers
- add regression coverage for the environment contract

## Root cause

All ten distributions used the same repository, workflow filename, and `pypi` environment. Those identical OIDC claims matched several PyPI projects and pending publishers. PyPI could mint a token scoped to a different project, causing uploads such as Langsmith to fail with `OIDC scoped token is not valid for project`.

## Required setup after merge

Create or allow GitHub to create environments named `pypi-<distribution>`. Update each existing PyPI trusted publisher and each pending publisher to use its exact matching environment, for example `pypi-kitaru-langsmith-importer`.

Failed runs tagged before this change retain the old workflow and environment. Recreate unpublished package tags on the merged `develop` commit before retrying them.

## Validation

- verified the workflow uses `pypi-${{ needs.build.outputs.distribution }}`
- verified the shared `environment: pypi` declaration is absent
- added a release-workflow regression assertion
- verified the setup documentation uses the same environment contract