### PR TITLE
Prepare Kitaru 0.22.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.22.0rc2]
+
+### Fixed
+
+- Fixed Helm rendering when the database TLS certificate settings are left empty.
+
 ## [0.22.0rc1]
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.22.0rc1"
+version = "0.22.0rc2"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/releases/python/kitaru/0.22.0rc2.toml
+++ b/releases/python/kitaru/0.22.0rc2.toml
@@ -1,0 +1,3 @@
+schema-version = 1
+kitaru-version = "0.22.0rc2"
+ui-tag = "kitaru-ui-v0.2.0-rc.1"

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.0rc1"
+version = "0.22.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## What changed

- bump the Kitaru package and lockfile to `0.22.0rc2`
- add the RC2 changelog entry for the Helm rendering fix
- declare the RC2 frontend artifact using `kitaru-ui-v0.2.0-rc.1`

## Why

RC2 includes the Helm null-value fix from PR #739 so the deployables workflow can lint and package the chart.

## Validation

- `uv lock --check --offline`
- `pytest tests/scripts/test_release_ui.py` (3 passed)
- Helm 3.9.2 lint (0 failed charts)