### PR TITLE
Harden deployable release failure handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,11 +173,19 @@ jobs:
           build-args: KITARU_VERSION=${{ needs.prepare.outputs.kitaru-version }}
           tags: zenmldocker/kitaru-server:${{ needs.prepare.outputs.bundle-version }}
       - name: Publish managed image
+        id: publish-managed-image
+        continue-on-error: true
         uses: ./.github/actions/publish-managed-image
         with:
           package-version: ${{ needs.prepare.outputs.kitaru-version }}
           image-tag: ${{ needs.prepare.outputs.bundle-version }}
           aws-role-arn: ${{ vars.KITARU_ECR_ROLE_ARN }}
+      - name: Report managed image failure
+        if: steps.publish-managed-image.outcome == 'failure'
+        run: |
+          echo "::warning::Managed image publication failed; continuing with the public release artifacts."
+          echo "### Managed image publication failed" >> "$GITHUB_STEP_SUMMARY"
+          echo "The private ECR image is unavailable for this release. Public Docker Hub images and the Helm chart continue publishing." >> "$GITHUB_STEP_SUMMARY"
       - name: Configure AWS credentials for Helm
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d  # v6.2.2
         with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,5 +7,8 @@ rules:
   # dangerous-triggers: docs.yml uses pull_request_target only for preview
   # cleanup on closed/drafted same-repo PRs. The cleanup job does not checkout
   # or run PR-controlled code; it only deletes a deterministic Worker name.
+  # release.yml follows a successful tag/manual package release. That upstream
+  # workflow does not run on pull requests, and release.yml verifies that the
+  # release commit belongs to develop before granting publish permissions.
   dangerous-triggers:
-    ignore: [docs.yml:3]
+    ignore: [docs.yml:3, release.yml:3]

--- a/docker/install-release-wheel.sh
+++ b/docker/install-release-wheel.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+attempt=1
+max_attempts=${KITARU_INSTALL_ATTEMPTS:-10}
+retry_delay=${KITARU_INSTALL_RETRY_DELAY:-15}
+
+while ! uv pip install \
+  --no-deps \
+  --only-binary=:all: \
+  --exclude-newer-package "kitaru=0 days" \
+  --refresh-package kitaru \
+  "kitaru==$KITARU_VERSION"
+do
+  if [ "$attempt" -ge "$max_attempts" ]; then
+    exit 1
+  fi
+  echo "Kitaru $KITARU_VERSION is not available yet; retrying"
+  sleep "$retry_delay"
+  attempt=$((attempt + 1))
+done

--- a/docker/release-client.Dockerfile
+++ b/docker/release-client.Dockerfile
@@ -49,6 +49,7 @@ ARG KITARU_VERSION
 
 COPY --from=uv /uv /uvx /bin/
 COPY --chown=$USERNAME:$USER_GID pyproject.toml uv.lock ./
+COPY --chown=$USERNAME:$USER_GID docker/install-release-wheel.sh ./
 
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy \
@@ -65,11 +66,7 @@ USER $USERNAME
 RUN test -n "$KITARU_VERSION" && \
   test "$(uv version --short)" = "$KITARU_VERSION" && \
   uv sync --locked --no-dev --no-install-project && \
-  uv pip install \
-    --no-deps \
-    --only-binary=:all: \
-    --exclude-newer-package "kitaru=0 days" \
-    "kitaru==$KITARU_VERSION" && \
+  sh ./install-release-wheel.sh && \
   uv pip check && \
   python -c "import kitaru" && \
   uv pip freeze > requirements.txt

--- a/docker/release-server.Dockerfile
+++ b/docker/release-server.Dockerfile
@@ -49,6 +49,7 @@ ARG KITARU_VERSION
 
 COPY --from=uv /uv /uvx /bin/
 COPY --chown=$USERNAME:$USER_GID pyproject.toml uv.lock ./
+COPY --chown=$USERNAME:$USER_GID docker/install-release-wheel.sh ./
 
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy \
@@ -70,11 +71,7 @@ RUN test -n "$KITARU_VERSION" && \
     --no-install-project \
     --extra server \
     --extra otel && \
-  uv pip install \
-    --no-deps \
-    --only-binary=:all: \
-    --exclude-newer-package "kitaru=0 days" \
-    "kitaru==$KITARU_VERSION" && \
+  sh ./install-release-wheel.sh && \
   uv pip check && \
   python -c \
     "from kitaru.server.api.main import app; assert callable(app)" && \

--- a/docker/release-worker.Dockerfile
+++ b/docker/release-worker.Dockerfile
@@ -49,6 +49,7 @@ ARG KITARU_VERSION
 
 COPY --from=uv /uv /uvx /bin/
 COPY --chown=$USERNAME:$USER_GID pyproject.toml uv.lock ./
+COPY --chown=$USERNAME:$USER_GID docker/install-release-wheel.sh ./
 
 ENV UV_COMPILE_BYTECODE=1 \
   UV_LINK_MODE=copy \
@@ -65,11 +66,7 @@ USER $USERNAME
 RUN test -n "$KITARU_VERSION" && \
   test "$(uv version --short)" = "$KITARU_VERSION" && \
   uv sync --locked --no-dev --no-install-project --extra worker && \
-  uv pip install \
-    --no-deps \
-    --only-binary=:all: \
-    --exclude-newer-package "kitaru=0 days" \
-    "kitaru==$KITARU_VERSION" && \
+  sh ./install-release-wheel.sh && \
   uv pip check && \
   python -c "import kitaru" && \
   uv pip freeze > requirements.txt

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8527,7 +8527,7 @@
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.21.0"
+    "version": "0.22.0rc2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -117,14 +118,93 @@ def test_core_release_publishes_deployables_without_waiting_for_plugins() -> Non
     assert "promote-latest:" in workflow
 
 
-def test_release_images_can_install_a_new_core_release() -> None:
+def test_release_images_use_the_pypi_propagation_retry() -> None:
     for dockerfile in (
         "docker/release-client.Dockerfile",
         "docker/release-server.Dockerfile",
         "docker/release-worker.Dockerfile",
     ):
         content = (REPO_ROOT / dockerfile).read_text()
-        assert '--exclude-newer-package "kitaru=0 days"' in content
+        assert "COPY --chown=$USERNAME:$USER_GID " in content
+        assert "docker/install-release-wheel.sh ./" in content
+        assert "sh ./install-release-wheel.sh" in content
+
+
+def test_release_wheel_install_retries_until_the_package_is_available(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    attempts = tmp_path / "attempts"
+    (fake_bin / "uv").write_text(
+        "#!/bin/sh\n"
+        'attempt=$(($(cat "$ATTEMPTS" 2>/dev/null || echo 0) + 1))\n'
+        'printf "%s\\n" "$attempt" > "$ATTEMPTS"\n'
+        'printf "%s\\n" "$*" >> "$UV_ARGS"\n'
+        '[ "$attempt" -ge 3 ]\n'
+    )
+    (fake_bin / "sleep").write_text('#!/bin/sh\nprintf "%s\\n" "$1" >> "$SLEEPS"\n')
+    (fake_bin / "uv").chmod(0o755)
+    (fake_bin / "sleep").chmod(0o755)
+    env = {
+        **os.environ,
+        "ATTEMPTS": str(attempts),
+        "KITARU_INSTALL_RETRY_DELAY": "0",
+        "KITARU_VERSION": "0.22.0rc2",
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "SLEEPS": str(tmp_path / "sleeps"),
+        "UV_ARGS": str(tmp_path / "uv-args"),
+    }
+
+    result = subprocess.run(
+        ["sh", str(REPO_ROOT / "docker" / "install-release-wheel.sh")],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert attempts.read_text() == "3\n"
+    assert (tmp_path / "sleeps").read_text() == "0\n0\n"
+    uv_args = (tmp_path / "uv-args").read_text().splitlines()
+    assert len(uv_args) == 3
+    assert all("--refresh-package kitaru" in args for args in uv_args)
+    assert all("kitaru==0.22.0rc2" in args for args in uv_args)
+
+
+def test_release_wheel_install_fails_after_the_attempt_limit(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    attempts = tmp_path / "attempts"
+    (fake_bin / "uv").write_text(
+        "#!/bin/sh\n"
+        'attempt=$(($(cat "$ATTEMPTS" 2>/dev/null || echo 0) + 1))\n'
+        'printf "%s\\n" "$attempt" > "$ATTEMPTS"\n'
+        "exit 1\n"
+    )
+    (fake_bin / "sleep").write_text("#!/bin/sh\nexit 0\n")
+    (fake_bin / "uv").chmod(0o755)
+    (fake_bin / "sleep").chmod(0o755)
+    env = {
+        **os.environ,
+        "ATTEMPTS": str(attempts),
+        "KITARU_INSTALL_ATTEMPTS": "3",
+        "KITARU_INSTALL_RETRY_DELAY": "0",
+        "KITARU_VERSION": "0.22.0rc2",
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+    }
+
+    result = subprocess.run(
+        ["sh", str(REPO_ROOT / "docker" / "install-release-wheel.sh")],
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert attempts.read_text() == "3\n"
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -6,7 +6,6 @@ import sys
 from pathlib import Path
 
 import pytest
-import yaml
 from scripts.release_units import (
     ReleaseInventoryError,
     build_plugin_matrix,
@@ -120,28 +119,19 @@ def test_core_release_publishes_deployables_without_waiting_for_plugins() -> Non
 
 
 def test_managed_image_failure_does_not_block_the_release() -> None:
-    workflow = yaml.safe_load(
-        (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
-    )
-    publish_steps = workflow["jobs"]["publish"]["steps"]
-    steps_by_name = {step["name"]: step for step in publish_steps if "name" in step}
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
+    managed_start = workflow.index("      - name: Publish managed image\n")
+    report_start = workflow.index("      - name: Report managed image failure\n")
+    helm_start = workflow.index("      - name: Configure AWS credentials for Helm\n")
+    managed_step = workflow[managed_start:report_start]
+    report_step = workflow[report_start:helm_start]
 
-    managed_step = steps_by_name["Publish managed image"]
-    report_step = steps_by_name["Report managed image failure"]
-    assert managed_step["id"] == "publish-managed-image"
-    assert managed_step["continue-on-error"] is True
-    assert report_step["if"] == "steps.publish-managed-image.outcome == 'failure'"
-    assert "::warning::Managed image publication failed" in report_step["run"]
-    assert "GITHUB_STEP_SUMMARY" in report_step["run"]
-    assert next(
-        index
-        for index, step in enumerate(publish_steps)
-        if step.get("name") == "Publish managed image"
-    ) < next(
-        index
-        for index, step in enumerate(publish_steps)
-        if step.get("name") == "Publish Helm chart"
-    )
+    assert "        id: publish-managed-image\n" in managed_step
+    assert "        continue-on-error: true\n" in managed_step
+    assert workflow.count("continue-on-error: true") == 1
+    assert "if: steps.publish-managed-image.outcome == 'failure'" in report_step
+    assert "::warning::Managed image publication failed" in report_step
+    assert "GITHUB_STEP_SUMMARY" in report_step
 
 
 def test_release_images_use_the_pypi_propagation_retry() -> None:

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 from scripts.release_units import (
     ReleaseInventoryError,
     build_plugin_matrix,
@@ -116,6 +117,31 @@ def test_core_release_publishes_deployables_without_waiting_for_plugins() -> Non
     assert 'bundle_version="${BASH_REMATCH[1]}-rc.${BASH_REMATCH[2]}"' in workflow
     assert 'gh release upload "$PACKAGE_TAG" bundle-dist/* --clobber' in workflow
     assert "promote-latest:" in workflow
+
+
+def test_managed_image_failure_does_not_block_the_release() -> None:
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
+    )
+    publish_steps = workflow["jobs"]["publish"]["steps"]
+    steps_by_name = {step["name"]: step for step in publish_steps if "name" in step}
+
+    managed_step = steps_by_name["Publish managed image"]
+    report_step = steps_by_name["Report managed image failure"]
+    assert managed_step["id"] == "publish-managed-image"
+    assert managed_step["continue-on-error"] is True
+    assert report_step["if"] == "steps.publish-managed-image.outcome == 'failure'"
+    assert "::warning::Managed image publication failed" in report_step["run"]
+    assert "GITHUB_STEP_SUMMARY" in report_step["run"]
+    assert next(
+        index
+        for index, step in enumerate(publish_steps)
+        if step.get("name") == "Publish managed image"
+    ) < next(
+        index
+        for index, step in enumerate(publish_steps)
+        if step.get("name") == "Publish Helm chart"
+    )
 
 
 def test_release_images_use_the_pypi_propagation_retry() -> None:


### PR DESCRIPTION
## What changed?

Deployable releases now tolerate the two external availability failures encountered during the `0.22.0rc2` release. Release-image builds retry an exact Kitaru wheel install while the PyPI package index catches up with the upload API. A failed private ECR publication no longer blocks the public Docker Hub images, Helm chart, or GitHub release attachment.

The managed-image attempt still runs. If it fails, the workflow emits an Actions warning and records the missing private image in the job summary. All required public publication steps remain fail-fast.

## Why?

The first RC2 run started ten seconds after the package workflow completed. PyPI's JSON API contained `0.22.0rc2`, but the index used by uv did not yet expose it. The rerun built and published all three Docker Hub images, then stopped because `KITARU_ECR_ROLE_ARN` was unavailable.

Kitaru v1 did not publish a managed server image to private ECR. Until that new v2 path has a usable role, its failure must not prevent the public release artifacts from completing. Cloud API staging will switch workspace creation to the Docker Hub image in separate work.

This PR also synchronizes the generated OpenAPI version with the RC2 project version. The RC2 preparation commit changed `pyproject.toml` without regenerating `openapi/openapi.json`, which caused the shared CI lint job to fail on every branch based on that commit.

## Reviewer Notes

The PyPI retry policy lives in one shell helper shared by the client, server, and worker release Dockerfiles. It makes ten attempts with a 15-second delay, refreshes only Kitaru's index metadata before each attempt, stops immediately after success, and preserves the exact-version, wheel-only, dependency-lock, and `uv pip check` contracts.

In the publish job, only `Publish managed image` has `continue-on-error: true`. The next step checks its actual outcome and reports a warning when the private image is missing. Docker Hub publication, Helm publication, GitHub release attachment, and stable `latest` promotion retain their existing failure behavior.

The release workflow uses `workflow_run` only after the tag/manual Python package workflow, which does not run on pull requests. The downstream workflow also verifies that the release commit belongs to `develop` before publishing. `.github/zizmor.yml` documents this trust boundary as a narrow `release.yml:3` exception for zizmor's general dangerous-trigger rule.

## Reproduction

1. Run `uv run pytest -q tests/scripts/test_release_units.py`. The 39 tests exercise eventual PyPI availability, per-attempt metadata refresh, retry delay, terminal failure, and the non-blocking ECR workflow contract.
2. Review a release run without `KITARU_ECR_ROLE_ARN`. The managed-image step should fail with a warning, while the Helm chart and GitHub release attachment continue. The job summary should state that the private ECR image is unavailable.
3. Build each release target with `KITARU_VERSION=0.22.0rc2` and import `kitaru` from each resulting image.

## Local checks run

- `uv run pytest -q tests/scripts/test_release_units.py` (39 passed)
- `uv run --no-project --with pytest --with packaging python -m pytest -q tests/scripts/test_release_units.py` (39 passed without PyYAML)
- zizmor 1.29 against all workflows and Dependabot config (no findings)
- `just check`
- `uv run bash scripts/check_openapi.sh`
- Built the RC2 client, server, and worker release images
- Imported `kitaru` successfully in all three images

Failed PyPI propagation run: https://github.com/zenml-io/kitaru/actions/runs/31706828760/job/94469380712#step:8:1

Failed private ECR run: https://github.com/zenml-io/kitaru/actions/runs/31706828760/job/94477156328
