### PR TITLE
Fix managed release OIDC environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,8 @@ jobs:
   publish:
     needs: prepare
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

- attach the `publish` job to the protected `pypi` environment
- make the GitHub OIDC subject match the trust policy for the managed ECR release role

## Root cause

The managed-image action assumes `github-kitaru-ecr-release`, whose trust policy accepts `repo:zenml-io/kitaru:environment:pypi`. The publish job did not declare that environment, so its OIDC subject could not match after the role ARN is configured.

## Validation

- `uv run pytest tests/scripts/test_release_units.py` (36 passed)
