### PR TITLE
Attribute TypeScript SDK analytics

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -26,6 +26,8 @@ export interface KitaruClientOptions extends KitaruEnvironmentOptions {
 type HttpMethod = "GET" | "PATCH" | "POST";
 
 const RETRYABLE_UPSERT_STATUSES = new Set([502, 503, 504]);
+const KITARU_CLIENT_HEADER = "X-Kitaru-Client";
+const KITARU_CLIENT_IDENTIFICATION = "kitaru-typescript";
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SESSION_ORIGINS = new Set(["imported", "recorded", "replay"]);
@@ -350,6 +352,7 @@ export class KitaruClient {
           method,
           headers: {
             Accept: "application/json",
+            [KITARU_CLIENT_HEADER]: KITARU_CLIENT_IDENTIFICATION,
             ...(body === undefined
               ? {}
               : { "Content-Type": "application/json" }),

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -60,6 +60,7 @@ describe("KitaruClient", () => {
     expect(url).toBe("https://explicit.example/v1/sessions");
     expect(init?.headers).toMatchObject({
       Authorization: "Bearer explicit-secret",
+      "X-Kitaru-Client": "kitaru-typescript",
     });
   });
 

--- a/src/kitaru/analytics/source.py
+++ b/src/kitaru/analytics/source.py
@@ -26,6 +26,7 @@ class AnalyticsSource(StrEnum):
     PYTHON = "kitaru-python"
     CLI = "kitaru-cli"
     MCP = "kitaru-mcp"
+    TYPESCRIPT = "kitaru-typescript"
     API = "kitaru-api"
     UI = "kitaru-ui"
 

--- a/tests/analytics/test_source.py
+++ b/tests/analytics/test_source.py
@@ -32,6 +32,7 @@ def test_format_client_header() -> None:
 def test_parse_client_header() -> None:
     """Parse the source from well-formed header values."""
     assert parse_client_header("kitaru-python/0.21.0") is AnalyticsSource.PYTHON
+    assert parse_client_header("kitaru-typescript") is AnalyticsSource.TYPESCRIPT
     assert parse_client_header("kitaru-ui/1.2.3") is AnalyticsSource.UI
     assert parse_client_header("kitaru-cli") is AnalyticsSource.CLI
 

--- a/tests/server/test_analytics_source.py
+++ b/tests/server/test_analytics_source.py
@@ -50,12 +50,19 @@ async def test_source_defaults_to_api(client: httpx.AsyncClient) -> None:
     assert response.json() == {"source": "kitaru-api"}
 
 
-async def test_source_parsed_from_client_header(client: httpx.AsyncClient) -> None:
+@pytest.mark.parametrize(
+    ("header", "source"),
+    [
+        ("kitaru-ui/0.3.0", "kitaru-ui"),
+        ("kitaru-typescript", "kitaru-typescript"),
+    ],
+)
+async def test_source_parsed_from_client_header(
+    client: httpx.AsyncClient, header: str, source: str
+) -> None:
     """Attribute requests to the source named in the client header."""
-    response = await client.get(
-        "/probe-source", headers={"X-Kitaru-Client": "kitaru-ui/0.3.0"}
-    )
-    assert response.json() == {"source": "kitaru-ui"}
+    response = await client.get("/probe-source", headers={"X-Kitaru-Client": header})
+    assert response.json() == {"source": source}
 
 
 async def test_unknown_client_header_falls_back_to_api(


### PR DESCRIPTION
## What changed?

TypeScript SDK requests now identify themselves as `kitaru-typescript` through the existing `X-Kitaru-Client` header. The Kitaru server recognizes that source and forwards server-side analytics with `Source-Context: kitaru-typescript` instead of attributing the events to the generic API source.

The Mastra and Vercel AI adapters inherit this attribution because they send requests through the core TypeScript client.

## Why?

Server-side events triggered by TypeScript clients were previously grouped under `kitaru-api`, so analytics could not distinguish direct API traffic from TypeScript SDK usage.

The header uses the stable source name without the npm package version because the server's analytics source pipeline currently discards the client version before forwarding events.

## Reviewer Notes

Follow one request from `KitaruClient.#request` through the analytics-source middleware. The client adds `X-Kitaru-Client: kitaru-typescript`; the middleware resolves it to `AnalyticsSource.TYPESCRIPT`; and the analytics client forwards that enum value as `Source-Context`.

Please confirm whether `analytics.zenml.io` has a separate source-context allowlist or reporting configuration that also needs `kitaru-typescript`. That service is outside this repository.

## Reproduction

1. Run `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @zenml-io/kitaru test`. The core client test inspects the outgoing request and verifies `X-Kitaru-Client: kitaru-typescript`.
2. Run `uv run pytest tests/analytics/test_source.py tests/server/test_analytics_source.py`. The server middleware test sends that header and observes `kitaru-typescript` as the active analytics source.

## Local checks run

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm test` (279 tests passed across core and adapters)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm lint`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm typecheck`
- `uv run pytest tests/analytics/test_source.py tests/server/test_analytics_source.py` (8 passed)
- `just check` through format, lint, type check, typos, YAML, and actions lint; the link step scanned installed `node_modules` and reported third-party broken links
