### PR TITLE
Prepare Kitaru 0.22.0rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.22.0rc3]
+
+### Changed
+
+- Updated the bundled Kitaru UI to `kitaru-ui-v0.2.0-rc.2`.
+
 ## [0.22.0rc2]
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.22.0rc2"
+version = "0.22.0rc3"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/releases/python/kitaru/0.22.0rc3.toml
+++ b/releases/python/kitaru/0.22.0rc3.toml
@@ -1,0 +1,3 @@
+schema-version = 1
+kitaru-version = "0.22.0rc3"
+ui-tag = "kitaru-ui-v0.2.0-rc.2"

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.0rc2"
+version = "0.22.0rc3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- prepare Kitaru `0.22.0rc3`
- pin the bundled frontend to `kitaru-ui-v0.2.0-rc.2`
- add the RC3 changelog entry and release declaration

## Validation

- `just check`
- `uv run pytest tests/scripts/test_release_ui.py tests/scripts/test_release_units.py`
- downloaded and checksum-verified `kitaru-ui-v0.2.0-rc.2`
- built the RC3 wheel and verified the bundled UI

## Reviewer Notes

Run `uv run python scripts/release_ui.py --version 0.22.0rc3` and confirm it resolves `kitaru-ui-v0.2.0-rc.2` with prerelease downloads enabled. After merge, create the `python/kitaru/v0.22.0rc3` tag to publish the release.
