### PR TITLE
Fix TypeScript package publishing

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -188,9 +188,9 @@ jobs:
             fi
             tarballs_to_publish+=("$tarball")
           }
-          preflight_package "@zenml-io/kitaru" "typescript-dist/zenml-io-kitaru-${VERSION}.tgz"
-          preflight_package "@zenml-io/kitaru-mastra" "typescript-dist/zenml-io-kitaru-mastra-${VERSION}.tgz"
-          preflight_package "@zenml-io/kitaru-vercel-ai" "typescript-dist/zenml-io-kitaru-vercel-ai-${VERSION}.tgz"
+          preflight_package "@zenml-io/kitaru" "./typescript-dist/zenml-io-kitaru-${VERSION}.tgz"
+          preflight_package "@zenml-io/kitaru-mastra" "./typescript-dist/zenml-io-kitaru-mastra-${VERSION}.tgz"
+          preflight_package "@zenml-io/kitaru-vercel-ai" "./typescript-dist/zenml-io-kitaru-vercel-ai-${VERSION}.tgz"
           for tarball in "${tarballs_to_publish[@]}"; do
             npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance
           done

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenml-io/kitaru",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "description": "TypeScript SDK and adapter foundation for Kitaru agent tracing and replay",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/mastra/package.json
+++ b/packages/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenml-io/kitaru-mastra",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "description": "Mastra adapter for Kitaru agent tracing and replay",
   "license": "Apache-2.0",
   "repository": {
@@ -38,7 +38,7 @@
     "mastra"
   ],
   "dependencies": {
-    "@zenml-io/kitaru": "workspace:0.1.0-rc.1"
+    "@zenml-io/kitaru": "workspace:0.1.0-rc.2"
   },
   "peerDependencies": {
     "@mastra/core": ">=1.51.0 <1.52.0"

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenml-io/kitaru-vercel-ai",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0-rc.2",
   "description": "Kitaru tracing and replay adapter for the Vercel AI SDK",
   "license": "Apache-2.0",
   "repository": {
@@ -38,7 +38,7 @@
     "vercel-ai-sdk"
   ],
   "dependencies": {
-    "@zenml-io/kitaru": "workspace:0.1.0-rc.1"
+    "@zenml-io/kitaru": "workspace:0.1.0-rc.2"
   },
   "peerDependencies": {
     "ai": ">=7.0.0 <8.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
   packages/mastra:
     dependencies:
       '@zenml-io/kitaru':
-        specifier: workspace:0.1.0-rc.1
+        specifier: workspace:0.1.0-rc.2
         version: link:../core
     devDependencies:
       '@mastra/core':
@@ -45,7 +45,7 @@ importers:
   packages/vercel-ai:
     dependencies:
       '@zenml-io/kitaru':
-        specifier: workspace:0.1.0-rc.1
+        specifier: workspace:0.1.0-rc.2
         version: link:../core
     devDependencies:
       ai:

--- a/tests/scripts/test_typescript_packages.py
+++ b/tests/scripts/test_typescript_packages.py
@@ -152,6 +152,7 @@ def test_typescript_release_workflow_contract() -> None:
     assert "permissions:\n      contents: write" in verify_source
     assert "--provenance" in publish_source
     assert "preflight_package" in publish_source
+    assert publish_source.count('"./typescript-dist/zenml-io-kitaru') == 3
     assert "NPM_CONFIG_USERCONFIG" in publish_source
     assert "else\n                view_status=$?" in publish_source
     assert "fi\n              view_status=$?" not in publish_source


### PR DESCRIPTION
## What changed?

TypeScript package publication now passes explicit local tarball paths to npm instead of paths that npm interprets as GitHub repository shorthands. The three lockstep packages advance to `0.1.0-rc.2`; the failed RC1 tag remains immutable and has no published npm versions behind it.

Related: #679

## Why?

The RC1 release build and artifact tests passed, but `npm publish "typescript-dist/...tgz"` attempted `git ls-remote` against a nonexistent GitHub repository and failed before publishing any package. Prefixing each path with `./` makes npm read the downloaded artifact as a local tarball. Reusing or moving the RC1 tag would break the release's immutable-tag contract, so the corrected release uses RC2.

Failed release evidence: https://github.com/zenml-io/kitaru/actions/runs/31782103179

## Reviewer Notes

The important behavior is in the publish job's three `preflight_package` calls. Those paths flow unchanged into `npm publish`, so each must remain explicitly relative. The workflow contract test prevents the prefix from being removed. The adapter manifests must continue to depend on the exact lockstep core version.

## Reproduction

1. Run `pnpm run pack:release` under Node 22.22.x.
2. Run `npm publish --dry-run --access public --tag rc ./typescript-dist/zenml-io-kitaru-0.1.0-rc.2.tgz` and repeat for the Mastra and Vercel AI tarballs.
3. Observe that npm identifies each local package and reports the `0.1.0-rc.2` package that it would publish. Without the leading `./`, npm instead attempts an SSH GitHub lookup.

After merge, manually dispatch **Release TypeScript packages** with `typescript/kitaru/v0.1.0-rc.2` before creating the RC2 tag.

## Local checks run

- `uv run pytest -q tests/scripts/test_typescript_packages.py`: 8 passed.
- `just yaml-check`: passed.
- `just actions-lint`: passed.
- `pnpm install --frozen-lockfile`: passed.
- `pnpm run pack:release` under Node 22.22.3: passed, including clean consumer installation and declaration imports.
- `npm publish --dry-run` with each corrected RC2 tarball path: passed.
