### PR TITLE
Simplify deployable release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,6 @@ jobs:
           helm lint ./helm
           mkdir bundle-dist
           helm package ./helm --destination bundle-dist
-          sha256sum -- bundle-dist/* > bundle-dist/SHA256SUMS
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: bundle-candidate
@@ -132,7 +131,7 @@ jobs:
     environment:
       name: pypi
     permissions:
-      contents: write
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -204,15 +203,6 @@ jobs:
           BUNDLE_VERSION: ${{ needs.prepare.outputs.bundle-version }}
           REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
         run: helm push "bundle-dist/kitaru-$BUNDLE_VERSION.tgz" "oci://$REGISTRY/zenml"
-      - name: Attach Helm chart to the core GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          PACKAGE_TAG: ${{ needs.prepare.outputs.package-tag }}
-        run: |
-          set -euo pipefail
-          gh release view "$PACKAGE_TAG" >/dev/null
-          gh release upload "$PACKAGE_TAG" bundle-dist/* --clobber
   promote-latest:
     if: needs.prepare.outputs.is-prerelease == 'false'
     needs: [prepare, publish]

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -114,7 +114,9 @@ def test_core_release_publishes_deployables_without_waiting_for_plugins() -> Non
     )
     assert "plugins/default-requirements.txt" not in workflow
     assert 'bundle_version="${BASH_REMATCH[1]}-rc.${BASH_REMATCH[2]}"' in workflow
-    assert 'gh release upload "$PACKAGE_TAG" bundle-dist/* --clobber' in workflow
+    assert "gh release upload" not in workflow
+    assert "SHA256SUMS" not in workflow
+    assert "contents: write" not in workflow
     assert "promote-latest:" in workflow
 
 


### PR DESCRIPTION
## Summary

- stop attaching Helm artifacts to the immutable Python GitHub release
- remove the duplicate bundle `SHA256SUMS`
- reduce the deployable publish job to read-only repository permissions
- keep Docker Hub, managed ECR, and OCI Helm publication unchanged

## Why

The RC3 deployable workflow successfully published every registry artifact, then failed because `gh release upload --clobber` tried to delete the Python release's existing `SHA256SUMS`. GitHub rejected the deletion because the release was immutable. The OCI registry already provides the Helm chart and its digest, so mutating the Python release adds failure modes without helping deployment.

## Validation

- `uv run pytest tests/scripts/test_release_units.py`
- `just check`

## Reviewer Notes

Inspect the `publish` job in `.github/workflows/release.yml`. It should finish after `helm push`, contain no GitHub release upload, generate no second checksum file, and require only `contents: read` plus `id-token: write`.
