### PR TITLE
Keep release OpenAPI versions in sync

### DIFF
--- a/.agents/skills/kitaru-dev/SKILL.md
+++ b/.agents/skills/kitaru-dev/SKILL.md
@@ -15,7 +15,8 @@ Use this when you need the command catalog beyond the daily loop in the root `AG
 - `uv sync --extra server`: include server components
 - `uv sync --extra worker`: include worker components
 - `uv sync --extra otel`: include OpenTelemetry integrations
-- `just check`: run formatting, lint, typecheck, typos, YAML, actions lint, and links
+- `just check`: run formatting, lint, OpenAPI freshness, typecheck, typos, YAML, actions lint, and links
+- `just openapi-check`: verify that the committed OpenAPI specification matches the application schema
 - `just fix`: auto-fix formatting, lint issues, and YAML
 - `just test`: run the full pytest suite
 - `just test tests/test_file.py::test_name`: run one targeted test

--- a/.agents/skills/kitaru-tests-release/SKILL.md
+++ b/.agents/skills/kitaru-tests-release/SKILL.md
@@ -109,8 +109,9 @@ Before creating a core tag:
 2. Confirm the intended release commits are on `develop` and identify the last immutable release tag.
 3. Review the changelog and version classification.
 4. Confirm no other release run is active.
-5. Run `just check`, the relevant base/CLI/MCP tests, `just mcp-schema-check`, `just cli-artifact-smoke`, `just plugin-artifact-smoke`, `just migration-check`, and `just build` as applicable. Run `just mcp-wheel-smoke` only after `just build`; it consumes the wheel under `dist/`.
-6. Dispatch `release-plugins.yml` with the proposed package tag when a non-publishing rehearsal is needed.
+5. After changing the core version, run `uv run python scripts/generate_openapi.py` and commit the updated `openapi/openapi.json`.
+6. Run `just check`, the relevant base/CLI/MCP tests, `just mcp-schema-check`, `just cli-artifact-smoke`, `just plugin-artifact-smoke`, `just migration-check`, and `just build` as applicable. Run `just mcp-wheel-smoke` only after `just build`; it consumes the wheel under `dist/`.
+7. Dispatch `release-plugins.yml` with the proposed package tag when a non-publishing rehearsal is needed.
 
 The core Python workflow builds and verifies the wheel, publishes it to PyPI, and creates the GitHub Release. The deployables workflow then verifies the core package, tests the release images, publishes the images and Helm chart, and attaches the chart to the core GitHub Release. Stable releases also move the Docker `latest` aliases.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ See `docs/README.md` for detailed documentation authoring guidelines.
 ## Running Checks
 
 ```bash
-just check  # Format, lint, typecheck, typos, YAML, links
+just check  # Format, lint, OpenAPI, typecheck, typos, YAML, actions, links
 just test   # Run all tests
 just fix    # Auto-fix formatting and lint issues
 ```

--- a/Justfile
+++ b/Justfile
@@ -11,12 +11,14 @@ UI_BUNDLE_ROOT := ".kitaru-ui-bundles"
 default:
     @just --list
 
-# Run all checks (format, lint, typecheck, typos, yaml, actions, links)
+# Run all checks (format, lint, OpenAPI, typecheck, typos, yaml, actions, links)
 check:
     @printf '─── Format Check ───────────────────────────────\n'
     @just format-check
     @printf '\n─── Lint ───────────────────────────────────────\n'
     @just lint
+    @printf '\n─── OpenAPI ────────────────────────────────────\n'
+    @just openapi-check
     @printf '\n─── Type Check ─────────────────────────────────\n'
     @just typecheck
     @printf '\n─── Typos ──────────────────────────────────────\n'
@@ -37,6 +39,10 @@ format-check:
 # Run linter
 lint:
     uv run ruff check .
+
+# Verify the committed OpenAPI specification matches the application schema
+openapi-check:
+    uv run bash scripts/check_openapi.sh
 
 # Run type checker
 typecheck:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8527,7 +8527,7 @@
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.22.0rc2"
+    "version": "0.22.0rc3"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## What changed?

Release preparation now keeps the committed OpenAPI version aligned with the Python package version. The RC3 snapshot is synchronized, and `just check` now runs the same OpenAPI freshness check that CI runs.

The contributor and release instructions document both the local gate and the required regeneration step after a core version change.

## Why?

The RC0 through RC3 preparation changes updated `pyproject.toml` without regenerating `openapi/openapi.json`. CI reported the resulting version mismatch inside its `lint` job, but the documented local `just check` command did not exercise that check. After a release preparation change reached `develop`, unrelated pull requests inherited the failure.

Related: #754, #755

## Reviewer Notes

The prevention mechanism lives in `Justfile`: `just check` now calls the existing `scripts/check_openapi.sh` contract. A future release version bump therefore fails locally unless the generated snapshot is committed. The release runbook names the regeneration command explicitly so the preparation commit contains the derived change rather than leaving cleanup to a later PR.

The OpenAPI schema content is unchanged apart from `info.version`, from `0.22.0rc2` to `0.22.0rc3`.

## Reproduction

1. Run `just --dry-run check` and confirm that `just openapi-check` is part of the normal check sequence.
2. Run `just openapi-check` and confirm it reports `OpenAPI specification is up to date.`
3. Read the package version in `pyproject.toml` and `info.version` in `openapi/openapi.json`; both should be `0.22.0rc3`.

## Local checks run

- `uv sync --frozen --all-extras`
- `just openapi-check`
- `just check`
