### PR TITLE
Prepare Kitaru 0.22.0rc4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.22.0rc4]
+
+### Changed
+
+- Prepared the fourth Kitaru 0.22 release candidate with TypeScript publishing fixes and simplified deployable release publishing.
+
 ## [0.22.0rc3]
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.22.0rc3"
+version = "0.22.0rc4"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/releases/python/kitaru/0.22.0rc4.toml
+++ b/releases/python/kitaru/0.22.0rc4.toml
@@ -1,0 +1,3 @@
+schema-version = 1
+kitaru-version = "0.22.0rc4"
+ui-tag = "kitaru-ui-v0.2.0-rc.2"

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.0rc3"
+version = "0.22.0rc4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- prepare Kitaru `0.22.0rc4`
- retain the bundled frontend pin at `kitaru-ui-v0.2.0-rc.2`
- include the TypeScript publishing fixes and simplified deployable release workflow now on `develop`

## Validation

- `uv run pytest tests/scripts/test_release_ui.py tests/scripts/test_release_units.py`
- `uv run python scripts/release_ui.py --version 0.22.0rc4`
- `just check`

## Reviewer Notes

Run `uv run python scripts/release_ui.py --version 0.22.0rc4` and confirm it resolves `kitaru-ui-v0.2.0-rc.2` with prerelease downloads enabled. After merge, create the `python/kitaru/v0.22.0rc4` tag to publish the release.
