### PR TITLE
Harden TypeScript release verification

### DIFF
--- a/.agents/skills/kitaru-tests-release/SKILL.md
+++ b/.agents/skills/kitaru-tests-release/SKILL.md
@@ -103,6 +103,8 @@ Do not describe the inherited `llm-integration.yml` provider markers or absent `
 
 After a successful core Python workflow, `.github/workflows/release.yml` automatically publishes the matching client, server, worker, and managed images plus the Helm chart. It converts Python RC versions such as `0.22.0rc1` to deployable tags such as `0.22.0-rc.1`. No separate bundle tag is used. A manual dispatch with the existing core package tag is the recovery path.
 
+`.github/workflows/release-typescript.yml` publishes `@zenml-io/kitaru`, `@zenml-io/kitaru-mastra`, and `@zenml-io/kitaru-vercel-ai` together from an immutable `typescript/kitaru/v<VERSION>` tag. Read `release/typescript.md` before preparing or recovering a TypeScript release. Manual dispatch is a non-publishing rehearsal; pushing the tag publishes the tested tarballs, waits for npm publish-time scanning, verifies a clean registry install, and creates the GitHub Release. The three packages use one lockstep stable or `-rc.N` version.
+
 Before creating a core tag:
 
 1. Fetch `develop`, `main`, and tags.
@@ -123,6 +125,7 @@ Do not use the removed `scripts/smoke-test.sh`, provider-area flags, remote-stac
 - Pull requests normally target `develop`; v2 feature work may target its explicit integration branch until that migration lands.
 - `main` tracks the latest released version only; do not push directly.
 - Python releases are cut with namespaced tags handled by `.github/workflows/release-plugins.yml`.
+- TypeScript releases are cut with `typescript/kitaru/v<VERSION>` tags handled by `.github/workflows/release-typescript.yml`; rehearse the exact tag through manual dispatch before pushing it.
 - A successful core Python release automatically starts `.github/workflows/release.yml`; manual dispatch is reserved for recovery.
 - Release preparation maintains the version in `pyproject.toml`; application code should use `importlib.metadata.version("kitaru")` rather than hardcoding it.
 - Update `CHANGELOG.md` under `[Unreleased]` for user-facing changes.

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -218,21 +218,26 @@ jobs:
           mkdir "$verification_dir"
           cd "$verification_dir"
           npm init --yes
-          installed=false
-          for _ in $(seq 1 10); do
-            if npm install --ignore-scripts \
-              "@zenml-io/kitaru@$VERSION" \
-              "@zenml-io/kitaru-mastra@$VERSION" \
-              "@zenml-io/kitaru-vercel-ai@$VERSION" \
-              "@mastra/core@1.51.0" \
-              "ai@7.0.55"; then
-              installed=true
+          registry_ready=false
+          for attempt in $(seq 1 60); do
+            if npm view "@zenml-io/kitaru@$VERSION" version >/dev/null 2>&1 && \
+              npm view "@zenml-io/kitaru-mastra@$VERSION" version >/dev/null 2>&1 && \
+              npm view "@zenml-io/kitaru-vercel-ai@$VERSION" version >/dev/null 2>&1; then
+              registry_ready=true
               break
             fi
-            rm -rf node_modules package-lock.json
-            sleep 10
+            if [ "$attempt" -lt 60 ]; then
+              echo "Waiting for npm publish-time scanning ($attempt/60)..."
+              sleep 20
+            fi
           done
-          test "$installed" = true
+          test "$registry_ready" = true
+          npm install --ignore-scripts \
+            "@zenml-io/kitaru@$VERSION" \
+            "@zenml-io/kitaru-mastra@$VERSION" \
+            "@zenml-io/kitaru-vercel-ai@$VERSION" \
+            "@mastra/core@1.51.0" \
+            "ai@7.0.55"
           node --input-type=module <<'NODE'
           import { KitaruClient } from "@zenml-io/kitaru";
           import { KitaruAgent } from "@zenml-io/kitaru-mastra";

--- a/release/typescript.md
+++ b/release/typescript.md
@@ -8,12 +8,23 @@ The TypeScript SDK is one release set for now. `@zenml-io/kitaru`, `@zenml-io/ki
 2. Use stable SemVer or an `-rc.N` prerelease. Release candidates are published under npm's `rc` tag; stable versions use `latest`.
 3. Run `pnpm run pack:check` locally.
 4. Run the **Release TypeScript packages** workflow manually with `typescript/kitaru/v<VERSION>`. A manual run builds and tests the artifacts but cannot publish them.
-5. After the change is on `develop`, push the same namespaced tag. The tag-triggered run publishes core first, then the two adapters, verifies a clean registry install, and creates a GitHub release.
+5. Download the `typescript-distributions` artifact from the rehearsal, verify `SHA256SUMS`, inspect the three tarballs, and smoke-test their public exports in a clean project.
+6. After the change is on `develop`, create the immutable tag on the exact rehearsed commit and push it. The tag-triggered run publishes core first, then the two adapters, verifies a clean registry install, and creates a GitHub release.
 
 Do not publish these packages from a local checkout. The workflow requires the tagged commit to be part of `develop` and publishes only the tarballs produced by its build job.
 
+## Verify and recover a release
+
+npm scans newly published packages before making them installable. The publish command can succeed while unauthenticated `npm view` and `npm install` still return 404. The workflow waits up to 20 minutes for all three packages to become visible before performing one clean installation and export check.
+
+If publishing succeeds but verification times out, do not create a new version or move the immutable tag. Confirm all three exact versions with `npm view`, then rerun the failed workflow jobs. The publish preflight downloads any existing version and skips it only when its tarball exactly matches the release artifact. After the run succeeds, confirm that the GitHub release is a prerelease for an RC and contains all three tarballs plus `SHA256SUMS`.
+
+The first published version of a new npm package may acquire a `latest` dist-tag even when it is published with `--tag rc`. The version remains a prerelease, and the `rc` tag remains the supported RC channel. Check all three dist-tags after the first release so the default-install behavior is an explicit choice.
+
 ## npm authentication
 
-Configure npm trusted publishing for each package with this repository, `.github/workflows/release-typescript.yml`, and the `npm-publish` GitHub environment.
+Configure npm trusted publishing separately for each package with organization `zenml-io`, repository `kitaru`, workflow filename `release-typescript.yml`, environment `npm-publish`, and the `npm publish` allowed action.
 
-Trusted publishing cannot create a new npm package. For the first release only, add a short-lived granular access token with publish access as the `NPM_TOKEN` environment secret, run the tag release, configure trusted publishing on all three newly created packages, then remove the secret and revoke the token. Later releases use GitHub Actions OIDC and need no npm token.
+Trusted publishing cannot create a new npm package. For the first release only, add a short-lived granular access token with publish access as the `NPM_TOKEN` repository or `npm-publish` environment secret, run the tag release, configure trusted publishing on all three newly created packages, then remove the secret and revoke the token. Later releases use GitHub Actions OIDC and need no npm token.
+
+After all three trusted publishers are configured, select npm's publishing-access option that disallows bypass-2FA tokens, remove `NPM_TOKEN` from GitHub, revoke the bootstrap token on npmjs.com, and use the next manual rehearsal plus RC tag to prove OIDC publishing end to end.

--- a/tests/scripts/test_typescript_packages.py
+++ b/tests/scripts/test_typescript_packages.py
@@ -157,6 +157,13 @@ def test_typescript_release_workflow_contract() -> None:
     assert "else\n                view_status=$?" in publish_source
     assert "fi\n              view_status=$?" not in publish_source
     assert "Verify registry installation" in verify_source
+    assert "for attempt in $(seq 1 60)" in verify_source
+    assert 'npm view "@zenml-io/kitaru@$VERSION" version' in verify_source
+    assert 'npm view "@zenml-io/kitaru-mastra@$VERSION" version' in verify_source
+    assert 'npm view "@zenml-io/kitaru-vercel-ai@$VERSION" version' in verify_source
+    assert 'echo "Waiting for npm publish-time scanning' in verify_source
+    assert "sleep 20" in verify_source
+    assert verify_source.count("npm install --ignore-scripts") == 1
     assert 'gh release view "$PACKAGE_TAG"' in verify_source
     assert "gh release upload" in verify_source
     assert "--clobber" in verify_source


### PR DESCRIPTION
## What changed?

TypeScript releases now wait up to 20 minutes for all three exact npm versions to clear publish-time scanning, then perform one clean registry installation and export check. The release runbook and repository release skill now cover rehearsal artifacts, immutable tagging, scan-delay recovery, first-release dist-tags, and the trusted-publishing bootstrap.

## Why?

The RC2 publish succeeded, but npm kept the new packages unavailable while it scanned them. The previous two-minute loop repeatedly installed the full dependency tree and then reported a false release failure. Lightweight availability probes now absorb that delay without repeating the expensive install.

All three live packages now trust `zenml-io/kitaru` via `release-typescript.yml` and the `npm-publish` environment. Their publishing settings disallow bypass-2FA tokens, and the temporary repository `NPM_TOKEN` has been removed.

## Reviewer Notes

Focus on the `verify-and-release` job. It probes each exact package version at 20-second intervals for up to 20 minutes, skips the final sleep, and performs the existing clean install only after every package is visible. The contract test names all three probes so a missing or duplicated adapter check cannot pass accidentally.

## Reproduction

Inspect [RC2 workflow attempt 2](https://github.com/zenml-io/kitaru/actions/runs/31783245887/attempts/2). The publish job succeeds, but `Verify registry installation` fails after about two minutes while npm is still scanning the packages. On the next TypeScript RC tag, the verification log should instead print `Waiting for npm publish-time scanning` until all three exact versions are visible, then run one clean install and create the GitHub release.

## Local checks run

- `uv run pytest -q tests/scripts/test_typescript_packages.py` (8 passed)
- `just yaml-check`
- `just actions-lint`
- `git diff --check`
