### PR TITLE
Scope worker claims by agent version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - All API routes moved from the `/v1` prefix to `/api/v1`.
+- Replaced the worker scope `kinds` field with explicit claims that can pin agent task claims to a specific agent version, so agent-specific workers on one server no longer claim each other's tasks. The `--kinds` worker CLI flag is replaced by the repeatable `--claim` flag.
 - Added public installation, adapter, replay-boundary, and runnable-example documentation for the TypeScript SDK, Mastra adapter, and Vercel AI SDK adapter.
 
 ### Fixed

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8545,6 +8545,7 @@
             "items": {
               "$ref": "#/components/schemas/WorkerClaim"
             },
+            "maxItems": 16,
             "minItems": 1,
             "title": "Claims",
             "type": "array"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8231,6 +8231,34 @@
         "title": "ValidationError",
         "type": "object"
       },
+      "WorkerClaim": {
+        "additionalProperties": false,
+        "description": "Worker claim.",
+        "properties": {
+          "agent_version_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Agent version the claim covers, None claims every agent version.",
+            "title": "Agent Version Id"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/TaskKind",
+            "description": "Task kind the claim covers."
+          }
+        },
+        "required": [
+          "kind"
+        ],
+        "title": "WorkerClaim",
+        "type": "object"
+      },
       "WorkerCreateRequest": {
         "additionalProperties": false,
         "description": "Worker create request.",
@@ -8512,6 +8540,15 @@
         "additionalProperties": false,
         "description": "Worker scope.",
         "properties": {
+          "claims": {
+            "description": "Claims the worker serves, combined by disjunction.",
+            "items": {
+              "$ref": "#/components/schemas/WorkerClaim"
+            },
+            "minItems": 1,
+            "title": "Claims",
+            "type": "array"
+          },
           "job_id": {
             "anyOf": [
               {
@@ -8524,21 +8561,6 @@
             ],
             "description": "Job the worker claims tasks from.",
             "title": "Job Id"
-          },
-          "kinds": {
-            "anyOf": [
-              {
-                "items": {
-                  "$ref": "#/components/schemas/TaskKind"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Task kinds the worker claims.",
-            "title": "Kinds"
           },
           "selectors": {
             "anyOf": [
@@ -8556,6 +8578,9 @@
             "title": "Selectors"
           }
         },
+        "required": [
+          "claims"
+        ],
         "title": "WorkerScope",
         "type": "object"
       }

--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -8032,6 +8032,19 @@ export interface components {
             type: string;
         };
         /**
+         * WorkerClaim
+         * @description Worker claim.
+         */
+        WorkerClaim: {
+            /**
+             * Agent Version Id
+             * @description Agent version the claim covers, None claims every agent version.
+             */
+            agent_version_id?: string | null;
+            /** @description Task kind the claim covers. */
+            kind: components["schemas"]["TaskKind"];
+        };
+        /**
          * WorkerCreateRequest
          * @description Worker create request.
          */
@@ -8204,15 +8217,15 @@ export interface components {
          */
         WorkerScope: {
             /**
+             * Claims
+             * @description Claims the worker serves, combined by disjunction.
+             */
+            claims: components["schemas"]["WorkerClaim"][];
+            /**
              * Job Id
              * @description Job the worker claims tasks from.
              */
             job_id?: string | null;
-            /**
-             * Kinds
-             * @description Task kinds the worker claims.
-             */
-            kinds?: components["schemas"]["TaskKind"][] | null;
             /**
              * Selectors
              * @description Label selectors the worker claims, combined by conjunction.

--- a/plugins/DEVELOPMENT.md
+++ b/plugins/DEVELOPMENT.md
@@ -222,8 +222,8 @@ export PATH="/tmp/kitaru-plugin-worker-venv/bin:$PATH"
 kitaru worker start \
   --server "$KITARU_API_URL" \
   --name local-wheel-worker \
-  --kinds importer \
-  --kinds evaluator
+  --claim importer \
+  --claim evaluator
 ```
 
 Keep the worker active while you create an import or evaluation job. Task subprocesses inherit `UV_FIND_LINKS` and resolve the candidate wheels.

--- a/src/kitaru/api_models/v1/worker.py
+++ b/src/kitaru/api_models/v1/worker.py
@@ -29,6 +29,8 @@ from kitaru.api_models.v1.filter import FilterableListParams
 from kitaru.api_models.v1.task import TaskKind
 from kitaru.base import FrozenModel
 
+_ALL_TASK_KINDS = frozenset(TaskKind)
+
 
 class LabelSelector(FrozenModel):
     """Label selector."""
@@ -40,11 +42,36 @@ class LabelSelector(FrozenModel):
     )
 
 
+class WorkerClaim(FrozenModel):
+    """Worker claim."""
+
+    kind: TaskKind = Field(description="Task kind the claim covers.")
+    agent_version_id: uuid.UUID | None = Field(
+        default=None,
+        description="Agent version the claim covers, None claims every agent version.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_claim(self) -> Self:
+        """Reject an agent version on a non-agent claim.
+
+        Raises:
+            ValueError: agent_version_id is set on a non-agent kind.
+
+        Returns:
+            The validated claim.
+        """
+        if self.agent_version_id is not None and self.kind is not TaskKind.AGENT:
+            raise ValueError("agent_version_id requires the agent kind")
+        return self
+
+
 class WorkerScope(FrozenModel):
     """Worker scope."""
 
-    kinds: list[TaskKind] | None = Field(
-        default=None, description="Task kinds the worker claims."
+    claims: list[WorkerClaim] = Field(
+        min_length=1,
+        description="Claims the worker serves, combined by disjunction.",
     )
     selectors: list[LabelSelector] | None = Field(
         default=None,
@@ -54,19 +81,41 @@ class WorkerScope(FrozenModel):
         default=None, description="Job the worker claims tasks from."
     )
 
+    @property
+    def claims_everything(self) -> bool:
+        """Whether the claims cover every kind with no agent pin.
+
+        Returns:
+            Whether the claims cover every kind with no agent pin.
+        """
+        return {claim.kind for claim in self.claims} == _ALL_TASK_KINDS and all(
+            claim.agent_version_id is None for claim in self.claims
+        )
+
     @model_validator(mode="after")
     def _validate_scope(self) -> Self:
-        """Reject empty scope lists and duplicate selector keys.
+        """Reject redundant claims, empty selector lists, and duplicate selector keys.
 
         Raises:
-            ValueError: kinds or selectors is set but empty, or two selectors
-                share a key.
+            ValueError: Two claims are equal, an agent version claim is
+                subsumed by an unversioned agent claim, selectors is set but
+                empty, or two selectors share a key.
 
         Returns:
             The validated scope.
         """
-        if self.kinds is not None and not self.kinds:
-            raise ValueError("kinds must not be empty when set")
+        seen: set[tuple[TaskKind, uuid.UUID | None]] = set()
+        for claim in self.claims:
+            entry = (claim.kind, claim.agent_version_id)
+            if entry in seen:
+                raise ValueError("claims must be unique")
+            seen.add(entry)
+        if (TaskKind.AGENT, None) in seen and any(
+            claim.agent_version_id is not None for claim in self.claims
+        ):
+            raise ValueError(
+                "agent version claims are redundant with an unversioned agent claim"
+            )
         if self.selectors is not None:
             if not self.selectors:
                 raise ValueError("selectors must not be empty when set")

--- a/src/kitaru/api_models/v1/worker.py
+++ b/src/kitaru/api_models/v1/worker.py
@@ -71,6 +71,7 @@ class WorkerScope(FrozenModel):
 
     claims: list[WorkerClaim] = Field(
         min_length=1,
+        max_length=16,
         description="Claims the worker serves, combined by disjunction.",
     )
     selectors: list[LabelSelector] | None = Field(

--- a/src/kitaru/cli/app.py
+++ b/src/kitaru/cli/app.py
@@ -36,7 +36,6 @@ from kitaru.api_models.v1.investigation import (
     InvestigationStatus,
 )
 from kitaru.api_models.v1.session import SessionOrigin, SessionStatus
-from kitaru.api_models.v1.task import TaskKind
 from kitaru.cli import (
     annotations,
     cohorts,
@@ -3778,7 +3777,12 @@ async def evaluation_get(evaluation: uuid.UUID, /) -> CommandResult:
 _WORKER_START_PARAMETERS = (
     ParameterSpec("--name", "string", "option", False, "Ephemeral worker name."),
     ParameterSpec(
-        "--kinds", "agent|evaluator|importer[]", "option", False, "Task kinds to claim."
+        "--claim",
+        "agent|evaluator|importer|agent=UUID[]",
+        "option",
+        False,
+        "Claim the worker serves: agent, evaluator, importer, or "
+        "agent=AGENT_VERSION_ID. Repeat for multiple claims.",
     ),
     ParameterSpec(
         "--selector",
@@ -3847,7 +3851,14 @@ _WORKER_START_PARAMETERS = (
 async def worker_start(
     *,
     name: str | None = None,
-    kinds: list[TaskKind] | None = None,
+    claims: Annotated[
+        list[str] | None,
+        Parameter(
+            name="--claim",
+            help="Claim the worker serves: agent, evaluator, importer, or "
+            "agent=AGENT_VERSION_ID. Repeat for multiple claims.",
+        ),
+    ] = None,
     selectors: Annotated[
         list[str] | None,
         Parameter(name="--selector", help="KEY=VALUE[,VALUE] or selector JSON."),
@@ -3869,7 +3880,7 @@ async def worker_start(
     return await workers.start_worker(
         target,
         name=name,
-        kinds=kinds,
+        claims=claims,
         selectors=selectors,
         job_id=job_id,
         concurrency=concurrency,

--- a/src/kitaru/cli/workers.py
+++ b/src/kitaru/cli/workers.py
@@ -27,7 +27,12 @@ from pydantic import ValidationError
 
 from kitaru.api_models.v1.filter import FilterCondition, FilterOp
 from kitaru.api_models.v1.task import TaskKind
-from kitaru.api_models.v1.worker import LabelSelector, WorkerListParams, WorkerScope
+from kitaru.api_models.v1.worker import (
+    LabelSelector,
+    WorkerClaim,
+    WorkerListParams,
+    WorkerScope,
+)
 from kitaru.cli.config import ResolvedTarget
 from kitaru.cli.output import (
     CLIError,
@@ -89,7 +94,7 @@ def load_worker_runtime() -> tuple[type[Any], type[Any]]:
 def build_worker_config(
     *,
     name: str | None = None,
-    kinds: list[TaskKind] | None = None,
+    claims: list[str] | None = None,
     selectors: list[str] | None = None,
     job_id: uuid.UUID | None = None,
     concurrency: int | None = None,
@@ -104,13 +109,13 @@ def build_worker_config(
 ) -> Any:
     """Merge explicit CLI values over ``KITARU_WORKER_*`` settings.
 
-    The optional job id refines the configured scope; it does not discard
-    configured kinds or selectors.
+    The optional job id refines the configured scope. It does not discard
+    configured claims or selectors.
     """
     _, config_type = load_worker_runtime()
     base = config_type()
     scope = WorkerScope(
-        kinds=kinds if kinds is not None else base.scope.kinds,
+        claims=_parse_claims(claims) if claims is not None else base.scope.claims,
         selectors=(
             _parse_selectors(selectors)
             if selectors is not None
@@ -157,6 +162,26 @@ def _parse_selectors(values: list[str]) -> list[LabelSelector]:
             ) from error
         selectors.append(selector)
     return selectors
+
+
+def _parse_claims(values: list[str]) -> list[WorkerClaim]:
+    """Parse compact ``KIND`` or ``agent=AGENT_VERSION_ID`` claim forms."""
+    claims: list[WorkerClaim] = []
+    for value in values:
+        try:
+            kind_value, separator, raw_agent_version_id = value.partition("=")
+            claim = WorkerClaim(
+                kind=TaskKind(kind_value.strip()),
+                agent_version_id=(
+                    uuid.UUID(raw_agent_version_id.strip()) if separator else None
+                ),
+            )
+        except (ValidationError, ValueError) as error:
+            raise CLIError(
+                "invalid_arguments", f"Invalid --claim {value!r}: {error}"
+            ) from error
+        claims.append(claim)
+    return claims
 
 
 def _parse_metadata(values: list[str]) -> dict[str, str]:
@@ -316,11 +341,7 @@ def _worker_summary(config: Any) -> dict[str, Any]:
     """Return a non-secret lifecycle projection of worker configuration."""
     return {
         "name": config.name,
-        "kinds": (
-            [kind.value for kind in config.scope.kinds]
-            if config.scope.kinds is not None
-            else None
-        ),
+        "claims": [_claim_syntax(claim) for claim in config.scope.claims],
         "selectors": (
             [selector.model_dump(mode="json") for selector in config.scope.selectors]
             if config.scope.selectors is not None
@@ -330,6 +351,13 @@ def _worker_summary(config: Any) -> dict[str, Any]:
         "concurrency": config.concurrency,
         "claim_batch_size": config.claim_batch_size,
     }
+
+
+def _claim_syntax(claim: WorkerClaim) -> str:
+    """Render a claim in the compact syntax ``--claim`` accepts."""
+    if claim.agent_version_id is not None:
+        return f"{claim.kind.value}={claim.agent_version_id}"
+    return claim.kind.value
 
 
 async def list_workers(

--- a/src/kitaru/server/adapters/db/orm/task.py
+++ b/src/kitaru/server/adapters/db/orm/task.py
@@ -49,7 +49,6 @@ from kitaru.server.domain.task import (
 )
 
 KIND_LENGTH = 16
-QUEUE_KEY_LENGTH = 64
 STATUS_LENGTH = 16
 ON_FAILURE_LENGTH = 16
 
@@ -68,13 +67,13 @@ TASK_JOB_ID_STATUS_INDEX = index_name("task", ["job_id", "status"])
 TASK_INPUT_SESSION_ID_INDEX = index_name("task", ["input_session_id"])
 TASK_RESULT_SESSION_ID_INDEX = index_name("task", ["result_session_id"])
 # Partial indexes covering the queue scans: a scope claiming everything reads
-# pending rows in id order, any other scope reads them per queue key, and the
-# staleness sweep reads in-flight rows by their last sign of life. The queue
-# key column uses the C collation so LIKE prefix claims scan the index as a
-# range and ORDER BY queue_key follows the index order without a sort.
-# Selectors filter the rows the claim scans fetch and use no index.
+# pending rows in id order, a kind claim reads them per kind, and a
+# version-pinned claim reads them per agent version. The staleness sweep
+# reads in-flight rows by their last sign of life. Selectors filter the rows
+# the claim scans fetch and use no index.
 TASK_PENDING_ID_INDEX = index_name("task", ["id"])
-TASK_PENDING_QUEUE_KEY_INDEX = index_name("task", ["queue_key", "id"])
+TASK_PENDING_KIND_INDEX = index_name("task", ["kind", "id"])
+TASK_PENDING_AGENT_VERSION_INDEX = index_name("task", ["agent_version_id", "id"])
 TASK_STALENESS_INDEX = index_name("task", ["heartbeat_at", "claimed_at"])
 
 TERMINAL_STATUS_VALUES = [status.value for status in TERMINAL_TASK_STATUSES]
@@ -135,8 +134,14 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         Index(TASK_RESULT_SESSION_ID_INDEX, "result_session_id"),
         Index(TASK_PENDING_ID_INDEX, "id", postgresql_where=text(PENDING_PREDICATE)),
         Index(
-            TASK_PENDING_QUEUE_KEY_INDEX,
-            "queue_key",
+            TASK_PENDING_KIND_INDEX,
+            "kind",
+            "id",
+            postgresql_where=text(PENDING_PREDICATE),
+        ),
+        Index(
+            TASK_PENDING_AGENT_VERSION_INDEX,
+            "agent_version_id",
             "id",
             postgresql_where=text(PENDING_PREDICATE),
         ),
@@ -148,7 +153,6 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     kind: Mapped[str] = mapped_column(String(KIND_LENGTH))
-    queue_key: Mapped[str] = mapped_column(String(QUEUE_KEY_LENGTH, collation="C"))
     job_id: Mapped[uuid.UUID]
     agent_version_id: Mapped[uuid.UUID | None]
     agent_id: Mapped[uuid.UUID | None]
@@ -186,7 +190,6 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         row = cls(
             id=task.id,
             kind=task.kind.value,
-            queue_key=task.queue_key,
             job_id=task.job_id,
             status=task.status.value,
             attempt=task.attempt,

--- a/src/kitaru/server/adapters/db/orm/task.py
+++ b/src/kitaru/server/adapters/db/orm/task.py
@@ -49,6 +49,7 @@ from kitaru.server.domain.task import (
 )
 
 KIND_LENGTH = 16
+QUEUE_KEY_LENGTH = 64
 STATUS_LENGTH = 16
 ON_FAILURE_LENGTH = 16
 
@@ -66,11 +67,14 @@ TASK_EVALUATOR_PAIR_UNIQUE_CONSTRAINT = unique_constraint_name(
 TASK_JOB_ID_STATUS_INDEX = index_name("task", ["job_id", "status"])
 TASK_INPUT_SESSION_ID_INDEX = index_name("task", ["input_session_id"])
 TASK_RESULT_SESSION_ID_INDEX = index_name("task", ["result_session_id"])
-# Partial indexes covering the two queue scans: the claim query reads pending
-# rows in id order and matches selectors against labels, the staleness sweep
-# reads in-flight rows by their last sign of life.
+# Partial indexes covering the queue scans: a scope claiming everything reads
+# pending rows in id order, any other scope reads them per queue key, and the
+# staleness sweep reads in-flight rows by their last sign of life. The queue
+# key column uses the C collation so LIKE prefix claims scan the index as a
+# range and ORDER BY queue_key follows the index order without a sort.
+# Selectors filter the rows the claim scans fetch and use no index.
 TASK_PENDING_ID_INDEX = index_name("task", ["id"])
-TASK_PENDING_LABELS_INDEX = index_name("task", ["labels"])
+TASK_PENDING_QUEUE_KEY_INDEX = index_name("task", ["queue_key", "id"])
 TASK_STALENESS_INDEX = index_name("task", ["heartbeat_at", "claimed_at"])
 
 TERMINAL_STATUS_VALUES = [status.value for status in TERMINAL_TASK_STATUSES]
@@ -131,9 +135,9 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         Index(TASK_RESULT_SESSION_ID_INDEX, "result_session_id"),
         Index(TASK_PENDING_ID_INDEX, "id", postgresql_where=text(PENDING_PREDICATE)),
         Index(
-            TASK_PENDING_LABELS_INDEX,
-            "labels",
-            postgresql_using="gin",
+            TASK_PENDING_QUEUE_KEY_INDEX,
+            "queue_key",
+            "id",
             postgresql_where=text(PENDING_PREDICATE),
         ),
         Index(
@@ -144,6 +148,7 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
 
     kind: Mapped[str] = mapped_column(String(KIND_LENGTH))
+    queue_key: Mapped[str] = mapped_column(String(QUEUE_KEY_LENGTH, collation="C"))
     job_id: Mapped[uuid.UUID]
     agent_version_id: Mapped[uuid.UUID | None]
     agent_id: Mapped[uuid.UUID | None]
@@ -181,6 +186,7 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         row = cls(
             id=task.id,
             kind=task.kind.value,
+            queue_key=task.queue_key,
             job_id=task.job_id,
             status=task.status.value,
             attempt=task.attempt,

--- a/src/kitaru/server/adapters/db/repositories/task_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/task_repository.py
@@ -16,16 +16,15 @@
 import uuid
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import NamedTuple
 
 from sqlalchemy import (
     ColumnElement,
-    UnaryExpression,
     func,
     not_,
     or_,
     select,
     true,
+    union_all,
     update,
 )
 
@@ -42,15 +41,7 @@ from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.task import TaskFilter
 from kitaru.server.domain.base import NotFoundError
-from kitaru.server.domain.task import (
-    AGENT_QUEUE_KEY_PREFIX,
-    EVALUATOR_QUEUE_KEY,
-    IMPORTER_QUEUE_KEY,
-    DuplicateEvaluationTask,
-    Task,
-    TaskNotFound,
-    agent_queue_key,
-)
+from kitaru.server.domain.task import DuplicateEvaluationTask, Task, TaskNotFound
 
 IN_FLIGHT_STATUS_VALUES = [TaskStatus.CLAIMED.value, TaskStatus.RUNNING.value]
 
@@ -65,48 +56,26 @@ TASK_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
 }
 
 
-class _ClaimTerm(NamedTuple):
-    """Claim term."""
+def _claim_terms(scope: WorkerScope) -> list[ColumnElement[bool]]:
+    """Build the claim conditions of a scope, one per bounded index scan.
 
-    condition: ColumnElement[bool]
-    order: tuple[UnaryExpression[uuid.UUID] | UnaryExpression[str], ...]
-
-
-def _claim_terms(scope: WorkerScope) -> list[_ClaimTerm]:
-    """Build the claim terms of a scope.
-
-    A scope claiming every kind with no agent pin collapses to one term over
-    the whole pending queue, read in id order.
+    A scope claiming everything collapses to one unconditioned term over the
+    whole pending queue.
 
     Args:
         scope: Claim scope stored on the worker row.
 
     Returns:
-        Terms, each read by its own bounded index scan.
+        Conditions, each read by its own bounded index scan.
     """
     if scope.claims_everything:
-        return [_ClaimTerm(condition=true(), order=(TaskORM.id.asc(),))]
-    terms: list[_ClaimTerm] = []
+        return [true()]
+    terms: list[ColumnElement[bool]] = []
     for claim in scope.claims:
-        if claim.kind is TaskKind.EVALUATOR:
-            key = EVALUATOR_QUEUE_KEY
-        elif claim.kind is TaskKind.IMPORTER:
-            key = IMPORTER_QUEUE_KEY
-        elif claim.agent_version_id is not None:
-            key = agent_queue_key(claim.agent_version_id)
+        if claim.agent_version_id is not None:
+            terms.append(TaskORM.agent_version_id == claim.agent_version_id)
         else:
-            # An unversioned agent claim spans every agent key, so it scans in
-            # index order and orders by id only within one key.
-            terms.append(
-                _ClaimTerm(
-                    condition=TaskORM.queue_key.like(f"{AGENT_QUEUE_KEY_PREFIX}%"),
-                    order=(TaskORM.queue_key.asc(), TaskORM.id.asc()),
-                )
-            )
-            continue
-        terms.append(
-            _ClaimTerm(condition=TaskORM.queue_key == key, order=(TaskORM.id.asc(),))
-        )
+            terms.append(TaskORM.kind == claim.kind.value)
     return terms
 
 
@@ -310,15 +279,11 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         """Hand pending tasks matching a scope to a worker, oldest first.
 
         A scope claiming everything runs one id-ordered locking scan. Any
-        other scope first reads up to ``limit`` candidate ids per claim term
-        through the queue key index and then locks the oldest ``limit`` of
-        the merged candidates, re-checking status because the candidate
-        reads ran unlocked. One query ordered across several queue keys
-        would sort every matching pending row on each poll, so exact global
-        ordering is traded for scan cost bounded by the limit: the merge
-        keeps oldest-first across terms exact within the candidate sets,
-        and an unversioned agent term reads its candidates in key order, so
-        its tiebreak among agent versions is per key rather than by age.
+        other scope reads up to ``limit`` candidate ids per claim term
+        through the partial indexes and locks the oldest ``limit`` of the
+        merged candidates in the same statement, re-checking status because
+        the candidate scans run unlocked. Each term is an equality read in
+        id order, so the merge is exactly oldest-first across the scope.
 
         Args:
             scope: Claim scope narrowing the queue.
@@ -336,36 +301,32 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
                 select(TaskORM)
                 .where(
                     TaskORM.status == TaskStatus.PENDING.value,
-                    terms[0].condition,
+                    terms[0],
                     *residual,
                 )
-                .order_by(*terms[0].order)
+                .order_by(TaskORM.id.asc())
                 .limit(limit)
                 .with_for_update(skip_locked=True)
             )
             rows = (await self._session.scalars(statement)).all()
         else:
-            candidate_ids: list[uuid.UUID] = []
-            for term in terms:
-                peek = (
-                    select(TaskORM.id)
-                    .where(
-                        TaskORM.status == TaskStatus.PENDING.value,
-                        term.condition,
-                        *residual,
-                    )
-                    .order_by(*term.order)
-                    .limit(limit)
-                )
-                candidate_ids.extend((await self._session.scalars(peek)).all())
-            oldest = sorted(candidate_ids)[:limit]
-            if not oldest:
-                return []
+            peeks = [
+                select(TaskORM.id)
+                .where(TaskORM.status == TaskStatus.PENDING.value, term, *residual)
+                .order_by(TaskORM.id.asc())
+                .limit(limit)
+                for term in terms
+            ]
+            candidates = union_all(
+                *[select(peek.subquery()) for peek in peeks]
+            ).subquery()
+            oldest = (
+                select(candidates.c.id).order_by(candidates.c.id.asc()).limit(limit)
+            ).scalar_subquery()
             statement = (
                 select(TaskORM)
                 .where(
-                    TaskORM.id.in_(oldest),
-                    TaskORM.status == TaskStatus.PENDING.value,
+                    TaskORM.id.in_(oldest), TaskORM.status == TaskStatus.PENDING.value
                 )
                 .order_by(TaskORM.id.asc())
                 .with_for_update(skip_locked=True)

--- a/src/kitaru/server/adapters/db/repositories/task_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/task_repository.py
@@ -16,8 +16,18 @@
 import uuid
 from collections.abc import Mapping, Sequence
 from datetime import datetime
+from typing import NamedTuple
 
-from sqlalchemy import ColumnElement, func, not_, or_, select, update
+from sqlalchemy import (
+    ColumnElement,
+    UnaryExpression,
+    func,
+    not_,
+    or_,
+    select,
+    true,
+    update,
+)
 
 from kitaru.api_models.v1.task import TaskKind, TaskStatus
 from kitaru.api_models.v1.worker import WorkerScope
@@ -33,9 +43,13 @@ from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.task import TaskFilter
 from kitaru.server.domain.base import NotFoundError
 from kitaru.server.domain.task import (
+    AGENT_QUEUE_KEY_PREFIX,
+    EVALUATOR_QUEUE_KEY,
+    IMPORTER_QUEUE_KEY,
     DuplicateEvaluationTask,
     Task,
     TaskNotFound,
+    agent_queue_key,
 )
 
 IN_FLIGHT_STATUS_VALUES = [TaskStatus.CLAIMED.value, TaskStatus.RUNNING.value]
@@ -51,21 +65,61 @@ TASK_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
 }
 
 
-def _scope_conditions(scope: WorkerScope) -> list[ColumnElement[bool]]:
-    """Build the claim conditions a worker scope narrows the queue by.
+class _ClaimTerm(NamedTuple):
+    """Claim term."""
 
-    An unpinned scope without selectors adds no condition and claims any
-    pending task.
+    condition: ColumnElement[bool]
+    order: tuple[UnaryExpression[uuid.UUID] | UnaryExpression[str], ...]
+
+
+def _claim_terms(scope: WorkerScope) -> list[_ClaimTerm]:
+    """Build the claim terms of a scope.
+
+    A scope claiming every kind with no agent pin collapses to one term over
+    the whole pending queue, read in id order.
 
     Args:
         scope: Claim scope stored on the worker row.
 
     Returns:
-        Conditions to AND into the claim query.
+        Terms, each read by its own bounded index scan.
+    """
+    if scope.claims_everything:
+        return [_ClaimTerm(condition=true(), order=(TaskORM.id.asc(),))]
+    terms: list[_ClaimTerm] = []
+    for claim in scope.claims:
+        if claim.kind is TaskKind.EVALUATOR:
+            key = EVALUATOR_QUEUE_KEY
+        elif claim.kind is TaskKind.IMPORTER:
+            key = IMPORTER_QUEUE_KEY
+        elif claim.agent_version_id is not None:
+            key = agent_queue_key(claim.agent_version_id)
+        else:
+            # An unversioned agent claim spans every agent key, so it scans in
+            # index order and orders by id only within one key.
+            terms.append(
+                _ClaimTerm(
+                    condition=TaskORM.queue_key.like(f"{AGENT_QUEUE_KEY_PREFIX}%"),
+                    order=(TaskORM.queue_key.asc(), TaskORM.id.asc()),
+                )
+            )
+            continue
+        terms.append(
+            _ClaimTerm(condition=TaskORM.queue_key == key, order=(TaskORM.id.asc(),))
+        )
+    return terms
+
+
+def _residual_conditions(scope: WorkerScope) -> list[ColumnElement[bool]]:
+    """Build the claim conditions a worker scope adds beyond its claims.
+
+    Args:
+        scope: Claim scope stored on the worker row.
+
+    Returns:
+        Conditions to AND into every claim term's query.
     """
     conditions: list[ColumnElement[bool]] = []
-    if scope.kinds:
-        conditions.append(TaskORM.kind.in_([kind.value for kind in scope.kinds]))
     if scope.job_id is not None:
         conditions.append(TaskORM.job_id == scope.job_id)
     for selector in scope.selectors or []:
@@ -255,6 +309,17 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
     ) -> list[Task]:
         """Hand pending tasks matching a scope to a worker, oldest first.
 
+        A scope claiming everything runs one id-ordered locking scan. Any
+        other scope first reads up to ``limit`` candidate ids per claim term
+        through the queue key index and then locks the oldest ``limit`` of
+        the merged candidates, re-checking status because the candidate
+        reads ran unlocked. One query ordered across several queue keys
+        would sort every matching pending row on each poll, so exact global
+        ordering is traded for scan cost bounded by the limit: the merge
+        keeps oldest-first across terms exact within the candidate sets,
+        and an unversioned agent term reads its candidates in key order, so
+        its tiebreak among agent versions is per key rather than by age.
+
         Args:
             scope: Claim scope narrowing the queue.
             worker_id: Worker claiming the tasks.
@@ -264,16 +329,48 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         Returns:
             Claimed tasks carrying their incremented attempt.
         """
-        statement = (
-            select(TaskORM)
-            .where(
-                TaskORM.status == TaskStatus.PENDING.value, *_scope_conditions(scope)
+        terms = _claim_terms(scope)
+        residual = _residual_conditions(scope)
+        if len(terms) == 1:
+            statement = (
+                select(TaskORM)
+                .where(
+                    TaskORM.status == TaskStatus.PENDING.value,
+                    terms[0].condition,
+                    *residual,
+                )
+                .order_by(*terms[0].order)
+                .limit(limit)
+                .with_for_update(skip_locked=True)
             )
-            .order_by(TaskORM.id.asc())
-            .limit(limit)
-            .with_for_update(skip_locked=True)
-        )
-        rows = (await self._session.scalars(statement)).all()
+            rows = (await self._session.scalars(statement)).all()
+        else:
+            candidate_ids: list[uuid.UUID] = []
+            for term in terms:
+                peek = (
+                    select(TaskORM.id)
+                    .where(
+                        TaskORM.status == TaskStatus.PENDING.value,
+                        term.condition,
+                        *residual,
+                    )
+                    .order_by(*term.order)
+                    .limit(limit)
+                )
+                candidate_ids.extend((await self._session.scalars(peek)).all())
+            oldest = sorted(candidate_ids)[:limit]
+            if not oldest:
+                return []
+            statement = (
+                select(TaskORM)
+                .where(
+                    TaskORM.id.in_(oldest),
+                    TaskORM.status == TaskStatus.PENDING.value,
+                )
+                .order_by(TaskORM.id.asc())
+                .with_for_update(skip_locked=True)
+            )
+            rows = (await self._session.scalars(statement)).all()
         if not rows:
             return []
         for row in rows:

--- a/src/kitaru/server/application/interfaces/task_repository.py
+++ b/src/kitaru/server/application/interfaces/task_repository.py
@@ -137,9 +137,10 @@ class TaskRepository(Protocol):
     ) -> list[Task]:
         """Hand pending tasks matching a scope to a worker, oldest first.
 
-        Rows are locked with ``FOR UPDATE SKIP LOCKED``, so concurrent claims
-        never hand the same task to two workers and never block on each
-        other.
+        An unversioned agent claim combined with other claims breaks age
+        ties among agent versions by queue key. Rows are locked with ``FOR
+        UPDATE SKIP LOCKED``, so concurrent claims never hand the same task
+        to two workers and never block on each other.
 
         Args:
             scope: Claim scope narrowing the queue.

--- a/src/kitaru/server/application/interfaces/task_repository.py
+++ b/src/kitaru/server/application/interfaces/task_repository.py
@@ -137,10 +137,9 @@ class TaskRepository(Protocol):
     ) -> list[Task]:
         """Hand pending tasks matching a scope to a worker, oldest first.
 
-        An unversioned agent claim combined with other claims breaks age
-        ties among agent versions by queue key. Rows are locked with ``FOR
-        UPDATE SKIP LOCKED``, so concurrent claims never hand the same task
-        to two workers and never block on each other.
+        Rows are locked with ``FOR UPDATE SKIP LOCKED``, so concurrent
+        claims never hand the same task to two workers and never block on
+        each other.
 
         Args:
             scope: Claim scope narrowing the queue.

--- a/src/kitaru/server/database/migrations/versions/002_task_claim_indexes.py
+++ b/src/kitaru/server/database/migrations/versions/002_task_claim_indexes.py
@@ -11,9 +11,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Add the task queue key.
+"""Add the task claim indexes.
 
-Revision ID: 002_task_queue_key
+Revision ID: 002_task_claim_indexes
 Revises: 001_initial
 Create Date: 2026-08-17
 
@@ -23,35 +23,24 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "002_task_queue_key"
+revision = "002_task_claim_indexes"
 down_revision = "001_initial"
 branch_labels = None
 depends_on = None
-
-_BACKFILL_QUEUE_KEY = """
-UPDATE task
-SET queue_key = CASE kind
-    WHEN 'agent' THEN 'agent:' || agent_version_id::text
-    WHEN 'evaluator' THEN 'evaluator'
-    WHEN 'importer' THEN 'importer'
-END
-"""
 
 
 def upgrade() -> None:
     """Upgrade database schema and/or data, creating a new revision."""
     with op.batch_alter_table("task", schema=None) as batch_op:
-        batch_op.add_column(
-            sa.Column("queue_key", sa.String(length=64, collation="C"), nullable=True)
-        )
-
-    op.execute(sa.text(_BACKFILL_QUEUE_KEY))
-
-    with op.batch_alter_table("task", schema=None) as batch_op:
-        batch_op.alter_column("queue_key", nullable=False)
         batch_op.create_index(
-            "ix_task_queue_key_id",
-            ["queue_key", "id"],
+            "ix_task_kind_id",
+            ["kind", "id"],
+            unique=False,
+            postgresql_where=sa.text("status = 'pending'"),
+        )
+        batch_op.create_index(
+            "ix_task_agent_version_id_id",
+            ["agent_version_id", "id"],
             unique=False,
             postgresql_where=sa.text("status = 'pending'"),
         )
@@ -73,6 +62,9 @@ def downgrade() -> None:
             postgresql_where=sa.text("status = 'pending'"),
         )
         batch_op.drop_index(
-            "ix_task_queue_key_id", postgresql_where=sa.text("status = 'pending'")
+            "ix_task_agent_version_id_id",
+            postgresql_where=sa.text("status = 'pending'"),
         )
-        batch_op.drop_column("queue_key")
+        batch_op.drop_index(
+            "ix_task_kind_id", postgresql_where=sa.text("status = 'pending'")
+        )

--- a/src/kitaru/server/database/migrations/versions/002_task_queue_key.py
+++ b/src/kitaru/server/database/migrations/versions/002_task_queue_key.py
@@ -1,0 +1,78 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Add the task queue key.
+
+Revision ID: 002_task_queue_key
+Revises: 001_initial
+Create Date: 2026-08-17
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "002_task_queue_key"
+down_revision = "001_initial"
+branch_labels = None
+depends_on = None
+
+_BACKFILL_QUEUE_KEY = """
+UPDATE task
+SET queue_key = CASE kind
+    WHEN 'agent' THEN 'agent:' || agent_version_id::text
+    WHEN 'evaluator' THEN 'evaluator'
+    WHEN 'importer' THEN 'importer'
+END
+"""
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    with op.batch_alter_table("task", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("queue_key", sa.String(length=64, collation="C"), nullable=True)
+        )
+
+    op.execute(sa.text(_BACKFILL_QUEUE_KEY))
+
+    with op.batch_alter_table("task", schema=None) as batch_op:
+        batch_op.alter_column("queue_key", nullable=False)
+        batch_op.create_index(
+            "ix_task_queue_key_id",
+            ["queue_key", "id"],
+            unique=False,
+            postgresql_where=sa.text("status = 'pending'"),
+        )
+        batch_op.drop_index(
+            "ix_task_labels",
+            postgresql_using="gin",
+            postgresql_where=sa.text("status = 'pending'"),
+        )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    with op.batch_alter_table("task", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_task_labels",
+            ["labels"],
+            unique=False,
+            postgresql_using="gin",
+            postgresql_where=sa.text("status = 'pending'"),
+        )
+        batch_op.drop_index(
+            "ix_task_queue_key_id", postgresql_where=sa.text("status = 'pending'")
+        )
+        batch_op.drop_column("queue_key")

--- a/src/kitaru/server/domain/task.py
+++ b/src/kitaru/server/domain/task.py
@@ -82,6 +82,24 @@ CONTRACT_ENV_NAMES = frozenset(
 )
 CONTRACT_ENV_PREFIX = "KITARU_TASK_"
 
+# Queue keys partition the pending queue. Every task computes exactly one key
+# from its identity at creation, and workers claim by key.
+EVALUATOR_QUEUE_KEY = "evaluator"
+IMPORTER_QUEUE_KEY = "importer"
+AGENT_QUEUE_KEY_PREFIX = "agent:"
+
+
+def agent_queue_key(agent_version_id: uuid.UUID) -> str:
+    """Build the queue key for an agent version.
+
+    Args:
+        agent_version_id: Agent version the key covers.
+
+    Returns:
+        Queue key.
+    """
+    return f"{AGENT_QUEUE_KEY_PREFIX}{agent_version_id}"
+
 
 class TaskNotFound(NotFoundError):
     """Raised when a task lookup does not resolve."""
@@ -297,6 +315,15 @@ class Task(DomainModel):
     @property
     def kind(self) -> TaskKind:
         """Kind of work the task runs.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        raise NotImplementedError
+
+    @property
+    def queue_key(self) -> str:
+        """Queue the task is claimed from.
 
         Raises:
             NotImplementedError: Always.
@@ -590,6 +617,15 @@ class AgentTask(Task):
         """
         return TaskKind.AGENT
 
+    @property
+    def queue_key(self) -> str:
+        """Queue the task is claimed from.
+
+        Returns:
+            Agent version queue key.
+        """
+        return agent_queue_key(self.agent_version_id)
+
     def check_result(self, result: Any) -> None:
         """Require a linked result session, the agent task's actual outcome.
 
@@ -618,6 +654,15 @@ class EvaluationTask(Task):
             Evaluator kind.
         """
         return TaskKind.EVALUATOR
+
+    @property
+    def queue_key(self) -> str:
+        """Queue the task is claimed from.
+
+        Returns:
+            Evaluator queue key.
+        """
+        return EVALUATOR_QUEUE_KEY
 
     def check_result(self, result: Any) -> None:
         """Require a non-empty list of evaluation results with unique names.
@@ -666,6 +711,15 @@ class ImportTask(Task):
             Importer kind.
         """
         return TaskKind.IMPORTER
+
+    @property
+    def queue_key(self) -> str:
+        """Queue the task is claimed from.
+
+        Returns:
+            Importer queue key.
+        """
+        return IMPORTER_QUEUE_KEY
 
     def check_result(self, result: Any) -> None:
         """Require a result payload.

--- a/src/kitaru/server/domain/task.py
+++ b/src/kitaru/server/domain/task.py
@@ -82,24 +82,6 @@ CONTRACT_ENV_NAMES = frozenset(
 )
 CONTRACT_ENV_PREFIX = "KITARU_TASK_"
 
-# Queue keys partition the pending queue. Every task computes exactly one key
-# from its identity at creation, and workers claim by key.
-EVALUATOR_QUEUE_KEY = "evaluator"
-IMPORTER_QUEUE_KEY = "importer"
-AGENT_QUEUE_KEY_PREFIX = "agent:"
-
-
-def agent_queue_key(agent_version_id: uuid.UUID) -> str:
-    """Build the queue key for an agent version.
-
-    Args:
-        agent_version_id: Agent version the key covers.
-
-    Returns:
-        Queue key.
-    """
-    return f"{AGENT_QUEUE_KEY_PREFIX}{agent_version_id}"
-
 
 class TaskNotFound(NotFoundError):
     """Raised when a task lookup does not resolve."""
@@ -315,15 +297,6 @@ class Task(DomainModel):
     @property
     def kind(self) -> TaskKind:
         """Kind of work the task runs.
-
-        Raises:
-            NotImplementedError: Always.
-        """
-        raise NotImplementedError
-
-    @property
-    def queue_key(self) -> str:
-        """Queue the task is claimed from.
 
         Raises:
             NotImplementedError: Always.
@@ -617,15 +590,6 @@ class AgentTask(Task):
         """
         return TaskKind.AGENT
 
-    @property
-    def queue_key(self) -> str:
-        """Queue the task is claimed from.
-
-        Returns:
-            Agent version queue key.
-        """
-        return agent_queue_key(self.agent_version_id)
-
     def check_result(self, result: Any) -> None:
         """Require a linked result session, the agent task's actual outcome.
 
@@ -654,15 +618,6 @@ class EvaluationTask(Task):
             Evaluator kind.
         """
         return TaskKind.EVALUATOR
-
-    @property
-    def queue_key(self) -> str:
-        """Queue the task is claimed from.
-
-        Returns:
-            Evaluator queue key.
-        """
-        return EVALUATOR_QUEUE_KEY
 
     def check_result(self, result: Any) -> None:
         """Require a non-empty list of evaluation results with unique names.
@@ -711,15 +666,6 @@ class ImportTask(Task):
             Importer kind.
         """
         return TaskKind.IMPORTER
-
-    @property
-    def queue_key(self) -> str:
-        """Queue the task is claimed from.
-
-        Returns:
-            Importer queue key.
-        """
-        return IMPORTER_QUEUE_KEY
 
     def check_result(self, result: Any) -> None:
         """Require a result payload.

--- a/src/kitaru/worker/config.py
+++ b/src/kitaru/worker/config.py
@@ -19,7 +19,8 @@ from typing import Any
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from kitaru.api_models.v1.worker import WorkerScope
+from kitaru.api_models.v1.task import TaskKind
+from kitaru.api_models.v1.worker import WorkerClaim, WorkerScope
 from kitaru.worker.heartbeat import DEFAULT_HEARTBEAT_INTERVAL_SECONDS
 
 RUN_POLL_INTERVAL_SECONDS = 2.0
@@ -33,7 +34,9 @@ class WorkerConfig(BaseSettings):
     )
 
     name: str | None = None
-    scope: WorkerScope = WorkerScope()
+    scope: WorkerScope = WorkerScope(
+        claims=[WorkerClaim(kind=kind) for kind in TaskKind]
+    )
     concurrency: int = Field(default=1, ge=1)
     claim_batch_size: int | None = Field(default=None, ge=1)
     poll_interval: float = Field(default=RUN_POLL_INTERVAL_SECONDS, gt=0)

--- a/tests/api_models/test_worker_models.py
+++ b/tests/api_models/test_worker_models.py
@@ -13,49 +13,88 @@
 #  permissions and limitations under the License.
 """Tests for worker API models."""
 
+import uuid
+
 import pytest
 from pydantic import ValidationError
 
 from kitaru.api_models.v1.task import TaskKind
-from kitaru.api_models.v1.worker import LabelSelector, WorkerScope
+from kitaru.api_models.v1.worker import LabelSelector, WorkerClaim, WorkerScope
 
 
-def test_empty_kinds_rejected() -> None:
-    """Reject an empty kinds list."""
+def test_empty_claims_rejected() -> None:
+    """Reject an empty claims list."""
     with pytest.raises(ValidationError):
-        WorkerScope(kinds=[])
+        WorkerScope(claims=[])
 
 
-def test_nonempty_kinds_accepted() -> None:
-    """Accept a non-empty kinds list."""
-    scope = WorkerScope(kinds=[TaskKind.AGENT])
-    assert scope.kinds == [TaskKind.AGENT]
+def test_duplicate_claims_rejected() -> None:
+    """Reject a claims list that repeats the same claim."""
+    with pytest.raises(ValidationError):
+        WorkerScope(
+            claims=[
+                WorkerClaim(kind=TaskKind.EVALUATOR),
+                WorkerClaim(kind=TaskKind.EVALUATOR),
+            ]
+        )
+
+
+def test_agent_version_on_non_agent_kind_rejected() -> None:
+    """Reject an agent_version_id on a non-agent claim."""
+    with pytest.raises(ValidationError):
+        WorkerClaim(kind=TaskKind.EVALUATOR, agent_version_id=uuid.uuid4())
+
+
+def test_versioned_agent_claim_alongside_unversioned_rejected() -> None:
+    """Reject a versioned agent claim alongside an unversioned agent claim."""
+    with pytest.raises(ValidationError):
+        WorkerScope(
+            claims=[
+                WorkerClaim(kind=TaskKind.AGENT),
+                WorkerClaim(kind=TaskKind.AGENT, agent_version_id=uuid.uuid4()),
+            ]
+        )
+
+
+def test_valid_mixed_scope_accepted() -> None:
+    """Accept a scope mixing a versioned agent claim with other kinds."""
+    agent_version_id = uuid.uuid4()
+    scope = WorkerScope(
+        claims=[
+            WorkerClaim(kind=TaskKind.AGENT, agent_version_id=agent_version_id),
+            WorkerClaim(kind=TaskKind.EVALUATOR),
+            WorkerClaim(kind=TaskKind.IMPORTER),
+        ]
+    )
+    assert len(scope.claims) == 3
 
 
 def test_empty_selectors_rejected() -> None:
     """Reject an empty selectors list."""
     with pytest.raises(ValidationError):
-        WorkerScope(selectors=[])
+        WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], selectors=[])
 
 
 def test_duplicate_selector_keys_rejected() -> None:
     """Reject selectors that repeat the same key."""
     with pytest.raises(ValidationError):
         WorkerScope(
+            claims=[WorkerClaim(kind=TaskKind.AGENT)],
             selectors=[
                 LabelSelector(key="team", values=["a"]),
                 LabelSelector(key="team", values=["b"]),
-            ]
+            ],
         )
 
 
 def test_unique_selector_keys_accepted() -> None:
     """Accept selectors with distinct keys."""
     scope = WorkerScope(
+        claims=[WorkerClaim(kind=TaskKind.AGENT)],
         selectors=[
             LabelSelector(key="team", values=["a"]),
             LabelSelector(key="region", values=["b"]),
-        ]
+        ],
     )
     assert scope.selectors is not None
     assert len(scope.selectors) == 2

--- a/tests/api_models/test_worker_models.py
+++ b/tests/api_models/test_worker_models.py
@@ -56,6 +56,18 @@ def test_versioned_agent_claim_alongside_unversioned_rejected() -> None:
         )
 
 
+def test_too_many_claims_rejected() -> None:
+    """Reject a claims list exceeding the maximum size."""
+    claims = [
+        WorkerClaim(kind=TaskKind.AGENT, agent_version_id=uuid.uuid4())
+        for _ in range(15)
+    ]
+    claims.append(WorkerClaim(kind=TaskKind.EVALUATOR))
+    claims.append(WorkerClaim(kind=TaskKind.IMPORTER))
+    with pytest.raises(ValidationError):
+        WorkerScope(claims=claims)
+
+
 def test_valid_mixed_scope_accepted() -> None:
     """Accept a scope mixing a versioned agent claim with other kinds."""
     agent_version_id = uuid.uuid4()

--- a/tests/cli/test_schema.py
+++ b/tests/cli/test_schema.py
@@ -41,11 +41,11 @@ def test_handler_parameters_match_command_schema() -> None:
                 "all_sessions" if name == "all" else name for name in schema_names
             ]
         if spec.path == ("worker", "start"):
-            # The singular public --selector option intentionally maps to the
-            # plural handler parameter that receives its repeatable values.
-            schema_names = [
-                "selectors" if name == "selector" else name for name in schema_names
-            ]
+            # The singular public --claim and --selector options intentionally
+            # map to the plural handler parameters that receive their
+            # repeatable values.
+            plural = {"claim": "claims", "selector": "selectors"}
+            schema_names = [plural.get(name, name) for name in schema_names]
         assert len(schema_names) == len(set(schema_names)), spec.command
         assert set(schema_names) == set(handler_names), spec.command
 

--- a/tests/cli/test_workers.py
+++ b/tests/cli/test_workers.py
@@ -31,6 +31,7 @@ import pytest
 from kitaru.api_models.v1.task import TaskKind
 from kitaru.api_models.v1.worker import (
     LabelSelector,
+    WorkerClaim,
     WorkerListParams,
     WorkerResponse,
     WorkerRuntime,
@@ -97,7 +98,7 @@ def _response(name: str, *, live: bool) -> WorkerResponse:
         created=now,
         updated=now,
         name=name,
-        scope={},
+        scope={"claims": [{"kind": "agent"}]},
         runtime=WorkerRuntime(platform="bare"),
         last_seen_at=datetime.now(UTC),
         live=live,
@@ -120,9 +121,9 @@ def _output_context(stdout: io.StringIO, stderr: io.StringIO) -> OutputContext:
 def test_config_merge_overrides_only_explicit_scope_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """CLI kinds refine env scope while preserving selectors and job id."""
+    """CLI claims refine env scope while preserving selectors and job id."""
     job_id = uuid.uuid4()
-    monkeypatch.setenv("KITARU_WORKER_SCOPE__KINDS", '["importer"]')
+    monkeypatch.setenv("KITARU_WORKER_SCOPE__CLAIMS", '[{"kind": "importer"}]')
     monkeypatch.setenv(
         "KITARU_WORKER_SCOPE__SELECTORS",
         '[{"key":"pool","values":["cpu"],"required":true}]',
@@ -132,12 +133,15 @@ def test_config_merge_overrides_only_explicit_scope_fields(
     monkeypatch.setenv("KITARU_WORKER_METADATA", '{"source":"env"}')
 
     config = workers.build_worker_config(
-        kinds=[TaskKind.AGENT, TaskKind.EVALUATOR],
+        claims=["agent", "evaluator"],
         concurrency=4,
         metadata=["source=cli", "pool=local"],
     )
 
-    assert config.scope.kinds == [TaskKind.AGENT, TaskKind.EVALUATOR]
+    assert config.scope.claims == [
+        WorkerClaim(kind=TaskKind.AGENT),
+        WorkerClaim(kind=TaskKind.EVALUATOR),
+    ]
     assert config.scope.selectors == [
         LabelSelector(key="pool", values=["cpu"], required=True)
     ]
@@ -145,6 +149,22 @@ def test_config_merge_overrides_only_explicit_scope_fields(
     assert config.concurrency == 4
     assert config.metadata == {"source": "cli", "pool": "local"}
     assert "request_timeout" not in type(config).model_fields
+
+
+def test_config_merge_parses_a_versioned_agent_claim() -> None:
+    """A --claim value of agent=UUID parses to a versioned agent claim."""
+    agent_version_id = uuid.uuid4()
+    config = workers.build_worker_config(claims=[f"agent={agent_version_id}"])
+    assert config.scope.claims == [
+        WorkerClaim(kind=TaskKind.AGENT, agent_version_id=agent_version_id)
+    ]
+
+
+def test_config_merge_rejects_an_invalid_claim_value() -> None:
+    """An unrecognized --claim value raises a CLI error."""
+    with pytest.raises(CLIError) as error:
+        workers.build_worker_config(claims=["bogus"])
+    assert error.value.kind == "invalid_arguments"
 
 
 def test_drain_timeout_merges_explicit_over_environment(
@@ -532,10 +552,10 @@ def test_missing_worker_extra_has_actionable_hint(
     assert error.value.hint == "Install kitaru[cli,worker]."
 
 
-def test_cli_start_passes_kind_scope_and_emits_stream_result(
+def test_cli_start_passes_claim_scope_and_emits_stream_result(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """The app maps CLI kinds into the generic worker without provider state."""
+    """The app maps CLI claims into the generic worker without provider state."""
     calls: list[tuple[ResolvedTarget, dict[str, Any]]] = []
 
     async def fake_start(target: ResolvedTarget, **options: Any) -> CommandResult:
@@ -552,9 +572,9 @@ def test_cli_start_passes_kind_scope_and_emits_stream_result(
                 "--server",
                 "https://api.example.com",
                 "--machine",
-                "--kinds",
+                "--claim",
                 "agent",
-                "--kinds",
+                "--claim",
                 "importer",
                 "--job-id",
                 str(job_id := uuid.uuid4()),
@@ -575,7 +595,7 @@ def test_cli_start_passes_kind_scope_and_emits_stream_result(
     assert payload["event"] == "stopped"
     target, options = calls[0]
     assert target.server_url == "https://api.example.com"
-    assert options["kinds"] == [TaskKind.AGENT, TaskKind.IMPORTER]
+    assert options["claims"] == ["agent", "importer"]
     assert options["job_id"] == job_id
     assert options["concurrency"] == 3
     assert options["drain_timeout"] == 15.0

--- a/tests/client/test_workers.py
+++ b/tests/client/test_workers.py
@@ -20,6 +20,7 @@ from datetime import UTC, datetime
 import pytest
 
 from conftest import (
+    UNSCOPED_WORKER_SCOPE,
     FakeAccountRepository,
     FakeAgentRepository,
     FakeAgentVersionRepository,
@@ -40,7 +41,9 @@ from conftest import (
     mint_worker_token,
 )
 from kitaru.api_models.v1.filter import FilterCondition, FilterOp
+from kitaru.api_models.v1.task import TaskKind
 from kitaru.api_models.v1.worker import (
+    WorkerClaim,
     WorkerCreateRequest,
     WorkerHeartbeatRequest,
     WorkerListParams,
@@ -163,7 +166,7 @@ async def test_create(api_client: KitaruAPIClient, account: Account) -> None:
     """Register a worker through the SDK."""
     registered = await api_client.workers.create(
         WorkerCreateRequest(
-            name="worker-1", scope=WorkerScope(), runtime=RUNTIME, metadata={}
+            name="worker-1", scope=UNSCOPED_WORKER_SCOPE, runtime=RUNTIME, metadata={}
         )
     )
     assert isinstance(registered, WorkerRegistrationResponse)
@@ -177,7 +180,7 @@ async def test_create_upsert(api_client: KitaruAPIClient) -> None:
     first = await api_client.workers.create(
         WorkerCreateRequest(
             name="worker-1",
-            scope=WorkerScope(kinds=["agent"]),
+            scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)]),
             runtime=RUNTIME,
             metadata={},
         )
@@ -185,20 +188,22 @@ async def test_create_upsert(api_client: KitaruAPIClient) -> None:
     second = await api_client.workers.create(
         WorkerCreateRequest(
             name="worker-1",
-            scope=WorkerScope(kinds=["importer"]),
+            scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)]),
             runtime=RUNTIME,
             metadata={},
         )
     )
     assert second.worker.id == first.worker.id
-    assert second.worker.scope == WorkerScope(kinds=["importer"])
+    assert second.worker.scope == WorkerScope(
+        claims=[WorkerClaim(kind=TaskKind.IMPORTER)]
+    )
 
 
 async def test_get(api_client: KitaruAPIClient) -> None:
     """Get a worker by id through the SDK."""
     created = await api_client.workers.create(
         WorkerCreateRequest(
-            name="worker-1", scope=WorkerScope(), runtime=RUNTIME, metadata={}
+            name="worker-1", scope=UNSCOPED_WORKER_SCOPE, runtime=RUNTIME, metadata={}
         )
     )
     loaded = await api_client.workers.get(created.worker.id)
@@ -216,7 +221,7 @@ async def test_list(api_client: KitaruAPIClient) -> None:
     for name in ["worker-1", "worker-2", "worker-3"]:
         await api_client.workers.create(
             WorkerCreateRequest(
-                name=name, scope=WorkerScope(), runtime=RUNTIME, metadata={}
+                name=name, scope=UNSCOPED_WORKER_SCOPE, runtime=RUNTIME, metadata={}
             )
         )
 
@@ -237,7 +242,7 @@ async def test_iter(api_client: KitaruAPIClient) -> None:
     for name in ["worker-1", "worker-2", "worker-3"]:
         await api_client.workers.create(
             WorkerCreateRequest(
-                name=name, scope=WorkerScope(), runtime=RUNTIME, metadata={}
+                name=name, scope=UNSCOPED_WORKER_SCOPE, runtime=RUNTIME, metadata={}
             )
         )
 
@@ -252,7 +257,7 @@ async def test_delete(api_client: KitaruAPIClient) -> None:
     """Delete a worker through the SDK."""
     created = await api_client.workers.create(
         WorkerCreateRequest(
-            name="worker-1", scope=WorkerScope(), runtime=RUNTIME, metadata={}
+            name="worker-1", scope=UNSCOPED_WORKER_SCOPE, runtime=RUNTIME, metadata={}
         )
     )
     await api_client.workers.delete(created.worker.id)
@@ -270,7 +275,7 @@ async def test_heartbeat(
     """Report held tasks through the SDK, receiving cancel_task_ids."""
     created = await api_client.workers.create(
         WorkerCreateRequest(
-            name="worker-1", scope=WorkerScope(), runtime=RUNTIME, metadata={}
+            name="worker-1", scope=UNSCOPED_WORKER_SCOPE, runtime=RUNTIME, metadata={}
         )
     )
     worker = created.worker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,8 +52,8 @@ from kitaru.api_models.v1.job import JobKind, JobStatus
 from kitaru.api_models.v1.replay import ReplayStatus
 from kitaru.api_models.v1.session import SessionOrigin, TokenUsage
 from kitaru.api_models.v1.tag import TagResourceType
-from kitaru.api_models.v1.task import TaskOnFailure, TaskStatus
-from kitaru.api_models.v1.worker import WorkerRuntime, WorkerScope
+from kitaru.api_models.v1.task import TaskKind, TaskOnFailure, TaskStatus
+from kitaru.api_models.v1.worker import WorkerClaim, WorkerRuntime, WorkerScope
 from kitaru.client.api_client import KitaruAPIClient
 from kitaru.client.credential_store import CredentialStore
 from kitaru.server.adapters.auth.auth_service import AuthService
@@ -214,12 +214,16 @@ from kitaru.server.domain.tag import (
     TagNotFound,
 )
 from kitaru.server.domain.task import (
+    AGENT_QUEUE_KEY_PREFIX,
+    EVALUATOR_QUEUE_KEY,
+    IMPORTER_QUEUE_KEY,
     AgentTask,
     DuplicateEvaluationTask,
     EvaluationTask,
     ImportTask,
     Task,
     TaskNotFound,
+    agent_queue_key,
 )
 from kitaru.server.domain.worker import Worker, WorkerNotFound
 from kitaru.server.filtering import (
@@ -236,6 +240,11 @@ from kitaru.transport import RetryTransport
 # runs, so register this module under the bare name and keep this file the
 # only conftest in the tree.
 sys.modules.setdefault("conftest", sys.modules[__name__])
+
+# Scope claiming every kind with no agent pin, the former empty-scope default.
+UNSCOPED_WORKER_SCOPE = WorkerScope(
+    claims=[WorkerClaim(kind=kind) for kind in TaskKind]
+)
 
 # Settings built without an explicit ANALYTICS_OPT_IN read this environment
 # variable, so no test server posts analytics to the real endpoint.
@@ -3290,7 +3299,7 @@ async def create_worker(
         Worker(
             owner_id=owner_id,
             name=name,
-            scope=scope if scope is not None else WorkerScope(),
+            scope=scope if scope is not None else UNSCOPED_WORKER_SCOPE,
             runtime=runtime if runtime is not None else WorkerRuntime(platform="bare"),
             metadata=metadata if metadata is not None else {},
             last_seen_at=last_seen_at
@@ -5049,18 +5058,34 @@ class FakeTaskRepository:
             if task_id in self._tasks
         }
 
-    def _matches_scope(self, task: Task, scope: WorkerScope) -> bool:
-        """Report whether a task matches a claim scope.
+    def _matches_claim(self, task: Task, claim: WorkerClaim) -> bool:
+        """Report whether a task's queue key matches a claim.
+
+        Args:
+            task: Candidate task.
+            claim: Claim from the worker's scope.
+
+        Returns:
+            Whether the claim covers the task's queue key.
+        """
+        if claim.kind is TaskKind.EVALUATOR:
+            return task.queue_key == EVALUATOR_QUEUE_KEY
+        if claim.kind is TaskKind.IMPORTER:
+            return task.queue_key == IMPORTER_QUEUE_KEY
+        if claim.agent_version_id is not None:
+            return task.queue_key == agent_queue_key(claim.agent_version_id)
+        return task.queue_key.startswith(AGENT_QUEUE_KEY_PREFIX)
+
+    def _matches_residual(self, task: Task, scope: WorkerScope) -> bool:
+        """Report whether a task matches a scope's conditions beyond its claims.
 
         Args:
             task: Candidate task.
             scope: Claim scope narrowing the queue.
 
         Returns:
-            Whether every scope term matches.
+            Whether the job pin and every selector match.
         """
-        if scope.kinds and task.kind not in scope.kinds:
-            return False
         if scope.job_id is not None and task.job_id != scope.job_id:
             return False
         for selector in scope.selectors or []:
@@ -5156,8 +5181,12 @@ class FakeTaskRepository:
     ) -> list[Task]:
         """Hand pending tasks matching a scope to a worker, oldest first.
 
-        Row locking has no in-memory counterpart, a single process never
-        contends with itself.
+        Ordering mirrors the SQL repository: a scope claiming everything
+        hands out the oldest pending tasks, any other scope merges up to
+        ``limit`` candidates per claim by id, and an unversioned agent claim
+        reads its candidates in queue key order before id. Row locking has
+        no in-memory counterpart, a single process never contends with
+        itself.
 
         Args:
             scope: Claim scope narrowing the queue.
@@ -5168,17 +5197,27 @@ class FakeTaskRepository:
         Returns:
             Claimed tasks carrying their incremented attempt.
         """
-        candidates = sorted(
+        pending = sorted(
             (
                 task
                 for task in self._tasks.values()
                 if task.status is TaskStatus.PENDING
-                and self._matches_scope(task, scope)
+                and self._matches_residual(task, scope)
             ),
             key=lambda task: task.id,
         )
+        if scope.claims_everything:
+            selected = pending[:limit]
+        else:
+            candidates: list[Task] = []
+            for claim in scope.claims:
+                bucket = [task for task in pending if self._matches_claim(task, claim)]
+                if claim.kind is TaskKind.AGENT and claim.agent_version_id is None:
+                    bucket.sort(key=lambda task: (task.queue_key, task.id))
+                candidates.extend(bucket[:limit])
+            selected = sorted(candidates, key=lambda task: task.id)[:limit]
         claimed: list[Task] = []
-        for task in candidates[:limit]:
+        for task in selected:
             claimed_task = task.model_copy()
             claimed_task.claim(worker_id, now)
             claimed.append(await self.update(claimed_task))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,16 +214,12 @@ from kitaru.server.domain.tag import (
     TagNotFound,
 )
 from kitaru.server.domain.task import (
-    AGENT_QUEUE_KEY_PREFIX,
-    EVALUATOR_QUEUE_KEY,
-    IMPORTER_QUEUE_KEY,
     AgentTask,
     DuplicateEvaluationTask,
     EvaluationTask,
     ImportTask,
     Task,
     TaskNotFound,
-    agent_queue_key,
 )
 from kitaru.server.domain.worker import Worker, WorkerNotFound
 from kitaru.server.filtering import (
@@ -5059,22 +5055,21 @@ class FakeTaskRepository:
         }
 
     def _matches_claim(self, task: Task, claim: WorkerClaim) -> bool:
-        """Report whether a task's queue key matches a claim.
+        """Report whether a task's kind and agent version match a claim.
 
         Args:
             task: Candidate task.
             claim: Claim from the worker's scope.
 
         Returns:
-            Whether the claim covers the task's queue key.
+            Whether the claim covers the task.
         """
-        if claim.kind is TaskKind.EVALUATOR:
-            return task.queue_key == EVALUATOR_QUEUE_KEY
-        if claim.kind is TaskKind.IMPORTER:
-            return task.queue_key == IMPORTER_QUEUE_KEY
         if claim.agent_version_id is not None:
-            return task.queue_key == agent_queue_key(claim.agent_version_id)
-        return task.queue_key.startswith(AGENT_QUEUE_KEY_PREFIX)
+            return (
+                isinstance(task, AgentTask)
+                and task.agent_version_id == claim.agent_version_id
+            )
+        return task.kind is claim.kind
 
     def _matches_residual(self, task: Task, scope: WorkerScope) -> bool:
         """Report whether a task matches a scope's conditions beyond its claims.
@@ -5181,12 +5176,9 @@ class FakeTaskRepository:
     ) -> list[Task]:
         """Hand pending tasks matching a scope to a worker, oldest first.
 
-        Ordering mirrors the SQL repository: a scope claiming everything
-        hands out the oldest pending tasks, any other scope merges up to
-        ``limit`` candidates per claim by id, and an unversioned agent claim
-        reads its candidates in queue key order before id. Row locking has
-        no in-memory counterpart, a single process never contends with
-        itself.
+        Ordering mirrors the SQL repository: the oldest pending tasks
+        matching the scope are handed out. Row locking has no in-memory
+        counterpart, a single process never contends with itself.
 
         Args:
             scope: Claim scope narrowing the queue.
@@ -5206,16 +5198,11 @@ class FakeTaskRepository:
             ),
             key=lambda task: task.id,
         )
-        if scope.claims_everything:
-            selected = pending[:limit]
-        else:
-            candidates: list[Task] = []
-            for claim in scope.claims:
-                bucket = [task for task in pending if self._matches_claim(task, claim)]
-                if claim.kind is TaskKind.AGENT and claim.agent_version_id is None:
-                    bucket.sort(key=lambda task: (task.queue_key, task.id))
-                candidates.extend(bucket[:limit])
-            selected = sorted(candidates, key=lambda task: task.id)[:limit]
+        selected = [
+            task
+            for task in pending
+            if any(self._matches_claim(task, claim) for claim in scope.claims)
+        ][:limit]
         claimed: list[Task] = []
         for task in selected:
             claimed_task = task.model_copy()

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -2123,6 +2123,7 @@
               "items": {
                 "$ref": "#/$defs/WorkerClaim"
               },
+              "maxItems": 16,
               "minItems": 1,
               "title": "Claims",
               "type": "array"

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -1903,6 +1903,35 @@
           "title": "ToolPolicyOnMiss",
           "type": "string"
         },
+        "WorkerClaim": {
+          "additionalProperties": false,
+          "description": "Worker claim.",
+          "properties": {
+            "agent_version_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Agent version the claim covers, None claims every agent version.",
+              "title": "Agent Version Id"
+            },
+            "kind": {
+              "$ref": "#/$defs/TaskKind",
+              "description": "Task kind the claim covers."
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "title": "WorkerClaim",
+          "type": "object"
+        },
         "WorkerResponse": {
           "description": "Worker response.",
           "properties": {
@@ -2089,6 +2118,15 @@
           "additionalProperties": false,
           "description": "Worker scope.",
           "properties": {
+            "claims": {
+              "description": "Claims the worker serves, combined by disjunction.",
+              "items": {
+                "$ref": "#/$defs/WorkerClaim"
+              },
+              "minItems": 1,
+              "title": "Claims",
+              "type": "array"
+            },
             "job_id": {
               "anyOf": [
                 {
@@ -2102,22 +2140,6 @@
               "default": null,
               "description": "Job the worker claims tasks from.",
               "title": "Job Id"
-            },
-            "kinds": {
-              "anyOf": [
-                {
-                  "items": {
-                    "$ref": "#/$defs/TaskKind"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Task kinds the worker claims.",
-              "title": "Kinds"
             },
             "selectors": {
               "anyOf": [
@@ -2136,6 +2158,9 @@
               "title": "Selectors"
             }
           },
+          "required": [
+            "claims"
+          ],
           "title": "WorkerScope",
           "type": "object"
         }

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,7 +6,7 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 151437,
+      "discovery_response_bytes": 151451,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
@@ -46,10 +46,10 @@
         },
         "kitaru_registry_read": {
           "$defs_count": 45,
-          "combined_bytes": 31279,
+          "combined_bytes": 31293,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25573
+          "output_bytes": 25587
         },
         "kitaru_review_manage": {
           "$defs_count": 30,
@@ -89,7 +89,7 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 77965,
+      "discovery_response_bytes": 77979,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
@@ -101,10 +101,10 @@
         },
         "kitaru_registry_read": {
           "$defs_count": 45,
-          "combined_bytes": 31279,
+          "combined_bytes": 31293,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25573
+          "output_bytes": 25587
         },
         "kitaru_review_read": {
           "$defs_count": 20,
@@ -116,7 +116,7 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 140045,
+      "discovery_response_bytes": 140059,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
@@ -149,10 +149,10 @@
         },
         "kitaru_registry_read": {
           "$defs_count": 45,
-          "combined_bytes": 31279,
+          "combined_bytes": 31293,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25573
+          "output_bytes": 25587
         },
         "kitaru_review_manage": {
           "$defs_count": 30,

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,7 +6,7 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 150988,
+      "discovery_response_bytes": 151437,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
@@ -45,11 +45,11 @@
           "output_bytes": 7317
         },
         "kitaru_registry_read": {
-          "$defs_count": 44,
-          "combined_bytes": 30830,
+          "$defs_count": 45,
+          "combined_bytes": 31279,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25124
+          "output_bytes": 25573
         },
         "kitaru_review_manage": {
           "$defs_count": 30,
@@ -89,7 +89,7 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 77516,
+      "discovery_response_bytes": 77965,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
@@ -100,11 +100,11 @@
           "output_bytes": 28453
         },
         "kitaru_registry_read": {
-          "$defs_count": 44,
-          "combined_bytes": 30830,
+          "$defs_count": 45,
+          "combined_bytes": 31279,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25124
+          "output_bytes": 25573
         },
         "kitaru_review_read": {
           "$defs_count": 20,
@@ -116,7 +116,7 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 139596,
+      "discovery_response_bytes": 140045,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
@@ -148,11 +148,11 @@
           "output_bytes": 7317
         },
         "kitaru_registry_read": {
-          "$defs_count": 44,
-          "combined_bytes": 30830,
+          "$defs_count": 45,
+          "combined_bytes": 31279,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25124
+          "output_bytes": 25573
         },
         "kitaru_review_manage": {
           "$defs_count": 30,

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -2123,6 +2123,7 @@
               "items": {
                 "$ref": "#/$defs/WorkerClaim"
               },
+              "maxItems": 16,
               "minItems": 1,
               "title": "Claims",
               "type": "array"

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -1903,6 +1903,35 @@
           "title": "ToolPolicyOnMiss",
           "type": "string"
         },
+        "WorkerClaim": {
+          "additionalProperties": false,
+          "description": "Worker claim.",
+          "properties": {
+            "agent_version_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Agent version the claim covers, None claims every agent version.",
+              "title": "Agent Version Id"
+            },
+            "kind": {
+              "$ref": "#/$defs/TaskKind",
+              "description": "Task kind the claim covers."
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "title": "WorkerClaim",
+          "type": "object"
+        },
         "WorkerResponse": {
           "description": "Worker response.",
           "properties": {
@@ -2089,6 +2118,15 @@
           "additionalProperties": false,
           "description": "Worker scope.",
           "properties": {
+            "claims": {
+              "description": "Claims the worker serves, combined by disjunction.",
+              "items": {
+                "$ref": "#/$defs/WorkerClaim"
+              },
+              "minItems": 1,
+              "title": "Claims",
+              "type": "array"
+            },
             "job_id": {
               "anyOf": [
                 {
@@ -2102,22 +2140,6 @@
               "default": null,
               "description": "Job the worker claims tasks from.",
               "title": "Job Id"
-            },
-            "kinds": {
-              "anyOf": [
-                {
-                  "items": {
-                    "$ref": "#/$defs/TaskKind"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Task kinds the worker claims.",
-              "title": "Kinds"
             },
             "selectors": {
               "anyOf": [
@@ -2136,6 +2158,9 @@
               "title": "Selectors"
             }
           },
+          "required": [
+            "claims"
+          ],
           "title": "WorkerScope",
           "type": "object"
         }

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -2123,6 +2123,7 @@
               "items": {
                 "$ref": "#/$defs/WorkerClaim"
               },
+              "maxItems": 16,
               "minItems": 1,
               "title": "Claims",
               "type": "array"

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -1903,6 +1903,35 @@
           "title": "ToolPolicyOnMiss",
           "type": "string"
         },
+        "WorkerClaim": {
+          "additionalProperties": false,
+          "description": "Worker claim.",
+          "properties": {
+            "agent_version_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Agent version the claim covers, None claims every agent version.",
+              "title": "Agent Version Id"
+            },
+            "kind": {
+              "$ref": "#/$defs/TaskKind",
+              "description": "Task kind the claim covers."
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "title": "WorkerClaim",
+          "type": "object"
+        },
         "WorkerResponse": {
           "description": "Worker response.",
           "properties": {
@@ -2089,6 +2118,15 @@
           "additionalProperties": false,
           "description": "Worker scope.",
           "properties": {
+            "claims": {
+              "description": "Claims the worker serves, combined by disjunction.",
+              "items": {
+                "$ref": "#/$defs/WorkerClaim"
+              },
+              "minItems": 1,
+              "title": "Claims",
+              "type": "array"
+            },
             "job_id": {
               "anyOf": [
                 {
@@ -2102,22 +2140,6 @@
               "default": null,
               "description": "Job the worker claims tasks from.",
               "title": "Job Id"
-            },
-            "kinds": {
-              "anyOf": [
-                {
-                  "items": {
-                    "$ref": "#/$defs/TaskKind"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Task kinds the worker claims.",
-              "title": "Kinds"
             },
             "selectors": {
               "anyOf": [
@@ -2136,6 +2158,9 @@
               "title": "Selectors"
             }
           },
+          "required": [
+            "claims"
+          ],
           "title": "WorkerScope",
           "type": "object"
         }

--- a/tests/mcp/test_handlers_protocol.py
+++ b/tests/mcp/test_handlers_protocol.py
@@ -19,7 +19,13 @@ from kitaru.api_models.v1.cohort import CohortResponse
 from kitaru.api_models.v1.investigation import InvestigationSessionResponse
 from kitaru.api_models.v1.session import SessionResponse
 from kitaru.api_models.v1.tag import TagResponse
-from kitaru.api_models.v1.worker import WorkerResponse, WorkerRuntime, WorkerScope
+from kitaru.api_models.v1.task import TaskKind
+from kitaru.api_models.v1.worker import (
+    WorkerClaim,
+    WorkerResponse,
+    WorkerRuntime,
+    WorkerScope,
+)
 from kitaru.mcp.lifecycle import MCPServerState
 from kitaru.mcp.models.activity import ActivityListRequest
 from kitaru.mcp.models.common import PageData
@@ -253,7 +259,7 @@ def _get_worker() -> WorkerResponse:
         id=uuid.uuid4(),
         owner_id=uuid.uuid4(),
         name="worker-a",
-        scope=WorkerScope(kinds=["agent"]),
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)]),
         runtime=WorkerRuntime(platform="docker", hostname="worker-a.local"),
         last_seen_at=now,
         live=True,
@@ -342,7 +348,7 @@ async def test_registry_worker_get_preserves_observation_fields() -> None:
     assert client.calls == [("get_worker", worker_id)]
     assert isinstance(worker, WorkerResponse)
     assert worker.id == worker_id
-    assert worker.scope.kinds == ["agent"]
+    assert worker.scope.claims == [WorkerClaim(kind=TaskKind.AGENT)]
     assert worker.runtime.platform == "docker"
     assert worker.metadata == {"region": "eu"}
     assert worker.last_seen_at == client.worker.last_seen_at
@@ -453,7 +459,7 @@ async def test_public_worker_get_has_canonical_structured_text_parity() -> None:
     assert json.loads(result.content[0].text) == result.structured_content
     data = result.structured_content["data"]
     assert data["id"] == str(worker_id)
-    assert data["scope"]["kinds"] == ["agent"]
+    assert data["scope"]["claims"] == [{"kind": "agent", "agent_version_id": None}]
     assert data["runtime"]["platform"] == "docker"
     assert data["metadata"] == {"region": "eu"}
     assert datetime.fromisoformat(data["last_seen_at"]) == client.worker.last_seen_at

--- a/tests/server/test_jobs_api_pg.py
+++ b/tests/server/test_jobs_api_pg.py
@@ -21,6 +21,7 @@ import pytest
 from conftest import db_settings, lifespan_client
 
 RUNTIME = {"platform": "bare"}
+SCOPE = {"claims": [{"kind": "agent"}]}
 
 
 @pytest.fixture
@@ -62,7 +63,12 @@ async def test_session_run_lifecycle_completes_the_job(
     registration = (
         await client.post(
             "/api/v1/workers",
-            json={"name": "worker-1", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
         )
     ).json()
     worker_headers = {"Authorization": f"Bearer {registration['token']}"}
@@ -189,7 +195,12 @@ async def test_heartbeat_reports_cancel_requested_tasks(
     registration = (
         await client.post(
             "/api/v1/workers",
-            json={"name": "worker-1", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
         )
     ).json()
     worker = registration["worker"]

--- a/tests/server/test_replay_service.py
+++ b/tests/server/test_replay_service.py
@@ -37,6 +37,8 @@ from kitaru.api_models.v1.filter import FilterOp
 from kitaru.api_models.v1.replay_config import HistoryScope, ToolPolicyOnMiss
 from kitaru.api_models.v1.session import SessionOrigin
 from kitaru.api_models.v1.session_node import NodeStatus, NodeType
+from kitaru.api_models.v1.task import TaskKind
+from kitaru.api_models.v1.worker import WorkerClaim, WorkerScope
 from kitaru.server.application.models.auth import (
     AuthContext,
     TaskPrincipal,
@@ -505,6 +507,76 @@ async def test_get_replay_result_session_id_appears_after_agent_task_links_it(
 
     refreshed = await services.replay_service.get_replay(bundle.replay.id, actor=ACTOR)
     assert refreshed.result_session_id == stored_task.result_session_id
+
+
+async def test_replay_agent_tasks_claim_only_their_scoped_version(
+    services: ReplayServices,
+) -> None:
+    """Two version-scoped workers each claim only their replay's agent version."""
+    first_version = await _agent_version(services, name="first")
+    second_version = await _agent_version(services, name="second")
+    first_baseline = await _session(services, first_version)
+    second_baseline = await _session(services, second_version)
+
+    first_bundle = await services.replay_service.create_replay(
+        ReplayCreate(
+            baseline_session_id=first_baseline.id,
+            agent_version_id=first_version.id,
+            evaluators=[],
+        ),
+        actor=ACTOR,
+    )
+    second_bundle = await services.replay_service.create_replay(
+        ReplayCreate(
+            baseline_session_id=second_baseline.id,
+            agent_version_id=second_version.id,
+            evaluators=[],
+        ),
+        actor=ACTOR,
+    )
+
+    first_worker = await create_worker(
+        services.workers,
+        ACTOR.account.id,
+        name="worker-first",
+        scope=WorkerScope(
+            claims=[WorkerClaim(kind=TaskKind.AGENT, agent_version_id=first_version.id)]
+        ),
+    )
+    second_worker = await create_worker(
+        services.workers,
+        ACTOR.account.id,
+        name="worker-second",
+        scope=WorkerScope(
+            claims=[
+                WorkerClaim(kind=TaskKind.AGENT, agent_version_id=second_version.id)
+            ]
+        ),
+    )
+
+    claimed_first = await services.task_service.claim_tasks(
+        10,
+        actor=WorkerAuthContext(
+            account=ACTOR.account, principal=WorkerPrincipal(worker_id=first_worker.id)
+        ),
+    )
+    claimed_second = await services.task_service.claim_tasks(
+        10,
+        actor=WorkerAuthContext(
+            account=ACTOR.account, principal=WorkerPrincipal(worker_id=second_worker.id)
+        ),
+    )
+
+    first_tasks, _ = await services.task_service.list_tasks(
+        TaskFilter(job_id=first_bundle.replay.job_id), actor=ACTOR
+    )
+    second_tasks, _ = await services.task_service.list_tasks(
+        TaskFilter(job_id=second_bundle.replay.job_id), actor=ACTOR
+    )
+    assert [item.task.id for item in claimed_first] == [task.id for task in first_tasks]
+    assert [item.task.id for item in claimed_second] == [
+        task.id for task in second_tasks
+    ]
 
 
 def _replay_service_with_analytics(

--- a/tests/server/test_replays_api_pg.py
+++ b/tests/server/test_replays_api_pg.py
@@ -24,6 +24,7 @@ from conftest import db_settings, lifespan_client
 from kitaru.cache_keys import compute_tool_cache_key
 
 RUNTIME = {"platform": "bare"}
+SCOPE = {"claims": [{"kind": "agent"}, {"kind": "evaluator"}, {"kind": "importer"}]}
 
 
 @pytest.fixture
@@ -102,7 +103,12 @@ async def test_replay_pipeline_completes_through_the_api(
     registration = (
         await client.post(
             "/api/v1/workers",
-            json={"name": "worker-1", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
         )
     ).json()
     worker_headers = {"Authorization": f"Bearer {registration['token']}"}

--- a/tests/server/test_task_cancellation_pg.py
+++ b/tests/server/test_task_cancellation_pg.py
@@ -23,10 +23,10 @@ from sqlalchemy import text
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
-from conftest import pg_session_with_engine, postgres_available
+from conftest import UNSCOPED_WORKER_SCOPE, pg_session_with_engine, postgres_available
 from kitaru.api_models.v1.job import JobKind, JobStatus
 from kitaru.api_models.v1.task import TaskStatus
-from kitaru.api_models.v1.worker import WorkerRuntime, WorkerScope
+from kitaru.api_models.v1.worker import WorkerRuntime
 from kitaru.server.adapters.db.encryption import AesGcmCipher
 from kitaru.server.adapters.db.errors import is_lock_not_available
 from kitaru.server.adapters.db.repositories.account_repository import (
@@ -168,7 +168,7 @@ async def test_hard_failure_report_survives_concurrent_job_cancel() -> None:
             Worker(
                 owner_id=owner.id,
                 name="worker",
-                scope=WorkerScope(),
+                scope=UNSCOPED_WORKER_SCOPE,
                 runtime=WorkerRuntime(platform="bare"),
                 last_seen_at=now,
             )
@@ -295,7 +295,7 @@ async def test_job_cancel_survives_concurrent_task_claim(
             Worker(
                 owner_id=owner.id,
                 name="worker",
-                scope=WorkerScope(),
+                scope=UNSCOPED_WORKER_SCOPE,
                 runtime=WorkerRuntime(platform="bare"),
                 last_seen_at=now,
             )
@@ -501,7 +501,7 @@ async def test_job_cancel_survives_concurrent_job_delete(
             Worker(
                 owner_id=owner.id,
                 name="worker",
-                scope=WorkerScope(),
+                scope=UNSCOPED_WORKER_SCOPE,
                 runtime=WorkerRuntime(platform="bare"),
                 last_seen_at=now,
             )

--- a/tests/server/test_task_repository.py
+++ b/tests/server/test_task_repository.py
@@ -24,6 +24,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from conftest import (
+    UNSCOPED_WORKER_SCOPE,
     FakeJobRepository,
     FakeTaskRepository,
     create_job,
@@ -33,7 +34,12 @@ from conftest import (
 from kitaru.api_models.v1.filter import FilterOp
 from kitaru.api_models.v1.job import JobKind
 from kitaru.api_models.v1.task import TaskKind, TaskStatus
-from kitaru.api_models.v1.worker import LabelSelector, WorkerRuntime, WorkerScope
+from kitaru.api_models.v1.worker import (
+    LabelSelector,
+    WorkerClaim,
+    WorkerRuntime,
+    WorkerScope,
+)
 from kitaru.server.adapters.db.orm.task import TaskORM
 from kitaru.server.adapters.db.repositories.account_repository import (
     SQLAccountRepository,
@@ -85,10 +91,12 @@ class Setup(NamedTuple):
     job_id: uuid.UUID
     agent_id: uuid.UUID
     agent_version_id: uuid.UUID
+    agent_version_id_2: uuid.UUID
     plugin_version_id: uuid.UUID
     payload_blob_id: uuid.UUID
     session_id: uuid.UUID
     worker_id: uuid.UUID
+    worker_id_2: uuid.UUID
 
 
 async def _seed_postgres(session: AsyncSession, engine: AsyncEngine) -> Setup:
@@ -102,6 +110,9 @@ async def _seed_postgres(session: AsyncSession, engine: AsyncEngine) -> Setup:
         Agent(owner_id=owner.id, name="assistant")
     )
     agent_version = await SQLAgentVersionRepository(session).create(
+        AgentVersion(owner_id=owner.id, agent_id=agent.id)
+    )
+    agent_version_2 = await SQLAgentVersionRepository(session).create(
         AgentVersion(owner_id=owner.id, agent_id=agent.id)
     )
     code_blob, _ = await SQLBlobRepository(session).create(
@@ -140,7 +151,16 @@ async def _seed_postgres(session: AsyncSession, engine: AsyncEngine) -> Setup:
         Worker(
             owner_id=owner.id,
             name="worker-1",
-            scope=WorkerScope(),
+            scope=UNSCOPED_WORKER_SCOPE,
+            runtime=WorkerRuntime(platform="bare"),
+            last_seen_at=datetime.now(UTC),
+        )
+    )
+    worker_2 = await SQLWorkerRepository(session).register(
+        Worker(
+            owner_id=owner.id,
+            name="worker-2",
+            scope=UNSCOPED_WORKER_SCOPE,
             runtime=WorkerRuntime(platform="bare"),
             last_seen_at=datetime.now(UTC),
         )
@@ -152,10 +172,12 @@ async def _seed_postgres(session: AsyncSession, engine: AsyncEngine) -> Setup:
         job_id=job.id,
         agent_id=agent.id,
         agent_version_id=agent_version.id,
+        agent_version_id_2=agent_version_2.id,
         plugin_version_id=plugin_version.id,
         payload_blob_id=payload.id,
         session_id=stored_session.id,
         worker_id=worker.id,
+        worker_id_2=worker_2.id,
     )
 
 
@@ -175,10 +197,12 @@ async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
             job_id=job.id,
             agent_id=uuid.uuid4(),
             agent_version_id=uuid.uuid4(),
+            agent_version_id_2=uuid.uuid4(),
             plugin_version_id=uuid.uuid4(),
             payload_blob_id=uuid.uuid4(),
             session_id=uuid.uuid4(),
             worker_id=uuid.uuid4(),
+            worker_id_2=uuid.uuid4(),
         )
         return
     if not await postgres_available():
@@ -347,10 +371,13 @@ async def test_query_filters_by_stale_before(setup: Setup) -> None:
     stale = await setup.tasks.create(_agent_task(setup))
     await setup.tasks.create(_agent_task(setup))
     await setup.tasks.claim_pending(
-        WorkerScope(), setup.worker_id, 1, datetime.now(UTC) - timedelta(hours=2)
+        UNSCOPED_WORKER_SCOPE,
+        setup.worker_id,
+        1,
+        datetime.now(UTC) - timedelta(hours=2),
     )
     await setup.tasks.claim_pending(
-        WorkerScope(), setup.worker_id, 1, datetime.now(UTC)
+        UNSCOPED_WORKER_SCOPE, setup.worker_id, 1, datetime.now(UTC)
     )
 
     tasks, next_cursor = await setup.tasks.query(
@@ -377,7 +404,7 @@ async def test_claim_pending_orders_by_id_and_locks_rows(setup: Setup) -> None:
     first = await setup.tasks.create(_agent_task(setup))
     second = await setup.tasks.create(_agent_task(setup))
     claimed = await setup.tasks.claim_pending(
-        WorkerScope(), setup.worker_id, 1, datetime.now(UTC)
+        UNSCOPED_WORKER_SCOPE, setup.worker_id, 1, datetime.now(UTC)
     )
     assert [task.id for task in claimed] == [first.id]
     assert claimed[0].attempt == 1
@@ -405,7 +432,10 @@ async def test_claim_pending_kind_filter(setup: Setup) -> None:
         )
     )
     claimed = await setup.tasks.claim_pending(
-        WorkerScope(kinds=[TaskKind.IMPORTER]), setup.worker_id, 10, datetime.now(UTC)
+        WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)]),
+        setup.worker_id,
+        10,
+        datetime.now(UTC),
     )
     assert [task.id for task in claimed] == [import_task.id]
     assert agent_task.id != import_task.id
@@ -417,7 +447,8 @@ async def test_claim_pending_required_selector(setup: Setup) -> None:
     await setup.tasks.create(_agent_task(setup, labels={"env": "dev"}))
     claimed = await setup.tasks.claim_pending(
         WorkerScope(
-            selectors=[LabelSelector(key="env", values=["prod"], required=True)]
+            claims=[WorkerClaim(kind=TaskKind.AGENT)],
+            selectors=[LabelSelector(key="env", values=["prod"], required=True)],
         ),
         setup.worker_id,
         10,
@@ -435,7 +466,8 @@ async def test_claim_pending_non_required_selector_matches_unlabeled(
     await setup.tasks.create(_agent_task(setup, labels={"env": "dev"}))
     claimed = await setup.tasks.claim_pending(
         WorkerScope(
-            selectors=[LabelSelector(key="env", values=["prod"], required=False)]
+            claims=[WorkerClaim(kind=TaskKind.AGENT)],
+            selectors=[LabelSelector(key="env", values=["prod"], required=False)],
         ),
         setup.worker_id,
         10,
@@ -448,21 +480,180 @@ async def test_claim_pending_job_pin(setup: Setup) -> None:
     """A job-pinned worker only claims that job's tasks."""
     pinned = await setup.tasks.create(_agent_task(setup))
     claimed = await setup.tasks.claim_pending(
-        WorkerScope(job_id=setup.job_id), setup.worker_id, 10, datetime.now(UTC)
+        WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=setup.job_id),
+        setup.worker_id,
+        10,
+        datetime.now(UTC),
     )
     assert [task.id for task in claimed] == [pinned.id]
 
     claimed_wrong_job = await setup.tasks.claim_pending(
-        WorkerScope(job_id=uuid.uuid4()), uuid.uuid4(), 10, datetime.now(UTC)
+        WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=uuid.uuid4()),
+        uuid.uuid4(),
+        10,
+        datetime.now(UTC),
     )
     assert claimed_wrong_job == []
+
+
+async def test_claim_pending_agent_version_scoped_workers_claim_only_their_own(
+    setup: Setup,
+) -> None:
+    """Two agent-version-scoped workers each claim only their own version's tasks."""
+    first_version_tasks = [
+        await setup.tasks.create(_agent_task(setup)) for _ in range(2)
+    ]
+    second_version_tasks = [
+        await setup.tasks.create(
+            _agent_task(setup, agent_version_id=setup.agent_version_id_2)
+        )
+        for _ in range(2)
+    ]
+    first_scope = WorkerScope(
+        claims=[
+            WorkerClaim(kind=TaskKind.AGENT, agent_version_id=setup.agent_version_id)
+        ]
+    )
+    second_scope = WorkerScope(
+        claims=[
+            WorkerClaim(kind=TaskKind.AGENT, agent_version_id=setup.agent_version_id_2)
+        ]
+    )
+
+    claimed_first = await setup.tasks.claim_pending(
+        first_scope, setup.worker_id, 10, datetime.now(UTC)
+    )
+    claimed_second = await setup.tasks.claim_pending(
+        second_scope, setup.worker_id_2, 10, datetime.now(UTC)
+    )
+    assert {task.id for task in claimed_first} == {
+        task.id for task in first_version_tasks
+    }
+    assert {task.id for task in claimed_second} == {
+        task.id for task in second_version_tasks
+    }
+
+
+async def test_claim_pending_unversioned_agent_claim_spans_every_version(
+    setup: Setup,
+) -> None:
+    """An unversioned agent claim claims tasks across every agent version."""
+    first_version_task = await setup.tasks.create(_agent_task(setup))
+    second_version_task = await setup.tasks.create(
+        _agent_task(setup, agent_version_id=setup.agent_version_id_2)
+    )
+    claimed = await setup.tasks.claim_pending(
+        WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)]),
+        setup.worker_id,
+        10,
+        datetime.now(UTC),
+    )
+    assert {task.id for task in claimed} == {
+        first_version_task.id,
+        second_version_task.id,
+    }
+
+
+async def test_claim_pending_kind_isolation_across_claims(setup: Setup) -> None:
+    """A version-scoped agent claim and an evaluator claim never cross kinds."""
+    agent_task = await setup.tasks.create(_agent_task(setup))
+    evaluation_task = await setup.tasks.create(
+        EvaluationTask(
+            job_id=setup.job_id,
+            plugin_version_id=setup.plugin_version_id,
+            input_session_id=setup.session_id,
+        )
+    )
+    await setup.tasks.create(
+        ImportTask(
+            job_id=setup.job_id,
+            plugin_version_id=setup.plugin_version_id,
+            payload_blob_id=setup.payload_blob_id,
+            agent_id=setup.agent_id,
+        )
+    )
+
+    claimed_by_agent_scope = await setup.tasks.claim_pending(
+        WorkerScope(
+            claims=[
+                WorkerClaim(
+                    kind=TaskKind.AGENT, agent_version_id=setup.agent_version_id
+                )
+            ]
+        ),
+        setup.worker_id,
+        10,
+        datetime.now(UTC),
+    )
+    assert [task.id for task in claimed_by_agent_scope] == [agent_task.id]
+
+    claimed_by_evaluator_scope = await setup.tasks.claim_pending(
+        WorkerScope(claims=[WorkerClaim(kind=TaskKind.EVALUATOR)]),
+        setup.worker_id_2,
+        10,
+        datetime.now(UTC),
+    )
+    assert [task.id for task in claimed_by_evaluator_scope] == [evaluation_task.id]
+
+
+async def test_claim_pending_merges_claims_oldest_first(setup: Setup) -> None:
+    """Mixed claims hand out the oldest eligible tasks regardless of kind."""
+    evaluation_task = await setup.tasks.create(
+        EvaluationTask(
+            job_id=setup.job_id,
+            plugin_version_id=setup.plugin_version_id,
+            input_session_id=setup.session_id,
+        )
+    )
+    agent_tasks = [await setup.tasks.create(_agent_task(setup)) for _ in range(5)]
+
+    claimed = await setup.tasks.claim_pending(
+        WorkerScope(
+            claims=[
+                WorkerClaim(kind=TaskKind.EVALUATOR),
+                WorkerClaim(
+                    kind=TaskKind.AGENT, agent_version_id=setup.agent_version_id
+                ),
+            ]
+        ),
+        setup.worker_id,
+        4,
+        datetime.now(UTC),
+    )
+    assert [task.id for task in claimed] == [
+        evaluation_task.id,
+        *[task.id for task in agent_tasks[:3]],
+    ]
+
+
+async def test_claim_pending_full_scope_takes_an_older_task_of_any_kind(
+    setup: Setup,
+) -> None:
+    """A scope claiming everything takes an older task before newer agent tasks."""
+    evaluation_task = await setup.tasks.create(
+        EvaluationTask(
+            job_id=setup.job_id,
+            plugin_version_id=setup.plugin_version_id,
+            input_session_id=setup.session_id,
+        )
+    )
+    for _ in range(3):
+        await setup.tasks.create(_agent_task(setup))
+
+    claimed = await setup.tasks.claim_pending(
+        UNSCOPED_WORKER_SCOPE, setup.worker_id, 1, datetime.now(UTC)
+    )
+    assert [task.id for task in claimed] == [evaluation_task.id]
 
 
 async def test_claim_stale(setup: Setup) -> None:
     """Lock one in-flight task whose last heartbeat predates the cutoff."""
     task = await setup.tasks.create(_agent_task(setup))
     claimed = await setup.tasks.claim_pending(
-        WorkerScope(), setup.worker_id, 10, datetime.now(UTC) - timedelta(hours=1)
+        UNSCOPED_WORKER_SCOPE,
+        setup.worker_id,
+        10,
+        datetime.now(UTC) - timedelta(hours=1),
     )
     assert len(claimed) == 1
 
@@ -480,7 +671,10 @@ async def test_list_stale_ids(setup: Setup) -> None:
     """Read the ids of in-flight tasks whose last heartbeat predates the cutoff."""
     task = await setup.tasks.create(_agent_task(setup))
     await setup.tasks.claim_pending(
-        WorkerScope(), setup.worker_id, 10, datetime.now(UTC) - timedelta(hours=1)
+        UNSCOPED_WORKER_SCOPE,
+        setup.worker_id,
+        10,
+        datetime.now(UTC) - timedelta(hours=1),
     )
 
     assert await setup.tasks.list_stale_ids(datetime.now(UTC), 10) == [task.id]
@@ -623,7 +817,7 @@ async def test_claim_pending_skip_locked_never_double_claims() -> None:
         async def claim_one() -> list[Task]:
             async with session_factory() as session:
                 claimed = await SQLTaskRepository(session).claim_pending(
-                    WorkerScope(), setup.worker_id, 1, datetime.now(UTC)
+                    UNSCOPED_WORKER_SCOPE, setup.worker_id, 1, datetime.now(UTC)
                 )
                 await session.commit()
                 return claimed

--- a/tests/server/test_task_repository.py
+++ b/tests/server/test_task_repository.py
@@ -537,7 +537,7 @@ async def test_claim_pending_agent_version_scoped_workers_claim_only_their_own(
 async def test_claim_pending_unversioned_agent_claim_spans_every_version(
     setup: Setup,
 ) -> None:
-    """An unversioned agent claim claims tasks across every agent version."""
+    """An unversioned agent claim claims tasks across every version, oldest first."""
     first_version_task = await setup.tasks.create(_agent_task(setup))
     second_version_task = await setup.tasks.create(
         _agent_task(setup, agent_version_id=setup.agent_version_id_2)
@@ -548,10 +548,45 @@ async def test_claim_pending_unversioned_agent_claim_spans_every_version(
         10,
         datetime.now(UTC),
     )
-    assert {task.id for task in claimed} == {
+    assert [task.id for task in claimed] == [
         first_version_task.id,
         second_version_task.id,
-    }
+    ]
+
+
+async def test_claim_pending_unversioned_agent_claim_does_not_starve_other_versions(
+    setup: Setup,
+) -> None:
+    """A young backlog in one agent version does not starve an older task in another."""
+    if setup.agent_version_id < setup.agent_version_id_2:
+        lower_version_id, higher_version_id = (
+            setup.agent_version_id,
+            setup.agent_version_id_2,
+        )
+    else:
+        lower_version_id, higher_version_id = (
+            setup.agent_version_id_2,
+            setup.agent_version_id,
+        )
+    limit = 4
+    older_task = await setup.tasks.create(
+        _agent_task(setup, agent_version_id=higher_version_id)
+    )
+    for _ in range(limit):
+        await setup.tasks.create(_agent_task(setup, agent_version_id=lower_version_id))
+
+    claimed = await setup.tasks.claim_pending(
+        WorkerScope(
+            claims=[
+                WorkerClaim(kind=TaskKind.AGENT),
+                WorkerClaim(kind=TaskKind.EVALUATOR),
+            ]
+        ),
+        setup.worker_id,
+        limit,
+        datetime.now(UTC),
+    )
+    assert older_task.id in {task.id for task in claimed}
 
 
 async def test_claim_pending_kind_isolation_across_claims(setup: Setup) -> None:
@@ -597,7 +632,7 @@ async def test_claim_pending_kind_isolation_across_claims(setup: Setup) -> None:
 
 
 async def test_claim_pending_merges_claims_oldest_first(setup: Setup) -> None:
-    """Mixed claims hand out the oldest eligible tasks regardless of kind."""
+    """Mixed claims hand out the oldest tasks in exact id order, regardless of kind."""
     evaluation_task = await setup.tasks.create(
         EvaluationTask(
             job_id=setup.job_id,

--- a/tests/server/test_task_service.py
+++ b/tests/server/test_task_service.py
@@ -50,6 +50,7 @@ from kitaru.api_models.v1.task import (
 )
 from kitaru.api_models.v1.worker import (
     LabelSelector,
+    WorkerClaim,
     WorkerScope,
 )
 from kitaru.server.application.events import EventDispatcher
@@ -197,7 +198,9 @@ async def test_claim_scope_kind_filter(services: JobAndTaskServices) -> None:
     await _claimable_agent_task(services, job_id)
     import_task = await _claimable_import_task(services, job_id)
     worker = await create_worker(
-        services.workers, ACTOR.account.id, scope=WorkerScope(kinds=[TaskKind.IMPORTER])
+        services.workers,
+        ACTOR.account.id,
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)]),
     )
 
     claimed = await services.task_service.claim_tasks(
@@ -215,7 +218,9 @@ async def test_claim_scope_job_pin(services: JobAndTaskServices) -> None:
     pinned = await _claimable_agent_task(services, job_id)
     await _claimable_agent_task(services, other_job_id)
     worker = await create_worker(
-        services.workers, ACTOR.account.id, scope=WorkerScope(job_id=job_id)
+        services.workers,
+        ACTOR.account.id,
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id),
     )
 
     claimed = await services.task_service.claim_tasks(
@@ -234,7 +239,8 @@ async def test_claim_scope_required_selector(services: JobAndTaskServices) -> No
         services.workers,
         ACTOR.account.id,
         scope=WorkerScope(
-            selectors=[LabelSelector(key="env", values=["prod"], required=True)]
+            claims=[WorkerClaim(kind=TaskKind.AGENT)],
+            selectors=[LabelSelector(key="env", values=["prod"], required=True)],
         ),
     )
 
@@ -256,7 +262,8 @@ async def test_claim_scope_non_required_selector_matches_unlabeled(
         services.workers,
         ACTOR.account.id,
         scope=WorkerScope(
-            selectors=[LabelSelector(key="env", values=["prod"], required=False)]
+            claims=[WorkerClaim(kind=TaskKind.AGENT)],
+            selectors=[LabelSelector(key="env", values=["prod"], required=False)],
         ),
     )
 

--- a/tests/server/test_task_sweeper_pg.py
+++ b/tests/server/test_task_sweeper_pg.py
@@ -22,6 +22,7 @@ import pytest
 from conftest import db_settings, lifespan_client
 
 RUNTIME = {"platform": "bare"}
+SCOPE = {"claims": [{"kind": "agent"}]}
 
 
 async def _wait_until(
@@ -86,7 +87,12 @@ async def test_background_sweep_abandons_a_stale_task_and_settles_the_job(
     registration = (
         await client.post(
             "/api/v1/workers",
-            json={"name": "worker-1", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
         )
     ).json()
     worker_headers = {"Authorization": f"Bearer {registration['token']}"}
@@ -170,7 +176,12 @@ async def test_background_sweep_reaches_replay_settlement_subscribers(
     registration = (
         await client.post(
             "/api/v1/workers",
-            json={"name": "worker-1", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
         )
     ).json()
     worker_headers = {"Authorization": f"Bearer {registration['token']}"}

--- a/tests/server/test_worker_repository.py
+++ b/tests/server/test_worker_repository.py
@@ -19,9 +19,20 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from conftest import FakeWorkerRepository, pg_session, postgres_available
+from conftest import (
+    UNSCOPED_WORKER_SCOPE,
+    FakeWorkerRepository,
+    pg_session,
+    postgres_available,
+)
 from kitaru.api_models.v1.filter import FilterOp
-from kitaru.api_models.v1.worker import LabelSelector, WorkerRuntime, WorkerScope
+from kitaru.api_models.v1.task import TaskKind
+from kitaru.api_models.v1.worker import (
+    LabelSelector,
+    WorkerClaim,
+    WorkerRuntime,
+    WorkerScope,
+)
 from kitaru.server.adapters.db.repositories.account_repository import (
     SQLAccountRepository,
 )
@@ -76,7 +87,7 @@ def _worker(
     return Worker(
         owner_id=owner_id,
         name=name,
-        scope=scope if scope is not None else WorkerScope(),
+        scope=scope if scope is not None else UNSCOPED_WORKER_SCOPE,
         runtime=runtime if runtime is not None else WorkerRuntime(platform="bare"),
         metadata=metadata if metadata is not None else {},
         last_seen_at=last_seen_at if last_seen_at is not None else datetime.now(UTC),
@@ -97,14 +108,16 @@ async def test_register_upsert_keeps_id_and_created(setup: Setup) -> None:
     """Re-registering under the same name keeps the id and created time."""
     repository, owner_id = setup
     first = await repository.register(
-        _worker(owner_id, scope=WorkerScope(kinds=["agent"]))
+        _worker(owner_id, scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)]))
     )
     second = await repository.register(
-        _worker(owner_id, scope=WorkerScope(kinds=["importer"]))
+        _worker(
+            owner_id, scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)])
+        )
     )
     assert second.id == first.id
     assert second.created == first.created
-    assert second.scope == WorkerScope(kinds=["importer"])
+    assert second.scope == WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)])
 
 
 async def test_register_upsert_renews_updated_and_last_seen_at(setup: Setup) -> None:
@@ -128,7 +141,7 @@ async def test_register_upsert_refreshes_scope_runtime_and_metadata(
     await repository.register(
         _worker(
             owner_id,
-            scope=WorkerScope(kinds=["agent"]),
+            scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)]),
             runtime=WorkerRuntime(platform="bare"),
             metadata={"region": "eu"},
         )
@@ -136,12 +149,12 @@ async def test_register_upsert_refreshes_scope_runtime_and_metadata(
     second = await repository.register(
         _worker(
             owner_id,
-            scope=WorkerScope(kinds=["importer"]),
+            scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)]),
             runtime=WorkerRuntime(platform="docker", hostname="worker-a"),
             metadata={"region": "us"},
         )
     )
-    assert second.scope == WorkerScope(kinds=["importer"])
+    assert second.scope == WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)])
     assert second.runtime == WorkerRuntime(platform="docker", hostname="worker-a")
     assert second.metadata == {"region": "us"}
 
@@ -264,11 +277,14 @@ async def test_delete_not_found(setup: Setup) -> None:
 
 
 async def test_scope_round_trip_selectors_and_job_pin(setup: Setup) -> None:
-    """Round-trip a scope carrying selectors, kinds, and a job pin through JSONB."""
+    """Round-trip a scope carrying claims, selectors, and a job pin through JSONB."""
     repository, owner_id = setup
     job_id = uuid.uuid4()
     scope = WorkerScope(
-        kinds=["agent", "evaluator"],
+        claims=[
+            WorkerClaim(kind=TaskKind.AGENT, agent_version_id=uuid.uuid4()),
+            WorkerClaim(kind=TaskKind.EVALUATOR),
+        ],
         selectors=[
             LabelSelector(key="agent_version", values=["v1", "v2"]),
             LabelSelector(key="team", values=["core"], required=True),

--- a/tests/server/test_worker_service.py
+++ b/tests/server/test_worker_service.py
@@ -18,9 +18,15 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from conftest import FakeWorkerRepository, create_worker
+from conftest import UNSCOPED_WORKER_SCOPE, FakeWorkerRepository, create_worker
 from kitaru.api_models.v1.filter import FilterOp
-from kitaru.api_models.v1.worker import LabelSelector, WorkerRuntime, WorkerScope
+from kitaru.api_models.v1.task import TaskKind
+from kitaru.api_models.v1.worker import (
+    LabelSelector,
+    WorkerClaim,
+    WorkerRuntime,
+    WorkerScope,
+)
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.models.worker import WorkerFilter
 from kitaru.server.application.services.worker_service import WorkerService
@@ -47,7 +53,7 @@ async def test_register_worker(service: WorkerService) -> None:
     """Register a new worker."""
     worker = await service.register_worker(
         name="worker-1",
-        scope=WorkerScope(),
+        scope=UNSCOPED_WORKER_SCOPE,
         runtime=WorkerRuntime(platform="bare"),
         metadata={"region": "eu"},
         actor=ACTOR,
@@ -65,21 +71,21 @@ async def test_register_worker_upsert_keeps_id_and_renews_timestamps(
     """Re-registering under the same name keeps id and created, renews updated."""
     first = await service.register_worker(
         name="worker-1",
-        scope=WorkerScope(kinds=["agent"]),
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)]),
         runtime=WorkerRuntime(platform="bare"),
         metadata={"region": "eu"},
         actor=ACTOR,
     )
     second = await service.register_worker(
         name="worker-1",
-        scope=WorkerScope(kinds=["importer"]),
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)]),
         runtime=WorkerRuntime(platform="docker"),
         metadata={"region": "us"},
         actor=ACTOR,
     )
     assert second.id == first.id
     assert second.created == first.created
-    assert second.scope == WorkerScope(kinds=["importer"])
+    assert second.scope == WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)])
     assert second.runtime.platform == "docker"
     assert second.metadata == {"region": "us"}
     assert second.last_seen_at >= first.last_seen_at
@@ -92,7 +98,7 @@ async def test_get_worker(service: WorkerService) -> None:
     """Load a stored worker by id."""
     created = await service.register_worker(
         name="worker-1",
-        scope=WorkerScope(),
+        scope=UNSCOPED_WORKER_SCOPE,
         runtime=WorkerRuntime(platform="bare"),
         metadata={},
         actor=ACTOR,
@@ -113,7 +119,7 @@ async def test_list_workers(service: WorkerService) -> None:
     for name in ["worker-1", "worker-2", "worker-3"]:
         await service.register_worker(
             name=name,
-            scope=WorkerScope(),
+            scope=UNSCOPED_WORKER_SCOPE,
             runtime=WorkerRuntime(platform="bare"),
             metadata={},
             actor=ACTOR,
@@ -160,7 +166,7 @@ async def test_delete_worker(service: WorkerService) -> None:
     """Delete a stored worker."""
     created = await service.register_worker(
         name="worker-1",
-        scope=WorkerScope(),
+        scope=UNSCOPED_WORKER_SCOPE,
         runtime=WorkerRuntime(platform="bare"),
         metadata={},
         actor=ACTOR,
@@ -179,7 +185,7 @@ async def test_delete_worker_not_found(service: WorkerService) -> None:
 async def test_worker_scope_round_trip(service: WorkerService) -> None:
     """Round-trip a scope carrying selectors and a job pin."""
     scope = WorkerScope(
-        kinds=["agent", "evaluator"],
+        claims=[WorkerClaim(kind=TaskKind.AGENT), WorkerClaim(kind=TaskKind.EVALUATOR)],
         selectors=[LabelSelector(key="agent_version", values=["v1", "v2"])],
         job_id=uuid.uuid4(),
     )
@@ -198,7 +204,7 @@ async def test_is_live_true(service: WorkerService) -> None:
     """Report a recently seen worker as live."""
     created = await service.register_worker(
         name="worker-1",
-        scope=WorkerScope(),
+        scope=UNSCOPED_WORKER_SCOPE,
         runtime=WorkerRuntime(platform="bare"),
         metadata={},
         actor=ACTOR,

--- a/tests/server/test_workers_api.py
+++ b/tests/server/test_workers_api.py
@@ -55,6 +55,7 @@ from kitaru.server.application.services.worker_service import WorkerService
 from kitaru.server.domain.account import Account
 
 RUNTIME = {"platform": "bare"}
+SCOPE = {"claims": [{"kind": "agent"}]}
 
 
 @pytest.fixture
@@ -134,7 +135,7 @@ async def test_register_worker(client: httpx.AsyncClient, account: Account) -> N
         "/api/v1/workers",
         json={
             "name": "worker-1",
-            "scope": {},
+            "scope": SCOPE,
             "runtime": RUNTIME,
             "metadata": {"region": "eu"},
         },
@@ -157,7 +158,7 @@ async def test_register_worker_upsert(client: httpx.AsyncClient) -> None:
             "/api/v1/workers",
             json={
                 "name": "worker-1",
-                "scope": {"kinds": ["agent"]},
+                "scope": {"claims": [{"kind": "agent"}]},
                 "runtime": RUNTIME,
                 "metadata": {"region": "eu"},
             },
@@ -168,7 +169,7 @@ async def test_register_worker_upsert(client: httpx.AsyncClient) -> None:
             "/api/v1/workers",
             json={
                 "name": "worker-1",
-                "scope": {"kinds": ["importer"]},
+                "scope": {"claims": [{"kind": "importer"}]},
                 "runtime": {"platform": "docker"},
                 "metadata": {"region": "us"},
             },
@@ -176,7 +177,9 @@ async def test_register_worker_upsert(client: httpx.AsyncClient) -> None:
     ).json()
     assert second["worker"]["id"] == first["worker"]["id"]
     assert second["worker"]["created"] == first["worker"]["created"]
-    assert second["worker"]["scope"]["kinds"] == ["importer"]
+    assert second["worker"]["scope"]["claims"] == [
+        {"kind": "importer", "agent_version_id": None}
+    ]
     assert second["worker"]["runtime"]["platform"] == "docker"
     assert second["worker"]["metadata"] == {"region": "us"}
     assert second["worker"]["updated"] > first["worker"]["updated"]
@@ -187,7 +190,7 @@ async def test_register_worker_invalid_name(client: httpx.AsyncClient) -> None:
     """Observe HTTP 422 for an invalid worker name."""
     response = await client.post(
         "/api/v1/workers",
-        json={"name": "in valid", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+        json={"name": "in valid", "scope": SCOPE, "runtime": RUNTIME, "metadata": {}},
     )
     assert response.status_code == 422
 
@@ -197,7 +200,12 @@ async def test_get_worker(client: httpx.AsyncClient) -> None:
     created = (
         await client.post(
             "/api/v1/workers",
-            json={"name": "worker-1", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
         )
     ).json()
     response = await client.get(f"/api/v1/workers/{created['worker']['id']}")
@@ -212,7 +220,12 @@ async def test_get_worker_with_its_own_token(
     created = (
         await client.post(
             "/api/v1/workers",
-            json={"name": "worker-1", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
         )
     ).json()
     worker_id = uuid.UUID(created["worker"]["id"])
@@ -231,13 +244,23 @@ async def test_get_worker_with_a_different_workers_token_is_forbidden(
     first = (
         await client.post(
             "/api/v1/workers",
-            json={"name": "worker-1", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
         )
     ).json()
     second = (
         await client.post(
             "/api/v1/workers",
-            json={"name": "worker-2", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={
+                "name": "worker-2",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
         )
     ).json()
     token = mint_worker_token(auth_service, uuid.UUID(first["worker"]["id"]), account)
@@ -261,7 +284,7 @@ async def test_list_workers(client: httpx.AsyncClient) -> None:
     for name in ["worker-1", "worker-2", "worker-3"]:
         response = await client.post(
             "/api/v1/workers",
-            json={"name": name, "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={"name": name, "scope": SCOPE, "runtime": RUNTIME, "metadata": {}},
         )
         assert response.status_code == 200
 
@@ -288,7 +311,12 @@ async def test_delete_worker(client: httpx.AsyncClient) -> None:
     created = (
         await client.post(
             "/api/v1/workers",
-            json={"name": "worker-1", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
         )
     ).json()
     response = await client.delete(f"/api/v1/workers/{created['worker']['id']}")

--- a/tests/server/test_workers_api_pg.py
+++ b/tests/server/test_workers_api_pg.py
@@ -21,6 +21,7 @@ import pytest
 from conftest import db_settings, lifespan_client
 
 RUNTIME = {"platform": "bare"}
+SCOPE = {"claims": [{"kind": "agent"}]}
 
 
 @pytest.fixture
@@ -36,7 +37,7 @@ async def test_workers_persist_across_requests(client: httpx.AsyncClient) -> Non
         "/api/v1/workers",
         json={
             "name": "worker-1",
-            "scope": {"kinds": ["agent"]},
+            "scope": SCOPE,
             "runtime": RUNTIME,
             "metadata": {"region": "eu"},
         },
@@ -62,7 +63,7 @@ async def test_upsert_persists_across_requests(client: httpx.AsyncClient) -> Non
             "/api/v1/workers",
             json={
                 "name": "worker-1",
-                "scope": {"kinds": ["agent"]},
+                "scope": SCOPE,
                 "runtime": RUNTIME,
                 "metadata": {"region": "eu"},
             },
@@ -74,7 +75,7 @@ async def test_upsert_persists_across_requests(client: httpx.AsyncClient) -> Non
             "/api/v1/workers",
             json={
                 "name": "worker-1",
-                "scope": {"kinds": ["importer"]},
+                "scope": {"claims": [{"kind": "importer"}]},
                 "runtime": {"platform": "docker"},
                 "metadata": {"region": "us"},
             },
@@ -88,7 +89,7 @@ async def test_upsert_persists_across_requests(client: httpx.AsyncClient) -> Non
     response = await client.get(f"/api/v1/workers/{first['id']}")
     assert response.status_code == 200
     body = response.json()
-    assert body["scope"]["kinds"] == ["importer"]
+    assert body["scope"]["claims"] == [{"kind": "importer", "agent_version_id": None}]
     assert body["runtime"]["platform"] == "docker"
     assert body["metadata"] == {"region": "us"}
 
@@ -98,7 +99,12 @@ async def test_delete_persists_across_requests(client: httpx.AsyncClient) -> Non
     created = (
         await client.post(
             "/api/v1/workers",
-            json={"name": "worker-1", "scope": {}, "runtime": RUNTIME, "metadata": {}},
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
         )
     ).json()["worker"]
     response = await client.delete(f"/api/v1/workers/{created['id']}")

--- a/tests/worker/fakes.py
+++ b/tests/worker/fakes.py
@@ -37,6 +37,7 @@ from kitaru.api_models.v1.task import (
     TaskWithSpec,
 )
 from kitaru.api_models.v1.worker import (
+    WorkerClaim,
     WorkerHeartbeatResponse,
     WorkerRegistrationResponse,
     WorkerResponse,
@@ -217,7 +218,7 @@ def make_worker_response(**overrides: Any) -> WorkerResponse:
         "id": uuid.uuid4(),
         "owner_id": OWNER_ID,
         "name": "worker-1",
-        "scope": WorkerScope(),
+        "scope": WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)]),
         "runtime": WorkerRuntime(platform="bare"),
         "last_seen_at": _now(),
         "live": True,

--- a/tests/worker/test_config.py
+++ b/tests/worker/test_config.py
@@ -18,7 +18,7 @@ import uuid
 import pytest
 
 from kitaru.api_models.v1.task import TaskKind
-from kitaru.api_models.v1.worker import LabelSelector, WorkerScope
+from kitaru.api_models.v1.worker import LabelSelector, WorkerClaim, WorkerScope
 from kitaru.worker.config import WorkerConfig
 from kitaru.worker.worker import default_worker_name
 
@@ -28,7 +28,9 @@ def test_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("KITARU_WORKER_CONCURRENCY", raising=False)
     config = WorkerConfig()
     assert config.name is None
-    assert config.scope == WorkerScope()
+    assert config.scope == WorkerScope(
+        claims=[WorkerClaim(kind=kind) for kind in TaskKind]
+    )
     assert config.concurrency == 1
     assert config.claim_batch_size is None
     assert config.timeout is None
@@ -51,15 +53,16 @@ def test_explicit_config_values_override_environment(
     assert config.concurrency == 2
 
 
-def test_scope_kinds_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """KITARU_WORKER_SCOPE__KINDS takes a JSON list of task kinds."""
-    monkeypatch.setenv("KITARU_WORKER_SCOPE__KINDS", '["importer"]')
+def test_scope_claims_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """KITARU_WORKER_SCOPE__CLAIMS takes a JSON list of claim objects."""
+    monkeypatch.setenv("KITARU_WORKER_SCOPE__CLAIMS", '[{"kind": "importer"}]')
     config = WorkerConfig()
-    assert config.scope.kinds == [TaskKind.IMPORTER]
+    assert config.scope.claims == [WorkerClaim(kind=TaskKind.IMPORTER)]
 
 
 def test_scope_selectors_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """KITARU_WORKER_SCOPE__SELECTORS takes a JSON list of selector objects."""
+    monkeypatch.setenv("KITARU_WORKER_SCOPE__CLAIMS", '[{"kind": "agent"}]')
     monkeypatch.setenv(
         "KITARU_WORKER_SCOPE__SELECTORS",
         '[{"key": "agent_version", "values": ["v1"], "required": false}]',
@@ -73,6 +76,7 @@ def test_scope_selectors_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_scope_job_id_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """KITARU_WORKER_SCOPE__JOB_ID takes a bare uuid value."""
     job_id = uuid.uuid4()
+    monkeypatch.setenv("KITARU_WORKER_SCOPE__CLAIMS", '[{"kind": "agent"}]')
     monkeypatch.setenv("KITARU_WORKER_SCOPE__JOB_ID", str(job_id))
     config = WorkerConfig()
     assert config.scope.job_id == job_id

--- a/tests/worker/test_worker.py
+++ b/tests/worker/test_worker.py
@@ -39,6 +39,7 @@ from kitaru.api_models.v1.task import (
     TaskStatus,
 )
 from kitaru.api_models.v1.worker import (
+    WorkerClaim,
     WorkerScope,
 )
 from kitaru.client.exceptions import APIError, NotFoundError
@@ -169,7 +170,11 @@ async def test_should_stop_false_without_stop_deadline_or_job(
 async def test_should_stop_true_when_pinned_job_settles(tmp_path: Path) -> None:
     """A job-pinned scope stops once the job reaches a terminal status."""
     job_id = uuid.uuid4()
-    worker = Worker(WorkerConfig(scope=WorkerScope(job_id=job_id)))
+    worker = Worker(
+        WorkerConfig(
+            scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id)
+        )
+    )
     client = FakeKitaruAPIClient()
     client.jobs.get_responses.append(make_job_response(status=JobStatus.COMPLETED))
     ctx = _ctx(tmp_path, client)
@@ -183,7 +188,11 @@ async def test_should_stop_false_when_pinned_job_still_running(
 ) -> None:
     """A job-pinned scope keeps polling while the job is not settled."""
     job_id = uuid.uuid4()
-    worker = Worker(WorkerConfig(scope=WorkerScope(job_id=job_id)))
+    worker = Worker(
+        WorkerConfig(
+            scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id)
+        )
+    )
     client = FakeKitaruAPIClient()
     client.jobs.get_responses.append(make_job_response(status=JobStatus.RUNNING))
     ctx = _ctx(tmp_path, client)
@@ -196,7 +205,11 @@ async def test_should_stop_false_when_the_pinned_job_read_fails(
 ) -> None:
     """A failed pinned-job read is logged and does not stop the loop."""
     job_id = uuid.uuid4()
-    worker = Worker(WorkerConfig(scope=WorkerScope(job_id=job_id)))
+    worker = Worker(
+        WorkerConfig(
+            scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id)
+        )
+    )
     client = FakeKitaruAPIClient()
     client.jobs.get_responses.append(NotFoundError(404, "job not found"))
     client.jobs.get_responses.append(httpx.ConnectError("down"))
@@ -244,7 +257,9 @@ async def test_claim_loop_full_claim_loops_again_without_sleeping(
     job_id = uuid.uuid4()
     client = FakeKitaruAPIClient()
     config = WorkerConfig(
-        scope=WorkerScope(job_id=job_id), concurrency=3, claim_batch_size=1
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id),
+        concurrency=3,
+        claim_batch_size=1,
     )
     worker = Worker(config)
     ctx = _ctx(tmp_path, client)
@@ -322,7 +337,10 @@ async def test_claim_loop_respects_the_concurrency_bound(tmp_path: Path) -> None
     """The claim request never asks for more than the free concurrency slots."""
     job_id = uuid.uuid4()
     client = FakeKitaruAPIClient()
-    config = WorkerConfig(scope=WorkerScope(job_id=job_id), concurrency=1)
+    config = WorkerConfig(
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id),
+        concurrency=1,
+    )
     worker = Worker(config)
     ctx = _ctx(tmp_path, client)
     client.jobs.get_responses.append(make_job_response(status=JobStatus.COMPLETED))
@@ -336,7 +354,10 @@ async def test_claim_size_is_clamped_to_endpoint_limit(tmp_path: Path) -> None:
     """The claim request never exceeds the endpoint's max batch size."""
     job_id = uuid.uuid4()
     client = FakeKitaruAPIClient()
-    config = WorkerConfig(scope=WorkerScope(job_id=job_id), concurrency=150)
+    config = WorkerConfig(
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id),
+        concurrency=150,
+    )
     worker = Worker(config)
     ctx = _ctx(tmp_path, client)
     client.jobs.get_responses.append(make_job_response(status=JobStatus.COMPLETED))
@@ -353,7 +374,9 @@ async def test_claim_loop_short_claim_checks_stop_before_sleeping(
     job_id = uuid.uuid4()
     client = FakeKitaruAPIClient()
     config = WorkerConfig(
-        scope=WorkerScope(job_id=job_id), concurrency=5, poll_interval=5.0
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id),
+        concurrency=5,
+        poll_interval=5.0,
     )
     worker = Worker(config)
     ctx = _ctx(tmp_path, client)
@@ -375,7 +398,9 @@ async def test_claim_loop_backoff_doubles_and_resets_on_success(
     job_id = uuid.uuid4()
     client = FakeKitaruAPIClient()
     config = WorkerConfig(
-        scope=WorkerScope(job_id=job_id), concurrency=1, poll_interval=1.0
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id),
+        concurrency=1,
+        poll_interval=1.0,
     )
     worker = Worker(config)
     ctx = _ctx(tmp_path, client)
@@ -401,7 +426,9 @@ async def test_claim_loop_backoff_caps_at_the_maximum(
     job_id = uuid.uuid4()
     client = FakeKitaruAPIClient()
     config = WorkerConfig(
-        scope=WorkerScope(job_id=job_id), concurrency=1, poll_interval=50.0
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id),
+        concurrency=1,
+        poll_interval=50.0,
     )
     worker = Worker(config)
     ctx = _ctx(tmp_path, client)
@@ -427,7 +454,9 @@ async def test_claim_loop_backs_off_on_a_transport_error(
     job_id = uuid.uuid4()
     client = FakeKitaruAPIClient()
     config = WorkerConfig(
-        scope=WorkerScope(job_id=job_id), concurrency=1, poll_interval=1.0
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id),
+        concurrency=1,
+        poll_interval=1.0,
     )
     worker = Worker(config)
     ctx = _ctx(tmp_path, client)
@@ -554,7 +583,9 @@ async def test_job_pinned_loop_claims_tasks_appended_after_empty_poll(
     job_id = uuid.uuid4()
     client = FakeKitaruAPIClient()
     config = WorkerConfig(
-        scope=WorkerScope(job_id=job_id), concurrency=2, poll_interval=0.01
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)], job_id=job_id),
+        concurrency=2,
+        poll_interval=0.01,
     )
     worker = Worker(config)
     ctx = _ctx(tmp_path, client)
@@ -615,7 +646,7 @@ async def test_run_registers_and_drains_a_claimed_task(
     client.tasks.update_responses.append(running_task)
     client.tasks.update_responses.append(completed_task)
 
-    scope = WorkerScope(kinds=[TaskKind.AGENT])
+    scope = WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)])
     config = WorkerConfig(
         name="worker-under-test",
         scope=scope,
@@ -662,7 +693,7 @@ async def test_run_pins_the_api_url_to_the_registration_server(
 
     config = WorkerConfig(
         name="worker-under-test",
-        scope=WorkerScope(kinds=[TaskKind.AGENT]),
+        scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)]),
         poll_interval=0.01,
         blob_cache_root=tmp_path / "blobs",
         payload_cache_root=tmp_path / "payloads",

--- a/tests/worker/test_worker_auth.py
+++ b/tests/worker/test_worker_auth.py
@@ -16,6 +16,7 @@
 from fastapi import FastAPI
 
 from conftest import (
+    UNSCOPED_WORKER_SCOPE,
     FakeAccountRepository,
     FakeApiKeyRepository,
     FakePasswordHasher,
@@ -23,7 +24,7 @@ from conftest import (
     asgi_api_client,
     local_settings,
 )
-from kitaru.api_models.v1.worker import WorkerCreateRequest, WorkerRuntime, WorkerScope
+from kitaru.api_models.v1.worker import WorkerCreateRequest, WorkerRuntime
 from kitaru.server.adapters.auth.auth_service import AuthService
 from kitaru.server.adapters.rest.dependencies import (
     get_auth_service,
@@ -88,7 +89,7 @@ def _registration_request(name: str = "worker-1") -> WorkerCreateRequest:
         Worker create request.
     """
     return WorkerCreateRequest(
-        name=name, scope=WorkerScope(), runtime=RUNTIME, metadata={}
+        name=name, scope=UNSCOPED_WORKER_SCOPE, runtime=RUNTIME, metadata={}
     )
 
 

--- a/v2_examples/vercel_ai_support_triage/demo.py
+++ b/v2_examples/vercel_ai_support_triage/demo.py
@@ -47,7 +47,8 @@ from kitaru.api_models.v1.session_node import (
     SessionNodeResponse,
 )
 from kitaru.api_models.v1.session_run import SessionRunCreateRequest
-from kitaru.api_models.v1.worker import WorkerScope
+from kitaru.api_models.v1.task import TaskKind
+from kitaru.api_models.v1.worker import WorkerClaim, WorkerScope
 from kitaru.client.api_client import KitaruAPIClient
 from kitaru.worker import Worker, WorkerConfig
 
@@ -154,7 +155,10 @@ async def _run_job(
     worker = Worker(
         WorkerConfig(
             name=f"vercel-ai-demo-{job_id}",
-            scope=WorkerScope(job_id=job_id),
+            scope=WorkerScope(
+                claims=[WorkerClaim(kind=kind) for kind in TaskKind],
+                job_id=job_id,
+            ),
             poll_interval=0.05,
             timeout=180,
             blob_cache_root=state_dir / "worker-blobs",


### PR DESCRIPTION
Workers now declare explicit scope claims, and agent task claims can be pinned to a specific agent version so agent-specific workers on one server no longer claim each other's tasks. Register claims with the repeatable `--claim` flag: `agent`, `evaluator`, `importer`, or `agent=<agent version id>`.

Tasks carry a queue key computed at creation, and each claim runs as a bounded index scan handing out the oldest eligible tasks first.

Fixes #743.