### PR TITLE
Serve the bundled Kitaru UI

### DIFF
--- a/.claude/skills/kitaru-dev-commands/SKILL.md
+++ b/.claude/skills/kitaru-dev-commands/SKILL.md
@@ -87,11 +87,11 @@ Read `FRONTEND-TESTING.md` before changing UI bundle, frontend smoke, Docker das
 just ui-bundle                           # Download latest stable UI bundle
 just UI_TAG=kitaru-ui-v0.2.0 ui-bundle  # Pin a stable UI bundle
 just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease
+docker compose up -d db
+just ui-serve                            # Serve the downloaded bundle from source
 ```
 
-The inherited `just ui-login` recipe calls `kitaru login` without the required `SERVER` argument or `--local`, so do not advertise it as a working v2 command. After preparing a bundle, set the printed `KITARU_UI_DIST_PATH` and use `uv run kitaru login SERVER` or `uv run kitaru login --local` against an already-running server.
-
-Do not advertise `just ui-smoke` or `just release-smoke` as working v2 checks while they still call the removed `scripts/smoke-test.sh`.
+`just ui-serve` runs the API server from source against the local compose database and serves the bundle at `http://localhost:8000`.
 
 The v2 Dockerfiles are `docker/dev-client.Dockerfile`, `docker/dev-server.Dockerfile`, `docker/release-client.Dockerfile`, and `docker/release-server.Dockerfile`. Follow `docker/CLAUDE.md`; do not use inherited v1 `server-image` recipes as v2 release evidence.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed TypeScript replay and recording edge cases, aligned credential redaction and provider diagnostics across adapters, and made the adapter examples reproducible, rerunnable, and part of CI.
 
 ### Added
+- The server now serves the bundled Kitaru UI at its root URL with SPA fallback. Setting `KITARU_SERVER_EXTERNAL_UI=true` makes it redirect to the configured dashboard URL instead of serving files, and `GET /v1/info` reports the served UI version.
 - Every filterable entity list filters by `id`, including `in` over a list of ids.
 - TypeScript SDK packages for the core client and replay runtime, with Mastra and Vercel AI SDK adapters and runnable examples.
 - TypeScript release packaging for the core, Mastra, and Vercel AI SDK packages, with lockstep release-candidate versions, clean-consumer tarball checks, npm publishing, and GitHub release artifacts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Fetching a pending device authorization by id no longer fails before an account approves it, so the device verification page can render.
 - Fixed TypeScript replay and recording edge cases, aligned credential redaction and provider diagnostics across adapters, and made the adapter examples reproducible, rerunnable, and part of CI.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- Fetching a pending device authorization by id no longer fails before an account approves it, so the device verification page can render.
+- Fetching a pending device authorization by id now succeeds when the request carries the device's user code, so the device verification page can render before an account approves it.
 - Fixed TypeScript replay and recording edge cases, aligned credential redaction and provider diagnostics across adapters, and made the adapter examples reproducible, rerunnable, and part of CI.
 
 ### Added

--- a/FRONTEND-TESTING.md
+++ b/FRONTEND-TESTING.md
@@ -6,11 +6,12 @@ It covers two different jobs that are easy to mix up:
 1. **Official Kitaru releases** bundle only stable/full Kitaru UI releases from
    `zenml-io/zenml-frontend-monorepo`.
 2. **Local testing** can choose a UI bundle explicitly, including prerelease UI
-   tags, by pointing a local Kitaru server at a downloaded `dist/` directory.
+   tags, by downloading it into the packaged location and running the server
+   from source against it.
 
-The safety rule is simple: Docker does not pick a UI release anymore. The Kitaru
-package already contains the UI, and Docker copies that packaged UI into the
-ZenML dashboard directory during image build.
+The safety rule is simple: official Kitaru builds only ever bundle a stable UI
+release. Prerelease UI testing is explicit, local, and never touches the
+release pipeline.
 
 ## Mental model
 
@@ -19,8 +20,10 @@ Think of the UI like a printed booklet that gets put inside the Kitaru box.
 - `scripts/download-ui.sh` chooses the booklet and puts it into
   `src/kitaru/_ui/dist/`.
 - `uv build` packs that booklet into the Python wheel.
-- `docker/Dockerfile` installs Kitaru and copies the booklet from the installed
-  package into the server dashboard.
+- The Kitaru server serves the booklet at its own root URL, straight out of
+  `src/kitaru/_ui/dist/`.
+- Release Docker images get the booklet by installing the published wheel.
+  There is no separate ZenML dashboard and no Docker copy step.
 
 That means there is one official UI choice per Kitaru build. There is no second
 hidden UI download during Docker build.
@@ -40,7 +43,7 @@ What happens:
   `zenml-io/zenml-frontend-monorepo`, searching across paginated GitHub release
   results instead of trusting only the first page.
 - The archive checksum is verified.
-- Files are extracted to `.kitaru-ui-bundles/current/dist/`.
+- Files are extracted to `src/kitaru/_ui/dist/`.
 - A `bundle_manifest.json` is written next to the dist directory.
 
 If the monorepo release assets require authentication, make sure your shell has
@@ -83,78 +86,31 @@ or smoke testing only, never in the official Kitaru release workflow.
 Tokened UI bundle jobs in CI must run only on trusted events such as `push`, not
 on `pull_request` code.
 
-## Start local Kitaru with the prepared UI
+## Serve the downloaded UI locally
 
-After preparing a bundle, start the local server with:
-
-```bash
-just ui-login
-```
-
-For a pinned bundle:
+After preparing a bundle, start the database and run the server from source:
 
 ```bash
-just UI_TAG=kitaru-ui-v0.2.0 ui-login
+docker compose up -d db
+just ui-serve
 ```
 
-For a prerelease bundle:
+`ui-serve` checks that `src/kitaru/_ui/dist/index.html` exists, then runs the
+API server against the local compose database with `KITARU_SERVER_DB_NAME` set
+to a dedicated database so UI testing does not share the default one.
 
-```bash
-just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-login
-```
+Open `http://localhost:8000` to see the served UI. If you download a different
+bundle with `just ui-bundle` or `just ui-bundle-prerelease`, restart `ui-serve`
+to pick it up.
 
-`ui-login` looks for the prepared bundle under `.kitaru-ui-bundles/.../dist` and
-runs `kitaru login` with `KITARU_UI_DIST_PATH` set.
+To confirm which bundle is live, check `GET /v1/info`. Its `ui_version` field
+reports the tag from the served bundle's `bundle_manifest.json`.
 
-Important: `KITARU_UI_DIST_PATH` only matters when the local server starts. If a
-local server is already running, restart it before testing a different UI:
+## External dashboard redirect
 
-```bash
-kitaru logout
-just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-login
-```
-
-## Direct local override without Just
-
-If you already have a UI `dist/` directory, point Kitaru at it directly:
-
-```bash
-KITARU_UI_DIST_PATH=/absolute/path/to/dist kitaru login
-```
-
-When working from this source checkout, the equivalent is usually:
-
-```bash
-KITARU_UI_DIST_PATH=/absolute/path/to/dist uv run kitaru login
-```
-
-The directory must contain `index.html`. If it does not, Kitaru raises a
-user-facing error instead of silently falling back to the stock ZenML dashboard.
-
-## Run the Kitaru smoke test against a selected UI
-
-Use this before asking someone to click around manually:
-
-```bash
-just ui-smoke
-```
-
-For a prerelease:
-
-```bash
-just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease
-just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-smoke
-```
-
-`ui-smoke` runs:
-
-```bash
-KITARU_UI_DIST_PATH=<prepared-dist> ./scripts/smoke-test.sh --keep-server
-```
-
-The `--keep-server` flag leaves the local server running after the automated
-checks finish, so you can open the dashboard and inspect the selected UI in a
-browser.
+Setting `KITARU_SERVER_EXTERNAL_UI=true` switches the server out of file-serving
+mode. It then serves no UI files itself and redirects every non-API path to
+`KITARU_SERVER_DASHBOARD_URL` instead.
 
 ## Prerelease smoke workflow in GitHub Actions
 
@@ -170,54 +126,32 @@ From GitHub:
 
 What the workflow does:
 
-- checks out the requested Kitaru ref;
+- checks out the workflow's own ref and the requested Kitaru ref separately, so
+  the trusted download script always runs from the trusted ref;
 - downloads the selected UI with `KITARU_UI_ALLOW_PRERELEASE=true`;
 - builds the Kitaru wheel and verifies the UI files are inside it;
-- optionally builds the Docker image from local source;
-- checks that the Docker image contains both the packaged Kitaru UI and the
-  copied ZenML dashboard files;
+- records the UI tag, repo, and checksum in the job summary;
+- optionally builds the server image from local source with
+  `docker/dev-server.Dockerfile`;
+- starts a PostgreSQL container and the server image against it;
+- checks that the running container's installed package contains the packaged
+  Kitaru UI files;
+- checks that the root route returns the UI's HTML shell;
+- checks that the device verification route renders without a generic error or
+  a `TemplateNotFound` failure;
 - publishes nothing: no PyPI package, no Docker image, no Helm chart, no Git tag,
   and no GitHub Release.
-
-## Docker testing notes
-
-For release-like Docker testing from this repo, use:
-
-```bash
-just server-image
-```
-
-This downloads a stable UI into `src/kitaru/_ui/dist/` first, installs Kitaru in
-the image, and then Docker copies the installed package UI into the dashboard.
-
-For a specific stable UI:
-
-```bash
-just UI_TAG=kitaru-ui-v0.2.0 server-image
-```
-
-For an unarchived local frontend build, use the separate dev-server image path:
-
-```bash
-cp -r /path/to/zenml-frontend-monorepo/apps/kitaru-ui/dist/ docker/kitaru-ui-dist/
-just server-dev-image
-```
-
-Keep these two Docker paths separate:
-
-- `server-image` tests packaged Kitaru UI, like release builds.
-- `server-dev-image` tests a raw local frontend `dist/` copied into the Docker
-  build context.
 
 ## Quick checklist for prerelease validation
 
 ```bash
 export KITARU_UI_RELEASE_TOKEN=<token-if-needed>
 just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-bundle-prerelease
-just UI_TAG=kitaru-ui-v0.3.0-rc.1 ui-smoke
+docker compose up -d db
+just ui-serve
 ```
 
-Then open the dashboard URL printed by `kitaru login` / the smoke test and click
-through the UI. If the UI is good, frontend maintainers can promote the
-`kitaru-ui-v*` release from prerelease to a full GitHub release. Only after that
-can an official Kitaru release bundle it by default.
+Then open `http://localhost:8000` and click through the UI. If the UI is good,
+frontend maintainers can promote the `kitaru-ui-v*` release from prerelease to a
+full GitHub release. Only after that can an official Kitaru release bundle it by
+default.

--- a/Justfile
+++ b/Justfile
@@ -5,7 +5,6 @@ ZENML_SERVER_TAG := "0.96.1"
 DOCKER_REPO := "zenmldocker/kitaru-server"
 DOCKER_TAG := "latest"
 UI_TAG := "latest"
-UI_BUNDLE_ROOT := ".kitaru-ui-bundles"
 
 # List available recipes
 default:
@@ -113,21 +112,19 @@ mcp-schema-check:
 mcp-wheel-smoke:
     uv run --no-sync python scripts/smoke_mcp_wheel.py dist
 
-# Download/extract a local Kitaru UI bundle for manual login/smoke testing.
+# Download/extract the Kitaru UI bundle into the packaged location the server serves.
 # Defaults to the latest stable kitaru-ui-v* release.
 # Pass UI_TAG=kitaru-ui-v0.2.0 to pin a stable release.
 ui-bundle:
     @set -e; \
     if [ "{{ UI_TAG }}" = "latest" ]; then \
-        dest="{{ UI_BUNDLE_ROOT }}/current"; \
-        printf 'Downloading latest stable Kitaru UI bundle into %s/dist\n' "$dest"; \
-        KITARU_UI_INSTALL_DIR="$dest" bash scripts/download-ui.sh; \
+        printf 'Downloading latest stable Kitaru UI bundle into src/kitaru/_ui/dist\n'; \
+        bash scripts/download-ui.sh; \
     else \
-        dest="{{ UI_BUNDLE_ROOT }}/{{ UI_TAG }}"; \
-        printf 'Downloading Kitaru UI bundle {{ UI_TAG }} into %s/dist\n' "$dest"; \
-        KITARU_UI_INSTALL_DIR="$dest" TAG="{{ UI_TAG }}" bash scripts/download-ui.sh; \
+        printf 'Downloading Kitaru UI bundle {{ UI_TAG }} into src/kitaru/_ui/dist\n'; \
+        TAG="{{ UI_TAG }}" bash scripts/download-ui.sh; \
     fi; \
-    printf '\nUse with: KITARU_UI_DIST_PATH=%s/dist uv run kitaru login\n' "$dest"
+    printf '\nThe server serves this bundle from src/kitaru/_ui/dist. Next: just ui-serve\n'
 
 # Download/extract an explicit prerelease Kitaru UI bundle for local testing.
 ui-bundle-prerelease:
@@ -136,21 +133,16 @@ ui-bundle-prerelease:
         printf 'Error: pass an explicit prerelease tag, e.g. UI_TAG=kitaru-ui-v0.3.0-rc.1\n' >&2; \
         exit 1; \
     fi; \
-    dest="{{ UI_BUNDLE_ROOT }}/{{ UI_TAG }}"; \
-    printf 'Downloading prerelease Kitaru UI bundle {{ UI_TAG }} into %s/dist\n' "$dest"; \
-    KITARU_UI_ALLOW_PRERELEASE=true KITARU_UI_INSTALL_DIR="$dest" TAG="{{ UI_TAG }}" bash scripts/download-ui.sh; \
-    printf '\nUse with: KITARU_UI_DIST_PATH=%s/dist uv run kitaru login\n' "$dest"
+    printf 'Downloading prerelease Kitaru UI bundle {{ UI_TAG }} into src/kitaru/_ui/dist\n'; \
+    KITARU_UI_ALLOW_PRERELEASE=true TAG="{{ UI_TAG }}" bash scripts/download-ui.sh; \
+    printf '\nThe server serves this bundle from src/kitaru/_ui/dist. Next: just ui-serve\n'
 
-# Start local Kitaru with a prepared UI bundle.
-ui-login:
-    @set -e; \
-    if [ "{{ UI_TAG }}" = "latest" ]; then \
-        dist="{{ UI_BUNDLE_ROOT }}/current/dist"; \
-    else \
-        dist="{{ UI_BUNDLE_ROOT }}/{{ UI_TAG }}/dist"; \
-    fi; \
-    test -f "$dist/index.html" || { printf 'Error: %s/index.html not found. Run just ui-bundle first.\n' "$dist" >&2; exit 1; }; \
-    KITARU_UI_DIST_PATH="$dist" uv run kitaru login
+# Run the API server from source, serving the downloaded UI bundle. Requires docker compose up -d db.
+ui-serve:
+    @test -f src/kitaru/_ui/dist/index.html || { printf 'Error: src/kitaru/_ui/dist/index.html not found. Run just ui-bundle first.\n' >&2; exit 1; }
+    KITARU_SERVER_DB_HOST=localhost KITARU_SERVER_DB_PORT=5433 KITARU_SERVER_DB_NAME=kitaru_ui \
+    KITARU_SERVER_JWT_SIGNING_KEY=dev KITARU_SERVER_SECRET_ENCRYPTION_KEY=dev KITARU_SERVER_ANALYTICS_OPT_IN=false \
+    exec uv run uvicorn kitaru.server.api.main:app --factory --port 8000
 
 # Audit the public example coverage manifest without running examples or providers.
 example-coverage-audit:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -10882,7 +10882,7 @@
         ]
       },
       "get": {
-        "description": "Get a device by id.\n\nClients observe HTTP 200 on success and 404 when no device has this id or\nanother account already approved it.\n\nArgs:\n    device_id: Id of the device.\n    service: Device service.\n    actor: Caller context.\n\nReturns:\n    Stored device.",
+        "description": "Get a device by id.\n\nClients observe HTTP 200 on success and 404 when no device has this id,\nanother account already approved it, or the user code of an unapproved\ndevice is missing or wrong.\n\nArgs:\n    device_id: Id of the device.\n    service: Device service.\n    actor: Caller context.\n    user_code: User code of a device no account approved yet.\n\nReturns:\n    Stored device.",
         "operationId": "get_device_v1_devices__device_id__get",
         "parameters": [
           {
@@ -10893,6 +10893,22 @@
               "format": "uuid",
               "title": "Device Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user_code",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Code"
             }
           }
         ],

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -5678,6 +5678,18 @@
             "description": "URL the server API is reachable at.",
             "title": "Server Url"
           },
+          "ui_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Kitaru UI version the server serves.",
+            "title": "Ui Version"
+          },
           "version": {
             "description": "Kitaru version the server runs.",
             "title": "Version",
@@ -12992,7 +13004,7 @@
     },
     "/v1/info": {
       "get": {
-        "description": "Report how this server identifies itself and authenticates its callers.\n\nThe endpoint is unauthenticated, because a client has to read it before it\ncan know which credential to present.\n\nArgs:\n    settings: Service settings governing auth behavior.\n\nReturns:\n    Server info.",
+        "description": "Report how this server identifies itself and authenticates its callers.\n\nThe endpoint is unauthenticated, because a client has to read it before it\ncan know which credential to present.\n\nArgs:\n    settings: Service settings governing auth behavior.\n    ui_version: UI version served by this process.\n\nReturns:\n    Server info.",
         "operationId": "get_info_v1_info_get",
         "responses": {
           "200": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -10882,7 +10882,7 @@
         ]
       },
       "get": {
-        "description": "Get a device by id.\n\nClients observe HTTP 200 on success and 404 when the caller owns no device\nwith this id.\n\nArgs:\n    device_id: Id of the device.\n    service: Device service.\n    actor: Caller context.\n\nReturns:\n    Stored device.",
+        "description": "Get a device by id.\n\nClients observe HTTP 200 on success and 404 when no device has this id or\nanother account already approved it.\n\nArgs:\n    device_id: Id of the device.\n    service: Device service.\n    actor: Caller context.\n\nReturns:\n    Stored device.",
         "operationId": "get_device_v1_devices__device_id__get",
         "parameters": [
           {

--- a/src/kitaru/api_models/v1/info.py
+++ b/src/kitaru/api_models/v1/info.py
@@ -37,6 +37,10 @@ class ServerInfoResponse(ResponseModel):
         description="Server ID.",
     )
     version: str = Field(description="Kitaru version the server runs.")
+    ui_version: str | None = Field(
+        default=None,
+        description="Kitaru UI version the server serves.",
+    )
     auth_scheme: AuthScheme = Field(description="Scheme used to authenticate requests.")
     server_url: str | None = Field(
         default=None,

--- a/src/kitaru/client/resources/devices.py
+++ b/src/kitaru/client/resources/devices.py
@@ -41,11 +41,14 @@ class DevicesResource:
         """
         self._client = client
 
-    async def get(self, device_id: uuid.UUID) -> DeviceResponse:
+    async def get(
+        self, device_id: uuid.UUID, user_code: str | None = None
+    ) -> DeviceResponse:
         """Get a device by id.
 
         Args:
             device_id: Id of the device.
+            user_code: User code of a device no account approved yet.
 
         Raises:
             APIError: The request failed, including 404 for a missing device.
@@ -53,7 +56,10 @@ class DevicesResource:
         Returns:
             Stored device.
         """
-        response = await self._client.request("GET", f"/v1/devices/{device_id}")
+        params = {} if user_code is None else {"user_code": user_code}
+        response = await self._client.request(
+            "GET", f"/v1/devices/{device_id}", params=params
+        )
         return DeviceResponse.model_validate(response.json())
 
     async def list(

--- a/src/kitaru/server/adapters/rest/dependencies.py
+++ b/src/kitaru/server/adapters/rest/dependencies.py
@@ -202,6 +202,19 @@ def get_app_settings(request: Request) -> APISettings:
     return settings
 
 
+def get_ui_version_state(request: Request) -> str | None:
+    """Return the served UI version attached to the application state.
+
+    Args:
+        request: Incoming request.
+
+    Returns:
+        UI version for this process, or None when no UI is served.
+    """
+    ui_version: str | None = request.app.state.ui_version
+    return ui_version
+
+
 def get_analytics_client(request: Request) -> AnalyticsClient:
     """Return the analytics client attached to the application state.
 

--- a/src/kitaru/server/adapters/rest/routers/devices.py
+++ b/src/kitaru/server/adapters/rest/routers/devices.py
@@ -72,8 +72,8 @@ async def get_device(
 ) -> DeviceResponse:
     """Get a device by id.
 
-    Clients observe HTTP 200 on success and 404 when the caller owns no device
-    with this id.
+    Clients observe HTTP 200 on success and 404 when no device has this id or
+    another account already approved it.
 
     Args:
         device_id: Id of the device.

--- a/src/kitaru/server/adapters/rest/routers/devices.py
+++ b/src/kitaru/server/adapters/rest/routers/devices.py
@@ -69,21 +69,24 @@ async def get_device(
     device_id: uuid.UUID,
     service: Annotated[DeviceService, Depends(get_device_service)],
     actor: Annotated[AuthContext, Depends(authorize)],
+    user_code: str | None = None,
 ) -> DeviceResponse:
     """Get a device by id.
 
-    Clients observe HTTP 200 on success and 404 when no device has this id or
-    another account already approved it.
+    Clients observe HTTP 200 on success and 404 when no device has this id,
+    another account already approved it, or the user code of an unapproved
+    device is missing or wrong.
 
     Args:
         device_id: Id of the device.
         service: Device service.
         actor: Caller context.
+        user_code: User code of a device no account approved yet.
 
     Returns:
         Stored device.
     """
-    device = await service.get_device(device_id, actor=actor)
+    device = await service.get_device(device_id, actor=actor, user_code=user_code)
     return device_to_response(device)
 
 

--- a/src/kitaru/server/adapters/rest/routers/info.py
+++ b/src/kitaru/server/adapters/rest/routers/info.py
@@ -19,7 +19,10 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 
 from kitaru.api_models.v1.info import AuthScheme, ServerInfoResponse
-from kitaru.server.adapters.rest.dependencies import get_app_settings
+from kitaru.server.adapters.rest.dependencies import (
+    get_app_settings,
+    get_ui_version_state,
+)
 from kitaru.server.api.config import APISettings
 
 router = APIRouter()
@@ -30,6 +33,7 @@ KITARU_VERSION = version("kitaru")
 @router.get("")
 async def get_info(
     settings: Annotated[APISettings, Depends(get_app_settings)],
+    ui_version: Annotated[str | None, Depends(get_ui_version_state)],
 ) -> ServerInfoResponse:
     """Report how this server identifies itself and authenticates its callers.
 
@@ -38,6 +42,7 @@ async def get_info(
 
     Args:
         settings: Service settings governing auth behavior.
+        ui_version: UI version served by this process.
 
     Returns:
         Server info.
@@ -48,6 +53,7 @@ async def get_info(
     return ServerInfoResponse(
         id=settings.SERVER_ID,
         version=KITARU_VERSION,
+        ui_version=ui_version,
         auth_scheme=settings.AUTH_SCHEME,
         server_url=settings.SERVER_URL.rstrip("/") or None,
         dashboard_url=settings.DASHBOARD_URL.rstrip("/") or None,

--- a/src/kitaru/server/api/app.py
+++ b/src/kitaru/server/api/app.py
@@ -83,6 +83,7 @@ from kitaru.server.api.bootstrap import (
 from kitaru.server.api.config import APISettings
 from kitaru.server.api.otel import configure_otel, instrument_engine, shutdown_otel
 from kitaru.server.api.task_sweeper import start_task_sweeper, stop_task_sweeper
+from kitaru.server.api.ui import get_ui_version, register_ui
 from kitaru.server.application.services.server_analytics import (
     ServerAnalytics,
     build_analytics_context,
@@ -367,4 +368,7 @@ def create_app(settings: APISettings) -> FastAPI:
     app.include_router(ui.router, prefix="/v1/ui", tags=["ui"])
     app.include_router(users.router, prefix="/v1/users", tags=["users"])
     app.include_router(workers.router, prefix="/v1/workers", tags=["workers"])
+    app.state.ui_version = None if settings.EXTERNAL_UI else get_ui_version()
+    # Register last so the UI catch-all only sees paths no API route matched.
+    register_ui(app, settings)
     return app

--- a/src/kitaru/server/api/config.py
+++ b/src/kitaru/server/api/config.py
@@ -79,6 +79,7 @@ class APISettings(Settings):
     AUTH_COOKIE_SECURE: bool | None = None
 
     DASHBOARD_URL: str = ""
+    EXTERNAL_UI: bool = False
     DEVICE_AUTH_TIMEOUT_SECONDS: int = 300
     DEVICE_AUTH_POLLING_INTERVAL_SECONDS: int = 5
     MAX_FAILED_DEVICE_AUTH_ATTEMPTS: int = 3
@@ -166,4 +167,18 @@ class APISettings(Settings):
                 raise ValueError("Set KITARU_SERVER_SERVER_ID")
         if not self.SECRET_ENCRYPTION_KEY:
             raise ValueError("Set KITARU_SERVER_SECRET_ENCRYPTION_KEY")
+        return self
+
+    @model_validator(mode="after")
+    def validate_ui_settings(self) -> Self:
+        """Validate UI serving settings.
+
+        Raises:
+            ValueError: A required setting is not set.
+
+        Returns:
+            The validated settings object.
+        """
+        if self.EXTERNAL_UI and not self.DASHBOARD_URL:
+            raise ValueError("Set KITARU_SERVER_DASHBOARD_URL")
         return self

--- a/src/kitaru/server/api/ui.py
+++ b/src/kitaru/server/api/ui.py
@@ -1,0 +1,177 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Bundled UI serving."""
+
+import importlib.resources
+import json
+import logging
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse, RedirectResponse, Response
+from starlette.staticfiles import StaticFiles
+from starlette.types import Scope
+
+from kitaru.server.api.config import APISettings
+
+logger = logging.getLogger(__name__)
+
+_RESERVED_PREFIXES = ("v1", "health", "docs", "redoc", "openapi.json")
+
+
+def _is_reserved_path(path: str) -> bool:
+    """Check whether a path belongs to a reserved API prefix.
+
+    Args:
+        path: Request path without a leading slash.
+
+    Returns:
+        Whether the path is the prefix itself or nested under it.
+    """
+    return any(
+        path == prefix or path.startswith(f"{prefix}/") for prefix in _RESERVED_PREFIXES
+    )
+
+
+def _get_ui_dist_dir() -> Path | None:
+    """Resolve the bundled UI build directory.
+
+    Returns:
+        Build directory, or None when no UI bundle is packaged.
+    """
+    dist_dir = Path(str(importlib.resources.files("kitaru") / "_ui" / "dist"))
+    if (dist_dir / "index.html").is_file():
+        return dist_dir
+    return None
+
+
+def get_ui_version() -> str | None:
+    """Read the version tag of the bundled UI.
+
+    Returns:
+        The manifest ``tag`` value, or None when no UI bundle is packaged.
+    """
+    dist_dir = _get_ui_dist_dir()
+    if dist_dir is None:
+        return None
+    manifest_path = dist_dir.parent / "bundle_manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    tag = manifest.get("tag")
+    return tag if isinstance(tag, str) else None
+
+
+class _ImmutableStaticFiles(StaticFiles):
+    """Static file server that marks its responses as immutable."""
+
+    async def get_response(self, path: str, scope: Scope) -> Response:
+        """Serve a static file with a long-lived, immutable cache header.
+
+        Args:
+            path: Path relative to the served directory.
+            scope: ASGI request scope.
+
+        Returns:
+            HTTP response for the requested file.
+        """
+        response = await super().get_response(path, scope)
+        if response.status_code == 200:
+            # Asset filenames are content-hashed, so a served asset never
+            # changes without also changing its URL.
+            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        return response
+
+
+def _register_external_ui_routes(app: FastAPI, settings: APISettings) -> None:
+    """Register a redirect to the configured external dashboard.
+
+    Args:
+        app: FastAPI application.
+        settings: API server settings.
+    """
+
+    @app.get("/{path:path}", include_in_schema=False)
+    async def redirect_to_dashboard(path: str) -> RedirectResponse:
+        """Redirect any non-API path to the external dashboard.
+
+        Args:
+            path: Request path without a leading slash.
+
+        Raises:
+            HTTPException: The path belongs to a reserved API prefix.
+
+        Returns:
+            Redirect to the configured dashboard URL.
+        """
+        if _is_reserved_path(path):
+            raise HTTPException(status_code=404)
+        return RedirectResponse(settings.DASHBOARD_URL)
+
+
+def _register_bundled_ui_routes(app: FastAPI, dist_dir: Path) -> None:
+    """Register routes serving the bundled UI build.
+
+    Args:
+        app: FastAPI application.
+        dist_dir: Bundled UI build directory.
+    """
+    app.mount(
+        "/assets",
+        _ImmutableStaticFiles(directory=dist_dir / "assets", check_dir=False),
+    )
+    root_files = {
+        entry.name
+        for entry in dist_dir.iterdir()
+        if entry.is_file() and entry.name != "index.html"
+    }
+
+    @app.get("/{path:path}", include_in_schema=False)
+    async def serve_ui(path: str) -> Response:
+        """Serve a bundled UI file, falling back to the SPA shell.
+
+        Args:
+            path: Request path without a leading slash.
+
+        Raises:
+            HTTPException: The path belongs to a reserved API prefix.
+
+        Returns:
+            The requested file, or the SPA shell for any other route.
+        """
+        if _is_reserved_path(path):
+            raise HTTPException(status_code=404)
+        if path in root_files:
+            return FileResponse(dist_dir / path)
+        return FileResponse(
+            dist_dir / "index.html", headers={"Cache-Control": "no-cache"}
+        )
+
+
+def register_ui(app: FastAPI, settings: APISettings) -> None:
+    """Register the bundled UI or external dashboard redirect routes.
+
+    Args:
+        app: FastAPI application.
+        settings: API server settings.
+    """
+    if settings.EXTERNAL_UI:
+        _register_external_ui_routes(app, settings)
+        return
+    dist_dir = _get_ui_dist_dir()
+    if dist_dir is None:
+        logger.info("No UI bundle found, UI serving is disabled.")
+        return
+    _register_bundled_ui_routes(app, dist_dir)

--- a/src/kitaru/server/application/services/device_service.py
+++ b/src/kitaru/server/application/services/device_service.py
@@ -37,6 +37,7 @@ from kitaru.server.domain.keys import (
     generate_secret,
     generate_user_code,
     hash_secret,
+    verify_secret,
 )
 from kitaru.server.utils import is_stale
 
@@ -189,25 +190,38 @@ class DeviceService:
         await self._touch(device, now)
         return device
 
-    async def get_device(self, device_id: uuid.UUID, actor: AuthContext) -> Device:
+    async def get_device(
+        self,
+        device_id: uuid.UUID,
+        actor: AuthContext,
+        user_code: str | None = None,
+    ) -> Device:
         """Get a device of the caller by id.
 
         Args:
             device_id: Id of the device.
             actor: Caller context.
+            user_code: Plaintext user code, required for a device no account
+                approved yet.
 
         Raises:
-            DeviceNotFound: No device has this id, or another account already
-                approved it.
+            DeviceNotFound: No device has this id, another account already
+                approved it, or the user code of an unapproved device is
+                missing or wrong.
 
         Returns:
             Stored device.
         """
-        # The verification page reads the device before the caller approves
-        # it, while it is still unclaimed.
-        return await self._get_owned_device(
-            device_id, actor.account.id, allow_unclaimed=True
-        )
+        device = await self._repository.get(device_id)
+        if device.account_id == actor.account.id:
+            return device
+        if (
+            device.account_id is None
+            and user_code is not None
+            and verify_secret(user_code, device.user_code_hash)
+        ):
+            return device
+        raise DeviceNotFound(device_id)
 
     async def list_devices(
         self, device_filter: DeviceFilter, actor: AuthContext

--- a/src/kitaru/server/application/services/device_service.py
+++ b/src/kitaru/server/application/services/device_service.py
@@ -197,12 +197,17 @@ class DeviceService:
             actor: Caller context.
 
         Raises:
-            DeviceNotFound: No device of the caller has this id.
+            DeviceNotFound: No device has this id, or another account already
+                approved it.
 
         Returns:
             Stored device.
         """
-        return await self._get_owned_device(device_id, actor.account.id)
+        # The verification page reads the device before the caller approves
+        # it, while it is still unclaimed.
+        return await self._get_owned_device(
+            device_id, actor.account.id, allow_unclaimed=True
+        )
 
     async def list_devices(
         self, device_filter: DeviceFilter, actor: AuthContext
@@ -242,7 +247,7 @@ class DeviceService:
         Returns:
             Updated device.
         """
-        device = await self.get_device(device_id, actor=actor)
+        device = await self._get_owned_device(device_id, actor.account.id)
         if locked is not None:
             device.update_locked(locked)
         if trusted is not None:
@@ -259,7 +264,7 @@ class DeviceService:
         Raises:
             DeviceNotFound: No device of the caller has this id.
         """
-        await self.get_device(device_id, actor=actor)
+        await self._get_owned_device(device_id, actor.account.id)
         await self._repository.delete(device_id)
 
     async def _get_owned_device(

--- a/tests/server/test_device_service.py
+++ b/tests/server/test_device_service.py
@@ -255,14 +255,36 @@ async def test_authorize_session_accepts_active_device(
     assert session_device.last_login is not None
 
 
-async def test_get_device_returns_unclaimed_pending_device(
+async def test_get_device_returns_unclaimed_device_for_valid_user_code(
     service: DeviceService,
 ) -> None:
-    """Return a pending device no account approved yet."""
-    device, _, _ = await service.request_authorization(DeviceFingerprint())
-    stored = await service.get_device(device.id, actor=ACTOR)
+    """Return a pending device no account approved yet for a valid user code."""
+    device, user_code, _ = await service.request_authorization(DeviceFingerprint())
+    stored = await service.get_device(device.id, actor=ACTOR, user_code=user_code)
     assert stored.id == device.id
     assert stored.account_id is None
+
+
+async def test_get_device_rejects_unclaimed_device_without_valid_user_code(
+    service: DeviceService,
+) -> None:
+    """Raise not found for an unapproved device without its user code."""
+    device, _, _ = await service.request_authorization(DeviceFingerprint())
+    with pytest.raises(DeviceNotFound):
+        await service.get_device(device.id, actor=ACTOR)
+    with pytest.raises(DeviceNotFound):
+        await service.get_device(device.id, actor=ACTOR, user_code="WRONG-CODE")
+
+
+async def test_get_device_returns_owned_device_without_user_code(
+    service: DeviceService, repository: FakeDeviceRepository
+) -> None:
+    """Return a device of the caller without requiring a user code."""
+    device, _, _ = await create_device(
+        repository, account_id=ACTOR.account.id, status=DeviceStatus.ACTIVE
+    )
+    stored = await service.get_device(device.id, actor=ACTOR)
+    assert stored.id == device.id
 
 
 async def test_get_device_rejects_foreign_account(

--- a/tests/server/test_device_service.py
+++ b/tests/server/test_device_service.py
@@ -255,6 +255,38 @@ async def test_authorize_session_accepts_active_device(
     assert session_device.last_login is not None
 
 
+async def test_get_device_returns_unclaimed_pending_device(
+    service: DeviceService,
+) -> None:
+    """Return a pending device no account approved yet."""
+    device, _, _ = await service.request_authorization(DeviceFingerprint())
+    stored = await service.get_device(device.id, actor=ACTOR)
+    assert stored.id == device.id
+    assert stored.account_id is None
+
+
+async def test_get_device_rejects_foreign_account(
+    service: DeviceService, repository: FakeDeviceRepository
+) -> None:
+    """Raise not found for a device another account already approved."""
+    device, _, _ = await create_device(
+        repository, account_id=FOREIGN_ACTOR.account.id, status=DeviceStatus.VERIFIED
+    )
+    with pytest.raises(DeviceNotFound):
+        await service.get_device(device.id, actor=ACTOR)
+
+
+async def test_update_and_delete_reject_unclaimed_device(
+    service: DeviceService,
+) -> None:
+    """Raise not found when updating or deleting a device no account approved."""
+    device, _, _ = await service.request_authorization(DeviceFingerprint())
+    with pytest.raises(DeviceNotFound):
+        await service.update_device(device.id, actor=ACTOR, locked=True)
+    with pytest.raises(DeviceNotFound):
+        await service.delete_device(device.id, actor=ACTOR)
+
+
 async def test_delete_expired_removes_claimed_and_unclaimed(
     repository: FakeDeviceRepository,
 ) -> None:

--- a/tests/server/test_devices_api.py
+++ b/tests/server/test_devices_api.py
@@ -126,6 +126,27 @@ async def test_get_device_foreign_owner(
     assert response.json() == {"detail": f"Device {device.id} was not found"}
 
 
+async def test_get_unclaimed_device_requires_user_code(
+    client: httpx.AsyncClient, repository: FakeDeviceRepository
+) -> None:
+    """Observe an unapproved device only with its user code."""
+    device, user_code, _ = await create_device(repository)
+
+    without_code = await client.get(f"/v1/devices/{device.id}")
+    assert without_code.status_code == 404
+
+    wrong_code = await client.get(
+        f"/v1/devices/{device.id}", params={"user_code": "WRONG-CODE"}
+    )
+    assert wrong_code.status_code == 404
+
+    with_code = await client.get(
+        f"/v1/devices/{device.id}", params={"user_code": user_code}
+    )
+    assert with_code.status_code == 200
+    assert with_code.json()["id"] == str(device.id)
+
+
 async def test_verify_device(
     client: httpx.AsyncClient, repository: FakeDeviceRepository
 ) -> None:

--- a/tests/server/test_ui_serving.py
+++ b/tests/server/test_ui_serving.py
@@ -1,0 +1,179 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for bundled UI serving."""
+
+import json
+from pathlib import Path
+
+import httpx
+import pydantic
+import pytest
+from fastapi import FastAPI
+
+from conftest import local_settings
+from kitaru.server.api import ui
+from kitaru.server.api.app import create_app
+
+
+@pytest.fixture
+def ui_dist_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Build a fake UI bundle and point the resolver at it."""
+    dist_dir = tmp_path / "dist"
+    assets_dir = dist_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    (dist_dir / "index.html").write_text("<html>index</html>", encoding="utf-8")
+    (assets_dir / "app-abc123.js").write_text("console.log('app')", encoding="utf-8")
+    (dist_dir / "favicon.svg").write_text("<svg></svg>", encoding="utf-8")
+    (tmp_path / "bundle_manifest.json").write_text(
+        json.dumps({"tag": "kitaru-ui-v0.9.0"}), encoding="utf-8"
+    )
+    monkeypatch.setattr(ui, "_get_ui_dist_dir", lambda: dist_dir)
+    return dist_dir
+
+
+def _build_client(app: FastAPI) -> httpx.AsyncClient:
+    """Build a client over the app's ASGI transport without following redirects.
+
+    Args:
+        app: FastAPI application.
+
+    Returns:
+        Client for issuing requests against the app.
+    """
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+        follow_redirects=False,
+    )
+
+
+async def test_root_serves_index_html(ui_dist_dir: Path) -> None:
+    """Serve the SPA shell with a no-cache header at the root URL."""
+    app = create_app(local_settings())
+    async with _build_client(app) as client:
+        response = await client.get("/")
+
+    assert response.status_code == 200
+    assert response.text == "<html>index</html>"
+    assert response.headers["Cache-Control"] == "no-cache"
+
+
+async def test_asset_is_served_with_immutable_cache_control(ui_dist_dir: Path) -> None:
+    """Serve a hashed asset with a long-lived, immutable cache header."""
+    app = create_app(local_settings())
+    async with _build_client(app) as client:
+        response = await client.get("/assets/app-abc123.js")
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "public, max-age=31536000, immutable"
+
+
+async def test_missing_asset_returns_404(ui_dist_dir: Path) -> None:
+    """Report 404 for an asset that does not exist in the bundle."""
+    app = create_app(local_settings())
+    async with _build_client(app) as client:
+        response = await client.get("/assets/missing.js")
+
+    assert response.status_code == 404
+
+
+async def test_root_file_is_served_directly(ui_dist_dir: Path) -> None:
+    """Serve a plain root file such as the favicon by its own path."""
+    app = create_app(local_settings())
+    async with _build_client(app) as client:
+        response = await client.get("/favicon.svg")
+
+    assert response.status_code == 200
+    assert response.text == "<svg></svg>"
+
+
+async def test_spa_route_falls_back_to_index_html(ui_dist_dir: Path) -> None:
+    """Serve the SPA shell for a client-side route with no matching file."""
+    app = create_app(local_settings())
+    async with _build_client(app) as client:
+        response = await client.get("/some/spa/route")
+
+    assert response.status_code == 200
+    assert response.text == "<html>index</html>"
+
+
+async def test_unmatched_api_path_returns_json_404(ui_dist_dir: Path) -> None:
+    """Report a JSON 404 for an unmatched API path instead of the SPA shell."""
+    app = create_app(local_settings())
+    async with _build_client(app) as client:
+        response = await client.get("/v1/does-not-exist")
+
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/json")
+
+
+async def test_without_bundle_root_returns_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Report 404 at the root URL when no UI bundle is packaged."""
+    monkeypatch.setattr(ui, "_get_ui_dist_dir", lambda: None)
+    app = create_app(local_settings())
+    async with _build_client(app) as client:
+        response = await client.get("/")
+
+    assert response.status_code == 404
+
+
+async def test_external_ui_redirects_to_dashboard() -> None:
+    """Redirect the root URL and any other path to the configured dashboard."""
+    settings = local_settings(EXTERNAL_UI=True, DASHBOARD_URL="https://ui.example.com")
+    app = create_app(settings)
+    async with _build_client(app) as client:
+        root_response = await client.get("/")
+        route_response = await client.get("/some/spa/route")
+
+    assert root_response.status_code == 307
+    assert root_response.headers["location"] == "https://ui.example.com"
+    assert route_response.status_code == 307
+    assert route_response.headers["location"] == "https://ui.example.com"
+
+
+async def test_external_ui_still_404s_unmatched_api_paths() -> None:
+    """Report 404 for an unmatched API path even under external UI mode."""
+    settings = local_settings(EXTERNAL_UI=True, DASHBOARD_URL="https://ui.example.com")
+    app = create_app(settings)
+    async with _build_client(app) as client:
+        response = await client.get("/v1/does-not-exist")
+
+    assert response.status_code == 404
+
+
+def test_external_ui_without_dashboard_url_is_rejected() -> None:
+    """Reject EXTERNAL_UI without a configured dashboard URL."""
+    with pytest.raises(pydantic.ValidationError, match="KITARU_SERVER_DASHBOARD_URL"):
+        local_settings(EXTERNAL_UI=True)
+
+
+async def test_info_reports_bundled_ui_version(ui_dist_dir: Path) -> None:
+    """Report the bundled UI version on the info endpoint."""
+    app = create_app(local_settings())
+    async with _build_client(app) as client:
+        response = await client.get("/v1/info")
+
+    assert response.json()["ui_version"] == "kitaru-ui-v0.9.0"
+
+
+async def test_info_reports_no_ui_version_in_external_mode(
+    ui_dist_dir: Path,
+) -> None:
+    """Report no UI version on the info endpoint under external UI mode."""
+    settings = local_settings(EXTERNAL_UI=True, DASHBOARD_URL="https://ui.example.com")
+    app = create_app(settings)
+    async with _build_client(app) as client:
+        response = await client.get("/v1/info")
+
+    assert response.json()["ui_version"] is None


### PR DESCRIPTION
The server serves the bundled Kitaru UI at its root URL with SPA fallback and immutable asset caching, redirects to the configured dashboard URL instead when `KITARU_SERVER_EXTERNAL_UI=true`, and reports the served UI version on `GET /v1/info`.