### PR TITLE
Add Vercel AI Agent support

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -237,12 +237,12 @@ jobs:
             "@zenml-io/kitaru-mastra@$VERSION" \
             "@zenml-io/kitaru-vercel-ai@$VERSION" \
             "@mastra/core@1.51.0" \
-            "ai@7.0.55"
+            "ai@7.0.65"
           node --input-type=module <<'NODE'
           import { KitaruClient } from "@zenml-io/kitaru";
           import { KitaruAgent } from "@zenml-io/kitaru-mastra";
-          import { createKitaruGenerateText } from "@zenml-io/kitaru-vercel-ai";
-          if (![KitaruClient, KitaruAgent, createKitaruGenerateText].every(Boolean)) {
+          import { createKitaruGenerateText, createKitaruToolLoopAgent } from "@zenml-io/kitaru-vercel-ai";
+          if (![KitaruClient, KitaruAgent, createKitaruGenerateText, createKitaruToolLoopAgent].every(Boolean)) {
             throw new Error("Published package exports are missing");
           }
           NODE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed TypeScript replay and recording edge cases, aligned credential redaction and provider diagnostics across adapters, and made the adapter examples reproducible, rerunnable, and part of CI.
 
 ### Added
+- Vercel AI SDK 7 `ToolLoopAgent` support for typed, non-streaming agent generation with Kitaru recording and safe replay boundaries.
 - Every filterable entity list filters by `id`, including `in` over a list of ids.
 - TypeScript SDK packages for the core client and replay runtime, with Mastra and Vercel AI SDK adapters and runnable examples.
 - TypeScript release packaging for the core, Mastra, and Vercel AI SDK packages, with lockstep release-candidate versions, clean-consumer tarball checks, npm publishing, and GitHub release artifacts.

--- a/docs/book/adapters/README.md
+++ b/docs/book/adapters/README.md
@@ -7,7 +7,7 @@ icon: puzzle-piece
 
 Adapters are the first of two ways into Kitaru: wrap the agent you already have, and every run is recorded natively. (The second — [importing the traces you already collect](../getting-started/import-your-traces.md) — needs no adapter at all.)
 
-An adapter leaves your framework in charge of the agent loop while recording the model and tool activity that the integration exposes. The same adapter makes [replay](../concepts/replay.md) work: it applies supported overrides at the model boundary and answers tool calls per the [tool policy](../guides/tool-policies.md). Capabilities differ by integration. In particular, the current TypeScript adapters support non-streaming calls only; each adapter page states its exact boundary.
+An adapter leaves your framework in charge of the agent loop while recording the model and tool activity that the integration exposes. The same adapter makes [replay](../concepts/replay.md) work: it applies supported overrides at the model boundary and answers tool calls per the [tool policy](../guides/tool-policies.md). Capabilities differ by integration. The current TypeScript adapters record non-streaming calls only; the Vercel adapter also preserves Agent `stream()` as a native, recording-free passthrough. Each adapter page states its exact boundary.
 
 ## Available adapters
 
@@ -27,7 +27,7 @@ LangChain agents and Deep Agents use the LangGraph adapter — their public fact
 
 | Framework | Install | Entry point |
 |---|---|---|
-| [Vercel AI SDK](vercel-ai.md) | `@zenml-io/kitaru-vercel-ai` | `createKitaruGenerateText` |
+| [Vercel AI SDK](vercel-ai.md) | `@zenml-io/kitaru-vercel-ai` | `createKitaruToolLoopAgent`, `createKitaruGenerateText` |
 | [Mastra](mastra.md) | `@zenml-io/kitaru-mastra` | `KitaruAgent` |
 
 Both build on `@zenml-io/kitaru`, the framework-neutral TypeScript client and adapter foundation. Its public client uses methods such as `createSession(...)` and `upsertSessionNodes(...)`; it deliberately does not provide a framework-neutral agent or streaming abstraction.
@@ -40,4 +40,4 @@ If your framework isn't covered, see [No adapter for your framework](custom.md) 
 
 ## Why the wrapper is enough
 
-"One wrapper, no rewrite" means you keep the framework's agent loop and native result types. The Python adapters expose framework-shaped runner or agent objects. Mastra adds a `KitaruAgent(existingAgent, options)` with `generate(...)`; the Vercel AI SDK adapter returns a native-signature `generateText(...)` function. Under a [worker](../concepts/workers.md), the same entrypoint reads the replay task environment, substitutes the recorded inputs, and applies the supported replay configuration. Your application does not need a separate replay branch.
+"One wrapper, no rewrite" means you keep the framework's agent loop and native result types. The Python adapters expose framework-shaped runner or agent objects. Mastra adds a `KitaruAgent(existingAgent, options)` with `generate(...)`; the Vercel AI SDK adapter returns either a public AI SDK Agent or a native-signature `generateText(...)` function. Under a [worker](../concepts/workers.md), the same entrypoint reads the replay task environment, substitutes the recorded inputs, and applies the supported replay configuration. Your application does not need a separate replay branch.

--- a/docs/book/adapters/vercel-ai.md
+++ b/docs/book/adapters/vercel-ai.md
@@ -16,7 +16,7 @@ Version `0.1.0-rc.2` is a pre-1.0 compatibility preview. Kitaru records non-stre
 Use Node 22.22 or later in the Node 22 release line. Install the adapter with AI SDK 7 and the provider package used by your agent. This OpenAI example uses the versions verified in the repository:
 
 ```bash
-pnpm add @zenml-io/kitaru-vercel-ai@0.1.0-rc.2 ai@7.0.65 @ai-sdk/openai@4.0.20
+pnpm add @zenml-io/kitaru-vercel-ai@0.1.0-rc.2 ai@7.0.65 @ai-sdk/openai@4.0.20 zod@4.4.3
 ```
 
 The adapter includes `@zenml-io/kitaru`, the framework-neutral TypeScript SDK, as a dependency.
@@ -61,7 +61,7 @@ console.log(result.text);
 
 The returned object implements AI SDK's public `Agent` interface. `version`, `id`, typed `tools`, all four Agent generic parameters, call-option validation, `prepareCall`, callbacks, runtime context, structured output, retries, timeouts, abort signals, and the native result object remain available. Each overlapping `generate()` invocation gets an independent Kitaru recorder and tool state.
 
-AI SDK's `Agent` interface also requires `stream()`. The adapter delegates that method directly to a native `ToolLoopAgent` without starting a Kitaru session. This preserves compatibility with native consumers, but Kitaru does not record the stream.
+AI SDK's `Agent` interface also requires `stream()`. During ordinary execution, the adapter delegates that method directly to a native `ToolLoopAgent` without starting a Kitaru session. This preserves compatibility with native consumers, but Kitaru does not record the stream. When `KITARU_REPLAY_ID` is set, `stream()` rejects before provider or tool execution because streaming replay is unsupported.
 
 ## Record a direct generation
 
@@ -132,7 +132,7 @@ Model replacement is opt-in. Set `allowedReplayModels` and provide `resolveModel
 const replayOptions = {
   agentId,
   allowedReplayModels: ["openai/gpt-5-nano"],
-  resolveModel: (modelId) => {
+  resolveModel: (modelId: string) => {
     if (modelId === "openai/gpt-5-nano") {
       return openai("gpt-5-nano");
     }
@@ -200,7 +200,7 @@ Version `0.1.0-rc.2` supports:
 
 - AI SDK `>=7.0.60 <8.0.0`;
 - non-streaming `ToolLoopAgent.generate()` with the public AI SDK Agent type;
-- native, recording-free Agent `stream()` passthrough;
+- native, recording-free Agent `stream()` passthrough outside replay;
 - non-streaming `generateText`;
 - prompt strings and message arrays;
 - local tools with an `execute` function;
@@ -208,9 +208,9 @@ Version `0.1.0-rc.2` supports:
 - `history`, `static`, and `passthrough` replay policies; and
 - bounded prompt, instruction, model-setting, and allowlisted model replacement during replay.
 
-It does not record streaming generation and does not wrap standalone `streamText`. Provider-executed tools, dynamic tools, tool approval, sandboxed replay, per-step overrides through `prepareStep`, async-iterable tools during replay, and the `llm` tool policy are unsupported in replay. Async-iterable local tools remain native during baseline recording, but cannot be replayed.
+It does not record streaming generation and does not wrap standalone `streamText`. Agent `stream()` rejects when replay is active. Provider-executed tools, dynamic tools, tool approval, sandboxed replay, per-step overrides through `prepareStep`, async-iterable tools during replay, and the `llm` tool policy are unsupported in replay. Async-iterable local tools remain native during baseline recording, but cannot be replayed.
 
-Manual approval is a two-call workflow in AI SDK, but Kitaru cannot persist a waiting Agent run without server and worker changes. When baseline `generate()` returns an approval request, the adapter returns the native result unchanged and marks the Kitaru session failed with `manual_approval_continuation_unsupported`. Agent replay rejects approval configuration and approval messages before any provider or tool side effect.
+Manual approval is a two-call workflow in AI SDK, but Kitaru cannot persist a waiting Agent run without server and worker changes. When baseline `generate()` returns an unresolved manual approval request, the adapter returns the native result unchanged and marks the Kitaru session failed with `manual_approval_continuation_unsupported`. Automatic approval decisions complete normally. Agent replay rejects approval configuration and approval messages before any provider or tool side effect.
 
 ## Runnable examples
 

--- a/docs/book/adapters/vercel-ai.md
+++ b/docs/book/adapters/vercel-ai.md
@@ -1,14 +1,14 @@
 ---
-description: Record and replay AI SDK 7 generateText calls with the Kitaru Vercel AI SDK adapter.
+description: Record and replay AI SDK 7 ToolLoopAgent and generateText calls with the Kitaru Vercel AI SDK adapter.
 icon: bolt
 ---
 
 # Vercel AI SDK Adapter
 
-`@zenml-io/kitaru-vercel-ai` adds Kitaru recording and replay to the Vercel [AI SDK](https://ai-sdk.dev) 7 `generateText` function. Replace the imported function with `createKitaruGenerateText(...)`; the returned function keeps the complete native `generateText` signature and returns the native AI SDK result object.
+`@zenml-io/kitaru-vercel-ai` adds Kitaru recording and replay to the Vercel [AI SDK](https://ai-sdk.dev) 7 `ToolLoopAgent` and `generateText` APIs. Use `createKitaruToolLoopAgent(...)` for an AI SDK Agent object or `createKitaruGenerateText(...)` for the direct function API. Both return native AI SDK results.
 
 {% hint style="info" %}
-Version `0.1.0-rc.1` is a pre-1.0 compatibility preview. It supports non-streaming `generateText` only, not `streamText`.
+Version `0.1.0-rc.2` is a pre-1.0 compatibility preview. Kitaru records non-streaming Agent `generate()` and direct `generateText` calls. Agent `stream()` remains available as a native, recording-free passthrough; standalone `streamText` is not wrapped.
 {% endhint %}
 
 ## Install
@@ -16,12 +16,54 @@ Version `0.1.0-rc.1` is a pre-1.0 compatibility preview. It supports non-streami
 Use Node 22.22 or later in the Node 22 release line. Install the adapter with AI SDK 7 and the provider package used by your agent. This OpenAI example uses the versions verified in the repository:
 
 ```bash
-pnpm add @zenml-io/kitaru-vercel-ai@0.1.0-rc.1 ai@7.0.55 @ai-sdk/openai@4.0.20
+pnpm add @zenml-io/kitaru-vercel-ai@0.1.0-rc.2 ai@7.0.65 @ai-sdk/openai@4.0.20
 ```
 
 The adapter includes `@zenml-io/kitaru`, the framework-neutral TypeScript SDK, as a dependency.
 
-## Record a generation
+## Record an Agent
+
+Pass native `ToolLoopAgent` settings and Kitaru configuration to `createKitaruToolLoopAgent`:
+
+```ts
+import { openai } from "@ai-sdk/openai";
+import { createKitaruToolLoopAgent } from "@zenml-io/kitaru-vercel-ai";
+import { tool } from "ai";
+import { z } from "zod";
+
+const agentId = process.env.KITARU_AGENT_ID;
+if (!agentId) {
+  throw new Error("KITARU_AGENT_ID is required");
+}
+
+const agent = createKitaruToolLoopAgent(
+  {
+    id: "support-agent",
+    instructions: "Investigate the request before answering.",
+    model: openai("gpt-5-nano"),
+    tools: {
+      lookupOrder: tool({
+        description: "Look up an order",
+        inputSchema: z.object({ orderId: z.string() }),
+        execute: async ({ orderId }) => findOrder(orderId),
+      }),
+    },
+  },
+  { agentId },
+);
+
+const result = await agent.generate({
+  prompt: "Why is order ord-123 delayed?",
+});
+
+console.log(result.text);
+```
+
+The returned object implements AI SDK's public `Agent` interface. `version`, `id`, typed `tools`, all four Agent generic parameters, call-option validation, `prepareCall`, callbacks, runtime context, structured output, retries, timeouts, abort signals, and the native result object remain available. Each overlapping `generate()` invocation gets an independent Kitaru recorder and tool state.
+
+AI SDK's `Agent` interface also requires `stream()`. The adapter delegates that method directly to a native `ToolLoopAgent` without starting a Kitaru session. This preserves compatibility with native consumers, but Kitaru does not record the stream.
+
+## Record a direct generation
 
 Register an agent in Kitaru, then pass its ID to the adapter:
 
@@ -46,7 +88,7 @@ console.log(result.text);
 
 Configure the Kitaru connection with `KITARU_API_URL` and either `KITARU_API_TOKEN` or `KITARU_API_KEY`. You can also pass `apiUrl` and `apiKey` to `createKitaruGenerateText`.
 
-The wrapper calls AI SDK's public `generateText`, callbacks, and local tool `execute` functions. It does not reproduce the AI SDK generation loop. Native options, callbacks, generic types, and return behavior therefore remain available. The adapter sets `maxRetries` to `0` so Kitaru records one provider attempt rather than hiding retries inside a node.
+The direct wrapper calls AI SDK's public `generateText`, callbacks, and local tool `execute` functions. It does not reproduce the AI SDK generation loop. Native options, callbacks, generic types, and return behavior therefore remain available. The direct wrapper sets `maxRetries` to `0` so Kitaru records one provider attempt rather than hiding retries inside a node. The Agent API preserves native retry settings.
 
 Each run creates a Kitaru session. It records one `llm_call` node per model step and one `tool_call` node per local tool execution, including model identity, provider, tokens, tool arguments, tool results, failures, and optional estimated cost. The adapter deliberately records `null` for LLM-node inputs rather than copying provider request data. Session inputs retain the effective prompt or messages, and the completed session summary retains the generated text and other bounded result metadata.
 
@@ -77,17 +119,17 @@ When AI SDK produces the object, Kitaru includes it in the session summary. If g
 
 ## Replay
 
-The same program records ordinary runs and executes replays. When a [worker](../concepts/workers.md) starts the registered command, it injects the task-scoped Kitaru connection, task ID, replay ID, and baseline inputs. The adapter then:
+The same program records ordinary runs and executes replays. When a [worker](../concepts/workers.md) starts the registered command, it injects the task-scoped Kitaru connection, task ID, replay ID, and baseline inputs. The adapter resolves an Agent's `prepareCall` first, then:
 
 1. replaces the caller's prompt or messages with the replay input;
 2. applies supported prompt, instruction, model-setting, and allowlisted model overrides;
-3. runs `generateText` again; and
+3. runs the native Agent or `generateText` call again; and
 4. answers each local tool call according to the replay's [tool policy](../guides/tool-policies.md).
 
 Model replacement is opt-in. Set `allowedReplayModels` and provide `resolveModel` to map each allowed Kitaru model ID to an AI SDK `LanguageModel`:
 
 ```ts
-const generateText = createKitaruGenerateText({
+const replayOptions = {
   agentId,
   allowedReplayModels: ["openai/gpt-5-nano"],
   resolveModel: (modelId) => {
@@ -96,10 +138,10 @@ const generateText = createKitaruGenerateText({
     }
     return undefined;
   },
-});
+};
 ```
 
-Unsafe or unallowlisted overrides fail before a model call begins.
+Pass `replayOptions` as the Kitaru options to either factory. Unsafe or unallowlisted overrides fail before a model call begins.
 
 ### Tool policies
 
@@ -154,9 +196,11 @@ The program should call the wrapped `generateText` function normally. It does no
 
 ## Supported boundary
 
-Version `0.1.0-rc.1` supports:
+Version `0.1.0-rc.2` supports:
 
-- AI SDK `>=7.0.0 <8.0.0`;
+- AI SDK `>=7.0.60 <8.0.0`;
+- non-streaming `ToolLoopAgent.generate()` with the public AI SDK Agent type;
+- native, recording-free Agent `stream()` passthrough;
 - non-streaming `generateText`;
 - prompt strings and message arrays;
 - local tools with an `execute` function;
@@ -164,7 +208,9 @@ Version `0.1.0-rc.1` supports:
 - `history`, `static`, and `passthrough` replay policies; and
 - bounded prompt, instruction, model-setting, and allowlisted model replacement during replay.
 
-It does not support streaming generation, provider-executed tools, dynamic tools, tool approval, sandboxed replay, per-step overrides through `prepareStep`, async-iterable tools during replay, or the `llm` tool policy. Async-iterable local tools remain native during baseline recording, but cannot be replayed.
+It does not record streaming generation and does not wrap standalone `streamText`. Provider-executed tools, dynamic tools, tool approval, sandboxed replay, per-step overrides through `prepareStep`, async-iterable tools during replay, and the `llm` tool policy are unsupported in replay. Async-iterable local tools remain native during baseline recording, but cannot be replayed.
+
+Manual approval is a two-call workflow in AI SDK, but Kitaru cannot persist a waiting Agent run without server and worker changes. When baseline `generate()` returns an approval request, the adapter returns the native result unchanged and marks the Kitaru session failed with `manual_approval_continuation_unsupported`. Agent replay rejects approval configuration and approval messages before any provider or tool side effect.
 
 ## Runnable examples
 

--- a/docs/book/getting-started/installation.md
+++ b/docs/book/getting-started/installation.md
@@ -60,10 +60,10 @@ See the [Mastra adapter](../adapters/mastra.md) for the wrapper, replay behavior
 
 {% tab title="Vercel AI SDK" %}
 ```bash
-pnpm add @zenml-io/kitaru-vercel-ai@rc ai@7.0.55
+pnpm add @zenml-io/kitaru-vercel-ai@rc ai@7.0.65
 ```
 
-See the [Vercel AI SDK adapter](../adapters/vercel-ai.md) for `generateText`, replay behavior, and supported boundary.
+See the [Vercel AI SDK adapter](../adapters/vercel-ai.md) for Agent and `generateText` recording, replay behavior, and the supported boundary.
 {% endtab %}
 
 {% tab title="Build an adapter" %}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.11",
     "@types/node": "22.20.1",
-    "ai": "7.0.55",
+    "ai": "7.0.65",
     "openapi-typescript": "7.13.0",
     "typescript": "5.9.3",
     "vitest": "4.1.10"

--- a/packages/core/src/adapter/step.ts
+++ b/packages/core/src/adapter/step.ts
@@ -30,6 +30,7 @@ export interface NormalizedModelStep {
   failed: boolean;
   inputs: JsonValue;
   model?: string;
+  modelSettings?: Record<string, JsonValue>;
   outputs: JsonValue;
   provider?: string;
   startedAt?: string;
@@ -125,7 +126,7 @@ export async function recordNormalizedStep(
       external_id: step.externalId,
       inputs: step.inputs,
       model: step.model,
-      model_params: state.effectiveModelSettings,
+      model_params: step.modelSettings ?? state.effectiveModelSettings,
       name: "model_request",
       node_type: "llm_call",
       outputs: step.outputs,

--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -1007,13 +1007,15 @@ export interface paths {
          * Get Device
          * @description Get a device by id.
          *
-         *     Clients observe HTTP 200 on success and 404 when the caller owns no device
-         *     with this id.
+         *     Clients observe HTTP 200 on success and 404 when no device has this id,
+         *     another account already approved it, or the user code of an unapproved
+         *     device is missing or wrong.
          *
          *     Args:
          *         device_id: Id of the device.
          *         service: Device service.
          *         actor: Caller context.
+         *         user_code: User code of a device no account approved yet.
          *
          *     Returns:
          *         Stored device.
@@ -1898,6 +1900,7 @@ export interface paths {
          *
          *     Args:
          *         settings: Service settings governing auth behavior.
+         *         ui_version: UI version served by this process.
          *
          *     Returns:
          *         Server info.
@@ -6669,6 +6672,11 @@ export interface components {
              */
             server_url?: string | null;
             /**
+             * Ui Version
+             * @description Kitaru UI version the server serves.
+             */
+            ui_version?: string | null;
+            /**
              * Version
              * @description Kitaru version the server runs.
              */
@@ -9578,7 +9586,9 @@ export interface operations {
     };
     get_device_v1_devices__device_id__get: {
         parameters: {
-            query?: never;
+            query?: {
+                user_code?: string | null;
+            };
             header?: never;
             path: {
                 device_id: string;

--- a/packages/core/test/adapter/run-recorder.test.ts
+++ b/packages/core/test/adapter/run-recorder.test.ts
@@ -77,6 +77,24 @@ describe("normalized run lifecycle", () => {
     });
   });
 
+  it("records model settings supplied for one step", async () => {
+    const client = fakeClient();
+    const run = await recorder(client);
+    await run.initialize();
+    await recordNormalizedStep(run.state, {
+      attributes: {},
+      failed: false,
+      inputs: null,
+      modelSettings: { temperature: 0.7 },
+      outputs: { text: "done" },
+      tools: [],
+    });
+
+    expect(client.nodes[1]?.nodes[0]?.model_params).toEqual({
+      temperature: 0.7,
+    });
+  });
+
   it("omits the provider id when the adapter reports no provider", async () => {
     const client = fakeClient();
     const run = await recorder(client);

--- a/packages/vercel-ai/README.md
+++ b/packages/vercel-ai/README.md
@@ -1,11 +1,11 @@
 # `@zenml-io/kitaru-vercel-ai`
 
-`@zenml-io/kitaru-vercel-ai` adds Kitaru recording and replay to the non-streaming AI SDK 7 `generateText` function.
+`@zenml-io/kitaru-vercel-ai` adds Kitaru recording and replay to AI SDK 7 `ToolLoopAgent.generate()` and the non-streaming `generateText` function.
 
 This adapter depends on the framework-neutral `@zenml-io/kitaru` package, whose repository directory is `packages/core/`. Release candidates use npm's `rc` tag and remain pre-1.0 compatibility previews.
 
 ```bash
-pnpm add @zenml-io/kitaru-vercel-ai@rc ai@7.0.55
+pnpm add @zenml-io/kitaru-vercel-ai@rc ai@7.0.65
 ```
 
 ## Links
@@ -16,19 +16,24 @@ pnpm add @zenml-io/kitaru-vercel-ai@rc ai@7.0.55
 
 ```ts
 import { openai } from "@ai-sdk/openai";
-import { createKitaruGenerateText } from "@zenml-io/kitaru-vercel-ai";
+import { createKitaruToolLoopAgent } from "@zenml-io/kitaru-vercel-ai";
 
-const generateText = createKitaruGenerateText({
-  agentId: "your-agent-id",
-});
+const agent = createKitaruToolLoopAgent(
+  {
+    id: "support-agent",
+    model: openai("gpt-5"),
+  },
+  { agentId: "your-kitaru-agent-id" },
+);
 
-const result = await generateText({
-  model: openai("gpt-5"),
+const result = await agent.generate({
   prompt: "Triage this support request",
 });
 ```
 
-The returned function has the native AI SDK `generateText` signature and returns its native result object. The adapter calls AI SDK's public `generateText`, callback, and local tool `execute` APIs; it does not reproduce the SDK's generation loop.
+The returned object implements AI SDK's public `Agent` interface. Its `generate()` method returns the native AI SDK result object, and its tools, call options, `prepareCall`, callbacks, runtime context, output type, retries, timeouts, and abort signal remain native. The adapter calls AI SDK's public `ToolLoopAgent`, callback, and local tool `execute` APIs; it does not reproduce the SDK's generation loop.
+
+`createKitaruGenerateText(...)` remains available when an application uses the function API directly.
 
 Replay supports local executable tools with passthrough, static, and history policies. Static and history hits return the configured value without calling the original `execute`; passthrough calls the original function. Replay registers tool calls in model-output order before local execution begins, so a failing earlier policy prevents later queued local side effects. Baseline execution retains AI SDK concurrency. Recorded node indexes represent completed adapter callbacks and parent-before-child storage, not provider-side start order or wall-clock order among concurrent work.
 
@@ -62,8 +67,10 @@ Each LLM node carries a `cost` attribute recording where the number came from: `
 
 ## Current scope
 
-This experimental release supports AI SDK 7 non-streaming `generateText` with local executable tools. It does not support streaming generation, provider-executed or dynamic tools, tool approval, sandboxed replay, per-step overrides through `prepareStep`, async-iterable tools during replay, or the LLM tool policy.
+This experimental release supports AI SDK `>=7.0.60 <8` for non-streaming `ToolLoopAgent.generate()` and `generateText` calls with local executable tools. The Agent's required `stream()` method remains a native, recording-free passthrough. Kitaru does not record streaming calls.
+
+Durable manual approval continuation is not supported. If `generate()` returns a tool approval request, the native result is returned but the Kitaru session is marked failed with an unsupported-continuation diagnostic. Agent replay rejects approval configuration or approval messages before model or tool execution. Replay also rejects provider-executed or dynamic tools, sandboxed tools, per-step overrides through `prepareStep`, async-iterable tools, and the LLM tool policy.
 
 Replay runs tools one at a time in model-output order. `ticketTimeoutMs` (30 seconds by default) bounds how long a queued tool waits for its predecessor to *start*, not how long that predecessor runs, so a slow passthrough tool does not fail the calls queued behind it.
 
-The adapter disables generation retries. Replay is execution, not a transaction. A passthrough tool can complete an external side effect before a later model or recording failure. The adapter reports that failure, but it cannot roll back the completed effect. Use application-level idempotency keys for side-effecting tools, or prefer static/history replay when execution must be suppressed.
+The direct `generateText` wrapper disables generation retries so one recorded node represents one provider attempt. The Agent API preserves native retry settings. Replay is execution, not a transaction. A passthrough tool can complete an external side effect before a later model or recording failure. The adapter reports that failure, but it cannot roll back the completed effect. Use application-level idempotency keys for side-effecting tools, or prefer static/history replay when execution must be suppressed.

--- a/packages/vercel-ai/README.md
+++ b/packages/vercel-ai/README.md
@@ -67,9 +67,9 @@ Each LLM node carries a `cost` attribute recording where the number came from: `
 
 ## Current scope
 
-This experimental release supports AI SDK `>=7.0.60 <8` for non-streaming `ToolLoopAgent.generate()` and `generateText` calls with local executable tools. The Agent's required `stream()` method remains a native, recording-free passthrough. Kitaru does not record streaming calls.
+This experimental release supports AI SDK `>=7.0.60 <8` for non-streaming `ToolLoopAgent.generate()` and `generateText` calls with local executable tools. The Agent's required `stream()` method remains a native, recording-free passthrough during ordinary execution. Kitaru does not record streaming calls, and `stream()` rejects before provider or tool execution when `KITARU_REPLAY_ID` is set.
 
-Durable manual approval continuation is not supported. If `generate()` returns a tool approval request, the native result is returned but the Kitaru session is marked failed with an unsupported-continuation diagnostic. Agent replay rejects approval configuration or approval messages before model or tool execution. Replay also rejects provider-executed or dynamic tools, sandboxed tools, per-step overrides through `prepareStep`, async-iterable tools, and the LLM tool policy.
+Durable manual approval continuation is not supported. If `generate()` returns an unresolved manual tool approval request, the native result is returned but the Kitaru session is marked failed with an unsupported-continuation diagnostic. Automatic approval decisions complete normally. Agent replay rejects approval configuration or approval messages before model or tool execution. Replay also rejects provider-executed or dynamic tools, sandboxed tools, per-step overrides through `prepareStep`, async-iterable tools, and the LLM tool policy.
 
 Replay runs tools one at a time in model-output order. `ticketTimeoutMs` (30 seconds by default) bounds how long a queued tool waits for its predecessor to *start*, not how long that predecessor runs, so a slow passthrough tool does not fail the calls queued behind it.
 

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -41,10 +41,10 @@
     "@zenml-io/kitaru": "workspace:0.1.0-rc.2"
   },
   "peerDependencies": {
-    "ai": ">=7.0.0 <8.0.0"
+    "ai": ">=7.0.60 <8.0.0"
   },
   "devDependencies": {
-    "ai": "7.0.55"
+    "ai": "7.0.65"
   },
   "scripts": {
     "build": "node ../../scripts/clean-typescript-dist.mjs && tsc -p tsconfig.build.json",

--- a/packages/vercel-ai/src/agent.ts
+++ b/packages/vercel-ai/src/agent.ts
@@ -204,6 +204,7 @@ function createKitaruToolLoopAgentImpl<
         if (runState === undefined) {
           throw new Error("Kitaru recorder was not initialized");
         }
+        state.pendingModelCall = undefined;
         try {
           await recordVercelStep(
             runState,
@@ -348,7 +349,6 @@ function createKitaruToolLoopAgentImpl<
         runtime.onLanguageModelCallEnd = async (
           event: LanguageModelCallEndEvent<ToolSet>,
         ) => {
-          state.pendingModelCall = undefined;
           if (replay.spec) {
             registerReplayTickets({
               event,

--- a/packages/vercel-ai/src/agent.ts
+++ b/packages/vercel-ai/src/agent.ts
@@ -22,7 +22,7 @@ import {
   type ToolLoopAgentSettings,
   type ToolSet,
 } from "ai";
-
+import { composeStopConditions } from "./failure.js";
 import {
   callerModelSettings,
   parseVercelReplayOverride,
@@ -279,6 +279,10 @@ export function createKitaruToolLoopAgent<
           tools: runtime.tools,
         });
         runtime.tools = wrappedTools;
+        runtime.stopWhen = composeStopConditions(
+          recorder.state,
+          runtime.stopWhen as never,
+        );
         runtime.onLanguageModelCallStart = async (
           event: LanguageModelCallStartEvent,
         ) => {

--- a/packages/vercel-ai/src/agent.ts
+++ b/packages/vercel-ai/src/agent.ts
@@ -288,11 +288,6 @@ export function createKitaruToolLoopAgent<
         runtime.onLanguageModelCallStart = async (
           event: LanguageModelCallStartEvent,
         ) => {
-          await (
-            callerOnLanguageModelCallStart as
-              | ((value: LanguageModelCallStartEvent) => unknown)
-              | undefined
-          )?.(event);
           state.pendingModelCall = {
             callId: event.callId,
             modelId: event.modelId,
@@ -303,6 +298,11 @@ export function createKitaruToolLoopAgent<
             startedAt: new Date().toISOString(),
           };
           state.currentModelSettings = state.pendingModelCall.modelSettings;
+          await (
+            callerOnLanguageModelCallStart as
+              | ((value: LanguageModelCallStartEvent) => unknown)
+              | undefined
+          )?.(event);
         };
         runtime.onLanguageModelCallEnd = async (
           event: LanguageModelCallEndEvent<ToolSet>,

--- a/packages/vercel-ai/src/agent.ts
+++ b/packages/vercel-ai/src/agent.ts
@@ -1,0 +1,384 @@
+import { createRequire } from "node:module";
+import { type JsonValue, KitaruClient } from "@zenml-io/kitaru";
+import {
+  projectRecordedInput,
+  RunRecorder,
+  recordedPayloadJson,
+  resolveReplayContext,
+  runResultSummary,
+  stripSystemMessages,
+} from "@zenml-io/kitaru/adapter";
+import {
+  type AgentCallParameters,
+  type AgentStreamParameters,
+  type GenerateTextResult,
+  type LanguageModel,
+  type LanguageModelCallEndEvent,
+  type LanguageModelCallStartEvent,
+  type Output,
+  type StepResult,
+  type StreamTextResult,
+  ToolLoopAgent,
+  type ToolLoopAgentSettings,
+  type ToolSet,
+} from "ai";
+
+import {
+  callerModelSettings,
+  parseVercelReplayOverride,
+  parseWorkerTaskInput,
+  type SafeReplayOverride,
+} from "./options.js";
+import {
+  recordFailedVercelModelCall,
+  recordVercelStep,
+} from "./step-recorder.js";
+import { ExecutionTickets } from "./tickets.js";
+import {
+  assertSupportedReplayTools,
+  hasApprovalResponse,
+  registerReplayTickets,
+  wrapTools,
+} from "./tool-wrapper.js";
+import type { KitaruToolLoopAgent, KitaruVercelAIOptions } from "./types.js";
+
+const packageMetadata: unknown = createRequire(import.meta.url)(
+  "../package.json",
+);
+if (
+  typeof packageMetadata !== "object" ||
+  packageMetadata === null ||
+  !("version" in packageMetadata) ||
+  typeof packageMetadata.version !== "string"
+) {
+  throw new TypeError("The package manifest must contain a string version");
+}
+const ADAPTER_VERSION = packageMetadata.version;
+
+type RuntimeSettings = Record<string, unknown> & {
+  messages?: unknown;
+  model: LanguageModel;
+  prompt?: unknown;
+  tools?: ToolSet;
+};
+
+interface InvocationState {
+  currentModelSettings?: Record<string, JsonValue>;
+  pendingModelCall?: Pick<
+    LanguageModelCallStartEvent,
+    "callId" | "modelId" | "provider"
+  > & {
+    modelSettings?: Record<string, JsonValue>;
+    startedAt: string;
+  };
+  recorder?: Awaited<ReturnType<typeof RunRecorder.create>>;
+  tickets?: ExecutionTickets;
+}
+
+function readableModelId(model: unknown): string | undefined {
+  if (typeof model === "string") {
+    return model;
+  }
+  if (typeof model !== "object" || model === null) {
+    return undefined;
+  }
+  const candidate = model as Record<string, unknown>;
+  return typeof candidate.modelId === "string" ? candidate.modelId : undefined;
+}
+
+function effectiveInput(settings: RuntimeSettings): unknown {
+  return settings.prompt !== undefined ? settings.prompt : settings.messages;
+}
+
+function applyOverride(
+  settings: RuntimeSettings,
+  override: SafeReplayOverride | undefined,
+  taskInput: string | JsonValue[] | undefined,
+): void {
+  const effectivePrompt =
+    override?.prompt ?? (typeof taskInput === "string" ? taskInput : undefined);
+  if (effectivePrompt !== undefined) {
+    settings.prompt = effectivePrompt;
+    delete settings.messages;
+  } else if (taskInput !== undefined) {
+    settings.messages = taskInput;
+    delete settings.prompt;
+  }
+  if (override?.systemPrompt !== undefined) {
+    settings.instructions = override.systemPrompt;
+    delete settings.system;
+    if (settings.messages !== undefined) {
+      settings.messages = stripSystemMessages(settings.messages);
+    }
+    if (Array.isArray(settings.prompt)) {
+      settings.prompt = stripSystemMessages(settings.prompt);
+    }
+  }
+  if (override?.modelSettings) {
+    Object.assign(settings, override.modelSettings);
+  }
+}
+
+function hasApprovalRequest(result: {
+  content: readonly { type: string }[];
+}): boolean {
+  return result.content.some((part) => part.type === "tool-approval-request");
+}
+
+function resultSummary(result: unknown, includeOutput: boolean): JsonValue {
+  return recordedPayloadJson(
+    runResultSummary(result, {
+      structuredOutputField: includeOutput ? "output" : undefined,
+    }),
+    "generation result",
+  );
+}
+
+/** Create an AI SDK ToolLoopAgent whose non-streaming calls are recorded by Kitaru. */
+export function createKitaruToolLoopAgent<
+  CALL_OPTIONS = never,
+  TOOLS extends ToolSet = Record<never, never>,
+  RUNTIME_CONTEXT extends Record<string, unknown> = Record<string, unknown>,
+  OUTPUT extends Output.Output = never,
+>(
+  settings: ToolLoopAgentSettings<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT>,
+  adapterOptions: KitaruVercelAIOptions,
+): KitaruToolLoopAgent<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT> {
+  const environment = adapterOptions.environment ?? process.env;
+  const client =
+    adapterOptions.client ??
+    new KitaruClient({
+      apiKey:
+        adapterOptions.apiKey ??
+        environment.KITARU_API_TOKEN ??
+        environment.KITARU_API_KEY,
+      apiUrl: adapterOptions.apiUrl ?? environment.KITARU_API_URL,
+      fetch: adapterOptions.fetch,
+      timeoutMs: adapterOptions.timeoutMs,
+    });
+
+  function invocationAgent(state: InvocationState) {
+    const callerPrepareCall = settings.prepareCall;
+    const callerOnStepEnd = settings.onStepEnd ?? settings.onStepFinish;
+    const invocationSettings = {
+      ...settings,
+      onStepEnd: async (step: StepResult<TOOLS>) => {
+        const runState = state.recorder?.state;
+        if (runState === undefined) {
+          throw new Error("Kitaru recorder was not initialized");
+        }
+        try {
+          await recordVercelStep(
+            runState,
+            step as StepResult<ToolSet>,
+            adapterOptions.costCalculator,
+            state.currentModelSettings,
+          );
+          state.currentModelSettings = undefined;
+        } catch (error) {
+          runState.storeFailure(error);
+          throw error;
+        }
+        await adapterOptions.configuredOnStepEnd?.(step as StepResult<ToolSet>);
+        await (
+          callerOnStepEnd as ((value: StepResult<TOOLS>) => unknown) | undefined
+        )?.(step);
+      },
+      onStepFinish: undefined,
+      prepareCall: async (baseCall: unknown) => {
+        const prepared = callerPrepareCall
+          ? await callerPrepareCall.call(settings, baseCall as never)
+          : baseCall;
+        const runtime = { ...(prepared as RuntimeSettings) };
+        const requestedModelId =
+          adapterOptions.requestedModelId ?? readableModelId(runtime.model);
+        if (!requestedModelId) {
+          throw new TypeError(
+            "requestedModelId is required when the model has no readable modelId",
+          );
+        }
+        const callerInput = effectiveInput(runtime);
+        const replay = await resolveReplayContext({
+          allowedReplayModels: adapterOptions.allowedReplayModels,
+          callerInput,
+          client,
+          environment,
+          requestedModelId,
+        });
+        const override = parseVercelReplayOverride(
+          replay.override,
+          "replay override",
+        );
+        const taskInput =
+          replay.effectiveRuntimeInput === callerInput
+            ? undefined
+            : parseWorkerTaskInput(replay.effectiveRuntimeInput);
+        applyOverride(runtime, override, taskInput);
+        if (replay.replacementModelId !== undefined) {
+          if (!adapterOptions.resolveModel) {
+            throw new TypeError(
+              `Cannot resolve replacement model '${replay.replacementModelId}' without resolveModel`,
+            );
+          }
+          const replacement = await adapterOptions.resolveModel(
+            replay.replacementModelId,
+          );
+          if (replacement === undefined || replacement === null) {
+            throw new TypeError(
+              `Replacement model '${replay.replacementModelId}' did not resolve`,
+            );
+          }
+          runtime.model = replacement;
+        }
+        if (replay.spec) {
+          if (
+            hasApprovalResponse(runtime.messages) ||
+            hasApprovalResponse(runtime.prompt)
+          ) {
+            throw new TypeError(
+              "Replay does not support pre-supplied tool approval messages",
+            );
+          }
+          assertSupportedReplayTools({
+            generationOptions: runtime,
+            spec: replay.spec,
+            tools: runtime.tools,
+          });
+        }
+
+        const recorder = await RunRecorder.create({
+          adapterVersion: ADAPTER_VERSION,
+          agentId: adapterOptions.agentId,
+          agentVersionId: adapterOptions.agentVersionId,
+          client,
+          effectiveInput: projectRecordedInput(replay.effectiveInput),
+          effectiveModelSettings: callerModelSettings(runtime),
+          framework: "vercel-ai-sdk",
+          name: adapterOptions.sessionName ?? environment.KITARU_SESSION_NAME,
+          replayId: replay.replayId,
+          requestedModelId,
+          sessionIdFile: environment.KITARU_SESSION_ID_FILE,
+          spec: replay.spec,
+        });
+        state.recorder = recorder;
+        state.tickets = new ExecutionTickets(adapterOptions.ticketTimeoutMs);
+        await recorder.initialize();
+
+        const callerOnLanguageModelCallStart =
+          runtime.onLanguageModelCallStart ??
+          runtime.experimental_onLanguageModelCallStart;
+        const callerOnLanguageModelCallEnd =
+          runtime.onLanguageModelCallEnd ??
+          runtime.experimental_onLanguageModelCallEnd;
+        delete runtime.experimental_onLanguageModelCallStart;
+        delete runtime.experimental_onLanguageModelCallEnd;
+
+        const wrappedTools = wrapTools({
+          state: recorder.state,
+          tickets: state.tickets,
+          tools: runtime.tools,
+        });
+        runtime.tools = wrappedTools;
+        runtime.onLanguageModelCallStart = async (
+          event: LanguageModelCallStartEvent,
+        ) => {
+          await (
+            callerOnLanguageModelCallStart as
+              | ((value: LanguageModelCallStartEvent) => unknown)
+              | undefined
+          )?.(event);
+          state.pendingModelCall = {
+            callId: event.callId,
+            modelId: event.modelId,
+            modelSettings: callerModelSettings(
+              event as unknown as Record<string, unknown>,
+            ),
+            provider: event.provider,
+            startedAt: new Date().toISOString(),
+          };
+          state.currentModelSettings = state.pendingModelCall.modelSettings;
+        };
+        runtime.onLanguageModelCallEnd = async (
+          event: LanguageModelCallEndEvent<ToolSet>,
+        ) => {
+          state.pendingModelCall = undefined;
+          if (replay.spec) {
+            registerReplayTickets({
+              event,
+              state: recorder.state,
+              tickets: state.tickets as ExecutionTickets,
+              tools: wrappedTools,
+            });
+          }
+          await (
+            callerOnLanguageModelCallEnd as
+              | ((value: LanguageModelCallEndEvent<ToolSet>) => unknown)
+              | undefined
+          )?.(event);
+        };
+        return runtime as never;
+      },
+    } satisfies ToolLoopAgentSettings<
+      CALL_OPTIONS,
+      TOOLS,
+      RUNTIME_CONTEXT,
+      OUTPUT
+    >;
+    return new ToolLoopAgent(invocationSettings);
+  }
+
+  return {
+    version: "agent-v1",
+    id: settings.id,
+    tools: settings.tools as TOOLS,
+    async generate(
+      options: AgentCallParameters<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT>,
+    ): Promise<GenerateTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>> {
+      const state: InvocationState = {};
+      try {
+        const result = await invocationAgent(state).generate(options);
+        if (state.recorder === undefined || state.tickets === undefined) {
+          throw new Error("Kitaru recorder was not initialized");
+        }
+        if (state.recorder.state.failure !== undefined) {
+          throw state.recorder.state.failure;
+        }
+        if (state.recorder.state.spec) {
+          state.tickets.assertConsumed();
+        }
+        if (hasApprovalRequest(result)) {
+          await state.recorder.fail(
+            new Error("manual_approval_continuation_unsupported"),
+          );
+          return result;
+        }
+        await state.recorder.complete(
+          resultSummary(result, settings.output !== undefined),
+        );
+        return result;
+      } catch (error) {
+        const primary = state.recorder?.state.failure ?? error;
+        if (state.pendingModelCall !== undefined && state.recorder) {
+          try {
+            await recordFailedVercelModelCall(
+              state.recorder.state,
+              state.pendingModelCall,
+              primary,
+            );
+          } catch {
+            // Preserve the runtime failure if best-effort trace recording fails.
+          }
+        }
+        await state.recorder?.fail(primary);
+        throw primary;
+      } finally {
+        state.tickets?.cancel(new Error("Kitaru generation finished"));
+      }
+    },
+    stream(
+      options: AgentStreamParameters<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT>,
+    ): PromiseLike<StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>> {
+      return new ToolLoopAgent(settings).stream(options);
+    },
+  };
+}

--- a/packages/vercel-ai/src/agent.ts
+++ b/packages/vercel-ai/src/agent.ts
@@ -120,10 +120,24 @@ function applyOverride(
   }
 }
 
-function hasApprovalRequest(result: {
-  content: readonly { type: string }[];
+function hasUnresolvedApprovalRequest(result: {
+  content: readonly {
+    approvalId?: string;
+    isAutomatic?: boolean;
+    type: string;
+  }[];
 }): boolean {
-  return result.content.some((part) => part.type === "tool-approval-request");
+  const resolvedApprovalIds = new Set(
+    result.content
+      .filter((part) => part.type === "tool-approval-response")
+      .map((part) => part.approvalId),
+  );
+  return result.content.some(
+    (part) =>
+      part.type === "tool-approval-request" &&
+      part.isAutomatic !== true &&
+      !resolvedApprovalIds.has(part.approvalId),
+  );
 }
 
 function resultSummary(result: unknown, includeOutput: boolean): JsonValue {
@@ -137,6 +151,28 @@ function resultSummary(result: unknown, includeOutput: boolean): JsonValue {
 
 /** Create an AI SDK ToolLoopAgent whose non-streaming calls are recorded by Kitaru. */
 export function createKitaruToolLoopAgent<
+  CALL_OPTIONS = never,
+  TOOLS extends ToolSet = Record<never, never>,
+  RUNTIME_CONTEXT extends Record<string, unknown> = Record<string, unknown>,
+  OUTPUT extends Output.Output = never,
+>(
+  settings: ToolLoopAgentSettings<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT>,
+  adapterOptions: KitaruVercelAIOptions,
+): KitaruToolLoopAgent<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT>;
+export function createKitaruToolLoopAgent(
+  settings: ToolLoopAgentSettings,
+  adapterOptions: KitaruVercelAIOptions,
+): KitaruToolLoopAgent;
+export function createKitaruToolLoopAgent(
+  // biome-ignore lint/suspicious/noExplicitAny: overload implementation erases generic settings
+  settings: any,
+  adapterOptions: KitaruVercelAIOptions,
+  // biome-ignore lint/suspicious/noExplicitAny: overload implementation erases generic result types
+): any {
+  return createKitaruToolLoopAgentImpl(settings, adapterOptions);
+}
+
+function createKitaruToolLoopAgentImpl<
   CALL_OPTIONS = never,
   TOOLS extends ToolSet = Record<never, never>,
   RUNTIME_CONTEXT extends Record<string, unknown> = Record<string, unknown>,
@@ -187,10 +223,15 @@ export function createKitaruToolLoopAgent<
       },
       onStepFinish: undefined,
       prepareCall: async (baseCall: unknown) => {
-        const prepared = callerPrepareCall
-          ? await callerPrepareCall.call(settings, baseCall as never)
-          : baseCall;
+        const prepared =
+          (callerPrepareCall
+            ? await callerPrepareCall.call(settings, baseCall as never)
+            : baseCall) ?? baseCall;
         const runtime = { ...(prepared as RuntimeSettings) };
+        const sandbox = (baseCall as RuntimeSettings).experimental_sandbox;
+        if (sandbox !== undefined) {
+          runtime.experimental_sandbox = sandbox;
+        }
         const requestedModelId =
           adapterOptions.requestedModelId ?? readableModelId(runtime.model);
         if (!requestedModelId) {
@@ -352,7 +393,7 @@ export function createKitaruToolLoopAgent<
         if (state.recorder.state.spec) {
           state.tickets.assertConsumed();
         }
-        if (hasApprovalRequest(result)) {
+        if (hasUnresolvedApprovalRequest(result)) {
           await state.recorder.fail(
             new Error("manual_approval_continuation_unsupported"),
           );
@@ -381,10 +422,13 @@ export function createKitaruToolLoopAgent<
         state.tickets?.cancel(new Error("Kitaru generation finished"));
       }
     },
-    stream(
+    async stream(
       options: AgentStreamParameters<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT>,
-    ): PromiseLike<StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>> {
-      return new ToolLoopAgent(settings).stream(options);
+    ): Promise<StreamTextResult<TOOLS, RUNTIME_CONTEXT, OUTPUT>> {
+      if (environment.KITARU_REPLAY_ID !== undefined) {
+        throw new TypeError("Agent stream replay is not supported");
+      }
+      return await new ToolLoopAgent(settings).stream(options);
     },
   };
 }

--- a/packages/vercel-ai/src/agent.ts
+++ b/packages/vercel-ai/src/agent.ts
@@ -64,6 +64,7 @@ type RuntimeSettings = Record<string, unknown> & {
 
 interface InvocationState {
   currentModelSettings?: Record<string, JsonValue>;
+  includeOutput?: boolean;
   pendingModelCall?: Pick<
     LanguageModelCallStartEvent,
     "callId" | "modelId" | "provider"
@@ -245,6 +246,7 @@ export function createKitaruToolLoopAgent<
             tools: runtime.tools,
           });
         }
+        state.includeOutput = runtime.output !== undefined;
 
         const recorder = await RunRecorder.create({
           adapterVersion: ADAPTER_VERSION,
@@ -357,7 +359,7 @@ export function createKitaruToolLoopAgent<
           return result;
         }
         await state.recorder.complete(
-          resultSummary(result, settings.output !== undefined),
+          resultSummary(result, state.includeOutput === true),
         );
         return result;
       } catch (error) {

--- a/packages/vercel-ai/src/index.ts
+++ b/packages/vercel-ai/src/index.ts
@@ -1,7 +1,10 @@
+export { createKitaruToolLoopAgent } from "./agent.js";
 export { createKitaruGenerateText } from "./generate-text.js";
 export type {
   KitaruCostCalculator,
   KitaruCostInput,
   KitaruGenerateText,
+  KitaruToolLoopAgent,
+  KitaruToolLoopAgentSettings,
   KitaruVercelAIOptions,
 } from "./types.js";

--- a/packages/vercel-ai/src/options.ts
+++ b/packages/vercel-ai/src/options.ts
@@ -3,6 +3,7 @@ import {
   assertSafeKeys,
   MODEL_SETTING_KEYS,
   parseModelSettings,
+  recordedPayloadJson,
   strictRecordedJson,
 } from "@zenml-io/kitaru/adapter";
 
@@ -122,9 +123,10 @@ export function callerModelSettings(
   const values = Object.fromEntries(
     [...MODEL_SETTING_KEYS]
       .filter((key) => options[key] !== undefined)
-      .map((key) => [key, options[key]]),
+      .map((key) => [
+        key,
+        recordedPayloadJson(options[key], `model setting '${key}'`),
+      ]),
   );
-  return Object.keys(values).length === 0
-    ? undefined
-    : parseModelSettings(values);
+  return Object.keys(values).length === 0 ? undefined : values;
 }

--- a/packages/vercel-ai/src/step-recorder.ts
+++ b/packages/vercel-ai/src/step-recorder.ts
@@ -146,6 +146,7 @@ export async function recordVercelStep(
   state: AdapterRunState,
   step: StepResult<ToolSet>,
   costCalculator?: KitaruCostCalculator,
+  modelSettings?: Record<string, JsonValue>,
 ): Promise<void> {
   const tokens = usageTokens(step.usage);
   const cost = await resolveCost(costCalculator, {
@@ -166,6 +167,7 @@ export async function recordVercelStep(
     failed: step.finishReason === "error",
     inputs: null,
     model: servedModelId(step),
+    modelSettings,
     outputs: stepOutputs(step, tools),
     provider: step.model.provider,
     tokens,
@@ -176,6 +178,7 @@ export async function recordVercelStep(
 export async function recordFailedVercelModelCall(
   state: AdapterRunState,
   call: Pick<LanguageModelCallStartEvent, "callId" | "modelId" | "provider"> & {
+    modelSettings?: Record<string, JsonValue>;
     startedAt: string;
   },
   error: unknown,
@@ -187,6 +190,7 @@ export async function recordFailedVercelModelCall(
     failed: true,
     inputs: null,
     model: call.modelId,
+    modelSettings: call.modelSettings,
     outputs: null,
     provider: call.provider,
     startedAt: call.startedAt,

--- a/packages/vercel-ai/src/types.ts
+++ b/packages/vercel-ai/src/types.ts
@@ -5,13 +5,30 @@ import type {
   CostInput,
 } from "@zenml-io/kitaru/adapter";
 import type {
+  Agent,
   GenerateTextOnStepEndCallback,
   generateText,
   LanguageModel,
+  Output,
+  ToolLoopAgentSettings,
   ToolSet,
 } from "ai";
 
 export type KitaruGenerateText = typeof generateText;
+
+export type KitaruToolLoopAgent<
+  CALL_OPTIONS = never,
+  TOOLS extends ToolSet = Record<never, never>,
+  RUNTIME_CONTEXT extends Record<string, unknown> = Record<string, unknown>,
+  OUTPUT extends Output.Output = never,
+> = Agent<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT>;
+
+export type KitaruToolLoopAgentSettings<
+  CALL_OPTIONS = never,
+  TOOLS extends ToolSet = Record<never, never>,
+  RUNTIME_CONTEXT extends Record<string, unknown> = Record<string, unknown>,
+  OUTPUT extends Output.Output = never,
+> = ToolLoopAgentSettings<CALL_OPTIONS, TOOLS, RUNTIME_CONTEXT, OUTPUT>;
 
 export type KitaruCostInput = CostInput;
 export type KitaruCostCalculator = CostCalculator;

--- a/packages/vercel-ai/test/agent-replay.test.ts
+++ b/packages/vercel-ai/test/agent-replay.test.ts
@@ -52,6 +52,16 @@ describe("ToolLoopAgent replay safety", () => {
     ],
     ["sandbox", {}, { experimental_sandbox: {} }],
     [
+      "sandbox omitted by prepareCall",
+      {
+        prepareCall: (call: Record<string, unknown>) => {
+          const { experimental_sandbox: _sandbox, ...prepared } = call;
+          return prepared;
+        },
+      },
+      { experimental_sandbox: {} },
+    ],
+    [
       "pre-supplied approval message",
       {},
       {
@@ -225,5 +235,42 @@ describe("ToolLoopAgent manual approval", () => {
       error: "manual_approval_continuation_unsupported",
       status: "failed",
     });
+  });
+
+  it("completes the session after an automatic approval", async () => {
+    const client = new FakeClient();
+    const execute = vi.fn(async () => "live");
+    const agent = createKitaruToolLoopAgent(
+      {
+        model: new MockLanguageModelV4({
+          doGenerate: [
+            toolResponse([
+              { id: "call-1", input: '{"value":"a"}', name: "write" },
+            ]),
+            textResponse("done"),
+          ],
+        }),
+        toolApproval: { write: async () => "approved" as const },
+        tools: {
+          write: tool({ execute, inputSchema: VALUE_INPUT }),
+        },
+      },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    const result = await agent.generate({ prompt: "go" });
+
+    expect(result.text).toBe("done");
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          isAutomatic: true,
+          type: "tool-approval-request",
+        }),
+        expect.objectContaining({ type: "tool-approval-response" }),
+      ]),
+    );
+    expect(execute).toHaveBeenCalledOnce();
+    expect(client.updated.at(-1)?.status).toBe("completed");
   });
 });

--- a/packages/vercel-ai/test/agent-replay.test.ts
+++ b/packages/vercel-ai/test/agent-replay.test.ts
@@ -1,0 +1,229 @@
+import { jsonSchema, tool } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
+import { describe, expect, it, vi } from "vitest";
+
+import { createKitaruToolLoopAgent } from "../src/index.js";
+import {
+  AGENT_ID,
+  FakeClient,
+  replayEnvironment,
+  replaySpec,
+  textResponse,
+  toolResponse,
+} from "./helpers.js";
+
+const VALUE_INPUT = jsonSchema<{ value: string }>({
+  additionalProperties: false,
+  properties: { value: { type: "string" } },
+  required: ["value"],
+  type: "object",
+});
+
+describe("ToolLoopAgent replay safety", () => {
+  it.each([
+    ["prepareStep", { prepareStep: () => ({}) }, {}],
+    [
+      "toolApproval",
+      { toolApproval: { write: async () => "approved" as const } },
+      {},
+    ],
+    [
+      "approval-gated tool",
+      {
+        tools: {
+          write: tool({
+            execute: vi.fn(async () => "live"),
+            inputSchema: VALUE_INPUT,
+            needsApproval: true,
+          }),
+        },
+      },
+      {},
+    ],
+    ["provider tool", { tools: { write: { type: "provider" } } }, {}],
+    [
+      "dynamic tool",
+      {
+        tools: {
+          write: { execute: vi.fn(async () => "live"), type: "dynamic" },
+        },
+      },
+      {},
+    ],
+    ["sandbox", {}, { experimental_sandbox: {} }],
+    [
+      "pre-supplied approval message",
+      {},
+      {
+        messages: [
+          {
+            content: [
+              { approvalId: "approval-1", type: "tool-approval-request" },
+            ],
+            role: "assistant",
+          },
+        ],
+      },
+    ],
+  ])("rejects %s before provider or tool side effects", async (_name, settings, call) => {
+    const client = new FakeClient({ replay: replaySpec() });
+    const model = new MockLanguageModelV4({
+      doGenerate: toolResponse([
+        { id: "call-1", input: '{"value":"a"}', name: "write" },
+      ]),
+    });
+    const execute = vi.fn(async () => "live");
+    const agent = createKitaruToolLoopAgent(
+      {
+        model,
+        tools: { write: tool({ execute, inputSchema: VALUE_INPUT }) },
+        ...settings,
+      } as never,
+      {
+        agentId: AGENT_ID,
+        client,
+        environment: replayEnvironment(),
+      },
+    );
+
+    await expect(
+      agent.generate({ prompt: "go", ...call } as never),
+    ).rejects.toThrow(/approval|dynamic|prepareStep|provider|sandbox/i);
+
+    expect(client.created).toHaveLength(0);
+    expect(model.doGenerateCalls).toHaveLength(0);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("applies replay overrides after prepareCall", async () => {
+    const preparedModel = new MockLanguageModelV4({
+      modelId: "prepared-model",
+      doGenerate: textResponse("prepared"),
+    });
+    const replacementModel = new MockLanguageModelV4({
+      modelId: "replacement-model",
+      doGenerate: textResponse("replacement"),
+    });
+    const client = new FakeClient({
+      replay: replaySpec(
+        { type: "passthrough" },
+        {
+          model: "replacement-model",
+          model_params: { temperature: 0.25 },
+          prompt: "replay prompt",
+        },
+      ),
+    });
+    const agent = createKitaruToolLoopAgent(
+      {
+        model: new MockLanguageModelV4(),
+        prepareCall: ({ options: _options, ...call }) => ({
+          ...call,
+          model: preparedModel,
+          prompt: "prepared prompt",
+        }),
+      },
+      {
+        agentId: AGENT_ID,
+        allowedReplayModels: ["replacement-model"],
+        client,
+        environment: replayEnvironment(),
+        resolveModel: async () => replacementModel,
+      },
+    );
+
+    const result = await agent.generate({ prompt: "caller prompt" });
+
+    expect(result.text).toBe("replacement");
+    expect(preparedModel.doGenerateCalls).toHaveLength(0);
+    expect(replacementModel.doGenerateCalls[0]).toMatchObject({
+      temperature: 0.25,
+    });
+    expect(replacementModel.doGenerateCalls[0]?.prompt).toEqual([
+      expect.objectContaining({
+        content: [{ text: "replay prompt", type: "text" }],
+        role: "user",
+      }),
+    ]);
+    expect(client.created[0]?.inputs).toBe("replay prompt");
+  });
+
+  it("replays a static local tool without executing it", async () => {
+    const client = new FakeClient({
+      replay: replaySpec({
+        cases: [
+          {
+            match: { value: "a" },
+            match_mode: "exact",
+            result: { source: "static" },
+          },
+        ],
+        on_miss: "fail",
+        type: "static",
+      }),
+    });
+    const execute = vi.fn(async () => ({ source: "live" }));
+    const model = new MockLanguageModelV4({
+      doGenerate: [
+        toolResponse([{ id: "call-1", input: '{"value":"a"}', name: "write" }]),
+        textResponse("done"),
+      ],
+    });
+    const agent = createKitaruToolLoopAgent(
+      {
+        model,
+        tools: { write: tool({ execute, inputSchema: VALUE_INPUT }) },
+      },
+      {
+        agentId: AGENT_ID,
+        client,
+        environment: replayEnvironment(),
+      },
+    );
+
+    const result = await agent.generate({ prompt: "go" });
+
+    expect(result.text).toBe("done");
+    expect(result.toolResults[0]?.output).toEqual({ source: "static" });
+    expect(execute).not.toHaveBeenCalled();
+    expect(client.updated.at(-1)?.status).toBe("completed");
+  });
+});
+
+describe("ToolLoopAgent manual approval", () => {
+  it("returns the native result and marks the session failed", async () => {
+    const client = new FakeClient();
+    const execute = vi.fn(async () => "live");
+    const agent = createKitaruToolLoopAgent(
+      {
+        model: new MockLanguageModelV4({
+          doGenerate: toolResponse([
+            { id: "call-1", input: '{"value":"a"}', name: "write" },
+          ]),
+        }),
+        tools: {
+          write: tool({
+            execute,
+            inputSchema: VALUE_INPUT,
+            needsApproval: true,
+          }),
+        },
+      },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    const result = await agent.generate({ prompt: "go" });
+
+    expect(Object.getPrototypeOf(result)).not.toBe(Object.prototype);
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "tool-approval-request" }),
+      ]),
+    );
+    expect(execute).not.toHaveBeenCalled();
+    expect(client.updated.at(-1)).toMatchObject({
+      error: "manual_approval_continuation_unsupported",
+      status: "failed",
+    });
+  });
+});

--- a/packages/vercel-ai/test/agent.test.ts
+++ b/packages/vercel-ai/test/agent.test.ts
@@ -1,4 +1,4 @@
-import { jsonSchema, tool } from "ai";
+import { jsonSchema, Output, tool } from "ai";
 import { MockLanguageModelV4 } from "ai/test";
 import { describe, expect, it } from "vitest";
 
@@ -178,6 +178,45 @@ describe("createKitaruToolLoopAgent", () => {
     expect(preparedModel.doGenerateCalls).toHaveLength(1);
     expect(events).toEqual(["configured:end", "call:end"]);
     expect(client.created[0]?.inputs).toBe("Help acme");
+  });
+
+  it("records structured output configured by prepareCall", async () => {
+    const client = new FakeClient();
+    const answerSchema = jsonSchema<{ answer: string }>(
+      {
+        additionalProperties: false,
+        properties: { answer: { type: "string" } },
+        required: ["answer"],
+        type: "object",
+      },
+      {
+        validate: (value) =>
+          typeof value === "object" &&
+          value !== null &&
+          typeof (value as { answer?: unknown }).answer === "string"
+            ? { success: true, value: value as { answer: string } }
+            : { success: false, error: new TypeError("invalid answer") },
+      },
+    );
+    const agent = createKitaruToolLoopAgent(
+      {
+        model: new MockLanguageModelV4({
+          doGenerate: textResponse('{"answer":"yes"}'),
+        }),
+        prepareCall: (call) => ({
+          ...call,
+          output: Output.object({ schema: answerSchema }),
+        }),
+      },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    const result = await agent.generate({ prompt: "Answer" });
+
+    expect(result.output).toEqual({ answer: "yes" });
+    expect(client.updated.at(-1)?.outputs).toMatchObject({
+      object: { answer: "yes" },
+    });
   });
 
   it("keeps recorder state separate for concurrent generate calls", async () => {

--- a/packages/vercel-ai/test/agent.test.ts
+++ b/packages/vercel-ai/test/agent.test.ts
@@ -102,6 +102,38 @@ describe("createKitaruToolLoopAgent", () => {
     ).toMatchObject({ error: "provider failed", status: "failed" });
   });
 
+  it("records provider failure when the start callback throws", async () => {
+    const client = new FakeClient();
+    const providerError = new Error("provider failed");
+    const model = new MockLanguageModelV4({
+      doGenerate: async () => {
+        throw providerError;
+      },
+    });
+    const agent = createKitaruToolLoopAgent(
+      {
+        maxRetries: 0,
+        model,
+        prepareCall: (call) => ({
+          ...call,
+          onLanguageModelCallStart: () => {
+            throw new Error("callback failed");
+          },
+        }),
+      },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    await expect(agent.generate({ prompt: "Help" })).rejects.toBe(
+      providerError,
+    );
+    expect(
+      client.nodeBatches
+        .flatMap((batch) => batch.nodes)
+        .find((node) => node.node_type === "llm_call"),
+    ).toMatchObject({ error: "provider failed", status: "failed" });
+  });
+
   it("stops before another model call after step recording fails", async () => {
     const client = new FakeClient({
       failNodeBatch: (_batch, index) => index === 1,

--- a/packages/vercel-ai/test/agent.test.ts
+++ b/packages/vercel-ai/test/agent.test.ts
@@ -167,6 +167,45 @@ describe("createKitaruToolLoopAgent", () => {
     ).toMatchObject({ error: "provider failed", status: "failed" });
   });
 
+  it("records the model call when a post-response tool callback throws", async () => {
+    const client = new FakeClient();
+    const callbackError = new Error("input callback failed");
+    const agent = createKitaruToolLoopAgent(
+      {
+        model: new MockLanguageModelV4({
+          doGenerate: toolResponse([{ id: "call-1", name: "work" }]),
+        }),
+        tools: {
+          work: tool({
+            execute: async () => "done",
+            inputSchema: jsonSchema<Record<never, never>>({
+              additionalProperties: false,
+              properties: {},
+              type: "object",
+            }),
+            onInputStart: () => {
+              throw callbackError;
+            },
+          }),
+        },
+      },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    await expect(agent.generate({ prompt: "Work" })).rejects.toBe(
+      callbackError,
+    );
+    expect(
+      client.nodeBatches
+        .flatMap((batch) => batch.nodes)
+        .find((node) => node.node_type === "llm_call"),
+    ).toMatchObject({ error: "input callback failed", status: "failed" });
+    expect(client.updated.at(-1)).toMatchObject({
+      error: "input callback failed",
+      status: "failed",
+    });
+  });
+
   it("stops before another model call after step recording fails", async () => {
     const client = new FakeClient({
       failNodeBatch: (_batch, index) => index === 1,

--- a/packages/vercel-ai/test/agent.test.ts
+++ b/packages/vercel-ai/test/agent.test.ts
@@ -102,6 +102,41 @@ describe("createKitaruToolLoopAgent", () => {
     ).toMatchObject({ error: "provider failed", status: "failed" });
   });
 
+  it("stops before another model call after step recording fails", async () => {
+    const client = new FakeClient({
+      failNodeBatch: (_batch, index) => index === 1,
+    });
+    const model = new MockLanguageModelV4({
+      doGenerate: [
+        toolResponse([{ id: "call-1", name: "work" }]),
+        textResponse("should not run"),
+      ],
+    });
+    const agent = createKitaruToolLoopAgent(
+      {
+        model,
+        stopWhen: () => false,
+        tools: {
+          work: tool({
+            execute: async () => "done",
+            inputSchema: jsonSchema<Record<never, never>>({
+              additionalProperties: false,
+              properties: {},
+              type: "object",
+            }),
+          }),
+        },
+      },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    await expect(agent.generate({ prompt: "Work" })).rejects.toThrow(
+      "node upload failed",
+    );
+    expect(model.doGenerateCalls).toHaveLength(1);
+    expect(client.updated.at(-1)?.status).toBe("failed");
+  });
+
   it("records the effective prepareCall model and preserves callbacks", async () => {
     const client = new FakeClient();
     const events: string[] = [];

--- a/packages/vercel-ai/test/agent.test.ts
+++ b/packages/vercel-ai/test/agent.test.ts
@@ -1,0 +1,218 @@
+import { jsonSchema, tool } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
+import { describe, expect, it } from "vitest";
+
+import { createKitaruToolLoopAgent } from "../src/index.js";
+import { AGENT_ID, FakeClient, textResponse, toolResponse } from "./helpers.js";
+
+describe("createKitaruToolLoopAgent", () => {
+  it("records generate calls and returns the native result", async () => {
+    const client = new FakeClient();
+    const model = new MockLanguageModelV4({
+      doGenerate: textResponse("recorded"),
+    });
+    const agent = createKitaruToolLoopAgent(
+      { id: "support-agent", model },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    const result = await agent.generate({ prompt: "Help" });
+
+    expect(result.text).toBe("recorded");
+    expect(Object.getPrototypeOf(result)).not.toBe(Object.prototype);
+    expect(agent.version).toBe("agent-v1");
+    expect(agent.id).toBe("support-agent");
+    expect(client.created).toHaveLength(1);
+    expect(client.updated.at(-1)?.status).toBe("completed");
+  });
+
+  it("preserves the native tools value when no tools are configured", () => {
+    const model = new MockLanguageModelV4();
+    const agent = createKitaruToolLoopAgent(
+      { model },
+      { agentId: AGENT_ID, client: new FakeClient(), environment: {} },
+    );
+
+    expect(agent.tools).toBeUndefined();
+  });
+
+  it("records model settings resolved by prepareStep", async () => {
+    const client = new FakeClient();
+    const model = new MockLanguageModelV4({
+      doGenerate: [
+        toolResponse([{ id: "call-1", name: "work" }]),
+        textResponse("done"),
+      ],
+    });
+    const agent = createKitaruToolLoopAgent(
+      {
+        model,
+        prepareStep: ({ stepNumber }) => ({
+          temperature: stepNumber === 0 ? 0.2 : 0.7,
+        }),
+        tools: {
+          work: tool({
+            execute: async () => "done",
+            inputSchema: jsonSchema<Record<never, never>>({
+              additionalProperties: false,
+              properties: {},
+              type: "object",
+            }),
+          }),
+        },
+      },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    await agent.generate({ prompt: "Work" });
+
+    const modelNodes = client.nodeBatches.flatMap((batch) =>
+      batch.nodes.filter((node) => node.node_type === "llm_call"),
+    );
+    expect(modelNodes.map((node) => node.model_params)).toEqual([
+      { temperature: 0.2 },
+      { temperature: 0.7 },
+    ]);
+  });
+
+  it("preserves provider error identity and fails the Kitaru session", async () => {
+    const client = new FakeClient();
+    const providerError = new Error("provider failed");
+    const model = new MockLanguageModelV4({
+      doGenerate: async () => {
+        throw providerError;
+      },
+    });
+    const agent = createKitaruToolLoopAgent(
+      { maxRetries: 0, model },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    await expect(agent.generate({ prompt: "Help" })).rejects.toBe(
+      providerError,
+    );
+    expect(client.updated.at(-1)).toMatchObject({
+      error: "provider failed",
+      status: "failed",
+    });
+    expect(
+      client.nodeBatches
+        .flatMap((batch) => batch.nodes)
+        .find((node) => node.node_type === "llm_call"),
+    ).toMatchObject({ error: "provider failed", status: "failed" });
+  });
+
+  it("records the effective prepareCall model and preserves callbacks", async () => {
+    const client = new FakeClient();
+    const events: string[] = [];
+    const originalModel = new MockLanguageModelV4();
+    const preparedModel = new MockLanguageModelV4({
+      doGenerate: textResponse("prepared"),
+    });
+    const agent = createKitaruToolLoopAgent(
+      {
+        callOptionsSchema: jsonSchema<{ tenant: string }>({
+          additionalProperties: false,
+          properties: { tenant: { type: "string" } },
+          required: ["tenant"],
+          type: "object",
+        }),
+        model: originalModel,
+        onEnd: () => {
+          events.push("configured:end");
+        },
+        prepareCall: ({ options, ...call }) => ({
+          ...call,
+          model: preparedModel,
+          prompt: `Help ${options.tenant}`,
+        }),
+      },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    const result = await agent.generate({
+      onEnd: () => {
+        events.push("call:end");
+      },
+      options: { tenant: "acme" },
+      prompt: "original",
+    });
+
+    expect(result.text).toBe("prepared");
+    expect(originalModel.doGenerateCalls).toHaveLength(0);
+    expect(preparedModel.doGenerateCalls).toHaveLength(1);
+    expect(events).toEqual(["configured:end", "call:end"]);
+    expect(client.created[0]?.inputs).toBe("Help acme");
+  });
+
+  it("keeps recorder state separate for concurrent generate calls", async () => {
+    const client = new FakeClient();
+    const model = new MockLanguageModelV4({
+      doGenerate: [textResponse("first"), textResponse("second")],
+    });
+    const agent = createKitaruToolLoopAgent(
+      { model },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    const [first, second] = await Promise.all([
+      agent.generate({ prompt: "one" }),
+      agent.generate({ prompt: "two" }),
+    ]);
+
+    expect(new Set([first.text, second.text])).toEqual(
+      new Set(["first", "second"]),
+    );
+    expect(client.created).toHaveLength(2);
+    expect(
+      client.updated.filter((update) => update.status === "completed"),
+    ).toHaveLength(2);
+  });
+
+  it("delegates stream calls without creating a Kitaru session", async () => {
+    const client = new FakeClient();
+    const model = new MockLanguageModelV4({
+      doStream: {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ id: "text-1", type: "text-start" });
+            controller.enqueue({
+              delta: "streamed",
+              id: "text-1",
+              type: "text-delta",
+            });
+            controller.enqueue({ id: "text-1", type: "text-end" });
+            controller.enqueue({
+              finishReason: { raw: "stop", unified: "stop" },
+              type: "finish",
+              usage: {
+                inputTokens: {
+                  cacheRead: undefined,
+                  cacheWrite: undefined,
+                  noCache: 1,
+                  total: 1,
+                },
+                outputTokens: {
+                  reasoning: undefined,
+                  text: 1,
+                  total: 1,
+                },
+              },
+            });
+            controller.close();
+          },
+        }),
+      },
+    });
+    const agent = createKitaruToolLoopAgent(
+      { model },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    const result = await agent.stream({ prompt: "Help" });
+
+    await expect(result.text).resolves.toBe("streamed");
+    expect(client.created).toHaveLength(0);
+    expect(client.replayReads).toBe(0);
+  });
+});

--- a/packages/vercel-ai/test/agent.test.ts
+++ b/packages/vercel-ai/test/agent.test.ts
@@ -1,9 +1,16 @@
 import { jsonSchema, Output, tool } from "ai";
 import { MockLanguageModelV4 } from "ai/test";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createKitaruToolLoopAgent } from "../src/index.js";
-import { AGENT_ID, FakeClient, textResponse, toolResponse } from "./helpers.js";
+import {
+  AGENT_ID,
+  FakeClient,
+  replayEnvironment,
+  replaySpec,
+  textResponse,
+  toolResponse,
+} from "./helpers.js";
 
 describe("createKitaruToolLoopAgent", () => {
   it("records generate calls and returns the native result", async () => {
@@ -73,6 +80,32 @@ describe("createKitaruToolLoopAgent", () => {
       { temperature: 0.2 },
       { temperature: 0.7 },
     ]);
+  });
+
+  it("records caller model settings without applying replay bounds", async () => {
+    const client = new FakeClient();
+    const onLanguageModelCallStart = vi.fn();
+    const agent = createKitaruToolLoopAgent(
+      {
+        model: new MockLanguageModelV4({ doGenerate: textResponse("done") }),
+        prepareCall: (call) => ({
+          ...call,
+          onLanguageModelCallStart,
+        }),
+        prepareStep: () => ({ temperature: 3, topK: 0 }),
+      },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    await agent.generate({ prompt: "Help" });
+
+    expect(onLanguageModelCallStart).toHaveBeenCalledOnce();
+    expect(
+      client.nodeBatches
+        .flatMap((batch) => batch.nodes)
+        .find((node) => node.node_type === "llm_call"),
+    ).toMatchObject({ model_params: { temperature: 3, topK: 0 } });
+    expect(client.updated.at(-1)?.status).toBe("completed");
   });
 
   it("preserves provider error identity and fails the Kitaru session", async () => {
@@ -212,6 +245,24 @@ describe("createKitaruToolLoopAgent", () => {
     expect(client.created[0]?.inputs).toBe("Help acme");
   });
 
+  it("uses the native call settings when prepareCall returns undefined", async () => {
+    const client = new FakeClient();
+    const model = new MockLanguageModelV4({ doGenerate: textResponse("done") });
+    const agent = createKitaruToolLoopAgent(
+      {
+        model,
+        prepareCall: (() => undefined) as never,
+      },
+      { agentId: AGENT_ID, client, environment: {} },
+    );
+
+    const result = await agent.generate({ prompt: "Help" });
+
+    expect(result.text).toBe("done");
+    expect(model.doGenerateCalls).toHaveLength(1);
+    expect(client.updated.at(-1)?.status).toBe("completed");
+  });
+
   it("records structured output configured by prepareCall", async () => {
     const client = new FakeClient();
     const answerSchema = jsonSchema<{ answer: string }>(
@@ -320,5 +371,35 @@ describe("createKitaruToolLoopAgent", () => {
     await expect(result.text).resolves.toBe("streamed");
     expect(client.created).toHaveLength(0);
     expect(client.replayReads).toBe(0);
+  });
+
+  it("rejects stream calls when replay is active", async () => {
+    const client = new FakeClient({ replay: replaySpec() });
+    const execute = vi.fn(async () => "live");
+    const model = new MockLanguageModelV4();
+    const agent = createKitaruToolLoopAgent(
+      {
+        model,
+        tools: {
+          work: tool({
+            execute,
+            inputSchema: jsonSchema<Record<never, never>>({
+              additionalProperties: false,
+              properties: {},
+              type: "object",
+            }),
+          }),
+        },
+      },
+      { agentId: AGENT_ID, client, environment: replayEnvironment() },
+    );
+
+    await expect(agent.stream({ prompt: "Help" })).rejects.toThrow(
+      "Agent stream replay is not supported",
+    );
+    expect(client.created).toHaveLength(0);
+    expect(client.replayReads).toBe(0);
+    expect(model.doStreamCalls).toHaveLength(0);
+    expect(execute).not.toHaveBeenCalled();
   });
 });

--- a/packages/vercel-ai/test/compatibility/ai-sdk-7.test.ts
+++ b/packages/vercel-ai/test/compatibility/ai-sdk-7.test.ts
@@ -3,6 +3,7 @@ import {
   isStepCount,
   jsonSchema,
   type ToolExecutionOptions,
+  ToolLoopAgent,
   tool,
 } from "ai";
 import { MockLanguageModelV4 } from "ai/test";
@@ -28,6 +29,191 @@ const EMPTY_INPUT = jsonSchema<Record<string, never>>({
 });
 
 describe("AI SDK 7 compatibility", () => {
+  it("validates call options before prepareCall or provider execution", async () => {
+    const events: string[] = [];
+    const model = new MockLanguageModelV4({
+      doGenerate: async () => {
+        events.push("provider");
+        throw new Error("provider should not run");
+      },
+    });
+    const agent = new ToolLoopAgent({
+      callOptionsSchema: jsonSchema<{ tenant: string }>(
+        {
+          additionalProperties: false,
+          properties: { tenant: { type: "string" } },
+          required: ["tenant"],
+          type: "object",
+        },
+        {
+          validate: (value) =>
+            typeof value === "object" &&
+            value !== null &&
+            typeof (value as { tenant?: unknown }).tenant === "string"
+              ? {
+                  success: true,
+                  value: value as { tenant: string },
+                }
+              : {
+                  error: new TypeError("tenant must be a string"),
+                  success: false,
+                },
+        },
+      ),
+      model,
+      prepareCall: ({ options, ...call }) => {
+        events.push(`prepare:${options.tenant}`);
+        return call;
+      },
+    });
+
+    await expect(
+      agent.generate({
+        options: { tenant: 42 as unknown as string },
+        prompt: "go",
+      }),
+    ).rejects.toThrow("tenant must be a string");
+    expect(events).toEqual([]);
+    expect(model.doGenerateCalls).toHaveLength(0);
+  });
+
+  it("applies prepared settings and runs constructor callbacks before call callbacks", async () => {
+    const events: string[] = [];
+    const originalModel = new MockLanguageModelV4();
+    const preparedModel = new MockLanguageModelV4({
+      doGenerate: {
+        content: [{ text: "prepared", type: "text" }],
+        finishReason: { raw: "stop", unified: "stop" },
+        usage: TEST_USAGE,
+        warnings: [],
+      },
+    });
+    const agent = new ToolLoopAgent({
+      callOptionsSchema: jsonSchema<{ tenant: string }>({
+        additionalProperties: false,
+        properties: { tenant: { type: "string" } },
+        required: ["tenant"],
+        type: "object",
+      }),
+      maxRetries: 2,
+      model: originalModel,
+      onEnd: () => {
+        events.push("constructor:end");
+      },
+      onStart: () => {
+        events.push("constructor:start");
+      },
+      onStepEnd: () => {
+        events.push("constructor:step-end");
+      },
+      onStepStart: () => {
+        events.push("constructor:step-start");
+      },
+      prepareCall: ({ maxRetries, options, ...call }) => {
+        events.push(`prepare:${options.tenant}:${maxRetries}`);
+        return {
+          ...call,
+          maxRetries,
+          model: preparedModel,
+          prompt: `Prepared for ${options.tenant}`,
+        };
+      },
+    });
+
+    const result = await agent.generate({
+      onEnd: () => {
+        events.push("call:end");
+      },
+      onStart: () => {
+        events.push("call:start");
+      },
+      onStepEnd: () => {
+        events.push("call:step-end");
+      },
+      onStepStart: () => {
+        events.push("call:step-start");
+      },
+      options: { tenant: "acme" },
+      prompt: "original",
+    });
+
+    expect(events).toEqual([
+      "prepare:acme:2",
+      "constructor:start",
+      "call:start",
+      "constructor:step-start",
+      "call:step-start",
+      "constructor:step-end",
+      "call:step-end",
+      "constructor:end",
+      "call:end",
+    ]);
+    expect(result.text).toBe("prepared");
+    expect(Object.getPrototypeOf(result)).not.toBe(Object.prototype);
+    expect(originalModel.doGenerateCalls).toHaveLength(0);
+    expect(preparedModel.doGenerateCalls).toHaveLength(1);
+  });
+
+  it("preserves provider error identity when retries are disabled", async () => {
+    const providerError = new Error("provider failed");
+    const agent = new ToolLoopAgent({
+      maxRetries: 0,
+      model: new MockLanguageModelV4({
+        doGenerate: async () => {
+          throw providerError;
+        },
+      }),
+    });
+
+    await expect(agent.generate({ prompt: "go" })).rejects.toBe(providerError);
+  });
+
+  it("forwards call cancellation to the provider", async () => {
+    const abortReason = new Error("cancelled by caller");
+    const controller = new AbortController();
+    let providerSignal: AbortSignal | undefined;
+    const agent = new ToolLoopAgent({
+      maxRetries: 0,
+      model: new MockLanguageModelV4({
+        doGenerate: async ({ abortSignal }) => {
+          providerSignal = abortSignal;
+          controller.abort(abortReason);
+          await Promise.resolve();
+          throw abortSignal?.reason;
+        },
+      }),
+    });
+
+    await expect(
+      agent.generate({ abortSignal: controller.signal, prompt: "go" }),
+    ).rejects.toBe(abortReason);
+    expect(providerSignal?.aborted).toBe(true);
+    expect(providerSignal?.reason).toBe(abortReason);
+  });
+
+  it("forwards call timeouts to the provider abort signal", async () => {
+    let providerSignal: AbortSignal | undefined;
+    const agent = new ToolLoopAgent({
+      maxRetries: 0,
+      model: new MockLanguageModelV4({
+        doGenerate: ({ abortSignal }) =>
+          new Promise((_, reject) => {
+            providerSignal = abortSignal;
+            abortSignal?.addEventListener(
+              "abort",
+              () => reject(abortSignal.reason),
+              { once: true },
+            );
+          }),
+      }),
+    });
+
+    await expect(
+      agent.generate({ prompt: "go", timeout: 5 }),
+    ).rejects.toBeDefined();
+    expect(providerSignal?.aborted).toBe(true);
+  });
+
   it("registers ordered parsed calls before serialized local execution", async () => {
     const events: string[] = [];
     const tickets = new ExecutionTickets();

--- a/packages/vercel-ai/test/types.test.ts
+++ b/packages/vercel-ai/test/types.test.ts
@@ -18,6 +18,7 @@ import { describe, expectTypeOf, it } from "vitest";
 import {
   createKitaruGenerateText,
   createKitaruToolLoopAgent,
+  type KitaruToolLoopAgentSettings,
 } from "../src/index.js";
 import { AGENT_ID, FakeClient } from "./helpers.js";
 
@@ -122,5 +123,17 @@ describe("declaration compatibility", () => {
         ],
       });
     expectTypeOf(createResponse).returns.toEqualTypeOf<Promise<Response>>();
+  });
+
+  it("accepts the exported settings alias with default generics", () => {
+    const settings: KitaruToolLoopAgentSettings = {
+      model: new MockLanguageModelV4(),
+    };
+
+    createKitaruToolLoopAgent(settings, {
+      agentId: AGENT_ID,
+      client: new FakeClient(),
+      environment: {},
+    });
   });
 });

--- a/packages/vercel-ai/test/types.test.ts
+++ b/packages/vercel-ai/test/types.test.ts
@@ -1,7 +1,24 @@
-import type { generateText } from "ai";
+import {
+  type Agent,
+  type AgentCallParameters,
+  type AgentStreamParameters,
+  createAgentUIStreamResponse,
+  type GenerateTextResult,
+  type generateText,
+  jsonSchema,
+  Output,
+  type StreamTextResult,
+  ToolLoopAgent,
+  type ToolLoopAgentSettings,
+  tool,
+} from "ai";
+import { MockLanguageModelV4 } from "ai/test";
 import { describe, expectTypeOf, it } from "vitest";
 
-import { createKitaruGenerateText } from "../src/index.js";
+import {
+  createKitaruGenerateText,
+  createKitaruToolLoopAgent,
+} from "../src/index.js";
 import { AGENT_ID, FakeClient } from "./helpers.js";
 
 describe("declaration compatibility", () => {
@@ -12,5 +29,98 @@ describe("declaration compatibility", () => {
       environment: {},
     });
     expectTypeOf(bound).toEqualTypeOf<typeof generateText>();
+  });
+
+  it("freezes all four public Agent generic parameters", () => {
+    type CallOptions = { tenant: string };
+    type RuntimeContext = { requestId: string };
+
+    const tools = {
+      lookup: tool({
+        execute: async ({ id }) => ({ name: id }),
+        inputSchema: jsonSchema<{ id: string }>({
+          additionalProperties: false,
+          properties: { id: { type: "string" } },
+          required: ["id"],
+          type: "object",
+        }),
+      }),
+    };
+    const output = Output.object({
+      schema: jsonSchema<{ answer: string }>({
+        additionalProperties: false,
+        properties: { answer: { type: "string" } },
+        required: ["answer"],
+        type: "object",
+      }),
+    });
+    const settings: ToolLoopAgentSettings<
+      CallOptions,
+      typeof tools,
+      RuntimeContext,
+      typeof output
+    > = {
+      callOptionsSchema: jsonSchema<CallOptions>({
+        additionalProperties: false,
+        properties: { tenant: { type: "string" } },
+        required: ["tenant"],
+        type: "object",
+      }),
+      model: new MockLanguageModelV4(),
+      output,
+      prepareCall: ({ options, ...call }) => ({
+        ...call,
+        instructions: `Tenant: ${options.tenant}`,
+      }),
+      runtimeContext: { requestId: "request-1" },
+      tools,
+    };
+    const nativeAgent = new ToolLoopAgent(settings);
+    const agent: Agent<
+      CallOptions,
+      typeof tools,
+      RuntimeContext,
+      typeof output
+    > = nativeAgent;
+
+    expectTypeOf(agent.version).toEqualTypeOf<"agent-v1">();
+    expectTypeOf(agent.tools).toEqualTypeOf<typeof tools>();
+    expectTypeOf(agent.generate)
+      .parameter(0)
+      .toEqualTypeOf<
+        AgentCallParameters<CallOptions, typeof tools, RuntimeContext>
+      >();
+    expectTypeOf(agent.generate).returns.toEqualTypeOf<
+      PromiseLike<
+        GenerateTextResult<typeof tools, RuntimeContext, typeof output>
+      >
+    >();
+    expectTypeOf(agent.stream)
+      .parameter(0)
+      .toEqualTypeOf<
+        AgentStreamParameters<CallOptions, typeof tools, RuntimeContext>
+      >();
+    expectTypeOf(agent.stream).returns.toEqualTypeOf<
+      PromiseLike<StreamTextResult<typeof tools, RuntimeContext, typeof output>>
+    >();
+
+    const kitaruAgent = createKitaruToolLoopAgent(settings, {
+      agentId: AGENT_ID,
+      client: new FakeClient(),
+      environment: {},
+    });
+    expectTypeOf(kitaruAgent).toEqualTypeOf<typeof agent>();
+    const createResponse = () =>
+      createAgentUIStreamResponse({
+        agent: kitaruAgent,
+        uiMessages: [
+          {
+            id: "message-1",
+            parts: [{ text: "hello", type: "text" }],
+            role: "user",
+          },
+        ],
+      });
+    expectTypeOf(createResponse).returns.toEqualTypeOf<Promise<Response>>();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 22.20.1
         version: 22.20.1
       ai:
-        specifier: 7.0.55
-        version: 7.0.55(zod@4.4.3)
+        specifier: 7.0.65
+        version: 7.0.65(zod@4.4.3)
       openapi-typescript:
         specifier: 7.13.0
         version: 7.13.0(typescript@5.9.3)
@@ -37,7 +37,7 @@ importers:
     devDependencies:
       '@mastra/core':
         specifier: 1.51.0
-        version: 1.51.0(ai@7.0.55(zod@3.25.76))(express@5.2.1)(zod@3.25.76)
+        version: 1.51.0(ai@7.0.65(zod@3.25.76))(express@5.2.1)(zod@3.25.76)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -49,8 +49,8 @@ importers:
         version: link:../core
     devDependencies:
       ai:
-        specifier: 7.0.55
-        version: 7.0.55(zod@4.4.3)
+        specifier: 7.0.65
+        version: 7.0.65(zod@4.4.3)
 
   v2_examples/mastra_support_triage:
     dependencies:
@@ -59,7 +59,7 @@ importers:
         version: 4.0.20(zod@3.25.76)
       '@mastra/core':
         specifier: 1.51.0
-        version: 1.51.0(ai@7.0.55(zod@3.25.76))(express@5.2.1)(zod@3.25.76)
+        version: 1.51.0(ai@7.0.65(zod@3.25.76))(express@5.2.1)(zod@3.25.76)
       '@zenml-io/kitaru-mastra':
         specifier: workspace:*
         version: link:../../packages/mastra
@@ -79,8 +79,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vercel-ai
       ai:
-        specifier: 7.0.55
-        version: 7.0.55(zod@4.4.3)
+        specifier: 7.0.65
+        version: 7.0.65(zod@4.4.3)
 
 packages:
 
@@ -99,8 +99,8 @@ packages:
       express:
         optional: true
 
-  '@ai-sdk/gateway@4.0.43':
-    resolution: {integrity: sha512-7KqJR7+8zKwxuZY7/G12QWRV8MDUMgrAUmR/Al99zN6OGB3KQe1Q9i2lAB8uyTBsxgdZjB07vH+ky+RG5m1aiA==}
+  '@ai-sdk/gateway@4.0.52':
+    resolution: {integrity: sha512-SXUM8jzzuTUJRq+EOgPd5to6DSx0EKslVn+IVZHbUEX6k/3vCPNrvjckbK26HnNxHU/STxm+zTSJteqrO+7Z0w==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -135,8 +135,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@5.0.23':
-    resolution: {integrity: sha512-mFvAAszenK8Xny3v+4Vntke5IcUkyzjss3gTBOxVWNrSIWmt/FhQ5gCgoJXW7IK11cklRaicMPwOXTnnBtaqFQ==}
+  '@ai-sdk/provider-utils@5.0.27':
+    resolution: {integrity: sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -163,8 +163,8 @@ packages:
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
     engines: {node: '>=22'}
 
-  '@ai-sdk/provider@4.0.6':
-    resolution: {integrity: sha512-YYXjvs8F3q/BdEn9tBDoDuQACotfR7c5foGw/ADsM6iAVC1JabqEjQSkwHv/Kg2vNIr1c2AVHcQb+JYsYk76Qw==}
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
     engines: {node: '>=22'}
 
   '@ai-sdk/ui-utils@1.2.11':
@@ -505,8 +505,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@7.0.55:
-    resolution: {integrity: sha512-B+oZTUFjrR7eV0mF9DUuaIaWvEoJM28yVvcnbUioqcyYYkvae4eY+KvvRkfti+UojsoKrwKiWHeNk0w+nUyvVg==}
+  ai@7.0.65:
+    resolution: {integrity: sha512-Uzom971mOHETL9tbeCWDEgbAA/Banj0KnR2obNEWPEUlGnAv2NJjFIxrUZ6F0XxHFDgGVVpnz86BB2CPOZZ83g==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1606,18 +1606,18 @@ snapshots:
     optionalDependencies:
       express: 5.2.1
 
-  '@ai-sdk/gateway@4.0.43(zod@3.25.76)':
+  '@ai-sdk/gateway@4.0.52(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.6
-      '@ai-sdk/provider-utils': 5.0.23(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@3.25.76)
       '@vercel/oidc': 3.2.0
       zod: 3.25.76
     optional: true
 
-  '@ai-sdk/gateway@4.0.43(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.52(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.6
-      '@ai-sdk/provider-utils': 5.0.23(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
@@ -1670,9 +1670,9 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@5.0.23(zod@3.25.76)':
+  '@ai-sdk/provider-utils@5.0.27(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 4.0.6
+      '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
@@ -1680,9 +1680,9 @@ snapshots:
       zod: 3.25.76
     optional: true
 
-  '@ai-sdk/provider-utils@5.0.23(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.27(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.6
+      '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
@@ -1713,7 +1713,7 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@4.0.6':
+  '@ai-sdk/provider@4.0.7':
     dependencies:
       json-schema: 0.4.0
 
@@ -1797,7 +1797,7 @@ snapshots:
     dependencies:
       '@lukeed/csprng': 1.1.0
 
-  '@mastra/core@1.51.0(ai@7.0.55(zod@3.25.76))(express@5.2.1)(zod@3.25.76)':
+  '@mastra/core@1.51.0(ai@7.0.65(zod@3.25.76))(express@5.2.1)(zod@3.25.76)':
     dependencies:
       '@a2a-js/sdk': 0.3.14(express@5.2.1)
       '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.28(zod@3.25.76)'
@@ -1814,7 +1814,7 @@ snapshots:
       '@sindresorhus/slugify': 2.2.1
       '@standard-schema/spec': 1.1.0
       ajv: 8.20.0
-      chat: 4.34.0(ai@7.0.55(zod@3.25.76))(zod@3.25.76)
+      chat: 4.34.0(ai@7.0.65(zod@3.25.76))(zod@3.25.76)
       croner: 10.0.1
       dotenv: 17.4.2
       execa: 9.6.1
@@ -2061,19 +2061,19 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@7.0.55(zod@3.25.76):
+  ai@7.0.65(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 4.0.43(zod@3.25.76)
-      '@ai-sdk/provider': 4.0.6
-      '@ai-sdk/provider-utils': 5.0.23(zod@3.25.76)
+      '@ai-sdk/gateway': 4.0.52(zod@3.25.76)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@3.25.76)
       zod: 3.25.76
     optional: true
 
-  ai@7.0.55(zod@4.4.3):
+  ai@7.0.65(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 4.0.43(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.6
-      '@ai-sdk/provider-utils': 5.0.23(zod@4.4.3)
+      '@ai-sdk/gateway': 4.0.52(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -2139,7 +2139,7 @@ snapshots:
 
   character-entities@2.0.2: {}
 
-  chat@4.34.0(ai@7.0.55(zod@3.25.76))(zod@3.25.76):
+  chat@4.34.0(ai@7.0.65(zod@3.25.76))(zod@3.25.76):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -2149,7 +2149,7 @@ snapshots:
       remend: 1.3.0
       unified: 11.0.5
     optionalDependencies:
-      ai: 7.0.55(zod@3.25.76)
+      ai: 7.0.65(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - supports-color

--- a/scripts/smoke-typescript-packages.mjs
+++ b/scripts/smoke-typescript-packages.mjs
@@ -68,8 +68,8 @@ try {
     join(consumerRoot, "index.mjs"),
     `import { KitaruClient } from "@zenml-io/kitaru";
 import { KitaruAgent } from "@zenml-io/kitaru-mastra";
-import { createKitaruGenerateText } from "@zenml-io/kitaru-vercel-ai";
-if (![KitaruClient, KitaruAgent, createKitaruGenerateText].every(Boolean)) {
+import { createKitaruGenerateText, createKitaruToolLoopAgent } from "@zenml-io/kitaru-vercel-ai";
+if (![KitaruClient, KitaruAgent, createKitaruGenerateText, createKitaruToolLoopAgent].every(Boolean)) {
   throw new Error("Packed package exports are missing");
 }
 `,
@@ -78,7 +78,7 @@ if (![KitaruClient, KitaruAgent, createKitaruGenerateText].every(Boolean)) {
     join(consumerRoot, "packages.ts"),
     `import { KitaruClient, type KitaruEnvironmentVariables } from "@zenml-io/kitaru";
 import { KitaruAgent, type KitaruAgentOptions } from "@zenml-io/kitaru-mastra";
-import { createKitaruGenerateText, type KitaruVercelAIOptions } from "@zenml-io/kitaru-vercel-ai";
+import { createKitaruGenerateText, createKitaruToolLoopAgent, type KitaruToolLoopAgentSettings, type KitaruVercelAIOptions } from "@zenml-io/kitaru-vercel-ai";
 const environment: KitaruEnvironmentVariables = { KITARU_API_URL: "http://localhost" };
 new KitaruClient({ apiUrl: environment.KITARU_API_URL });
 const mastraOptions: KitaruAgentOptions = {
@@ -88,6 +88,8 @@ const mastraOptions: KitaruAgentOptions = {
 new KitaruAgent({ generate: async () => ({}) }, mastraOptions);
 const vercelOptions: KitaruVercelAIOptions = { agentId: "package-smoke" };
 createKitaruGenerateText(vercelOptions);
+declare const agentSettings: KitaruToolLoopAgentSettings;
+createKitaruToolLoopAgent(agentSettings, vercelOptions);
 `,
   );
   writeFileSync(

--- a/scripts/smoke-typescript-packages.mjs
+++ b/scripts/smoke-typescript-packages.mjs
@@ -118,7 +118,7 @@ createKitaruGenerateText(vercelOptions);
       join(smokeRoot, "npm-cache"),
       ...tarballs,
       "@mastra/core@1.51.0",
-      "ai@7.0.55",
+      "ai@7.0.65",
     ],
     consumerRoot,
   );

--- a/v2_examples/vercel_ai_support_triage/README.md
+++ b/v2_examples/vercel_ai_support_triage/README.md
@@ -1,6 +1,6 @@
 # Vercel AI SDK support triage
 
-This demo records and replays an AI SDK 7 `generateText` call using OpenAI `gpt-5-nano`. The agent investigates a delayed order and suspected duplicate charge with three local tools:
+This demo records and replays an AI SDK 7 `ToolLoopAgent` using OpenAI `gpt-5-nano`. The application calls the agent's native `generate()` method. The agent investigates a delayed order and suspected duplicate charge with three local tools:
 
 - `lookupAccount` and `lookupOrder` read copied, versioned fixtures.
 - `queueRefundReview` appends one line on every real call.

--- a/v2_examples/vercel_ai_support_triage/package.json
+++ b/v2_examples/vercel_ai_support_triage/package.json
@@ -10,7 +10,7 @@
     "@ai-sdk/openai": "4.0.20",
     "@zenml-io/kitaru": "workspace:*",
     "@zenml-io/kitaru-vercel-ai": "workspace:*",
-    "ai": "7.0.55"
+    "ai": "7.0.65"
   },
   "scripts": {
     "build": "node ../../scripts/clean-typescript-dist.mjs && tsc -p tsconfig.json",

--- a/v2_examples/vercel_ai_support_triage/src/agent.ts
+++ b/v2_examples/vercel_ai_support_triage/src/agent.ts
@@ -1,11 +1,10 @@
 import { openai } from "@ai-sdk/openai";
 import type { AdapterClient } from "@zenml-io/kitaru/adapter";
 import type { KitaruCostInput } from "@zenml-io/kitaru-vercel-ai";
-import { createKitaruGenerateText } from "@zenml-io/kitaru-vercel-ai";
+import { createKitaruToolLoopAgent } from "@zenml-io/kitaru-vercel-ai";
 import { type LanguageModel, stepCountIs } from "ai";
 
 import { createDeterministicModel } from "./deterministic-model.js";
-import { BASELINE_PROMPT } from "./prompts.js";
 import { supportTools } from "./tools.js";
 
 export const REQUESTED_MODEL_ID = "openai/gpt-5-nano";
@@ -59,27 +58,27 @@ export function estimateSupportCost({
   return Number(dollars.toFixed(10));
 }
 
-export function createSupportGenerateText(client?: AdapterClient) {
-  const generateText = createKitaruGenerateText({
-    agentId: requiredEnvironment("KITARU_AGENT_ID"),
-    agentVersionId: process.env.KITARU_AGENT_VERSION_ID,
-    allowedReplayModels: [REQUESTED_MODEL_ID],
-    client,
-    costCalculator: estimateSupportCost,
-    requestedModelId: REQUESTED_MODEL_ID,
-    resolveModel,
-    sessionName: "Vercel AI SDK support triage",
-  });
-
-  return () =>
-    generateText({
+export function createSupportAgent(client?: AdapterClient) {
+  return createKitaruToolLoopAgent(
+    {
+      id: "support-triage",
       instructions: SUPPORT_INSTRUCTIONS,
       maxOutputTokens: 2000,
       model: configuredModel(),
-      prompt: BASELINE_PROMPT,
       stopWhen: stepCountIs(5),
       tools: supportTools,
-    });
+    },
+    {
+      agentId: requiredEnvironment("KITARU_AGENT_ID"),
+      agentVersionId: process.env.KITARU_AGENT_VERSION_ID,
+      allowedReplayModels: [REQUESTED_MODEL_ID],
+      client,
+      costCalculator: estimateSupportCost,
+      requestedModelId: REQUESTED_MODEL_ID,
+      resolveModel,
+      sessionName: "Vercel AI SDK support triage",
+    },
+  );
 }
 
 function requiredEnvironment(name: string): string {

--- a/v2_examples/vercel_ai_support_triage/src/main.ts
+++ b/v2_examples/vercel_ai_support_triage/src/main.ts
@@ -1,4 +1,5 @@
-import { createSupportGenerateText } from "./agent.js";
+import { createSupportAgent } from "./agent.js";
+import { BASELINE_PROMPT } from "./prompts.js";
 import { SmokeClient } from "./smoke-client.js";
 
 function requiredEnvironment(name: string): string {
@@ -17,9 +18,9 @@ async function main(): Promise<void> {
   if (process.env.KITARU_VERCEL_AI_TEST_MODEL !== "1") {
     requiredEnvironment("OPENAI_API_KEY");
   }
-  const result = await createSupportGenerateText(
+  const result = await createSupportAgent(
     smoke ? new SmokeClient() : undefined,
-  )();
+  ).generate({ prompt: BASELINE_PROMPT });
   console.log(result.text);
 }
 

--- a/v2_examples/vercel_ai_ticket_resolver/package.json
+++ b/v2_examples/vercel_ai_ticket_resolver/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "4.0.20",
-    "ai": "7.0.55"
+    "ai": "7.0.65"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.11",

--- a/v2_examples/vercel_ai_ticket_resolver/pnpm-lock.yaml
+++ b/v2_examples/vercel_ai_ticket_resolver/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 4.0.20
         version: 4.0.20(zod@4.4.3)
       ai:
-        specifier: 7.0.55
-        version: 7.0.55(zod@4.4.3)
+        specifier: 7.0.65
+        version: 7.0.65(zod@4.4.3)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.11
@@ -30,8 +30,8 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@4.0.43':
-    resolution: {integrity: sha512-7KqJR7+8zKwxuZY7/G12QWRV8MDUMgrAUmR/Al99zN6OGB3KQe1Q9i2lAB8uyTBsxgdZjB07vH+ky+RG5m1aiA==}
+  '@ai-sdk/gateway@4.0.52':
+    resolution: {integrity: sha512-SXUM8jzzuTUJRq+EOgPd5to6DSx0EKslVn+IVZHbUEX6k/3vCPNrvjckbK26HnNxHU/STxm+zTSJteqrO+7Z0w==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -48,8 +48,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@5.0.23':
-    resolution: {integrity: sha512-mFvAAszenK8Xny3v+4Vntke5IcUkyzjss3gTBOxVWNrSIWmt/FhQ5gCgoJXW7IK11cklRaicMPwOXTnnBtaqFQ==}
+  '@ai-sdk/provider-utils@5.0.27':
+    resolution: {integrity: sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -58,8 +58,8 @@ packages:
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
     engines: {node: '>=22'}
 
-  '@ai-sdk/provider@4.0.6':
-    resolution: {integrity: sha512-YYXjvs8F3q/BdEn9tBDoDuQACotfR7c5foGw/ADsM6iAVC1JabqEjQSkwHv/Kg2vNIr1c2AVHcQb+JYsYk76Qw==}
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
     engines: {node: '>=22'}
 
   '@biomejs/biome@2.3.11':
@@ -269,8 +269,8 @@ packages:
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
-  ai@7.0.55:
-    resolution: {integrity: sha512-B+oZTUFjrR7eV0mF9DUuaIaWvEoJM28yVvcnbUioqcyYYkvae4eY+KvvRkfti+UojsoKrwKiWHeNk0w+nUyvVg==}
+  ai@7.0.65:
+    resolution: {integrity: sha512-Uzom971mOHETL9tbeCWDEgbAA/Banj0KnR2obNEWPEUlGnAv2NJjFIxrUZ6F0XxHFDgGVVpnz86BB2CPOZZ83g==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -560,10 +560,10 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@4.0.43(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.52(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.6
-      '@ai-sdk/provider-utils': 5.0.23(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
@@ -581,9 +581,9 @@ snapshots:
       eventsource-parser: 3.1.1
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@5.0.23(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.27(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.6
+      '@ai-sdk/provider': 4.0.7
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.1
@@ -594,7 +594,7 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@4.0.6':
+  '@ai-sdk/provider@4.0.7':
     dependencies:
       json-schema: 0.4.0
 
@@ -741,11 +741,11 @@ snapshots:
 
   '@workflow/serde@4.1.0': {}
 
-  ai@7.0.55(zod@4.4.3):
+  ai@7.0.65(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 4.0.43(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.6
-      '@ai-sdk/provider-utils': 5.0.23(zod@4.4.3)
+      '@ai-sdk/gateway': 4.0.52(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.27(zod@4.4.3)
       zod: 4.4.3
 
   assertion-error@2.0.1: {}


### PR DESCRIPTION
## What changed?

Kitaru can now record and safely replay non-streaming AI SDK 7 `ToolLoopAgent.generate()` calls through a public Agent-compatible factory. Applications keep the AI SDK abstraction they already use, including typed call options, `prepareCall`, `prepareStep`, native result objects, callbacks, structured output, retries, timeouts, abort signals, runtime context, and tool metadata.

The Agent's required `stream()` method remains a native, recording-free passthrough. This PR does not add standalone `streamText` recording. Manual approval continuation also remains unsupported because it cannot survive Kitaru's worker/process boundary without server changes. The native approval result is returned, while the Kitaru session records a stable unsupported-continuation failure.

Replay resolves dynamic call configuration before applying Kitaru input and model overrides. It allows tools that AI SDK can execute automatically. Unresolved manual approval, `prepareStep`, provider-tool, dynamic-tool, sandbox, streaming, and other non-interceptable replay modes fail before session creation, provider execution, or a live tool side effect.

The verified AI SDK fixture is updated to `7.0.65`, with a peer floor of `>=7.0.60 <8`. Adapter docs, installation docs, package docs, examples, lockfiles, the tarball smoke consumer, and the changelog now use that boundary.

Related: #761

## Why?

Developers should not have to rewrite a reusable AI SDK Agent as a direct `generateText` call to use Kitaru. This adds the Agent-first part of #761 within the existing TypeScript client contract, without changing the Python server, API, SDK, worker, OpenAPI source, or persistence model.

The narrower boundary is deliberate. Kitaru does not currently provide a durable waiting state for cross-process approval continuation, and its product/UI stack does not support streaming traces. The docs state those limits instead of implying incomplete support.

## Reviewer Notes

Start with `packages/vercel-ai/src/agent.ts`. The returned facade implements AI SDK's public `Agent` interface. Each `generate()` call constructs an independent native `ToolLoopAgent`, resolves caller configuration, performs replay preflight, initializes one recorder, wraps local tools, and returns the native result.

The main safety invariant is that unsupported replay modes fail before `RunRecorder.initialize()` and before any model or tool call. `packages/vercel-ai/test/agent-replay.test.ts` uses session, model, and tool spies to pin that ordering.

Per-step model settings are captured from AI SDK's model-call start event and attached to the matching recorded step. This keeps traces accurate when baseline `prepareStep` changes temperature or other call settings.

`stream()` intentionally calls a native `ToolLoopAgent` with the original settings and creates no Kitaru session. UI helper compatibility is checked at the public TypeScript type boundary; this PR does not add Kitaru-specific UI wrappers.

The final simplify pass kept the Agent path local. It did not refactor the stable direct `generateText` adapter into a shared abstraction.

Session-settled decisions carried from planning: prioritize Agent generation, keep streaming as a recording-free native passthrough, make no Python or server changes, and fail closed for unsupported replay and manual approval continuation.

## Reproduction

Build and run the deterministic support-triage Agent:

```bash
pnpm build
KITARU_VERCEL_AI_SMOKE=1 \
KITARU_VERCEL_AI_TEST_MODEL=1 \
KITARU_AGENT_ID=018f0000-0000-7000-8000-000000000100 \
node v2_examples/vercel_ai_support_triage/dist/main.js
```

The command should print a JSON decision with `"decision":"refund_review"`, evidence for the delayed order and duplicate charge, and `"nextAction":"refund_review_queued"`.

For the replay safety contract, run:

```bash
pnpm --filter @zenml-io/kitaru-vercel-ai test
```

The suite should pass the Agent baseline, type compatibility, replay preflight, native error identity, approval boundary, and recording-free stream passthrough cases.

## Local checks run

- Node `22.22.3`: `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm pack:check`, including build, tarball installation, runtime import, and clean-consumer TypeScript compilation
- Vercel AI support-triage deterministic smoke
- Standalone ticket-resolver `pnpm --ignore-workspace install --frozen-lockfile`, lint, typecheck, and build
- Final `git diff --check`

## Post-Deploy Monitoring & Validation

This is an SDK release change, not a server deployment. For the first release candidate that includes it:

- verify a clean consumer can install `@zenml-io/kitaru-vercel-ai` with AI SDK `7.0.65`;
- run one baseline Agent recording and one static/history replay against a development Kitaru server;
- confirm tool-less Agent metadata remains `undefined`, native errors keep their identity, and `prepareStep` values appear on the correct LLM nodes;
- watch failed TypeScript sessions for `manual_approval_continuation_unsupported` and confirm those calls still return the native approval result to the application; and
- roll back by reverting this commit and publishing the previous adapter release candidate if the public Agent contract or package peer range causes consumer regressions.
