### PR TITLE
Prepare Kitaru 0.22.0rc5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.22.0rc5]
+
+### Changed
+
+- Prepared the fifth Kitaru 0.22 release candidate with `kitaru-ui-v0.2.0-rc.3` and the current `develop` source.
+- Removed stale documentation for the retired OpenTelemetry plugin.
+
 ## [0.22.0rc4]
 
 ### Changed

--- a/GAPS.md
+++ b/GAPS.md
@@ -96,8 +96,8 @@ publish.
 ## Resolved since Aug 3 (docs updated Aug 4)
 
 - ~~Langfuse importer packaging~~ — **resolved, mechanism in flux**: the
-  separate `kitaru-importer-langfuse` PyPI package is gone. `langfuse`,
-  `braintrust`, and `otlp` importers plus `cost`/`latency`/
+  separate `kitaru-importer-langfuse` PyPI package is gone. `langfuse`
+  and `braintrust` importers plus `cost`/`latency`/
   `tool-call-patterns` evaluators are bundled in the `kitaru` package.
   Docs use `--importer langfuse@latest` with no code to write. **But
   see the Aug 5 seeding note below** — startup auto-seeding was removed
@@ -209,8 +209,7 @@ publish.
 - **Perf hardening** (#683 lock contention, #686 node-read batching) —
   no docs impact. Agent-guidance refresh merged.
 - **In-flight branches to watch**: `feat/built-in-deterministic-evaluators`
-  (likely grows the built-in evaluator set), `codex/surface-session-prompts`,
-  and `codex/v2-importer-braintrust-otlp` (still cooking).
+  (likely grows the built-in evaluator set) and `codex/surface-session-prompts`.
 
 ## Aug 7 afternoon deltas (docs updated Aug 7)
 
@@ -233,11 +232,11 @@ publish.
 - **Plugin story settled (#670)** — plugins are now proper packages
   under `plugins/packages/` (`kitaru-langfuse-importer`,
   `kitaru-langsmith-importer`, `kitaru-braintrust-importer`,
-  `kitaru-opentelemetry-importer`, `kitaru-jsonl-importer`,
+  `kitaru-jsonl-importer`,
   `kitaru-evaluator`) with their own release workflow
   (`release-plugins.yml`) and candidate wheels baked into the server
   image. **Startup seeding is real now**: `DEFAULT_PLUGIN_DEFINITIONS`
-  is populated — five importers and thirteen evaluators register at
+  is populated — four importers and thirteen evaluators register at
   server startup under the **`kitaru/` namespace**
   (`--importer kitaru/langfuse@latest`, `--evaluator
   kitaru/cost@latest`). New built-ins: the **LangSmith** importer, a

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ support.run_sync("Refund order #4821 — the card reader was double-charged.")
 ```
 
 Already tracing elsewhere? Import instead of wrapping — same result.
-Importers for Langfuse, LangSmith, Braintrust, and OpenTelemetry are
-built in:
+Importers for Langfuse, LangSmith, Braintrust, and native Kitaru JSONL
+are built in:
 
 ```bash
 kitaru session import langfuse-export.jsonl \
@@ -138,9 +138,9 @@ Vercel AI SDK (`@zenml-io/kitaru-vercel-ai`) and Mastra
 TypeScript packages require Node 22.22 or later in the Node 22 release line. Start with the [Mastra adapter](https://docs.zenml.io/kitaru/adapters/mastra) or [Vercel AI SDK adapter](https://docs.zenml.io/kitaru/adapters/vercel-ai), then run the focused examples under [`v2_examples/`](https://github.com/zenml-io/kitaru/tree/develop/v2_examples).
 
 **Framework not on that list? You are not blocked.** Import the traces
-you already collect — Langfuse, LangSmith, Braintrust and OpenTelemetry
-importers are built in, and any other format converts to Kitaru JSONL or
-OTLP. Or write a project-local adapter: the recording API is two client
+you already collect from Langfuse, LangSmith, or Braintrust with the
+built-in importers, and convert any other format to Kitaru JSONL. Or
+write a project-local adapter: the recording API is two client
 calls, and an agent skill will draft it for you. Or wrap nothing at all —
 register the agent as a function, and Kitaru asks *your* system to run
 it, then adopts the trace you import. See

--- a/docs/book/adapters/README.md
+++ b/docs/book/adapters/README.md
@@ -34,7 +34,7 @@ Both build on `@zenml-io/kitaru`, the framework-neutral TypeScript client and ad
 
 If your framework isn't covered, see [No adapter for your framework](custom.md) for three options available today:
 
-- **Import** — your framework already emits traces to Langfuse, LangSmith, Braintrust, or OpenTelemetry? [Import them](../getting-started/import-your-traces.md); sessions from imports can be replayed and evaluated like any other. Any other format converts to [Kitaru JSONL or OTLP](../guides/importing-sessions.md).
+- **Import** — your framework already emits traces to Langfuse, LangSmith, or Braintrust? [Import them](../getting-started/import-your-traces.md); sessions from imports can be replayed and evaluated like any other. Convert any other format to [Kitaru JSONL](../guides/importing-sessions.md).
 - **Record directly** — create a session and ingest its nodes with the Python or TypeScript client. The `kitaru-adapter-builder` [agent skill](../agent-native/skills.md) will write that integration with you.
 - **Hand the run back to your own system** — register the agent version as a function instead of a command, and Kitaru calls you to run it. See [Let Kitaru call your agent](custom.md#let-kitaru-call-your-agent).
 

--- a/docs/book/getting-started/import-your-traces.md
+++ b/docs/book/getting-started/import-your-traces.md
@@ -13,7 +13,7 @@ Imports execute on a [worker](../concepts/workers.md) in your environment. The e
 
 ## 1. Register the agent the traces belong to
 
-Importers for **Langfuse, LangSmith, Braintrust, OpenTelemetry, and a native JSONL format** are built in — registered at server startup under the `kitaru/` namespace, so there is no importer code to write for those. Anything else comes in through a [custom importer](../guides/import-langfuse-traces.md#writing-your-own-importer).
+Importers for **Langfuse, LangSmith, Braintrust, and a native JSONL format** are built in — registered at server startup under the `kitaru/` namespace, so there is no importer code to write for those. Anything else comes in through a [custom importer](../guides/import-langfuse-traces.md#writing-your-own-importer).
 
 Register the agent these traces belong to, if you haven't:
 

--- a/docs/book/guides/import-langfuse-traces.md
+++ b/docs/book/guides/import-langfuse-traces.md
@@ -42,7 +42,7 @@ Set `agent_version_id` when you know which code produced the traces — it's wha
 
 ## The built-in importers
 
-Kitaru ships five importers as default plugins, registered at server startup under the `kitaru/` namespace — `kitaru/langfuse`, `kitaru/langsmith`, `kitaru/braintrust`, `kitaru/opentelemetry`, and `kitaru/kitaru-jsonl` (a native JSONL shape) — so `--importer kitaru/langfuse@latest` always resolves. They run on your worker like any other importer; there is nothing to write.
+Kitaru ships four importers as default plugins, registered at server startup under the `kitaru/` namespace — `kitaru/langfuse`, `kitaru/langsmith`, `kitaru/braintrust`, and `kitaru/kitaru-jsonl` (a native JSONL shape) — so `--importer kitaru/langfuse@latest` always resolves. They run on your worker like any other importer; there is nothing to write.
 
 The Langfuse importer parses **Langfuse JSONL exports** — up to 50 MiB per payload (the importer's own cap, separate from the server's configurable blob limit) — and understands three record shapes: `trace`, `observation`, and raw `ingestion_event` lines. Traces map to sessions; observations map to nodes with their parent relationships, timings, model names, token usage, and cost preserved. `params`:
 

--- a/docs/book/guides/importing-sessions.md
+++ b/docs/book/guides/importing-sessions.md
@@ -207,7 +207,7 @@ The import job result reports created, skipped, and failed counts plus a bounded
 
 You have two ways in, and neither requires waiting for us to ship an importer.
 
-**Convert to a format Kitaru already reads.** Write out [Kitaru JSONL](#create-kitaru-jsonl) — one session object per line, exactly the contract above — or emit OTLP with `gen_ai.*` attributes and import with `kitaru/opentelemetry@latest`. This is the right choice for a one-off backfill or an export you can transform with a script. Nothing gets installed or registered.
+**Convert to Kitaru JSONL.** Write out [Kitaru JSONL](#create-kitaru-jsonl) — one session object per line, exactly the contract above. This is the right choice for a one-off backfill or an export you can transform with a script. Nothing gets installed or registered.
 
 **Write an importer.** Worth it when the conversion is ongoing, or when the source needs real normalization rather than a field rename. The contract is one function:
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8539,7 +8539,7 @@
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.22.0rc4"
+    "version": "0.22.0rc5"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.22.0rc4"
+version = "0.22.0rc5"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/releases/python/kitaru/0.22.0rc5.toml
+++ b/releases/python/kitaru/0.22.0rc5.toml
@@ -1,0 +1,3 @@
+schema-version = 1
+kitaru-version = "0.22.0rc5"
+ui-tag = "kitaru-ui-v0.2.0-rc.3"

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.0rc4"
+version = "0.22.0rc5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- prepare Kitaru `0.22.0rc5`
- pin the expected frontend release `kitaru-ui-v0.2.0-rc.3`
- remove remaining documentation references to OpenTelemetry and OTLP as importers

## Validation

- `uv run --extra server pytest tests/scripts/test_release_ui.py tests/scripts/test_release_units.py` (43 passed)
- `uv run python scripts/release_ui.py --version 0.22.0rc5`
- `just check`
- repository-wide search confirms there are no remaining OpenTelemetry or OTLP importer references

The frontend archive and checksum cannot be verified until `kitaru-ui-v0.2.0-rc.3` is published.

## Reviewer Notes

Before merging or tagging, confirm that frontend release `kitaru-ui-v0.2.0-rc.3` contains `kitaru-ui.tar.gz` and its checksum. After merging, tag the release as `python/kitaru/v0.22.0rc5`.
