### PR TITLE
Fix local RC image tag

### DIFF
--- a/src/kitaru/cli/local_runtime.py
+++ b/src/kitaru/cli/local_runtime.py
@@ -397,7 +397,10 @@ def _get_server_image(package_version: str) -> tuple[str, bool]:
             "No published local server image is available for this development build.",
             hint=f"Set {LOCAL_IMAGE_ENV} to a compatible local image.",
         )
-    return f"zenmldocker/kitaru-server:{package_version}", False
+    image_version = package_version
+    if parsed_version.pre is not None and parsed_version.pre[0] == "rc":
+        image_version = f"{parsed_version.base_version}-rc.{parsed_version.pre[1]}"
+    return f"zenmldocker/kitaru-server:{image_version}", False
 
 
 async def _ensure_image(

--- a/src/kitaru/cli/local_runtime.py
+++ b/src/kitaru/cli/local_runtime.py
@@ -379,16 +379,17 @@ def _format_image_version(version: Version) -> str:
     """Format a PEP 440 version as a Docker-compatible image tag."""
     canonical_version = str(version)
     base_version = version.base_version
+    image_base_version = base_version.replace("!", ".epoch.")
     suffix = canonical_version.removeprefix(base_version)
     if not suffix:
-        return base_version
+        return image_base_version
 
     public_suffix, local_separator, local_suffix = suffix.partition("+")
     public_suffix = re.sub(r"([A-Za-z]+)([0-9]+)", r"\1.\2", public_suffix).strip(".")
     suffix_parts = [public_suffix] if public_suffix else []
     if local_separator:
         suffix_parts.append(f"local.{local_suffix}")
-    return f"{base_version}-{'.'.join(suffix_parts)}"
+    return f"{image_base_version}-{'.'.join(suffix_parts)}"
 
 
 def _get_server_image(package_version: str) -> tuple[str, bool]:

--- a/src/kitaru/cli/local_runtime.py
+++ b/src/kitaru/cli/local_runtime.py
@@ -397,12 +397,15 @@ def _get_server_image(package_version: str) -> tuple[str, bool]:
             "No published local server image is available for this development build.",
             hint=f"Set {LOCAL_IMAGE_ENV} to a compatible local image.",
         )
-    image_version = package_version
+    suffix_parts: list[str] = []
     if parsed_version.pre is not None:
         prerelease_type, prerelease_number = parsed_version.pre
-        image_version = (
-            f"{parsed_version.base_version}-{prerelease_type}.{prerelease_number}"
-        )
+        suffix_parts.extend((prerelease_type, str(prerelease_number)))
+    if parsed_version.post is not None:
+        suffix_parts.extend(("post", str(parsed_version.post)))
+    image_version = package_version
+    if suffix_parts:
+        image_version = f"{parsed_version.base_version}-{'.'.join(suffix_parts)}"
     return f"zenmldocker/kitaru-server:{image_version}", False
 
 

--- a/src/kitaru/cli/local_runtime.py
+++ b/src/kitaru/cli/local_runtime.py
@@ -375,6 +375,22 @@ async def _validate_docker(runner: DockerCommandRunner) -> None:
         )
 
 
+def _format_image_version(version: Version) -> str:
+    """Format a PEP 440 version as a Docker-compatible image tag."""
+    canonical_version = str(version)
+    base_version = version.base_version
+    suffix = canonical_version.removeprefix(base_version)
+    if not suffix:
+        return base_version
+
+    public_suffix, local_separator, local_suffix = suffix.partition("+")
+    public_suffix = re.sub(r"([A-Za-z]+)([0-9]+)", r"\1.\2", public_suffix).strip(".")
+    suffix_parts = [public_suffix] if public_suffix else []
+    if local_separator:
+        suffix_parts.append(f"local.{local_suffix}")
+    return f"{base_version}-{'.'.join(suffix_parts)}"
+
+
 def _get_server_image(package_version: str) -> tuple[str, bool]:
     override = os.environ.get(LOCAL_IMAGE_ENV)
     if override:
@@ -397,15 +413,7 @@ def _get_server_image(package_version: str) -> tuple[str, bool]:
             "No published local server image is available for this development build.",
             hint=f"Set {LOCAL_IMAGE_ENV} to a compatible local image.",
         )
-    suffix_parts: list[str] = []
-    if parsed_version.pre is not None:
-        prerelease_type, prerelease_number = parsed_version.pre
-        suffix_parts.extend((prerelease_type, str(prerelease_number)))
-    if parsed_version.post is not None:
-        suffix_parts.extend(("post", str(parsed_version.post)))
-    image_version = package_version
-    if suffix_parts:
-        image_version = f"{parsed_version.base_version}-{'.'.join(suffix_parts)}"
+    image_version = _format_image_version(parsed_version)
     return f"zenmldocker/kitaru-server:{image_version}", False
 
 

--- a/src/kitaru/cli/local_runtime.py
+++ b/src/kitaru/cli/local_runtime.py
@@ -398,8 +398,11 @@ def _get_server_image(package_version: str) -> tuple[str, bool]:
             hint=f"Set {LOCAL_IMAGE_ENV} to a compatible local image.",
         )
     image_version = package_version
-    if parsed_version.pre is not None and parsed_version.pre[0] == "rc":
-        image_version = f"{parsed_version.base_version}-rc.{parsed_version.pre[1]}"
+    if parsed_version.pre is not None:
+        prerelease_type, prerelease_number = parsed_version.pre
+        image_version = (
+            f"{parsed_version.base_version}-{prerelease_type}.{prerelease_number}"
+        )
     return f"zenmldocker/kitaru-server:{image_version}", False
 
 

--- a/tests/cli/test_local_runtime.py
+++ b/tests/cli/test_local_runtime.py
@@ -18,6 +18,7 @@ import os
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
 from kitaru.cli import local_runtime
 from kitaru.cli.local_runtime import (
@@ -307,6 +308,28 @@ def test_release_suffix_uses_docker_image_tag(
 
     assert image == f"zenmldocker/kitaru-server:{image_version}"
     assert overridden is False
+
+
+@pytest.mark.parametrize(
+    ("package_version", "image_version"),
+    [
+        ("0.22.0", "0.22.0"),
+        ("0.22.0rc5.post2", "0.22.0-rc.5.post.2"),
+        ("0.22.0.dev3", "0.22.0-dev.3"),
+        ("0.22.0+macos.arm64", "0.22.0-local.macos.arm64"),
+        (
+            "0.22.0rc5.post2.dev3+macos.arm64",
+            "0.22.0-rc.5.post.2.dev.3.local.macos.arm64",
+        ),
+    ],
+)
+def test_image_version_formatter_supports_pep440_suffixes(
+    package_version: str, image_version: str
+) -> None:
+    """All canonical PEP 440 suffixes produce Docker-compatible tags."""
+    assert (
+        local_runtime._format_image_version(Version(package_version)) == image_version
+    )
 
 
 def test_runtime_files_contain_no_world_readable_secrets(runtime_paths) -> None:

--- a/tests/cli/test_local_runtime.py
+++ b/tests/cli/test_local_runtime.py
@@ -317,6 +317,7 @@ def test_release_suffix_uses_docker_image_tag(
         ("0.22.0rc5.post2", "0.22.0-rc.5.post.2"),
         ("0.22.0.dev3", "0.22.0-dev.3"),
         ("0.22.0+macos.arm64", "0.22.0-local.macos.arm64"),
+        ("1!0.22.0rc5", "1.epoch.0.22.0-rc.5"),
         (
             "0.22.0rc5.post2.dev3+macos.arm64",
             "0.22.0-rc.5.post.2.dev.3.local.macos.arm64",

--- a/tests/cli/test_local_runtime.py
+++ b/tests/cli/test_local_runtime.py
@@ -287,6 +287,16 @@ def test_development_version_requires_an_override(monkeypatch) -> None:
         local_runtime._get_server_image("0.22.0.dev1")
 
 
+def test_release_candidate_uses_published_image_tag(monkeypatch) -> None:
+    """PEP 440 release candidates map to the published Docker tag format."""
+    monkeypatch.delenv(local_runtime.LOCAL_IMAGE_ENV, raising=False)
+
+    image, overridden = local_runtime._get_server_image("0.22.0rc5")
+
+    assert image == "zenmldocker/kitaru-server:0.22.0-rc.5"
+    assert overridden is False
+
+
 def test_runtime_files_contain_no_world_readable_secrets(runtime_paths) -> None:
     """Generated runtime secrets are restricted to the current user."""
     local_runtime._write_runtime_files(

--- a/tests/cli/test_local_runtime.py
+++ b/tests/cli/test_local_runtime.py
@@ -293,12 +293,14 @@ def test_development_version_requires_an_override(monkeypatch) -> None:
         ("0.22.0a1", "0.22.0-a.1"),
         ("0.22.0b3", "0.22.0-b.3"),
         ("0.22.0rc5", "0.22.0-rc.5"),
+        ("0.22.0.post2", "0.22.0-post.2"),
+        ("0.22.0rc5.post2", "0.22.0-rc.5.post.2"),
     ],
 )
-def test_prerelease_uses_docker_image_tag(
+def test_release_suffix_uses_docker_image_tag(
     monkeypatch, package_version: str, image_version: str
 ) -> None:
-    """PEP 440 prereleases map to the Docker tag format."""
+    """PEP 440 release suffixes map to the Docker tag format."""
     monkeypatch.delenv(local_runtime.LOCAL_IMAGE_ENV, raising=False)
 
     image, overridden = local_runtime._get_server_image(package_version)

--- a/tests/cli/test_local_runtime.py
+++ b/tests/cli/test_local_runtime.py
@@ -287,13 +287,23 @@ def test_development_version_requires_an_override(monkeypatch) -> None:
         local_runtime._get_server_image("0.22.0.dev1")
 
 
-def test_release_candidate_uses_published_image_tag(monkeypatch) -> None:
-    """PEP 440 release candidates map to the published Docker tag format."""
+@pytest.mark.parametrize(
+    ("package_version", "image_version"),
+    [
+        ("0.22.0a1", "0.22.0-a.1"),
+        ("0.22.0b3", "0.22.0-b.3"),
+        ("0.22.0rc5", "0.22.0-rc.5"),
+    ],
+)
+def test_prerelease_uses_docker_image_tag(
+    monkeypatch, package_version: str, image_version: str
+) -> None:
+    """PEP 440 prereleases map to the Docker tag format."""
     monkeypatch.delenv(local_runtime.LOCAL_IMAGE_ENV, raising=False)
 
-    image, overridden = local_runtime._get_server_image("0.22.0rc5")
+    image, overridden = local_runtime._get_server_image(package_version)
 
-    assert image == "zenmldocker/kitaru-server:0.22.0-rc.5"
+    assert image == f"zenmldocker/kitaru-server:{image_version}"
     assert overridden is False
 
 


### PR DESCRIPTION
## Summary

- Add a generic PEP 440 to Docker image-tag formatter based on the canonical version suffix.
- Convert prerelease, post-release, development, local, and combined suffixes without branching on individual `Version` fields.
- Keep published-image selection policy separate from version formatting.

## Root cause

The local runtime used the installed Python package version unchanged as the Docker image tag. PEP 440 uses compact suffix syntax, while deployable image tags use a hyphen and dotted suffix components.

## Reviewer Notes

`_format_image_version` supports canonical PEP 440 suffixes generically, including combined forms. `_get_server_image` continues to require `KITARU_LOCAL_IMAGE` for development and local builds, so self-built images remain an explicit selection and do not trigger registry pulls by default.

### Reproduction

1. Install the `0.22.0rc5` CLI package.
2. Run `kitaru login --local`.
3. Confirm Docker pulls `zenmldocker/kitaru-server:0.22.0-rc.5` instead of `zenmldocker/kitaru-server:0.22.0rc5`.

Validation: `uv run pytest tests/cli/test_local_runtime.py` and `just check`.