### PR TITLE
Prepare Kitaru 0.22.0rc6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Prepared the sixth Kitaru 0.22 release candidate with the local prerelease image-tag fix and `kitaru-ui-v0.2.0-rc.4`.
+- Prepared the sixth Kitaru 0.22 release candidate with the local prerelease image-tag fix and `kitaru-ui-v0.2.0-rc.3`.
 
 ## [0.22.0rc5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.22.0rc6]
+
+### Changed
+
+- Prepared the sixth Kitaru 0.22 release candidate with the local prerelease image-tag fix and `kitaru-ui-v0.2.0-rc.3`.
+
 ## [0.22.0rc5]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- Prepared the sixth Kitaru 0.22 release candidate with the local prerelease image-tag fix and `kitaru-ui-v0.2.0-rc.3`.
+- Prepared the sixth Kitaru 0.22 release candidate with the local prerelease image-tag fix and `kitaru-ui-v0.2.0-rc.4`.
 
 ## [0.22.0rc5]
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8539,7 +8539,7 @@
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.22.0rc5"
+    "version": "0.22.0rc6"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.22.0rc5"
+version = "0.22.0rc6"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/releases/python/kitaru/0.22.0rc6.toml
+++ b/releases/python/kitaru/0.22.0rc6.toml
@@ -1,0 +1,3 @@
+schema-version = 1
+kitaru-version = "0.22.0rc6"
+ui-tag = "kitaru-ui-v0.2.0-rc.3"

--- a/releases/python/kitaru/0.22.0rc6.toml
+++ b/releases/python/kitaru/0.22.0rc6.toml
@@ -1,3 +1,3 @@
 schema-version = 1
 kitaru-version = "0.22.0rc6"
-ui-tag = "kitaru-ui-v0.2.0-rc.3"
+ui-tag = "kitaru-ui-v0.2.0-rc.4"

--- a/releases/python/kitaru/0.22.0rc6.toml
+++ b/releases/python/kitaru/0.22.0rc6.toml
@@ -1,3 +1,3 @@
 schema-version = 1
 kitaru-version = "0.22.0rc6"
-ui-tag = "kitaru-ui-v0.2.0-rc.4"
+ui-tag = "kitaru-ui-v0.2.0-rc.3"

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.0rc5"
+version = "0.22.0rc6"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- prepare Kitaru `0.22.0rc6`
- pin frontend release `kitaru-ui-v0.2.0-rc.3`
- include the local prerelease image-tag fix now on `develop`

## Impact

This creates the release declaration and aligns the Python package, lockfile, OpenAPI document, and changelog on `0.22.0rc6`.

## Validation

- `uv run pytest tests/scripts/test_release_ui.py tests/scripts/test_release_units.py` (43 passed)
- `uv run python scripts/release_ui.py --version 0.22.0rc6`
- `just check`
- confirmed `kitaru-ui-v0.2.0-rc.3` is published with `kitaru-ui.tar.gz` and `kitaru-ui.tar.gz.sha256`

## Reviewer Notes

After merging, tag the release as `python/kitaru/v0.22.0rc6`.
