### PR TITLE
Prepare Kitaru 0.22.0rc7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.22.0rc7]
+
+### Changed
+
+- Prepared the seventh Kitaru 0.22 release candidate with `kitaru-ui-v0.2.0-rc.4`.
 
 ### Fixed
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8539,7 +8539,7 @@
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.22.0rc6"
+    "version": "0.22.0rc7"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.22.0rc6"
+version = "0.22.0rc7"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/releases/python/kitaru/0.22.0rc7.toml
+++ b/releases/python/kitaru/0.22.0rc7.toml
@@ -1,0 +1,3 @@
+schema-version = 1
+kitaru-version = "0.22.0rc7"
+ui-tag = "kitaru-ui-v0.2.0-rc.4"

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.0rc6"
+version = "0.22.0rc7"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- prepare Kitaru `0.22.0rc7`
- pin the expected frontend release `kitaru-ui-v0.2.0-rc.4`

## Impact

This aligns the Python package, lockfile, OpenAPI document, changelog, and release declaration on `0.22.0rc7`.

## Validation

- `uv run pytest tests/scripts/test_release_ui.py tests/scripts/test_release_units.py` (43 passed)
- `uv run python scripts/release_ui.py --version 0.22.0rc7`
- `just check`
- frontend archive verification pending publication of `kitaru-ui-v0.2.0-rc.4`

## Reviewer Notes

Before merging or tagging, confirm that frontend release `kitaru-ui-v0.2.0-rc.4` contains `kitaru-ui.tar.gz` and `kitaru-ui.tar.gz.sha256`. After merging, tag the release as `python/kitaru/v0.22.0rc7`.
