### PR TITLE
Gate release tags by branch

### DIFF
--- a/.agents/skills/kitaru-tests-release/SKILL.md
+++ b/.agents/skills/kitaru-tests-release/SKILL.md
@@ -49,7 +49,7 @@ Use the PostgreSQL-backed tests for transaction, locking, migration, or cross-re
 - Run `just plugin-artifact-smoke` after changing plugin package metadata, default definitions, requirement pins, or release installation paths.
 - The smoke builds Kitaru and every selected plugin as wheels, installs them into a clean environment, loads each configured package entrypoint, and verifies idempotent default registration.
 - CI runs plugin distributions as a package matrix. Keep the matrix aligned with `plugins/packages/` and the choices in `.github/workflows/release-plugins.yml`.
-- Plugin workflow dispatches are dry-runs. A package tag triggers publishing only when its commit is contained in `main`.
+- Plugin workflow dispatches are dry-runs. A package tag triggers publishing only when its commit is contained in `develop` or `main`.
 - Kitaru release dry-runs build plugin-owned candidate images from `plugins/candidate-wheels`; production release Dockerfiles continue to install exact versions from PyPI.
 - Commit `plugins/candidate.Dockerfile` and `plugins/docker-compose.candidate.yml`. Do not commit generated files under `plugins/candidate-wheels/`.
 - Keep production release Dockerfiles unchanged when a plugin change only needs local candidate-wheel testing.
@@ -99,7 +99,7 @@ Do not describe the inherited `llm-integration.yml` provider markers or absent `
 
 ## Release Workflows
 
-`.github/workflows/release-plugins.yml` publishes one Python distribution from an immutable namespaced tag. A core tag such as `python/kitaru/v0.22.0rc1` publishes Kitaru to PyPI and creates its GitHub Release. Plugin tags publish independently and do not gate the core release.
+`.github/workflows/route-release-tag.yml` accepts release tags only when their commits are contained in `develop` or `main`, then dispatches the matching release workflow. `.github/workflows/release-plugins.yml` publishes one Python distribution from an immutable namespaced tag. A core tag such as `python/kitaru/v0.22.0rc1` publishes Kitaru to PyPI and creates its GitHub Release. Plugin tags publish independently and do not gate the core release.
 
 After a successful core Python workflow, `.github/workflows/release.yml` automatically publishes the matching client, server, worker, and managed images plus the Helm chart. It converts Python RC versions such as `0.22.0rc1` to deployable tags such as `0.22.0-rc.1`. No separate bundle tag is used. A manual dispatch with the existing core package tag is the recovery path.
 

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -1,17 +1,17 @@
 ---
 name: Release Kitaru plugins
 on:
+  repository_dispatch:
+    types: [release-kitaru-plugin]
   workflow_dispatch:
     inputs:
       package-tag:
         description: Plugin package tag to rehearse, such as python/kitaru-langgraph/v0.4.0.
         required: true
         type: string
-  push:
-    tags: [python/**, '!python/kitaru/**']
 permissions: {}
 concurrency:
-  group: release-plugin-${{ github.ref_name }}
+  group: release-plugin-${{ github.event.client_payload['package-tag'] || inputs.package-tag }}
   cancel-in-progress: false
 jobs:
   build:
@@ -26,6 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ github.event.client_payload['package-tag'] || inputs.package-tag }}
           fetch-depth: 0
           persist-credentials: false
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
@@ -35,16 +36,10 @@ jobs:
       - name: Resolve package from the release inventory
         id: metadata
         env:
-          DISPATCH_TAG: ${{ inputs.package-tag }}
-          EVENT_NAME: ${{ github.event_name }}
-          PUSH_TAG: ${{ github.ref_name }}
+          DISPATCH_TAG: ${{ github.event.client_payload['package-tag'] || inputs.package-tag }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = push ]; then
-            package_tag="$PUSH_TAG"
-          else
-            package_tag="$DISPATCH_TAG"
-          fi
+          package_tag="$DISPATCH_TAG"
           unit=$(uv run --no-project --with packaging==26.2 python scripts/release_units.py resolve --tag "$package_tag" --format json)
           distribution=$(jq -r '.unit.distribution' <<<"$unit")
           project_dir=$(jq -r '.unit.path' <<<"$unit")
@@ -73,10 +68,11 @@ jobs:
       - name: Validate release source
         run: |
           set -euo pipefail
-          git fetch origin develop
+          git fetch origin develop main
           release_sha=$(git rev-parse HEAD)
-          if ! git merge-base --is-ancestor "$release_sha" origin/develop; then
-            echo "::error::$PACKAGE_TAG points to $release_sha, which is not on develop."
+          if ! git merge-base --is-ancestor "$release_sha" origin/develop && \
+            ! git merge-base --is-ancestor "$release_sha" origin/main; then
+            echo "::error::$PACKAGE_TAG points to $release_sha, which is not on develop or main."
             exit 1
           fi
       - name: Build plugin
@@ -107,7 +103,7 @@ jobs:
           if-no-files-found: error
           retention-days: 90
   publish-python:
-    if: github.event_name == 'push'
+    if: github.event_name == 'repository_dispatch'
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -125,7 +121,7 @@ jobs:
           packages-dir: package-dist
           skip-existing: true
   create-release:
-    if: github.event_name == 'push'
+    if: github.event_name == 'repository_dispatch'
     needs: [build, publish-python]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -1,17 +1,17 @@
 ---
 name: Release TypeScript packages
 on:
+  repository_dispatch:
+    types: [release-kitaru-typescript]
   workflow_dispatch:
     inputs:
       package-tag:
         description: Namespaced package tag to rehearse, such as typescript/kitaru/v0.1.0-rc.1.
         required: true
         type: string
-  push:
-    tags: [typescript/kitaru/v*]
 permissions: {}
 concurrency:
-  group: release-typescript-${{ github.ref_name }}
+  group: release-typescript-${{ github.event.client_payload['package-tag'] || inputs.package-tag }}
   cancel-in-progress: false
 env:
   KITARU_ANALYTICS_OPT_IN: false
@@ -40,6 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ github.event.client_payload['package-tag'] || inputs.package-tag }}
           fetch-depth: 0
           persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
@@ -56,16 +57,10 @@ jobs:
       - name: Resolve package metadata
         id: metadata
         env:
-          DISPATCH_TAG: ${{ inputs.package-tag }}
-          EVENT_NAME: ${{ github.event_name }}
-          PUSH_TAG: ${{ github.ref_name }}
+          DISPATCH_TAG: ${{ github.event.client_payload['package-tag'] || inputs.package-tag }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = push ]; then
-            package_tag="$PUSH_TAG"
-          else
-            package_tag="$DISPATCH_TAG"
-          fi
+          package_tag="$DISPATCH_TAG"
           metadata=$(node scripts/typescript-packages.mjs --tag "$package_tag")
           version=$(jq -r '.version' <<<"$metadata")
           npm_tag=$(jq -r '.npm_tag' <<<"$metadata")
@@ -85,10 +80,11 @@ jobs:
       - name: Validate release source
         run: |
           set -euo pipefail
-          git fetch origin develop
+          git fetch origin develop main
           release_sha=$(git rev-parse HEAD)
-          if ! git merge-base --is-ancestor "$release_sha" origin/develop; then
-            echo "::error::$PACKAGE_TAG points to $release_sha, which is not on develop."
+          if ! git merge-base --is-ancestor "$release_sha" origin/develop && \
+            ! git merge-base --is-ancestor "$release_sha" origin/main; then
+            echo "::error::$PACKAGE_TAG points to $release_sha, which is not on develop or main."
             exit 1
           fi
       - run: pnpm install --frozen-lockfile
@@ -114,7 +110,7 @@ jobs:
           if-no-files-found: error
           retention-days: 90
   publish:
-    if: github.event_name == 'push'
+    if: github.event_name == 'repository_dispatch'
     needs: build
     runs-on: ubuntu-latest
     environment: npm-publish
@@ -195,7 +191,7 @@ jobs:
             npm publish "$tarball" --access public --tag "$NPM_TAG" --provenance
           done
   verify-and-release:
-    if: github.event_name == 'push'
+    if: github.event_name == 'repository_dispatch'
     needs: [build, publish]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,17 @@
 ---
 name: Release Kitaru
 on:
+  repository_dispatch:
+    types: [release-kitaru]
   workflow_dispatch:
     inputs:
       package-tag:
         description: Core package tag to rehearse, such as python/kitaru/v0.22.0rc4.
         required: true
         type: string
-  push:
-    tags: [python/kitaru/v*]
 permissions: {}
 concurrency:
-  group: release-kitaru-${{ github.ref_name }}
+  group: release-kitaru-${{ github.event.client_payload['package-tag'] || inputs.package-tag }}
   cancel-in-progress: false
 jobs:
   build:
@@ -26,6 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ github.event.client_payload['package-tag'] || inputs.package-tag }}
           fetch-depth: 0
           persist-credentials: false
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
@@ -35,16 +36,10 @@ jobs:
       - name: Resolve release metadata
         id: metadata
         env:
-          DISPATCH_TAG: ${{ inputs.package-tag }}
-          EVENT_NAME: ${{ github.event_name }}
-          PUSH_TAG: ${{ github.ref_name }}
+          DISPATCH_TAG: ${{ github.event.client_payload['package-tag'] || inputs.package-tag }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = push ]; then
-            package_tag="$PUSH_TAG"
-          else
-            package_tag="$DISPATCH_TAG"
-          fi
+          package_tag="$DISPATCH_TAG"
           unit=$(uv run --no-project --with packaging==26.2 python scripts/release_units.py resolve --tag "$package_tag" --format json)
           distribution=$(jq -r '.unit.distribution' <<<"$unit")
           version=$(jq -r '.unit.version' <<<"$unit")
@@ -77,10 +72,11 @@ jobs:
       - name: Validate release source
         run: |
           set -euo pipefail
-          git fetch origin develop
+          git fetch origin develop main
           release_sha=$(git rev-parse HEAD)
-          if ! git merge-base --is-ancestor "$release_sha" origin/develop; then
-            echo "::error::$PACKAGE_TAG points to $release_sha, which is not on develop."
+          if ! git merge-base --is-ancestor "$release_sha" origin/develop && \
+            ! git merge-base --is-ancestor "$release_sha" origin/main; then
+            echo "::error::$PACKAGE_TAG points to $release_sha, which is not on develop or main."
             exit 1
           fi
       - name: Resolve exact frontend artifact
@@ -128,7 +124,7 @@ jobs:
           if-no-files-found: error
           retention-days: 90
   publish-python:
-    if: github.event_name == 'push'
+    if: github.event_name == 'repository_dispatch'
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -278,7 +274,7 @@ jobs:
   create-release:
     if: >-
       always() &&
-      github.event_name == 'push' &&
+      github.event_name == 'repository_dispatch' &&
       needs.publish-python.result == 'success' &&
       needs.publish-deployables.result == 'success' &&
       (needs.build.outputs.is-prerelease == 'true' ||

--- a/.github/workflows/route-release-tag.yml
+++ b/.github/workflows/route-release-tag.yml
@@ -1,0 +1,45 @@
+---
+name: Route release tag
+on:
+  push:
+    tags: [python/**, typescript/kitaru/v*]
+permissions: {}
+jobs:
+  route:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check release branch
+        id: source
+        run: |
+          set -euo pipefail
+          git fetch origin develop main
+          release_sha=$(git rev-parse HEAD)
+          if git merge-base --is-ancestor "$release_sha" origin/develop || \
+            git merge-base --is-ancestor "$release_sha" origin/main; then
+            echo 'eligible=true' >> "$GITHUB_OUTPUT"
+          else
+            echo "Skipping $GITHUB_REF_NAME because $release_sha is not on develop or main."
+          fi
+      - name: Dispatch release workflow
+        if: steps.source.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |-
+          set -euo pipefail
+          case "$GITHUB_REF_NAME" in
+            python/kitaru/v*) event_type=release-kitaru ;;
+            python/*) event_type=release-kitaru-plugin ;;
+            typescript/kitaru/v*) event_type=release-kitaru-typescript ;;
+            *) echo "::error::Unsupported release tag $GITHUB_REF_NAME"; exit 1 ;;
+          esac
+          jq -n \
+            --arg event_type "$event_type" \
+            --arg package_tag "$GITHUB_REF_NAME" \
+            '{event_type: $event_type, client_payload: {"package-tag": $package_tag}}' | \
+            gh api --method POST "repos/$GITHUB_REPOSITORY/dispatches" --input -

--- a/plugins/DEVELOPMENT.md
+++ b/plugins/DEVELOPMENT.md
@@ -350,7 +350,7 @@ Every manual dispatch is a dry-run. It checks out the selected branch SHA, valid
 
 ## Publish a plugin
 
-Publish only after the release commit is contained in `main`. This requirement couples plugin publishing to the repository's `main` promotion cadence.
+Publish only after the release commit is contained in `develop` or `main`.
 
 ```bash
 git fetch origin main --tags
@@ -364,7 +364,7 @@ git tag -a "$TAG" "$RELEASE_SHA" -m "$TAG"
 git push origin "$TAG"
 ```
 
-The tag push starts the `Release Kitaru plugins` workflow. The workflow derives the plugin package and version from the tag. It rejects a tag whose commit is not contained in `origin/develop`. It then runs the tests, builds the selected distribution, publishes through PyPI Trusted Publishing, and creates a GitHub Release with the wheel, source distribution, and checksums.
+The tag push starts the release tag router. The router starts the `Release Kitaru plugins` workflow only when the tagged commit is contained in `origin/develop` or `origin/main`. The release workflow derives the plugin package and version from the tag, runs the tests, builds the selected distribution, publishes through PyPI Trusted Publishing, and creates a GitHub Release with the wheel, source distribution, and checksums.
 
 If publication stops after PyPI accepts one or more files, rerun the failed jobs from the same workflow run. The rerun downloads the original build artifact, skips files that PyPI already accepted, finishes any remaining artifacts, and creates the GitHub Release if it does not exist. Do not move or recreate the release tag.
 

--- a/release/typescript.md
+++ b/release/typescript.md
@@ -9,9 +9,9 @@ The TypeScript SDK is one release set for now. `@zenml-io/kitaru`, `@zenml-io/ki
 3. Run `pnpm run pack:check` locally.
 4. Run the **Release TypeScript packages** workflow manually with `typescript/kitaru/v<VERSION>`. A manual run builds and tests the artifacts but cannot publish them.
 5. Download the `typescript-distributions` artifact from the rehearsal, verify `SHA256SUMS`, inspect the three tarballs, and smoke-test their public exports in a clean project.
-6. After the change is on `develop`, create the immutable tag on the exact rehearsed commit and push it. The tag-triggered run publishes core first, then the two adapters, verifies a clean registry install, and creates a GitHub release.
+6. After the change is on `develop` or `main`, create the immutable tag on the exact rehearsed commit and push it. The release tag router then starts the publishing workflow, which publishes core first, then the two adapters, verifies a clean registry install, and creates a GitHub release.
 
-Do not publish these packages from a local checkout. The workflow requires the tagged commit to be part of `develop` and publishes only the tarballs produced by its build job.
+Do not publish these packages from a local checkout. The router requires the tagged commit to be part of `develop` or `main`, and the release workflow publishes only the tarballs produced by its build job.
 
 ## Verify and recover a release
 

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -108,7 +108,7 @@ def test_core_release_publishes_deployables_without_waiting_for_plugins() -> Non
     ).read_text()
 
     assert "workflow_run:" not in workflow
-    assert "python/kitaru/v*" in workflow
+    assert "types: [release-kitaru]" in workflow
     assert "bundle/kitaru/v*" not in workflow
     assert "publish-deployables:" in workflow
     assert "plugins/default-requirements.txt" not in workflow
@@ -121,7 +121,26 @@ def test_core_release_publishes_deployables_without_waiting_for_plugins() -> Non
     )
     assert "promote-latest:" in workflow
     assert "publish-deployables:" not in plugin_workflow
-    assert "!python/kitaru/**" in plugin_workflow
+    assert "types: [release-kitaru-plugin]" in plugin_workflow
+
+
+def test_release_tags_are_routed_only_from_release_branches() -> None:
+    router = (REPO_ROOT / ".github" / "workflows" / "route-release-tag.yml").read_text()
+    release_workflows = [
+        (REPO_ROOT / ".github" / "workflows" / name).read_text()
+        for name in ("release.yml", "release-plugins.yml", "release-typescript.yml")
+    ]
+
+    assert "tags: [python/**, typescript/kitaru/v*]" in router
+    assert "git fetch origin develop main" in router
+    assert 'git merge-base --is-ancestor "$release_sha" origin/develop' in router
+    assert 'git merge-base --is-ancestor "$release_sha" origin/main' in router
+    assert "if: steps.source.outputs.eligible == 'true'" in router
+    assert 'gh api --method POST "repos/$GITHUB_REPOSITORY/dispatches"' in router
+    for workflow in release_workflows:
+        assert "repository_dispatch:" in workflow
+        assert "  push:\n" not in workflow
+        assert "github.event_name == 'repository_dispatch'" in workflow
 
 
 def test_managed_image_failure_does_not_block_the_release() -> None:
@@ -328,8 +347,7 @@ def test_plugin_matrix_is_generated_from_the_nine_plugin_units() -> None:
 def test_plugin_release_workflow_resolves_plugin_tags_from_the_inventory() -> None:
     workflow = (REPO_ROOT / ".github" / "workflows" / "release-plugins.yml").read_text()
 
-    assert "python/**" in workflow
-    assert "!python/kitaru/**" in workflow
+    assert "types: [release-kitaru-plugin]" in workflow
     assert "scripts/release_units.py resolve --tag" in workflow
     assert "scripts/release_ui.py --version" not in workflow
     assert "uv version" not in workflow

--- a/tests/scripts/test_typescript_packages.py
+++ b/tests/scripts/test_typescript_packages.py
@@ -141,8 +141,8 @@ def test_typescript_release_workflow_contract() -> None:
         "\n  verify-and-release:\n", maxsplit=1
     )
 
-    assert "typescript/kitaru/v*" in workflow_source
-    assert "if: github.event_name == 'push'" in publish_source
+    assert "types: [release-kitaru-typescript]" in workflow_source
+    assert "if: github.event_name == 'repository_dispatch'" in publish_source
     assert "needs: build" in publish_source
     assert "needs: [build, publish]" in verify_source
     assert "node scripts/typescript-packages.mjs --tag" in workflow_source


### PR DESCRIPTION
## Summary

- add a release tag router that accepts tagged commits reachable from `develop` or `main`
- dispatch core Python, plugin, and TypeScript publishing workflows only after the branch check passes
- preserve manual workflows as non-publishing rehearsals and retain defense-in-depth source validation
- update release guidance and workflow contract tests

## Why

Tag filters run for every matching tag regardless of which branch contains the tagged commit. The existing source check happened inside each release workflow, so tags on feature-only commits still started release runs before failing validation.

With this change, a feature-branch-only tag ends in the small router without dispatching a release workflow. Eligible tags dispatch the matching workflow with the immutable package tag.

## Validation

- `uv run pytest -q tests/scripts/test_release_units.py tests/scripts/test_typescript_packages.py` (49 passed)
- `just check`
- `just zizmor`

## Reviewer Notes

To reproduce the routing behavior, push a matching release tag whose commit exists only on a feature branch and confirm that only `Route release tag` runs and reports the skip. For an eligible test, tag a commit reachable from `develop` or `main` and confirm the router dispatches the matching release workflow with that tag. Manual dispatches of the release workflows should continue to build and test without publishing.