### PR TITLE
Clarify Vercel stream replay boundary

### DIFF
--- a/docs/book/adapters/README.md
+++ b/docs/book/adapters/README.md
@@ -7,7 +7,7 @@ icon: puzzle-piece
 
 Adapters are the first of two ways into Kitaru: wrap the agent you already have, and every run is recorded natively. (The second — [importing the traces you already collect](../getting-started/import-your-traces.md) — needs no adapter at all.)
 
-An adapter leaves your framework in charge of the agent loop while recording the model and tool activity that the integration exposes. The same adapter makes [replay](../concepts/replay.md) work: it applies supported overrides at the model boundary and answers tool calls per the [tool policy](../guides/tool-policies.md). Capabilities differ by integration. The current TypeScript adapters record non-streaming calls only; the Vercel adapter also preserves Agent `stream()` as a native, recording-free passthrough. Each adapter page states its exact boundary.
+An adapter leaves your framework in charge of the agent loop while recording the model and tool activity that the integration exposes. The same adapter makes [replay](../concepts/replay.md) work: it applies supported overrides at the model boundary and answers tool calls per the [tool policy](../guides/tool-policies.md). Capabilities differ by integration. The current TypeScript adapters record non-streaming calls only; the Vercel adapter also preserves Agent `stream()` outside replay as a native, recording-free passthrough. Each adapter page states its exact boundary.
 
 ## Available adapters
 

--- a/docs/book/adapters/vercel-ai.md
+++ b/docs/book/adapters/vercel-ai.md
@@ -8,7 +8,7 @@ icon: bolt
 `@zenml-io/kitaru-vercel-ai` adds Kitaru recording and replay to the Vercel [AI SDK](https://ai-sdk.dev) 7 `ToolLoopAgent` and `generateText` APIs. Use `createKitaruToolLoopAgent(...)` for an AI SDK Agent object or `createKitaruGenerateText(...)` for the direct function API. Both return native AI SDK results.
 
 {% hint style="info" %}
-Version `0.1.0-rc.2` is a pre-1.0 compatibility preview. Kitaru records non-streaming Agent `generate()` and direct `generateText` calls. Agent `stream()` remains available as a native, recording-free passthrough; standalone `streamText` is not wrapped.
+Version `0.1.0-rc.2` is a pre-1.0 compatibility preview. Kitaru records non-streaming Agent `generate()` and direct `generateText` calls. Agent `stream()` remains available outside replay as a native, recording-free passthrough; standalone `streamText` is not wrapped.
 {% endhint %}
 
 ## Install


### PR DESCRIPTION
## Summary

Clarify that the Vercel AI Agent `stream()` passthrough is available only outside replay. This keeps the adapters overview and the page-level compatibility hint consistent with the runtime boundary added in #768.

Related: #768

## Reviewer Notes

This is a docs-only correction. It does not change adapter behavior.

### Reproduction

Run:

```bash
rg -n "stream.*outside replay" docs/book/adapters/README.md docs/book/adapters/vercel-ai.md
```

Both introductory statements should now match the detailed supported-boundary section. `uvx typos`, targeted offline link checking, and `git diff --check` pass.
