### PR TITLE
Clarify local image conflicts

### DIFF
--- a/src/kitaru/cli/local_runtime.py
+++ b/src/kitaru/cli/local_runtime.py
@@ -196,8 +196,13 @@ async def start_local_runtime(
         elif state.server_image != image and not upgrade:
             raise CLIError(
                 "conflict",
-                "The local deployment uses a different Kitaru server image.",
-                hint="Run `kitaru login --local --upgrade` to replace it.",
+                f"Your local Kitaru server uses {state.server_image}, but this "
+                f"login expects {image}. Kitaru will not replace the server "
+                "container without your approval.",
+                hint=(
+                    "Run `kitaru login --local --upgrade` to use the expected "
+                    "image. Your local database will be kept."
+                ),
                 details={"current_image": state.server_image, "requested_image": image},
             )
         if state is None:

--- a/tests/cli/test_local_runtime.py
+++ b/tests/cli/test_local_runtime.py
@@ -167,7 +167,7 @@ async def test_version_mismatch_requires_explicit_upgrade(
     )
     monkeypatch.delenv(local_runtime.LOCAL_IMAGE_ENV, raising=False)
 
-    with pytest.raises(CLIError, match="different Kitaru server image") as raised:
+    with pytest.raises(CLIError, match="Your local Kitaru server uses") as raised:
         await local_runtime.start_local_runtime(
             package_version="0.21.0",
             upgrade=False,
@@ -177,7 +177,15 @@ async def test_version_mismatch_requires_explicit_upgrade(
         )
 
     assert raised.value.kind == "conflict"
+    assert "zenmldocker/kitaru-server:0.20.0" in raised.value.message
+    assert "zenmldocker/kitaru-server:0.21.0" in raised.value.message
+    assert "without your approval" in raised.value.message
     assert "--upgrade" in str(raised.value.hint)
+    assert "database will be kept" in str(raised.value.hint)
+    assert raised.value.details == {
+        "current_image": "zenmldocker/kitaru-server:0.20.0",
+        "requested_image": "zenmldocker/kitaru-server:0.21.0",
+    }
 
 
 async def test_upgrade_refreshes_release_image(runtime_paths, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Improve the `kitaru login --local` image-conflict error so users can see the image used by their existing local server and the image expected by the current login. Clarify that Kitaru requires explicit approval before replacing the server container and that `--upgrade` preserves the local PostgreSQL database.

Add regression assertions for the human-facing explanation, both image tags, the recovery command, the data-preservation guarantee, and the existing structured error details.

## Reviewer Notes

The previous error reported only that the images differed and told users to replace the deployment. In terminal output, the structured `current_image` and `requested_image` details are not shown, and "replace" could suggest that local data will be deleted.

### Reproduction

1. Create a CLI-owned local deployment with one Kitaru version.
2. Install or run a newer Kitaru CLI version.
3. Run `kitaru login --local` without `--upgrade`.
4. Confirm the error shows both image tags, explains the explicit approval boundary, and states that `kitaru login --local --upgrade` keeps the local database.

Validation: `uv run pytest tests/cli/test_local_runtime.py` (27 passed), plus focused Ruff formatting and lint checks.