### PR TITLE
Improve CLI connection error messages

### DIFF
--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -1900,6 +1900,7 @@ export interface paths {
          *
          *     Args:
          *         settings: Service settings governing auth behavior.
+         *         server_id: Persisted server id.
          *         ui_version: UI version served by this process.
          *
          *     Returns:
@@ -4604,15 +4605,25 @@ export interface components {
          */
         EvaluationStats: {
             /**
-             * Average
-             * @description Mean score of float evaluations, share of true results of bool evaluations, null for other data types.
-             */
-            average?: number | null;
-            /**
              * Count
              * @description Number of aggregated evaluations.
              */
             count: number;
+            /**
+             * Max
+             * @description Highest score of float and bool evaluations, null for other data types.
+             */
+            max?: number | null;
+            /**
+             * Mean
+             * @description Mean score of float evaluations, share of true results of bool evaluations, null for other data types.
+             */
+            mean?: number | null;
+            /**
+             * Min
+             * @description Lowest score of float and bool evaluations, null for other data types.
+             */
+            min?: number | null;
             /**
              * Pass Rate
              * @description Share of passed evaluations among those carrying a passed flag, null when none do.

--- a/src/kitaru/cli/app.py
+++ b/src/kitaru/cli/app.py
@@ -235,6 +235,7 @@ class Invocation:
     no_browser: bool
     stdin: TextIO
     _credential_store: CredentialStore | None = None
+    _resolved_target: ResolvedTarget | None = None
 
     @property
     def credential_store(self) -> CredentialStore:
@@ -242,6 +243,13 @@ class Invocation:
         if self._credential_store is None:
             self._credential_store = CredentialStore()
         return self._credential_store
+
+    @property
+    def resolved_server_url(self) -> str | None:
+        """Return the server resolved during this invocation, if any."""
+        if self._resolved_target is None:
+            return None
+        return self._resolved_target.server_url
 
     def resolve_target(self, explicit_server: str | None = None) -> ResolvedTarget:
         """Resolve a server from command and global inputs."""
@@ -254,7 +262,9 @@ class Invocation:
                     "The command SERVER and global --server identify "
                     "different servers.",
                 )
-        return resolve_target(explicit_server=explicit_server or self.server)
+        target = resolve_target(explicit_server=explicit_server or self.server)
+        self._resolved_target = target
+        return target
 
 
 _INVOCATION: ContextVar[Invocation | None] = ContextVar(
@@ -428,7 +438,10 @@ async def _launch(
     except asyncio.CancelledError:
         raise
     except BaseException as exception:
-        error = _convert_error(exception)
+        error = _convert_error(
+            exception,
+            server_url=invocation.resolved_server_url,
+        )
         return emit_error(
             error,
             exception=exception,
@@ -670,7 +683,7 @@ async def login(
     """Authenticate with a server and store its credential when required."""
     invocation = _invocation()
     chosen_server = server or invocation.server
-    if server and invocation.server:
+    if chosen_server and not local:
         invocation.resolve_target(server)
     return await auth_commands.login(
         server=chosen_server,
@@ -3976,7 +3989,9 @@ def _emit_early_error(
         reset_output_context(token)
 
 
-def _convert_error(exception: BaseException) -> CLIError:
+def _convert_error(
+    exception: BaseException, *, server_url: str | None = None
+) -> CLIError:
     """Map SDK, validation, and transport failures to stable CLI errors."""
     if isinstance(exception, CLIError):
         return exception
@@ -4005,21 +4020,72 @@ def _convert_error(exception: BaseException) -> CLIError:
                 "network_error", exception.detail, retryable=True, details=details
             )
         return CLIError("internal_error", str(exception), details=details)
+    if isinstance(exception, httpx.TransportError):
+        server_url = _get_transport_server_url(exception, server_url)
     if isinstance(exception, httpx.TimeoutException):
+        message = (
+            f"The request to {server_url} timed out."
+            if server_url
+            else "The server request timed out."
+        )
         return CLIError(
             "network_error",
-            "The server request timed out.",
+            message,
             retryable=True,
+            details={"server_url": server_url} if server_url else None,
             hint="Check the selected server with `kitaru status`, then retry.",
         )
     if isinstance(exception, httpx.TransportError):
+        location = f" at {server_url}" if server_url else ""
         return CLIError(
             "network_error",
-            f"The server is unavailable: {exception}",
+            f"The server{location} is unavailable: {exception}",
             retryable=True,
+            details={"server_url": server_url} if server_url else None,
             hint="Check the selected server with `kitaru status`, then retry.",
         )
     return CLIError("internal_error", str(exception) or type(exception).__name__)
+
+
+def _get_transport_server_url(
+    exception: httpx.TransportError,
+    selected_server_url: str | None = None,
+) -> str | None:
+    """Return the selected server or a secret-safe failed request origin."""
+    try:
+        request_url = exception.request.url
+    except RuntimeError:
+        request_url = None
+    if selected_server_url:
+        selected_url = httpx.URL(selected_server_url)
+        if request_url is None or (
+            request_url.scheme,
+            request_url.host,
+            request_url.port,
+        ) == (
+            selected_url.scheme,
+            selected_url.host,
+            selected_url.port,
+        ):
+            return str(
+                selected_url.copy_with(
+                    username=None,
+                    password=None,
+                    query=None,
+                    fragment=None,
+                )
+            ).rstrip("/")
+    if request_url is None:
+        return None
+    return str(
+        request_url.copy_with(
+            username=None,
+            password=None,
+            path="/",
+            query=None,
+            fragment=None,
+        )
+    ).rstrip("/")
 
 
 def _parse_bool(value: str) -> bool:

--- a/src/kitaru/cli/auth.py
+++ b/src/kitaru/cli/auth.py
@@ -29,6 +29,7 @@ from kitaru.client.control_plane_auth import control_plane_login
 from kitaru.client.credential_store import CredentialStore
 from kitaru.client.credentials import ApiToken
 from kitaru.client.device_auth import device_login
+from kitaru.client.exceptions import NotFoundError
 
 LOCAL_SERVER_URL = "http://localhost:8000"
 
@@ -140,7 +141,18 @@ async def login(
     credential_stored = False
     credential_kind = "none"
     try:
-        info = await client.info.get()
+        try:
+            info = await client.info.get()
+        except NotFoundError as error:
+            raise CLIError(
+                "invalid_configuration",
+                f"Kitaru is not available at {server_url}. "
+                "Check the URL or deployment.",
+                details={
+                    "status_code": error.status_code,
+                    "server_url": server_url,
+                },
+            ) from error
         if info.auth_scheme is AuthScheme.NONE:
             _reject_auth_inputs(
                 username=username,

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -19,7 +19,9 @@ import json
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
+import httpx
 import pytest
 
 import kitaru.cli
@@ -504,6 +506,99 @@ def test_http_413_maps_to_invalid_arguments_with_server_detail() -> None:
     assert error.kind == "invalid_arguments"
     assert error.message == "payload exceeds configured cap"
     assert error.details == {"status_code": 413}
+
+
+def test_transport_error_falls_back_to_secret_safe_request_origin() -> None:
+    """A transport error without invocation state omits paths and query values."""
+    request = httpx.Request(
+        "GET",
+        "https://user:password@api.example.com/v1/workers?credential=secret#token",
+    )
+
+    error = app_module._convert_error(
+        httpx.ConnectError("connection refused", request=request)
+    )
+
+    assert error.message == (
+        "The server at https://api.example.com is unavailable: connection refused"
+    )
+    assert error.details == {"server_url": "https://api.example.com"}
+    assert "credential" not in error.message
+    assert "secret" not in error.message
+    assert "user" not in error.message
+    assert "password" not in error.message
+    assert "token" not in error.message
+
+
+def test_transport_error_reports_different_failed_request_origin() -> None:
+    """A request to another service is not attributed to the selected server."""
+    request = httpx.Request("GET", "https://control.example.com/v1/token")
+
+    error = app_module._convert_error(
+        httpx.ConnectError("connection refused", request=request),
+        server_url="https://api.example.com/kitaru",
+    )
+
+    assert error.message == (
+        "The server at https://control.example.com is unavailable: connection refused"
+    )
+    assert error.details == {"server_url": "https://control.example.com"}
+
+
+def test_transport_error_without_request_uses_selected_server() -> None:
+    """Resolved invocation state identifies errors without request metadata."""
+    error = app_module._convert_error(
+        httpx.ConnectError("connection refused"),
+        server_url="https://api.example.com/kitaru",
+    )
+
+    assert error.message == (
+        "The server at https://api.example.com/kitaru is unavailable: "
+        "connection refused"
+    )
+    assert error.details == {"server_url": "https://api.example.com/kitaru"}
+
+
+def test_login_network_error_preserves_selected_server_path(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A login transport failure identifies the full selected server URL."""
+    server = "https://api.example.com/kitaru"
+
+    async def fail_login(**options: Any) -> CommandResult:
+        request = httpx.Request("GET", f"{options['server']}/v1/info")
+        raise httpx.ConnectError("connection refused", request=request)
+
+    monkeypatch.setattr(app_module.auth_commands, "login", fail_login)
+
+    assert app_module.main(["login", server, "--output", "json"]) == 6
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert payload["error"]["message"] == (
+        f"The server at {server} is unavailable: connection refused"
+    )
+    assert payload["error"]["details"] == {"server_url": server}
+
+
+def test_login_timeout_identifies_selected_server(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A login timeout identifies the full selected server URL."""
+    server = "https://api.example.com/kitaru"
+
+    async def fail_login(**options: Any) -> CommandResult:
+        request = httpx.Request("GET", f"{options['server']}/v1/info")
+        raise httpx.ReadTimeout("read timed out", request=request)
+
+    monkeypatch.setattr(app_module.auth_commands, "login", fail_login)
+
+    assert app_module.main(["login", server, "--output", "json"]) == 6
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+    assert payload["error"]["message"] == f"The request to {server} timed out."
+    assert payload["error"]["details"] == {"server_url": server}
 
 
 def test_lazy_entry_point_reports_missing_cli_extra(monkeypatch, capsys) -> None:

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -15,6 +15,7 @@
 
 import io
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 
@@ -25,7 +26,7 @@ from kitaru.cli.output import CLIError
 from kitaru.client.config import get_server_url
 from kitaru.client.credential_store import CredentialStore
 from kitaru.client.credentials import ApiToken
-from kitaru.client.exceptions import AuthenticationError
+from kitaru.client.exceptions import AuthenticationError, NotFoundError
 
 
 @dataclass
@@ -48,7 +49,12 @@ class FakeAuthResource:
 class FakeClient:
     """Minimal client exposing info, auth, and close behavior."""
 
-    def __init__(self, scheme: AuthScheme, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        scheme: AuthScheme,
+        error: Exception | None = None,
+        info_error: Exception | None = None,
+    ) -> None:
         """Initialize the fake client."""
         self.auth = FakeAuthResource(error)
         self.closed = False
@@ -56,6 +62,8 @@ class FakeClient:
 
         class InfoResource:
             async def get(self) -> ServerInfoResponse:
+                if info_error:
+                    raise info_error
                 return info
 
         self.info = InfoResource()
@@ -63,6 +71,44 @@ class FakeClient:
     async def close(self) -> None:
         """Record client closure."""
         self.closed = True
+
+
+async def test_login_explains_when_kitaru_is_not_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing info endpoint identifies the unavailable Kitaru deployment."""
+    credential_store = CredentialStore(tmp_path / "credentials.json")
+    server = "https://preview.example.com"
+    client = FakeClient(
+        AuthScheme.NONE,
+        info_error=NotFoundError(404, "Not found"),
+    )
+    monkeypatch.setattr(auth, "KitaruAPIClient", lambda **_: client)
+
+    with pytest.raises(CLIError) as raised:
+        await auth.login(
+            server=server,
+            local=False,
+            username=None,
+            password_stdin=False,
+            api_key_stdin=False,
+            credential_store=credential_store,
+            timeout=30,
+            non_interactive=True,
+            no_browser=True,
+            stdin=io.StringIO(),
+        )
+
+    assert raised.value.kind == "invalid_configuration"
+    assert str(raised.value) == (
+        f"Kitaru is not available at {server}. Check the URL or deployment."
+    )
+    assert raised.value.details == {
+        "status_code": 404,
+        "server_url": server,
+    }
+    assert credential_store.list() == []
+    assert client.closed is True
 
 
 async def test_api_key_is_validated_before_replacing_stored_credential(

--- a/tests/cli/test_workers.py
+++ b/tests/cli/test_workers.py
@@ -25,6 +25,7 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 
+import httpx
 import pytest
 
 from kitaru.api_models.v1.task import TaskKind
@@ -580,3 +581,46 @@ def test_cli_start_passes_kind_scope_and_emits_stream_result(
     assert options["drain_timeout"] == 15.0
     assert "request_timeout" not in options
     assert captured.err == ""
+
+
+def test_cli_start_network_error_identifies_server(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A worker connection failure names the server it could not reach."""
+    server = "https://api.example.com/kitaru"
+
+    async def fail_start(target: ResolvedTarget, **options: Any) -> CommandResult:
+        request = httpx.Request("GET", f"{target.server_url}/v1/workers")
+        raise httpx.ConnectError(
+            "All connection attempts failed",
+            request=request,
+        )
+
+    monkeypatch.setattr(workers, "start_worker", fail_start)
+
+    assert (
+        app_module.main(
+            [
+                "worker",
+                "start",
+                "--server",
+                server,
+                "--output",
+                "json",
+            ]
+        )
+        == 6
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["error"] == {
+        "kind": "network_error",
+        "message": (
+            f"The server at {server} is unavailable: All connection attempts failed"
+        ),
+        "retryable": True,
+        "details": {"server_url": server},
+        "hint": "Check the selected server with `kitaru status`, then retry.",
+    }


### PR DESCRIPTION
## Summary

CLI connection failures now identify the server that could not be reached. Login also explains when a URL does not expose a Kitaru API instead of returning the generic `Not found` message.

The transport error path preserves a selected base path when the failed request uses the same host. If a secondary service such as the control plane fails, it reports that failed request origin instead. Request paths, query strings, fragments, and URL credentials are not included in fallback output.

## Reviewer Notes

### Reproduction

Login against a URL without a Kitaru API now reports:

```console
$ uv run kitaru login https://preview.example.com
Error: Kitaru is not available at https://preview.example.com. Check the URL or deployment.
```

A worker connection failure now reports the selected server:

```console
$ uv run kitaru worker start --name returns-example-worker
starting: {"claim_batch_size": null, "concurrency": 1, "job_id": null, "kinds": null, "name": "returns-example-worker", "selectors": null}
Error: The server at https://api.example.com is unavailable: All connection attempts failed
Hint: Check the selected server with `kitaru status`, then retry.
```

Please pay particular attention to the origin-aware transport mapping in `src/kitaru/cli/app.py`. The full selected URL is used only when it matches the origin of the failed request.

The latest `develop` OpenAPI change had not regenerated `packages/core/src/generated/openapi.ts`. The first CI run exposed that mismatch, so this PR also includes the generated TypeScript sync required by the repository contract.

### Validation

- `just check`
- `uv run pytest tests/cli -q` (`369 passed`)
- TypeScript generate-check, lint, typecheck, build, package smoke, and `313` tests
- GitHub CI (`39/39` checks passed)
- Manual login check against the reported staging URL
- Manual worker check against an unavailable local port

## Post-deploy monitoring

No additional operational monitoring is required. During the next release smoke test, confirm that login 404s name the attempted URL and worker connection failures name the selected server without request paths or query values. Revert this commit if the CLI reports the wrong host or exposes request-specific URL data.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
