### PR TITLE
Add CLI and MCP concept parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - TypeScript cloud examples now reuse CLI logins without exporting a token, verify dedicated-worker access before creating remote resources, isolate exact-job recovery state, and stop when a mutation or cancellation cannot be journaled safely.
 
 ### Added
+- Standalone replay CLI create, list, and get commands; cohort baseline selection in the CLI and MCP; and native MCP reads for tags and workers plus capability-gated tag lifecycle operations.
 - Vercel AI SDK 7 `ToolLoopAgent` support for typed, non-streaming agent generation with Kitaru recording and safe replay boundaries.
 - The server now serves the bundled Kitaru UI at its root URL with SPA fallback. Setting `KITARU_SERVER_EXTERNAL_UI=true` makes it redirect to the configured dashboard URL instead of serving files, and `GET /v1/info` reports the served UI version.
 - Every filterable entity list filters by `id`, including `in` over a list of ids.

--- a/docs/book/agent-native/mcp-server.md
+++ b/docs/book/agent-native/mcp-server.md
@@ -5,7 +5,7 @@ icon: plug
 
 # Drive it from your coding agent
 
-Everything in the Kitaru loop is scriptable: the CLI covers the whole record → replay → improve journey, and a typed async Python client sits over a plain REST API. The MCP server exposes a bounded set of typed tools for inspecting sessions and replays, importing sessions from existing blobs, managing evaluators and investigations, and starting evaluations or experiment runs. Single-session replay creation and blob upload remain CLI or Python-client operations.
+Everything in the Kitaru loop is scriptable: the CLI covers the whole record → replay → improve journey, and a typed async Python client sits over a plain REST API. The MCP server exposes a bounded set of typed tools for inspecting sessions, replays, tags, and workers, importing sessions from existing blobs, managing evaluators, investigations, and tags, and starting evaluations or experiment runs. Single-session replay creation and blob upload remain CLI or Python-client operations.
 
 The division of labor: **Kitaru observes your production agents; your coding assistant is how you talk to Kitaru.**
 
@@ -36,19 +36,25 @@ Tools are gated by a **capability mode** — `read-only` (the default), `standar
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
-| `kitaru_registry_read` | read-only | Read agents, cohorts, experiments, importers, evaluators, and their versions |
+| `kitaru_registry_read` | read-only | Read agents, cohorts, experiments, importers, evaluators, and their versions; list and filter tags; list workers or get one by exact UUID |
 | `kitaru_activity_read` | read-only | Read sessions, replays, evaluations, runs, jobs, and their children |
 | `kitaru_review_read` | read-only | Read [investigations and annotations](../concepts/investigations.md) |
 | `kitaru_cohorts_manage` | standard | Create or update cohorts and cohort versions |
 | `kitaru_experiments_manage` | standard | Create or update experiments |
 | `kitaru_session_import` | standard | Import sessions from an already-uploaded blob |
-| `kitaru_review_manage` | standard | Run investigations: complete or skip sessions, answer questions, annotate |
+| `kitaru_review_manage` | standard | Manage investigations and annotations; create or rename tags and link them to resources |
 | `kitaru_workflow_start` | standard | Start a session evaluation or experiment run, return immediately |
 | `kitaru_evaluators_manage` | standard | Create or update evaluators from an existing blob or pinned package |
 | `kitaru_workflow_cancel` | destructive | Cancel a job or experiment run |
-| `kitaru_delete` | destructive | Delete a cohort, experiment, investigation, annotation, evaluator, version, or run |
+| `kitaru_delete` | destructive | Delete a cohort, experiment, investigation, annotation, evaluator, version, run, or tag; unlink an exact tag-resource tuple |
 
 Start assistants in `read-only`, move to `standard` when you want them building cohorts and starting runs, and reserve `destructive` for sessions where you're watching.
+
+Tag operations follow the same split. In `read-only`, `kitaru_registry_read` can list tags and filter them by name. Existing filtered registry or activity reads can then find sessions, agent versions, cohort versions, cohorts, experiments, and experiment runs carrying that tag. The MCP server cannot enumerate a tag's links directly. In `standard`, `kitaru_review_manage` supports `create_tag`, `update_tag`, and `link_tag`. In `destructive`, `kitaru_delete` can unlink one exact `(tag, resource type, resource id)` tuple or delete the tag. Deleting a tag also deletes every link that points from it.
+
+Worker inspection is deliberately read-only. Use `kitaru_registry_read` with `kind: "worker"` to list workers, or `operation: "get_worker"` with an exact worker UUID. The returned `live` and `last_seen_at` fields report recent heartbeat observations; they do not guarantee that a worker will claim a particular task. Worker registration, task assignment, credentials, and lifecycle control remain outside MCP.
+
+`kitaru_review_manage` accepts `pending`, `in_progress`, or `completed` when updating an investigation. This does not bypass server transition rules: for example, the server can still reject moving a completed investigation back to pending. A linked session's verdict remains a separate field and does not accept `pending`.
 
 ## The other surfaces
 
@@ -59,7 +65,7 @@ export KITARU_API_URL="http://localhost:8000"
 export KITARU_API_KEY="KITKEY_..."
 ```
 
-- **CLI** — the full journey has commands: `kitaru session import`, `kitaru session evaluate`, `kitaru cohort create`, `kitaru experiment run start`, plus registration, workers, and jobs. Commands take `--output json`, so assistant-driven invocations parse cleanly.
+- **CLI** — the full journey has commands: `kitaru session import`, `kitaru replay create`, `kitaru session evaluate`, `kitaru cohort create`, `kitaru experiment run start`, plus registration, workers, and jobs. Commands take `--output json`, so assistant-driven invocations parse cleanly.
 - **Python client** — `KitaruAPIClient()` reaches everything, including single-session replays. Your assistant writes the same snippets these docs show.
 - **REST** — the server's OpenAPI schema at `/docs` on your server, when the assistant wants the raw contract.
 

--- a/docs/book/concepts/agents-and-sessions.md
+++ b/docs/book/concepts/agents-and-sessions.md
@@ -99,7 +99,9 @@ kitaru session list --agent support-agent --origin recorded
 kitaru session nodes <session-id> --include-payloads
 ```
 
-Sessions attach to the rest of the system by reference: a [cohort version](cohorts.md) pins a set of session ids, an [evaluation](evaluators.md) row scores one session, and a [replay](replay.md) points at its baseline session and produces a result session. **Tags** group sessions ad hoc before they graduate into a cohort — apply one to a whole import with `kitaru session import --tag ...`, then select on it anywhere (`kitaru session evaluate --tag ...`, or a `tag` filter on any list).
+Sessions attach to the rest of the system by reference: a [cohort version](cohorts.md) pins a set of session ids, an [evaluation](evaluators.md) row scores one session, and a [replay](replay.md) points at its baseline session and produces a result session. **Tags** group resources ad hoc before they graduate into a cohort or another durable structure. A tag can link to a session, cohort, cohort version, agent version, experiment, or experiment run. Apply one to a whole import with `kitaru session import --tag ...`, then select on it anywhere that resource supports a `tag` filter, such as `kitaru session evaluate --tag ...`.
+
+The native MCP server can list and filter tags, use existing filtered reads to rediscover tagged resources, and create, rename, link, unlink, or delete tags according to its capability mode. It cannot enumerate every link belonging to a tag. Deleting a tag removes all of its resource links; it does not delete the linked resources.
 
 ## Where sessions come from
 

--- a/docs/book/concepts/cohorts.md
+++ b/docs/book/concepts/cohorts.md
@@ -49,7 +49,15 @@ kitaru cohort version create refund-regression \
   --add-session <id> --remove-session <id> --display-version week-33
 ```
 
-The first version starts from an empty list; each later version is the previous list minus `remove_session_ids` plus `add_session_ids`. The delta applies to the latest version by default — pass `baseline_id` to branch from an earlier one. Versions are server-numbered, `display_version` carries whatever you call the snapshot, and versions can be tagged and filtered by tag like sessions.
+The first version starts from an empty list; each later version is the previous list minus `remove_session_ids` plus `add_session_ids`. The delta applies to the latest version by default. To branch from an exact earlier version in the CLI, pass its UUID with `--baseline`:
+
+```bash
+kitaru cohort version create refund-regression \
+  --baseline <cohort-version-id> \
+  --add-session <id> --display-version alternative-week-33
+```
+
+In the Python client and REST request, the same field is named `baseline_id`. Versions are server-numbered, `display_version` carries whatever you call the snapshot, and versions can be tagged and filtered by tag like sessions.
 
 Immutability is the point. When an experiment run reports "12 of 14 sessions improved," that claim stays checkable forever, because cohort version 3 will always contain exactly those 14 sessions. Re-running the experiment on the same version is an apples-to-apples comparison; adding this week's failures is a new version, and the numbers say which version they came from.
 

--- a/docs/book/concepts/replay.md
+++ b/docs/book/concepts/replay.md
@@ -13,6 +13,21 @@ The discipline comes first: **replay unchanged before you change anything.** An 
 
 A replay names a **baseline session**, the **agent version** to run (by default, the version the baseline was recorded with), an optional **override**, a **tool policy**, and at least one [evaluator](evaluators.md). The server turns it into a job; a [worker](workers.md) in your environment starts your agent from its run spec, feeding it the baseline's inputs. The re-run records a fresh session (`origin: replay`), and the evaluators score it as soon as it completes.
 
+For a one-off replay, the CLI exposes the same create, list, and get flow:
+
+```bash
+kitaru replay create <baseline-session-id> \
+  --evaluator refund-check@1 \
+  --tool-policy '{"default":{"type":"history","scope":"baseline","on_miss":"fail"}}' \
+  --evaluate-baselines --output json
+kitaru replay list --output json
+kitaru replay get <replay-id> --output json
+```
+
+Creation returns immediately with the replay and its job. Use `kitaru job watch <job-id>` to follow it, `kitaru job get <job-id> --tasks` to inspect task failures, or `kitaru job cancel <job-id>` to request cancellation.
+
+{% hint style="warning" %} `kitaru replay create` is not idempotent. If the command fails after the server accepted it, retrying can create another replay and job. Run `kitaru replay list` and check for the first replay before retrying. Omitting `--tool-policy` uses the server default, which may execute live tools. {% endhint %}
+
 ```python
 import asyncio
 from kitaru.client import KitaruAPIClient
@@ -75,7 +90,7 @@ The tool policy decides what happens when the re-running agent calls a tool. The
 | --- | --- |
 | `history` | The recorded result for the same call, matched by tool name and arguments, from the baseline (or a wider scope). `on_miss` decides what an unrecorded call does: `fail`, `passthrough`, or `error_result`. |
 | `static` | A canned result you define per case — exact or subset argument matching. |
-| `passthrough` | The real tool, live. This is the default when you set no policy. |
+| `passthrough` | The real tool, live. This is the current server default when you set no policy. |
 | `llm` | A model answers the tool call in-distribution. The API accepts it, but adapter support varies; PydanticAI, Mastra, and Vercel AI SDK currently reject it. |
 
 For the "nothing touches real systems" guarantee, set `default=HistoryConfig(scope="baseline", on_miss="fail")` — recorded calls are answered from the recording and anything novel stops the replay instead of hitting production. The full matrix, including per-tool overrides and history scopes, is in [Tool policies](../guides/tool-policies.md).

--- a/docs/book/concepts/workers.md
+++ b/docs/book/concepts/workers.md
@@ -48,6 +48,9 @@ Check what's alive:
 
 ```bash
 kitaru worker list
+kitaru worker get <worker-id>
 ```
+
+A worker record exposes `last_seen_at`, the time of its last observed heartbeat, and `live`, the server's current liveness calculation. These are observations, not assignment guarantees: a worker can become unavailable after its last heartbeat, and a live worker may not match a task's scope or win its claim. The native MCP server exposes the same list and exact-UUID get operations through the read-only `kitaru_registry_read` tool. It cannot register, update, delete, or control workers.
 
 A worker that stops heartbeating loses its tasks: the server requeues them for the next worker (or fails them at the retry cap), so a crashed pod never strands a replay.

--- a/docs/book/guides/replay-and-overrides.md
+++ b/docs/book/guides/replay-and-overrides.md
@@ -12,6 +12,28 @@ Replay re-executes a recorded [session](../concepts/agents-and-sessions.md) to p
 
 This guide assumes the [Quickstart](../getting-started/quickstart.md) setup: a registered agent with a run command, a registered [evaluator](../concepts/evaluators.md), and a [worker](../concepts/workers.md) running in the agent's environment.
 
+## Create the one-off replay from the CLI
+
+Create an unchanged reproduction with an explicit recorded-history policy:
+
+```bash
+kitaru replay create <baseline-session-id> \
+  --evaluator refund-check@1 \
+  --tool-policy '{"default":{"type":"history","scope":"baseline","on_miss":"fail"}}' \
+  --evaluate-baselines --output json
+```
+
+The JSON result contains the replay ID and job ID. The command queues work and returns; it does not wait for the worker:
+
+```bash
+kitaru job watch <job-id>
+kitaru replay get <replay-id> --output json
+```
+
+Use `kitaru job get <job-id> --tasks` for task errors and `kitaru job cancel <job-id>` to request cancellation. `kitaru replay list --output json` lists both standalone and experiment-created replays.
+
+{% hint style="warning" %} Replay creation is not idempotent. An ambiguous network failure can mean the server created the replay and job even though the CLI did not receive the response. Check `kitaru replay list` before retrying, or the retry may create a duplicate replay and job. Omitting `--tool-policy` uses the server default and may execute live tools. {% endhint %}
+
 ## The three-session discipline
 
 Every trustworthy comparison involves three sessions:
@@ -57,7 +79,7 @@ Field by field:
 - `baseline_session_id` — the recording to re-run.
 - `agent_version_id` — which code runs. Omitted, it's the version the baseline was recorded with (the faithful choice). Point it at a newly registered version to replay old traffic **against your working tree**.
 - `override` — the fork. Omit it for a pure reproduction.
-- `tool_policy` — what tool calls hit. **The default is `passthrough`: live tools.** For a replay that touches nothing real, set a `history` policy as above. Details in [Tool policies](tool-policies.md).
+- `tool_policy` — what tool calls hit. If omitted, the server applies its default, which currently passes calls through to live tools. For a replay that touches nothing real, set a `history` policy as above. Details in [Tool policies](tool-policies.md).
 - `evaluators` — at least one, always. A replay is never just "it ran"; it's evaluated on arrival.
 - `evaluate_baselines` — score the original session with the same evaluators, so the comparison exists as soon as the replay settles.
 

--- a/src/kitaru/cli/app.py
+++ b/src/kitaru/cli/app.py
@@ -48,6 +48,7 @@ from kitaru.cli import (
     jobs,
     local_runtime,
     registration,
+    replays,
     scaffold,
     sessions,
     workers,
@@ -199,6 +200,11 @@ job_app = App(
     help=GROUP_DESCRIPTIONS["job"],
     default_parameter=Parameter(negative=False),
 )
+replay_app = App(
+    name="replay",
+    help=GROUP_DESCRIPTIONS["replay"],
+    default_parameter=Parameter(negative=False),
+)
 local_app = App(
     name="local",
     help=GROUP_DESCRIPTIONS["local"],
@@ -222,6 +228,7 @@ app.command(session_app, name="session")
 app.command(evaluation_app, name="evaluation")
 app.command(worker_app, name="worker")
 app.command(job_app, name="job")
+app.command(replay_app, name="replay")
 app.command(local_app, name="local")
 
 
@@ -2470,6 +2477,126 @@ async def experiment_delete(
     """Delete one exact experiment."""
     async with _open_asset_client() as client:
         return await experiments.delete_experiment(client, experiment, force=force)
+
+
+@_register(
+    replay_app,
+    _spec(
+        ("replay", "create"),
+        "Create one standalone replay from an exact baseline session.",
+        parameters=(
+            ParameterSpec("BASELINE", "UUID", "argument", True, "Baseline session ID."),
+            ParameterSpec(
+                "--evaluator",
+                "EVALUATOR@VERSION[]",
+                "option",
+                True,
+                "Exact evaluator version; repeat for additional evaluators.",
+            ),
+            ParameterSpec(
+                "--evaluator-params",
+                "EVALUATOR@VERSION=JSON_OBJECT[]",
+                "option",
+                False,
+                "Parameters for a selected evaluator token.",
+            ),
+            ParameterSpec(
+                "--agent",
+                "AGENT@VERSION",
+                "option",
+                False,
+                "Exact agent version; omit to use the baseline's recorded version.",
+            ),
+            ParameterSpec(
+                "--override",
+                "JSON object",
+                "option",
+                False,
+                "Replay model, prompt, or model-parameter override.",
+            ),
+            ParameterSpec(
+                "--tool-policy",
+                "JSON object",
+                "option",
+                False,
+                "Tool policy; omitting it uses the server default and may execute "
+                "live tools.",
+            ),
+            ParameterSpec(
+                "--evaluate-baselines",
+                "boolean",
+                "option",
+                False,
+                "Also score the baseline session.",
+            ),
+        ),
+        read_only=False,
+        side_effects=("creates_remote_state",),
+        idempotency="non_idempotent_replay_created_per_request",
+        errors=_ASSET_WRITE_ERRORS,
+    ),
+)
+async def replay_create(
+    baseline: uuid.UUID,
+    /,
+    *,
+    evaluator: list[str],
+    evaluator_params: list[str] | None = None,
+    agent: str | None = None,
+    override: str | None = None,
+    tool_policy: str | None = None,
+    evaluate_baselines: bool = False,
+) -> CommandResult:
+    """Create one standalone replay without waiting for its job."""
+    async with _open_asset_client() as client:
+        return await replays.create_replay(
+            client,
+            baseline,
+            evaluators=evaluator,
+            evaluator_params=evaluator_params,
+            agent=agent,
+            override=override,
+            tool_policy=tool_policy,
+            evaluate_baselines=evaluate_baselines,
+        )
+
+
+@_register(
+    replay_app,
+    _spec(
+        ("replay", "list"),
+        "List standalone and experiment-created replays.",
+        parameters=_LIST_PARAMETERS,
+        errors=_COLLECTION_READ_ERRORS,
+    ),
+)
+async def replay_list(
+    *,
+    size: int = 20,
+    cursor: str | None = None,
+    sort: str = "created:desc",
+    filter: str | None = None,
+) -> CommandResult:
+    """List one server page of replays."""
+    async with _open_asset_client() as client:
+        return await replays.list_replays(
+            client, size=size, cursor=cursor, sort=sort, filter=filter
+        )
+
+
+@_register(
+    replay_app,
+    _spec(
+        ("replay", "get"),
+        "Get one replay by exact UUID.",
+        parameters=(ParameterSpec("REPLAY", "UUID", "argument", True, "Replay ID."),),
+        errors=_UUID_READ_ERRORS,
+    ),
+)
+async def replay_get(replay: uuid.UUID, /) -> CommandResult:
+    """Get one replay without remapping its status."""
+    async with _open_asset_client() as client:
+        return await replays.get_replay(client, replay)
 
 
 @_register(

--- a/src/kitaru/cli/app.py
+++ b/src/kitaru/cli/app.py
@@ -1642,6 +1642,13 @@ async def cohort_delete(cohort: str, /, *, force: bool = False) -> CommandResult
                 "Ordered session IDs to remove.",
             ),
             ParameterSpec(
+                "--baseline",
+                "UUID",
+                "option",
+                False,
+                "Exact cohort version the membership delta applies to.",
+            ),
+            ParameterSpec(
                 "--display-version",
                 "string",
                 "option",
@@ -1661,6 +1668,7 @@ async def cohort_version_create(
     *,
     add_session: list[uuid.UUID] | None = None,
     remove_session: list[uuid.UUID] | None = None,
+    baseline: uuid.UUID | None = None,
     display_version: str | None = None,
 ) -> CommandResult:
     """Create an immutable version from an ordered membership delta."""
@@ -1670,6 +1678,7 @@ async def cohort_version_create(
             cohort,
             add_session_ids=add_session,
             remove_session_ids=remove_session,
+            baseline_id=baseline,
             display_version=display_version,
         )
 

--- a/src/kitaru/cli/cohorts.py
+++ b/src/kitaru/cli/cohorts.py
@@ -245,9 +245,15 @@ async def create_cohort_version(
     )
     warnings = []
     if not additions and not removals:
-        warnings.append(
-            "No sessions were added or removed; cohort membership is unchanged."
-        )
+        if baseline_id is None:
+            warnings.append(
+                "No sessions were added or removed; cohort membership is unchanged."
+            )
+        else:
+            warnings.append(
+                "No sessions were added or removed; the new version copies "
+                f"the membership of baseline {baseline_id}."
+            )
     return CommandResult(item=version.model_dump(mode="json"), warnings=warnings)
 
 

--- a/src/kitaru/cli/cohorts.py
+++ b/src/kitaru/cli/cohorts.py
@@ -216,6 +216,7 @@ async def create_cohort_version(
     add_session_ids: list[uuid.UUID] | None,
     remove_session_ids: list[uuid.UUID] | None,
     display_version: str | None,
+    baseline_id: uuid.UUID | None = None,
 ) -> CommandResult:
     """Create an immutable version from an ordered membership delta."""
     additions = list(add_session_ids or [])
@@ -236,6 +237,7 @@ async def create_cohort_version(
     version = await client.cohorts.create_version(
         cohort.id,
         CohortVersionCreateRequest(
+            baseline_id=baseline_id,
             add_session_ids=additions,
             remove_session_ids=removals,
             display_version=display_version,

--- a/src/kitaru/cli/experiments.py
+++ b/src/kitaru/cli/experiments.py
@@ -20,25 +20,15 @@ from kitaru.api_models.v1.experiment import (
     ExperimentCreateRequest,
     ExperimentUpdateRequest,
 )
-from kitaru.api_models.v1.replay_config import ReplayOverride, ToolPolicy
 from kitaru.cli.output import CLIError, CommandResult
 from kitaru.cli.registration import (
     list_params,
     page_result,
-    parse_json_object,
+    parse_replay_override,
+    parse_tool_policy,
     resolve_asset,
     resolve_evaluator_configs,
 )
-
-
-def parse_replay_override(value: str, *, option: str) -> ReplayOverride:
-    """Parse an inline replay override using the existing API model."""
-    return ReplayOverride.model_validate(parse_json_object(value, option=option))
-
-
-def parse_tool_policy(value: str, *, option: str) -> ToolPolicy:
-    """Parse an inline tool policy using the existing API model."""
-    return ToolPolicy.model_validate(parse_json_object(value, option=option))
 
 
 async def create_experiment(

--- a/src/kitaru/cli/registration.py
+++ b/src/kitaru/cli/registration.py
@@ -44,6 +44,7 @@ from kitaru.api_models.v1.importer import (
 )
 from kitaru.api_models.v1.investigation import InvestigationListParams
 from kitaru.api_models.v1.plugin import PackagePluginSource, ScriptPluginSource
+from kitaru.api_models.v1.replay import ReplayListParams
 from kitaru.api_models.v1.replay_config import EvaluatorConfig
 from kitaru.api_models.v1.session import SessionListParams
 from kitaru.cli.config import build_api_client, resolve_credential
@@ -657,6 +658,7 @@ def list_params(
         "experiment_run",
         "importer",
         "investigation",
+        "replay",
         "session",
     ],
     *,
@@ -676,6 +678,7 @@ def list_params(
         "experiment_run": ExperimentRunListParams,
         "importer": ImporterListParams,
         "investigation": InvestigationListParams,
+        "replay": ReplayListParams,
         "session": SessionListParams,
     }[kind]
     return build_list_params(

--- a/src/kitaru/cli/registration.py
+++ b/src/kitaru/cli/registration.py
@@ -45,7 +45,11 @@ from kitaru.api_models.v1.importer import (
 from kitaru.api_models.v1.investigation import InvestigationListParams
 from kitaru.api_models.v1.plugin import PackagePluginSource, ScriptPluginSource
 from kitaru.api_models.v1.replay import ReplayListParams
-from kitaru.api_models.v1.replay_config import EvaluatorConfig
+from kitaru.api_models.v1.replay_config import (
+    EvaluatorConfig,
+    ReplayOverride,
+    ToolPolicy,
+)
 from kitaru.api_models.v1.session import SessionListParams
 from kitaru.cli.config import build_api_client, resolve_credential
 from kitaru.cli.output import CLIError, CommandResult
@@ -433,6 +437,16 @@ def parse_json_object(value: str | None, *, option: str) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise CLIError("invalid_arguments", f"{option} must contain a JSON object.")
     return parsed
+
+
+def parse_replay_override(value: str, *, option: str) -> ReplayOverride:
+    """Parse an inline replay override using the existing API model."""
+    return ReplayOverride.model_validate(parse_json_object(value, option=option))
+
+
+def parse_tool_policy(value: str, *, option: str) -> ToolPolicy:
+    """Parse an inline tool policy using the existing API model."""
+    return ToolPolicy.model_validate(parse_json_object(value, option=option))
 
 
 async def resolve_evaluator_configs(

--- a/src/kitaru/cli/replays.py
+++ b/src/kitaru/cli/replays.py
@@ -1,0 +1,77 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+"""Standalone replay CLI commands."""
+
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+from kitaru.api_models.v1.replay import ReplayCreateRequest
+from kitaru.cli.experiments import parse_replay_override, parse_tool_policy
+from kitaru.cli.output import CommandResult
+from kitaru.cli.registration import (
+    get_agent_version,
+    list_params,
+    page_result,
+    resolve_evaluator_configs,
+)
+
+
+async def create_replay(
+    client: Any,
+    baseline_session_id: uuid.UUID,
+    *,
+    evaluators: Sequence[str],
+    evaluator_params: Sequence[str] | None,
+    agent: str | None,
+    override: str | None,
+    tool_policy: str | None,
+    evaluate_baselines: bool,
+) -> CommandResult:
+    """Create one standalone replay with exact evaluator versions."""
+    fields: dict[str, Any] = {"baseline_session_id": baseline_session_id}
+    if agent is not None:
+        _, agent_version = await get_agent_version(client, agent)
+        fields["agent_version_id"] = agent_version.id
+    if override is not None:
+        fields["override"] = parse_replay_override(override, option="--override")
+    if tool_policy is not None:
+        fields["tool_policy"] = parse_tool_policy(tool_policy, option="--tool-policy")
+    configs, _, _ = await resolve_evaluator_configs(
+        client, evaluators, evaluator_params or []
+    )
+    fields["evaluators"] = configs
+    fields["evaluate_baselines"] = evaluate_baselines
+
+    replay = await client.replays.create(ReplayCreateRequest(**fields))
+    return CommandResult(
+        item=replay.model_dump(mode="json"),
+        event="created",
+        next_actions=[
+            f"kitaru job watch {replay.job_id}",
+            f"kitaru job cancel {replay.job_id}",
+            f"kitaru replay get {replay.id}",
+        ],
+    )
+
+
+async def list_replays(
+    client: Any,
+    *,
+    size: int,
+    cursor: str | None,
+    sort: str,
+    filter: str | None,
+) -> CommandResult:
+    """List one server page of standalone and experiment-created replays."""
+    params = list_params("replay", size=size, cursor=cursor, sort=sort, filter=filter)
+    return page_result(await client.replays.list(params), size=size)
+
+
+async def get_replay(client: Any, replay_id: uuid.UUID) -> CommandResult:
+    """Get one replay without remapping its status."""
+    replay = await client.replays.get(replay_id)
+    return CommandResult(item=replay.model_dump(mode="json"))

--- a/src/kitaru/cli/replays.py
+++ b/src/kitaru/cli/replays.py
@@ -10,12 +10,13 @@ from collections.abc import Sequence
 from typing import Any
 
 from kitaru.api_models.v1.replay import ReplayCreateRequest
-from kitaru.cli.experiments import parse_replay_override, parse_tool_policy
 from kitaru.cli.output import CommandResult
 from kitaru.cli.registration import (
     get_agent_version,
     list_params,
     page_result,
+    parse_replay_override,
+    parse_tool_policy,
     resolve_evaluator_configs,
 )
 

--- a/src/kitaru/cli/schema.py
+++ b/src/kitaru/cli/schema.py
@@ -81,6 +81,7 @@ GROUP_DESCRIPTIONS = {
     "experiment": "Configure experiments and manage asynchronous runs.",
     "importer": "Develop, register, and inspect importers.",
     "investigation": "Create investigations and review their linked sessions.",
+    "replay": "Create and inspect standalone replays.",
     "session": "Import and inspect sessions and their nodes.",
     "worker": "Run and inspect generic local workers.",
     "job": "Inspect, watch, and cancel jobs.",

--- a/src/kitaru/mcp/models/common.py
+++ b/src/kitaru/mcp/models/common.py
@@ -27,7 +27,9 @@ from kitaru.api_models.v1.job import JobResponse
 from kitaru.api_models.v1.replay import ReplayResponse
 from kitaru.api_models.v1.session import SessionResponse
 from kitaru.api_models.v1.session_node import SessionNodeResponse
+from kitaru.api_models.v1.tag import TagResponse
 from kitaru.api_models.v1.task import TaskResponse
+from kitaru.api_models.v1.worker import WorkerResponse
 
 
 class MCPModel(BaseModel):
@@ -92,6 +94,8 @@ RegistryItem = (
     | ImporterVersionResponse
     | EvaluatorVersionResponse
     | AgentResponse
+    | TagResponse
+    | WorkerResponse
 )
 
 

--- a/src/kitaru/mcp/models/common.py
+++ b/src/kitaru/mcp/models/common.py
@@ -27,7 +27,7 @@ from kitaru.api_models.v1.job import JobResponse
 from kitaru.api_models.v1.replay import ReplayResponse
 from kitaru.api_models.v1.session import SessionResponse
 from kitaru.api_models.v1.session_node import SessionNodeResponse
-from kitaru.api_models.v1.tag import TagResponse
+from kitaru.api_models.v1.tag import TagLinkResponse, TagResourceType, TagResponse
 from kitaru.api_models.v1.task import TaskResponse
 from kitaru.api_models.v1.worker import WorkerResponse
 
@@ -142,7 +142,7 @@ class ReviewReadResult(ToolResult):
 class ReviewManageResult(ToolResult):
     """Typed investigation and annotation management result."""
 
-    data: ReviewItem | None = None
+    data: ReviewItem | TagResponse | TagLinkResponse | None = None
 
 
 class CohortsManageResult(ToolResult):
@@ -239,6 +239,7 @@ DeleteKind = Literal[
     "investigation",
     "annotation",
     "evaluator",
+    "tag",
 ]
 
 
@@ -250,7 +251,17 @@ class DeleteReceipt(MCPModel):
     deleted: Literal[True]
 
 
+class TagLinkDeleteReceipt(MCPModel):
+    """Receipt for deleting one exact tag-to-resource link."""
+
+    kind: Literal["tag_link"]
+    tag_id: uuid.UUID
+    resource_type: TagResourceType
+    resource_id: uuid.UUID
+    deleted: Literal[True]
+
+
 class DeleteResult(ToolResult):
     """Allowlisted deletion result."""
 
-    data: DeleteReceipt | None = None
+    data: DeleteReceipt | TagLinkDeleteReceipt | None = None

--- a/src/kitaru/mcp/models/management.py
+++ b/src/kitaru/mcp/models/management.py
@@ -67,6 +67,7 @@ class CohortVersionCreate(MCPModel):
 
     operation: Literal["create_version"]
     cohort_id: uuid.UUID
+    baseline_id: uuid.UUID | None = None
     add_session_ids: list[uuid.UUID] = Field(default_factory=list)
     remove_session_ids: list[uuid.UUID] = Field(default_factory=list)
     display_version: str | None = None

--- a/src/kitaru/mcp/models/registry.py
+++ b/src/kitaru/mcp/models/registry.py
@@ -13,14 +13,13 @@ from kitaru.mcp.models.common import MCPModel, PageOptions
 from kitaru.mcp.references import ParentKind
 
 VersionedKind = Literal["agent", "cohort", "importer", "evaluator"]
-RegistryListKind = ParentKind | Literal["tag", "worker"]
 
 
 class RegistryListRequest(PageOptions):
     """List one page of registry parents, tags, or workers."""
 
     operation: Literal["list"]
-    kind: RegistryListKind
+    kind: ParentKind | Literal["tag", "worker"]
     filter: Filter | None = None
 
 

--- a/src/kitaru/mcp/models/registry.py
+++ b/src/kitaru/mcp/models/registry.py
@@ -4,22 +4,23 @@
 """Strict registry-read tool inputs."""
 
 import uuid
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from kitaru.api_models.v1.filter import Filter
 from kitaru.mcp.models.common import MCPModel, PageOptions
 from kitaru.mcp.references import ParentKind
 
 VersionedKind = Literal["agent", "cohort", "importer", "evaluator"]
+RegistryListKind = ParentKind | Literal["tag", "worker"]
 
 
 class RegistryListRequest(PageOptions):
-    """List one page of registry parents."""
+    """List one page of registry parents, tags, or workers."""
 
     operation: Literal["list"]
-    kind: ParentKind
+    kind: RegistryListKind
     filter: Filter | None = None
 
 
@@ -37,6 +38,21 @@ class RegistryListVersionsRequest(PageOptions):
     operation: Literal["list_versions"]
     kind: VersionedKind
     parent_reference: str = Field(min_length=1)
+    filter: Filter | None = None
+
+    @model_validator(mode="after")
+    def _validate_filter_support(self) -> Self:
+        """Reject filters for plugin version endpoints that do not support them."""
+        if self.kind in {"importer", "evaluator"} and self.filter is not None:
+            raise ValueError("filter is supported only for agent and cohort versions")
+        return self
+
+
+class RegistryGetWorkerRequest(MCPModel):
+    """Get one worker by its exact UUID."""
+
+    operation: Literal["get_worker"]
+    worker_id: uuid.UUID
 
 
 class RegistryGetVersionRequest(MCPModel):
@@ -53,6 +69,7 @@ RegistryReadRequest = Annotated[
     RegistryListRequest
     | RegistryGetRequest
     | RegistryListVersionsRequest
+    | RegistryGetWorkerRequest
     | RegistryGetVersionRequest,
     Field(discriminator="operation"),
 ]

--- a/src/kitaru/mcp/models/review.py
+++ b/src/kitaru/mcp/models/review.py
@@ -14,6 +14,7 @@ from kitaru.api_models.v1.filter import Filter
 from kitaru.api_models.v1.investigation import (
     InvestigationSessionInput,
     InvestigationSessionVerdict,
+    InvestigationStatus,
 )
 from kitaru.api_models.v1.tag import TagResourceType
 from kitaru.mcp.models.common import MCPModel, PageOptions
@@ -77,7 +78,7 @@ class InvestigationUpdate(MCPModel):
     name: str | None = None
     description: str | None = None
     clear_description: bool = False
-    status: Literal["pending", "in_progress", "completed"] | None = None
+    status: InvestigationStatus | None = None
 
     @model_validator(mode="after")
     def _validate_update(self) -> "InvestigationUpdate":

--- a/src/kitaru/mcp/models/review.py
+++ b/src/kitaru/mcp/models/review.py
@@ -15,6 +15,7 @@ from kitaru.api_models.v1.investigation import (
     InvestigationSessionInput,
     InvestigationSessionVerdict,
 )
+from kitaru.api_models.v1.tag import TagResourceType
 from kitaru.mcp.models.common import MCPModel, PageOptions
 
 ReviewKind = Literal["investigation", "annotation"]
@@ -135,12 +136,39 @@ class AnnotationUpdate(MCPModel):
     value: JsonValue = Field()
 
 
+class TagCreate(MCPModel):
+    """Create a tag."""
+
+    operation: Literal["create_tag"]
+    name: str = Field(min_length=1)
+
+
+class TagUpdate(MCPModel):
+    """Rename one tag by exact UUID."""
+
+    operation: Literal["update_tag"]
+    tag_id: uuid.UUID
+    name: str = Field(min_length=1)
+
+
+class TagLink(MCPModel):
+    """Link one tag to one exact resource."""
+
+    operation: Literal["link_tag"]
+    tag_id: uuid.UUID
+    resource_type: TagResourceType
+    resource_id: uuid.UUID
+
+
 ReviewManageRequest = Annotated[
     InvestigationCreate
     | InvestigationUpdate
     | SetInvestigationSessionVerdict
     | ManualAnnotationCreate
     | InvestigationAnswerCreate
-    | AnnotationUpdate,
+    | AnnotationUpdate
+    | TagCreate
+    | TagUpdate
+    | TagLink,
     Field(discriminator="operation"),
 ]

--- a/src/kitaru/mcp/models/review.py
+++ b/src/kitaru/mcp/models/review.py
@@ -76,7 +76,7 @@ class InvestigationUpdate(MCPModel):
     name: str | None = None
     description: str | None = None
     clear_description: bool = False
-    status: Literal["in_progress", "completed"] | None = None
+    status: Literal["pending", "in_progress", "completed"] | None = None
 
     @model_validator(mode="after")
     def _validate_update(self) -> "InvestigationUpdate":

--- a/src/kitaru/mcp/models/workflows.py
+++ b/src/kitaru/mcp/models/workflows.py
@@ -9,6 +9,7 @@ from typing import Annotated, Literal
 from pydantic import Field, model_validator
 
 from kitaru.api_models.v1.base import JsonValue
+from kitaru.api_models.v1.tag import TagResourceType
 from kitaru.mcp.models.common import DeleteKind, MCPModel
 from kitaru.mcp.models.management import EvaluatorSelection
 
@@ -77,8 +78,23 @@ WorkflowCancelRequest = Annotated[
 ]
 
 
-class DeleteRequest(MCPModel):
+class ResourceDelete(MCPModel):
     """Delete one allowlisted exact resource."""
 
     kind: DeleteKind
     id: uuid.UUID
+
+
+class TagLinkDelete(MCPModel):
+    """Delete one exact tag-to-resource link."""
+
+    kind: Literal["tag_link"]
+    tag_id: uuid.UUID
+    resource_type: TagResourceType
+    resource_id: uuid.UUID
+
+
+DeleteRequest = Annotated[
+    ResourceDelete | TagLinkDelete,
+    Field(discriminator="kind"),
+]

--- a/src/kitaru/mcp/registry.py
+++ b/src/kitaru/mcp/registry.py
@@ -84,7 +84,7 @@ def _annotations(
 async def registry_read_tool(
     request: RegistryReadRequest, context: Context
 ) -> RegistryReadResult:
-    """Read Kitaru registry parents and versions using bounded exact operations."""
+    """Read registry parents, versions, tags, and workers with bounded operations."""
     return cast(
         RegistryReadResult,
         await _invoke(context, request, RegistryReadResult, handle_registry_read),

--- a/src/kitaru/mcp/registry.py
+++ b/src/kitaru/mcp/registry.py
@@ -146,7 +146,7 @@ async def session_import_tool(
 async def review_manage_tool(
     request: ReviewManageRequest, context: Context
 ) -> ReviewManageResult:
-    """Create or update investigations, linked statuses, and annotations."""
+    """Create or update investigations, annotations, tags, and tag links."""
     return cast(
         ReviewManageResult,
         await _invoke(context, request, ReviewManageResult, handle_review_manage),
@@ -186,7 +186,7 @@ async def workflow_cancel_tool(
 
 
 async def delete_tool(request: DeleteRequest, context: Context) -> DeleteResult:
-    """Delete one exact allowlisted registry, review, or run resource."""
+    """Delete one exact allowlisted resource or tag link."""
     return cast(
         DeleteResult, await _invoke(context, request, DeleteResult, handle_delete)
     )

--- a/src/kitaru/mcp/tools/cohorts.py
+++ b/src/kitaru/mcp/tools/cohorts.py
@@ -40,6 +40,7 @@ async def handle_cohorts_manage(
         )
     if isinstance(request, CohortVersionCreate):
         dto = CohortVersionCreateRequest(
+            baseline_id=request.baseline_id,
             add_session_ids=request.add_session_ids,
             remove_session_ids=request.remove_session_ids,
             display_version=request.display_version,

--- a/src/kitaru/mcp/tools/destructive.py
+++ b/src/kitaru/mcp/tools/destructive.py
@@ -4,7 +4,12 @@
 """Narrow destructive-mode handlers."""
 
 from kitaru.mcp.lifecycle import MCPServerState
-from kitaru.mcp.models.workflows import DeleteRequest, JobCancel, WorkflowCancelRequest
+from kitaru.mcp.models.workflows import (
+    DeleteRequest,
+    JobCancel,
+    TagLinkDelete,
+    WorkflowCancelRequest,
+)
 
 
 async def handle_workflow_cancel(
@@ -25,6 +30,17 @@ async def handle_workflow_cancel(
 
 async def handle_delete(state: MCPServerState, request: DeleteRequest) -> object:
     """Delete one exact allowlisted resource."""
+    if isinstance(request, TagLinkDelete):
+        await state.client.tags.delete_link(
+            request.tag_id, request.resource_type, request.resource_id
+        )
+        return {
+            "kind": request.kind,
+            "tag_id": str(request.tag_id),
+            "resource_type": request.resource_type.value,
+            "resource_id": str(request.resource_id),
+            "deleted": True,
+        }
     if request.kind == "cohort":
         await state.client.cohorts.delete(request.id)
     elif request.kind == "cohort_version":
@@ -37,6 +53,8 @@ async def handle_delete(state: MCPServerState, request: DeleteRequest) -> object
         await state.client.investigations.delete(request.id)
     elif request.kind == "annotation":
         await state.client.annotations.delete(request.id)
-    else:
+    elif request.kind == "evaluator":
         await state.client.evaluators.delete(request.id)
+    else:
+        await state.client.tags.delete(request.id)
     return {"kind": request.kind, "id": str(request.id), "deleted": True}

--- a/src/kitaru/mcp/tools/registry.py
+++ b/src/kitaru/mcp/tools/registry.py
@@ -13,12 +13,15 @@ from kitaru.api_models.v1.cohort_version import CohortVersionListParams
 from kitaru.api_models.v1.evaluator import EvaluatorListParams
 from kitaru.api_models.v1.experiment import ExperimentListParams
 from kitaru.api_models.v1.importer import ImporterListParams
+from kitaru.api_models.v1.tag import TagListParams
+from kitaru.api_models.v1.worker import WorkerListParams
 from kitaru.mcp.errors import MCPToolError
 from kitaru.mcp.lifecycle import MCPServerState
 from kitaru.mcp.models.common import PageData, PageMetadata, RegistryItem
 from kitaru.mcp.models.registry import (
     RegistryGetRequest,
     RegistryGetVersionRequest,
+    RegistryGetWorkerRequest,
     RegistryListRequest,
     RegistryListVersionsRequest,
     RegistryReadRequest,
@@ -36,11 +39,17 @@ async def handle_registry_read(
 ) -> object:
     """Execute one bounded registry operation."""
     client = state.client
+    if isinstance(request, RegistryGetWorkerRequest):
+        return await client.workers.get(request.worker_id)
     if isinstance(request, RegistryGetRequest):
         return await resolve_parent(client, request.kind, request.reference)
     if isinstance(request, RegistryListRequest):
         common = request.model_dump(include={"cursor", "size", "sort", "filter"})
-        if request.kind is ParentKind.AGENT:
+        if request.kind == "tag":
+            page = await client.tags.list(TagListParams.model_validate(common))
+        elif request.kind == "worker":
+            page = await client.workers.list(WorkerListParams.model_validate(common))
+        elif request.kind is ParentKind.AGENT:
             page = await client.agents.list(AgentListParams.model_validate(common))
         elif request.kind is ParentKind.COHORT:
             page = await client.cohorts.list(CohortListParams.model_validate(common))
@@ -60,7 +69,7 @@ async def handle_registry_read(
     if isinstance(request, RegistryListVersionsRequest):
         kind = ParentKind(request.kind)
         parent = await resolve_parent(client, kind, request.parent_reference)
-        common = request.model_dump(include={"cursor", "size", "sort"})
+        common = request.model_dump(include={"cursor", "size", "sort", "filter"})
         if request.kind == "agent":
             page = await client.agents.list_versions(
                 parent.id, AgentVersionListParams.model_validate(common)
@@ -70,10 +79,12 @@ async def handle_registry_read(
                 parent.id, CohortVersionListParams.model_validate(common)
             )
         elif request.kind == "importer":
+            common.pop("filter", None)
             page = await client.importers.list_versions(
                 parent.id, ListParams.model_validate(common)
             )
         else:
+            common.pop("filter", None)
             page = await client.evaluators.list_versions(
                 parent.id, ListParams.model_validate(common)
             )

--- a/src/kitaru/mcp/tools/review.py
+++ b/src/kitaru/mcp/tools/review.py
@@ -16,6 +16,11 @@ from kitaru.api_models.v1.investigation import (
     InvestigationSessionUpdateRequest,
     InvestigationUpdateRequest,
 )
+from kitaru.api_models.v1.tag import (
+    TagCreateRequest,
+    TagLinkCreateRequest,
+    TagUpdateRequest,
+)
 from kitaru.mcp.lifecycle import MCPServerState
 from kitaru.mcp.models.common import PageData, ReviewItem
 from kitaru.mcp.models.review import (
@@ -29,6 +34,9 @@ from kitaru.mcp.models.review import (
     ReviewManageRequest,
     ReviewReadRequest,
     SetInvestigationSessionVerdict,
+    TagCreate,
+    TagLink,
+    TagUpdate,
 )
 from kitaru.mcp.tools.registry import build_page_data
 
@@ -109,7 +117,20 @@ async def handle_review_manage(
                 value=request.value,
             )
         )
-    assert isinstance(request, AnnotationUpdate)
-    return await state.client.annotations.update(
-        request.annotation_id, AnnotationUpdateRequest(value=request.value)
+    if isinstance(request, AnnotationUpdate):
+        return await state.client.annotations.update(
+            request.annotation_id, AnnotationUpdateRequest(value=request.value)
+        )
+    if isinstance(request, TagCreate):
+        return await state.client.tags.create(TagCreateRequest(name=request.name))
+    if isinstance(request, TagUpdate):
+        return await state.client.tags.update(
+            request.tag_id, TagUpdateRequest(name=request.name)
+        )
+    assert isinstance(request, TagLink)
+    return await state.client.tags.create_link(
+        request.tag_id,
+        TagLinkCreateRequest(
+            resource_type=request.resource_type, resource_id=request.resource_id
+        ),
     )

--- a/tests/cli/test_cohorts.py
+++ b/tests/cli/test_cohorts.py
@@ -431,6 +431,7 @@ async def test_version_create_preserves_order_and_empty_delta() -> None:
     first = uuid.uuid4()
     second = uuid.uuid4()
     removed = uuid.uuid4()
+    baseline_id = uuid.uuid4()
 
     result = await cohorts.create_cohort_version(
         client,
@@ -438,8 +439,10 @@ async def test_version_create_preserves_order_and_empty_delta() -> None:
         add_session_ids=[first, second],
         remove_session_ids=[removed],
         display_version="candidate",
+        baseline_id=baseline_id,
     )
     _, request = client.created_versions[-1]
+    assert request.baseline_id == baseline_id
     assert request.add_session_ids == [first, second]
     assert request.remove_session_ids == [removed]
     assert request.display_version == "candidate"
@@ -451,11 +454,13 @@ async def test_version_create_preserves_order_and_empty_delta() -> None:
         add_session_ids=None,
         remove_session_ids=None,
         display_version=None,
+        baseline_id=None,
     )
     assert "membership is unchanged" in empty.warnings[0]
     _, request = client.created_versions[-1]
     assert request.add_session_ids == []
     assert request.remove_session_ids == []
+    assert request.baseline_id is None
 
 
 async def test_version_create_rejects_overlap_before_lookup() -> None:
@@ -470,6 +475,7 @@ async def test_version_create_rejects_overlap_before_lookup() -> None:
             add_session_ids=[session_id],
             remove_session_ids=[session_id],
             display_version=None,
+            baseline_id=None,
         )
 
     assert error.value.kind == "invalid_arguments"
@@ -491,6 +497,7 @@ async def test_version_create_rejects_duplicates_before_lookup(option: str) -> N
             add_session_ids=[session_id, session_id] if option == "add" else None,
             remove_session_ids=[session_id, session_id] if option == "remove" else None,
             display_version=None,
+            baseline_id=None,
         )
 
     assert client.cohort_lookups == 0
@@ -660,6 +667,7 @@ def test_public_cohort_version_argv_covers_all_commands(
     client = argv_client
     added_session_id = uuid.uuid4()
     removed_session_id = uuid.uuid4()
+    baseline_id = uuid.uuid4()
 
     assert (
         app_module.main(
@@ -672,6 +680,8 @@ def test_public_cohort_version_argv_covers_all_commands(
                 str(added_session_id),
                 "--remove-session",
                 str(removed_session_id),
+                "--baseline",
+                str(baseline_id),
             ]
         )
         == 0
@@ -681,6 +691,7 @@ def test_public_cohort_version_argv_covers_all_commands(
     _, request = client.created_versions[-1]
     assert request.add_session_ids == [added_session_id]
     assert request.remove_session_ids == [removed_session_id]
+    assert request.baseline_id == baseline_id
 
     assert (
         app_module.main(["cohort", "version", "list", "regression", "--size", "1"]) == 0

--- a/tests/cli/test_cohorts.py
+++ b/tests/cli/test_cohorts.py
@@ -463,6 +463,30 @@ async def test_version_create_preserves_order_and_empty_delta() -> None:
     assert request.baseline_id is None
 
 
+async def test_version_create_empty_delta_copies_explicit_baseline() -> None:
+    """An empty delta against an explicit baseline reports copied membership."""
+    client = StubCohortClient()
+    baseline_id = uuid.uuid4()
+
+    result = await cohorts.create_cohort_version(
+        client,
+        "regression",
+        add_session_ids=None,
+        remove_session_ids=None,
+        display_version=None,
+        baseline_id=baseline_id,
+    )
+
+    assert result.warnings == [
+        "No sessions were added or removed; the new version copies "
+        f"the membership of baseline {baseline_id}."
+    ]
+    _, request = client.created_versions[-1]
+    assert request.baseline_id == baseline_id
+    assert request.add_session_ids == []
+    assert request.remove_session_ids == []
+
+
 async def test_version_create_rejects_overlap_before_lookup() -> None:
     """The same session cannot appear in both sides of a membership delta."""
     client = StubCohortClient()

--- a/tests/cli/test_replays.py
+++ b/tests/cli/test_replays.py
@@ -1,0 +1,331 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+"""Standalone replay CLI behavior."""
+
+import json
+import uuid
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from kitaru.api_models.v1.replay import (
+    ReplayCreateRequest,
+    ReplayListParams,
+    ReplayResponse,
+    ReplayStatus,
+)
+from kitaru.cli import app as app_module
+from kitaru.cli import replays
+from kitaru.cli.output import CLIError
+
+
+class StubReplayClient:
+    """Protocol-shaped client recording replay and resolution calls."""
+
+    def __init__(self) -> None:
+        self.agent = SimpleNamespace(
+            id=uuid.uuid4(), name="assistant", latest_version=2
+        )
+        self.agent_version = SimpleNamespace(
+            id=uuid.uuid4(), agent_id=self.agent.id, version=2
+        )
+        self.evaluator = SimpleNamespace(
+            id=uuid.uuid4(), name="quality", latest_version=3
+        )
+        self.evaluator_version = SimpleNamespace(
+            id=uuid.uuid4(), evaluator_id=self.evaluator.id, version=3
+        )
+        self.replay_id = uuid.uuid4()
+        self.job_id = uuid.uuid4()
+        self.baseline_id = uuid.uuid4()
+        now = datetime.now(UTC)
+        self.replay = ReplayResponse(
+            id=self.replay_id,
+            job_id=self.job_id,
+            experiment_run_id=None,
+            baseline_session_id=self.baseline_id,
+            result_session_id=None,
+            override=None,
+            tool_policy={"default": {"type": "passthrough"}, "tools": {}},
+            evaluators=[{"evaluator": "quality", "version": 3, "params": {}}],
+            evaluate_baselines=False,
+            status=ReplayStatus.PENDING,
+            error=None,
+            created=now,
+            updated=now,
+        )
+        self.create_calls: list[ReplayCreateRequest] = []
+        self.list_calls: list[ReplayListParams] = []
+        self.get_calls: list[uuid.UUID] = []
+        self.agents = self._Agents(self)
+        self.evaluators = self._Evaluators(self)
+        self.replays = self._Replays(self)
+
+    class _Agents:
+        def __init__(self, owner: "StubReplayClient") -> None:
+            self.owner = owner
+
+        async def list(self, params: Any) -> Any:
+            return SimpleNamespace(items=[self.owner.agent], next_cursor=None)
+
+        async def get(self, agent_id: uuid.UUID) -> Any:
+            assert agent_id == self.owner.agent.id
+            return self.owner.agent
+
+        async def iter_versions(self, agent_id: uuid.UUID):
+            assert agent_id == self.owner.agent.id
+            yield self.owner.agent_version
+
+    class _Evaluators:
+        def __init__(self, owner: "StubReplayClient") -> None:
+            self.owner = owner
+
+        async def list(self, params: Any) -> Any:
+            return SimpleNamespace(items=[self.owner.evaluator], next_cursor=None)
+
+        async def get(self, evaluator_id: uuid.UUID) -> Any:
+            assert evaluator_id == self.owner.evaluator.id
+            return self.owner.evaluator
+
+        async def get_version(self, evaluator_id: uuid.UUID, version: int) -> Any:
+            assert evaluator_id == self.owner.evaluator.id
+            assert version == self.owner.evaluator_version.version
+            return self.owner.evaluator_version
+
+    class _Replays:
+        def __init__(self, owner: "StubReplayClient") -> None:
+            self.owner = owner
+
+        async def create(self, request: ReplayCreateRequest) -> ReplayResponse:
+            self.owner.create_calls.append(request)
+            return self.owner.replay
+
+        async def list(self, params: ReplayListParams) -> Any:
+            self.owner.list_calls.append(params)
+            return SimpleNamespace(items=[self.owner.replay], next_cursor="next")
+
+        async def get(self, replay_id: uuid.UUID) -> ReplayResponse:
+            self.owner.get_calls.append(replay_id)
+            return self.owner.replay
+
+
+async def test_create_forwards_all_supported_fields_and_next_actions() -> None:
+    """Create resolves exact versions and returns the finite follow-up commands."""
+    client = StubReplayClient()
+
+    result = await replays.create_replay(
+        client,
+        client.baseline_id,
+        evaluators=["quality@3"],
+        evaluator_params=['quality@3={"threshold":0.8}'],
+        agent="assistant@2",
+        override='{"model":"gpt-5"}',
+        tool_policy=(
+            '{"default":{"type":"history","scope":"baseline",'
+            '"on_miss":"fail"},"tools":{}}'
+        ),
+        evaluate_baselines=True,
+    )
+
+    [request] = client.create_calls
+    assert request.model_dump(mode="json", exclude_unset=True) == {
+        "baseline_session_id": str(client.baseline_id),
+        "agent_version_id": str(client.agent_version.id),
+        "override": {"model": "gpt-5"},
+        "tool_policy": {
+            "default": {"type": "history", "scope": "baseline", "on_miss": "fail"},
+            "tools": {},
+        },
+        "evaluators": [
+            {"evaluator": "quality", "version": 3, "params": {"threshold": 0.8}}
+        ],
+        "evaluate_baselines": True,
+    }
+    assert result.item["id"] == str(client.replay_id)
+    assert result.item["job_id"] == str(client.job_id)
+    assert result.next_actions == [
+        f"kitaru job watch {client.job_id}",
+        f"kitaru job cancel {client.job_id}",
+        f"kitaru replay get {client.replay_id}",
+    ]
+
+
+async def test_create_omits_server_decided_optional_fields() -> None:
+    """An omitted agent, override, and policy remain unset on the wire model."""
+    client = StubReplayClient()
+
+    await replays.create_replay(
+        client,
+        client.baseline_id,
+        evaluators=["quality@3"],
+        evaluator_params=None,
+        agent=None,
+        override=None,
+        tool_policy=None,
+        evaluate_baselines=False,
+    )
+
+    [request] = client.create_calls
+    assert request.model_dump(mode="json", exclude_unset=True) == {
+        "baseline_session_id": str(client.baseline_id),
+        "evaluators": [{"evaluator": "quality", "version": 3, "params": {}}],
+        "evaluate_baselines": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("evaluators", "evaluator_params", "override", "message"),
+    [
+        ([], None, None, "Provide at least one --evaluator"),
+        (["quality@3", "quality@3"], None, None, "must be unique"),
+        (["quality@3"], ["other@1={}"], None, "is not a selected evaluator"),
+        (["quality@3"], ["quality@3"], None, "must be EVALUATOR@VERSION"),
+        (["quality@3"], ["quality@3={"], None, "is not valid JSON"),
+        (["quality@3"], None, "[]", "must contain a JSON object"),
+    ],
+)
+async def test_invalid_create_inputs_do_not_mutate(
+    evaluators: list[str],
+    evaluator_params: list[str] | None,
+    override: str | None,
+    message: str,
+) -> None:
+    """Local input failures occur before replay creation."""
+    client = StubReplayClient()
+
+    with pytest.raises(CLIError, match=message):
+        await replays.create_replay(
+            client,
+            client.baseline_id,
+            evaluators=evaluators,
+            evaluator_params=evaluator_params,
+            agent=None,
+            override=override,
+            tool_policy=None,
+            evaluate_baselines=False,
+        )
+
+    assert client.create_calls == []
+
+
+async def test_create_rejects_tokens_resolving_to_same_evaluator_version() -> None:
+    """Aliases cannot make one evaluator version run twice."""
+    client = StubReplayClient()
+
+    with pytest.raises(CLIError, match="resolved to the same evaluator version"):
+        await replays.create_replay(
+            client,
+            client.baseline_id,
+            evaluators=["quality@3", f"{client.evaluator.id}@3"],
+            evaluator_params=None,
+            agent=None,
+            override=None,
+            tool_policy=None,
+            evaluate_baselines=False,
+        )
+
+    assert client.create_calls == []
+
+
+async def test_list_and_get_preserve_sdk_results() -> None:
+    """Finite reads forward pagination and do not remap replay state."""
+    client = StubReplayClient()
+
+    listed = await replays.list_replays(
+        client,
+        size=7,
+        cursor="cursor",
+        sort="created:asc",
+        filter='{"field":"status","op":"eq","value":"pending"}',
+    )
+    pending = await replays.get_replay(client, client.replay_id)
+    client.replay.status = ReplayStatus.COMPLETED
+    completed = await replays.get_replay(client, client.replay_id)
+
+    [params] = client.list_calls
+    assert params.model_dump(mode="json", exclude_unset=True) == {
+        "cursor": "cursor",
+        "size": 7,
+        "sort": "created:asc",
+        "filter": '{"field": "status", "op": "eq", "value": "pending"}',
+    }
+    assert listed.page == {"limit": 7, "next_cursor": "next", "truncated": True}
+    assert pending.item["status"] == "pending"
+    assert completed.item["status"] == "completed"
+    assert client.get_calls == [client.replay_id, client.replay_id]
+
+
+@pytest.fixture
+def argv_client(monkeypatch: pytest.MonkeyPatch) -> StubReplayClient:
+    """Route public replay commands through one recording client."""
+    client = StubReplayClient()
+
+    @asynccontextmanager
+    async def fake_open_client():
+        yield client
+
+    monkeypatch.setattr(app_module, "_open_asset_client", fake_open_client)
+    return client
+
+
+def test_public_replay_argv_covers_all_leaves(
+    argv_client: StubReplayClient, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The public root exposes create, list, and exact get commands."""
+    client = argv_client
+
+    assert (
+        app_module.main(
+            [
+                "replay",
+                "create",
+                str(client.baseline_id),
+                "--evaluator",
+                "quality@3",
+                "--output",
+                "json",
+            ]
+        )
+        == 0
+    )
+    created = json.loads(capsys.readouterr().out)
+    assert created["command"] == "replay.create"
+    assert created["item"]["job_id"] == str(client.job_id)
+
+    assert app_module.main(["replay", "list", "--size", "7"]) == 0
+    assert json.loads(capsys.readouterr().out)["command"] == "replay.list"
+
+    assert app_module.main(["replay", "get", str(client.replay_id)]) == 0
+    assert json.loads(capsys.readouterr().out)["item"]["status"] == "pending"
+
+
+def test_public_invalid_create_is_structured_and_does_not_mutate(
+    argv_client: StubReplayClient, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Malformed inline JSON fails locally before replay creation."""
+    client = argv_client
+
+    assert (
+        app_module.main(
+            [
+                "replay",
+                "create",
+                str(client.baseline_id),
+                "--evaluator",
+                "quality@3",
+                "--tool-policy",
+                "{",
+            ]
+        )
+        == 2
+    )
+    error = json.loads(capsys.readouterr().err)
+    assert error["command"] == "replay.create"
+    assert error["error"]["kind"] == "invalid_arguments"
+    assert client.create_calls == []

--- a/tests/cli/test_schema.py
+++ b/tests/cli/test_schema.py
@@ -70,6 +70,7 @@ def test_top_level_schema_includes_completed_stage_one_slices() -> None:
         "login",
         "local",
         "logout",
+        "replay",
         "schema",
         "session",
         "status",
@@ -94,6 +95,7 @@ def test_top_level_schema_includes_completed_stage_one_slices() -> None:
     )
     assert descriptions["evaluator"] == "Develop, register, and inspect evaluators."
     assert descriptions["session"] == "Import and inspect sessions and their nodes."
+    assert descriptions["replay"] == "Create and inspect standalone replays."
 
 
 def test_command_schema_contains_behavior_and_error_contracts() -> None:
@@ -134,6 +136,20 @@ def test_command_schema_contains_behavior_and_error_contracts() -> None:
     assert worker_start["streams"] is True
     assert worker_start["output_modes"] == ["auto", "text", "json", "jsonl"]
     assert worker_start["side_effects"]["executes_local_code"] is True
+
+    replay_commands = {item["command"]: item for item in describe_schema(("replay",))}
+    assert set(replay_commands) == {"replay.create", "replay.get", "replay.list"}
+    replay_create = replay_commands["replay.create"]
+    assert replay_create["read_only"] is False
+    assert replay_create["side_effects"]["creates_remote_state"] is True
+    assert replay_create["idempotency"] == "non_idempotent_replay_created_per_request"
+    policy = next(
+        parameter
+        for parameter in replay_create["parameters"]
+        if parameter["name"] == "--tool-policy"
+    )
+    assert "server default" in policy["description"]
+    assert "live tools" in policy["description"]
 
     [annotation_create] = describe_schema(("annotation", "create"))
     selector = next(

--- a/tests/cli/test_schema.py
+++ b/tests/cli/test_schema.py
@@ -253,6 +253,12 @@ def test_cohort_schema_describes_exact_and_destructive_commands() -> None:
     assert commands["cohort.version.create"]["idempotency"] == (
         "non_idempotent_server_assigned_version"
     )
+    parameters = {
+        parameter["name"]: parameter
+        for parameter in commands["cohort.version.create"]["parameters"]
+    }
+    assert parameters["--baseline"]["type"] == "UUID"
+    assert parameters["--baseline"]["required"] is False
     assert commands["cohort.update"]["idempotency"] == "idempotent replacement"
     assert commands["cohort.version.update"]["idempotency"] == (
         "idempotent replacement"

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -6,7 +6,7 @@
       "openWorldHint": true,
       "readOnlyHint": true
     },
-    "description": "Read Kitaru registry parents and versions using bounded exact operations.",
+    "description": "Read registry parents, versions, tags, and workers with bounded operations.",
     "inputSchema": {
       "$defs": {
         "AndFilter": {
@@ -252,9 +252,31 @@
           "title": "RegistryGetVersionRequest",
           "type": "object"
         },
+        "RegistryGetWorkerRequest": {
+          "additionalProperties": false,
+          "description": "Get one worker by its exact UUID.",
+          "properties": {
+            "operation": {
+              "const": "get_worker",
+              "title": "Operation",
+              "type": "string"
+            },
+            "worker_id": {
+              "format": "uuid",
+              "title": "Worker Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "worker_id"
+          ],
+          "title": "RegistryGetWorkerRequest",
+          "type": "object"
+        },
         "RegistryListRequest": {
           "additionalProperties": false,
-          "description": "List one page of registry parents.",
+          "description": "List one page of registry parents, tags, or workers.",
           "properties": {
             "cursor": {
               "anyOf": [
@@ -290,7 +312,19 @@
               "title": "Filter"
             },
             "kind": {
-              "$ref": "#/$defs/ParentKind"
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ParentKind"
+                },
+                {
+                  "enum": [
+                    "tag",
+                    "worker"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "title": "Kind"
             },
             "operation": {
               "const": "list",
@@ -333,6 +367,27 @@
               ],
               "default": null,
               "title": "Cursor"
+            },
+            "filter": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/FilterCondition"
+                },
+                {
+                  "$ref": "#/$defs/AndFilter"
+                },
+                {
+                  "$ref": "#/$defs/OrFilter"
+                },
+                {
+                  "$ref": "#/$defs/NotFilter"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Filter"
             },
             "kind": {
               "enum": [
@@ -383,6 +438,7 @@
             "mapping": {
               "get": "#/$defs/RegistryGetRequest",
               "get_version": "#/$defs/RegistryGetVersionRequest",
+              "get_worker": "#/$defs/RegistryGetWorkerRequest",
               "list": "#/$defs/RegistryListRequest",
               "list_versions": "#/$defs/RegistryListVersionsRequest"
             },
@@ -397,6 +453,9 @@
             },
             {
               "$ref": "#/$defs/RegistryListVersionsRequest"
+            },
+            {
+              "$ref": "#/$defs/RegistryGetWorkerRequest"
             },
             {
               "$ref": "#/$defs/RegistryGetVersionRequest"
@@ -1283,6 +1342,38 @@
           "title": "LLMConfig",
           "type": "object"
         },
+        "LabelSelector": {
+          "additionalProperties": false,
+          "description": "Label selector.",
+          "properties": {
+            "key": {
+              "description": "Label key.",
+              "title": "Key",
+              "type": "string"
+            },
+            "required": {
+              "default": false,
+              "description": "Whether a task lacking the key fails the match.",
+              "title": "Required",
+              "type": "boolean"
+            },
+            "values": {
+              "description": "Values the label may take.",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "title": "Values",
+              "type": "array"
+            }
+          },
+          "required": [
+            "key",
+            "values"
+          ],
+          "title": "LabelSelector",
+          "type": "object"
+        },
         "PackagePluginSource": {
           "additionalProperties": false,
           "description": "Package plugin source.",
@@ -1311,7 +1402,7 @@
           "title": "PackagePluginSource",
           "type": "object"
         },
-        "PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__": {
+        "PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__TagResponse__WorkerResponse__": {
           "additionalProperties": false,
           "properties": {
             "items": {
@@ -1343,6 +1434,12 @@
                   },
                   {
                     "$ref": "#/$defs/AgentResponse"
+                  },
+                  {
+                    "$ref": "#/$defs/TagResponse"
+                  },
+                  {
+                    "$ref": "#/$defs/WorkerResponse"
                   }
                 ]
               },
@@ -1357,7 +1454,7 @@
             "items",
             "page"
           ],
-          "title": "PageData[Union[CohortResponse, ExperimentResponse, ImporterResponse, EvaluatorResponse, AgentVersionResponse, CohortVersionResponse, ImporterVersionResponse, EvaluatorVersionResponse, AgentResponse]]",
+          "title": "PageData[Union[CohortResponse, ExperimentResponse, ImporterResponse, EvaluatorResponse, AgentVersionResponse, CohortVersionResponse, ImporterVersionResponse, EvaluatorVersionResponse, AgentResponse, TagResponse, WorkerResponse]]",
           "type": "object"
         },
         "PageMetadata": {
@@ -1625,6 +1722,59 @@
           "title": "StaticMatchMode",
           "type": "string"
         },
+        "TagResponse": {
+          "description": "Tag response.",
+          "properties": {
+            "created": {
+              "description": "Creation time.",
+              "format": "date-time",
+              "title": "Created",
+              "type": "string"
+            },
+            "id": {
+              "description": "Tag id.",
+              "format": "uuid",
+              "title": "Id",
+              "type": "string"
+            },
+            "name": {
+              "description": "Tag name.",
+              "title": "Name",
+              "type": "string"
+            },
+            "owner_id": {
+              "description": "Id of the owning account.",
+              "format": "uuid",
+              "title": "Owner Id",
+              "type": "string"
+            },
+            "updated": {
+              "description": "Last modification time.",
+              "format": "date-time",
+              "title": "Updated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "created",
+            "updated",
+            "owner_id",
+            "id",
+            "name"
+          ],
+          "title": "TagResponse",
+          "type": "object"
+        },
+        "TaskKind": {
+          "description": "Kind of work a task runs.",
+          "enum": [
+            "agent",
+            "evaluator",
+            "importer"
+          ],
+          "title": "TaskKind",
+          "type": "string"
+        },
         "ToolError": {
           "additionalProperties": false,
           "description": "Stable, bounded error returned by a tool handler.",
@@ -1752,6 +1902,242 @@
           ],
           "title": "ToolPolicyOnMiss",
           "type": "string"
+        },
+        "WorkerResponse": {
+          "description": "Worker response.",
+          "properties": {
+            "created": {
+              "description": "Creation time.",
+              "format": "date-time",
+              "title": "Created",
+              "type": "string"
+            },
+            "id": {
+              "description": "Worker id.",
+              "format": "uuid",
+              "title": "Id",
+              "type": "string"
+            },
+            "last_seen_at": {
+              "description": "Time of the worker's last heartbeat.",
+              "format": "date-time",
+              "title": "Last Seen At",
+              "type": "string"
+            },
+            "live": {
+              "description": "Whether the worker is considered alive.",
+              "title": "Live",
+              "type": "boolean"
+            },
+            "metadata": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Arbitrary metadata.",
+              "title": "Metadata",
+              "type": "object"
+            },
+            "name": {
+              "description": "Worker name.",
+              "title": "Name",
+              "type": "string"
+            },
+            "owner_id": {
+              "description": "Id of the owning account.",
+              "format": "uuid",
+              "title": "Owner Id",
+              "type": "string"
+            },
+            "runtime": {
+              "$ref": "#/$defs/WorkerRuntime",
+              "description": "Runtime the worker reports."
+            },
+            "scope": {
+              "$ref": "#/$defs/WorkerScope",
+              "description": "Tasks this worker is willing to claim."
+            },
+            "updated": {
+              "description": "Last modification time.",
+              "format": "date-time",
+              "title": "Updated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "created",
+            "updated",
+            "owner_id",
+            "id",
+            "name",
+            "scope",
+            "runtime",
+            "last_seen_at",
+            "live",
+            "metadata"
+          ],
+          "title": "WorkerResponse",
+          "type": "object"
+        },
+        "WorkerRuntime": {
+          "additionalProperties": false,
+          "description": "Worker runtime.",
+          "properties": {
+            "arch": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported architecture.",
+              "title": "Arch"
+            },
+            "hostname": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported hostname.",
+              "title": "Hostname"
+            },
+            "kitaru_version": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Kitaru version.",
+              "title": "Kitaru Version"
+            },
+            "namespace": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Kubernetes namespace.",
+              "title": "Namespace"
+            },
+            "os": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported operating system.",
+              "title": "Os"
+            },
+            "platform": {
+              "description": "Runtime platform, e.g. kubernetes, docker, bare.",
+              "title": "Platform",
+              "type": "string"
+            },
+            "pod": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Kubernetes pod name.",
+              "title": "Pod"
+            },
+            "python_version": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Python version.",
+              "title": "Python Version"
+            }
+          },
+          "required": [
+            "platform"
+          ],
+          "title": "WorkerRuntime",
+          "type": "object"
+        },
+        "WorkerScope": {
+          "additionalProperties": false,
+          "description": "Worker scope.",
+          "properties": {
+            "job_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Job the worker claims tasks from.",
+              "title": "Job Id"
+            },
+            "kinds": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/TaskKind"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Task kinds the worker claims.",
+              "title": "Kinds"
+            },
+            "selectors": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/LabelSelector"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Label selectors the worker claims, combined by conjunction.",
+              "title": "Selectors"
+            }
+          },
+          "title": "WorkerScope",
+          "type": "object"
         }
       },
       "additionalProperties": false,
@@ -1787,7 +2173,13 @@
               "$ref": "#/$defs/AgentResponse"
             },
             {
-              "$ref": "#/$defs/PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__"
+              "$ref": "#/$defs/TagResponse"
+            },
+            {
+              "$ref": "#/$defs/WorkerResponse"
+            },
+            {
+              "$ref": "#/$defs/PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__TagResponse__WorkerResponse__"
             },
             {
               "type": "null"
@@ -5435,6 +5827,19 @@
               "title": "Add Session Ids",
               "type": "array"
             },
+            "baseline_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Baseline Id"
+            },
             "cohort_id": {
               "format": "uuid",
               "title": "Cohort Id",
@@ -7216,7 +7621,7 @@
       "openWorldHint": true,
       "readOnlyHint": false
     },
-    "description": "Create or update investigations, linked statuses, and annotations.",
+    "description": "Create or update investigations, annotations, tags, and tag links.",
     "inputSchema": {
       "$defs": {
         "AnnotationSelector": {
@@ -7540,6 +7945,7 @@
               "anyOf": [
                 {
                   "enum": [
+                    "pending",
                     "in_progress",
                     "completed"
                   ],
@@ -7635,6 +8041,101 @@
           ],
           "title": "SetInvestigationSessionVerdict",
           "type": "object"
+        },
+        "TagCreate": {
+          "additionalProperties": false,
+          "description": "Create a tag.",
+          "properties": {
+            "name": {
+              "minLength": 1,
+              "title": "Name",
+              "type": "string"
+            },
+            "operation": {
+              "const": "create_tag",
+              "title": "Operation",
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "name"
+          ],
+          "title": "TagCreate",
+          "type": "object"
+        },
+        "TagLink": {
+          "additionalProperties": false,
+          "description": "Link one tag to one exact resource.",
+          "properties": {
+            "operation": {
+              "const": "link_tag",
+              "title": "Operation",
+              "type": "string"
+            },
+            "resource_id": {
+              "format": "uuid",
+              "title": "Resource Id",
+              "type": "string"
+            },
+            "resource_type": {
+              "$ref": "#/$defs/TagResourceType"
+            },
+            "tag_id": {
+              "format": "uuid",
+              "title": "Tag Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "tag_id",
+            "resource_type",
+            "resource_id"
+          ],
+          "title": "TagLink",
+          "type": "object"
+        },
+        "TagResourceType": {
+          "description": "Resource kind a tag link points at.",
+          "enum": [
+            "session",
+            "cohort",
+            "cohort_version",
+            "agent_version",
+            "experiment",
+            "experiment_run"
+          ],
+          "title": "TagResourceType",
+          "type": "string"
+        },
+        "TagUpdate": {
+          "additionalProperties": false,
+          "description": "Rename one tag by exact UUID.",
+          "properties": {
+            "name": {
+              "minLength": 1,
+              "title": "Name",
+              "type": "string"
+            },
+            "operation": {
+              "const": "update_tag",
+              "title": "Operation",
+              "type": "string"
+            },
+            "tag_id": {
+              "format": "uuid",
+              "title": "Tag Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "tag_id",
+            "name"
+          ],
+          "title": "TagUpdate",
+          "type": "object"
         }
       },
       "properties": {
@@ -7644,9 +8145,12 @@
               "answer_question": "#/$defs/InvestigationAnswerCreate",
               "create_annotation": "#/$defs/ManualAnnotationCreate",
               "create_investigation": "#/$defs/InvestigationCreate",
+              "create_tag": "#/$defs/TagCreate",
+              "link_tag": "#/$defs/TagLink",
               "set_session_verdict": "#/$defs/SetInvestigationSessionVerdict",
               "update_annotation": "#/$defs/AnnotationUpdate",
-              "update_investigation": "#/$defs/InvestigationUpdate"
+              "update_investigation": "#/$defs/InvestigationUpdate",
+              "update_tag": "#/$defs/TagUpdate"
             },
             "propertyName": "operation"
           },
@@ -7668,6 +8172,15 @@
             },
             {
               "$ref": "#/$defs/AnnotationUpdate"
+            },
+            {
+              "$ref": "#/$defs/TagCreate"
+            },
+            {
+              "$ref": "#/$defs/TagUpdate"
+            },
+            {
+              "$ref": "#/$defs/TagLink"
             }
           ],
           "title": "Request"
@@ -8095,6 +8608,111 @@
           "title": "InvestigationStatus",
           "type": "string"
         },
+        "TagLinkResponse": {
+          "description": "Tag link response.",
+          "properties": {
+            "created": {
+              "description": "Creation time.",
+              "format": "date-time",
+              "title": "Created",
+              "type": "string"
+            },
+            "id": {
+              "description": "Tag link id.",
+              "format": "uuid",
+              "title": "Id",
+              "type": "string"
+            },
+            "resource_id": {
+              "description": "Resource tagged.",
+              "format": "uuid",
+              "title": "Resource Id",
+              "type": "string"
+            },
+            "resource_type": {
+              "$ref": "#/$defs/TagResourceType",
+              "description": "Kind of resource tagged."
+            },
+            "tag_id": {
+              "description": "Tag applied.",
+              "format": "uuid",
+              "title": "Tag Id",
+              "type": "string"
+            },
+            "updated": {
+              "description": "Last modification time.",
+              "format": "date-time",
+              "title": "Updated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "created",
+            "updated",
+            "id",
+            "tag_id",
+            "resource_type",
+            "resource_id"
+          ],
+          "title": "TagLinkResponse",
+          "type": "object"
+        },
+        "TagResourceType": {
+          "description": "Resource kind a tag link points at.",
+          "enum": [
+            "session",
+            "cohort",
+            "cohort_version",
+            "agent_version",
+            "experiment",
+            "experiment_run"
+          ],
+          "title": "TagResourceType",
+          "type": "string"
+        },
+        "TagResponse": {
+          "description": "Tag response.",
+          "properties": {
+            "created": {
+              "description": "Creation time.",
+              "format": "date-time",
+              "title": "Created",
+              "type": "string"
+            },
+            "id": {
+              "description": "Tag id.",
+              "format": "uuid",
+              "title": "Id",
+              "type": "string"
+            },
+            "name": {
+              "description": "Tag name.",
+              "title": "Name",
+              "type": "string"
+            },
+            "owner_id": {
+              "description": "Id of the owning account.",
+              "format": "uuid",
+              "title": "Owner Id",
+              "type": "string"
+            },
+            "updated": {
+              "description": "Last modification time.",
+              "format": "date-time",
+              "title": "Updated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "created",
+            "updated",
+            "owner_id",
+            "id",
+            "name"
+          ],
+          "title": "TagResponse",
+          "type": "object"
+        },
         "ToolError": {
           "additionalProperties": false,
           "description": "Stable, bounded error returned by a tool handler.",
@@ -8159,6 +8777,12 @@
             },
             {
               "$ref": "#/$defs/AnnotationResponse"
+            },
+            {
+              "$ref": "#/$defs/TagResponse"
+            },
+            {
+              "$ref": "#/$defs/TagLinkResponse"
             },
             {
               "type": "null"
@@ -10018,10 +10642,10 @@
       "openWorldHint": true,
       "readOnlyHint": false
     },
-    "description": "Delete one exact allowlisted registry, review, or run resource.",
+    "description": "Delete one exact allowlisted resource or tag link.",
     "inputSchema": {
       "$defs": {
-        "DeleteRequest": {
+        "ResourceDelete": {
           "additionalProperties": false,
           "description": "Delete one allowlisted exact resource.",
           "properties": {
@@ -10038,7 +10662,8 @@
                 "experiment_run",
                 "investigation",
                 "annotation",
-                "evaluator"
+                "evaluator",
+                "tag"
               ],
               "title": "Kind",
               "type": "string"
@@ -10048,13 +10673,80 @@
             "kind",
             "id"
           ],
-          "title": "DeleteRequest",
+          "title": "ResourceDelete",
           "type": "object"
+        },
+        "TagLinkDelete": {
+          "additionalProperties": false,
+          "description": "Delete one exact tag-to-resource link.",
+          "properties": {
+            "kind": {
+              "const": "tag_link",
+              "title": "Kind",
+              "type": "string"
+            },
+            "resource_id": {
+              "format": "uuid",
+              "title": "Resource Id",
+              "type": "string"
+            },
+            "resource_type": {
+              "$ref": "#/$defs/TagResourceType"
+            },
+            "tag_id": {
+              "format": "uuid",
+              "title": "Tag Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "tag_id",
+            "resource_type",
+            "resource_id"
+          ],
+          "title": "TagLinkDelete",
+          "type": "object"
+        },
+        "TagResourceType": {
+          "description": "Resource kind a tag link points at.",
+          "enum": [
+            "session",
+            "cohort",
+            "cohort_version",
+            "agent_version",
+            "experiment",
+            "experiment_run"
+          ],
+          "title": "TagResourceType",
+          "type": "string"
         }
       },
       "properties": {
         "request": {
-          "$ref": "#/$defs/DeleteRequest"
+          "discriminator": {
+            "mapping": {
+              "annotation": "#/$defs/ResourceDelete",
+              "cohort": "#/$defs/ResourceDelete",
+              "cohort_version": "#/$defs/ResourceDelete",
+              "evaluator": "#/$defs/ResourceDelete",
+              "experiment": "#/$defs/ResourceDelete",
+              "experiment_run": "#/$defs/ResourceDelete",
+              "investigation": "#/$defs/ResourceDelete",
+              "tag": "#/$defs/ResourceDelete",
+              "tag_link": "#/$defs/TagLinkDelete"
+            },
+            "propertyName": "kind"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/ResourceDelete"
+            },
+            {
+              "$ref": "#/$defs/TagLinkDelete"
+            }
+          ],
+          "title": "Request"
         }
       },
       "required": [
@@ -10088,7 +10780,8 @@
                 "experiment_run",
                 "investigation",
                 "annotation",
-                "evaluator"
+                "evaluator",
+                "tag"
               ],
               "title": "Kind",
               "type": "string"
@@ -10101,6 +10794,57 @@
           ],
           "title": "DeleteReceipt",
           "type": "object"
+        },
+        "TagLinkDeleteReceipt": {
+          "additionalProperties": false,
+          "description": "Receipt for deleting one exact tag-to-resource link.",
+          "properties": {
+            "deleted": {
+              "const": true,
+              "title": "Deleted",
+              "type": "boolean"
+            },
+            "kind": {
+              "const": "tag_link",
+              "title": "Kind",
+              "type": "string"
+            },
+            "resource_id": {
+              "format": "uuid",
+              "title": "Resource Id",
+              "type": "string"
+            },
+            "resource_type": {
+              "$ref": "#/$defs/TagResourceType"
+            },
+            "tag_id": {
+              "format": "uuid",
+              "title": "Tag Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "tag_id",
+            "resource_type",
+            "resource_id",
+            "deleted"
+          ],
+          "title": "TagLinkDeleteReceipt",
+          "type": "object"
+        },
+        "TagResourceType": {
+          "description": "Resource kind a tag link points at.",
+          "enum": [
+            "session",
+            "cohort",
+            "cohort_version",
+            "agent_version",
+            "experiment",
+            "experiment_run"
+          ],
+          "title": "TagResourceType",
+          "type": "string"
         },
         "ToolError": {
           "additionalProperties": false,
@@ -10162,10 +10906,14 @@
               "$ref": "#/$defs/DeleteReceipt"
             },
             {
+              "$ref": "#/$defs/TagLinkDeleteReceipt"
+            },
+            {
               "type": "null"
             }
           ],
-          "default": null
+          "default": null,
+          "title": "Data"
         },
         "error": {
           "anyOf": [

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -7898,6 +7898,16 @@
           "title": "InvestigationSessionVerdict",
           "type": "string"
         },
+        "InvestigationStatus": {
+          "description": "Investigation status.",
+          "enum": [
+            "pending",
+            "in_progress",
+            "completed"
+          ],
+          "title": "InvestigationStatus",
+          "type": "string"
+        },
         "InvestigationUpdate": {
           "additionalProperties": false,
           "description": "Sparsely update investigation metadata.",
@@ -7944,19 +7954,13 @@
             "status": {
               "anyOf": [
                 {
-                  "enum": [
-                    "pending",
-                    "in_progress",
-                    "completed"
-                  ],
-                  "type": "string"
+                  "$ref": "#/$defs/InvestigationStatus"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "default": null,
-              "title": "Status"
+              "default": null
             }
           },
           "required": [

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,7 +6,7 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 140483,
+      "discovery_response_bytes": 150876,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
@@ -18,17 +18,17 @@
         },
         "kitaru_cohorts_manage": {
           "$defs_count": 7,
-          "combined_bytes": 6333,
-          "input_bytes": 2970,
+          "combined_bytes": 6446,
+          "input_bytes": 3083,
           "maximum_nesting_depth": 7,
           "output_bytes": 3363
         },
         "kitaru_delete": {
-          "$defs_count": 3,
-          "combined_bytes": 2041,
-          "input_bytes": 519,
+          "$defs_count": 7,
+          "combined_bytes": 3984,
+          "input_bytes": 1642,
           "maximum_nesting_depth": 7,
-          "output_bytes": 1522
+          "output_bytes": 2342
         },
         "kitaru_evaluators_manage": {
           "$defs_count": 11,
@@ -45,18 +45,18 @@
           "output_bytes": 7317
         },
         "kitaru_registry_read": {
-          "$defs_count": 37,
-          "combined_bytes": 25618,
-          "input_bytes": 4989,
+          "$defs_count": 44,
+          "combined_bytes": 30830,
+          "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 20629
+          "output_bytes": 25124
         },
         "kitaru_review_manage": {
-          "$defs_count": 22,
-          "combined_bytes": 14492,
-          "input_bytes": 6857,
+          "$defs_count": 29,
+          "combined_bytes": 17628,
+          "input_bytes": 8355,
           "maximum_nesting_depth": 8,
-          "output_bytes": 7635
+          "output_bytes": 9273
         },
         "kitaru_review_read": {
           "$defs_count": 20,
@@ -89,7 +89,7 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 72302,
+      "discovery_response_bytes": 77516,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
@@ -100,11 +100,11 @@
           "output_bytes": 28453
         },
         "kitaru_registry_read": {
-          "$defs_count": 37,
-          "combined_bytes": 25618,
-          "input_bytes": 4989,
+          "$defs_count": 44,
+          "combined_bytes": 30830,
+          "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 20629
+          "output_bytes": 25124
         },
         "kitaru_review_read": {
           "$defs_count": 20,
@@ -116,7 +116,7 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 131021,
+      "discovery_response_bytes": 139484,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
@@ -128,8 +128,8 @@
         },
         "kitaru_cohorts_manage": {
           "$defs_count": 7,
-          "combined_bytes": 6333,
-          "input_bytes": 2970,
+          "combined_bytes": 6446,
+          "input_bytes": 3083,
           "maximum_nesting_depth": 7,
           "output_bytes": 3363
         },
@@ -148,18 +148,18 @@
           "output_bytes": 7317
         },
         "kitaru_registry_read": {
-          "$defs_count": 37,
-          "combined_bytes": 25618,
-          "input_bytes": 4989,
+          "$defs_count": 44,
+          "combined_bytes": 30830,
+          "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 20629
+          "output_bytes": 25124
         },
         "kitaru_review_manage": {
-          "$defs_count": 22,
-          "combined_bytes": 14492,
-          "input_bytes": 6857,
+          "$defs_count": 29,
+          "combined_bytes": 17628,
+          "input_bytes": 8355,
           "maximum_nesting_depth": 8,
-          "output_bytes": 7635
+          "output_bytes": 9273
         },
         "kitaru_review_read": {
           "$defs_count": 20,

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,7 +6,7 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 150876,
+      "discovery_response_bytes": 150988,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
@@ -52,10 +52,10 @@
           "output_bytes": 25124
         },
         "kitaru_review_manage": {
-          "$defs_count": 29,
-          "combined_bytes": 17628,
-          "input_bytes": 8355,
-          "maximum_nesting_depth": 8,
+          "$defs_count": 30,
+          "combined_bytes": 17740,
+          "input_bytes": 8467,
+          "maximum_nesting_depth": 7,
           "output_bytes": 9273
         },
         "kitaru_review_read": {
@@ -116,7 +116,7 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 139484,
+      "discovery_response_bytes": 139596,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
@@ -155,10 +155,10 @@
           "output_bytes": 25124
         },
         "kitaru_review_manage": {
-          "$defs_count": 29,
-          "combined_bytes": 17628,
-          "input_bytes": 8355,
-          "maximum_nesting_depth": 8,
+          "$defs_count": 30,
+          "combined_bytes": 17740,
+          "input_bytes": 8467,
+          "maximum_nesting_depth": 7,
           "output_bytes": 9273
         },
         "kitaru_review_read": {

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -6,7 +6,7 @@
       "openWorldHint": true,
       "readOnlyHint": true
     },
-    "description": "Read Kitaru registry parents and versions using bounded exact operations.",
+    "description": "Read registry parents, versions, tags, and workers with bounded operations.",
     "inputSchema": {
       "$defs": {
         "AndFilter": {
@@ -252,9 +252,31 @@
           "title": "RegistryGetVersionRequest",
           "type": "object"
         },
+        "RegistryGetWorkerRequest": {
+          "additionalProperties": false,
+          "description": "Get one worker by its exact UUID.",
+          "properties": {
+            "operation": {
+              "const": "get_worker",
+              "title": "Operation",
+              "type": "string"
+            },
+            "worker_id": {
+              "format": "uuid",
+              "title": "Worker Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "worker_id"
+          ],
+          "title": "RegistryGetWorkerRequest",
+          "type": "object"
+        },
         "RegistryListRequest": {
           "additionalProperties": false,
-          "description": "List one page of registry parents.",
+          "description": "List one page of registry parents, tags, or workers.",
           "properties": {
             "cursor": {
               "anyOf": [
@@ -290,7 +312,19 @@
               "title": "Filter"
             },
             "kind": {
-              "$ref": "#/$defs/ParentKind"
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ParentKind"
+                },
+                {
+                  "enum": [
+                    "tag",
+                    "worker"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "title": "Kind"
             },
             "operation": {
               "const": "list",
@@ -333,6 +367,27 @@
               ],
               "default": null,
               "title": "Cursor"
+            },
+            "filter": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/FilterCondition"
+                },
+                {
+                  "$ref": "#/$defs/AndFilter"
+                },
+                {
+                  "$ref": "#/$defs/OrFilter"
+                },
+                {
+                  "$ref": "#/$defs/NotFilter"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Filter"
             },
             "kind": {
               "enum": [
@@ -383,6 +438,7 @@
             "mapping": {
               "get": "#/$defs/RegistryGetRequest",
               "get_version": "#/$defs/RegistryGetVersionRequest",
+              "get_worker": "#/$defs/RegistryGetWorkerRequest",
               "list": "#/$defs/RegistryListRequest",
               "list_versions": "#/$defs/RegistryListVersionsRequest"
             },
@@ -397,6 +453,9 @@
             },
             {
               "$ref": "#/$defs/RegistryListVersionsRequest"
+            },
+            {
+              "$ref": "#/$defs/RegistryGetWorkerRequest"
             },
             {
               "$ref": "#/$defs/RegistryGetVersionRequest"
@@ -1283,6 +1342,38 @@
           "title": "LLMConfig",
           "type": "object"
         },
+        "LabelSelector": {
+          "additionalProperties": false,
+          "description": "Label selector.",
+          "properties": {
+            "key": {
+              "description": "Label key.",
+              "title": "Key",
+              "type": "string"
+            },
+            "required": {
+              "default": false,
+              "description": "Whether a task lacking the key fails the match.",
+              "title": "Required",
+              "type": "boolean"
+            },
+            "values": {
+              "description": "Values the label may take.",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "title": "Values",
+              "type": "array"
+            }
+          },
+          "required": [
+            "key",
+            "values"
+          ],
+          "title": "LabelSelector",
+          "type": "object"
+        },
         "PackagePluginSource": {
           "additionalProperties": false,
           "description": "Package plugin source.",
@@ -1311,7 +1402,7 @@
           "title": "PackagePluginSource",
           "type": "object"
         },
-        "PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__": {
+        "PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__TagResponse__WorkerResponse__": {
           "additionalProperties": false,
           "properties": {
             "items": {
@@ -1343,6 +1434,12 @@
                   },
                   {
                     "$ref": "#/$defs/AgentResponse"
+                  },
+                  {
+                    "$ref": "#/$defs/TagResponse"
+                  },
+                  {
+                    "$ref": "#/$defs/WorkerResponse"
                   }
                 ]
               },
@@ -1357,7 +1454,7 @@
             "items",
             "page"
           ],
-          "title": "PageData[Union[CohortResponse, ExperimentResponse, ImporterResponse, EvaluatorResponse, AgentVersionResponse, CohortVersionResponse, ImporterVersionResponse, EvaluatorVersionResponse, AgentResponse]]",
+          "title": "PageData[Union[CohortResponse, ExperimentResponse, ImporterResponse, EvaluatorResponse, AgentVersionResponse, CohortVersionResponse, ImporterVersionResponse, EvaluatorVersionResponse, AgentResponse, TagResponse, WorkerResponse]]",
           "type": "object"
         },
         "PageMetadata": {
@@ -1625,6 +1722,59 @@
           "title": "StaticMatchMode",
           "type": "string"
         },
+        "TagResponse": {
+          "description": "Tag response.",
+          "properties": {
+            "created": {
+              "description": "Creation time.",
+              "format": "date-time",
+              "title": "Created",
+              "type": "string"
+            },
+            "id": {
+              "description": "Tag id.",
+              "format": "uuid",
+              "title": "Id",
+              "type": "string"
+            },
+            "name": {
+              "description": "Tag name.",
+              "title": "Name",
+              "type": "string"
+            },
+            "owner_id": {
+              "description": "Id of the owning account.",
+              "format": "uuid",
+              "title": "Owner Id",
+              "type": "string"
+            },
+            "updated": {
+              "description": "Last modification time.",
+              "format": "date-time",
+              "title": "Updated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "created",
+            "updated",
+            "owner_id",
+            "id",
+            "name"
+          ],
+          "title": "TagResponse",
+          "type": "object"
+        },
+        "TaskKind": {
+          "description": "Kind of work a task runs.",
+          "enum": [
+            "agent",
+            "evaluator",
+            "importer"
+          ],
+          "title": "TaskKind",
+          "type": "string"
+        },
         "ToolError": {
           "additionalProperties": false,
           "description": "Stable, bounded error returned by a tool handler.",
@@ -1752,6 +1902,242 @@
           ],
           "title": "ToolPolicyOnMiss",
           "type": "string"
+        },
+        "WorkerResponse": {
+          "description": "Worker response.",
+          "properties": {
+            "created": {
+              "description": "Creation time.",
+              "format": "date-time",
+              "title": "Created",
+              "type": "string"
+            },
+            "id": {
+              "description": "Worker id.",
+              "format": "uuid",
+              "title": "Id",
+              "type": "string"
+            },
+            "last_seen_at": {
+              "description": "Time of the worker's last heartbeat.",
+              "format": "date-time",
+              "title": "Last Seen At",
+              "type": "string"
+            },
+            "live": {
+              "description": "Whether the worker is considered alive.",
+              "title": "Live",
+              "type": "boolean"
+            },
+            "metadata": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Arbitrary metadata.",
+              "title": "Metadata",
+              "type": "object"
+            },
+            "name": {
+              "description": "Worker name.",
+              "title": "Name",
+              "type": "string"
+            },
+            "owner_id": {
+              "description": "Id of the owning account.",
+              "format": "uuid",
+              "title": "Owner Id",
+              "type": "string"
+            },
+            "runtime": {
+              "$ref": "#/$defs/WorkerRuntime",
+              "description": "Runtime the worker reports."
+            },
+            "scope": {
+              "$ref": "#/$defs/WorkerScope",
+              "description": "Tasks this worker is willing to claim."
+            },
+            "updated": {
+              "description": "Last modification time.",
+              "format": "date-time",
+              "title": "Updated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "created",
+            "updated",
+            "owner_id",
+            "id",
+            "name",
+            "scope",
+            "runtime",
+            "last_seen_at",
+            "live",
+            "metadata"
+          ],
+          "title": "WorkerResponse",
+          "type": "object"
+        },
+        "WorkerRuntime": {
+          "additionalProperties": false,
+          "description": "Worker runtime.",
+          "properties": {
+            "arch": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported architecture.",
+              "title": "Arch"
+            },
+            "hostname": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported hostname.",
+              "title": "Hostname"
+            },
+            "kitaru_version": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Kitaru version.",
+              "title": "Kitaru Version"
+            },
+            "namespace": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Kubernetes namespace.",
+              "title": "Namespace"
+            },
+            "os": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported operating system.",
+              "title": "Os"
+            },
+            "platform": {
+              "description": "Runtime platform, e.g. kubernetes, docker, bare.",
+              "title": "Platform",
+              "type": "string"
+            },
+            "pod": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Kubernetes pod name.",
+              "title": "Pod"
+            },
+            "python_version": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Python version.",
+              "title": "Python Version"
+            }
+          },
+          "required": [
+            "platform"
+          ],
+          "title": "WorkerRuntime",
+          "type": "object"
+        },
+        "WorkerScope": {
+          "additionalProperties": false,
+          "description": "Worker scope.",
+          "properties": {
+            "job_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Job the worker claims tasks from.",
+              "title": "Job Id"
+            },
+            "kinds": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/TaskKind"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Task kinds the worker claims.",
+              "title": "Kinds"
+            },
+            "selectors": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/LabelSelector"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Label selectors the worker claims, combined by conjunction.",
+              "title": "Selectors"
+            }
+          },
+          "title": "WorkerScope",
+          "type": "object"
         }
       },
       "additionalProperties": false,
@@ -1787,7 +2173,13 @@
               "$ref": "#/$defs/AgentResponse"
             },
             {
-              "$ref": "#/$defs/PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__"
+              "$ref": "#/$defs/TagResponse"
+            },
+            {
+              "$ref": "#/$defs/WorkerResponse"
+            },
+            {
+              "$ref": "#/$defs/PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__TagResponse__WorkerResponse__"
             },
             {
               "type": "null"

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -6,7 +6,7 @@
       "openWorldHint": true,
       "readOnlyHint": true
     },
-    "description": "Read Kitaru registry parents and versions using bounded exact operations.",
+    "description": "Read registry parents, versions, tags, and workers with bounded operations.",
     "inputSchema": {
       "$defs": {
         "AndFilter": {
@@ -252,9 +252,31 @@
           "title": "RegistryGetVersionRequest",
           "type": "object"
         },
+        "RegistryGetWorkerRequest": {
+          "additionalProperties": false,
+          "description": "Get one worker by its exact UUID.",
+          "properties": {
+            "operation": {
+              "const": "get_worker",
+              "title": "Operation",
+              "type": "string"
+            },
+            "worker_id": {
+              "format": "uuid",
+              "title": "Worker Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "worker_id"
+          ],
+          "title": "RegistryGetWorkerRequest",
+          "type": "object"
+        },
         "RegistryListRequest": {
           "additionalProperties": false,
-          "description": "List one page of registry parents.",
+          "description": "List one page of registry parents, tags, or workers.",
           "properties": {
             "cursor": {
               "anyOf": [
@@ -290,7 +312,19 @@
               "title": "Filter"
             },
             "kind": {
-              "$ref": "#/$defs/ParentKind"
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ParentKind"
+                },
+                {
+                  "enum": [
+                    "tag",
+                    "worker"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "title": "Kind"
             },
             "operation": {
               "const": "list",
@@ -333,6 +367,27 @@
               ],
               "default": null,
               "title": "Cursor"
+            },
+            "filter": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/FilterCondition"
+                },
+                {
+                  "$ref": "#/$defs/AndFilter"
+                },
+                {
+                  "$ref": "#/$defs/OrFilter"
+                },
+                {
+                  "$ref": "#/$defs/NotFilter"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Filter"
             },
             "kind": {
               "enum": [
@@ -383,6 +438,7 @@
             "mapping": {
               "get": "#/$defs/RegistryGetRequest",
               "get_version": "#/$defs/RegistryGetVersionRequest",
+              "get_worker": "#/$defs/RegistryGetWorkerRequest",
               "list": "#/$defs/RegistryListRequest",
               "list_versions": "#/$defs/RegistryListVersionsRequest"
             },
@@ -397,6 +453,9 @@
             },
             {
               "$ref": "#/$defs/RegistryListVersionsRequest"
+            },
+            {
+              "$ref": "#/$defs/RegistryGetWorkerRequest"
             },
             {
               "$ref": "#/$defs/RegistryGetVersionRequest"
@@ -1283,6 +1342,38 @@
           "title": "LLMConfig",
           "type": "object"
         },
+        "LabelSelector": {
+          "additionalProperties": false,
+          "description": "Label selector.",
+          "properties": {
+            "key": {
+              "description": "Label key.",
+              "title": "Key",
+              "type": "string"
+            },
+            "required": {
+              "default": false,
+              "description": "Whether a task lacking the key fails the match.",
+              "title": "Required",
+              "type": "boolean"
+            },
+            "values": {
+              "description": "Values the label may take.",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "title": "Values",
+              "type": "array"
+            }
+          },
+          "required": [
+            "key",
+            "values"
+          ],
+          "title": "LabelSelector",
+          "type": "object"
+        },
         "PackagePluginSource": {
           "additionalProperties": false,
           "description": "Package plugin source.",
@@ -1311,7 +1402,7 @@
           "title": "PackagePluginSource",
           "type": "object"
         },
-        "PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__": {
+        "PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__TagResponse__WorkerResponse__": {
           "additionalProperties": false,
           "properties": {
             "items": {
@@ -1343,6 +1434,12 @@
                   },
                   {
                     "$ref": "#/$defs/AgentResponse"
+                  },
+                  {
+                    "$ref": "#/$defs/TagResponse"
+                  },
+                  {
+                    "$ref": "#/$defs/WorkerResponse"
                   }
                 ]
               },
@@ -1357,7 +1454,7 @@
             "items",
             "page"
           ],
-          "title": "PageData[Union[CohortResponse, ExperimentResponse, ImporterResponse, EvaluatorResponse, AgentVersionResponse, CohortVersionResponse, ImporterVersionResponse, EvaluatorVersionResponse, AgentResponse]]",
+          "title": "PageData[Union[CohortResponse, ExperimentResponse, ImporterResponse, EvaluatorResponse, AgentVersionResponse, CohortVersionResponse, ImporterVersionResponse, EvaluatorVersionResponse, AgentResponse, TagResponse, WorkerResponse]]",
           "type": "object"
         },
         "PageMetadata": {
@@ -1625,6 +1722,59 @@
           "title": "StaticMatchMode",
           "type": "string"
         },
+        "TagResponse": {
+          "description": "Tag response.",
+          "properties": {
+            "created": {
+              "description": "Creation time.",
+              "format": "date-time",
+              "title": "Created",
+              "type": "string"
+            },
+            "id": {
+              "description": "Tag id.",
+              "format": "uuid",
+              "title": "Id",
+              "type": "string"
+            },
+            "name": {
+              "description": "Tag name.",
+              "title": "Name",
+              "type": "string"
+            },
+            "owner_id": {
+              "description": "Id of the owning account.",
+              "format": "uuid",
+              "title": "Owner Id",
+              "type": "string"
+            },
+            "updated": {
+              "description": "Last modification time.",
+              "format": "date-time",
+              "title": "Updated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "created",
+            "updated",
+            "owner_id",
+            "id",
+            "name"
+          ],
+          "title": "TagResponse",
+          "type": "object"
+        },
+        "TaskKind": {
+          "description": "Kind of work a task runs.",
+          "enum": [
+            "agent",
+            "evaluator",
+            "importer"
+          ],
+          "title": "TaskKind",
+          "type": "string"
+        },
         "ToolError": {
           "additionalProperties": false,
           "description": "Stable, bounded error returned by a tool handler.",
@@ -1752,6 +1902,242 @@
           ],
           "title": "ToolPolicyOnMiss",
           "type": "string"
+        },
+        "WorkerResponse": {
+          "description": "Worker response.",
+          "properties": {
+            "created": {
+              "description": "Creation time.",
+              "format": "date-time",
+              "title": "Created",
+              "type": "string"
+            },
+            "id": {
+              "description": "Worker id.",
+              "format": "uuid",
+              "title": "Id",
+              "type": "string"
+            },
+            "last_seen_at": {
+              "description": "Time of the worker's last heartbeat.",
+              "format": "date-time",
+              "title": "Last Seen At",
+              "type": "string"
+            },
+            "live": {
+              "description": "Whether the worker is considered alive.",
+              "title": "Live",
+              "type": "boolean"
+            },
+            "metadata": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Arbitrary metadata.",
+              "title": "Metadata",
+              "type": "object"
+            },
+            "name": {
+              "description": "Worker name.",
+              "title": "Name",
+              "type": "string"
+            },
+            "owner_id": {
+              "description": "Id of the owning account.",
+              "format": "uuid",
+              "title": "Owner Id",
+              "type": "string"
+            },
+            "runtime": {
+              "$ref": "#/$defs/WorkerRuntime",
+              "description": "Runtime the worker reports."
+            },
+            "scope": {
+              "$ref": "#/$defs/WorkerScope",
+              "description": "Tasks this worker is willing to claim."
+            },
+            "updated": {
+              "description": "Last modification time.",
+              "format": "date-time",
+              "title": "Updated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "created",
+            "updated",
+            "owner_id",
+            "id",
+            "name",
+            "scope",
+            "runtime",
+            "last_seen_at",
+            "live",
+            "metadata"
+          ],
+          "title": "WorkerResponse",
+          "type": "object"
+        },
+        "WorkerRuntime": {
+          "additionalProperties": false,
+          "description": "Worker runtime.",
+          "properties": {
+            "arch": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported architecture.",
+              "title": "Arch"
+            },
+            "hostname": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported hostname.",
+              "title": "Hostname"
+            },
+            "kitaru_version": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Kitaru version.",
+              "title": "Kitaru Version"
+            },
+            "namespace": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Kubernetes namespace.",
+              "title": "Namespace"
+            },
+            "os": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported operating system.",
+              "title": "Os"
+            },
+            "platform": {
+              "description": "Runtime platform, e.g. kubernetes, docker, bare.",
+              "title": "Platform",
+              "type": "string"
+            },
+            "pod": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Kubernetes pod name.",
+              "title": "Pod"
+            },
+            "python_version": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Reported Python version.",
+              "title": "Python Version"
+            }
+          },
+          "required": [
+            "platform"
+          ],
+          "title": "WorkerRuntime",
+          "type": "object"
+        },
+        "WorkerScope": {
+          "additionalProperties": false,
+          "description": "Worker scope.",
+          "properties": {
+            "job_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Job the worker claims tasks from.",
+              "title": "Job Id"
+            },
+            "kinds": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/TaskKind"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Task kinds the worker claims.",
+              "title": "Kinds"
+            },
+            "selectors": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/$defs/LabelSelector"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Label selectors the worker claims, combined by conjunction.",
+              "title": "Selectors"
+            }
+          },
+          "title": "WorkerScope",
+          "type": "object"
         }
       },
       "additionalProperties": false,
@@ -1787,7 +2173,13 @@
               "$ref": "#/$defs/AgentResponse"
             },
             {
-              "$ref": "#/$defs/PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__"
+              "$ref": "#/$defs/TagResponse"
+            },
+            {
+              "$ref": "#/$defs/WorkerResponse"
+            },
+            {
+              "$ref": "#/$defs/PageData_Union_CohortResponse__ExperimentResponse__ImporterResponse__EvaluatorResponse__AgentVersionResponse__CohortVersionResponse__ImporterVersionResponse__EvaluatorVersionResponse__AgentResponse__TagResponse__WorkerResponse__"
             },
             {
               "type": "null"
@@ -5435,6 +5827,19 @@
               "title": "Add Session Ids",
               "type": "array"
             },
+            "baseline_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Baseline Id"
+            },
             "cohort_id": {
               "format": "uuid",
               "title": "Cohort Id",
@@ -7216,7 +7621,7 @@
       "openWorldHint": true,
       "readOnlyHint": false
     },
-    "description": "Create or update investigations, linked statuses, and annotations.",
+    "description": "Create or update investigations, annotations, tags, and tag links.",
     "inputSchema": {
       "$defs": {
         "AnnotationSelector": {
@@ -7540,6 +7945,7 @@
               "anyOf": [
                 {
                   "enum": [
+                    "pending",
                     "in_progress",
                     "completed"
                   ],
@@ -7635,6 +8041,101 @@
           ],
           "title": "SetInvestigationSessionVerdict",
           "type": "object"
+        },
+        "TagCreate": {
+          "additionalProperties": false,
+          "description": "Create a tag.",
+          "properties": {
+            "name": {
+              "minLength": 1,
+              "title": "Name",
+              "type": "string"
+            },
+            "operation": {
+              "const": "create_tag",
+              "title": "Operation",
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "name"
+          ],
+          "title": "TagCreate",
+          "type": "object"
+        },
+        "TagLink": {
+          "additionalProperties": false,
+          "description": "Link one tag to one exact resource.",
+          "properties": {
+            "operation": {
+              "const": "link_tag",
+              "title": "Operation",
+              "type": "string"
+            },
+            "resource_id": {
+              "format": "uuid",
+              "title": "Resource Id",
+              "type": "string"
+            },
+            "resource_type": {
+              "$ref": "#/$defs/TagResourceType"
+            },
+            "tag_id": {
+              "format": "uuid",
+              "title": "Tag Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "tag_id",
+            "resource_type",
+            "resource_id"
+          ],
+          "title": "TagLink",
+          "type": "object"
+        },
+        "TagResourceType": {
+          "description": "Resource kind a tag link points at.",
+          "enum": [
+            "session",
+            "cohort",
+            "cohort_version",
+            "agent_version",
+            "experiment",
+            "experiment_run"
+          ],
+          "title": "TagResourceType",
+          "type": "string"
+        },
+        "TagUpdate": {
+          "additionalProperties": false,
+          "description": "Rename one tag by exact UUID.",
+          "properties": {
+            "name": {
+              "minLength": 1,
+              "title": "Name",
+              "type": "string"
+            },
+            "operation": {
+              "const": "update_tag",
+              "title": "Operation",
+              "type": "string"
+            },
+            "tag_id": {
+              "format": "uuid",
+              "title": "Tag Id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "operation",
+            "tag_id",
+            "name"
+          ],
+          "title": "TagUpdate",
+          "type": "object"
         }
       },
       "properties": {
@@ -7644,9 +8145,12 @@
               "answer_question": "#/$defs/InvestigationAnswerCreate",
               "create_annotation": "#/$defs/ManualAnnotationCreate",
               "create_investigation": "#/$defs/InvestigationCreate",
+              "create_tag": "#/$defs/TagCreate",
+              "link_tag": "#/$defs/TagLink",
               "set_session_verdict": "#/$defs/SetInvestigationSessionVerdict",
               "update_annotation": "#/$defs/AnnotationUpdate",
-              "update_investigation": "#/$defs/InvestigationUpdate"
+              "update_investigation": "#/$defs/InvestigationUpdate",
+              "update_tag": "#/$defs/TagUpdate"
             },
             "propertyName": "operation"
           },
@@ -7668,6 +8172,15 @@
             },
             {
               "$ref": "#/$defs/AnnotationUpdate"
+            },
+            {
+              "$ref": "#/$defs/TagCreate"
+            },
+            {
+              "$ref": "#/$defs/TagUpdate"
+            },
+            {
+              "$ref": "#/$defs/TagLink"
             }
           ],
           "title": "Request"
@@ -8095,6 +8608,111 @@
           "title": "InvestigationStatus",
           "type": "string"
         },
+        "TagLinkResponse": {
+          "description": "Tag link response.",
+          "properties": {
+            "created": {
+              "description": "Creation time.",
+              "format": "date-time",
+              "title": "Created",
+              "type": "string"
+            },
+            "id": {
+              "description": "Tag link id.",
+              "format": "uuid",
+              "title": "Id",
+              "type": "string"
+            },
+            "resource_id": {
+              "description": "Resource tagged.",
+              "format": "uuid",
+              "title": "Resource Id",
+              "type": "string"
+            },
+            "resource_type": {
+              "$ref": "#/$defs/TagResourceType",
+              "description": "Kind of resource tagged."
+            },
+            "tag_id": {
+              "description": "Tag applied.",
+              "format": "uuid",
+              "title": "Tag Id",
+              "type": "string"
+            },
+            "updated": {
+              "description": "Last modification time.",
+              "format": "date-time",
+              "title": "Updated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "created",
+            "updated",
+            "id",
+            "tag_id",
+            "resource_type",
+            "resource_id"
+          ],
+          "title": "TagLinkResponse",
+          "type": "object"
+        },
+        "TagResourceType": {
+          "description": "Resource kind a tag link points at.",
+          "enum": [
+            "session",
+            "cohort",
+            "cohort_version",
+            "agent_version",
+            "experiment",
+            "experiment_run"
+          ],
+          "title": "TagResourceType",
+          "type": "string"
+        },
+        "TagResponse": {
+          "description": "Tag response.",
+          "properties": {
+            "created": {
+              "description": "Creation time.",
+              "format": "date-time",
+              "title": "Created",
+              "type": "string"
+            },
+            "id": {
+              "description": "Tag id.",
+              "format": "uuid",
+              "title": "Id",
+              "type": "string"
+            },
+            "name": {
+              "description": "Tag name.",
+              "title": "Name",
+              "type": "string"
+            },
+            "owner_id": {
+              "description": "Id of the owning account.",
+              "format": "uuid",
+              "title": "Owner Id",
+              "type": "string"
+            },
+            "updated": {
+              "description": "Last modification time.",
+              "format": "date-time",
+              "title": "Updated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "created",
+            "updated",
+            "owner_id",
+            "id",
+            "name"
+          ],
+          "title": "TagResponse",
+          "type": "object"
+        },
         "ToolError": {
           "additionalProperties": false,
           "description": "Stable, bounded error returned by a tool handler.",
@@ -8159,6 +8777,12 @@
             },
             {
               "$ref": "#/$defs/AnnotationResponse"
+            },
+            {
+              "$ref": "#/$defs/TagResponse"
+            },
+            {
+              "$ref": "#/$defs/TagLinkResponse"
             },
             {
               "type": "null"

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -7898,6 +7898,16 @@
           "title": "InvestigationSessionVerdict",
           "type": "string"
         },
+        "InvestigationStatus": {
+          "description": "Investigation status.",
+          "enum": [
+            "pending",
+            "in_progress",
+            "completed"
+          ],
+          "title": "InvestigationStatus",
+          "type": "string"
+        },
         "InvestigationUpdate": {
           "additionalProperties": false,
           "description": "Sparsely update investigation metadata.",
@@ -7944,19 +7954,13 @@
             "status": {
               "anyOf": [
                 {
-                  "enum": [
-                    "pending",
-                    "in_progress",
-                    "completed"
-                  ],
-                  "type": "string"
+                  "$ref": "#/$defs/InvestigationStatus"
                 },
                 {
                   "type": "null"
                 }
               ],
-              "default": null,
-              "title": "Status"
+              "default": null
             }
           },
           "required": [

--- a/tests/mcp/test_handlers_protocol.py
+++ b/tests/mcp/test_handlers_protocol.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import pytest
 from mcp.server import MCPServer, ServerRequestContext
@@ -15,8 +15,11 @@ from pydantic import ValidationError
 
 from kitaru.api_models.v1.agent import AgentResponse
 from kitaru.api_models.v1.base import Page
+from kitaru.api_models.v1.cohort import CohortResponse
 from kitaru.api_models.v1.investigation import InvestigationSessionResponse
 from kitaru.api_models.v1.session import SessionResponse
+from kitaru.api_models.v1.tag import TagResponse
+from kitaru.api_models.v1.worker import WorkerResponse, WorkerRuntime, WorkerScope
 from kitaru.mcp.lifecycle import MCPServerState
 from kitaru.mcp.models.activity import ActivityListRequest
 from kitaru.mcp.models.common import PageData
@@ -25,11 +28,17 @@ from kitaru.mcp.models.management import (
     CohortVersionCreate,
     ExperimentUpdate,
 )
+from kitaru.mcp.models.registry import (
+    RegistryGetWorkerRequest,
+    RegistryListRequest,
+    RegistryListVersionsRequest,
+)
 from kitaru.mcp.server import create_server
 from kitaru.mcp.settings import CapabilityMode, MCPSettings
 from kitaru.mcp.tools.activity import handle_activity_read
 from kitaru.mcp.tools.cohorts import handle_cohorts_manage
 from kitaru.mcp.tools.experiments import handle_experiments_manage
+from kitaru.mcp.tools.registry import handle_registry_read
 
 
 class UpdateClient:
@@ -115,6 +124,57 @@ class FakeClient:
         self.closed += 1
 
 
+class RegistryClient:
+    """Capture bounded tag, worker, and version registry reads."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+        self.tag = _get_tag()
+        self.worker = _get_worker()
+        self.tags = SimpleNamespace(list=self._list_tags)
+        self.workers = SimpleNamespace(list=self._list_workers, get=self._get_worker)
+        self.agents = SimpleNamespace(
+            get=self._get_agent_parent,
+            list_versions=self._list_agent_versions,
+        )
+        self.cohorts = SimpleNamespace(
+            get=self._get_cohort_parent,
+            list_versions=self._list_cohort_versions,
+        )
+
+    async def _list_tags(self, params: object) -> Page[TagResponse]:
+        self.calls.append(("list_tags", params))
+        return Page(items=[self.tag], next_cursor="tags-next")
+
+    async def _list_workers(self, params: object) -> Page[WorkerResponse]:
+        self.calls.append(("list_workers", params))
+        return Page(items=[self.worker], next_cursor="workers-next")
+
+    async def _get_worker(self, worker_id: uuid.UUID) -> WorkerResponse:
+        self.calls.append(("get_worker", worker_id))
+        return self.worker.model_copy(update={"id": worker_id})
+
+    async def _get_agent_parent(self, agent_id: uuid.UUID) -> AgentResponse:
+        self.calls.append(("get_agent", agent_id))
+        return _get_agent().model_copy(update={"id": agent_id})
+
+    async def _list_agent_versions(
+        self, agent_id: uuid.UUID, params: object
+    ) -> Page[AgentResponse]:
+        self.calls.append(("list_agent_versions", (agent_id, params)))
+        return Page(items=[], next_cursor=None)
+
+    async def _get_cohort_parent(self, cohort_id: uuid.UUID) -> CohortResponse:
+        self.calls.append(("get_cohort", cohort_id))
+        return _get_cohort().model_copy(update={"id": cohort_id})
+
+    async def _list_cohort_versions(
+        self, cohort_id: uuid.UUID, params: object
+    ) -> Page[CohortResponse]:
+        self.calls.append(("list_cohort_versions", (cohort_id, params)))
+        return Page(items=[], next_cursor=None)
+
+
 def _get_session(session_id: uuid.UUID | None = None) -> SessionResponse:
     now = datetime.now(UTC)
     return SessionResponse(
@@ -147,6 +207,21 @@ def _get_agent() -> AgentResponse:
     )
 
 
+def _get_cohort() -> CohortResponse:
+    now = datetime.now(UTC)
+    return CohortResponse(
+        id=uuid.uuid4(),
+        owner_id=uuid.uuid4(),
+        name="regression-cases",
+        description=None,
+        agent_id=uuid.uuid4(),
+        metadata={},
+        latest_version=1,
+        created=now,
+        updated=now,
+    )
+
+
 def _get_investigation_session() -> InvestigationSessionResponse:
     now = datetime.now(UTC)
     return InvestigationSessionResponse(
@@ -156,6 +231,33 @@ def _get_investigation_session() -> InvestigationSessionResponse:
         position=0,
         questions=[],
         verdict=None,
+        created=now,
+        updated=now,
+    )
+
+
+def _get_tag() -> TagResponse:
+    now = datetime.now(UTC)
+    return TagResponse(
+        id=uuid.uuid4(),
+        owner_id=uuid.uuid4(),
+        name="regression",
+        created=now,
+        updated=now,
+    )
+
+
+def _get_worker() -> WorkerResponse:
+    now = datetime.now(UTC)
+    return WorkerResponse(
+        id=uuid.uuid4(),
+        owner_id=uuid.uuid4(),
+        name="worker-a",
+        scope=WorkerScope(kinds=["agent"]),
+        runtime=WorkerRuntime(platform="docker", hostname="worker-a.local"),
+        last_seen_at=now,
+        live=True,
+        metadata={"region": "eu"},
         created=now,
         updated=now,
     )
@@ -194,6 +296,83 @@ async def test_activity_returns_exactly_one_page_and_preserves_cursor() -> None:
     assert result.page.size == 3
     assert result.page.next_cursor == "opaque"
     assert result.page.has_more is True
+
+
+@pytest.mark.parametrize("kind", ["tag", "worker"])
+async def test_registry_tag_and_worker_lists_make_one_bounded_call(kind: str) -> None:
+    client = RegistryClient()
+    result = cast(
+        PageData,
+        await handle_registry_read(
+            _get_state(cast(Any, client)),
+            RegistryListRequest(
+                operation="list",
+                kind=kind,
+                cursor="before",
+                size=3,
+                sort="name:asc",
+                filter={"field": "name", "op": "contains", "value": "reg"},
+            ),
+        ),
+    )
+
+    assert len(client.calls) == 1
+    call_name, params = client.calls[0]
+    assert call_name == f"list_{kind}s"
+    assert params.cursor == "before"
+    assert params.size == 3
+    assert params.sort == "name:asc"
+    assert params.filter is not None
+    assert params.filter.field == "name"
+    assert params.filter.op == "contains"
+    assert params.filter.value == "reg"
+    assert result.page.size == 3
+    assert result.page.has_more is True
+
+
+async def test_registry_worker_get_preserves_observation_fields() -> None:
+    client = RegistryClient()
+    worker_id = uuid.uuid4()
+
+    worker = await handle_registry_read(
+        _get_state(cast(Any, client)),
+        RegistryGetWorkerRequest(operation="get_worker", worker_id=worker_id),
+    )
+
+    assert client.calls == [("get_worker", worker_id)]
+    assert isinstance(worker, WorkerResponse)
+    assert worker.id == worker_id
+    assert worker.scope.kinds == ["agent"]
+    assert worker.runtime.platform == "docker"
+    assert worker.metadata == {"region": "eu"}
+    assert worker.last_seen_at == client.worker.last_seen_at
+    assert worker.live is True
+
+
+@pytest.mark.parametrize("kind", ["agent", "cohort"])
+async def test_registry_version_filter_is_forwarded_only_for_supported_kinds(
+    kind: Literal["agent", "cohort"],
+) -> None:
+    client = RegistryClient()
+    parent_id = uuid.uuid4()
+    request = RegistryListVersionsRequest(
+        operation="list_versions",
+        kind=kind,
+        parent_reference=str(parent_id),
+        filter={"field": "tags", "op": "contains", "value": "regression"},
+    )
+
+    await handle_registry_read(_get_state(cast(Any, client)), request)
+
+    _, (_, params) = client.calls[-1]
+    assert params.filter == request.filter
+    with pytest.raises(ValidationError, match="filter"):
+        RegistryListVersionsRequest(
+            operation="list_versions",
+            kind="importer",
+            parent_reference="importer-name",
+            filter=request.filter,
+        )
 
 
 async def test_public_sdk_serializes_non_empty_list_pages() -> None:
@@ -250,6 +429,35 @@ async def test_public_sdk_call_has_canonical_structured_text_parity() -> None:
     assert result.structured_content is not None
     assert json.loads(result.content[0].text) == result.structured_content
     assert result.structured_content["data"]["id"] == str(item_id)
+
+
+async def test_public_worker_get_has_canonical_structured_text_parity() -> None:
+    client = RegistryClient()
+    server, context = _get_context(cast(Any, client))
+    worker_id = uuid.uuid4()
+    result = await server.call_tool(
+        "kitaru_registry_read",
+        {
+            "request": {
+                "operation": "get_worker",
+                "worker_id": str(worker_id),
+            }
+        },
+        context,
+    )
+
+    assert isinstance(result, CallToolResult)
+    assert isinstance(result.content[0], TextContent)
+    assert result.is_error is False
+    assert result.structured_content is not None
+    assert json.loads(result.content[0].text) == result.structured_content
+    data = result.structured_content["data"]
+    assert data["id"] == str(worker_id)
+    assert data["scope"]["kinds"] == ["agent"]
+    assert data["runtime"]["platform"] == "docker"
+    assert data["metadata"] == {"region": "eu"}
+    assert datetime.fromisoformat(data["last_seen_at"]) == client.worker.last_seen_at
+    assert data["live"] is True
 
 
 async def test_remote_response_validation_is_not_reported_as_bad_arguments() -> None:

--- a/tests/mcp/test_handlers_protocol.py
+++ b/tests/mcp/test_handlers_protocol.py
@@ -38,7 +38,10 @@ class UpdateClient:
     def __init__(self) -> None:
         self.cohort_updates: list[object] = []
         self.experiment_updates: list[object] = []
-        self.cohorts = SimpleNamespace(update=self._update_cohort)
+        self.cohort_version_creates: list[object] = []
+        self.cohorts = SimpleNamespace(
+            update=self._update_cohort, create_version=self._create_cohort_version
+        )
         self.experiments = SimpleNamespace(update=self._update_experiment)
 
     async def _update_cohort(self, _item_id: uuid.UUID, request: object) -> object:
@@ -47,6 +50,12 @@ class UpdateClient:
 
     async def _update_experiment(self, _item_id: uuid.UUID, request: object) -> object:
         self.experiment_updates.append(request)
+        return SimpleNamespace()
+
+    async def _create_cohort_version(
+        self, _item_id: uuid.UUID, request: object
+    ) -> object:
+        self.cohort_version_creates.append(request)
         return SimpleNamespace()
 
 
@@ -388,3 +397,28 @@ async def test_clear_flags_forward_explicit_null_update_fields() -> None:
         "override": None,
         "tool_policy": None,
     }
+
+
+async def test_cohort_version_create_forwards_optional_baseline() -> None:
+    client = UpdateClient()
+    state = MCPServerState(MCPSettings(), cast(Any, client))
+    baseline_id = uuid.uuid4()
+
+    await handle_cohorts_manage(
+        state,
+        CohortVersionCreate(
+            operation="create_version",
+            cohort_id=uuid.uuid4(),
+            baseline_id=baseline_id,
+        ),
+    )
+    await handle_cohorts_manage(
+        state,
+        CohortVersionCreate(
+            operation="create_version",
+            cohort_id=uuid.uuid4(),
+        ),
+    )
+
+    assert cast(Any, client.cohort_version_creates[0]).baseline_id == baseline_id
+    assert cast(Any, client.cohort_version_creates[1]).baseline_id is None

--- a/tests/mcp/test_registry_runtime.py
+++ b/tests/mcp/test_registry_runtime.py
@@ -117,6 +117,35 @@ async def test_registry_schema_exposes_only_supported_tag_and_worker_reads() -> 
         assert f'"{unsupported}"' not in schema
 
 
+async def test_capability_schemas_place_tag_mutations_by_risk() -> None:
+    read_only = await create_server(
+        MCPSettings(mode=CapabilityMode.READ_ONLY)
+    ).list_tools()
+    standard = await create_server(
+        MCPSettings(mode=CapabilityMode.STANDARD)
+    ).list_tools()
+    destructive = await create_server(
+        MCPSettings(mode=CapabilityMode.DESTRUCTIVE)
+    ).list_tools()
+
+    assert "kitaru_review_manage" not in {tool.name for tool in read_only}
+    standard_by_name = {tool.name: tool for tool in standard}
+    assert "kitaru_delete" not in standard_by_name
+    review_schema = json.dumps(
+        standard_by_name["kitaru_review_manage"].input_schema, sort_keys=True
+    )
+    for operation in ("create_tag", "update_tag", "link_tag"):
+        assert f'"{operation}"' in review_schema
+
+    destructive_by_name = {tool.name: tool for tool in destructive}
+    delete_tool = destructive_by_name["kitaru_delete"]
+    assert delete_tool.annotations is not None
+    assert delete_tool.annotations.destructive_hint is True
+    delete_schema = json.dumps(delete_tool.input_schema, sort_keys=True)
+    assert '"tag"' in delete_schema
+    assert '"tag_link"' in delete_schema
+
+
 def test_success_and_error_structured_text_parity_and_redaction() -> None:
     now = datetime.now(UTC)
     agent = AgentResponse(

--- a/tests/mcp/test_registry_runtime.py
+++ b/tests/mcp/test_registry_runtime.py
@@ -103,6 +103,20 @@ async def test_activity_child_schema_exposes_only_kind_specific_fields() -> None
     assert "include_payloads" not in sorted_fields
 
 
+async def test_registry_schema_exposes_only_supported_tag_and_worker_reads() -> None:
+    tools = await create_server(MCPSettings()).list_tools()
+    registry = next(tool for tool in tools if tool.name == "kitaru_registry_read")
+    schema = json.dumps(registry.input_schema, sort_keys=True)
+
+    assert '"tag"' in schema
+    assert '"worker"' in schema
+    assert '"get_worker"' in schema
+    assert '"get_tag"' not in schema
+    assert '"list_tag_links"' not in schema
+    for unsupported in ("create_worker", "update_worker", "delete_worker"):
+        assert f'"{unsupported}"' not in schema
+
+
 def test_success_and_error_structured_text_parity_and_redaction() -> None:
     now = datetime.now(UTC)
     agent = AgentResponse(

--- a/tests/mcp/test_review_workflows.py
+++ b/tests/mcp/test_review_workflows.py
@@ -22,6 +22,7 @@ from kitaru.api_models.v1.evaluator import (
 from kitaru.api_models.v1.investigation import InvestigationSessionVerdict
 from kitaru.api_models.v1.job import JobResponse
 from kitaru.api_models.v1.plugin import PackagePluginSource
+from kitaru.client.exceptions import APIError
 from kitaru.mcp.errors import MCPToolError
 from kitaru.mcp.lifecycle import MCPServerState
 from kitaru.mcp.models.common import PageData
@@ -207,10 +208,28 @@ async def test_review_annotation_list_routes_to_annotations() -> None:
     assert result.page.size == 3
 
 
-def test_review_management_rejects_noop_and_unknown_verdict() -> None:
+@pytest.mark.parametrize("status", ["pending", "in_progress", "completed"])
+def test_review_management_accepts_every_investigation_status(status: str) -> None:
+    request = InvestigationUpdate.model_validate(
+        {
+            "operation": "update_investigation",
+            "investigation_id": uuid.uuid4(),
+            "status": status,
+        }
+    )
+    assert request.status == status
+
+
+def test_review_management_rejects_noop_null_status_and_unknown_verdict() -> None:
     with pytest.raises(ValidationError, match="change at least one"):
         InvestigationUpdate(
             operation="update_investigation", investigation_id=uuid.uuid4()
+        )
+    with pytest.raises(ValidationError, match="status cannot be null"):
+        InvestigationUpdate(
+            operation="update_investigation",
+            investigation_id=uuid.uuid4(),
+            status=None,
         )
     adapter = TypeAdapter(ReviewManageRequest)
     with pytest.raises(ValidationError):
@@ -270,6 +289,14 @@ async def test_review_clear_and_verdict_forward_typed_sparse_dtos() -> None:
     )
     await handle_review_manage(
         _get_state(client),
+        InvestigationUpdate(
+            operation="update_investigation",
+            investigation_id=uuid.uuid4(),
+            status="pending",
+        ),
+    )
+    await handle_review_manage(
+        _get_state(client),
         SetInvestigationSessionVerdict(
             operation="set_session_verdict",
             investigation_id=uuid.uuid4(),
@@ -281,9 +308,30 @@ async def test_review_clear_and_verdict_forward_typed_sparse_dtos() -> None:
     assert cast(Any, updates[1]).model_dump(exclude_unset=True) == {
         "status": "completed"
     }
+    assert cast(Any, updates[2]).model_dump(exclude_unset=True) == {"status": "pending"}
     assert cast(Any, session_updates[0]).model_dump(mode="json") == {
         "verdict": "acceptable"
     }
+
+
+async def test_investigation_pending_preserves_downstream_transition_error() -> None:
+    error = APIError(409, "Cannot move a completed investigation to pending.")
+
+    async def update(_id: uuid.UUID, _request: object) -> object:
+        raise error
+
+    client = SimpleNamespace(investigations=SimpleNamespace(update=update))
+    with pytest.raises(APIError) as raised:
+        await handle_review_manage(
+            _get_state(client),
+            InvestigationUpdate(
+                operation="update_investigation",
+                investigation_id=uuid.uuid4(),
+                status="pending",
+            ),
+        )
+
+    assert raised.value is error
 
 
 async def test_review_creates_and_updates_forward_typed_sdk_dtos() -> None:

--- a/tests/mcp/test_review_workflows.py
+++ b/tests/mcp/test_review_workflows.py
@@ -302,14 +302,6 @@ async def test_review_clear_and_verdict_forward_typed_sparse_dtos() -> None:
     )
     await handle_review_manage(
         _get_state(client),
-        InvestigationUpdate(
-            operation="update_investigation",
-            investigation_id=uuid.uuid4(),
-            status="pending",
-        ),
-    )
-    await handle_review_manage(
-        _get_state(client),
         SetInvestigationSessionVerdict(
             operation="set_session_verdict",
             investigation_id=uuid.uuid4(),
@@ -321,7 +313,6 @@ async def test_review_clear_and_verdict_forward_typed_sparse_dtos() -> None:
     assert cast(Any, updates[1]).model_dump(exclude_unset=True) == {
         "status": "completed"
     }
-    assert cast(Any, updates[2]).model_dump(exclude_unset=True) == {"status": "pending"}
     assert cast(Any, session_updates[0]).model_dump(mode="json") == {
         "verdict": "acceptable"
     }

--- a/tests/mcp/test_review_workflows.py
+++ b/tests/mcp/test_review_workflows.py
@@ -22,6 +22,14 @@ from kitaru.api_models.v1.evaluator import (
 from kitaru.api_models.v1.investigation import InvestigationSessionVerdict
 from kitaru.api_models.v1.job import JobResponse
 from kitaru.api_models.v1.plugin import PackagePluginSource
+from kitaru.api_models.v1.tag import (
+    TagCreateRequest,
+    TagLinkCreateRequest,
+    TagLinkResponse,
+    TagResourceType,
+    TagResponse,
+    TagUpdateRequest,
+)
 from kitaru.client.exceptions import APIError
 from kitaru.mcp.errors import MCPToolError
 from kitaru.mcp.lifecycle import MCPServerState
@@ -44,11 +52,16 @@ from kitaru.mcp.models.review import (
     ReviewListSessions,
     ReviewManageRequest,
     SetInvestigationSessionVerdict,
+    TagCreate,
+    TagLink,
+    TagUpdate,
 )
 from kitaru.mcp.models.workflows import (
     DeleteRequest,
     EvaluationStart,
     ExperimentRunStart,
+    ResourceDelete,
+    TagLinkDelete,
 )
 from kitaru.mcp.server import create_server
 from kitaru.mcp.settings import CapabilityMode, MCPSettings
@@ -414,6 +427,178 @@ async def test_review_creates_and_updates_forward_typed_sdk_dtos() -> None:
         == "root-cause"
     )
     assert cast(Any, annotation_updates[0]).model_dump(mode="json") == {"value": True}
+
+
+async def test_review_tag_mutations_forward_typed_sdk_dtos() -> None:
+    calls: list[tuple[str, object, object | None]] = []
+    now = datetime.now(UTC)
+    tag_id = uuid.uuid4()
+    resource_id = uuid.uuid4()
+    tag = TagResponse(
+        id=tag_id,
+        owner_id=uuid.uuid4(),
+        name="regression",
+        created=now,
+        updated=now,
+    )
+    link = TagLinkResponse(
+        id=uuid.uuid4(),
+        tag_id=tag_id,
+        resource_type=TagResourceType.SESSION,
+        resource_id=resource_id,
+        created=now,
+        updated=now,
+    )
+
+    async def create(request: TagCreateRequest) -> TagResponse:
+        calls.append(("create", request, None))
+        return tag
+
+    async def update(
+        received_tag_id: uuid.UUID, request: TagUpdateRequest
+    ) -> TagResponse:
+        calls.append(("update", received_tag_id, request))
+        return tag
+
+    async def create_link(
+        received_tag_id: uuid.UUID, request: TagLinkCreateRequest
+    ) -> TagLinkResponse:
+        calls.append(("link", received_tag_id, request))
+        return link
+
+    state = _get_state(
+        SimpleNamespace(
+            tags=SimpleNamespace(create=create, update=update, create_link=create_link)
+        )
+    )
+    assert (
+        await handle_review_manage(
+            state, TagCreate(operation="create_tag", name="regression")
+        )
+        is tag
+    )
+    assert (
+        await handle_review_manage(
+            state,
+            TagUpdate(operation="update_tag", tag_id=tag_id, name="known-failure"),
+        )
+        is tag
+    )
+    assert (
+        await handle_review_manage(
+            state,
+            TagLink(
+                operation="link_tag",
+                tag_id=tag_id,
+                resource_type=TagResourceType.SESSION,
+                resource_id=resource_id,
+            ),
+        )
+        is link
+    )
+
+    assert isinstance(calls[0][1], TagCreateRequest)
+    assert calls[0][1].model_dump() == {"name": "regression"}
+    assert calls[1][1] == tag_id
+    assert isinstance(calls[1][2], TagUpdateRequest)
+    assert calls[1][2].model_dump() == {"name": "known-failure"}
+    assert calls[2][1] == tag_id
+    assert isinstance(calls[2][2], TagLinkCreateRequest)
+    assert calls[2][2].model_dump(mode="json") == {
+        "resource_type": "session",
+        "resource_id": str(resource_id),
+    }
+
+
+async def test_review_tag_create_has_typed_protocol_result() -> None:
+    now = datetime.now(UTC)
+    tag = TagResponse(
+        id=uuid.uuid4(),
+        owner_id=uuid.uuid4(),
+        name="regression",
+        created=now,
+        updated=now,
+    )
+
+    async def create(request: TagCreateRequest) -> TagResponse:
+        assert isinstance(request, TagCreateRequest)
+        return tag
+
+    server, context = _get_context(
+        SimpleNamespace(tags=SimpleNamespace(create=create)), CapabilityMode.STANDARD
+    )
+    result = await server.call_tool(
+        "kitaru_review_manage",
+        {"request": {"operation": "create_tag", "name": "regression"}},
+        context,
+    )
+
+    assert isinstance(result, CallToolResult)
+    assert result.is_error is False
+    assert result.structured_content is not None
+    assert result.structured_content["data"]["id"] == str(tag.id)
+    assert json.loads(cast(TextContent, result.content[0]).text) == (
+        result.structured_content
+    )
+
+
+@pytest.mark.parametrize(
+    ("status_code", "code", "message"),
+    [
+        (409, "conflict", "conflicts with current remote state"),
+        (404, "not_found", "was not found"),
+    ],
+)
+async def test_review_tag_api_errors_use_redacted_protocol_envelope(
+    status_code: int, code: str, message: str
+) -> None:
+    async def create(_request: TagCreateRequest) -> TagResponse:
+        raise APIError(status_code, "Bearer sensitive-token")
+
+    server, context = _get_context(
+        SimpleNamespace(tags=SimpleNamespace(create=create)), CapabilityMode.STANDARD
+    )
+    result = await server.call_tool(
+        "kitaru_review_manage",
+        {"request": {"operation": "create_tag", "name": "regression"}},
+        context,
+    )
+
+    assert isinstance(result, CallToolResult)
+    assert result.is_error is True
+    assert result.structured_content is not None
+    assert result.structured_content["error"]["code"] == code
+    assert message in result.structured_content["error"]["message"]
+    assert "sensitive-token" not in cast(TextContent, result.content[0]).text
+
+
+@pytest.mark.parametrize("resource_type", list(TagResourceType))
+def test_tag_link_accepts_every_public_resource_type(
+    resource_type: TagResourceType,
+) -> None:
+    request = TypeAdapter(ReviewManageRequest).validate_python(
+        {
+            "operation": "link_tag",
+            "tag_id": uuid.uuid4(),
+            "resource_type": resource_type.value,
+            "resource_id": uuid.uuid4(),
+        }
+    )
+    assert isinstance(request, TagLink)
+    assert request.resource_type is resource_type
+
+
+def test_tag_mutations_reject_unknown_resource_type_before_handler() -> None:
+    adapter = TypeAdapter(ReviewManageRequest)
+    with pytest.raises(ValidationError):
+        adapter.validate_python(
+            {
+                "operation": "link_tag",
+                "tag_id": uuid.uuid4(),
+                "resource_type": "worker",
+                "resource_id": uuid.uuid4(),
+            }
+        )
 
 
 def test_evaluation_start_caps_pairs_and_rejects_duplicates() -> None:
@@ -872,8 +1057,19 @@ async def test_script_evaluator_version_rejects_mismatched_blob() -> None:
     assert create_calls == []
 
 
-@pytest.mark.parametrize("kind", ["investigation", "annotation", "evaluator"])
-async def test_delete_supports_new_exact_resources(kind: str) -> None:
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "cohort",
+        "cohort_version",
+        "experiment",
+        "experiment_run",
+        "investigation",
+        "annotation",
+        "evaluator",
+    ],
+)
+async def test_existing_delete_payloads_keep_exact_resource_behavior(kind: str) -> None:
     deleted: list[tuple[str, uuid.UUID]] = []
 
     def delete_resource(resource: str) -> Any:
@@ -883,6 +1079,10 @@ async def test_delete_supports_new_exact_resources(kind: str) -> None:
         return delete
 
     client = SimpleNamespace(
+        cohorts=SimpleNamespace(delete=delete_resource("cohort")),
+        cohort_versions=SimpleNamespace(delete=delete_resource("cohort_version")),
+        experiments=SimpleNamespace(delete=delete_resource("experiment")),
+        experiment_runs=SimpleNamespace(delete=delete_resource("experiment_run")),
         investigations=SimpleNamespace(delete=delete_resource("investigation")),
         annotations=SimpleNamespace(delete=delete_resource("annotation")),
         evaluators=SimpleNamespace(delete=delete_resource("evaluator")),
@@ -892,8 +1092,69 @@ async def test_delete_supports_new_exact_resources(kind: str) -> None:
         dict[str, Any],
         await handle_delete(
             _get_state(client),
-            DeleteRequest(kind=cast(Any, kind), id=item_id),
+            ResourceDelete(kind=cast(Any, kind), id=item_id),
         ),
     )
     assert deleted == [(kind, item_id)]
     assert result == {"kind": kind, "id": str(item_id), "deleted": True}
+
+
+async def test_delete_supports_tag_and_exact_tag_link_receipts() -> None:
+    calls: list[tuple[object, ...]] = []
+    tag_id = uuid.uuid4()
+    resource_id = uuid.uuid4()
+
+    async def delete(received_tag_id: uuid.UUID) -> None:
+        calls.append(("tag", received_tag_id))
+
+    async def delete_link(
+        received_tag_id: uuid.UUID,
+        resource_type: TagResourceType,
+        received_resource_id: uuid.UUID,
+    ) -> None:
+        calls.append(("tag_link", received_tag_id, resource_type, received_resource_id))
+
+    state = _get_state(
+        SimpleNamespace(tags=SimpleNamespace(delete=delete, delete_link=delete_link))
+    )
+    deleted = await handle_delete(state, ResourceDelete(kind="tag", id=tag_id))
+    unlinked = await handle_delete(
+        state,
+        TagLinkDelete(
+            kind="tag_link",
+            tag_id=tag_id,
+            resource_type=TagResourceType.COHORT_VERSION,
+            resource_id=resource_id,
+        ),
+    )
+
+    assert calls == [
+        ("tag", tag_id),
+        ("tag_link", tag_id, TagResourceType.COHORT_VERSION, resource_id),
+    ]
+    assert deleted == {"kind": "tag", "id": str(tag_id), "deleted": True}
+    assert unlinked == {
+        "kind": "tag_link",
+        "tag_id": str(tag_id),
+        "resource_type": "cohort_version",
+        "resource_id": str(resource_id),
+        "deleted": True,
+    }
+
+
+def test_tag_link_delete_requires_exact_valid_tuple() -> None:
+    adapter = TypeAdapter(DeleteRequest)
+    base = {
+        "kind": "tag_link",
+        "tag_id": uuid.uuid4(),
+        "resource_type": "session",
+        "resource_id": uuid.uuid4(),
+    }
+    assert isinstance(adapter.validate_python(base), TagLinkDelete)
+    for field in ("tag_id", "resource_type", "resource_id"):
+        with pytest.raises(ValidationError):
+            adapter.validate_python(
+                {key: value for key, value in base.items() if key != field}
+            )
+    with pytest.raises(ValidationError):
+        adapter.validate_python({**base, "resource_type": "worker"})


### PR DESCRIPTION
## What changed?

Kitaru's operator interfaces now represent the missing public concepts without changing the server contract. The CLI can create, list, and inspect standalone replays, and cohort version creation accepts an exact baseline version. MCP clients can read tags and worker liveness, manage the tag lifecycle, branch cohort versions from a baseline, and move investigations into `pending`.

The MCP inventory remains fixed at 3 read-only, 9 standard, and 11 destructive tools. The new operations extend the existing typed tools instead of adding tool names. Documentation and MCP schema snapshots describe the new commands, capability modes, retry risks, tag cascade behavior, and worker-data limitations.

## Why?

The REST client exposed these concepts, but the CLI and MCP server had drifted behind it. Operators and agents had to leave their chosen interface for standalone replay work, tag operations, worker visibility, and two existing workflow fields.

This PR closes those gaps using only CLI, MCP, tests, documentation, and changelog changes. It does not modify the server, API models, client, worker, adapters, OpenAPI, or scripts.

## Reviewer Notes

Start with `kitaru schema replay --output json` and `kitaru replay create --help`. Replay creation is intentionally non-idempotent: an ambiguous retry can create another replay and job, so the CLI and docs direct users to list replays before retrying. If no tool policy is supplied, the server default applies and may permit live tool execution.

For MCP, inspect the request unions behind `kitaru_registry_read`, `kitaru_review_manage`, and `kitaru_delete`. Tags and workers extend registry reads; tag create/update/link use standard mode; tag delete/unlink remain destructive. Existing `{kind, id}` delete payloads are unchanged.

The structured Compound Engineering review completed with eight lenses, including an independent cross-model adversarial pass. Its one validated finding, a misleading empty-delta warning when branching a cohort from an older baseline, was fixed and covered before this PR was opened.

## Reproduction

```bash
uv run --extra cli kitaru schema replay --output json
uv run --extra cli kitaru replay create --help
just mcp-schema-check
```

The replay schema should contain `create`, `list`, and `get`, with structured output metadata and the server-default/live-tools warning. The MCP report should retain the 3/9/11 tool inventory and stay below its schema budgets while exposing tag and worker request variants.

For focused behavior verification:

```bash
uv run pytest \
  tests/cli/test_cohorts.py \
  tests/cli/test_replays.py \
  tests/cli/test_schema.py \
  tests/mcp/test_handlers_protocol.py \
  tests/mcp/test_review_workflows.py \
  tests/mcp/test_registry_runtime.py \
  tests/mcp/test_schema_budget.py
```

Expected result: 108 tests pass.

## Local checks run

- `uv run pytest ...` for the focused CLI/MCP suite: 108 passed.
- `just mcp-schema-check`: passed; inventory 3/9/11, largest tool 33,543 bytes, destructive discovery 150,988 bytes.
- `just cli-artifact-smoke`: passed.
- `just docs-build`: passed; 156 documentation pages materialized.
- Tracked Python files passed Ruff check and format check. `just typecheck` passed.
- Full pytest run: 3,452 passed, 2 skipped, 10 unrelated failures in existing server analytics/error-handler tests and the TypeScript Mastra example under local Node 26 instead of its required Node 22.
- `just check` is blocked only by pre-existing untracked example files with Ruff errors. `just docs-validate` is unavailable because `docs/package.json` has no `validate:export` script.

## Post-Deploy Monitoring & Validation

- During the first release containing this change, the owning Kitaru engineer should check CLI replay command failures, MCP schema/startup errors, and API 4xx/5xx responses for replay, tag, and worker operations.
- Healthy behavior is successful replay create/list/get, typed tag mutations, worker reads with liveness data, and unchanged MCP inventory and schema budgets.
- Roll back this PR if existing MCP delete payloads stop validating, the fixed tool inventory changes, or the new CLI commands fail against the current server API.
