### PR TITLE
Add Langfuse root unwrapping

### DIFF
--- a/docs/book/guides/import-langfuse-traces.md
+++ b/docs/book/guides/import-langfuse-traces.md
@@ -50,6 +50,18 @@ The Langfuse importer parses **Langfuse JSONL exports** — up to 50 MiB per pay
 | --- | --- |
 | `source_instance` | The Langfuse project the export came from. Optional when the export itself carries project ids; required when it doesn't — it anchors the sessions' external identity. |
 | `filename` | Optional label used as a fallback source name. |
+| `unwrap_root_names` | Optional array of root observation names to omit from the node tree. Their children become roots, while their input, output, status, and timing continue to define the session turn. Roots without children remain in the tree. |
+
+Use `unwrap_root_names` when instrumentation adds a wrapper around a complete agent run and that wrapper duplicates the run node in Kitaru:
+
+```bash
+kitaru session import langfuse-export.jsonl \
+  --importer kitaru/langfuse@latest \
+  --agent support-agent@latest \
+  --params '{"source_instance":"my-langfuse-project","unwrap_root_names":["resolve-ticket"]}' \
+  --media-type application/x-ndjson \
+  --wait
+```
 
 Import in slices as often as you like — dedup makes it safe.
 

--- a/examples/pydantic_ai_ticket_resolver/README.md
+++ b/examples/pydantic_ai_ticket_resolver/README.md
@@ -130,7 +130,7 @@ uv run kitaru session import \
   --importer kitaru/langfuse@latest \
   --agent returns-resolver@1 \
   --tag returns-baseline \
-  --params '{"source_instance":"canonical-returns-example"}' \
+  --params '{"source_instance":"canonical-returns-example","unwrap_root_names":["resolve-ticket"]}' \
   --media-type application/x-ndjson \
   --wait
 ```

--- a/plugins/default-requirements.txt
+++ b/plugins/default-requirements.txt
@@ -1,5 +1,5 @@
 kitaru-braintrust-importer==0.1.0rc0
 kitaru-evaluator==0.1.0rc0
 kitaru-jsonl-importer==0.1.0rc0
-kitaru-langfuse-importer==0.1.0rc0
+kitaru-langfuse-importer==0.1.0rc1
 kitaru-langsmith-importer==0.1.0rc0

--- a/plugins/packages/langfuse-importer/CHANGELOG.md
+++ b/plugins/packages/langfuse-importer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.0rc1
+
+- Add opt-in unwrapping for named root observations.
+
 ## 0.1.0rc0
 
 - Initial release candidate for the Langfuse trace importer.

--- a/plugins/packages/langfuse-importer/pyproject.toml
+++ b/plugins/packages/langfuse-importer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru-langfuse-importer"
-version = "0.1.0rc0"
+version = "0.1.0rc1"
 description = "Langfuse trace importer for Kitaru."
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
+++ b/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
@@ -572,6 +572,18 @@ def _join_value(
     return next(iter(values)), selector, False
 
 
+def _get_unwrap_root_names(params: dict[str, Any]) -> set[str]:
+    """Return validated observation names whose trace roots should be omitted."""
+    value = params.get("unwrap_root_names")
+    if value is None:
+        return set()
+    if not isinstance(value, list):
+        raise InvalidImport("unwrap_root_names must be an array of strings")
+    if any(not isinstance(item, str) or not item.strip() for item in value):
+        raise InvalidImport("unwrap_root_names must contain only non-empty strings")
+    return {item.strip() for item in value}
+
+
 def _metadata_value(record: dict[str, Any], *keys: str) -> Any:
     """Return the first non-empty value from Langfuse metadata layers."""
     metadata = _dict(record.get("metadata"))
@@ -994,6 +1006,8 @@ class LangfuseJSONLImporter:
         warnings: list[str] = []
         if trace_fallback:
             warnings.append("No Langfuse session id found; grouped by trace id")
+        unwrap_root_names = _get_unwrap_root_names(params)
+        unwrapped_root_names: set[str] = set()
         raw_nodes: list[tuple[str, str | None, dict[str, Any]]] = []
         turns: list[_Turn] = []
         trace_names: list[str] = []
@@ -1025,6 +1039,23 @@ class LangfuseJSONLImporter:
                 )
             root = roots[0] if roots else (ordered[0] if ordered else {})
             root_by_trace[trace_id] = root
+            child_counts: dict[str, int] = defaultdict(int)
+            for record in ordered:
+                parent = _first(record, "parentObservationId", "parent_observation_id")
+                if parent is not None:
+                    child_counts[str(parent)] += 1
+            unwrapped_root_ids = {
+                str(candidate["id"])
+                for candidate in roots
+                if candidate.get("id") is not None
+                and str(candidate.get("name") or "") in unwrap_root_names
+                and child_counts[str(candidate["id"])] > 0
+            }
+            unwrapped_root_names.update(
+                str(candidate.get("name"))
+                for candidate in roots
+                if str(candidate.get("id") or "") in unwrapped_root_ids
+            )
             turn_input = _decode_json(_first(root, "traceInput", "input"))
             turn_output = _decode_json(_first(root, "traceOutput", "output"))
             trace_start = min(
@@ -1061,12 +1092,20 @@ class LangfuseJSONLImporter:
                     raise InvalidImport(
                         f"Trace '{trace_id}' contains an observation without an id"
                     )
+                if observation_id in unwrapped_root_ids:
+                    continue
                 parent = _first(record, "parentObservationId", "parent_observation_id")
                 parent_id = str(parent) if parent is not None else None
                 parent_source_id = (
-                    f"{trace_id}:{parent_id}" if parent_id in ids else None
+                    f"{trace_id}:{parent_id}"
+                    if parent_id in ids and parent_id not in unwrapped_root_ids
+                    else None
                 )
-                if parent and parent_source_id is None:
+                if (
+                    parent
+                    and parent_source_id is None
+                    and parent_id not in unwrapped_root_ids
+                ):
                     warnings.append(
                         f"Observation '{observation_id}' references a missing parent"
                     )
@@ -1190,6 +1229,7 @@ class LangfuseJSONLImporter:
             "langfuse.session_id": source_id,
             "langfuse.trace_ids": [turn.trace_id for turn in turns],
             "langfuse.join_paths": sorted(join_paths),
+            "langfuse.unwrapped_root_names": sorted(unwrapped_root_names),
             "langfuse.environments": sorted(
                 {
                     str(value)

--- a/plugins/tests/importers/test_langfuse.py
+++ b/plugins/tests/importers/test_langfuse.py
@@ -254,6 +254,67 @@ def test_imports_multiturn_observations() -> None:
     assert nodes["trace-2:tool-1"].tool_name == "weather"
 
 
+def test_unwraps_named_root_observations() -> None:
+    """Promote children while retaining session data from an omitted root."""
+    parsed = sessions(
+        jsonl(
+            observation(
+                "wrapper",
+                "trace-1",
+                input_={"message": "hello"},
+                output={"answer": "done"},
+                name="resolve-ticket",
+                level="ERROR",
+                statusMessage="wrapper failed",
+            ),
+            observation(
+                "agent",
+                "trace-1",
+                parent_id="wrapper",
+                name="agent run",
+            ),
+            observation(
+                "generation",
+                "trace-1",
+                parent_id="agent",
+                observation_type="GENERATION",
+            ),
+        ),
+        {"unwrap_root_names": ["resolve-ticket"]},
+    )
+
+    assert len(parsed) == 1
+    session = parsed[0]
+    assert session.inputs["turns"][0]["inputs"] == {"message": "hello"}
+    assert session.outputs == {"answer": "done"}
+    assert session.status is SessionStatus.FAILED
+    assert session.error == "wrapper failed"
+    assert [node.name for node in session.nodes] == ["agent run"]
+    assert [node.name for node in session.nodes[0].children] == ["generation"]
+    assert session.metadata["langfuse.unwrapped_root_names"] == ["resolve-ticket"]
+
+
+def test_rejects_invalid_unwrap_root_names() -> None:
+    """Require unwrap_root_names to contain non-empty strings."""
+    content = jsonl(observation("root", "trace-1"))
+
+    parsed_failures = failures(content, {"unwrap_root_names": "root"})
+
+    assert len(parsed_failures) == 1
+    assert "unwrap_root_names must be an array" in parsed_failures[0].error
+
+
+def test_retains_named_root_without_children() -> None:
+    """Keep a matched root when it has no children to promote."""
+    parsed = sessions(
+        jsonl(observation("root", "trace-1", name="resolve-ticket")),
+        {"unwrap_root_names": ["resolve-ticket"]},
+    )
+
+    assert [node.name for node in parsed[0].nodes] == ["resolve-ticket"]
+    assert parsed[0].metadata["langfuse.unwrapped_root_names"] == []
+
+
 def test_trace_without_session_id_becomes_one_turn_session() -> None:
     """Use a trace id when Langfuse has no session id."""
     parsed = sessions(

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -1025,7 +1025,7 @@ requires-dist = [{ name = "kitaru", editable = "../" }]
 
 [[package]]
 name = "kitaru-langfuse-importer"
-version = "0.1.0rc0"
+version = "0.1.0rc1"
 source = { editable = "packages/langfuse-importer" }
 dependencies = [
     { name = "kitaru" },

--- a/src/kitaru/server/api/bootstrap.py
+++ b/src/kitaru/server/api/bootstrap.py
@@ -116,8 +116,8 @@ DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = (
         description="Import Langfuse JSON and JSONL trace exports.",
         provider="langfuse",
         entrypoint="kitaru_langfuse_importer.importer:parse",
-        requirement="kitaru-langfuse-importer==0.1.0rc0",
-        display_version="0.1.0rc0",
+        requirement="kitaru-langfuse-importer==0.1.0rc1",
+        display_version="0.1.0rc1",
     ),
     DefaultPluginDefinition(
         kind=PluginKind.IMPORTER,


### PR DESCRIPTION
## Summary

- add an opt-in `unwrap_root_names` parameter to the Langfuse importer
- promote children of matching root observations while preserving session-level input, output, status, error, and timing
- record applied root names in session metadata and retain matching roots that have no children
- update the ticket resolver example, importer documentation, tests, and plugin version metadata

## Why

Framework instrumentation can add a wrapper observation around a complete agent run. Importing both the wrapper and the framework's agent-run span produces a redundant level in Kitaru's node tree.

## Reviewer Notes

The behavior is opt-in and matches roots by exact observation name. A named root is omitted only when it has at least one child. Session data continues to come from the original source root.

### Reproduction

Run:

```bash
uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests/importers/test_langfuse.py
```

Then import the ticket resolver fixture with:

```json
{"source_instance":"canonical-returns-example","unwrap_root_names":["resolve-ticket"]}
```

Each imported session should have `agent run` as its root while retaining the `resolve-ticket` input and output at the session level.

Validation completed locally:

- 26 Langfuse importer tests
- 374 plugin and default-plugin tests
- Ruff formatting and lint
- Ty type checking
- plugin artifact smoke
- offline documentation link check
