### PR TITLE
Fix API prefix release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,16 @@ jobs:
         run: uv sync --frozen
         env:
           UV_FIND_LINKS: ${{ github.workspace }}/plugins/candidate-wheels
+      - name: Install candidate artifacts in standalone example
+        working-directory: examples/pydantic_ai_ticket_resolver
+        run: >-
+          uv pip install
+          --python .venv/bin/python
+          --reinstall
+          --no-deps
+          ../../plugins/candidate-wheels/kitaru-*.whl
+          ../../plugins/candidate-wheels/kitaru_pydantic_ai-*.whl
+          ../../plugins/candidate-wheels/kitaru_langfuse_importer-*.whl
       - name: Start local Kitaru server
         run: |
           uv run uvicorn kitaru.server.api.main:app --factory --host 127.0.0.1 --port 8000 >"$RUNNER_TEMP/kitaru-server.log" 2>&1 &
@@ -243,10 +253,10 @@ jobs:
         run: uv run --with pyyaml python scripts/audit-example-coverage.py
       - name: Test canonical example contracts
         working-directory: examples/pydantic_ai_ticket_resolver
-        run: uv run --frozen --with pytest python -m pytest -q tests/test_contract.py
+        run: uv run --no-sync --with pytest python -m pytest -q tests/test_contract.py
       - name: Run canonical example end to end
         working-directory: examples/pydantic_ai_ticket_resolver
-        run: uv run --frozen --with pytest python -m pytest -q tests/test_e2e.py
+        run: uv run --no-sync --with pytest python -m pytest -q tests/test_e2e.py
         env:
           KITARU_CANONICAL_E2E: '1'
           KITARU_CANONICAL_SERVER_URL: http://127.0.0.1:8000

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -92,6 +92,7 @@ jobs:
             exit 1
           fi
       - run: pnpm install --frozen-lockfile
+      - run: pnpm run generate:check
       - run: pnpm run lint
       - run: pnpm run typecheck
       - run: pnpm run test:built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Worker plugin subprocesses now resolve their dependencies outside the worker's current project, preventing a task from resynchronizing or mutating the host project environment.
 - Fetching a pending device authorization by id now succeeds when the request carries the device's user code, so the device verification page can render before an account approves it.
 - Fixed TypeScript replay and recording edge cases, aligned credential redaction and provider diagnostics across adapters, and made the adapter examples reproducible, rerunnable, and part of CI.
 - TypeScript cloud examples now reuse CLI logins without exporting a token, verify dedicated-worker access before creating remote resources, isolate exact-job recovery state, and stop when a mutation or cancellation cannot be journaled safely.

--- a/packages/core/test/resources/lifecycle.test.ts
+++ b/packages/core/test/resources/lifecycle.test.ts
@@ -168,7 +168,10 @@ describe("execution lifecycle resources", () => {
         `https://api.example/api/v1/experiment-runs/${RELATED_ID}/jobs?size=10`,
         "GET",
       ],
-      [`https://api.example/api/v1/experiment-runs/${RELATED_ID}/cancel`, "POST"],
+      [
+        `https://api.example/api/v1/experiment-runs/${RELATED_ID}/cancel`,
+        "POST",
+      ],
       [`https://api.example/api/v1/experiment-runs/${RELATED_ID}`, "DELETE"],
       [`https://api.example/api/v1/experiments/${ID}`, "DELETE"],
     ]);

--- a/packages/core/test/resources/management.test.ts
+++ b/packages/core/test/resources/management.test.ts
@@ -180,7 +180,10 @@ describe("management resources", () => {
         `https://api.example/api/v1/investigations?filter=${encodeURIComponent(JSON.stringify({ field: "status", op: "eq", value: "pending" }))}`,
         "GET",
       ],
-      [`https://api.example/api/v1/investigations/${ID}/sessions?size=1`, "GET"],
+      [
+        `https://api.example/api/v1/investigations/${ID}/sessions?size=1`,
+        "GET",
+      ],
       [
         `https://api.example/api/v1/investigations/${ID}/sessions?cursor=next&size=1`,
         "GET",

--- a/src/kitaru/worker/process.py
+++ b/src/kitaru/worker/process.py
@@ -330,8 +330,9 @@ def get_python_run_argv(
 ) -> list[str]:
     """Build the argv running a python module with its arguments.
 
-    Runs the module directly when there are no dependencies, otherwise
-    through ``uv run`` with each dependency passed as ``--with``.
+    Runs the module directly when there are no dependencies. Otherwise, it
+    layers each dependency over the worker's Python environment without
+    discovering or synchronizing a project from the worker's current directory.
 
     Args:
         module: Module to run.
@@ -343,7 +344,14 @@ def get_python_run_argv(
     """
     if not dependencies:
         return [sys.executable, "-m", module, *args]
-    parts = ["uv", "run"]
+    parts = [
+        "uv",
+        "run",
+        "--no-project",
+        "--python",
+        sys.executable,
+        "--prerelease=allow",
+    ]
     for dependency in dependencies:
         parts.extend(["--with", dependency])
     parts.extend(["python", "-m", module, *args])

--- a/tests/scripts/test_typescript_packages.py
+++ b/tests/scripts/test_typescript_packages.py
@@ -146,6 +146,7 @@ def test_typescript_release_workflow_contract() -> None:
     assert "needs: build" in publish_source
     assert "needs: [build, publish]" in verify_source
     assert "node scripts/typescript-packages.mjs --tag" in workflow_source
+    assert "run: pnpm run generate:check" in build_source
     assert "run: pnpm run pack:release:built" in build_source
     assert "uv sync --frozen --extra server --extra cli --extra worker" in build_source
     assert "run: uv run pytest -q tests/typescript" in build_source
@@ -215,3 +216,16 @@ def test_typescript_ci_validates_the_standalone_ticket_resolver() -> None:
         "pnpm test:e2e",
     ):
         assert command in job
+
+
+def test_canonical_example_ci_installs_candidate_python_artifacts() -> None:
+    workflow_source = CI_WORKFLOW_PATH.read_text()
+    job = workflow_source.split("\n  canonical-example:\n", maxsplit=1)[1].split(
+        "\n  links:\n", maxsplit=1
+    )[0]
+
+    assert "Install candidate artifacts in standalone example" in job
+    assert "../../plugins/candidate-wheels/kitaru-*.whl" in job
+    assert "../../plugins/candidate-wheels/kitaru_pydantic_ai-*.whl" in job
+    assert "../../plugins/candidate-wheels/kitaru_langfuse_importer-*.whl" in job
+    assert job.count("uv run --no-sync --with pytest") == 2

--- a/tests/worker/test_handlers.py
+++ b/tests/worker/test_handlers.py
@@ -15,6 +15,7 @@
 
 import hashlib
 import json
+import sys
 import uuid
 from pathlib import Path
 
@@ -157,6 +158,10 @@ async def test_evaluation_handler_script_plugin_materializes_and_sets_path(
     assert process.command == [
         "uv",
         "run",
+        "--no-project",
+        "--python",
+        sys.executable,
+        "--prerelease=allow",
         "--with",
         "numpy",
         "python",
@@ -184,6 +189,10 @@ async def test_evaluation_handler_package_plugin_skips_materialization(
     assert process.command == [
         "uv",
         "run",
+        "--no-project",
+        "--python",
+        sys.executable,
+        "--prerelease=allow",
         "--with",
         "pkg==1.0",
         "python",
@@ -269,6 +278,10 @@ async def test_import_handler_package_plugin_materializes_only_the_payload(
     assert process.command == [
         "uv",
         "run",
+        "--no-project",
+        "--python",
+        sys.executable,
+        "--prerelease=allow",
         "--with",
         "pkg==2.0",
         "python",

--- a/tests/worker/test_process.py
+++ b/tests/worker/test_process.py
@@ -313,11 +313,15 @@ def test_get_python_run_argv_without_dependencies() -> None:
 
 
 def test_get_python_run_argv_with_dependencies() -> None:
-    """Dependencies route the invocation through uv run --with."""
+    """Dependencies run outside the worker's current project environment."""
     argv = get_python_run_argv("kitaru.task", ["import"], ["requests<3", "rich>=13"])
     assert argv == [
         "uv",
         "run",
+        "--no-project",
+        "--python",
+        sys.executable,
+        "--prerelease=allow",
         "--with",
         "requests<3",
         "--with",

--- a/v2_examples/mastra_support_triage/test/management.test.ts
+++ b/v2_examples/mastra_support_triage/test/management.test.ts
@@ -127,7 +127,12 @@ describe("runOwnedJob", () => {
     const cancel = vi
       .fn()
       .mockRejectedValue(
-        new KitaruApiError("POST", `/api/v1/jobs/${JOB_ID}/cancel`, 409, "race"),
+        new KitaruApiError(
+          "POST",
+          `/api/v1/jobs/${JOB_ID}/cancel`,
+          409,
+          "race",
+        ),
       );
     const get = vi
       .fn()


### PR DESCRIPTION
## Summary

- install the locally built Kitaru and plugin wheels into the canonical example environment before its contract and end-to-end tests
- run the example tests with `--no-sync` so the frozen lock cannot restore the older PyPI artifacts
- isolate dependency-bearing worker subprocesses from the current project while layering dependencies over the worker Python environment
- verify generated TypeScript OpenAPI types in the tag-driven release workflow
- apply the formatting required after the `/api/v1` changes in #781

## Why

#781 exposed that canonical-example CI started the current server but exercised the frozen PyPI SDK and plugin wheels. The first CI run also showed that `uv run --with` inside an importer task rediscovered that frozen example project and restored the older SDK again. That one subprocess then called `/v1/tasks/.../spec` while every other candidate component called `/api/v1`.

This PR makes the artifact boundary explicit and prevents task dependency resolution from synchronizing the host project. No `/v1` compatibility routes are added. The prerelease clients are not treated as a backward-compatibility contract.

## Reviewer Notes

Reproduce the focused checks with:

```bash
uv run pytest -q tests/scripts/test_typescript_packages.py
uv run pytest -q tests/worker/test_process.py tests/worker/test_handlers.py
pnpm run generate:check
pnpm run lint
pnpm run typecheck
pnpm run test:built
pnpm run pack:check:built
actionlint .github/workflows/ci.yml .github/workflows/release-typescript.yml
```

The candidate-wheel rehearsal passed locally. The frozen example environment first installed the registry packages, the new command replaced all three with wheels from `plugins/candidate-wheels`, and the full canonical end-to-end test passed against a current source server. Server logs showed the importer, worker, and remaining test flow using `/api/v1` throughout.

This should merge before #793.
