### PR TITLE
Resolve the dashboard review link in `kitaru investigation create`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- `kitaru investigation create` returns the dashboard review page as a `review` link, resolved from the server-stated dashboard URL or, for servers hosting the bundled UI, from the URL the client logged into.
+
 ## [0.22.0rc7]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
-
-### Added
-
-- `kitaru investigation create` returns the dashboard review page as a `review` link, resolved from the server-stated dashboard URL or, for servers hosting the bundled UI, from the URL the client logged into.
-
 ## [0.22.0rc7]
 
 ### Changed
@@ -80,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - TypeScript cloud examples now reuse CLI logins without exporting a token, verify dedicated-worker access before creating remote resources, isolate exact-job recovery state, and stop when a mutation or cancellation cannot be journaled safely.
 
 ### Added
+- `kitaru investigation create` returns the dashboard review page as a `review` link, resolved from the server-stated dashboard URL or, for servers hosting the bundled UI, from the URL the client logged into.
 - Standalone replay CLI create, list, and get commands; cohort baseline selection in the CLI and MCP; and native MCP reads for tags and workers plus capability-gated tag lifecycle operations.
 - Vercel AI SDK 7 `ToolLoopAgent` support for typed, non-streaming agent generation with Kitaru recording and safe replay boundaries.
 - The server now serves the bundled Kitaru UI at its root URL with SPA fallback. Setting `KITARU_SERVER_EXTERNAL_UI=true` makes it redirect to the configured dashboard URL instead of serving files, and `GET /api/v1/info` reports the served UI version.

--- a/src/kitaru/cli/investigations.py
+++ b/src/kitaru/cli/investigations.py
@@ -17,6 +17,8 @@ import json
 import uuid
 from typing import Any
 
+import httpx
+
 from kitaru.api_models.v1.investigation import (
     InvestigationCreateRequest,
     InvestigationSessionHighlight,
@@ -30,6 +32,8 @@ from kitaru.api_models.v1.investigation import (
 )
 from kitaru.cli.output import CLIError, CommandResult
 from kitaru.cli.registration import list_params, page_result, resolve_asset
+from kitaru.client.dashboard_urls import get_investigation_review_url
+from kitaru.client.exceptions import APIError
 
 
 def _parse_session_key_token(token: str, *, option: str) -> tuple[uuid.UUID, str]:
@@ -170,8 +174,26 @@ async def create_investigation(
             sessions=sessions,
         )
     )
+    review_url: str | None = None
+    warnings: list[str] = []
+    try:
+        info = await client.info.get()
+    except (APIError, httpx.HTTPError):
+        warnings.append(
+            "Could not resolve a dashboard review link because the server "
+            "info request failed. The investigation was created."
+        )
+    else:
+        review_url = get_investigation_review_url(
+            info,
+            client.base_url,
+            agent_id=investigation.agent_id,
+            investigation_id=investigation.id,
+        )
     return CommandResult(
         item=investigation.model_dump(mode="json"),
+        links={"review": review_url} if review_url else {},
+        warnings=warnings,
         next_actions=[
             f"kitaru investigation session list {investigation.id}",
             f"kitaru investigation get {investigation.id}",

--- a/src/kitaru/cli/investigations.py
+++ b/src/kitaru/cli/investigations.py
@@ -178,7 +178,10 @@ async def create_investigation(
     warnings: list[str] = []
     try:
         info = await client.info.get()
-    except (APIError, httpx.HTTPError):
+    # ValueError covers malformed info payloads: JSON decoding and Pydantic
+    # validation errors both derive from it, and a version-skewed server must
+    # not fail a create that already succeeded.
+    except (APIError, httpx.HTTPError, ValueError):
         warnings.append(
             "Could not resolve a dashboard review link because the server "
             "info request failed. The investigation was created."

--- a/src/kitaru/client/dashboard_urls.py
+++ b/src/kitaru/client/dashboard_urls.py
@@ -1,0 +1,66 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Dashboard URL resolution from server info."""
+
+import uuid
+
+from kitaru.api_models.v1.info import ServerInfoResponse
+from kitaru.client.config import normalize_server_url
+
+
+def get_dashboard_base_url(info: ServerInfoResponse, api_url: str) -> str | None:
+    """Resolve the base URL of the dashboard serving this server.
+
+    Args:
+        info: Server info reported by the selected server.
+        api_url: URL the client reaches the server API at.
+
+    Returns:
+        The dashboard base URL without a trailing slash, or None when the
+        deployment reports no dashboard and serves no UI itself.
+    """
+    if info.dashboard_url:
+        return normalize_server_url(info.dashboard_url)
+    # A server that reports a UI version serves the bundled UI at its own
+    # origin, so the URL the client already reaches the API at is also the
+    # dashboard base. The server cannot state that URL itself because behind
+    # a proxy it only sees the untrusted Host header.
+    if info.ui_version:
+        return normalize_server_url(info.server_url or api_url)
+    return None
+
+
+def get_investigation_review_url(
+    info: ServerInfoResponse,
+    api_url: str,
+    *,
+    agent_id: uuid.UUID,
+    investigation_id: uuid.UUID,
+) -> str | None:
+    """Resolve the dashboard review page URL for an investigation.
+
+    Args:
+        info: Server info reported by the selected server.
+        api_url: URL the client reaches the server API at.
+        agent_id: Agent the investigation belongs to.
+        investigation_id: Investigation to review.
+
+    Returns:
+        The absolute review page URL, or None when the deployment has no
+        reachable dashboard.
+    """
+    base = get_dashboard_base_url(info, api_url)
+    if base is None:
+        return None
+    return f"{base}/agents/{agent_id}/investigations/{investigation_id}/review"

--- a/tests/cli/test_investigations.py
+++ b/tests/cli/test_investigations.py
@@ -310,7 +310,7 @@ def _validation_error() -> Exception:
 async def test_create_warns_when_server_info_is_unavailable(
     info_error: Exception,
 ) -> None:
-    """A failed or unparseable info request keeps the investigation and warns."""
+    """A failed or unparsable info request keeps the investigation and warns."""
     client = StubInvestigationClient()
     client.info_error = info_error
 

--- a/tests/cli/test_investigations.py
+++ b/tests/cli/test_investigations.py
@@ -294,10 +294,25 @@ async def test_create_omits_review_link_for_api_only_server() -> None:
     assert result.warnings == []
 
 
-async def test_create_warns_when_server_info_is_unavailable() -> None:
-    """A failed info request keeps the created investigation and warns."""
+def _validation_error() -> Exception:
+    try:
+        ServerInfoResponse.model_validate({})
+    except Exception as error:
+        return error
+    raise AssertionError("expected validation to fail")
+
+
+@pytest.mark.parametrize(
+    "info_error",
+    [APIError(503, "unavailable"), _validation_error()],
+    ids=["api_error", "malformed_payload"],
+)
+async def test_create_warns_when_server_info_is_unavailable(
+    info_error: Exception,
+) -> None:
+    """A failed or unparseable info request keeps the investigation and warns."""
     client = StubInvestigationClient()
-    client.info_error = APIError(503, "unavailable")
+    client.info_error = info_error
 
     result = await _create_minimal(client)
 

--- a/tests/cli/test_investigations.py
+++ b/tests/cli/test_investigations.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import pytest
 
+from kitaru.api_models.v1.info import AuthScheme, ServerInfoResponse
 from kitaru.api_models.v1.investigation import (
     InvestigationCreateRequest,
     InvestigationListParams,
@@ -35,6 +36,7 @@ from kitaru.cli import app as app_module
 from kitaru.cli import investigations
 from kitaru.cli.output import CLIError
 from kitaru.cli.schema import describe_schema
+from kitaru.client.exceptions import APIError
 
 
 @dataclass
@@ -100,8 +102,25 @@ class StubInvestigationClient:
         self.session_update_calls: list[
             tuple[uuid.UUID, uuid.UUID, InvestigationSessionUpdateRequest]
         ] = []
+        self.base_url = "https://api.kitaru.example.com/"
+        self.server_info = ServerInfoResponse(
+            version="0.0.0",
+            auth_scheme=AuthScheme.LOCAL,
+            ui_version="1.2.3",
+        )
+        self.info_error: Exception | None = None
         self.agents = self._Agents(self)
         self.investigations = self._Investigations(self)
+        self.info = self._Info(self)
+
+    class _Info:
+        def __init__(self, owner: "StubInvestigationClient") -> None:
+            self.owner = owner
+
+        async def get(self) -> ServerInfoResponse:
+            if self.owner.info_error is not None:
+                raise self.owner.info_error
+            return self.owner.server_info
 
     class _Agents:
         def __init__(self, owner: "StubInvestigationClient") -> None:
@@ -224,6 +243,68 @@ async def test_create_maps_sessions_questions_and_highlights_to_sdk() -> None:
         ],
     }
     assert result.item["id"] == str(client.investigation.id)
+
+
+async def _create_minimal(client: StubInvestigationClient) -> Any:
+    return await investigations.create_investigation(
+        client,
+        "triage",
+        agent="assistant",
+        description=None,
+        session_ids=client.session_ids,
+        session_questions=[
+            f"{session_id}:root-cause=What caused it?"
+            for session_id in client.session_ids
+        ],
+        session_highlights=[],
+    )
+
+
+async def test_create_links_review_url_from_dashboard_url() -> None:
+    """Create links the review page under a server-stated dashboard URL."""
+    client = StubInvestigationClient()
+    client.server_info = ServerInfoResponse(
+        version="0.0.0",
+        auth_scheme=AuthScheme.CONTROL_PLANE,
+        dashboard_url="https://cloud.example.com/kitaru-workspaces/ws-1/",
+    )
+
+    result = await _create_minimal(client)
+
+    assert result.links == {
+        "review": (
+            "https://cloud.example.com/kitaru-workspaces/ws-1"
+            f"/agents/{client.agent.id}"
+            f"/investigations/{client.investigation.id}/review"
+        )
+    }
+    assert result.warnings == []
+
+
+async def test_create_omits_review_link_for_api_only_server() -> None:
+    """A server without a dashboard or UI yields no review link."""
+    client = StubInvestigationClient()
+    client.server_info = ServerInfoResponse(
+        version="0.0.0", auth_scheme=AuthScheme.LOCAL
+    )
+
+    result = await _create_minimal(client)
+
+    assert result.links == {}
+    assert result.warnings == []
+
+
+async def test_create_warns_when_server_info_is_unavailable() -> None:
+    """A failed info request keeps the created investigation and warns."""
+    client = StubInvestigationClient()
+    client.info_error = APIError(503, "unavailable")
+
+    result = await _create_minimal(client)
+
+    assert result.item["id"] == str(client.investigation.id)
+    assert result.links == {}
+    assert len(result.warnings) == 1
+    assert "review link" in result.warnings[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/client/test_dashboard_urls.py
+++ b/tests/client/test_dashboard_urls.py
@@ -1,0 +1,82 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Dashboard URL resolution behavior."""
+
+import uuid
+
+from kitaru.api_models.v1.info import AuthScheme, ServerInfoResponse
+from kitaru.client.dashboard_urls import (
+    get_dashboard_base_url,
+    get_investigation_review_url,
+)
+
+API_URL = "https://api.example.com/"
+
+
+def _info(**overrides: str | None) -> ServerInfoResponse:
+    return ServerInfoResponse(
+        version="0.0.0", auth_scheme=AuthScheme.LOCAL, **overrides
+    )
+
+
+def test_stated_dashboard_url_wins() -> None:
+    """A server-stated dashboard URL is used as-is, without its trailing slash."""
+    info = _info(
+        dashboard_url="https://cloud.example.com/kitaru-workspaces/ws-1/",
+        ui_version="1.0.0",
+        server_url="https://elsewhere.example.com",
+    )
+    base = get_dashboard_base_url(info, API_URL)
+    assert base == "https://cloud.example.com/kitaru-workspaces/ws-1"
+
+
+def test_bundled_ui_prefers_stated_server_url() -> None:
+    """A bundled-UI server that states its own URL is reached through it."""
+    info = _info(ui_version="1.0.0", server_url="https://kitaru.example.com/")
+    assert get_dashboard_base_url(info, API_URL) == "https://kitaru.example.com"
+
+
+def test_bundled_ui_falls_back_to_the_login_url() -> None:
+    """A bundled-UI server with no stated URLs is reached where the client is."""
+    info = _info(ui_version="1.0.0")
+    assert get_dashboard_base_url(info, API_URL) == "https://api.example.com"
+
+
+def test_api_only_server_has_no_dashboard() -> None:
+    """A server with no dashboard URL and no UI resolves to no base."""
+    assert get_dashboard_base_url(_info(), API_URL) is None
+
+
+def test_review_url_appends_the_stable_route() -> None:
+    """The review URL joins the base with the agent and investigation route."""
+    agent_id = uuid.uuid4()
+    investigation_id = uuid.uuid4()
+    url = get_investigation_review_url(
+        _info(ui_version="1.0.0"),
+        API_URL,
+        agent_id=agent_id,
+        investigation_id=investigation_id,
+    )
+    assert url == (
+        "https://api.example.com"
+        f"/agents/{agent_id}/investigations/{investigation_id}/review"
+    )
+
+
+def test_review_url_is_none_without_a_dashboard() -> None:
+    """No dashboard base means no review URL."""
+    url = get_investigation_review_url(
+        _info(), API_URL, agent_id=uuid.uuid4(), investigation_id=uuid.uuid4()
+    )
+    assert url is None


### PR DESCRIPTION
Closes the client-side half of the discussion in #794. After #796 fixed the managed dashboard URL, the agreed approach is that clients resolve the review page themselves, the way ZenML's `dashboard_utils` does: use the server-stated `dashboard_url` when there is one, and for servers hosting the bundled UI fall back to the URL the client logged into (`ui_version` in `/api/v1/info` proves a UI is being served). A server behind a proxy cannot state its own public address, so the login URL is the only trustworthy base in that case.

## What changed

- New `kitaru.client.dashboard_urls` module with `get_dashboard_base_url` and `get_investigation_review_url`. Pure functions over `ServerInfoResponse`; resolution order is `dashboard_url` → (`server_url` or the client's API URL) when `ui_version` is set → `None`.
- `kitaru investigation create` fetches `/api/v1/info` after creating and puts the resolved URL in the existing top-level `links` output as `links.review`. Human output renders it through the existing footer; `--output json` carries it as `links.review`.
- The helper lives in the client package (not the CLI) so MCP, which creates investigations through the same SDK, can reuse it later.

## Reviewer Notes

The risky part is the fallback rule in `get_dashboard_base_url`. If it is wrong in the "no dashboard_url, no ui_version" case, an API-only deployment would get a confident link to a page that does not exist — so that case deliberately returns `None` and the CLI omits the link without a warning (a UI-less deployment is a valid state, not an error). If it is wrong in the bundled-UI case, local onboarding hands out a broken link; the tests in `tests/client/test_dashboard_urls.py` pin the precedence including trailing slashes.

The second thing worth attention is failure behavior in `create_investigation`: the info request is decoration, so an `APIError`, a transport error, or a malformed info payload from a version-skewed server must not fail a create that already succeeded. It downgrades to a warning on stderr and the investigation is still returned. `tests/cli/test_investigations.py::test_create_warns_when_server_info_is_unavailable` covers this.

The route literal `/agents/{agent}/investigations/{id}/review` is the stable shape both frontends serve (direct UI at its root, managed under the `/kitaru-workspaces/{ws}` base that `dashboard_url` now points at after #796).

### Reproduction

Against a local server with the bundled UI:

```bash
kitaru investigation create triage --agent AGENT --session SESSION --session-question "SESSION:root-cause=What caused it?" --output json
```

Expect a top-level `links.review` of the form `http://localhost:8000/agents/AGENT_ID/investigations/INV_ID/review`, and the same URL as a labeled `review:` line in human output. Against a managed workspace (post-#796 Helm value) the link starts with the `/kitaru-workspaces/WORKSPACE_ID` base. Against an API-only server there is no `links.review` and no warning.

Local checks run: `just fix`, format/lint/typecheck/typos/yaml/openapi/actions checks, and the full test suite (10 pre-existing failures reproduce identically on clean `origin/develop`: `tests/server/test_analytics_source.py`, `test_deadlock_handler.py`, `test_pool_timeout_handler.py`, `tests/typescript/test_mastra_adapter.py`; unrelated to this change). `/simplify` was run and applied.
