### PR TITLE
Add inferred Langfuse tool-call links

### DIFF
--- a/docs/book/guides/import-langfuse-traces.md
+++ b/docs/book/guides/import-langfuse-traces.md
@@ -50,6 +50,7 @@ The Langfuse importer parses **Langfuse JSONL exports** — up to 50 MiB per pay
 | --- | --- |
 | `source_instance` | The Langfuse project the export came from. Optional when the export itself carries project ids; required when it doesn't — it anchors the sessions' external identity. |
 | `filename` | Optional label used as a fallback source name. |
+| `infer_tool_call_links` | Optional boolean, default `true`. The importer matches tool-call ids emitted by a generation with `gen_ai.tool.call.id` on tool observations and adds the generation as a secondary parent. The Langfuse observation parent remains the primary parent. Unmatched or ambiguous ids remain unchanged. Set this to `false` to keep only the source observation hierarchy. |
 
 Import in slices as often as you like — dedup makes it safe.
 

--- a/plugins/default-requirements.txt
+++ b/plugins/default-requirements.txt
@@ -1,5 +1,5 @@
 kitaru-braintrust-importer==0.1.0rc0
 kitaru-evaluator==0.1.0rc0
 kitaru-jsonl-importer==0.1.0rc0
-kitaru-langfuse-importer==0.1.0rc0
+kitaru-langfuse-importer==0.1.0rc1
 kitaru-langsmith-importer==0.1.0rc0

--- a/plugins/packages/langfuse-importer/CHANGELOG.md
+++ b/plugins/packages/langfuse-importer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.0rc1
+
+- Add causal links from tool spans to the model calls that requested them, with an option to disable inference.
+
 ## 0.1.0rc0
 
 - Initial release candidate for the Langfuse trace importer.

--- a/plugins/packages/langfuse-importer/pyproject.toml
+++ b/plugins/packages/langfuse-importer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru-langfuse-importer"
-version = "0.1.0rc0"
+version = "0.1.0rc1"
 description = "Langfuse trace importer for Kitaru."
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
+++ b/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
@@ -837,8 +837,129 @@ def _tokens(record: dict[str, Any]) -> TokenUsage | None:
     )
 
 
+def _tool_call_ids(value: Any) -> set[str]:
+    """Return tool-call ids emitted by one model output."""
+    result: set[str] = set()
+
+    def walk(item: Any, *, tool_call: bool = False) -> None:
+        item = _decode_json(item)
+        if isinstance(item, list):
+            for child in item:
+                walk(child, tool_call=tool_call)
+            return
+        if not isinstance(item, dict):
+            return
+
+        item_type = str(item.get("type") or "").lower()
+        is_tool_call = tool_call or item_type in {
+            "function_call",
+            "tool_call",
+            "tool_use",
+        }
+        if is_tool_call:
+            call_id = _first(item, "id", "toolCallId", "tool_call_id")
+            if call_id not in (None, ""):
+                result.add(str(call_id))
+
+        for key, child in item.items():
+            walk(child, tool_call=key in {"toolCalls", "tool_calls"})
+
+    walk(value)
+    return result
+
+
+def _tool_call_id(record: dict[str, Any]) -> str | None:
+    """Return the causal tool-call id recorded on one tool observation."""
+    value = _first(record, "toolCallId", "tool_call_id") or _metadata_value(
+        record,
+        "gen_ai.tool.call.id",
+        "tool_call_id",
+        "toolCallId",
+    )
+    return str(value) if value not in (None, "") else None
+
+
+def _infer_tool_call_secondary_parents(
+    nodes_with_parents: list[tuple[str, str | None, dict[str, Any]]],
+) -> dict[str, list[str]]:
+    """Match tool observations to the model outputs that requested them."""
+    primary_parents = {
+        external_id: parent
+        for external_id, parent, _ in nodes_with_parents
+        if parent is not None
+    }
+    requesting_nodes: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for external_id, _, record in nodes_with_parents:
+        node_type, _ = _node_type(record)
+        if node_type is not NodeType.LLM_CALL:
+            continue
+        trace_id = str(_first(record, "traceId", "trace_id") or "")
+        for call_id in _tool_call_ids(record.get("output")):
+            requesting_nodes[(trace_id, call_id)].add(external_id)
+
+    inferred: dict[str, list[str]] = {}
+    for external_id, primary_parent, record in nodes_with_parents:
+        node_type, _ = _node_type(record)
+        if node_type is not NodeType.TOOL_CALL:
+            continue
+        call_id = _tool_call_id(record)
+        if call_id is None:
+            continue
+        trace_id = str(_first(record, "traceId", "trace_id") or "")
+        candidates = requesting_nodes.get((trace_id, call_id), set())
+        if len(candidates) != 1:
+            continue
+        requesting_node = next(iter(candidates))
+        ancestors: set[str] = set()
+        current = primary_parent
+        while current is not None and current not in ancestors:
+            ancestors.add(current)
+            current = primary_parents.get(current)
+        if requesting_node not in ancestors:
+            inferred[external_id] = [requesting_node]
+    return inferred
+
+
+def _flatten_node_tree(roots: list[ImportedNode]) -> list[ImportedNode]:
+    """Flatten an imported node tree in ingestion order."""
+    flattened: list[ImportedNode] = []
+
+    def walk(node: ImportedNode) -> None:
+        flattened.append(node)
+        for child in node.children:
+            walk(child)
+
+    for root in roots:
+        walk(root)
+    return flattened
+
+
+def _apply_secondary_parent_indexes(
+    roots: list[ImportedNode], secondary_parents: dict[str, list[str]]
+) -> None:
+    """Resolve secondary external ids to depth-first ingestion indexes."""
+    flattened = _flatten_node_tree(roots)
+
+    index_by_external_id = {
+        node.external_id: index
+        for index, node in enumerate(flattened)
+        if node.external_id is not None
+    }
+    for index, node in enumerate(flattened):
+        inferred_indexes = {
+            parent_index
+            for external_id in secondary_parents.get(node.external_id or "", [])
+            if (parent_index := index_by_external_id.get(external_id)) is not None
+            and parent_index < index
+        }
+        node.secondary_parent_indexes = sorted(
+            {*node.secondary_parent_indexes, *inferred_indexes}
+        )
+
+
 def _build_node_tree(
     nodes_with_parents: list[tuple[ImportedNode, str | None]],
+    secondary_parents: dict[str, list[str]] | None = None,
 ) -> list[ImportedNode]:
     """Build and validate the parsed-node tree."""
     external_ids = [node.external_id for node, _ in nodes_with_parents]
@@ -874,6 +995,8 @@ def _build_node_tree(
             roots.append(node)
     if nodes_with_parents and not roots:
         raise InvalidImport("The imported node graph contains no root node")
+    if secondary_parents:
+        _apply_secondary_parent_indexes(roots, secondary_parents)
     return roots
 
 
@@ -892,6 +1015,9 @@ class LangfuseJSONLImporter:
         Returns:
             Imported sessions and isolated import failures.
         """
+        infer_tool_call_links = params.get("infer_tool_call_links", True)
+        if not isinstance(infer_tool_call_links, bool):
+            raise InvalidImport("infer_tool_call_links must be a boolean")
         records = _parse_records(content)
         shape = _detect_shape(records[0])
         if shape == _EVENT_SHAPE:
@@ -946,6 +1072,7 @@ class LangfuseJSONLImporter:
                         join_paths=join_paths[source_id],
                         trace_fallback=source_id in fallback_sessions,
                         file_framework=file_framework,
+                        infer_tool_call_links=infer_tool_call_links,
                     )
                 )
             except InvalidImport as exc:
@@ -967,6 +1094,7 @@ class LangfuseJSONLImporter:
         join_paths: set[str],
         trace_fallback: bool,
         file_framework: str | None,
+        infer_tool_call_links: bool,
     ) -> ImportedSession:
         """Parse one grouped Langfuse session."""
         project_ids = {
@@ -1087,6 +1215,11 @@ class LangfuseJSONLImporter:
                 item[0],
             )
         )
+        secondary_parents = (
+            _infer_tool_call_secondary_parents(raw_nodes)
+            if infer_tool_call_links
+            else {}
+        )
         nodes_with_parents: list[tuple[ImportedNode, str | None]] = []
         for source_node_id, parent_source_id, record in raw_nodes:
             node_type, tool_name = _node_type(record)
@@ -1156,6 +1289,7 @@ class LangfuseJSONLImporter:
 
         nodes = [node for node, _ in nodes_with_parents]
         _populate_node_fields(nodes)
+        node_tree = _build_node_tree(nodes_with_parents, secondary_parents)
         latest_turn = turns[-1]
         latest_root = root_by_trace[latest_turn.trace_id]
         latest_root_status = _node_status(latest_root)
@@ -1230,6 +1364,11 @@ class LangfuseJSONLImporter:
             "source_completeness": "unknown",
             "normalization_warnings": warnings,
         }
+        if infer_tool_call_links:
+            metadata["langfuse.inferred_tool_call_link_count"] = sum(
+                len(node.secondary_parent_indexes)
+                for node in _flatten_node_tree(node_tree)
+            )
         framework = (
             _detect_framework(params.get("framework"))
             or _detect_framework(
@@ -1259,7 +1398,7 @@ class LangfuseJSONLImporter:
             ended_at=ended_at,
             metadata=metadata,
             framework=framework,
-            nodes=_build_node_tree(nodes_with_parents),
+            nodes=node_tree,
         )
 
 

--- a/plugins/tests/importers/test_langfuse.py
+++ b/plugins/tests/importers/test_langfuse.py
@@ -22,7 +22,14 @@ import pytest
 import kitaru_langfuse_importer.importer as langfuse_module
 from kitaru.api_models.v1.session import SessionStatus
 from kitaru.api_models.v1.session_node import NodeStatus, NodeType
-from kitaru.task.importer import ImportedNode, ImportedSession, ImportFailure
+from kitaru.task.importer import (
+    ImportedNode,
+    ImportedSession,
+    ImportFailure,
+)
+from kitaru.task.importer import (
+    flatten_nodes as flatten_imported_nodes,
+)
 from kitaru_langfuse_importer.importer import (
     InvalidImport,
     LangfuseJSONLImporter,
@@ -134,6 +141,136 @@ def test_unified_parse_preserves_node_trace_id() -> None:
 
     assert isinstance(parsed[0], ImportedSession)
     assert parsed[0].nodes[0].trace_id == "trace-1"
+
+
+def test_infers_tool_call_secondary_parent_by_default() -> None:
+    """Link a tool span to the model output that requested the call by default."""
+    content = jsonl(
+        observation("root", "trace-1", input_={"message": "Weather?"}),
+        observation(
+            "generation",
+            "trace-1",
+            parent_id="root",
+            observation_type="GENERATION",
+            output=[
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {
+                            "type": "tool_call",
+                            "id": "call-weather",
+                            "name": "get_weather",
+                        }
+                    ],
+                }
+            ],
+            start_time="2026-07-24T10:00:00.100000Z",
+        ),
+        observation(
+            "tool",
+            "trace-1",
+            parent_id="root",
+            observation_type="TOOL",
+            input_={"city": "Delft"},
+            output={"temperature": 18},
+            start_time="2026-07-24T10:00:00.200000Z",
+            metadata={
+                "attributes": {
+                    "gen_ai.tool.call.id": "call-weather",
+                    "gen_ai.tool.name": "get_weather",
+                }
+            },
+        ),
+    )
+
+    [session] = sessions(content)
+    nodes = flatten_imported_nodes(session.nodes)
+    tool = next(node for node in nodes if node.external_id == "trace-1:tool")
+
+    assert tool.parent_index == 0
+    assert tool.secondary_parent_indexes == [1]
+    assert session.metadata["langfuse.inferred_tool_call_link_count"] == 1
+
+
+def test_tool_call_link_inference_can_be_disabled() -> None:
+    """Keep provider parentage unchanged when inference is disabled."""
+    content = jsonl(
+        observation("root", "trace-1"),
+        observation(
+            "generation",
+            "trace-1",
+            parent_id="root",
+            observation_type="GENERATION",
+            output={"tool_calls": [{"id": "call-weather"}]},
+        ),
+        observation(
+            "tool",
+            "trace-1",
+            parent_id="root",
+            observation_type="TOOL",
+            metadata={"attributes": {"gen_ai.tool.call.id": "call-weather"}},
+        ),
+    )
+
+    [session] = sessions(content, {"infer_tool_call_links": False})
+    tool = next(
+        node
+        for node in flatten_imported_nodes(session.nodes)
+        if node.external_id == "trace-1:tool"
+    )
+
+    assert tool.secondary_parent_indexes == []
+    assert "langfuse.inferred_tool_call_link_count" not in session.metadata
+
+
+def test_tool_call_link_inference_skips_ambiguous_ids() -> None:
+    """Leave a tool unchanged when several model outputs reuse its call id."""
+    content = jsonl(
+        observation("root", "trace-1"),
+        observation(
+            "generation-1",
+            "trace-1",
+            parent_id="root",
+            observation_type="GENERATION",
+            output={"tool_calls": [{"id": "reused-call"}]},
+            start_time="2026-07-24T10:00:00.100000Z",
+        ),
+        observation(
+            "generation-2",
+            "trace-1",
+            parent_id="root",
+            observation_type="GENERATION",
+            output={"tool_calls": [{"id": "reused-call"}]},
+            start_time="2026-07-24T10:00:00.200000Z",
+        ),
+        observation(
+            "tool",
+            "trace-1",
+            parent_id="root",
+            observation_type="TOOL",
+            start_time="2026-07-24T10:00:00.300000Z",
+            metadata={"attributes": {"gen_ai.tool.call.id": "reused-call"}},
+        ),
+    )
+
+    [session] = sessions(content, {"infer_tool_call_links": True})
+    tool = next(
+        node
+        for node in flatten_imported_nodes(session.nodes)
+        if node.external_id == "trace-1:tool"
+    )
+
+    assert tool.secondary_parent_indexes == []
+    assert session.metadata["langfuse.inferred_tool_call_link_count"] == 0
+
+
+def test_rejects_non_boolean_tool_call_link_option() -> None:
+    """Reject string values that could enable inference by accident."""
+    with pytest.raises(InvalidImport, match="infer_tool_call_links must be a boolean"):
+        LangfuseJSONLImporter().parse(
+            jsonl(observation("root", "trace-1")),
+            {"infer_tool_call_links": "true"},
+        )
 
 
 def test_redacted_session_ids_fall_back_to_trace_ids() -> None:

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -1025,7 +1025,7 @@ requires-dist = [{ name = "kitaru", editable = "../" }]
 
 [[package]]
 name = "kitaru-langfuse-importer"
-version = "0.1.0rc0"
+version = "0.1.0rc1"
 source = { editable = "packages/langfuse-importer" }
 dependencies = [
     { name = "kitaru" },

--- a/src/kitaru/server/api/bootstrap.py
+++ b/src/kitaru/server/api/bootstrap.py
@@ -116,8 +116,8 @@ DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = (
         description="Import Langfuse JSON and JSONL trace exports.",
         provider="langfuse",
         entrypoint="kitaru_langfuse_importer.importer:parse",
-        requirement="kitaru-langfuse-importer==0.1.0rc0",
-        display_version="0.1.0rc0",
+        requirement="kitaru-langfuse-importer==0.1.0rc1",
+        display_version="0.1.0rc1",
     ),
     DefaultPluginDefinition(
         kind=PluginKind.IMPORTER,


### PR DESCRIPTION
## Summary

- infer Langfuse tool-call links by default
- match tool-call ids from generation outputs with `gen_ai.tool.call.id` on tool observations
- retain Langfuse observation parentage as the primary hierarchy and store the requesting generation as a secondary parent
- support `infer_tool_call_links: false` for imports that should retain only the source hierarchy
- skip missing, ambiguous, already represented, or ingestion-order-invalid links
- publish the behavior as `kitaru-langfuse-importer==0.1.0rc1` and update the default catalog and documentation

## Why

PydanticAI OpenTelemetry traces record LLM generations and their tool executions as siblings under the agent span. The causal relationship is available through the tool-call id, but the Langfuse importer previously left that relationship unused. Default inference gives Kitaru the causal edge without changing the source span hierarchy or implying that tool execution occurred inside the completed LLM span.

Braintrust and LangSmith remain unchanged. Their supported exports already express tool execution under the requesting LLM through provider parent fields, so heuristic id matching would add no reliable coverage.

## Reviewer Notes

Please focus on tool-call id extraction across PydanticAI, OpenAI-style, and Anthropic-style output shapes, ambiguity handling, and the conversion from external ids to parent-before-child ingestion indexes. Existing callers can disable inference with `infer_tool_call_links: false` when they need the unmodified provider graph.

### Reproduction

1. Build a Langfuse trace with one root agent observation.
2. Add a sibling generation whose output contains a tool call with id `call-weather`.
3. Add a sibling tool observation with metadata `gen_ai.tool.call.id=call-weather`.
4. Parse without `infer_tool_call_links` and confirm the tool keeps the root agent as `parent_index` and lists the generation index in `secondary_parent_indexes`.
5. Parse with `params={"infer_tool_call_links": false}` and confirm `secondary_parent_indexes` remains empty.
6. Duplicate the call id across two generation outputs and confirm no secondary link is added.

## Validation

- `just check`
- `uv run --project plugins --frozen pytest -q -c plugins/pyproject.toml plugins/tests tests/server/test_default_plugins.py` (375 passed)
- focused Langfuse importer tests (27 passed)
- plugin formatting, lint, and type checks
- focused and full plugin artifact smoke tests
- candidate Docker server registration and restart idempotency check for `kitaru-langfuse-importer==0.1.0rc1`
- parsed the referenced ten-session PydanticAI fixture: default behavior linked 33 of 33 tool spans; `infer_tool_call_links: false` linked 0
