### PR TITLE
Add Logfire trace importer

### DIFF
--- a/plugins/DEVELOPMENT.md
+++ b/plugins/DEVELOPMENT.md
@@ -93,7 +93,7 @@ docker run --rm kitaru-plugin-e2e:local \
   python -c 'from kitaru.server.api.bootstrap import DEFAULT_PLUGIN_DEFINITIONS; print(f"definitions={len(DEFAULT_PLUGIN_DEFINITIONS)}"); [print(d.kind.value, d.name, d.requirement, d.entrypoint) for d in DEFAULT_PLUGIN_DEFINITIONS]'
 ```
 
-The current catalog contains four importers and thirteen evaluators. Adapter distributions are installed directly by agent projects and are not registered in this catalog.
+The current catalog contains five importers and thirteen evaluators. Adapter distributions are installed directly by agent projects and are not registered in this catalog.
 
 ## Start the candidate server
 
@@ -257,6 +257,7 @@ Use the package directory and distribution name from this table:
 | `jsonl-importer` | `kitaru-jsonl-importer` | `jsonl-importer-vX.Y.Z` |
 | `langfuse-importer` | `kitaru-langfuse-importer` | `langfuse-importer-vX.Y.Z` |
 | `langgraph` | `kitaru-langgraph` | `langgraph-vX.Y.Z` |
+| `logfire-importer` | `kitaru-logfire-importer` | `logfire-importer-vX.Y.Z` |
 | `langsmith-importer` | `kitaru-langsmith-importer` | `langsmith-importer-vX.Y.Z` |
 | `openai-agents` | `kitaru-openai-agents` | `openai-agents-vX.Y.Z` |
 | `pydantic-ai` | `kitaru-pydantic-ai` | `pydantic-ai-vX.Y.Z` |

--- a/plugins/default-requirements.txt
+++ b/plugins/default-requirements.txt
@@ -2,4 +2,5 @@ kitaru-braintrust-importer==0.1.0rc0
 kitaru-evaluator==0.1.0rc0
 kitaru-jsonl-importer==0.1.0rc0
 kitaru-langfuse-importer==0.1.0rc1
+kitaru-logfire-importer==0.1.0rc0
 kitaru-langsmith-importer==0.1.0rc0

--- a/plugins/packages/logfire-importer/CHANGELOG.md
+++ b/plugins/packages/logfire-importer/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0rc0
+
+- Add the Logfire records-query importer.

--- a/plugins/packages/logfire-importer/pyproject.toml
+++ b/plugins/packages/logfire-importer/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "kitaru-logfire-importer"
+version = "0.1.0rc0"
+description = "Logfire records-query importer for Kitaru."
+license = "Apache-2.0"
+requires-python = ">=3.11"
+dependencies = ["kitaru>=0.22.0rc0,<0.23"]
+
+[build-system]
+requires = ["hatchling==1.32.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/kitaru_logfire_importer"]

--- a/plugins/packages/logfire-importer/src/kitaru_logfire_importer/__init__.py
+++ b/plugins/packages/logfire-importer/src/kitaru_logfire_importer/__init__.py
@@ -1,0 +1,5 @@
+"""Logfire importer plugin for Kitaru."""
+
+from kitaru_logfire_importer.importer import parse
+
+__all__ = ["parse"]

--- a/plugins/packages/logfire-importer/src/kitaru_logfire_importer/importer.py
+++ b/plugins/packages/logfire-importer/src/kitaru_logfire_importer/importer.py
@@ -1,0 +1,801 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Logfire records-query importer plugin."""
+
+import json
+import re
+from collections import defaultdict
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from kitaru.api_models.v1.imports import ImportFailure
+from kitaru.api_models.v1.session import SessionStatus, TokenUsage
+from kitaru.api_models.v1.session_node import NodeStatus, NodeType
+from kitaru.task.importer import ImportedNode, ImportedSession
+
+MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+_DEFAULT_JOIN_PATHS = (
+    "attributes.session.id",
+    "attributes.session_id",
+    "attributes.conversation_id",
+    "attributes.thread_id",
+    "attributes.gen_ai.conversation.id",
+    "attributes.conversation.id",
+)
+_METADATA_COLUMNS = (
+    "deployment_environment",
+    "service_name",
+    "service_namespace",
+    "service_version",
+    "otel_scope_name",
+    "otel_scope_version",
+    "tags",
+)
+_ATTRIBUTE_METADATA_KEYS = {
+    "agent_name",
+    "deployment.environment.name",
+    "gen_ai.agent.name",
+    "gen_ai.conversation.id",
+    "gen_ai.operation.name",
+    "gen_ai.provider.name",
+    "gen_ai.request.model",
+    "gen_ai.response.model",
+    "gen_ai.system",
+    "service.name",
+    "service.version",
+    "session.id",
+    "session_id",
+    "thread_id",
+    "user.id",
+}
+_FRAMEWORK_PATTERNS = (
+    (re.compile(r"pydantic[._ -]?ai", re.IGNORECASE), "pydantic-ai"),
+    (re.compile(r"langgraph", re.IGNORECASE), "langgraph"),
+    (re.compile(r"openai[._ -]?agents?", re.IGNORECASE), "openai-agents"),
+    (re.compile(r"google[._ -]?adk", re.IGNORECASE), "google-adk"),
+    (
+        re.compile(r"claude[._ -]?agent[._ -]?sdk|claudeagentsdk", re.IGNORECASE),
+        "claude-agent-sdk",
+    ),
+)
+
+
+class InvalidImport(ValueError):
+    """Raised when a Logfire payload cannot be parsed."""
+
+
+@dataclass(frozen=True, slots=True)
+class _Turn:
+    """One Logfire trace within a session."""
+
+    trace_id: str
+    inputs: Any
+    outputs: Any
+    started_at: datetime | None
+    ended_at: datetime | None
+
+
+def _decode_json(value: Any) -> Any:
+    """Decode JSON-encoded query columns while preserving ordinary strings."""
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if not stripped or stripped[0] not in '[{"':
+        return value
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return value
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    """Return a decoded dictionary or an empty dictionary."""
+    decoded = _decode_json(value)
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _datetime(value: Any) -> datetime | None:
+    """Parse a Logfire timestamp."""
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _integer(value: Any) -> int | None:
+    """Parse an integer attribute."""
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _decimal(value: Any) -> Decimal | None:
+    """Parse a decimal attribute."""
+    if value in (None, ""):
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _parse_records(content: bytes) -> list[dict[str, Any]]:
+    """Parse Logfire JSON, JSONL, or streaming NDJSON output."""
+    if len(content) > MAX_UPLOAD_BYTES:
+        raise InvalidImport("Logfire import exceeds the 50 MiB upload limit")
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise InvalidImport("Import file must be UTF-8 JSON or JSONL") from exc
+    if not text.strip():
+        raise InvalidImport("Import file contains no JSON records")
+    try:
+        decoded = json.loads(text)
+    except json.JSONDecodeError:
+        values: list[Any] = []
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                values.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise InvalidImport(f"Line {line_number} is not valid JSON") from exc
+    else:
+        if isinstance(decoded, dict) and isinstance(decoded.get("data"), list):
+            values = decoded["data"]
+        elif isinstance(decoded, list):
+            values = decoded
+        else:
+            values = [decoded]
+
+    records: list[dict[str, Any]] = []
+    for line_number, value in enumerate(values, start=1):
+        if not isinstance(value, dict):
+            raise InvalidImport(f"Record {line_number} must be a JSON object")
+        message_type = value.get("type")
+        if message_type in {"schema", "explain", "end"}:
+            continue
+        if message_type == "error":
+            raise InvalidImport(
+                str(
+                    value.get("message")
+                    or value.get("error")
+                    or "Logfire query export failed"
+                )
+            )
+        if message_type == "data" and isinstance(value.get("rows"), list):
+            rows = value["rows"]
+            if not all(isinstance(row, dict) for row in rows):
+                raise InvalidImport(
+                    f"Record {line_number} contains a non-object Logfire row"
+                )
+            records.extend(rows)
+        elif message_type == "data" and isinstance(value.get("data"), dict):
+            records.append(value["data"])
+        else:
+            records.append(value)
+    if not records:
+        raise InvalidImport("Import file contains no Logfire data rows")
+    return records
+
+
+def _path_parts(path: str) -> list[str]:
+    """Parse a dotted path or RFC 6901 JSON Pointer."""
+    if not path.strip():
+        raise InvalidImport("join path must be non-empty")
+    if not path.startswith("/"):
+        return path.split(".")
+    parts = path[1:].split("/")
+    if any(re.search(r"~(?:[^01]|$)", part) for part in parts):
+        raise InvalidImport("join path contains an invalid JSON Pointer escape")
+    return [part.replace("~1", "/").replace("~0", "~") for part in parts]
+
+
+def _path_value(record: dict[str, Any], path: str) -> Any:
+    """Resolve a grouping path, including dotted OpenTelemetry attribute keys."""
+    parts = _path_parts(path)
+    current: Any = record
+    for index, part in enumerate(parts):
+        current = _decode_json(current)
+        if not isinstance(current, dict):
+            return None
+        if part in current:
+            current = current[part]
+            continue
+        remainder = ".".join(parts[index:])
+        return current.get(remainder)
+    return _decode_json(current)
+
+
+def _is_missing_identity(value: Any) -> bool:
+    """Return whether a grouping value has no usable identity."""
+    if value in (None, ""):
+        return True
+    if not isinstance(value, str):
+        return False
+    return value.strip().casefold() in {"[redacted]", "[scrubbed]"}
+
+
+def _join_value(
+    records: list[dict[str, Any]], params: dict[str, Any], trace_id: str
+) -> tuple[str, str, bool]:
+    """Select the stable session identity for one trace."""
+    configured = params.get("join_on")
+    if configured is not None and not isinstance(configured, str):
+        raise InvalidImport("join_on must be a dotted path or JSON pointer")
+    paths = (configured,) if configured else _DEFAULT_JOIN_PATHS
+    for path in paths:
+        values = {
+            str(value)
+            for record in records
+            if not _is_missing_identity(value := _path_value(record, path))
+        }
+        if len(values) > 1:
+            raise InvalidImport(
+                f"Trace '{trace_id}' has conflicting values at join path '{path}'"
+            )
+        if values:
+            return next(iter(values)), path, False
+    if configured:
+        raise InvalidImport(
+            f"Trace '{trace_id}' has no value at join path '{configured}'"
+        )
+    return trace_id, "trace_id", True
+
+
+def _attributes(record: dict[str, Any]) -> dict[str, Any]:
+    """Return decoded span attributes."""
+    return _dict(record.get("attributes"))
+
+
+def _attribute(record: dict[str, Any], *names: str) -> Any:
+    """Return the first non-empty span attribute."""
+    attributes = _attributes(record)
+    for name in names:
+        value = attributes.get(name)
+        if value not in (None, ""):
+            return _decode_json(value)
+    return None
+
+
+def _node_type(record: dict[str, Any]) -> tuple[NodeType, str | None]:
+    """Map OpenTelemetry GenAI semantics to a Kitaru node type."""
+    operation = str(_attribute(record, "gen_ai.operation.name") or "").casefold()
+    span_name = str(record.get("span_name") or "")
+    tool_name = _attribute(
+        record,
+        "gen_ai.tool.name",
+        "tool.name",
+        "tool_name",
+    )
+    if operation in {"execute_tool", "tool", "tool_call"} or tool_name:
+        return NodeType.TOOL_CALL, str(tool_name or span_name or "tool")
+    if operation in {
+        "chat",
+        "completion",
+        "embeddings",
+        "generate_content",
+        "text_completion",
+    } or _attribute(
+        record,
+        "gen_ai.request.model",
+        "gen_ai.response.model",
+        "gen_ai.system",
+    ):
+        return NodeType.LLM_CALL, None
+    return NodeType.SPAN, None
+
+
+def _node_status(record: dict[str, Any]) -> NodeStatus:
+    """Map Logfire status and level fields."""
+    status = str(
+        record.get("otel_status_code") or record.get("status_code") or ""
+    ).casefold()
+    level = record.get("level")
+    level_number = _integer(level)
+    if status == "error" or record.get("is_exception") is True:
+        return NodeStatus.FAILED
+    if isinstance(level, str) and level.casefold() in {"error", "fatal"}:
+        return NodeStatus.FAILED
+    if level_number is not None and level_number >= 17:
+        return NodeStatus.FAILED
+    return NodeStatus.COMPLETED
+
+
+def _payload(record: dict[str, Any], *names: str) -> Any:
+    """Return the first decoded payload attribute."""
+    return _attribute(record, *names)
+
+
+def _tokens(record: dict[str, Any]) -> TokenUsage | None:
+    """Map OpenTelemetry GenAI token attributes."""
+    values = (
+        _integer(
+            _attribute(
+                record,
+                "gen_ai.usage.input_tokens",
+                "gen_ai.usage.prompt_tokens",
+            )
+        ),
+        _integer(
+            _attribute(
+                record,
+                "gen_ai.usage.output_tokens",
+                "gen_ai.usage.completion_tokens",
+            )
+        ),
+        _integer(
+            _attribute(
+                record,
+                "gen_ai.usage.details.cache_read_tokens",
+                "gen_ai.usage.cached_input_tokens",
+            )
+        ),
+        _integer(_attribute(record, "gen_ai.usage.details.reasoning_tokens")),
+    )
+    if all(value is None for value in values):
+        return None
+    return TokenUsage(
+        input_tokens=values[0],
+        output_tokens=values[1],
+        cached_input_tokens=values[2],
+        reasoning_tokens=values[3],
+    )
+
+
+def _source_metadata(record: dict[str, Any]) -> dict[str, Any]:
+    """Select bounded Logfire metadata for filtering and debugging."""
+    metadata = {
+        f"logfire.{column}": record[column]
+        for column in _METADATA_COLUMNS
+        if record.get(column) not in (None, "", [])
+    }
+    attributes = _attributes(record)
+    for key in _ATTRIBUTE_METADATA_KEYS:
+        if attributes.get(key) not in (None, ""):
+            metadata[f"logfire.attributes.{key}"] = attributes[key]
+    return metadata
+
+
+def _detect_framework(records: list[dict[str, Any]], configured: Any) -> str | None:
+    """Detect one supported agent framework."""
+    evidence = [str(configured or "")]
+    for record in records:
+        evidence.extend(
+            str(value)
+            for value in (
+                record.get("otel_scope_name"),
+                record.get("span_name"),
+                _attribute(record, "gen_ai.agent.name"),
+            )
+            if value
+        )
+    joined = "\n".join(evidence)
+    matches = {
+        framework
+        for pattern, framework in _FRAMEWORK_PATTERNS
+        if pattern.search(joined)
+    }
+    return next(iter(matches)) if len(matches) == 1 else None
+
+
+def _build_node_tree(
+    nodes_with_parents: list[tuple[ImportedNode, str | None]],
+) -> list[ImportedNode]:
+    """Build an acyclic node tree while preserving orphans as roots."""
+    ids = [node.external_id for node, _ in nodes_with_parents]
+    if len(ids) != len(set(ids)):
+        raise InvalidImport("The import contains duplicate span ids")
+    by_id = {node.external_id: node for node, _ in nodes_with_parents}
+    parents = {
+        node.external_id: parent
+        for node, parent in nodes_with_parents
+        if node.external_id is not None and parent in by_id
+    }
+    for node_id in parents:
+        seen: set[str] = set()
+        current: str | None = node_id
+        while current in parents:
+            if current in seen:
+                raise InvalidImport("The imported span graph contains a parent cycle")
+            seen.add(current)
+            current = parents[current]
+    roots: list[ImportedNode] = []
+    for node, parent in nodes_with_parents:
+        if parent in by_id:
+            by_id[parent].children.append(node)
+        else:
+            roots.append(node)
+    return roots
+
+
+class LogfireRecordsImporter:
+    """Normalize exported rows from Logfire's records table."""
+
+    def parse(
+        self, content: bytes, params: dict[str, Any]
+    ) -> Iterator[ImportedSession | ImportFailure]:
+        """Parse Logfire records into sessions and isolated failures."""
+        records = _parse_records(content)
+        traces: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        failures: list[ImportFailure] = []
+        for line_number, record in enumerate(records, start=1):
+            trace_id = record.get("trace_id")
+            span_id = record.get("span_id")
+            if trace_id in (None, "") or span_id in (None, ""):
+                failures.append(
+                    ImportFailure(
+                        line=line_number,
+                        external_id=str(trace_id) if trace_id else None,
+                        error="Logfire row lacks trace_id or span_id",
+                    )
+                )
+                continue
+            traces[str(trace_id)].append(record)
+
+        grouped: dict[str, list[tuple[str, list[dict[str, Any]]]]] = defaultdict(list)
+        join_paths: dict[str, set[str]] = defaultdict(set)
+        fallback_sessions: set[str] = set()
+        for trace_id, rows in traces.items():
+            try:
+                session_id, join_path, fallback = _join_value(rows, params, trace_id)
+            except InvalidImport as exc:
+                failures.append(
+                    ImportFailure(
+                        line=len(failures) + 1,
+                        external_id=trace_id,
+                        error=str(exc),
+                    )
+                )
+                continue
+            grouped[session_id].append((trace_id, rows))
+            join_paths[session_id].add(join_path)
+            if fallback:
+                fallback_sessions.add(session_id)
+
+        for session_id, session_traces in sorted(grouped.items()):
+            try:
+                yield self._parse_session(
+                    session_id,
+                    session_traces,
+                    params,
+                    join_paths=join_paths[session_id],
+                    trace_fallback=session_id in fallback_sessions,
+                )
+            except InvalidImport as exc:
+                yield ImportFailure(
+                    line=len(failures) + 1,
+                    external_id=session_id,
+                    error=str(exc),
+                )
+        yield from failures
+
+    def _parse_session(
+        self,
+        session_id: str,
+        traces: list[tuple[str, list[dict[str, Any]]]],
+        params: dict[str, Any],
+        *,
+        join_paths: set[str],
+        trace_fallback: bool,
+    ) -> ImportedSession:
+        """Normalize one grouped Logfire session."""
+        project_ids = {
+            str(row["project_id"])
+            for _, rows in traces
+            for row in rows
+            if row.get("project_id") not in (None, "")
+        }
+        if len(project_ids) > 1:
+            raise InvalidImport(
+                f"Session '{session_id}' contains conflicting Logfire project ids"
+            )
+        source_instance_value = (
+            params.get("source_instance")
+            or params.get("project_id")
+            or next(iter(project_ids), None)
+        )
+        source_instance = (
+            str(source_instance_value).strip() if source_instance_value else "logfire"
+        )
+        warnings: list[str] = []
+        if not source_instance_value:
+            warnings.append(
+                "No Logfire project identity supplied; using source_instance 'logfire'"
+            )
+        if trace_fallback:
+            warnings.append("No session attribute found; grouped by trace id")
+
+        turns: list[_Turn] = []
+        nodes_with_parents: list[tuple[ImportedNode, str | None]] = []
+        all_records: list[dict[str, Any]] = []
+        roots_by_trace: dict[str, dict[str, Any]] = {}
+        for trace_id, rows in traces:
+            ordered = sorted(
+                rows,
+                key=lambda row: (
+                    _datetime(row.get("start_timestamp"))
+                    or datetime.min.replace(tzinfo=UTC),
+                    str(row.get("span_id")),
+                ),
+            )
+            ids = {str(row["span_id"]) for row in ordered}
+            roots = [
+                row
+                for row in ordered
+                if row.get("parent_span_id") in (None, "")
+                or str(row.get("parent_span_id")) not in ids
+            ]
+            if len(roots) != 1:
+                warnings.append(f"Trace '{trace_id}' has {len(roots)} root records")
+            root = roots[0] if roots else ordered[0]
+            roots_by_trace[trace_id] = root
+            trace_start = min(
+                (
+                    timestamp
+                    for row in ordered
+                    if (timestamp := _datetime(row.get("start_timestamp")))
+                ),
+                default=None,
+            )
+            trace_end = max(
+                (
+                    timestamp
+                    for row in ordered
+                    if (timestamp := _datetime(row.get("end_timestamp")))
+                ),
+                default=None,
+            )
+            turn_input = _payload(
+                root,
+                "input",
+                "inputs",
+                "raw_input",
+                "pydantic_ai.all_messages",
+                "gen_ai.input.messages",
+                "gen_ai.prompt",
+            )
+            turn_output = _payload(
+                root,
+                "output",
+                "outputs",
+                "final_result",
+                "gen_ai.output.messages",
+                "gen_ai.completion",
+            )
+            turns.append(
+                _Turn(trace_id, turn_input, turn_output, trace_start, trace_end)
+            )
+            for row in ordered:
+                span_id = str(row["span_id"])
+                parent_id = row.get("parent_span_id")
+                parent_external_id = (
+                    f"{trace_id}:{parent_id}"
+                    if parent_id not in (None, "") and str(parent_id) in ids
+                    else None
+                )
+                if parent_id not in (None, "") and parent_external_id is None:
+                    warnings.append(
+                        f"Span '{span_id}' references missing parent '{parent_id}'"
+                    )
+                node_type, tool_name = _node_type(row)
+                status = _node_status(row)
+                error = None
+                if status is NodeStatus.FAILED:
+                    error_value = (
+                        row.get("exception_message")
+                        or row.get("otel_status_message")
+                        or row.get("message")
+                    )
+                    error = str(error_value) if error_value else "Logfire span failed"
+                inputs = _payload(
+                    row,
+                    "input",
+                    "inputs",
+                    "raw_input",
+                    "pydantic_ai.all_messages",
+                    "gen_ai.input.messages",
+                    "gen_ai.prompt",
+                    "tool.arguments",
+                    "gen_ai.tool.call.arguments",
+                )
+                outputs = _payload(
+                    row,
+                    "output",
+                    "outputs",
+                    "final_result",
+                    "gen_ai.output.messages",
+                    "gen_ai.completion",
+                    "tool.result",
+                    "gen_ai.tool.call.result",
+                )
+                nodes_with_parents.append(
+                    (
+                        ImportedNode(
+                            external_id=f"{trace_id}:{span_id}",
+                            trace_id=trace_id,
+                            node_type=node_type,
+                            name=str(
+                                row.get("span_name")
+                                or row.get("message")
+                                or row.get("kind")
+                                or "span"
+                            ),
+                            status=status,
+                            error=error,
+                            started_at=_datetime(row.get("start_timestamp")),
+                            ended_at=_datetime(row.get("end_timestamp")),
+                            inputs=inputs,
+                            outputs=outputs,
+                            requested_model=(
+                                str(value)
+                                if (value := _attribute(row, "gen_ai.request.model"))
+                                else None
+                            ),
+                            model=(
+                                str(value)
+                                if (
+                                    value := _attribute(
+                                        row,
+                                        "gen_ai.response.model",
+                                        "gen_ai.request.model",
+                                    )
+                                )
+                                else None
+                            ),
+                            model_provider=(
+                                str(value)
+                                if (
+                                    value := _attribute(
+                                        row,
+                                        "gen_ai.provider.name",
+                                        "gen_ai.system",
+                                    )
+                                )
+                                else None
+                            ),
+                            tokens=_tokens(row),
+                            cost=_decimal(
+                                _attribute(
+                                    row,
+                                    "gen_ai.usage.cost",
+                                    "gen_ai.cost.total",
+                                    "operation.cost",
+                                )
+                            ),
+                            model_params=_dict(
+                                _attribute(
+                                    row,
+                                    "gen_ai.request.parameters",
+                                    "model_parameters",
+                                    "model_request_parameters",
+                                    "model_settings",
+                                )
+                            )
+                            or None,
+                            tool_name=tool_name,
+                            attributes={
+                                "logfire.kind": row.get("kind"),
+                                "logfire.level": row.get("level"),
+                                "logfire.message": row.get("message"),
+                                "logfire.attributes": _attributes(row),
+                            },
+                            metadata=_source_metadata(row),
+                            children=[],
+                        ),
+                        parent_external_id,
+                    )
+                )
+            all_records.extend(ordered)
+
+        turns.sort(
+            key=lambda turn: (
+                turn.started_at or datetime.min.replace(tzinfo=UTC),
+                turn.trace_id,
+            )
+        )
+        nodes_with_parents.sort(
+            key=lambda item: (
+                item[0].started_at or datetime.min.replace(tzinfo=UTC),
+                item[0].external_id or "",
+            )
+        )
+        node_tree = _build_node_tree(nodes_with_parents)
+        latest_turn = turns[-1]
+        latest_root = roots_by_trace[latest_turn.trace_id]
+        session_status = (
+            SessionStatus.FAILED
+            if _node_status(latest_root) is NodeStatus.FAILED
+            else SessionStatus.COMPLETED
+        )
+        metadata: dict[str, Any] = {
+            "logfire.session_id": session_id,
+            "logfire.project_id": next(iter(project_ids), None),
+            "logfire.trace_ids": [turn.trace_id for turn in turns],
+            "logfire.join_paths": sorted(join_paths),
+            "logfire.services": sorted(
+                {
+                    str(row["service_name"])
+                    for row in all_records
+                    if row.get("service_name") not in (None, "")
+                }
+            ),
+            "logfire.environments": sorted(
+                {
+                    str(row["deployment_environment"])
+                    for row in all_records
+                    if row.get("deployment_environment") not in (None, "")
+                }
+            ),
+            "source_trace_count": len(turns),
+            "source_completeness": "query-dependent",
+            "normalization_warnings": warnings,
+        }
+        latest_error = (
+            latest_root.get("exception_message")
+            or latest_root.get("otel_status_message")
+            if session_status is SessionStatus.FAILED
+            else None
+        )
+        return ImportedSession(
+            external_id=f"{source_instance}:{session_id}",
+            name=str(
+                latest_root.get("span_name") or latest_root.get("message") or session_id
+            ),
+            status=session_status,
+            inputs={
+                "schema_version": 1,
+                "turns": [
+                    {
+                        "source_trace_id": turn.trace_id,
+                        "inputs": turn.inputs,
+                        "outputs": turn.outputs,
+                    }
+                    for turn in turns
+                ],
+            },
+            outputs=latest_turn.outputs,
+            error=str(latest_error) if latest_error else None,
+            started_at=min(
+                (turn.started_at for turn in turns if turn.started_at), default=None
+            ),
+            ended_at=max(
+                (turn.ended_at for turn in turns if turn.ended_at), default=None
+            ),
+            metadata=metadata,
+            framework=_detect_framework(all_records, params.get("framework")),
+            nodes=node_tree,
+        )
+
+
+def parse(
+    content: bytes, params: dict[str, Any]
+) -> Iterator[ImportedSession | ImportFailure]:
+    """Parse a Logfire records-query export through the importer contract."""
+    yield from LogfireRecordsImporter().parse(content, params)

--- a/plugins/pyproject.toml
+++ b/plugins/pyproject.toml
@@ -41,6 +41,7 @@ known-first-party = [
     "kitaru_jsonl_importer",
     "kitaru_langfuse_importer",
     "kitaru_langgraph",
+    "kitaru_logfire_importer",
     "kitaru_langsmith_importer",
     "kitaru_openai_agents",
     "kitaru_pydantic_ai",

--- a/plugins/tests/importers/test_logfire.py
+++ b/plugins/tests/importers/test_logfire.py
@@ -1,0 +1,288 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Logfire records-query importer plugin tests."""
+
+import json
+from decimal import Decimal
+from typing import Any
+
+from kitaru.api_models.v1.imports import ImportFailure
+from kitaru.api_models.v1.session import SessionStatus
+from kitaru.api_models.v1.session_node import NodeStatus, NodeType
+from kitaru.task.importer import ImportedNode, ImportedSession
+from kitaru_logfire_importer.importer import LogfireRecordsImporter
+
+
+def row(
+    span_id: str,
+    *,
+    trace_id: str = "trace-1",
+    parent_span_id: str | None = None,
+    span_name: str | None = None,
+    start_timestamp: str = "2026-07-22T13:15:00Z",
+    attributes: dict[str, Any] | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Build one sanitized Logfire records-table row."""
+    return {
+        "project_id": "project-1",
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "span_name": span_name or span_id,
+        "message": span_name or span_id,
+        "kind": "span",
+        "level": 9,
+        "start_timestamp": start_timestamp,
+        "end_timestamp": "2026-07-22T13:15:01Z",
+        "service_name": "support-agent",
+        "deployment_environment": "test",
+        "otel_scope_name": "pydantic-ai",
+        "attributes": {
+            "gen_ai.conversation.id": "conversation-1",
+            "gen_ai.agent.name": "support-agent",
+            **(attributes or {}),
+        },
+        **extra,
+    }
+
+
+def jsonl(*records: dict[str, Any]) -> bytes:
+    """Encode records as JSONL."""
+    return b"\n".join(json.dumps(record).encode() for record in records)
+
+
+def parse(
+    content: bytes, params: dict[str, Any] | None = None
+) -> list[ImportedSession | ImportFailure]:
+    """Parse one test payload."""
+    return list(LogfireRecordsImporter().parse(content, params or {}))
+
+
+def flatten(nodes: list[ImportedNode]) -> list[ImportedNode]:
+    """Flatten imported nodes depth-first."""
+    return [node for root in nodes for node in (root, *flatten(root.children))]
+
+
+def test_maps_trace_corpus_genai_spans() -> None:
+    """Map the GenAI fields represented in the Kitaru trace corpus."""
+    content = jsonl(
+        row(
+            "tool",
+            parent_span_id="root",
+            span_name="execute_tool lookup_order",
+            start_timestamp="2026-07-22T13:15:00.200000Z",
+            attributes={
+                "gen_ai.operation.name": "execute_tool",
+                "gen_ai.tool.name": "lookup_order",
+                "gen_ai.tool.call.arguments": {"order_reference": "KIT-2481"},
+                "gen_ai.tool.call.result": {"status": "in_transit"},
+            },
+        ),
+        row(
+            "llm",
+            parent_span_id="root",
+            span_name="chat claude-haiku-4-5",
+            start_timestamp="2026-07-22T13:15:00.100000Z",
+            attributes={
+                "gen_ai.operation.name": "chat",
+                "gen_ai.input.messages": [
+                    {"role": "user", "parts": [{"content": "Track KIT-2481"}]}
+                ],
+                "gen_ai.output.messages": [
+                    {"role": "assistant", "parts": [{"content": "Checking"}]}
+                ],
+                "gen_ai.provider.name": "anthropic",
+                "gen_ai.request.model": "claude-haiku-4-5",
+                "gen_ai.response.model": "claude-haiku-4-5-20251001",
+                "gen_ai.usage.input_tokens": 507,
+                "gen_ai.usage.output_tokens": 77,
+                "operation.cost": 0.000892,
+                "model_request_parameters": {"temperature": 0},
+            },
+        ),
+        row(
+            "root",
+            span_name="invoke_agent support-agent",
+            attributes={
+                "gen_ai.operation.name": "invoke_agent",
+                "input": "Track KIT-2481",
+                "final_result": "In transit",
+            },
+        ),
+    )
+
+    [session] = parse(content)
+
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == "project-1:conversation-1"
+    assert session.status is SessionStatus.COMPLETED
+    assert session.outputs == "In transit"
+    assert session.framework == "pydantic-ai"
+    assert session.metadata["logfire.project_id"] == "project-1"
+    nodes = {node.external_id: node for node in flatten(session.nodes)}
+    llm = nodes["trace-1:llm"]
+    assert llm.node_type is NodeType.LLM_CALL
+    assert llm.model_provider == "anthropic"
+    assert llm.requested_model == "claude-haiku-4-5"
+    assert llm.model == "claude-haiku-4-5-20251001"
+    assert llm.tokens is not None
+    assert llm.tokens.input_tokens == 507
+    assert llm.tokens.output_tokens == 77
+    assert llm.cost == Decimal("0.000892")
+    assert llm.model_params == {"temperature": 0}
+    tool = nodes["trace-1:tool"]
+    assert tool.node_type is NodeType.TOOL_CALL
+    assert tool.tool_name == "lookup_order"
+    assert tool.inputs == {"order_reference": "KIT-2481"}
+    assert tool.outputs == {"status": "in_transit"}
+    assert tool in nodes["trace-1:root"].children
+
+
+def test_groups_conversation_traces_as_ordered_turns() -> None:
+    """Group out-of-order traces by conversation and sort their turns."""
+    content = jsonl(
+        row(
+            "root-2",
+            trace_id="trace-2",
+            start_timestamp="2026-07-22T13:16:00Z",
+            attributes={"input": "second", "final_result": "two"},
+        ),
+        row(
+            "root-1",
+            trace_id="trace-1",
+            attributes={"input": "first", "final_result": "one"},
+        ),
+    )
+
+    [session] = parse(content)
+
+    assert isinstance(session, ImportedSession)
+    assert [turn["source_trace_id"] for turn in session.inputs["turns"]] == [
+        "trace-1",
+        "trace-2",
+    ]
+    assert session.outputs == "two"
+    assert session.metadata["source_trace_count"] == 2
+
+
+def test_parses_streaming_query_api_ndjson() -> None:
+    """Read schema, batched rows, and terminal messages from Query API v2."""
+    payload = b"\n".join(
+        json.dumps(message).encode()
+        for message in (
+            {"type": "schema", "schema": {"fields": []}},
+            {"type": "data", "rows": [row("root")]},
+            {"type": "end", "row_count": 1},
+        )
+    )
+
+    [session] = parse(payload)
+
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == "project-1:conversation-1"
+
+
+def test_uses_configured_join_path() -> None:
+    """Use a caller-selected attribute for session grouping."""
+    record = row("root", attributes={"customer.case/id": "case-9"})
+
+    [session] = parse(jsonl(record), {"join_on": "/attributes/customer.case~1id"})
+
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == "project-1:case-9"
+    assert session.metadata["logfire.join_paths"] == ["/attributes/customer.case~1id"]
+
+
+def test_falls_back_to_trace_id_with_warning() -> None:
+    """Keep traces separate when no conversation identity was recorded."""
+    record = row(
+        "root",
+        attributes={
+            "gen_ai.agent.name": "support-agent",
+            "gen_ai.conversation.id": None,
+        },
+    )
+
+    [session] = parse(jsonl(record))
+
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == "project-1:trace-1"
+    assert "grouped by trace id" in session.metadata["normalization_warnings"][0]
+
+
+def test_isolates_rows_missing_trace_identity() -> None:
+    """Import valid traces while reporting malformed rows."""
+    invalid = row("missing-trace")
+    invalid.pop("trace_id")
+
+    parsed = parse(jsonl(row("root"), invalid))
+
+    assert len(parsed) == 2
+    assert any(isinstance(item, ImportedSession) for item in parsed)
+    [failure] = [item for item in parsed if isinstance(item, ImportFailure)]
+    assert failure.error == "Logfire row lacks trace_id or span_id"
+
+
+def test_maps_failed_trace_and_missing_parent() -> None:
+    """Preserve failures and keep orphan spans importable."""
+    content = jsonl(
+        row(
+            "failed",
+            parent_span_id="missing",
+            is_exception=True,
+            exception_message="lookup failed",
+        )
+    )
+
+    [session] = parse(content)
+
+    assert isinstance(session, ImportedSession)
+    assert session.status is SessionStatus.FAILED
+    assert session.nodes[0].status is NodeStatus.FAILED
+    assert session.nodes[0].error == "lookup failed"
+    assert "references missing parent" in session.metadata["normalization_warnings"][0]
+
+
+def test_uses_root_status_after_recovered_child_failure() -> None:
+    """Keep a completed session when an internal failed span was recovered."""
+    content = jsonl(
+        row("root"),
+        row(
+            "failed-tool",
+            parent_span_id="root",
+            is_exception=True,
+            exception_message="retryable failure",
+        ),
+    )
+
+    [session] = parse(content)
+
+    assert isinstance(session, ImportedSession)
+    assert session.status is SessionStatus.COMPLETED
+    assert flatten(session.nodes)[1].status is NodeStatus.FAILED
+
+
+def test_rejects_parent_cycles_per_session() -> None:
+    """Report a cyclic span graph without aborting the file parser."""
+    parsed = parse(
+        jsonl(
+            row("one", parent_span_id="two"),
+            row("two", parent_span_id="one"),
+        )
+    )
+
+    [failure] = parsed
+    assert isinstance(failure, ImportFailure)
+    assert "parent cycle" in failure.error

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-10T10:08:22.409882Z"
+exclude-newer = "2026-08-14T14:14:47.699825Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -20,6 +20,7 @@ members = [
     "kitaru-langfuse-importer",
     "kitaru-langgraph",
     "kitaru-langsmith-importer",
+    "kitaru-logfire-importer",
     "kitaru-openai-agents",
     "kitaru-pydantic-ai",
 ]
@@ -1064,6 +1065,17 @@ provides-extras = ["deepagents"]
 name = "kitaru-langsmith-importer"
 version = "0.1.0rc0"
 source = { editable = "packages/langsmith-importer" }
+dependencies = [
+    { name = "kitaru" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "kitaru", editable = "../" }]
+
+[[package]]
+name = "kitaru-logfire-importer"
+version = "0.1.0rc0"
+source = { editable = "packages/logfire-importer" }
 dependencies = [
     { name = "kitaru" },
 ]

--- a/release/release-units.toml
+++ b/release/release-units.toml
@@ -89,6 +89,16 @@ tag-prefix = "python/kitaru-langgraph/v"
 checks = ["plugin package (langgraph)"]
 
 [[units]]
+slug = "logfire-importer"
+path = "plugins/packages/logfire-importer"
+distribution = "kitaru-logfire-importer"
+registry = "pypi"
+version-source = "plugins/packages/logfire-importer/pyproject.toml"
+default-catalog = true
+tag-prefix = "python/kitaru-logfire-importer/v"
+checks = ["plugin package (logfire-importer)"]
+
+[[units]]
 slug = "langsmith-importer"
 path = "plugins/packages/langsmith-importer"
 distribution = "kitaru-langsmith-importer"

--- a/src/kitaru/server/api/bootstrap.py
+++ b/src/kitaru/server/api/bootstrap.py
@@ -121,6 +121,15 @@ DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = (
     ),
     DefaultPluginDefinition(
         kind=PluginKind.IMPORTER,
+        name=f"{RESERVED_NAMESPACE}/logfire",
+        description="Import Logfire records-query JSON and NDJSON exports.",
+        provider="logfire",
+        entrypoint="kitaru_logfire_importer.importer:parse",
+        requirement="kitaru-logfire-importer==0.1.0rc0",
+        display_version="0.1.0rc0",
+    ),
+    DefaultPluginDefinition(
+        kind=PluginKind.IMPORTER,
         name=f"{RESERVED_NAMESPACE}/langsmith",
         description="Import LangSmith run-query and bulk-export records.",
         provider="langsmith",

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -25,6 +25,7 @@ EXPECTED_UNITS = {
     "jsonl-importer": "kitaru-jsonl-importer",
     "langfuse-importer": "kitaru-langfuse-importer",
     "langgraph": "kitaru-langgraph",
+    "logfire-importer": "kitaru-logfire-importer",
     "langsmith-importer": "kitaru-langsmith-importer",
     "openai-agents": "kitaru-openai-agents",
     "pydantic-ai": "kitaru-pydantic-ai",
@@ -35,6 +36,7 @@ EXPECTED_DEFAULT_DISTRIBUTIONS = {
     "kitaru-evaluator",
     "kitaru-jsonl-importer",
     "kitaru-langfuse-importer",
+    "kitaru-logfire-importer",
     "kitaru-langsmith-importer",
 }
 
@@ -61,7 +63,7 @@ def release_repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_inventory_describes_exactly_the_nine_python_distributions() -> None:
+def test_inventory_describes_exactly_the_ten_python_distributions() -> None:
     inventory = load_inventory()
 
     assert {unit.slug: unit.distribution for unit in inventory.units} == EXPECTED_UNITS
@@ -435,7 +437,7 @@ def _run_cli(*arguments: str) -> subprocess.CompletedProcess[str]:
     [
         (["list"], "SLUG\tDISTRIBUTION\tVERSION\tDEFAULT\tTAG"),
         (["resolve", "--unit", "kitaru"], "python/kitaru/v"),
-        (["validate"], "Validated 9 release units."),
+        (["validate"], "Validated 10 release units."),
     ],
 )
 def test_cli_text_commands_succeed(


### PR DESCRIPTION
## Summary

- add a self-contained `kitaru-logfire-importer` distribution for Logfire Query API v2 JSON, JSONL, and streaming NDJSON exports
- normalize project, conversation, trace, span hierarchy, GenAI model and tool fields, tokens, cost, errors, framework metadata, and partial row failures
- register Logfire in the default importer catalog and release inventory
- add coverage derived from representative exports in `zenml-io/kitaru-trace-corpus`

## Validation

- `just check`
- `uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests tests/server/test_default_plugins.py` (383 passed)
- `just plugin-artifact-smoke`
- parsed all 9 Logfire `records.jsonl` and `records.ndjson` exports in `zenml-io/kitaru-trace-corpus`, producing 11 sessions and 0 failures

## Reviewer Notes

Run `uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests/importers/test_logfire.py` for the focused contract. To reproduce the corpus check, clone `zenml-io/kitaru-trace-corpus`, then pass every file under `exports/logfire/**/api/records.{jsonl,ndjson}` through `kitaru_logfire_importer.importer.parse`. Review session grouping around `gen_ai.conversation.id`, fallback grouping by `trace_id`, and the explicit `source_instance` override for exports without `project_id`.