### PR TITLE
Prepare Kitaru 0.22.0rc9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.22.0rc9]
+
+### Added
+
+- Added the Logfire records-query importer as a default plugin at `0.1.0rc0`.
+
+### Changed
+
+- Prepared the ninth Kitaru 0.22 release candidate with `kitaru-ui-v0.2.0-rc.5` and the Langfuse importer at `0.1.0rc2`.
+
 ## [0.22.0rc8]
 
 ### Changed

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8589,7 +8589,7 @@
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.22.0rc8"
+    "version": "0.22.0rc9"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/plugins/default-requirements.txt
+++ b/plugins/default-requirements.txt
@@ -1,6 +1,6 @@
 kitaru-braintrust-importer==0.1.0rc0
 kitaru-evaluator==0.1.0rc0
 kitaru-jsonl-importer==0.1.0rc0
-kitaru-langfuse-importer==0.1.0rc1
+kitaru-langfuse-importer==0.1.0rc2
 kitaru-logfire-importer==0.1.0rc0
 kitaru-langsmith-importer==0.1.0rc0

--- a/plugins/packages/langfuse-importer/CHANGELOG.md
+++ b/plugins/packages/langfuse-importer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.0rc2
+
+- Align the Langfuse importer release candidate with Kitaru 0.22.0rc9.
+
 ## 0.1.0rc1
 
 - Add causal links from tool spans to the model calls that requested them, with an option to disable inference.

--- a/plugins/packages/langfuse-importer/pyproject.toml
+++ b/plugins/packages/langfuse-importer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru-langfuse-importer"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 description = "Langfuse trace importer for Kitaru."
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -923,7 +923,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.0rc8"
+version = "0.22.0rc9"
 source = { editable = "../" }
 dependencies = [
     { name = "httpx" },
@@ -1026,7 +1026,7 @@ requires-dist = [{ name = "kitaru", editable = "../" }]
 
 [[package]]
 name = "kitaru-langfuse-importer"
-version = "0.1.0rc1"
+version = "0.1.0rc2"
 source = { editable = "packages/langfuse-importer" }
 dependencies = [
     { name = "kitaru" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.22.0rc8"
+version = "0.22.0rc9"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/releases/python/kitaru/0.22.0rc9.toml
+++ b/releases/python/kitaru/0.22.0rc9.toml
@@ -1,0 +1,3 @@
+schema-version = 1
+kitaru-version = "0.22.0rc9"
+ui-tag = "kitaru-ui-v0.2.0-rc.5"

--- a/src/kitaru/server/api/bootstrap.py
+++ b/src/kitaru/server/api/bootstrap.py
@@ -116,8 +116,8 @@ DEFAULT_PLUGIN_DEFINITIONS: tuple[DefaultPluginDefinition, ...] = (
         description="Import Langfuse JSON and JSONL trace exports.",
         provider="langfuse",
         entrypoint="kitaru_langfuse_importer.importer:parse",
-        requirement="kitaru-langfuse-importer==0.1.0rc1",
-        display_version="0.1.0rc1",
+        requirement="kitaru-langfuse-importer==0.1.0rc2",
+        display_version="0.1.0rc2",
     ),
     DefaultPluginDefinition(
         kind=PluginKind.IMPORTER,

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.0rc8"
+version = "0.22.0rc9"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- prepare Kitaru `0.22.0rc9`
- reuse frontend `kitaru-ui-v0.2.0-rc.5` from RC8
- prepare `kitaru-langfuse-importer==0.1.0rc2`
- include the new `kitaru-logfire-importer==0.1.0rc0`
- update the default plugin catalog, lockfiles, changelogs, OpenAPI version, and core release declaration

## Release order

1. Remove the stale `python/kitaru/v0.22.0rc9` tag, whose workflow failed during metadata resolution before publishing artifacts.
2. Merge this PR to `develop`.
3. Publish `python/kitaru/v0.22.0rc9` from the merged commit.
4. Verify the Kitaru `0.22.0rc9` artifact.
5. Publish `python/kitaru-langfuse-importer/v0.1.0rc2` and `python/kitaru-logfire-importer/v0.1.0rc0` from the same merged commit.
6. Verify both plugin artifacts.

The plugin distributions require `kitaru>=0.22.0rc0,<0.23`, so publishing core RC9 first satisfies their dependency range.

## Validation

- `git diff --check`
- `just check`
- `uv run --no-project --with packaging==26.2 python scripts/release_units.py validate`
- `uv run python scripts/release_ui.py --version 0.22.0rc9`
- `uv run pytest -q tests/scripts/test_release_ui.py tests/scripts/test_release_units.py`
- plugin Ruff format and lint checks
- plugin `ty check`
- plugin tests: 384 passed
- `just plugin-artifact-smoke`

## Reviewer Notes

Review `releases/python/kitaru/0.22.0rc9.toml` for the RC.5 frontend selection, then compare the Langfuse and Logfire versions across their package metadata, `plugins/default-requirements.txt`, `src/kitaru/server/api/bootstrap.py`, and `plugins/uv.lock`. Run the release metadata and artifact smoke commands above to reproduce the release-path checks.