### PR TITLE
Prepare TypeScript 0.1.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenml-io/kitaru",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript SDK and adapter foundation for Kitaru agent tracing and replay",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/mastra/package.json
+++ b/packages/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenml-io/kitaru-mastra",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Mastra adapter for Kitaru agent tracing and replay",
   "license": "Apache-2.0",
   "repository": {
@@ -38,7 +38,7 @@
     "mastra"
   ],
   "dependencies": {
-    "@zenml-io/kitaru": "workspace:0.1.0"
+    "@zenml-io/kitaru": "workspace:0.1.1"
   },
   "peerDependencies": {
     "@mastra/core": ">=1.51.0 <1.52.0"

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenml-io/kitaru-vercel-ai",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Kitaru tracing and replay adapter for the Vercel AI SDK",
   "license": "Apache-2.0",
   "repository": {
@@ -38,7 +38,7 @@
     "vercel-ai-sdk"
   ],
   "dependencies": {
-    "@zenml-io/kitaru": "workspace:0.1.0"
+    "@zenml-io/kitaru": "workspace:0.1.1"
   },
   "peerDependencies": {
     "ai": ">=7.0.60 <8.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
   packages/mastra:
     dependencies:
       '@zenml-io/kitaru':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.1.1
         version: link:../core
     devDependencies:
       '@mastra/core':
@@ -45,7 +45,7 @@ importers:
   packages/vercel-ai:
     dependencies:
       '@zenml-io/kitaru':
-        specifier: workspace:0.1.0
+        specifier: workspace:0.1.1
         version: link:../core
     devDependencies:
       ai:


### PR DESCRIPTION
## What changed?

Prepare `@zenml-io/kitaru`, `@zenml-io/kitaru-mastra`, and `@zenml-io/kitaru-vercel-ai` as the lockstep `0.1.1` release. This makes the TypeScript client's merged `KITARU_ACTIVE_SKILL` attribution available in published packages. Both adapters retain an exact workspace dependency on the matching core version.

Related: #803

## Release plan

This PR only prepares the TypeScript release set. Merging it does not publish anything.

After merge, rehearse `typescript/kitaru/v0.1.1` manually and inspect the generated `typescript-distributions` artifact. Then create the immutable tag on the exact rehearsed commit. The tag-triggered workflow publishes core first, followed by the Mastra and Vercel AI adapters, under npm's `latest` tag.

## Reviewer Notes

@schustmi and @alexejpenner, please confirm that all three manifests use `0.1.1` and that both adapter dependency pins use `workspace:0.1.1`. Please also confirm that `0.1.1` is the intended patch release for the skill-attribution change from #803.

Reproduce the release metadata and artifact checks with:

```bash
PATH=/opt/homebrew/opt/node@22/bin:$PATH node scripts/typescript-packages.mjs --tag typescript/kitaru/v0.1.1
PATH=/opt/homebrew/opt/node@22/bin:$PATH CI=true pnpm run pack:check
```

The metadata command reports version `0.1.1`, npm tag `latest`, and `prerelease: false`. The package check builds and smoke-tests all three `0.1.1` tarballs.

## Validation

- `CI=true pnpm install --frozen-lockfile`
- `node scripts/typescript-packages.mjs --tag typescript/kitaru/v0.1.1`
- `CI=true pnpm run pack:check`
- `CI=true pnpm run lint`
- `CI=true pnpm run typecheck`
- `CI=true pnpm run test:built` (411 tests passed)
- `git diff --check`
- `uv run --no-project --with packaging==26.2 python scripts/release_units.py validate`

`just check` passed formatting, Ruff, OpenAPI generation, Python type checking, typos, YAML validation, and Actions lint. Its final offline link check failed on a pre-existing broken repository link from `examples/v2/mcp/README.md` to the removed `docs/book/agent-native/mcp-server.md`; the local dependency installation also exposed broken links inside generated `node_modules` content. This PR does not change documentation or links.

## Post-release verification

After the later tag-triggered publication, confirm that all three exact versions resolve through `npm view`, all three `latest` dist-tags resolve to `0.1.1`, the clean-install export check passes, and the GitHub Release contains the three tarballs plus `SHA256SUMS`. Do not move or reuse the tag if publication or registry verification fails.
