### PR TITLE
Prepare Kitaru 0.22.0rc10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.22.0rc10]
+
 ### Added
 
 - Restored the SDK reference docs generator (`scripts/generate_sdk_docs.py`) for the v2 SDK: a reviewed `PUBLIC_API` allowlist over `kitaru.client` (including the resource method groups such as `client.sessions`), `kitaru.task`, and the developer-facing `kitaru.api_models.v1` types, re-enabling `just generate-docs` and the `sdkdocs.kitaru.ai` build and deploy pipeline.
 - Added a v2 CLI reference generator (`scripts/generate_cli_docs.py`) that renders `sdkdocs.kitaru.ai` CLI pages from the `kitaru schema` contract, replacing the stale v1 CLI reference.
+
+### Changed
+
+- Prepared the tenth Kitaru 0.22 release candidate with `kitaru-ui-v0.2.0-rc.6` and the Langfuse importer at `0.1.0rc3`.
 
 ## [0.22.0rc9]
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8595,7 +8595,7 @@
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.22.0rc9"
+    "version": "0.22.0rc10"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -923,7 +923,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.0rc9"
+version = "0.22.0rc10"
 source = { editable = "../" }
 dependencies = [
     { name = "httpx" },
@@ -981,6 +981,8 @@ provides-extras = ["mcp", "cli", "examples", "server", "worker", "otel"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "griffe", specifier = ">=1.13.0,<2.0.0" },
+    { name = "griffe-typingdoc", specifier = ">=0.2.8,<1.0.0" },
     { name = "import-linter", specifier = ">=2.0" },
     { name = "pip-audit", specifier = ">=2.10,<3" },
     { name = "pydantic-ai-slim", extras = ["openai"], specifier = ">=2.14.1,<2.23" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.22.0rc9"
+version = "0.22.0rc10"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/releases/python/kitaru/0.22.0rc10.toml
+++ b/releases/python/kitaru/0.22.0rc10.toml
@@ -1,0 +1,3 @@
+schema-version = 1
+kitaru-version = "0.22.0rc10"
+ui-tag = "kitaru-ui-v0.2.0-rc.6"

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.0rc9"
+version = "0.22.0rc10"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Prepare Kitaru `0.22.0rc10` from the current `develop` branch.

## Changes

- Set the core package, root lockfile, plugin workspace lockfile, and OpenAPI version to `0.22.0rc10`.
- Add the RC10 release declaration selecting `kitaru-ui-v0.2.0-rc.6`.
- Preserve `kitaru-langfuse-importer==0.1.0rc3` as the exact default Langfuse importer requirement and display version.
- Move the current unreleased SDK and CLI reference work into the RC10 changelog section.

## Artifact status

- Core `0.22.0rc10`: unpublished; PyPI version and Git tag are unused.
- Frontend `kitaru-ui-v0.2.0-rc.6`: not published; release assets are pending.
- Langfuse importer `0.1.0rc3`: already published and selected by the default plugin catalog.

Do not create the core tag until the frontend release contains both `kitaru-ui.tar.gz` and `kitaru-ui.tar.gz.sha256`.

## Publication order

1. Publish and verify `kitaru-ui-v0.2.0-rc.6` from the frontend repository.
2. Merge this PR.
3. Tag the reviewed merge commit as `python/kitaru/v0.22.0rc10`.
4. Verify the core package and deployable artifacts.

## Validation

- `git diff --check`
- `just check`
- release inventory validation: 10 units
- RC10 frontend declaration validation
- release UI and release unit tests: 44 passed
- plugin workspace format, lint, and type checks
- plugin workspace tests: 388 passed
- `just plugin-artifact-smoke`
- `just build`
- built `kitaru-0.22.0rc10.tar.gz` and `kitaru-0.22.0rc10-py3-none-any.whl`

## Reviewer Notes

1. Confirm `pyproject.toml`, `uv.lock`, `plugins/uv.lock`, and `openapi/openapi.json` report `0.22.0rc10`.
2. Confirm `releases/python/kitaru/0.22.0rc10.toml` selects `kitaru-ui-v0.2.0-rc.6`.
3. Confirm `plugins/default-requirements.txt` and `DEFAULT_PLUGIN_DEFINITIONS` select `kitaru-langfuse-importer==0.1.0rc3` with display version `0.1.0rc3`.
4. Verify both frontend assets before creating the core tag.
