### PR TITLE
Cascade agent deletion to related resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Restored the SDK reference docs generator (`scripts/generate_sdk_docs.py`) for the v2 SDK: a reviewed `PUBLIC_API` allowlist over `kitaru.client` (including the resource method groups such as `client.sessions`), `kitaru.task`, and the developer-facing `kitaru.api_models.v1` types, re-enabling `just generate-docs` and the `sdkdocs.kitaru.ai` build and deploy pipeline.
 - Added a v2 CLI reference generator (`scripts/generate_cli_docs.py`) that renders `sdkdocs.kitaru.ai` CLI pages from the `kitaru schema` contract, replacing the stale v1 CLI reference.
 
+### Changed
+
+- Deleting an agent now cascades to its versions, sessions, cohorts, experiments, investigations, and jobs instead of failing when the agent is referenced.
+
 ## [0.22.0rc9]
 
 ### Added

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -9050,7 +9050,7 @@
     },
     "/api/v1/agents/{agent_id}": {
       "delete": {
-        "description": "Delete an agent.\n\nClients observe HTTP 204 on success, 404 when no agent has this id, and\n409 when the agent has versions.\n\nArgs:\n    agent_id: Id of the agent.\n    service: Agent service.\n    actor: Caller context.",
+        "description": "Delete an agent.\n\nDeleting an agent cascades its versions, sessions, cohorts, experiments,\ninvestigations, and jobs. Clients observe HTTP 204 on success and 404\nwhen no agent has this id.\n\nArgs:\n    agent_id: Id of the agent.\n    service: Agent service.\n    actor: Caller context.",
         "operationId": "delete_agent_api_v1_agents__agent_id__delete",
         "parameters": [
           {

--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -222,8 +222,9 @@ export interface paths {
          * Delete Agent
          * @description Delete an agent.
          *
-         *     Clients observe HTTP 204 on success, 404 when no agent has this id, and
-         *     409 when the agent has versions.
+         *     Deleting an agent cascades its versions, sessions, cohorts, experiments,
+         *     investigations, and jobs. Clients observe HTTP 204 on success and 404
+         *     when no agent has this id.
          *
          *     Args:
          *         agent_id: Id of the agent.

--- a/src/kitaru/client/resources/agents.py
+++ b/src/kitaru/client/resources/agents.py
@@ -150,8 +150,7 @@ class AgentsResource:
             agent_id: Id of the agent.
 
         Raises:
-            APIError: The request failed, including 404 for a missing agent
-                and 409 when the agent has versions.
+            APIError: The request failed, including 404 for a missing agent.
         """
         await self._client.request("DELETE", f"/api/v1/agents/{agent_id}")
 

--- a/src/kitaru/server/adapters/db/orm/agent_version.py
+++ b/src/kitaru/server/adapters/db/orm/agent_version.py
@@ -52,7 +52,10 @@ class AgentVersionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             "agent_id", "version", name=AGENT_VERSION_AGENT_ID_VERSION_UNIQUE_CONSTRAINT
         ),
         ForeignKeyConstraint(
-            ["agent_id"], ["agent.id"], name=AGENT_VERSION_AGENT_ID_FOREIGN_KEY
+            ["agent_id"],
+            ["agent.id"],
+            name=AGENT_VERSION_AGENT_ID_FOREIGN_KEY,
+            ondelete="CASCADE",
         ),
         ForeignKeyConstraint(
             ["owner_id"], ["account.id"], name=AGENT_VERSION_OWNER_ID_FOREIGN_KEY

--- a/src/kitaru/server/adapters/db/orm/cohort.py
+++ b/src/kitaru/server/adapters/db/orm/cohort.py
@@ -43,7 +43,10 @@ class CohortORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     __table_args__ = (
         UniqueConstraint("name", name=COHORT_NAME_UNIQUE_CONSTRAINT),
         ForeignKeyConstraint(
-            ["agent_id"], ["agent.id"], name=COHORT_AGENT_ID_FOREIGN_KEY
+            ["agent_id"],
+            ["agent.id"],
+            name=COHORT_AGENT_ID_FOREIGN_KEY,
+            ondelete="CASCADE",
         ),
     )
 

--- a/src/kitaru/server/adapters/db/orm/experiment.py
+++ b/src/kitaru/server/adapters/db/orm/experiment.py
@@ -124,7 +124,10 @@ class ExperimentORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             ["owner_id"], ["account.id"], name=EXPERIMENT_OWNER_ID_FOREIGN_KEY
         ),
         ForeignKeyConstraint(
-            ["agent_id"], ["agent.id"], name=EXPERIMENT_AGENT_ID_FOREIGN_KEY
+            ["agent_id"],
+            ["agent.id"],
+            name=EXPERIMENT_AGENT_ID_FOREIGN_KEY,
+            ondelete="CASCADE",
         ),
         ForeignKeyConstraint(
             ["replay_config_id"],

--- a/src/kitaru/server/adapters/db/orm/investigation.py
+++ b/src/kitaru/server/adapters/db/orm/investigation.py
@@ -48,7 +48,10 @@ class InvestigationORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             ["owner_id"], ["account.id"], name=INVESTIGATION_OWNER_ID_FOREIGN_KEY
         ),
         ForeignKeyConstraint(
-            ["agent_id"], ["agent.id"], name=INVESTIGATION_AGENT_ID_FOREIGN_KEY
+            ["agent_id"],
+            ["agent.id"],
+            name=INVESTIGATION_AGENT_ID_FOREIGN_KEY,
+            ondelete="CASCADE",
         ),
         Index(INVESTIGATION_OWNER_ID_INDEX, "owner_id"),
         Index(INVESTIGATION_AGENT_ID_INDEX, "agent_id"),

--- a/src/kitaru/server/adapters/db/orm/session.py
+++ b/src/kitaru/server/adapters/db/orm/session.py
@@ -80,7 +80,10 @@ class SessionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             name=SESSION_AGENT_ID_NUMBER_UNIQUE_CONSTRAINT,
         ),
         ForeignKeyConstraint(
-            ["agent_id"], ["agent.id"], name=SESSION_AGENT_ID_FOREIGN_KEY
+            ["agent_id"],
+            ["agent.id"],
+            name=SESSION_AGENT_ID_FOREIGN_KEY,
+            ondelete="CASCADE",
         ),
         ForeignKeyConstraint(
             ["agent_version_id"],

--- a/src/kitaru/server/adapters/db/orm/task.py
+++ b/src/kitaru/server/adapters/db/orm/task.py
@@ -97,7 +97,10 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             name=TASK_AGENT_VERSION_ID_FOREIGN_KEY,
         ),
         ForeignKeyConstraint(
-            ["agent_id"], ["agent.id"], name=TASK_AGENT_ID_FOREIGN_KEY
+            ["agent_id"],
+            ["agent.id"],
+            name=TASK_AGENT_ID_FOREIGN_KEY,
+            ondelete="CASCADE",
         ),
         ForeignKeyConstraint(
             ["plugin_version_id"],

--- a/src/kitaru/server/adapters/db/repositories/agent_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/agent_repository.py
@@ -16,22 +16,23 @@
 import uuid
 from collections.abc import Mapping
 
-from sqlalchemy import select
+from sqlalchemy import ColumnElement, Select, delete, or_, select
+from sqlalchemy.orm import InstrumentedAttribute
 
 from kitaru.server.adapters.db.filtering import FilterBinding, compile_filter_expression
 from kitaru.server.adapters.db.orm.agent import AGENT_NAME_UNIQUE_CONSTRAINT, AgentORM
-from kitaru.server.adapters.db.orm.agent_version import (
-    AGENT_VERSION_AGENT_ID_FOREIGN_KEY,
-)
+from kitaru.server.adapters.db.orm.agent_version import AgentVersionORM
+from kitaru.server.adapters.db.orm.cohort import CohortORM
+from kitaru.server.adapters.db.orm.experiment import ExperimentORM
+from kitaru.server.adapters.db.orm.experiment_run import ExperimentRunORM
+from kitaru.server.adapters.db.orm.job import JobORM
+from kitaru.server.adapters.db.orm.replay import ReplayORM
+from kitaru.server.adapters.db.orm.session import SessionORM
+from kitaru.server.adapters.db.orm.task import TaskORM
 from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.agent import AgentFilter
-from kitaru.server.domain.agent import (
-    Agent,
-    AgentInUse,
-    AgentNotFound,
-    DuplicateAgentName,
-)
+from kitaru.server.domain.agent import Agent, AgentNotFound, DuplicateAgentName
 from kitaru.server.domain.base import NotFoundError
 
 AGENT_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
@@ -136,14 +137,107 @@ class SQLAgentRepository(BaseSQLRepository[AgentORM]):
     async def delete(self, agent_id: uuid.UUID) -> None:
         """Delete an agent by id.
 
+        Deleting an agent cascades its versions, sessions, cohorts, experiments,
+        investigations, and jobs.
+
         Args:
             agent_id: Id of the agent.
 
         Raises:
             AgentNotFound: No agent has this id.
-            AgentInUse: The agent has versions and cannot be deleted.
         """
-        await self._delete_row(
-            agent_id,
-            {AGENT_VERSION_AGENT_ID_FOREIGN_KEY: lambda: AgentInUse(agent_id)},
+        session_ids = select(SessionORM.id).where(SessionORM.agent_id == agent_id)
+        version_ids = select(AgentVersionORM.id).where(
+            AgentVersionORM.agent_id == agent_id
+        )
+        experiment_ids = select(ExperimentORM.id).where(
+            ExperimentORM.agent_id == agent_id
+        )
+        # Every row a concurrent writer could reference is locked before any
+        # of the subtree is deleted, so such an insert waits on its parent
+        # and fails on the foreign key once the delete commits instead of
+        # landing between two delete statements. Rows are locked in the order
+        # the write paths take them: task rows first and in id order, then
+        # the agent, experiments, cohorts, sessions, and versions. The job set
+        # is read again once those are locked, since no job for the agent can
+        # commit after that, and tasks of jobs that appeared in between are
+        # locked then.
+        job_ids = await self._get_job_ids(agent_id, session_ids, version_ids)
+        await self._lock_rows(TaskORM.id, TaskORM.job_id.in_(job_ids))
+        row = await self._get_row(agent_id, exclusive=True)
+        await self._lock_rows(ExperimentORM.id, ExperimentORM.agent_id == agent_id)
+        await self._lock_rows(CohortORM.id, CohortORM.agent_id == agent_id)
+        await self._lock_rows(SessionORM.id, SessionORM.agent_id == agent_id)
+        await self._lock_rows(AgentVersionORM.id, AgentVersionORM.agent_id == agent_id)
+        job_ids = await self._get_job_ids(agent_id, session_ids, version_ids)
+        await self._lock_rows(TaskORM.id, TaskORM.job_id.in_(job_ids))
+        await self._lock_rows(JobORM.id, JobORM.id.in_(job_ids))
+        # The database checks a restricting foreign key after each cascade
+        # step rather than at the end of the statement, so rows behind such
+        # keys are deleted before the agent row in dependency order.
+        await self._session.execute(delete(JobORM).where(JobORM.id.in_(job_ids)))
+        await self._session.execute(
+            delete(ExperimentRunORM).where(
+                ExperimentRunORM.experiment_id.in_(experiment_ids)
+            )
+        )
+        await self._session.execute(
+            delete(CohortORM).where(CohortORM.agent_id == agent_id)
+        )
+        await self._session.execute(
+            delete(SessionORM).where(SessionORM.agent_id == agent_id)
+        )
+        await self._session.delete(row)
+        await self._session.flush()
+
+    async def _get_job_ids(
+        self,
+        agent_id: uuid.UUID,
+        session_ids: Select[tuple[uuid.UUID]],
+        version_ids: Select[tuple[uuid.UUID]],
+    ) -> list[uuid.UUID]:
+        """Get the ids of the jobs whose tasks or replays belong to an agent.
+
+        Args:
+            agent_id: Id of the agent.
+            session_ids: Select of the agent's session ids.
+            version_ids: Select of the agent's version ids.
+
+        Returns:
+            Job ids in ascending order.
+        """
+        task_job_ids = select(TaskORM.job_id).where(
+            or_(
+                TaskORM.agent_id == agent_id,
+                TaskORM.agent_version_id.in_(version_ids),
+                TaskORM.input_session_id.in_(session_ids),
+                TaskORM.result_session_id.in_(session_ids),
+            )
+        )
+        replay_job_ids = select(ReplayORM.job_id).where(
+            ReplayORM.baseline_session_id.in_(session_ids)
+        )
+        result = await self._session.scalars(
+            select(JobORM.id)
+            .where(or_(JobORM.id.in_(task_job_ids), JobORM.id.in_(replay_job_ids)))
+            .order_by(JobORM.id.asc())
+        )
+        return list(result.all())
+
+    async def _lock_rows(
+        self,
+        id_column: InstrumentedAttribute[uuid.UUID],
+        condition: ColumnElement[bool],
+    ) -> None:
+        """Lock the matching rows in id order for the rest of the transaction.
+
+        Args:
+            id_column: Id column of the table.
+            condition: Filter selecting the rows to lock.
+        """
+        await self._session.execute(
+            select(id_column)
+            .where(condition)
+            .order_by(id_column.asc())
+            .with_for_update()
         )

--- a/src/kitaru/server/adapters/db/repositories/base.py
+++ b/src/kitaru/server/adapters/db/repositories/base.py
@@ -132,6 +132,27 @@ class BaseSQLRepository(Generic[RowT]):
         except IntegrityError as exc:
             self._raise_translated(exc, constraints)
 
+    async def _add_all(
+        self,
+        rows: Sequence[UUIDPrimaryKeyMixin],
+        constraints: ConstraintErrors | None = None,
+    ) -> None:
+        """Add rows and flush, translating constraint violations.
+
+        Args:
+            rows: Rows to add.
+            constraints: Domain error factories keyed by constraint name.
+
+        Raises:
+            DomainError: A mapped constraint was violated.
+        """
+        try:
+            async with self._session.begin_nested():
+                self._session.add_all(rows)
+                await self._session.flush()
+        except IntegrityError as exc:
+            self._raise_translated(exc, constraints)
+
     async def _flush(self, constraints: ConstraintErrors | None = None) -> None:
         """Flush pending changes, translating constraint violations.
 

--- a/src/kitaru/server/adapters/db/repositories/cohort_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/cohort_repository.py
@@ -25,12 +25,14 @@ from kitaru.server.adapters.db.filtering import (
     compile_filter_expression,
 )
 from kitaru.server.adapters.db.orm.cohort import (
+    COHORT_AGENT_ID_FOREIGN_KEY,
     COHORT_NAME_UNIQUE_CONSTRAINT,
     CohortORM,
 )
 from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.cohort import CohortFilter
+from kitaru.server.domain.agent import AgentNotFound
 from kitaru.server.domain.base import NotFoundError
 from kitaru.server.domain.cohort import Cohort, CohortNotFound, DuplicateCohortName
 
@@ -66,6 +68,7 @@ class SQLCohortRepository(BaseSQLRepository[CohortORM]):
 
         Raises:
             DuplicateCohortName: The cohort name is already registered.
+            AgentNotFound: No agent has the cohort's agent id.
 
         Returns:
             Stored cohort with timestamps set.
@@ -73,7 +76,10 @@ class SQLCohortRepository(BaseSQLRepository[CohortORM]):
         row = CohortORM.from_domain(cohort)
         await self._add(
             row,
-            {COHORT_NAME_UNIQUE_CONSTRAINT: lambda: DuplicateCohortName(cohort.name)},
+            {
+                COHORT_NAME_UNIQUE_CONSTRAINT: lambda: DuplicateCohortName(cohort.name),
+                COHORT_AGENT_ID_FOREIGN_KEY: lambda: AgentNotFound(cohort.agent_id),
+            },
         )
         return row.to_domain()
 

--- a/src/kitaru/server/adapters/db/repositories/experiment_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/experiment_repository.py
@@ -26,6 +26,7 @@ from kitaru.server.adapters.db.filtering import (
     compile_filter_expression,
 )
 from kitaru.server.adapters.db.orm.experiment import (
+    EXPERIMENT_AGENT_ID_FOREIGN_KEY,
     EXPERIMENT_NAME_UNIQUE_CONSTRAINT,
     ExperimentORM,
     ReplayConfigORM,
@@ -37,6 +38,7 @@ from kitaru.server.adapters.db.orm.replay import REPLAY_REPLAY_CONFIG_ID_FOREIGN
 from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.experiment import ExperimentFilter
+from kitaru.server.domain.agent import AgentNotFound
 from kitaru.server.domain.base import NotFoundError
 from kitaru.server.domain.experiment import (
     DuplicateExperimentName,
@@ -83,6 +85,7 @@ class SQLExperimentRepository(BaseSQLRepository[ExperimentORM]):
         Raises:
             DuplicateExperimentName: The experiment name is already
                 registered.
+            AgentNotFound: No agent has the experiment's agent id.
 
         Returns:
             Stored experiment with timestamps set.
@@ -93,7 +96,10 @@ class SQLExperimentRepository(BaseSQLRepository[ExperimentORM]):
             {
                 EXPERIMENT_NAME_UNIQUE_CONSTRAINT: lambda: DuplicateExperimentName(
                     experiment.name
-                )
+                ),
+                EXPERIMENT_AGENT_ID_FOREIGN_KEY: lambda: AgentNotFound(
+                    experiment.agent_id
+                ),
             },
         )
         return row.to_domain()

--- a/src/kitaru/server/adapters/db/repositories/experiment_run_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/experiment_run_repository.py
@@ -28,12 +28,14 @@ from kitaru.server.adapters.db.filtering import (
 from kitaru.server.adapters.db.orm.agent_version import AgentVersionORM
 from kitaru.server.adapters.db.orm.cohort_version import CohortVersionORM
 from kitaru.server.adapters.db.orm.experiment_run import (
+    EXPERIMENT_RUN_AGENT_VERSION_ID_FOREIGN_KEY,
     EXPERIMENT_RUN_NUMBER_UNIQUE_CONSTRAINT,
     ExperimentRunORM,
 )
 from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.experiment_run import ExperimentRunFilter
+from kitaru.server.domain.agent_version import AgentVersionNotFound
 from kitaru.server.domain.base import NotFoundError
 from kitaru.server.domain.experiment_run import (
     DuplicateExperimentRunNumber,
@@ -90,6 +92,8 @@ class SQLExperimentRunRepository(BaseSQLRepository[ExperimentRunORM]):
         Raises:
             DuplicateExperimentRunNumber: The experiment already has a run
                 with this number.
+            AgentVersionNotFound: No agent version has the run's agent
+                version id.
 
         Returns:
             Stored experiment run with timestamps set.
@@ -100,7 +104,10 @@ class SQLExperimentRunRepository(BaseSQLRepository[ExperimentRunORM]):
             {
                 EXPERIMENT_RUN_NUMBER_UNIQUE_CONSTRAINT: lambda: (
                     DuplicateExperimentRunNumber(run.experiment_id, run.number)
-                )
+                ),
+                EXPERIMENT_RUN_AGENT_VERSION_ID_FOREIGN_KEY: lambda: (
+                    AgentVersionNotFound(run.agent_version_id)
+                ),
             },
         )
         return row.to_domain()

--- a/src/kitaru/server/adapters/db/repositories/investigation_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/investigation_repository.py
@@ -19,7 +19,10 @@ from collections.abc import Mapping, Sequence
 from sqlalchemy import func, select
 
 from kitaru.server.adapters.db.filtering import FilterBinding, compile_filter_expression
-from kitaru.server.adapters.db.orm.investigation import InvestigationORM
+from kitaru.server.adapters.db.orm.investigation import (
+    INVESTIGATION_AGENT_ID_FOREIGN_KEY,
+    InvestigationORM,
+)
 from kitaru.server.adapters.db.orm.investigation_session import InvestigationSessionORM
 from kitaru.server.adapters.db.pagination import paginate, paginate_by_index
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
@@ -27,6 +30,7 @@ from kitaru.server.application.models.investigation import (
     InvestigationFilter,
     InvestigationSessionFilter,
 )
+from kitaru.server.domain.agent import AgentNotFound
 from kitaru.server.domain.base import NotFoundError
 from kitaru.server.domain.investigation import (
     Investigation,
@@ -138,15 +142,21 @@ class SQLInvestigationRepository(BaseSQLRepository[InvestigationORM]):
             investigation: Investigation to store.
             sessions: Ordered investigation_session rows to link.
 
+        Raises:
+            AgentNotFound: No agent has the investigation's agent id.
+
         Returns:
             Stored investigation with timestamps set.
         """
         row = InvestigationORM.from_domain(investigation)
-        self._session.add(row)
-        self._session.add_all(
-            [InvestigationSessionORM.from_domain(session) for session in sessions]
+        await self._add_all(
+            [row, *(InvestigationSessionORM.from_domain(link) for link in sessions)],
+            {
+                INVESTIGATION_AGENT_ID_FOREIGN_KEY: lambda: AgentNotFound(
+                    investigation.agent_id
+                )
+            },
         )
-        await self._flush()
         completed = sum(1 for session in sessions if session.verdict is not None)
         return row.to_domain(len(sessions), completed)
 

--- a/src/kitaru/server/adapters/db/repositories/replay_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/replay_repository.py
@@ -27,6 +27,7 @@ from kitaru.server.adapters.db.filtering import (
     compile_filter_expression,
 )
 from kitaru.server.adapters.db.orm.replay import (
+    REPLAY_BASELINE_SESSION_ID_FOREIGN_KEY,
     REPLAY_JOB_ID_UNIQUE_CONSTRAINT,
     REPLAY_RUN_BASELINE_UNIQUE_CONSTRAINT,
     ReplayORM,
@@ -42,6 +43,7 @@ from kitaru.server.domain.replay import (
     ReplayAlreadyExistsForJob,
     ReplayNotFound,
 )
+from kitaru.server.domain.session import SessionNotFound
 from kitaru.server.filtering import FilterCondition
 
 
@@ -116,6 +118,7 @@ class SQLReplayRepository(BaseSQLRepository[ReplayORM]):
             DuplicateReplayForBaseline: The run already holds a replay for
                 this baseline session.
             ReplayAlreadyExistsForJob: The job already has a replay.
+            SessionNotFound: No session has the replay's baseline session id.
 
         Returns:
             Stored replay with timestamps set.
@@ -132,6 +135,9 @@ class SQLReplayRepository(BaseSQLRepository[ReplayORM]):
                 REPLAY_JOB_ID_UNIQUE_CONSTRAINT: lambda: ReplayAlreadyExistsForJob(
                     replay.job_id
                 ),
+                REPLAY_BASELINE_SESSION_ID_FOREIGN_KEY: lambda: SessionNotFound(
+                    replay.baseline_session_id
+                ),
             },
         )
         return row.to_domain()
@@ -145,6 +151,7 @@ class SQLReplayRepository(BaseSQLRepository[ReplayORM]):
         Raises:
             IntegrityError: The batch collides on (job_id) or
                 (experiment_run_id, baseline_session_id).
+            NotFoundError: No session has a replay's baseline session id.
 
         Returns:
             Stored replays with timestamps set, in the same order.
@@ -152,8 +159,14 @@ class SQLReplayRepository(BaseSQLRepository[ReplayORM]):
         if not replays:
             return []
         rows = [ReplayORM.from_domain(replay) for replay in replays]
-        self._session.add_all(rows)
-        await self._flush()
+        await self._add_all(
+            rows,
+            {
+                REPLAY_BASELINE_SESSION_ID_FOREIGN_KEY: lambda: NotFoundError(
+                    "Baseline session was not found"
+                )
+            },
+        )
         return [row.to_domain() for row in rows]
 
     async def get(self, replay_id: uuid.UUID) -> Replay:

--- a/src/kitaru/server/adapters/db/repositories/session_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/session_repository.py
@@ -14,7 +14,7 @@
 """SQL session repository."""
 
 import uuid
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from datetime import UTC, datetime
 
 from sqlalchemy import ColumnElement, CursorResult, func, select, update
@@ -36,6 +36,8 @@ from kitaru.server.adapters.db.orm.cohort_version_session import (
 from kitaru.server.adapters.db.orm.evaluation import EvaluationORM
 from kitaru.server.adapters.db.orm.replay import ReplayORM
 from kitaru.server.adapters.db.orm.session import (
+    SESSION_AGENT_ID_FOREIGN_KEY,
+    SESSION_AGENT_VERSION_ID_FOREIGN_KEY,
     SESSION_IMPORTED_FROM_EXTERNAL_ID_UNIQUE_CONSTRAINT,
     SessionORM,
 )
@@ -48,7 +50,8 @@ from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.session import SessionFilter
 from kitaru.server.domain.agent import AgentNotFound
-from kitaru.server.domain.base import NotFoundError
+from kitaru.server.domain.agent_version import AgentVersionNotFound
+from kitaru.server.domain.base import DomainError, NotFoundError
 from kitaru.server.domain.session import (
     DuplicateSessionExternalId,
     Session,
@@ -233,19 +236,26 @@ class SQLSessionRepository(BaseSQLRepository[SessionORM]):
         Raises:
             DuplicateSessionExternalId: The imported_from and external id pair is
                 already registered.
+            AgentNotFound: No agent has the session's agent id.
+            AgentVersionNotFound: No agent version has the session's agent
+                version id.
 
         Returns:
             Stored session with timestamps set.
         """
         row = SessionORM.from_domain(session)
-        await self._add(
-            row,
-            {
-                SESSION_IMPORTED_FROM_EXTERNAL_ID_UNIQUE_CONSTRAINT: lambda: (
-                    self._duplicate_external_id(session)
-                )
-            },
-        )
+        constraints: dict[str, Callable[[], DomainError]] = {
+            SESSION_IMPORTED_FROM_EXTERNAL_ID_UNIQUE_CONSTRAINT: lambda: (
+                self._duplicate_external_id(session)
+            ),
+            SESSION_AGENT_ID_FOREIGN_KEY: lambda: AgentNotFound(session.agent_id),
+        }
+        if session.agent_version_id is not None:
+            agent_version_id = session.agent_version_id
+            constraints[SESSION_AGENT_VERSION_ID_FOREIGN_KEY] = lambda: (
+                AgentVersionNotFound(agent_version_id)
+            )
+        await self._add(row, constraints)
         return row.to_domain()
 
     async def get(self, session_id: uuid.UUID, exclusive: bool = False) -> Session:

--- a/src/kitaru/server/adapters/db/repositories/task_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/task_repository.py
@@ -14,7 +14,7 @@
 """SQL task repository."""
 
 import uuid
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
 
 from sqlalchemy import (
@@ -33,14 +33,20 @@ from kitaru.api_models.v1.worker import WorkerScope
 from kitaru.server.adapters.db.filtering import FilterBinding, compile_filter_expression
 from kitaru.server.adapters.db.orm.job import JobORM
 from kitaru.server.adapters.db.orm.task import (
+    TASK_AGENT_ID_FOREIGN_KEY,
+    TASK_AGENT_VERSION_ID_FOREIGN_KEY,
     TASK_EVALUATOR_PAIR_UNIQUE_CONSTRAINT,
+    TASK_INPUT_SESSION_ID_FOREIGN_KEY,
     TERMINAL_STATUS_VALUES,
     TaskORM,
 )
 from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.task import TaskFilter
-from kitaru.server.domain.base import NotFoundError
+from kitaru.server.domain.agent import AgentNotFound
+from kitaru.server.domain.agent_version import AgentVersionNotFound
+from kitaru.server.domain.base import DomainError, NotFoundError
+from kitaru.server.domain.session import SessionNotFound
 from kitaru.server.domain.task import DuplicateEvaluationTask, Task, TaskNotFound
 
 IN_FLIGHT_STATUS_VALUES = [TaskStatus.CLAIMED.value, TaskStatus.RUNNING.value]
@@ -127,19 +133,32 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         Raises:
             DuplicateEvaluationTask: The job already holds an evaluator task
                 for this input session and plugin version.
+            NotFoundError: No agent, agent version, or session has an id the
+                task references.
 
         Returns:
             Stored task with timestamps set.
         """
         row = TaskORM.from_domain(task)
-        await self._add(
-            row,
-            {
-                TASK_EVALUATOR_PAIR_UNIQUE_CONSTRAINT: lambda: DuplicateEvaluationTask(
-                    row.job_id, row.input_session_id, row.plugin_version_id
-                )
-            },
-        )
+        constraints: dict[str, Callable[[], DomainError]] = {
+            TASK_EVALUATOR_PAIR_UNIQUE_CONSTRAINT: lambda: DuplicateEvaluationTask(
+                row.job_id, row.input_session_id, row.plugin_version_id
+            ),
+        }
+        if row.agent_id is not None:
+            agent_id = row.agent_id
+            constraints[TASK_AGENT_ID_FOREIGN_KEY] = lambda: AgentNotFound(agent_id)
+        if row.agent_version_id is not None:
+            agent_version_id = row.agent_version_id
+            constraints[TASK_AGENT_VERSION_ID_FOREIGN_KEY] = lambda: (
+                AgentVersionNotFound(agent_version_id)
+            )
+        if row.input_session_id is not None:
+            input_session_id = row.input_session_id
+            constraints[TASK_INPUT_SESSION_ID_FOREIGN_KEY] = lambda: SessionNotFound(
+                input_session_id
+            )
+        await self._add(row, constraints)
         return row.to_domain()
 
     async def create_many(self, tasks: list[Task]) -> list[Task]:
@@ -148,14 +167,28 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         Args:
             tasks: Tasks to store.
 
+        Raises:
+            NotFoundError: No agent, agent version, or session has an id a
+                task references.
+
         Returns:
             Stored tasks with timestamps set, in the same order.
         """
         if not tasks:
             return []
         rows = [TaskORM.from_domain(task) for task in tasks]
-        self._session.add_all(rows)
-        await self._flush()
+        await self._add_all(
+            rows,
+            {
+                TASK_AGENT_ID_FOREIGN_KEY: lambda: NotFoundError("Agent was not found"),
+                TASK_AGENT_VERSION_ID_FOREIGN_KEY: lambda: NotFoundError(
+                    "Agent version was not found"
+                ),
+                TASK_INPUT_SESSION_ID_FOREIGN_KEY: lambda: NotFoundError(
+                    "Input session was not found"
+                ),
+            },
+        )
         return [row.to_domain() for row in rows]
 
     async def get(self, task_id: uuid.UUID, exclusive: bool = False) -> Task:

--- a/src/kitaru/server/adapters/rest/routers/agents.py
+++ b/src/kitaru/server/adapters/rest/routers/agents.py
@@ -164,8 +164,9 @@ async def delete_agent(
 ) -> None:
     """Delete an agent.
 
-    Clients observe HTTP 204 on success, 404 when no agent has this id, and
-    409 when the agent has versions.
+    Deleting an agent cascades its versions, sessions, cohorts, experiments,
+    investigations, and jobs. Clients observe HTTP 204 on success and 404
+    when no agent has this id.
 
     Args:
         agent_id: Id of the agent.

--- a/src/kitaru/server/application/interfaces/agent_repository.py
+++ b/src/kitaru/server/application/interfaces/agent_repository.py
@@ -80,11 +80,13 @@ class AgentRepository(Protocol):
     async def delete(self, agent_id: uuid.UUID) -> None:
         """Delete an agent by id.
 
+        Deleting an agent cascades its versions, sessions, cohorts, experiments,
+        investigations, and jobs.
+
         Args:
             agent_id: Id of the agent.
 
         Raises:
             AgentNotFound: No agent has this id.
-            AgentInUse: The agent has versions and cannot be deleted.
         """
         ...

--- a/src/kitaru/server/application/services/agent_service.py
+++ b/src/kitaru/server/application/services/agent_service.py
@@ -121,13 +121,15 @@ class AgentService:
     async def delete_agent(self, agent_id: uuid.UUID, actor: AuthContext) -> None:
         """Delete an agent.
 
+        Deleting an agent cascades its versions, sessions, cohorts, experiments,
+        investigations, and jobs.
+
         Args:
             agent_id: Id of the agent.
             actor: Caller context.
 
         Raises:
             AgentNotFound: No agent has this id.
-            AgentInUse: The agent has versions and cannot be deleted.
         """
         _ = actor
         await self._repository.delete(agent_id)

--- a/src/kitaru/server/application/services/session_service.py
+++ b/src/kitaru/server/application/services/session_service.py
@@ -122,19 +122,26 @@ class SessionService:
         Returns:
             Created session.
         """
-        task_id = None
+        principal = (
+            actor.principal if isinstance(actor.principal, TaskPrincipal) else None
+        )
+        task_id = principal.task_id if principal is not None else None
         task = None
-        if isinstance(actor.principal, TaskPrincipal):
-            task_id = actor.principal.task_id
-            task = await self._tasks.get(task_id, exclusive=True)
-            task.check_running()
-            # Check the attempt on the locked task so a requeue cannot race
-            # the result link.
-            task.check_attempt(actor.principal.attempt)
-            if isinstance(task, AgentTask) and task.result_session_id is not None:
-                raise TaskResultSessionAlreadyLinked(task.id)
+        if principal is not None:
+            task = await self._tasks.get(principal.task_id)
+            self._check_task_accepts_result(task, principal)
         agent_id, agent_version_id = await self._resolve_agent(command, task)
+        # The number is allocated on a separate connection that updates the
+        # agent row, so it runs before the task row lock. Holding the task
+        # lock while waiting on the agent row would be a lock wait the
+        # database cannot see and could deadlock undetected with a writer
+        # that locks the agent row before task rows.
         number = await self._repository.allocate_session_number(agent_id)
+        if principal is not None:
+            # Check again on the locked task so a requeue cannot race the
+            # result link.
+            task = await self._tasks.get(principal.task_id, exclusive=True)
+            self._check_task_accepts_result(task, principal)
         session = Session(
             owner_id=actor.account.id,
             agent_id=agent_id,
@@ -168,6 +175,25 @@ class SessionService:
                 analytics_events.build_session_completed_properties(stored),
             )
         return stored
+
+    @staticmethod
+    def _check_task_accepts_result(task: Task, principal: TaskPrincipal) -> None:
+        """Check that a task principal may record a result session.
+
+        Args:
+            task: Task the principal acts for.
+            principal: Task principal.
+
+        Raises:
+            TaskNotRunning: The task is not running.
+            TaskAttemptMismatch: The principal's attempt is superseded.
+            TaskResultSessionAlreadyLinked: The task already has a result
+                session.
+        """
+        task.check_running()
+        task.check_attempt(principal.attempt)
+        if isinstance(task, AgentTask) and task.result_session_id is not None:
+            raise TaskResultSessionAlreadyLinked(task.id)
 
     async def _resolve_agent(
         self, command: SessionCreate, task: Task | None

--- a/src/kitaru/server/database/migrations/versions/001_initial.py
+++ b/src/kitaru/server/database/migrations/versions/001_initial.py
@@ -295,7 +295,10 @@ def upgrade() -> None:
             "capabilities", postgresql.JSONB(astext_type=sa.Text()), nullable=False
         ),
         sa.ForeignKeyConstraint(
-            ["agent_id"], ["agent.id"], name="fk_agent_version_agent_id"
+            ["agent_id"],
+            ["agent.id"],
+            name="fk_agent_version_agent_id",
+            ondelete="CASCADE",
         ),
         sa.ForeignKeyConstraint(
             ["owner_id"], ["account.id"], name="fk_agent_version_owner_id"
@@ -319,7 +322,12 @@ def upgrade() -> None:
         sa.Column("agent_id", sa.Uuid(), nullable=False),
         sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.Column("latest_version", sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(["agent_id"], ["agent.id"], name="fk_cohort_agent_id"),
+        sa.ForeignKeyConstraint(
+            ["agent_id"],
+            ["agent.id"],
+            name="fk_cohort_agent_id",
+            ondelete="CASCADE",
+        ),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("name", name="uq_cohort_name"),
     )
@@ -355,7 +363,10 @@ def upgrade() -> None:
         sa.Column("agent_id", sa.Uuid(), nullable=False),
         sa.Column("replay_config_id", sa.Uuid(), nullable=False),
         sa.ForeignKeyConstraint(
-            ["agent_id"], ["agent.id"], name="fk_experiment_agent_id"
+            ["agent_id"],
+            ["agent.id"],
+            name="fk_experiment_agent_id",
+            ondelete="CASCADE",
         ),
         sa.ForeignKeyConstraint(
             ["owner_id"], ["account.id"], name="fk_experiment_owner_id"
@@ -532,7 +543,12 @@ def upgrade() -> None:
         sa.Column("reasoning_tokens", sa.BigInteger(), nullable=True),
         sa.Column("llm_call_count", sa.Integer(), nullable=False),
         sa.Column("tool_call_count", sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(["agent_id"], ["agent.id"], name="fk_session_agent_id"),
+        sa.ForeignKeyConstraint(
+            ["agent_id"],
+            ["agent.id"],
+            name="fk_session_agent_id",
+            ondelete="CASCADE",
+        ),
         sa.ForeignKeyConstraint(
             ["agent_version_id"],
             ["agent_version.id"],
@@ -759,7 +775,12 @@ def upgrade() -> None:
             postgresql.JSONB(none_as_null=True, astext_type=sa.Text()),
             nullable=True,
         ),
-        sa.ForeignKeyConstraint(["agent_id"], ["agent.id"], name="fk_task_agent_id"),
+        sa.ForeignKeyConstraint(
+            ["agent_id"],
+            ["agent.id"],
+            name="fk_task_agent_id",
+            ondelete="CASCADE",
+        ),
         sa.ForeignKeyConstraint(
             ["agent_version_id"], ["agent_version.id"], name="fk_task_agent_version_id"
         ),
@@ -906,7 +927,10 @@ def upgrade() -> None:
         sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.ForeignKeyConstraint(
-            ["agent_id"], ["agent.id"], name="fk_investigation_agent_id"
+            ["agent_id"],
+            ["agent.id"],
+            name="fk_investigation_agent_id",
+            ondelete="CASCADE",
         ),
         sa.ForeignKeyConstraint(
             ["owner_id"], ["account.id"], name="fk_investigation_owner_id"

--- a/src/kitaru/server/domain/agent.py
+++ b/src/kitaru/server/domain/agent.py
@@ -52,18 +52,6 @@ class DuplicateAgentName(ConflictError):
         super().__init__(f"Agent name '{name}' is already registered")
 
 
-class AgentInUse(ConflictError):
-    """Raised when an agent has versions and cannot be deleted."""
-
-    def __init__(self, agent_id: uuid.UUID) -> None:
-        """Initialize the error.
-
-        Args:
-            agent_id: Id of the agent that cannot be deleted.
-        """
-        super().__init__(f"Agent {agent_id} has versions and cannot be deleted")
-
-
 class Agent(DomainModel):
     """Agent."""
 

--- a/tests/client/test_agents.py
+++ b/tests/client/test_agents.py
@@ -174,13 +174,15 @@ async def test_delete(api_client: KitaruAPIClient) -> None:
         await api_client.agents.get(created.id)
 
 
-async def test_delete_in_use(api_client: KitaruAPIClient) -> None:
-    """Surface HTTP 409 as a typed error when the agent has versions."""
+async def test_delete_cascades_versions(api_client: KitaruAPIClient) -> None:
+    """Delete an agent together with its versions through the SDK."""
     created = await api_client.agents.create(AgentCreateRequest(name="assistant"))
-    await api_client.agents.create_version(created.id, AgentVersionCreateRequest())
-    with pytest.raises(APIError) as exc_info:
-        await api_client.agents.delete(created.id)
-    assert exc_info.value.status_code == 409
+    version = await api_client.agents.create_version(
+        created.id, AgentVersionCreateRequest()
+    )
+    await api_client.agents.delete(created.id)
+    with pytest.raises(NotFoundError):
+        await api_client.agent_versions.get(version.id)
 
 
 async def test_create_version(api_client: KitaruAPIClient) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,12 +118,7 @@ from kitaru.server.domain.account import (
     AccountNotFound,
     DuplicateAccountName,
 )
-from kitaru.server.domain.agent import (
-    Agent,
-    AgentInUse,
-    AgentNotFound,
-    DuplicateAgentName,
-)
+from kitaru.server.domain.agent import Agent, AgentNotFound, DuplicateAgentName
 from kitaru.server.domain.agent_version import (
     AgentCapabilities,
     AgentVersion,
@@ -1622,17 +1617,19 @@ class FakeAgentRepository:
         Args:
             agent_id: Id of the agent.
 
+        Deleting an agent cascades its versions.
+
         Raises:
             AgentNotFound: No agent has this id.
-            AgentInUse: The agent has versions and cannot be deleted.
         """
         if agent_id not in self._agents:
             raise AgentNotFound(agent_id)
-        if self._agent_versions is not None and any(
-            version.agent_id == agent_id
-            for version in self._agent_versions._versions.values()
-        ):
-            raise AgentInUse(agent_id)
+        if self._agent_versions is not None:
+            self._agent_versions._versions = {
+                version_id: version
+                for version_id, version in self._agent_versions._versions.items()
+                if version.agent_id != agent_id
+            }
         del self._agents[agent_id]
 
 
@@ -1668,8 +1665,8 @@ class FakeAgentVersionRepository:
 
         Args:
             agents: Fake agent repository sharing the version counter. Also
-                wired back onto the agent repository so its delete can check
-                for versions.
+                wired back onto the agent repository so its delete cascades
+                versions.
             tags: Fake tag repository, consulted by the ``tag`` filter.
         """
         self._agents = agents

--- a/tests/server/test_agent_repository.py
+++ b/tests/server/test_agent_repository.py
@@ -38,13 +38,8 @@ from kitaru.server.application.interfaces.agent_version_repository import (
 )
 from kitaru.server.application.models.agent import AgentFilter
 from kitaru.server.domain.account import Account
-from kitaru.server.domain.agent import (
-    Agent,
-    AgentInUse,
-    AgentNotFound,
-    DuplicateAgentName,
-)
-from kitaru.server.domain.agent_version import AgentVersion
+from kitaru.server.domain.agent import Agent, AgentNotFound, DuplicateAgentName
+from kitaru.server.domain.agent_version import AgentVersion, AgentVersionNotFound
 from kitaru.server.filtering import FilterCondition
 
 Setup = tuple[AgentRepository, uuid.UUID, Callable[[], AgentVersionRepository]]
@@ -228,12 +223,15 @@ async def test_delete_not_found(setup: Setup) -> None:
         await repository.delete(missing_id)
 
 
-async def test_delete_in_use(setup: Setup) -> None:
-    """Reject deleting an agent that has versions."""
+async def test_delete_cascades_versions(setup: Setup) -> None:
+    """Delete an agent together with its versions."""
     repository, owner_id, make_version_repository = setup
     agent = await repository.create(Agent(owner_id=owner_id, name="assistant"))
     version_repository = make_version_repository()
-    await version_repository.create(AgentVersion(owner_id=owner_id, agent_id=agent.id))
+    version = await version_repository.create(
+        AgentVersion(owner_id=owner_id, agent_id=agent.id)
+    )
 
-    with pytest.raises(AgentInUse, match=f"Agent {agent.id} has versions"):
-        await repository.delete(agent.id)
+    await repository.delete(agent.id)
+    with pytest.raises(AgentVersionNotFound):
+        await version_repository.get(version.id)

--- a/tests/server/test_agent_service.py
+++ b/tests/server/test_agent_service.py
@@ -31,7 +31,8 @@ from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.services.agent_service import AgentService
 from kitaru.server.application.services.server_analytics import ServerAnalytics
 from kitaru.server.domain.account import Account
-from kitaru.server.domain.agent import AgentInUse, AgentNotFound, DuplicateAgentName
+from kitaru.server.domain.agent import AgentNotFound, DuplicateAgentName
+from kitaru.server.domain.agent_version import AgentVersionNotFound
 from kitaru.server.domain.base import ValidationError
 from kitaru.server.filtering import FilterCondition
 
@@ -246,16 +247,16 @@ async def test_delete_agent_not_found(service: AgentService) -> None:
         await service.delete_agent(uuid.uuid4(), actor=ACTOR)
 
 
-async def test_delete_agent_in_use(
+async def test_delete_agent_cascades_versions(
     service: AgentService, repository: FakeAgentRepository
 ) -> None:
-    """Reject deleting an agent that has versions."""
+    """Delete an agent together with its versions."""
     created = await create_agent(repository, ACTOR.account.id)
-    await create_agent_version(
-        FakeAgentVersionRepository(repository), created.id, ACTOR.account.id
-    )
-    with pytest.raises(AgentInUse, match=f"Agent {created.id} has versions"):
-        await service.delete_agent(created.id, actor=ACTOR)
+    versions = FakeAgentVersionRepository(repository)
+    version = await create_agent_version(versions, created.id, ACTOR.account.id)
+    await service.delete_agent(created.id, actor=ACTOR)
+    with pytest.raises(AgentVersionNotFound):
+        await versions.get(version.id)
 
 
 async def test_create_agent_tracks_agent_created(

--- a/tests/server/test_agents_api.py
+++ b/tests/server/test_agents_api.py
@@ -199,17 +199,17 @@ async def test_delete_agent_not_found(client: httpx.AsyncClient) -> None:
     assert response.status_code == 404
 
 
-async def test_delete_agent_in_use(
-    client: httpx.AsyncClient, agent_repository: FakeAgentRepository
-) -> None:
-    """Observe HTTP 409 when the agent has versions."""
+async def test_delete_agent_cascades_versions(client: httpx.AsyncClient) -> None:
+    """Delete an agent together with its versions."""
     created = (await client.post("/api/v1/agents", json={"name": "assistant"})).json()
-    await client.post(f"/api/v1/agents/{created['id']}/versions", json={})
+    version = (
+        await client.post(f"/api/v1/agents/{created['id']}/versions", json={})
+    ).json()
     response = await client.delete(f"/api/v1/agents/{created['id']}")
-    assert response.status_code == 409
-    assert response.json() == {
-        "detail": f"Agent {created['id']} has versions and cannot be deleted"
-    }
+    assert response.status_code == 204
+
+    response = await client.get(f"/api/v1/agent-versions/{version['id']}")
+    assert response.status_code == 404
 
 
 async def test_create_agent_version(client: httpx.AsyncClient) -> None:

--- a/tests/server/test_agents_api_pg.py
+++ b/tests/server/test_agents_api_pg.py
@@ -154,13 +154,167 @@ async def test_create_version_with_secrets_round_trips(
     ]
 
 
-async def test_delete_agent_restricted_by_versions(client: httpx.AsyncClient) -> None:
-    """Translate the FK restriction into HTTP 409 when versions exist."""
+async def test_delete_agent_cascades_related_resources(
+    client: httpx.AsyncClient,
+) -> None:
+    """Delete an agent together with everything that references it."""
     agent = (await client.post("/api/v1/agents", json={"name": "assistant"})).json()
-    await client.post(f"/api/v1/agents/{agent['id']}/versions", json={})
+    agent_id = agent["id"]
+    version = (
+        await client.post(
+            f"/api/v1/agents/{agent_id}/versions",
+            json={"run_spec": {"command": "run.sh", "timeout_seconds": 60}},
+        )
+    ).json()
+    session = (
+        await client.post(
+            "/api/v1/sessions",
+            json={
+                "agent_id": agent_id,
+                "agent_version_id": version["id"],
+                "origin": "recorded",
+                "inputs": {"q": "hi"},
+                "outputs": None,
+            },
+        )
+    ).json()
+    cohort = (
+        await client.post("/api/v1/cohorts", json={"name": "c1", "agent_id": agent_id})
+    ).json()
+    cohort_version = (
+        await client.post(
+            f"/api/v1/cohorts/{cohort['id']}/versions",
+            json={"add_session_ids": [session["id"]]},
+        )
+    ).json()
+    blob = (
+        await client.post(
+            "/api/v1/blobs",
+            files={"file": ("score.py", b"def score(): pass", "text/plain")},
+        )
+    ).json()
+    evaluator = (
+        await client.post(
+            "/api/v1/evaluators", json={"name": "accuracy", "metadata": {}}
+        )
+    ).json()
+    await client.post(
+        f"/api/v1/evaluators/{evaluator['id']}/versions",
+        json={
+            "source": {"type": "script", "blob_id": blob["id"], "entrypoint": "score"}
+        },
+    )
+    experiment = (
+        await client.post(
+            "/api/v1/experiments",
+            json={
+                "name": "exp1",
+                "agent_id": agent_id,
+                "evaluators": [{"evaluator": "accuracy"}],
+            },
+        )
+    ).json()
+    experiment_run = (
+        await client.post(
+            f"/api/v1/experiments/{experiment['id']}/runs",
+            json={
+                "cohort_version_id": cohort_version["id"],
+                "agent_version_id": version["id"],
+            },
+        )
+    ).json()
+    investigation = (
+        await client.post(
+            "/api/v1/investigations",
+            json={
+                "agent_id": agent_id,
+                "name": "inv1",
+                "sessions": [
+                    {
+                        "session_id": session["id"],
+                        "questions": [{"key": "cause", "question": "Why?"}],
+                    }
+                ],
+            },
+        )
+    ).json()
+    replay = (
+        await client.post(
+            "/api/v1/replays",
+            json={
+                "baseline_session_id": session["id"],
+                "evaluators": [{"evaluator": "accuracy"}],
+            },
+        )
+    ).json()
+    # Drive the ad hoc replay to its evaluator task so a task referencing
+    # the agent only through its input session exists.
+    registration = (
+        await client.post(
+            "/api/v1/workers",
+            json={
+                "name": "worker-1",
+                "scope": {"claims": [{"kind": "agent"}, {"kind": "evaluator"}]},
+                "runtime": {"platform": "bare"},
+                "metadata": {},
+            },
+        )
+    ).json()
+    worker_headers = {"Authorization": f"Bearer {registration['token']}"}
+    claimed = (
+        await client.post(
+            "/api/v1/tasks/claim", json={"max_tasks": 10}, headers=worker_headers
+        )
+    ).json()
+    agent_entry = next(
+        entry
+        for entry in claimed["tasks"]
+        if entry["task"]["kind"] == "agent"
+        and entry["task"]["job_id"] == replay["job_id"]
+    )
+    agent_task_headers = {"Authorization": f"Bearer {agent_entry['token']}"}
+    await client.patch(
+        f"/api/v1/tasks/{agent_entry['task']['id']}",
+        json={"status": "running"},
+        headers=agent_task_headers,
+    )
+    result_session = (
+        await client.post(
+            "/api/v1/sessions",
+            json={"origin": "replay", "inputs": None, "outputs": None},
+            headers=agent_task_headers,
+        )
+    ).json()
+    await client.patch(
+        f"/api/v1/sessions/{result_session['id']}",
+        json={"status": "completed", "outputs": {}},
+    )
+    await client.patch(
+        f"/api/v1/tasks/{agent_entry['task']['id']}",
+        json={"status": "completed"},
+        headers=agent_task_headers,
+    )
+    claimed = (
+        await client.post(
+            "/api/v1/tasks/claim", json={"max_tasks": 10}, headers=worker_headers
+        )
+    ).json()
+    assert any(entry["task"]["kind"] == "evaluator" for entry in claimed["tasks"])
 
-    response = await client.delete(f"/api/v1/agents/{agent['id']}")
-    assert response.status_code == 409
-    assert response.json() == {
-        "detail": f"Agent {agent['id']} has versions and cannot be deleted"
-    }
+    response = await client.delete(f"/api/v1/agents/{agent_id}")
+    assert response.status_code == 204
+
+    for path in (
+        f"/api/v1/agents/{agent_id}",
+        f"/api/v1/agent-versions/{version['id']}",
+        f"/api/v1/sessions/{session['id']}",
+        f"/api/v1/sessions/{result_session['id']}",
+        f"/api/v1/cohorts/{cohort['id']}",
+        f"/api/v1/cohort-versions/{cohort_version['id']}",
+        f"/api/v1/experiments/{experiment['id']}",
+        f"/api/v1/experiment-runs/{experiment_run['id']}",
+        f"/api/v1/investigations/{investigation['id']}",
+        f"/api/v1/replays/{replay['id']}",
+    ):
+        response = await client.get(path)
+        assert response.status_code == 404, path

--- a/tests/server/test_referenced_not_found_pg.py
+++ b/tests/server/test_referenced_not_found_pg.py
@@ -1,0 +1,256 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Foreign key violations on a missing parent translate to not-found errors."""
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from conftest import pg_session_with_engine, postgres_available
+from kitaru.api_models.v1.job import JobKind
+from kitaru.api_models.v1.session import SessionOrigin
+from kitaru.server.adapters.db.repositories.account_repository import (
+    SQLAccountRepository,
+)
+from kitaru.server.adapters.db.repositories.agent_repository import SQLAgentRepository
+from kitaru.server.adapters.db.repositories.cohort_repository import (
+    SQLCohortRepository,
+)
+from kitaru.server.adapters.db.repositories.cohort_version_repository import (
+    SQLCohortVersionRepository,
+)
+from kitaru.server.adapters.db.repositories.experiment_repository import (
+    SQLExperimentRepository,
+)
+from kitaru.server.adapters.db.repositories.experiment_run_repository import (
+    SQLExperimentRunRepository,
+)
+from kitaru.server.adapters.db.repositories.investigation_repository import (
+    SQLInvestigationRepository,
+)
+from kitaru.server.adapters.db.repositories.job_repository import SQLJobRepository
+from kitaru.server.adapters.db.repositories.replay_repository import (
+    SQLReplayRepository,
+)
+from kitaru.server.adapters.db.repositories.session_repository import (
+    SQLSessionRepository,
+)
+from kitaru.server.adapters.db.repositories.task_repository import SQLTaskRepository
+from kitaru.server.domain.account import Account
+from kitaru.server.domain.agent import Agent, AgentNotFound
+from kitaru.server.domain.agent_version import AgentVersionNotFound
+from kitaru.server.domain.base import NotFoundError
+from kitaru.server.domain.cohort import Cohort
+from kitaru.server.domain.cohort_version import CohortVersion
+from kitaru.server.domain.experiment import Experiment
+from kitaru.server.domain.experiment_run import ExperimentRun
+from kitaru.server.domain.investigation import Investigation
+from kitaru.server.domain.job import Job
+from kitaru.server.domain.replay import Replay
+from kitaru.server.domain.replay_config import (
+    PassthroughConfig,
+    ReplayConfig,
+    ToolPolicy,
+)
+from kitaru.server.domain.session import Session, SessionNotFound
+from kitaru.server.domain.task import AgentTask
+
+Setup = tuple[AsyncSession, AsyncEngine]
+
+
+@pytest.fixture
+async def setup() -> AsyncGenerator[Setup, None]:
+    """Provide a PostgreSQL session and its engine on a fresh database."""
+    if not await postgres_available():
+        pytest.skip("PostgreSQL is not reachable")
+    async with pg_session_with_engine() as (session, engine):
+        yield session, engine
+
+
+async def _owner_id(session: AsyncSession) -> uuid.UUID:
+    return (await SQLAccountRepository(session).create(Account(name="owner"))).id
+
+
+async def test_session_missing_agent(setup: Setup) -> None:
+    """Translate the agent foreign key on a session insert."""
+    session, engine = setup
+    owner_id = await _owner_id(session)
+    missing = uuid.uuid4()
+    with pytest.raises(AgentNotFound, match=f"Agent {missing} was not found"):
+        await SQLSessionRepository(session, engine).create(
+            Session(
+                owner_id=owner_id,
+                agent_id=missing,
+                number=1,
+                origin=SessionOrigin.RECORDED,
+            )
+        )
+
+
+async def test_session_missing_agent_version(setup: Setup) -> None:
+    """Translate the agent version foreign key on a session insert."""
+    session, engine = setup
+    owner_id = await _owner_id(session)
+    agent = await SQLAgentRepository(session).create(
+        Agent(owner_id=owner_id, name="assistant")
+    )
+    missing = uuid.uuid4()
+    with pytest.raises(AgentVersionNotFound):
+        await SQLSessionRepository(session, engine).create(
+            Session(
+                owner_id=owner_id,
+                agent_id=agent.id,
+                agent_version_id=missing,
+                number=1,
+                origin=SessionOrigin.RECORDED,
+            )
+        )
+
+
+async def test_cohort_missing_agent(setup: Setup) -> None:
+    """Translate the agent foreign key on a cohort insert."""
+    session, _ = setup
+    owner_id = await _owner_id(session)
+    with pytest.raises(AgentNotFound):
+        await SQLCohortRepository(session).create(
+            Cohort(owner_id=owner_id, name="cohort", agent_id=uuid.uuid4())
+        )
+
+
+async def test_experiment_missing_agent(setup: Setup) -> None:
+    """Translate the agent foreign key on an experiment insert."""
+    session, _ = setup
+    owner_id = await _owner_id(session)
+    experiments = SQLExperimentRepository(session)
+    config = await experiments.create_replay_config(
+        ReplayConfig(
+            owner_id=owner_id,
+            tool_policy=ToolPolicy(default=PassthroughConfig()),
+            evaluators=[],
+        )
+    )
+    with pytest.raises(AgentNotFound):
+        await experiments.create(
+            Experiment(
+                owner_id=owner_id,
+                name="experiment",
+                agent_id=uuid.uuid4(),
+                replay_config_id=config.id,
+            )
+        )
+
+
+async def test_experiment_run_missing_agent_version(setup: Setup) -> None:
+    """Translate the agent version foreign key on an experiment run insert."""
+    session, _ = setup
+    owner_id = await _owner_id(session)
+    agent = await SQLAgentRepository(session).create(
+        Agent(owner_id=owner_id, name="assistant")
+    )
+    experiments = SQLExperimentRepository(session)
+    config = await experiments.create_replay_config(
+        ReplayConfig(
+            owner_id=owner_id,
+            tool_policy=ToolPolicy(default=PassthroughConfig()),
+            evaluators=[],
+        )
+    )
+    experiment = await experiments.create(
+        Experiment(
+            owner_id=owner_id,
+            name="experiment",
+            agent_id=agent.id,
+            replay_config_id=config.id,
+        )
+    )
+    cohort = await SQLCohortRepository(session).create(
+        Cohort(owner_id=owner_id, name="cohort", agent_id=agent.id)
+    )
+    cohort_version = await SQLCohortVersionRepository(session).create(
+        CohortVersion(owner_id=owner_id, cohort_id=cohort.id, session_count=0), []
+    )
+    with pytest.raises(AgentVersionNotFound):
+        await SQLExperimentRunRepository(session).create(
+            ExperimentRun(
+                owner_id=owner_id,
+                experiment_id=experiment.id,
+                number=1,
+                cohort_version_id=cohort_version.id,
+                agent_version_id=uuid.uuid4(),
+            )
+        )
+
+
+async def test_investigation_missing_agent(setup: Setup) -> None:
+    """Translate the agent foreign key on an investigation insert."""
+    session, _ = setup
+    owner_id = await _owner_id(session)
+    with pytest.raises(AgentNotFound):
+        await SQLInvestigationRepository(session).create(
+            Investigation(
+                owner_id=owner_id,
+                agent_id=uuid.uuid4(),
+                name="investigation",
+                total_sessions=0,
+                completed_sessions=0,
+            ),
+            [],
+        )
+
+
+async def test_replay_missing_baseline_session(setup: Setup) -> None:
+    """Translate the baseline session foreign key on replay inserts."""
+    session, _ = setup
+    owner_id = await _owner_id(session)
+    job = await SQLJobRepository(session).create(
+        Job(owner_id=owner_id, kind=JobKind.REPLAY)
+    )
+    config = await SQLExperimentRepository(session).create_replay_config(
+        ReplayConfig(
+            owner_id=owner_id,
+            tool_policy=ToolPolicy(default=PassthroughConfig()),
+            evaluators=[],
+        )
+    )
+    missing = uuid.uuid4()
+    replay = Replay(
+        owner_id=owner_id,
+        job_id=job.id,
+        replay_config_id=config.id,
+        baseline_session_id=missing,
+    )
+    replays = SQLReplayRepository(session)
+    with pytest.raises(SessionNotFound, match=f"Session {missing} was not found"):
+        await replays.create(replay)
+    with pytest.raises(NotFoundError, match="Baseline session was not found"):
+        await replays.create_many([replay])
+
+
+async def test_task_missing_references(setup: Setup) -> None:
+    """Translate the agent version foreign key on task inserts."""
+    session, _ = setup
+    owner_id = await _owner_id(session)
+    job = await SQLJobRepository(session).create(
+        Job(owner_id=owner_id, kind=JobKind.SESSION_RUN)
+    )
+    tasks = SQLTaskRepository(session)
+    missing_version = uuid.uuid4()
+    with pytest.raises(AgentVersionNotFound):
+        await tasks.create(AgentTask(job_id=job.id, agent_version_id=missing_version))
+    with pytest.raises(NotFoundError, match="Agent version was not found"):
+        await tasks.create_many(
+            [AgentTask(job_id=job.id, agent_version_id=missing_version)]
+        )


### PR DESCRIPTION
Deleting an agent now cascades to its versions, sessions, cohorts, experiments, investigations, and jobs instead of returning 409 or failing with a 500 on a referencing row.