### PR TITLE
Raise default worker concurrency to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Raised the default worker concurrency from 1 to 10, so `kitaru worker start` runs up to ten tasks in parallel without a flag. Set `--concurrency` or `KITARU_WORKER_CONCURRENCY` to restore the previous single-slot behavior.
+
 ## [0.22.0rc10]
 
 ### Added

--- a/docs/book/deploy/workers.md
+++ b/docs/book/deploy/workers.md
@@ -25,7 +25,7 @@ kitaru worker start
 | Variable | Default | Meaning |
 | --- | --- | --- |
 | `KITARU_WORKER_NAME` | hostname-pid | Stable name; restarts reuse the worker registration. In Kubernetes the pod name works out of the box. |
-| `KITARU_WORKER_CONCURRENCY` | 1 | Tasks run in parallel |
+| `KITARU_WORKER_CONCURRENCY` | 10 | Tasks run in parallel |
 | `KITARU_WORKER_SCOPE__CLAIMS` | all | JSON list of claims, such as `{"kind":"agent"}` or `{"kind":"agent","agent_version_id":"<UUID>"}` |
 | `KITARU_WORKER_SCOPE__SELECTORS` | none | JSON label selectors (e.g. limit to one agent version's environment) |
 | `KITARU_WORKER_SCOPE__JOB_ID` | none | Claim one job's tasks, drain, exit |

--- a/src/kitaru/worker/config.py
+++ b/src/kitaru/worker/config.py
@@ -25,6 +25,10 @@ from kitaru.worker.heartbeat import DEFAULT_HEARTBEAT_INTERVAL_SECONDS
 
 RUN_POLL_INTERVAL_SECONDS = 2.0
 
+# Worker tasks spend nearly all their wall time awaiting model and tool calls, so a
+# single slot leaves the process idle while queued work waits for a free worker.
+DEFAULT_CONCURRENCY = 10
+
 
 class WorkerConfig(BaseSettings):
     """Worker configuration."""
@@ -37,7 +41,7 @@ class WorkerConfig(BaseSettings):
     scope: WorkerScope = WorkerScope(
         claims=[WorkerClaim(kind=kind) for kind in TaskKind]
     )
-    concurrency: int = Field(default=1, ge=1)
+    concurrency: int = Field(default=DEFAULT_CONCURRENCY, ge=1)
     claim_batch_size: int | None = Field(default=None, ge=1)
     poll_interval: float = Field(default=RUN_POLL_INTERVAL_SECONDS, gt=0)
     heartbeat_interval: float = Field(default=DEFAULT_HEARTBEAT_INTERVAL_SECONDS, gt=0)

--- a/src/kitaru/worker/config.py
+++ b/src/kitaru/worker/config.py
@@ -25,8 +25,6 @@ from kitaru.worker.heartbeat import DEFAULT_HEARTBEAT_INTERVAL_SECONDS
 
 RUN_POLL_INTERVAL_SECONDS = 2.0
 
-# Worker tasks spend nearly all their wall time awaiting model and tool calls, so a
-# single slot leaves the process idle while queued work waits for a free worker.
 DEFAULT_CONCURRENCY = 10
 
 

--- a/tests/worker/test_config.py
+++ b/tests/worker/test_config.py
@@ -19,7 +19,7 @@ import pytest
 
 from kitaru.api_models.v1.task import TaskKind
 from kitaru.api_models.v1.worker import LabelSelector, WorkerClaim, WorkerScope
-from kitaru.worker.config import WorkerConfig
+from kitaru.worker.config import DEFAULT_CONCURRENCY, WorkerConfig
 from kitaru.worker.worker import default_worker_name
 
 
@@ -31,7 +31,7 @@ def test_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.scope == WorkerScope(
         claims=[WorkerClaim(kind=kind) for kind in TaskKind]
     )
-    assert config.concurrency == 1
+    assert config.concurrency == DEFAULT_CONCURRENCY
     assert config.claim_batch_size is None
     assert config.timeout is None
     assert config.metadata == {}


### PR DESCRIPTION
A worker started with `kitaru worker start` and no flags ran exactly one task at a time. Since a worker task spends nearly all of its wall time awaiting model and tool calls rather than burning CPU, that left the process mostly idle while queued tasks waited for a free slot. This raises the out-of-the-box default to 10.

Nothing about the configuration surface changes: `--concurrency` and `KITARU_WORKER_CONCURRENCY` both still work, and either one restores the old behavior with a value of `1`.

## Reviewer Notes

The interesting part of this change is **where** the default lives, and it is worth a moment before reading the diff.

`kitaru worker start` has no default of its own. The CLI option is declared as `concurrency: int | None = None` (`src/kitaru/cli/workers.py:100`), and `build_worker_config` builds an `explicit` dict and applies only the entries that are not `None` on top of the settings object. The `None` is deliberate: it is an "the user said nothing" marker. It is what lets `KITARU_WORKER_CONCURRENCY` survive, because pydantic-settings reads the environment when the field is not passed explicitly.

That means there are two ways to raise the default, and only one of them is correct:

- Give the CLI option a real default of `10`. The flag would then pass `10` on every invocation, the value would land in `explicit`, and it would overwrite whatever `KITARU_WORKER_CONCURRENCY` said. The environment variable would silently stop working.
- Move the field default on `WorkerConfig` (`src/kitaru/worker/config.py`). The precedence chain stays intact: flag beats environment variable beats default.

This PR does the second. The new `DEFAULT_CONCURRENCY` constant sits next to `RUN_POLL_INTERVAL_SECONDS` so the number has one home and the reasoning is recorded next to it.

**What breaks if this is wrong.** If the default had been put on the flag, no test would have failed and no error would have appeared. Workers in containers configured purely through `KITARU_WORKER_CONCURRENCY` would just quietly ignore their setting and run at 10. That is the failure mode worth checking in review: `tests/worker/test_config.py` covers all three layers (`test_defaults`, `test_concurrency_from_env`, `test_explicit_config_values_override_environment`), and the latter two use values other than 10 so they still discriminate.

**Scope worth calling out.** `WorkerConfig` is exported from `kitaru.worker`, so this also changes the default for anyone constructing `Worker(WorkerConfig())` in Python, not only for CLI users. That seemed right for a default meant to describe good worker behavior rather than good CLI behavior, but it is a deliberate widening and is flagged here rather than buried.

**Knock-on effect on claiming.** `claim_batch_size` still defaults to `None`, and the claim loop falls back to the number of free slots (`src/kitaru/worker/worker.py:249-258`). So a freshly started worker now asks for up to 10 tasks in one claim request instead of 1, still bounded by `_MAX_CLAIM_BATCH = 100`. That is the intended consequence, not an accident, but it is the line to look at if claim behavior ever looks surprising.

### Reproduction

Start a worker and read the `starting` lifecycle event, which reports the concurrency it resolved:

```bash
kitaru --output jsonl worker start --timeout 2
```

Look at the first JSONL line: `item.concurrency` is now `10` where it was `1`.

Then confirm the precedence chain is still intact:

```bash
# environment variable still wins over the default
KITARU_WORKER_CONCURRENCY=3 kitaru --output jsonl worker start --timeout 2   # -> 3

# explicit flag still wins over the environment variable
KITARU_WORKER_CONCURRENCY=3 kitaru --output jsonl worker start --concurrency 7 --timeout 2   # -> 7
```

If the second command reports `10`, the default was put in the wrong place.

### Local checks run

`just test` (3571 passed), `just typecheck`, `just format-check`, and `ruff check` on the changed files all pass.

Two unrelated things were red locally and are **not** touched by this PR:

- `tests/server/test_pool_timeout_handler.py` fails on my machine only when a Kitaru UI bundle has been downloaded into `src/kitaru/`. The bundle makes `create_app` register a catch-all route that serves `index.html` with a 200 for any unmatched path, which shadows the `/probe-*` routes the test appends afterwards. Both tests pass in a clean worktree with no bundle present, so this is a pre-existing environment sensitivity in that test rather than a regression.
- `just lint` reports 7 `E501` errors in `examples/canonical_example/evaluator.py`, which is untracked work-in-progress on my machine and is not part of this branch.
