### PR TITLE
Fix SDK docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,6 +90,9 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # The repository root is a pnpm workspace. Letting the action infer
+          # pnpm makes its temporary Wrangler install fail at the workspace root.
+          packageManager: npm
           wranglerVersion: ${{ env.WRANGLER_VERSION }}
           command: deploy
       - name: Deploy redirect worker
@@ -104,5 +107,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: npm
           wranglerVersion: ${{ env.WRANGLER_VERSION }}
           command: deploy --config wrangler.redirect.toml


### PR DESCRIPTION
## What changed?

The SDK reference workflow now installs its pinned Wrangler version with npm for both Cloudflare deployment steps.

## Why?

The repository root became a pnpm workspace in #679. The Cloudflare action then inferred pnpm and its temporary Wrangler install failed with `ERR_PNPM_ADDING_TO_ROOT`, after the v2 docs had built successfully. This left `sdkdocs.kitaru.ai` on the previous v1 deployment.

## Reviewer Notes

The important behavior is the explicit `packageManager: npm` input on both Wrangler steps. The action still uses the pinned Wrangler version and the same checked-in Cloudflare configuration; only its temporary package installation changes. If either deployment step is missed, the SDK site and `kitaru.ai/docs/*` redirects can diverge.

### Reproduction

1. Open the failed manual deployment: https://github.com/zenml-io/kitaru/actions/runs/32114562331.
2. Confirm that generation and the static build passed, then `Deploy production docs` failed while running `pnpm add wrangler@4.95.0` at the workspace root.
3. After merge, manually dispatch `SDK Reference Docs` from `develop`.
4. Confirm that both Cloudflare deployment steps pass and `https://sdkdocs.kitaru.ai/cli/` lists the v2 commands without the retired `flow`, `executions`, or `model` groups.

## Local checks run

- `just yaml-check`
- `just actions-lint`
- `just zizmor`
