### PR TITLE
Add user-facing client methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added user-facing methods to `KitaruClient` and `KitaruSyncClient`: get agents and experiments by name or id, list sessions and session nodes, replay a session or start an experiment run and wait for the result. The one-method-per-endpoint API client stays reachable as `client.api`.
+
 ## [0.22.0]
 
 ### Changed

--- a/src/kitaru/client/client.py
+++ b/src/kitaru/client/client.py
@@ -13,9 +13,52 @@
 #  permissions and limitations under the License.
 """Kitaru client."""
 
+import asyncio
+import time
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable
 from types import TracebackType
+from typing import TypeVar
 
+from kitaru.api_models.v1.agent import AgentListParams, AgentResponse
+from kitaru.api_models.v1.base import Page
+from kitaru.api_models.v1.experiment import ExperimentListParams, ExperimentResponse
+from kitaru.api_models.v1.experiment_run import (
+    ExperimentRunCreateRequest,
+    ExperimentRunResponse,
+    ExperimentRunStatus,
+)
+from kitaru.api_models.v1.filter import FilterCondition, FilterOp
+from kitaru.api_models.v1.replay import (
+    ReplayCreateRequest,
+    ReplayResponse,
+    ReplayStatus,
+)
+from kitaru.api_models.v1.replay_config import (
+    EvaluatorConfig,
+    ReplayOverride,
+    ToolPolicy,
+)
+from kitaru.api_models.v1.session import SessionListParams, SessionResponse
+from kitaru.api_models.v1.session_node import SessionNodeResponse
 from kitaru.client.api_client import KitaruAPIClient
+from kitaru.client.exceptions import KitaruClientError, NotFoundError
+
+TERMINAL_REPLAY_STATUSES = frozenset(
+    {ReplayStatus.COMPLETED, ReplayStatus.FAILED, ReplayStatus.CANCELED}
+)
+TERMINAL_EXPERIMENT_RUN_STATUSES = frozenset(
+    {
+        ExperimentRunStatus.COMPLETED,
+        ExperimentRunStatus.FAILED,
+        ExperimentRunStatus.CANCELED,
+    }
+)
+
+
+NamedT = TypeVar("NamedT", AgentResponse, ExperimentResponse)
+ListParamsT = TypeVar("ListParamsT", AgentListParams, ExperimentListParams)
+StatusT = TypeVar("StatusT", ReplayResponse, ExperimentRunResponse)
 
 
 class KitaruClient:
@@ -28,6 +71,15 @@ class KitaruClient:
             api_client: API client used to send requests.
         """
         self._api_client = api_client or KitaruAPIClient()
+
+    @property
+    def api(self) -> KitaruAPIClient:
+        """API client with one method per endpoint.
+
+        Returns:
+            API client with one method per endpoint.
+        """
+        return self._api_client
 
     async def close(self) -> None:
         """Close the underlying API client."""
@@ -55,3 +107,342 @@ class KitaruClient:
             traceback: Exception traceback.
         """
         await self.close()
+
+    async def get_agent(self, agent: uuid.UUID | str) -> AgentResponse:
+        """Get an agent by id or name.
+
+        Args:
+            agent: Id or name of the agent.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing agent.
+
+        Returns:
+            Stored agent.
+        """
+        if isinstance(agent, uuid.UUID):
+            return await self._api_client.agents.get(agent)
+        return await self._get_by_name(
+            "agent", agent, AgentListParams, self._api_client.agents.list
+        )
+
+    def list_agents(self) -> AsyncIterator[AgentResponse]:
+        """Iterate over all agents.
+
+        Returns:
+            Async iterator over every agent.
+        """
+        return self._api_client.agents.iter()
+
+    async def get_session(self, session_id: uuid.UUID) -> SessionResponse:
+        """Get a session by id.
+
+        Args:
+            session_id: Id of the session.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing session.
+
+        Returns:
+            Stored session.
+        """
+        return await self._api_client.sessions.get(session_id)
+
+    async def list_sessions(
+        self, agent: uuid.UUID | str | None = None
+    ) -> AsyncIterator[SessionResponse]:
+        """Iterate over sessions, optionally scoped to one agent.
+
+        Args:
+            agent: Id or name of the agent to scope to.
+
+        Raises:
+            APIError: The request failed.
+
+        Returns:
+            Async iterator over every matching session.
+        """
+        params = SessionListParams()
+        if agent is not None:
+            agent_id = (await self.get_agent(agent)).id
+            params = SessionListParams(
+                filter=FilterCondition(
+                    field="agent_id", op=FilterOp.EQ, value=str(agent_id)
+                )
+            )
+        async for session in self._api_client.sessions.iter(params):
+            yield session
+
+    def list_session_nodes(
+        self, session_id: uuid.UUID
+    ) -> AsyncIterator[SessionNodeResponse]:
+        """Iterate over the nodes of a session in index order.
+
+        Args:
+            session_id: Id of the session.
+
+        Returns:
+            Async iterator over every node.
+        """
+        return self._api_client.sessions.iter_nodes(session_id)
+
+    async def replay(
+        self,
+        session_id: uuid.UUID,
+        evaluators: list[EvaluatorConfig],
+        agent_version_id: uuid.UUID | None = None,
+        override: ReplayOverride | None = None,
+        tool_policy: ToolPolicy | None = None,
+        evaluate_baselines: bool = False,
+        wait: bool = True,
+        timeout: float | None = None,
+    ) -> ReplayResponse:
+        """Replay a session and optionally wait for it to finish.
+
+        Args:
+            session_id: Id of the session to replay.
+            evaluators: Evaluators run against the result session.
+            agent_version_id: Agent version to replay with, the session's
+                recorded version when unset.
+            override: Override to apply.
+            tool_policy: Tool policy to apply.
+            evaluate_baselines: Whether to also score the baseline session.
+            wait: Whether to wait for the replay to reach a terminal status.
+            timeout: Seconds to wait before giving up.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing session
+                or agent version.
+            TimeoutError: The replay did not finish within the timeout.
+
+        Returns:
+            Replay, in a terminal status when waited for.
+        """
+        request = ReplayCreateRequest(
+            baseline_session_id=session_id,
+            agent_version_id=agent_version_id,
+            override=override,
+            tool_policy=tool_policy,
+            evaluators=evaluators,
+            evaluate_baselines=evaluate_baselines,
+        )
+        replay = await self._api_client.replays.create(request)
+        if wait:
+            replay = await self.wait_for_replay(replay.id, timeout=timeout)
+        return replay
+
+    async def get_replay(self, replay_id: uuid.UUID) -> ReplayResponse:
+        """Get a replay by id.
+
+        Args:
+            replay_id: Id of the replay.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing replay.
+
+        Returns:
+            Stored replay.
+        """
+        return await self._api_client.replays.get(replay_id)
+
+    async def wait_for_replay(
+        self,
+        replay_id: uuid.UUID,
+        timeout: float | None = None,
+        poll_interval: float = 2.0,
+    ) -> ReplayResponse:
+        """Wait for a replay to reach a terminal status.
+
+        Args:
+            replay_id: Id of the replay.
+            timeout: Seconds to wait before giving up.
+            poll_interval: Seconds between status checks.
+
+        Raises:
+            APIError: The request failed.
+            TimeoutError: The replay did not finish within the timeout.
+
+        Returns:
+            Replay in a terminal status.
+        """
+        return await self._wait_for_status(
+            lambda: self._api_client.replays.get(replay_id),
+            lambda replay: replay.status in TERMINAL_REPLAY_STATUSES,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+
+    async def get_experiment(self, experiment: uuid.UUID | str) -> ExperimentResponse:
+        """Get an experiment by id or name.
+
+        Args:
+            experiment: Id or name of the experiment.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing
+                experiment.
+
+        Returns:
+            Stored experiment.
+        """
+        if isinstance(experiment, uuid.UUID):
+            return await self._api_client.experiments.get(experiment)
+        return await self._get_by_name(
+            "experiment",
+            experiment,
+            ExperimentListParams,
+            self._api_client.experiments.list,
+        )
+
+    def list_experiments(self) -> AsyncIterator[ExperimentResponse]:
+        """Iterate over all experiments.
+
+        Returns:
+            Async iterator over every experiment.
+        """
+        return self._api_client.experiments.iter()
+
+    async def run_experiment(
+        self,
+        experiment: uuid.UUID | str,
+        cohort_version_id: uuid.UUID,
+        agent_version_id: uuid.UUID,
+        evaluate_baselines: bool = False,
+        wait: bool = True,
+        timeout: float | None = None,
+    ) -> ExperimentRunResponse:
+        """Start an experiment run and optionally wait for it to finish.
+
+        Args:
+            experiment: Id or name of the experiment.
+            cohort_version_id: Cohort version whose sessions are replayed.
+            agent_version_id: Agent version to replay with.
+            evaluate_baselines: Whether to also score each baseline session.
+            wait: Whether to wait for the run to reach a terminal status.
+            timeout: Seconds to wait before giving up.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing
+                experiment, cohort version, or agent version.
+            TimeoutError: The run did not finish within the timeout.
+
+        Returns:
+            Experiment run, in a terminal status when waited for.
+        """
+        experiment_id = (await self.get_experiment(experiment)).id
+        request = ExperimentRunCreateRequest(
+            cohort_version_id=cohort_version_id,
+            agent_version_id=agent_version_id,
+            evaluate_baselines=evaluate_baselines,
+        )
+        run = await self._api_client.experiments.start_run(experiment_id, request)
+        if wait:
+            run = await self.wait_for_experiment_run(run.id, timeout=timeout)
+        return run
+
+    async def get_experiment_run(self, run_id: uuid.UUID) -> ExperimentRunResponse:
+        """Get an experiment run by id.
+
+        Args:
+            run_id: Id of the experiment run.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing run.
+
+        Returns:
+            Stored experiment run.
+        """
+        return await self._api_client.experiment_runs.get(run_id)
+
+    async def wait_for_experiment_run(
+        self,
+        run_id: uuid.UUID,
+        timeout: float | None = None,
+        poll_interval: float = 2.0,
+    ) -> ExperimentRunResponse:
+        """Wait for an experiment run to reach a terminal status.
+
+        Args:
+            run_id: Id of the experiment run.
+            timeout: Seconds to wait before giving up.
+            poll_interval: Seconds between status checks.
+
+        Raises:
+            APIError: The request failed.
+            TimeoutError: The run did not finish within the timeout.
+
+        Returns:
+            Experiment run in a terminal status.
+        """
+        return await self._wait_for_status(
+            lambda: self._api_client.experiment_runs.get(run_id),
+            lambda run: run.status in TERMINAL_EXPERIMENT_RUN_STATUSES,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+
+    async def _get_by_name(
+        self,
+        kind: str,
+        name: str,
+        params_type: type[ListParamsT],
+        load_page: Callable[[ListParamsT], Awaitable[Page[NamedT]]],
+    ) -> NamedT:
+        """Get one resource by its exact name.
+
+        Args:
+            kind: Resource kind used in error messages.
+            name: Name of the resource.
+            params_type: List params type of the resource.
+            load_page: List method of the resource.
+
+        Raises:
+            NotFoundError: No resource has the name.
+            KitaruClientError: More than one resource has the name.
+
+        Returns:
+            Matching resource.
+        """
+        params = params_type(
+            size=2, filter=FilterCondition(field="name", op=FilterOp.EQ, value=name)
+        )
+        page = await load_page(params)
+        matches = [item for item in page.items if item.name == name]
+        if not matches:
+            raise NotFoundError(404, f"{kind.title()} {name!r} was not found")
+        if len(matches) > 1:
+            raise KitaruClientError(f"More than one {kind} has the exact name {name!r}")
+        return matches[0]
+
+    async def _wait_for_status(
+        self,
+        load: Callable[[], Awaitable[StatusT]],
+        is_terminal: Callable[[StatusT], bool],
+        timeout: float | None,
+        poll_interval: float,
+    ) -> StatusT:
+        """Poll a resource until it reaches a terminal status.
+
+        Args:
+            load: Loads the current resource state.
+            is_terminal: Whether the resource reached a terminal status.
+            timeout: Seconds to wait before giving up.
+            poll_interval: Seconds between status checks.
+
+        Raises:
+            TimeoutError: The resource did not reach a terminal status within
+                the timeout.
+
+        Returns:
+            Resource in a terminal status.
+        """
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            resource = await load()
+            if is_terminal(resource):
+                return resource
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Timed out after {timeout} seconds waiting for {resource.id}"
+                )
+            await asyncio.sleep(poll_interval)

--- a/src/kitaru/client/sync_client.py
+++ b/src/kitaru/client/sync_client.py
@@ -15,10 +15,22 @@
 
 import asyncio
 import threading
-from collections.abc import Coroutine
+import uuid
+from collections.abc import AsyncIterator, Coroutine, Iterator
 from types import TracebackType
 from typing import Any, TypeVar
 
+from kitaru.api_models.v1.agent import AgentResponse
+from kitaru.api_models.v1.experiment import ExperimentResponse
+from kitaru.api_models.v1.experiment_run import ExperimentRunResponse
+from kitaru.api_models.v1.replay import ReplayResponse
+from kitaru.api_models.v1.replay_config import (
+    EvaluatorConfig,
+    ReplayOverride,
+    ToolPolicy,
+)
+from kitaru.api_models.v1.session import SessionResponse
+from kitaru.api_models.v1.session_node import SessionNodeResponse
 from kitaru.client.api_client import KitaruAPIClient
 from kitaru.client.client import KitaruClient
 
@@ -39,6 +51,15 @@ class KitaruSyncClient:
         self._thread.start()
         self._client = KitaruClient(api_client=api_client)
 
+    @property
+    def api(self) -> KitaruAPIClient:
+        """API client with one method per endpoint.
+
+        Returns:
+            API client with one method per endpoint.
+        """
+        return self._client.api
+
     def _run(self, coro: Coroutine[Any, Any, T]) -> T:
         """Run a coroutine on the event loop thread and wait for the result.
 
@@ -49,6 +70,25 @@ class KitaruSyncClient:
             Coroutine result.
         """
         return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+
+    def _iterate(self, iterator: AsyncIterator[T]) -> Iterator[T]:
+        """Drain an async iterator on the event loop thread one item at a time.
+
+        Args:
+            iterator: Async iterator to drain.
+
+        Returns:
+            Iterator over the same items.
+        """
+
+        async def next_item() -> T:
+            return await anext(iterator)
+
+        while True:
+            try:
+                yield self._run(next_item())
+            except StopAsyncIteration:
+                return
 
     def close(self) -> None:
         """Close the underlying client and stop the event loop thread."""
@@ -79,3 +119,254 @@ class KitaruSyncClient:
             traceback: Exception traceback.
         """
         self.close()
+
+    def get_agent(self, agent: uuid.UUID | str) -> AgentResponse:
+        """Get an agent by id or name.
+
+        Args:
+            agent: Id or name of the agent.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing agent.
+
+        Returns:
+            Stored agent.
+        """
+        return self._run(self._client.get_agent(agent))
+
+    def list_agents(self) -> Iterator[AgentResponse]:
+        """Iterate over all agents.
+
+        Returns:
+            Iterator over every agent.
+        """
+        return self._iterate(self._client.list_agents())
+
+    def get_session(self, session_id: uuid.UUID) -> SessionResponse:
+        """Get a session by id.
+
+        Args:
+            session_id: Id of the session.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing session.
+
+        Returns:
+            Stored session.
+        """
+        return self._run(self._client.get_session(session_id))
+
+    def list_sessions(
+        self, agent: uuid.UUID | str | None = None
+    ) -> Iterator[SessionResponse]:
+        """Iterate over sessions, optionally scoped to one agent.
+
+        Args:
+            agent: Id or name of the agent to scope to.
+
+        Raises:
+            APIError: The request failed.
+
+        Returns:
+            Iterator over every matching session.
+        """
+        return self._iterate(self._client.list_sessions(agent))
+
+    def list_session_nodes(
+        self, session_id: uuid.UUID
+    ) -> Iterator[SessionNodeResponse]:
+        """Iterate over the nodes of a session in index order.
+
+        Args:
+            session_id: Id of the session.
+
+        Returns:
+            Iterator over every node.
+        """
+        return self._iterate(self._client.list_session_nodes(session_id))
+
+    def replay(
+        self,
+        session_id: uuid.UUID,
+        evaluators: list[EvaluatorConfig],
+        agent_version_id: uuid.UUID | None = None,
+        override: ReplayOverride | None = None,
+        tool_policy: ToolPolicy | None = None,
+        evaluate_baselines: bool = False,
+        wait: bool = True,
+        timeout: float | None = None,
+    ) -> ReplayResponse:
+        """Replay a session and optionally wait for it to finish.
+
+        Args:
+            session_id: Id of the session to replay.
+            evaluators: Evaluators run against the result session.
+            agent_version_id: Agent version to replay with, the session's
+                recorded version when unset.
+            override: Override to apply.
+            tool_policy: Tool policy to apply.
+            evaluate_baselines: Whether to also score the baseline session.
+            wait: Whether to wait for the replay to reach a terminal status.
+            timeout: Seconds to wait before giving up.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing session
+                or agent version.
+            TimeoutError: The replay did not finish within the timeout.
+
+        Returns:
+            Replay, in a terminal status when waited for.
+        """
+        return self._run(
+            self._client.replay(
+                session_id,
+                evaluators,
+                agent_version_id=agent_version_id,
+                override=override,
+                tool_policy=tool_policy,
+                evaluate_baselines=evaluate_baselines,
+                wait=wait,
+                timeout=timeout,
+            )
+        )
+
+    def get_replay(self, replay_id: uuid.UUID) -> ReplayResponse:
+        """Get a replay by id.
+
+        Args:
+            replay_id: Id of the replay.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing replay.
+
+        Returns:
+            Stored replay.
+        """
+        return self._run(self._client.get_replay(replay_id))
+
+    def wait_for_replay(
+        self,
+        replay_id: uuid.UUID,
+        timeout: float | None = None,
+        poll_interval: float = 2.0,
+    ) -> ReplayResponse:
+        """Wait for a replay to reach a terminal status.
+
+        Args:
+            replay_id: Id of the replay.
+            timeout: Seconds to wait before giving up.
+            poll_interval: Seconds between status checks.
+
+        Raises:
+            APIError: The request failed.
+            TimeoutError: The replay did not finish within the timeout.
+
+        Returns:
+            Replay in a terminal status.
+        """
+        return self._run(
+            self._client.wait_for_replay(
+                replay_id, timeout=timeout, poll_interval=poll_interval
+            )
+        )
+
+    def get_experiment(self, experiment: uuid.UUID | str) -> ExperimentResponse:
+        """Get an experiment by id or name.
+
+        Args:
+            experiment: Id or name of the experiment.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing
+                experiment.
+
+        Returns:
+            Stored experiment.
+        """
+        return self._run(self._client.get_experiment(experiment))
+
+    def list_experiments(self) -> Iterator[ExperimentResponse]:
+        """Iterate over all experiments.
+
+        Returns:
+            Iterator over every experiment.
+        """
+        return self._iterate(self._client.list_experiments())
+
+    def run_experiment(
+        self,
+        experiment: uuid.UUID | str,
+        cohort_version_id: uuid.UUID,
+        agent_version_id: uuid.UUID,
+        evaluate_baselines: bool = False,
+        wait: bool = True,
+        timeout: float | None = None,
+    ) -> ExperimentRunResponse:
+        """Start an experiment run and optionally wait for it to finish.
+
+        Args:
+            experiment: Id or name of the experiment.
+            cohort_version_id: Cohort version whose sessions are replayed.
+            agent_version_id: Agent version to replay with.
+            evaluate_baselines: Whether to also score each baseline session.
+            wait: Whether to wait for the run to reach a terminal status.
+            timeout: Seconds to wait before giving up.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing
+                experiment, cohort version, or agent version.
+            TimeoutError: The run did not finish within the timeout.
+
+        Returns:
+            Experiment run, in a terminal status when waited for.
+        """
+        return self._run(
+            self._client.run_experiment(
+                experiment,
+                cohort_version_id,
+                agent_version_id,
+                evaluate_baselines=evaluate_baselines,
+                wait=wait,
+                timeout=timeout,
+            )
+        )
+
+    def get_experiment_run(self, run_id: uuid.UUID) -> ExperimentRunResponse:
+        """Get an experiment run by id.
+
+        Args:
+            run_id: Id of the experiment run.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing run.
+
+        Returns:
+            Stored experiment run.
+        """
+        return self._run(self._client.get_experiment_run(run_id))
+
+    def wait_for_experiment_run(
+        self,
+        run_id: uuid.UUID,
+        timeout: float | None = None,
+        poll_interval: float = 2.0,
+    ) -> ExperimentRunResponse:
+        """Wait for an experiment run to reach a terminal status.
+
+        Args:
+            run_id: Id of the experiment run.
+            timeout: Seconds to wait before giving up.
+            poll_interval: Seconds between status checks.
+
+        Raises:
+            APIError: The request failed.
+            TimeoutError: The run did not finish within the timeout.
+
+        Returns:
+            Experiment run in a terminal status.
+        """
+        return self._run(
+            self._client.wait_for_experiment_run(
+                run_id, timeout=timeout, poll_interval=poll_interval
+            )
+        )

--- a/tests/client/test_kitaru_client.py
+++ b/tests/client/test_kitaru_client.py
@@ -1,0 +1,419 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Round-trip tests for the async user-facing Kitaru client."""
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from conftest import (
+    FakeAgentRepository,
+    FakeAgentVersionRepository,
+    FakeReplayRepository,
+    FakeSessionNodeRepository,
+    FakeSessionRepository,
+    FakeTaskRepository,
+    asgi_api_client,
+)
+from kitaru.api_models.v1.agent import AgentCreateRequest, AgentResponse
+from kitaru.api_models.v1.base import Page
+from kitaru.api_models.v1.experiment import ExperimentResponse
+from kitaru.api_models.v1.experiment_run import (
+    ExperimentRunCreateRequest,
+    ExperimentRunResponse,
+    ExperimentRunStatus,
+)
+from kitaru.api_models.v1.replay import ReplayResponse, ReplayStatus
+from kitaru.api_models.v1.replay_config import EvaluatorConfig
+from kitaru.api_models.v1.session import SessionCreateRequest, SessionOrigin
+from kitaru.api_models.v1.session_node import (
+    NodeStatus,
+    NodeType,
+    SessionNodeBatchRequest,
+    SessionNodeCreateRequest,
+)
+from kitaru.client.api_client import KitaruAPIClient
+from kitaru.client.client import KitaruClient
+from kitaru.client.exceptions import KitaruClientError, NotFoundError
+from kitaru.server.adapters.rest.dependencies import (
+    authorize,
+    authorize_with_task,
+    get_agent_service,
+    get_session_node_service,
+    get_session_service,
+)
+from kitaru.server.api.app import create_app
+from kitaru.server.api.config import APISettings
+from kitaru.server.application.models.auth import AuthContext
+from kitaru.server.application.services.agent_service import AgentService
+from kitaru.server.application.services.session_node_service import (
+    SessionNodeService,
+)
+from kitaru.server.application.services.session_service import SessionService
+from kitaru.server.domain.account import Account
+
+ACCOUNT = Account(id=uuid.uuid4(), name="ann")
+
+
+def _agent_response(**overrides: Any) -> AgentResponse:
+    """Build an agent response with sensible defaults."""
+    now = datetime.now(UTC)
+    values: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "owner_id": uuid.uuid4(),
+        "created": now,
+        "updated": now,
+        "name": "assistant",
+        "description": None,
+        "latest_version": 1,
+    }
+    values.update(overrides)
+    return AgentResponse(**values)
+
+
+def _experiment_response(**overrides: Any) -> ExperimentResponse:
+    """Build an experiment response with sensible defaults."""
+    now = datetime.now(UTC)
+    values: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "owner_id": uuid.uuid4(),
+        "created": now,
+        "updated": now,
+        "name": "regression",
+        "description": None,
+        "agent_id": uuid.uuid4(),
+        "override": None,
+        "tool_policy": {"default": {"type": "passthrough"}, "tools": {}},
+        "evaluators": [{"evaluator": "accuracy", "version": 1, "params": {}}],
+    }
+    values.update(overrides)
+    return ExperimentResponse(**values)
+
+
+def _replay_response(**overrides: Any) -> ReplayResponse:
+    """Build a replay response with sensible defaults."""
+    now = datetime.now(UTC)
+    values: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "job_id": uuid.uuid4(),
+        "experiment_run_id": None,
+        "baseline_session_id": uuid.uuid4(),
+        "result_session_id": None,
+        "override": None,
+        "tool_policy": {"default": {"type": "passthrough"}, "tools": {}},
+        "evaluators": [{"evaluator": "accuracy", "version": 1, "params": {}}],
+        "evaluate_baselines": False,
+        "status": ReplayStatus.PENDING,
+        "error": None,
+        "created": now,
+        "updated": now,
+    }
+    values.update(overrides)
+    return ReplayResponse(**values)
+
+
+def _experiment_run_response(**overrides: Any) -> ExperimentRunResponse:
+    """Build an experiment run response with sensible defaults."""
+    now = datetime.now(UTC)
+    values: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "owner_id": uuid.uuid4(),
+        "created": now,
+        "updated": now,
+        "experiment_id": uuid.uuid4(),
+        "number": 1,
+        "status": ExperimentRunStatus.RUNNING,
+        "cohort_version_id": uuid.uuid4(),
+        "agent_version_id": uuid.uuid4(),
+        "evaluate_baselines": False,
+        "started_at": None,
+        "ended_at": None,
+        "error": None,
+        "progress": {
+            "pending": 1,
+            "evaluating": 0,
+            "completed": 0,
+            "failed": 0,
+            "canceled": 0,
+            "total": 1,
+        },
+    }
+    values.update(overrides)
+    return ExperimentRunResponse(**values)
+
+
+def _mock_client() -> tuple[KitaruAPIClient, KitaruClient]:
+    """Build a KitaruClient over a bare, unrouted API client for mocking."""
+    api_client = KitaruAPIClient(base_url="http://test", api_key="k")
+    return api_client, KitaruClient(api_client=api_client)
+
+
+@pytest.fixture
+async def api_client() -> AsyncGenerator[KitaruAPIClient, None]:
+    """Provide an API client routed to the app with fake-backed services."""
+    app = create_app(
+        APISettings(
+            DB_HOST="localhost",
+            SECRET_ENCRYPTION_KEY="test-encryption-key",
+            JWT_SIGNING_KEY="test-signing-key-0123456789abcdef",
+        )
+    )
+    agent_repository = FakeAgentRepository()
+    session_repository = FakeSessionRepository()
+    node_repository = FakeSessionNodeRepository()
+    agent_service = AgentService(repository=agent_repository)
+    session_service = SessionService(
+        repository=session_repository,
+        task_repository=FakeTaskRepository(),
+        agent_version_repository=FakeAgentVersionRepository(agent_repository),
+        replay_repository=FakeReplayRepository(),
+    )
+    node_service = SessionNodeService(
+        repository=node_repository,
+        session_repository=session_repository,
+        task_repository=FakeTaskRepository(),
+    )
+    app.dependency_overrides[get_agent_service] = lambda: agent_service
+    app.dependency_overrides[get_session_service] = lambda: session_service
+    app.dependency_overrides[get_session_node_service] = lambda: node_service
+    app.dependency_overrides[authorize] = lambda: AuthContext(account=ACCOUNT)
+    app.dependency_overrides[authorize_with_task] = lambda: AuthContext(account=ACCOUNT)
+    async with asgi_api_client(app) as client:
+        yield client
+
+
+@pytest.fixture
+def client(api_client: KitaruAPIClient) -> KitaruClient:
+    """Provide a KitaruClient wrapping the fake-backed API client."""
+    return KitaruClient(api_client=api_client)
+
+
+async def test_get_agent_by_id(
+    client: KitaruClient, api_client: KitaruAPIClient
+) -> None:
+    """Get an agent by id."""
+    created = await api_client.agents.create(AgentCreateRequest(name="assistant"))
+    loaded = await client.get_agent(created.id)
+    assert loaded == created
+
+
+async def test_get_agent_by_name(
+    client: KitaruClient, api_client: KitaruAPIClient
+) -> None:
+    """Get an agent by its exact name."""
+    created = await api_client.agents.create(AgentCreateRequest(name="assistant"))
+    loaded = await client.get_agent("assistant")
+    assert loaded == created
+
+
+async def test_get_agent_by_name_not_found(client: KitaruClient) -> None:
+    """Raise NotFoundError for an unknown agent name."""
+    with pytest.raises(NotFoundError):
+        await client.get_agent("missing")
+
+
+async def test_get_agent_duplicate_name_raises() -> None:
+    """Raise KitaruClientError when two agents share the exact name."""
+    api_client, client = _mock_client()
+    duplicates = [_agent_response(name="assistant"), _agent_response(name="assistant")]
+    api_client.agents.list = AsyncMock(
+        return_value=Page(items=duplicates, next_cursor=None)
+    )
+
+    with pytest.raises(KitaruClientError):
+        await client.get_agent("assistant")
+
+
+async def test_list_agents(client: KitaruClient, api_client: KitaruAPIClient) -> None:
+    """Iterate over every agent."""
+    for name in ["assistant", "reviewer"]:
+        await api_client.agents.create(AgentCreateRequest(name=name))
+
+    names = [agent.name async for agent in client.list_agents()]
+    assert names == ["reviewer", "assistant"]
+
+
+async def test_list_sessions_filters_by_resolved_agent_id(
+    client: KitaruClient, api_client: KitaruAPIClient
+) -> None:
+    """Scope sessions to the resolved agent id."""
+    assistant = await api_client.agents.create(AgentCreateRequest(name="assistant"))
+    reviewer = await api_client.agents.create(AgentCreateRequest(name="reviewer"))
+    for agent_id in (assistant.id, assistant.id, reviewer.id):
+        await api_client.sessions.create(
+            SessionCreateRequest(
+                agent_id=agent_id,
+                origin=SessionOrigin.RECORDED,
+                inputs={},
+                outputs=None,
+            )
+        )
+
+    sessions = [session async for session in client.list_sessions(agent="assistant")]
+    assert len(sessions) == 2
+    assert all(session.agent_id == assistant.id for session in sessions)
+
+
+async def test_list_session_nodes(
+    client: KitaruClient, api_client: KitaruAPIClient
+) -> None:
+    """Iterate over the nodes of a session in index order."""
+    agent = await api_client.agents.create(AgentCreateRequest(name="assistant"))
+    session = await api_client.sessions.create(
+        SessionCreateRequest(
+            agent_id=agent.id,
+            origin=SessionOrigin.RECORDED,
+            inputs={},
+            outputs=None,
+        )
+    )
+    await api_client.sessions.ingest_nodes(
+        session.id,
+        SessionNodeBatchRequest(
+            nodes=[
+                SessionNodeCreateRequest(
+                    index=0,
+                    node_type=NodeType.LLM_CALL,
+                    name="call-1",
+                    status=NodeStatus.COMPLETED,
+                    inputs={},
+                    outputs={},
+                    attributes={},
+                ),
+                SessionNodeCreateRequest(
+                    index=1,
+                    node_type=NodeType.LLM_CALL,
+                    name="call-2",
+                    status=NodeStatus.COMPLETED,
+                    inputs={},
+                    outputs={},
+                    attributes={},
+                ),
+            ]
+        ),
+    )
+
+    nodes = [node async for node in client.list_session_nodes(session.id)]
+    assert [node.index for node in nodes] == [0, 1]
+
+
+async def test_replay_wait_true_returns_terminal_replay() -> None:
+    """Wait for a replay to reach a terminal status and return it."""
+    api_client, client = _mock_client()
+    session_id = uuid.uuid4()
+    pending = _replay_response(status=ReplayStatus.PENDING)
+    completed = _replay_response(id=pending.id, status=ReplayStatus.COMPLETED)
+    api_client.replays.create = AsyncMock(return_value=pending)
+    api_client.replays.get = AsyncMock(return_value=completed)
+
+    result = await client.replay(
+        session_id, evaluators=[EvaluatorConfig(evaluator="accuracy")]
+    )
+
+    assert result.status == ReplayStatus.COMPLETED
+    api_client.replays.get.assert_awaited_once_with(pending.id)
+
+
+async def test_replay_wait_false_returns_immediately() -> None:
+    """Return immediately without polling when wait is False."""
+    api_client, client = _mock_client()
+    session_id = uuid.uuid4()
+    pending = _replay_response(status=ReplayStatus.PENDING)
+    api_client.replays.create = AsyncMock(return_value=pending)
+    api_client.replays.get = AsyncMock()
+
+    result = await client.replay(
+        session_id, evaluators=[EvaluatorConfig(evaluator="accuracy")], wait=False
+    )
+
+    assert result is pending
+    api_client.replays.get.assert_not_awaited()
+
+
+async def test_wait_for_replay_polls_until_terminal() -> None:
+    """Poll a replay until it reaches a terminal status."""
+    api_client, client = _mock_client()
+    replay_id = uuid.uuid4()
+    pending = _replay_response(id=replay_id, status=ReplayStatus.PENDING)
+    completed = _replay_response(id=replay_id, status=ReplayStatus.COMPLETED)
+    api_client.replays.get = AsyncMock(side_effect=[pending, pending, completed])
+
+    result = await client.wait_for_replay(replay_id, poll_interval=0)
+
+    assert result.status == ReplayStatus.COMPLETED
+    assert api_client.replays.get.await_count == 3
+
+
+async def test_wait_for_replay_times_out() -> None:
+    """Raise TimeoutError when the replay never reaches a terminal status."""
+    api_client, client = _mock_client()
+    replay_id = uuid.uuid4()
+    pending = _replay_response(id=replay_id, status=ReplayStatus.PENDING)
+    api_client.replays.get = AsyncMock(return_value=pending)
+
+    with pytest.raises(TimeoutError):
+        await client.wait_for_replay(replay_id, timeout=0.05, poll_interval=0)
+
+
+async def test_run_experiment_resolves_by_name_and_waits() -> None:
+    """Resolve the experiment by name, start a run, and wait for it to finish."""
+    api_client, client = _mock_client()
+    experiment = _experiment_response(name="regression")
+    cohort_version_id = uuid.uuid4()
+    agent_version_id = uuid.uuid4()
+    running = _experiment_run_response(
+        experiment_id=experiment.id,
+        cohort_version_id=cohort_version_id,
+        agent_version_id=agent_version_id,
+        status=ExperimentRunStatus.RUNNING,
+    )
+    completed = _experiment_run_response(
+        id=running.id,
+        experiment_id=experiment.id,
+        cohort_version_id=cohort_version_id,
+        agent_version_id=agent_version_id,
+        status=ExperimentRunStatus.COMPLETED,
+    )
+    api_client.experiments.list = AsyncMock(
+        return_value=Page(items=[experiment], next_cursor=None)
+    )
+    api_client.experiments.start_run = AsyncMock(return_value=running)
+    api_client.experiment_runs.get = AsyncMock(return_value=completed)
+
+    result = await client.run_experiment(
+        "regression",
+        cohort_version_id=cohort_version_id,
+        agent_version_id=agent_version_id,
+        evaluate_baselines=True,
+    )
+
+    assert result.status == ExperimentRunStatus.COMPLETED
+    api_client.experiments.start_run.assert_awaited_once_with(
+        experiment.id,
+        ExperimentRunCreateRequest(
+            cohort_version_id=cohort_version_id,
+            agent_version_id=agent_version_id,
+            evaluate_baselines=True,
+        ),
+    )
+
+
+def test_api_returns_underlying_client() -> None:
+    """Expose the underlying API client."""
+    api_client, client = _mock_client()
+    assert client.api is api_client

--- a/tests/client/test_kitaru_sync_client.py
+++ b/tests/client/test_kitaru_sync_client.py
@@ -1,0 +1,159 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Round-trip tests for the synchronous user-facing Kitaru client."""
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kitaru.api_models.v1.agent import AgentListParams, AgentResponse
+from kitaru.api_models.v1.base import Page
+from kitaru.api_models.v1.replay import ReplayResponse, ReplayStatus
+from kitaru.api_models.v1.replay_config import EvaluatorConfig
+from kitaru.client.api_client import KitaruAPIClient
+from kitaru.client.exceptions import NotFoundError
+from kitaru.client.sync_client import KitaruSyncClient
+
+
+def _agent_response(**overrides: Any) -> AgentResponse:
+    """Build an agent response with sensible defaults."""
+    now = datetime.now(UTC)
+    values: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "owner_id": uuid.uuid4(),
+        "created": now,
+        "updated": now,
+        "name": "assistant",
+        "description": None,
+        "latest_version": 1,
+    }
+    values.update(overrides)
+    return AgentResponse(**values)
+
+
+def _replay_response(**overrides: Any) -> ReplayResponse:
+    """Build a replay response with sensible defaults."""
+    now = datetime.now(UTC)
+    values: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "job_id": uuid.uuid4(),
+        "experiment_run_id": None,
+        "baseline_session_id": uuid.uuid4(),
+        "result_session_id": None,
+        "override": None,
+        "tool_policy": {"default": {"type": "passthrough"}, "tools": {}},
+        "evaluators": [{"evaluator": "accuracy", "version": 1, "params": {}}],
+        "evaluate_baselines": False,
+        "status": ReplayStatus.PENDING,
+        "error": None,
+        "created": now,
+        "updated": now,
+    }
+    values.update(overrides)
+    return ReplayResponse(**values)
+
+
+@pytest.fixture
+def mock_client() -> Iterator[tuple[KitaruAPIClient, KitaruSyncClient]]:
+    """Provide a KitaruSyncClient over a bare, unrouted API client for mocking."""
+    api_client = KitaruAPIClient(base_url="http://test", api_key="k")
+    client = KitaruSyncClient(api_client=api_client)
+    yield api_client, client
+    client.close()
+
+
+def test_context_manager_returns_self_and_closes_the_loop() -> None:
+    """Enter the context manager and stop the event loop thread on exit."""
+    api_client = KitaruAPIClient(base_url="http://test", api_key="k")
+    with KitaruSyncClient(api_client=api_client) as client:
+        assert client.api is api_client
+    assert client._loop.is_closed()
+
+
+def test_get_agent_by_name(
+    mock_client: tuple[KitaruAPIClient, KitaruSyncClient],
+) -> None:
+    """Get an agent by its exact name."""
+    api_client, client = mock_client
+    agent = _agent_response(name="assistant")
+    api_client.agents.list = AsyncMock(
+        return_value=Page(items=[agent], next_cursor=None)
+    )
+
+    loaded = client.get_agent("assistant")
+
+    assert loaded == agent
+
+
+def test_get_agent_by_name_not_found(
+    mock_client: tuple[KitaruAPIClient, KitaruSyncClient],
+) -> None:
+    """Raise NotFoundError for an unknown agent name."""
+    api_client, client = mock_client
+    api_client.agents.list = AsyncMock(return_value=Page(items=[], next_cursor=None))
+
+    with pytest.raises(NotFoundError):
+        client.get_agent("missing")
+
+
+def test_list_agents_yields_items_lazily(
+    mock_client: tuple[KitaruAPIClient, KitaruSyncClient],
+) -> None:
+    """Drain agents one at a time instead of collecting the whole page upfront."""
+    api_client, client = mock_client
+    first = _agent_response(name="assistant")
+    second = _agent_response(name="reviewer")
+    advanced: list[str] = []
+
+    async def fake_iter(
+        params: AgentListParams | None = None,
+    ) -> AsyncIterator[AgentResponse]:
+        advanced.append("first")
+        yield first
+        advanced.append("second")
+        yield second
+
+    api_client.agents.iter = cast(Any, fake_iter)
+    iterator = client.list_agents()
+
+    assert advanced == []
+    assert next(iterator) == first
+    assert advanced == ["first"]
+    assert next(iterator) == second
+    assert advanced == ["first", "second"]
+    with pytest.raises(StopIteration):
+        next(iterator)
+
+
+def test_replay_wait_true_returns_terminal_replay(
+    mock_client: tuple[KitaruAPIClient, KitaruSyncClient],
+) -> None:
+    """Wait for a replay to reach a terminal status and return it."""
+    api_client, client = mock_client
+    session_id = uuid.uuid4()
+    pending = _replay_response(status=ReplayStatus.PENDING)
+    completed = _replay_response(id=pending.id, status=ReplayStatus.COMPLETED)
+    api_client.replays.create = AsyncMock(return_value=pending)
+    api_client.replays.get = AsyncMock(return_value=completed)
+
+    result = client.replay(
+        session_id, evaluators=[EvaluatorConfig(evaluator="accuracy")]
+    )
+
+    assert result.status == ReplayStatus.COMPLETED
+    api_client.replays.get.assert_awaited_once_with(pending.id)


### PR DESCRIPTION
Adds a minimal set of user-facing methods to `KitaruClient` and `KitaruSyncClient` for agents, sessions, replays, and experiment runs, with the endpoint-level API client kept reachable as `client.api`.