### PR TITLE
Tighten GitBook docs voice

### DIFF
--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -5,29 +5,29 @@ icon: hand-wave
 
 # Welcome to Kitaru
 
-Your agent has already been tested thousands of times, in production. Each of those runs is sitting in a trace store as a transcript you can read but not run. Kitaru makes them runnable: it records (or imports) each run as a **session**, then **replays** it against your real code, with the recording answering for the world the original run saw. Change the prompt, swap the model, or point replay at the fix in your working tree, and see what improved and what broke before it ships.
+Your agent has already been tested thousands of times in production. Most of that evidence is sitting in a trace store as something you can read but not run. Kitaru makes it runnable: it records or imports each run as a **session**, then **replays** it against your real code, with the recording answering for the world the original run saw. Change the prompt, swap the model, or point replay at the fix in your working tree, and see what improved and what broke before it ships.
 
 {% hint style="success" %}
 **Who it's for:** Teams with an agent in front of real users, where regression testing today means re-running a few samples and eyeballing the output. Kitaru replaces that with [evaluators](concepts/evaluators.md), [cohorts](concepts/cohorts.md), and [experiments](concepts/experiments.md) over your actual traffic. If you're prototyping and haven't shipped, it will feel like more machinery than you need.
 {% endhint %}
 
-**Frameworks:** adapters ship for [PydanticAI](adapters/pydantic-ai.md), [LangGraph](adapters/langgraph.md), and the [OpenAI Agents SDK](adapters/openai-agents.md) in Python, and for [Mastra](adapters/mastra.md) and the [Vercel AI SDK](adapters/vercel-ai.md) in TypeScript. Any other framework still works: [import your traces](getting-started/import-your-traces.md) (Langfuse, LangSmith, Braintrust, Logfire, and plain JSONL importers are built in), [write a custom importer](guides/custom-importer.md) (about a page of Python, and an agent skill drafts it), or [build a small adapter](adapters/custom.md) (the recording API is two client calls).
+**Frameworks:** adapters ship for [PydanticAI](adapters/pydantic-ai.md), [LangGraph](adapters/langgraph.md), and the [OpenAI Agents SDK](adapters/openai-agents.md) in Python, and for [Mastra](adapters/mastra.md) and the [Vercel AI SDK](adapters/vercel-ai.md) in TypeScript. Other frameworks still work: [import your traces](getting-started/import-your-traces.md) with the built-in Langfuse, LangSmith, Braintrust, Logfire, or JSONL importers; [write a custom importer](guides/custom-importer.md), usually about a page of Python; or [build a small adapter](adapters/custom.md), where the recording API is two client calls.
 
 {% hint style="info" %}
 Kitaru has both a Python and a TypeScript SDK, and both talk to the same server. The CLI ships with the Python package.
 {% endhint %}
 
-**Kitaru is built to be driven by agents.** The whole product is written for coding assistants as much as for you: the MCP server gives Claude Code, Codex, or Cursor bounded Kitaru operations, the agent skills teach it the procedures, and the CLI speaks JSON. You supply the judgment; your assistant does the legwork. [Set up your coding agent](agent-native/setup.md) takes a few minutes.
+**Kitaru is built to be driven by agents.** The MCP server gives Claude Code, Codex, Cursor, and other coding assistants bounded Kitaru operations. The agent skills teach the procedures, and the CLI speaks JSON when a shell command is the right tool. You bring the judgment; your assistant handles the investigation work. [Set up your coding agent](agent-native/setup.md) takes a few minutes.
 
 Kitaru is open source (Apache 2.0) and self-hosted, from the team behind [ZenML](https://zenml.io): ZenML is for ML pipelines, Kitaru is for agents.
 
 ## The loop
 
 - **Record.** Wrap your agent or import your traces (both shown below). Either way, runs land as [sessions](concepts/agents-and-sessions.md).
-- **Replay.** [Re-execute a session](concepts/replay.md) against your real code. Tool calls are answered from the recording, so nothing touches real systems. Unchanged, the replay reproduces the original: the faithful baseline that makes a diff trustworthy. Then fork it with a different model, a new prompt, or your working tree's code.
-- **Improve.** This is where your judgment enters. In an [investigation](concepts/investigations.md), your coding assistant authors the review and interviews you against the evidence, asking the questions Kitaru needs clarity on, and pins your answers to the exact trace as annotations. Those judgments calibrate the [evaluators](concepts/evaluators.md) that score both sides; [cohorts](concepts/cohorts.md) freeze the population; [experiments](concepts/experiments.md) replay a cohort against a change and show what improved and what regressed. The cohort that caught a failure becomes the regression gate that keeps it caught.
+- **Replay.** [Re-execute a session](concepts/replay.md) against your real code. Tool calls are answered from the recording, so nothing touches real systems. An unchanged replay gives you the faithful baseline. Then fork it with a different model, a new prompt, or your working tree's code.
+- **Improve.** This is where your judgment enters. In an [investigation](concepts/investigations.md), your coding assistant authors the review, walks you through the evidence, asks the questions Kitaru needs answered, and pins your answers to the exact trace as annotations. Those judgments calibrate the [evaluators](concepts/evaluators.md) that evaluate both sides; [cohorts](concepts/cohorts.md) freeze the population; [experiments](concepts/experiments.md) replay a cohort against a change and show what improved and what regressed. The cohort that caught a failure becomes the regression gate that keeps it caught.
 
-Day to day, you work this loop as five steps: **observe** a recorded behavior, **judge** what should have happened, **define** the behavior to test, **replay** the changed agent, and **compare** the evidence. Record gets you the raw material; observe, judge, and define are Improve's judgment capture; replay and compare close the loop. The [Quickstart](getting-started/quickstart.md) walks all five. To try it in a controlled environment, ask your assistant for the `kitaru-guided-tour` skill, which runs the loop on the public [`kitaru-template`](https://github.com/zenml-io/kitaru-template), or follow the [complete returns-agent tutorial](tutorials/returns-agent/README.md) manually.
+In daily work, that loop becomes five steps: **observe** a recorded behavior, **judge** what should have happened, **define** the behavior to test, **replay** the changed agent, and **compare** the evidence. Recording gives you the raw material; observe, judge, and define turn human judgment into durable criteria; replay and compare close the loop. The [Quickstart](getting-started/quickstart.md) walks all five. To try it in a controlled environment, ask your assistant for the `kitaru-guided-tour` skill, which runs the loop on the public [`kitaru-template`](https://github.com/zenml-io/kitaru-template), or follow the [complete returns-agent tutorial](tutorials/returns-agent/README.md) manually.
 
 ## Do I have to run it in production?
 
@@ -63,7 +63,7 @@ support.run_sync("Refund order #4821, the card reader double-charged me.")
 {% endtab %}
 {% endtabs %}
 
-Replays, imports, and evaluations all execute offline, on [workers](concepts/workers.md) in your environment. None of it touches your production traffic. An adapter does run inside your agent's process to record; if you don't want anything of Kitaru's near production, the import path never gets close to it.
+Replays, imports, and evaluations run offline on [workers](concepts/workers.md) in your environment. None of that touches your production traffic. An adapter does run inside your agent's process to record; if you do not want Kitaru near production, the import path never gets close to it.
 
 ## Built to sit in your stack
 

--- a/docs/book/agent-native/setup.md
+++ b/docs/book/agent-native/setup.md
@@ -5,16 +5,16 @@ icon: robot
 
 # Set up your coding agent
 
-Kitaru observes your production agents; your coding assistant is how you talk to Kitaru. Everything in the loop is scriptable, and two installable pieces make the assistant a first-class driver:
+Kitaru observes your production agents; your coding assistant is how you talk to Kitaru. The whole loop is scriptable, and two installable pieces let the assistant drive it without improvising:
 
-- The **MCP server** gives it typed, bounded Kitaru operations, gated so it cannot do anything destructive unless you allow it.
-- The **agent skills** give it the judgment: which sessions are worth reviewing, when a behavior is real enough to freeze into a cohort, and what a replay result does and does not prove.
+- The **MCP server** gives it typed, bounded Kitaru operations, with capability modes for actions that create, change, or delete state.
+- The **agent skills** give it the workflow: which sessions are worth reviewing, when a behavior is clear enough to freeze into a cohort, and what a replay result does and does not prove.
 
-Skills and MCP are complementary, not alternatives: the skills say how to work, the server bounds what can be touched.
+Skills and MCP work together: the skills say how to work, and the server bounds what can be touched.
 
 ## Install the MCP server
 
-Assistants that speak MCP (Claude Code, Cursor, and friends) get typed tools instead of shelling out:
+Assistants that speak MCP, such as Claude Code and Cursor, get typed tools instead of relying on shell commands for every operation:
 
 ```bash
 uv add "kitaru[mcp]"
@@ -33,12 +33,12 @@ Then register it with your assistant (`.mcp.json` for Claude Code):
 }
 ```
 
-Installing with uv puts the `kitaru-mcp` executable inside your project's virtual environment. Your assistant starts the server as a plain subprocess and never activates that environment, so a bare `kitaru-mcp` is not on `PATH` and the process dies before it says anything. Going through `uv run` avoids that.
+Installing with uv puts the `kitaru-mcp` executable inside your project's virtual environment. Your assistant starts the server as a plain subprocess and does not activate that environment first, so a bare `kitaru-mcp` is often missing from `PATH`. Going through `uv run` gives the assistant the right environment.
 
 {% hint style="warning" %}
 Two settings trip people up:
 
-- The `--server` URL must be the server you are actually logged into. `http://localhost:8000` is only right after `kitaru login --local`; on a managed or self-hosted workspace, use your workspace URL. `kitaru status` shows the URL it resolved and whether your credential works there. The MCP server does not follow the CLI's current selection, and a mismatch usually looks like an empty workspace.
+- The `--server` URL must match the server you are logged into. `http://localhost:8000` is only right after `kitaru login --local`; on a managed or self-hosted workspace, use your workspace URL. `kitaru status` shows the URL it resolved and whether your credential works there. The MCP server does not follow the CLI's current selection, and a mismatch usually looks like an empty workspace.
 - The default mode is `read-only`, which leaves an assistant mid-investigation with nothing it can write. `--mode standard` lets it build cohorts and start runs; read-only is still a sensible place to start, as long as you expect that.
 {% endhint %}
 
@@ -46,7 +46,7 @@ The server needs an explicit target: `--server URL`, `KITARU_MCP_SERVER`, or `KI
 
 ## Capability modes and tools
 
-Tools are gated by a **capability mode**, either `read-only` (the default), `standard`, or `destructive`, set with `--mode` or `KITARU_MCP_MODE`. Tools above the current mode aren't just blocked; they're never registered, so the assistant doesn't even see them:
+Tools are gated by a **capability mode**, either `read-only` (the default), `standard`, or `destructive`, set with `--mode` or `KITARU_MCP_MODE`. Tools above the current mode are never registered, so the assistant does not see them:
 
 | Tool | Mode | What it does |
 | --- | --- | --- |
@@ -62,17 +62,17 @@ Tools are gated by a **capability mode**, either `read-only` (the default), `sta
 | `kitaru_workflow_cancel` | destructive | Cancel a job or experiment run |
 | `kitaru_delete` | destructive | Delete a cohort, experiment, investigation, annotation, evaluator, version, run, or tag; unlink an exact tag-resource tuple |
 
-Start assistants in `read-only`, move to `standard` when you want them building cohorts and starting runs, and reserve `destructive` for sessions where you're watching.
+Start assistants in `read-only`, move to `standard` when you want them building cohorts and starting runs, and reserve `destructive` for sessions where you are watching closely.
 
 Tag operations follow the same split. In `read-only`, `kitaru_registry_read` can list tags and filter them by name. Existing filtered registry or activity reads can then find sessions, agent versions, cohort versions, cohorts, experiments, and experiment runs carrying that tag. The MCP server cannot enumerate a tag's links directly. In `standard`, `kitaru_review_manage` supports `create_tag`, `update_tag`, and `link_tag`. In `destructive`, `kitaru_delete` can unlink one exact `(tag, resource type, resource id)` tuple or delete the tag. Deleting a tag also deletes every link that points from it.
 
-Worker inspection is deliberately read-only. Use `kitaru_registry_read` with `kind: "worker"` to list workers, or `operation: "get_worker"` with an exact worker UUID. The returned `live` and `last_seen_at` fields report recent heartbeat observations; they do not guarantee that a worker will claim a particular task. Worker registration, task assignment, credentials, and lifecycle control remain outside MCP.
+Worker inspection is read-only by design. Use `kitaru_registry_read` with `kind: "worker"` to list workers, or `operation: "get_worker"` with an exact worker UUID. The returned `live` and `last_seen_at` fields report recent heartbeat observations; they do not guarantee that a worker will claim a particular task. Worker registration, task assignment, credentials, and lifecycle control remain outside MCP.
 
 `kitaru_review_manage` accepts `pending`, `in_progress`, or `completed` when updating an investigation. This does not bypass server transition rules: for example, the server can still reject moving a completed investigation back to pending. A linked session's verdict remains a separate field and does not accept `pending`.
 
 ## Install the agent skills
 
-Skills ship separately from Kitaru, as Markdown procedures in [`zenml-io/kitaru-skills`](https://github.com/zenml-io/kitaru-skills). A skill does not start another service or process; your assistant reads the document and follows its procedure with the tools already available in the host.
+Skills ship separately from Kitaru as Markdown procedures in [`zenml-io/kitaru-skills`](https://github.com/zenml-io/kitaru-skills). A skill does not start another service or process; your assistant reads the document and follows its procedure with the tools already available in the host.
 
 {% tabs %}
 {% tab title="Any skill-aware host" %}
@@ -91,11 +91,11 @@ npx skills add zenml-io/kitaru-skills
 
 If your host supports neither, copy the skill directory you want into wherever it reads skills from.
 
-**Verify:** run `kitaru` with no arguments. It searches project and user locations (and the Claude marketplace) for installed Kitaru skills and prints the installation command if it finds none. Machine-readable output reports the same under a `skills` key, so an assistant can check its own footing before it starts.
+**Verify:** run `kitaru` with no arguments. It searches project and user locations, plus the Claude marketplace, for installed Kitaru skills and prints the installation command if it finds none. Machine-readable output reports the same under a `skills` key, so an assistant can check its own setup before it starts.
 
 ## The investigation skill
 
-`kitaru-investigation` is the front door for your own agent, and it embodies the design: **you don't author investigations, your assistant does**. It maps your sessions, generates a baseline [investigation](../concepts/investigations.md) (the worklist, the questions, the evidence highlights), and interviews you against the trace; your job is answering. Use it when you have one surprising session, or a larger population you want to sample before defining a failure category.
+`kitaru-investigation` is the front door for your own agent, and it reflects the product design: **you do not author investigations, your assistant does**. It maps your sessions, generates a baseline [investigation](../concepts/investigations.md), and interviews you against the trace. Your job is answering. Use it when you have one surprising session, or a larger population you want to sample before defining a failure category.
 
 It picks one of two entry paths from what you already have:
 
@@ -106,9 +106,9 @@ It picks one of two entry paths from what you already have:
 
 It begins by surveying the selected sessions, then examines relevant ones in detail. If the review identifies a useful set of cases, it can help you create a [cohort](../concepts/cohorts.md) version for later replays. It can also select an installed evaluator that matches your criterion, and writes a new one only if none fit.
 
-**You assign the human labels.** The assistant selects, summarizes, and organizes evidence, but an [annotation](../concepts/investigations.md) should record your judgment rather than the assistant's suggestion. Observed behavior stays separate from expected behavior: the procedure distinguishes the agent's actions, dependency behavior, and product requirements instead of labeling every unexpected outcome an agent failure.
+**You assign the human labels.** The assistant selects, summarizes, and organizes evidence, but an [annotation](../concepts/investigations.md) should record your judgment rather than the assistant's suggestion. Observed behavior stays separate from expected behavior: the procedure distinguishes the agent's actions, dependency behavior, and product requirements instead of treating every unexpected outcome as an agent failure.
 
-Before creating remote state or using worker or model compute, the skill explains the operation and asks for confirmation where required. You must confirm cohort membership explicitly. If a required payload, permission, or worker is missing, the skill records a checkpoint so the investigation can resume later. Open observations come before proposed failure categories, which reduces the risk that an early taxonomy biases the first review batch.
+Before creating remote state or using worker or model compute, the skill explains the operation and asks for confirmation where required. You must confirm cohort membership explicitly. If a required payload, permission, or worker is missing, the skill records a checkpoint so the investigation can resume later. Open observations come before proposed failure categories, which helps keep the first review batch from inheriting a bad taxonomy.
 
 ## The other skills
 
@@ -120,11 +120,11 @@ Before creating remote state or using worker or model compute, the skill explain
 | [`kitaru-adapter-builder`](../adapters/README.md) | Building a Python or TypeScript [adapter](../adapters/README.md) for a framework that Kitaru does not support yet, with explicit recording and replay capabilities |
 | [`kitaru-importer-builder`](../guides/importing-sessions.md) | Building and locally validating an importer for an unsupported provider export; registration requires separate approval |
 
-The replay skill deliberately stops short of the deployment decision: it reports what the evidence supports and leaves the call to you. The two builder skills default to finishing on your machine, and register or upload only when you ask for each step.
+The replay skill stops short of the deployment decision: it reports what the evidence supports and leaves the call to you. The two builder skills default to finishing on your machine, and register or upload only when you ask for each step.
 
 ## Skills, MCP, and the CLI
 
-Skills define the procedure and identify decisions that require human judgment. The MCP server provides bounded Kitaru operations and gates destructive ones. Skills fall back to the structured CLI for operations MCP does not cover, such as uploading a local file or waiting for a job; you can also follow every procedure manually with the CLI.
+Skills define the procedure and identify decisions that require human judgment. The MCP server provides bounded Kitaru operations and gates destructive ones. Skills fall back to the structured CLI for operations MCP does not cover, such as uploading a local file or waiting for a job. You can also follow every procedure manually with the CLI.
 
 None of the three executes your agent on the Kitaru server. Replays run on a [worker](../concepts/workers.md) you control, in the environment you configured for it. Guardrails worth setting:
 
@@ -175,4 +175,4 @@ Here are five things our support lead says a good refund reply does: <criteria>.
 Take every session where refund-quality failed, freeze them into a cohort called refund-hard-cases, and start an experiment that replays them with the system prompt in prompts/support_v2.txt.
 ```
 
-Each is a bounded task with a verifiable artifact at the end (a session, an evaluator version, an experiment run), which is exactly the shape coding assistants are good at.
+Each is a bounded task with a verifiable artifact at the end: a session, an evaluator version, or an experiment run. That shape gives both you and the assistant something concrete to inspect.

--- a/docs/book/concepts/README.md
+++ b/docs/book/concepts/README.md
@@ -5,23 +5,23 @@ icon: lightbulb
 
 # Overview
 
-Kitaru's object model is small, and every piece exists to serve one loop: **record → replay → improve**.
+Kitaru's object model is small. Every piece exists to serve one loop: **record → replay → improve**.
 
 - Your production agent leaves **[sessions](agents-and-sessions.md)**, recordings of every model call, tool call, and decision, either recorded live by an [adapter](../adapters/README.md) or [imported](../getting-started/import-your-traces.md) from the traces you already collect.
-- **[Investigations](investigations.md)** are where your judgment enters, and they carry the whole loop. Your coding assistant maps the sessions, builds a review worklist, and interviews you against the evidence, asking the questions Kitaru needs clarity on; your answers land as **annotations** pinned to exact trace locations. They are the ground truth evaluators are calibrated against and cohorts are justified by.
-- **[Replay](replay.md)** re-executes a session against your real code. Unchanged, it reproduces the original: the faithful baseline. Forked with one thing different (a model, a prompt, a code change), it answers a counterfactual you can trust.
-- **[Evaluators](evaluators.md)** score sessions and write evaluations, which are typed, versioned verdicts. Human labels land in the same table.
+- **[Investigations](investigations.md)** are where your judgment enters. Your coding assistant maps the sessions, builds a review worklist, interviews you against the evidence, and pins your answers as **annotations** on exact trace locations. They are the ground truth evaluators are calibrated against and cohorts are justified by.
+- **[Replay](replay.md)** re-executes a session against your real code. Unchanged, it reproduces the original and gives you the faithful baseline. Forked with one thing different, such as a model, prompt, or code change, it answers a counterfactual you can trust.
+- **[Evaluators](evaluators.md)** evaluate sessions and write evaluations, which are typed, versioned verdicts. Human labels land in the same table.
 - **[Cohorts](cohorts.md)** freeze a population of sessions into immutable versions, so results stay comparable.
-- **[Experiments](experiments.md)** replay a cohort against a change and score both sides, showing what improved and what regressed before you ship.
+- **[Experiments](experiments.md)** replay a cohort against a change and evaluate both sides, showing what improved and what regressed before you ship.
 - **[Workers](workers.md)** execute all of it in your environment. The server coordinates; your infrastructure runs the code and holds the data.
 
-The mental model in one sentence: traces tell you what happened; Kitaru re-runs it. A trace you can only read is a transcript. A session is a recording your test bench can execute, which is what turns production's past into your test suite.
+The short version: traces tell you what happened; Kitaru re-runs it. A trace you can only read is a transcript. A session is a recording your test bench can execute, which is what turns production's past into your test suite.
 
 ## How the pieces reference each other
 
-An **agent** is the identity everything attaches to; an **agent version** pins the code (a run spec a worker can execute). A **session** belongs to an agent and optionally a version. A **cohort version** pins session ids. An **experiment** pins the change (override + tool policy + evaluators); an **experiment run** pins a cohort version and an agent version and fans out one **replay** per session. Every replay produces a new session, and **evaluations** land on sessions from either side, which is why comparing a baseline to a fork is just reading two sets of rows.
+An **agent** is the identity everything attaches to; an **agent version** pins the code, as a run spec a worker can execute. A **session** belongs to an agent and optionally a version. A **cohort version** pins session ids. An **experiment** pins the change: override, tool policy, and evaluators. An **experiment run** pins a cohort version and an agent version, then fans out one **replay** per session. Every replay produces a new session, and **evaluations** land on sessions from either side, which is why comparing a baseline to a fork means reading two sets of rows.
 
-Nothing is recomputed behind your back and nothing is mutable where it matters: cohort versions, agent versions, and evaluator versions are frozen at creation, so any number you read can be traced to exactly the code, population, and criteria that produced it.
+Nothing is recomputed behind your back, and nothing is mutable where it matters. Cohort versions, agent versions, and evaluator versions are frozen at creation, so any number you read can be traced to the code, population, and criteria that produced it.
 
 ## Where to start
 

--- a/docs/book/concepts/agents-and-sessions.md
+++ b/docs/book/concepts/agents-and-sessions.md
@@ -5,12 +5,12 @@ icon: film
 
 # Agents & Sessions
 
-Most traces are transcripts: you read them. A Kitaru **session** is a recording you can run. It holds everything one agent run did (every model call, tool call, and decision, in order, with inputs and outputs), and that is exactly what [replay](replay.md) needs to re-execute the run against your real code.
+Most traces are transcripts: you read them. A Kitaru **session** is a recording you can run. It holds everything one agent run did, including every model call, tool call, and decision, in order, with inputs and outputs. That is what [replay](replay.md) needs to re-execute the run against your real code.
 
 Two nouns carry the whole data model:
 
 - An **agent** is the stable identity your runs attach to. You register it once, and every session, cohort, and experiment references it.
-- A **session** is one recorded run of that agent. Sessions arrive three ways: recorded live by an adapter, [imported](../getting-started/import-your-traces.md) from your existing traces, or produced by a replay. All three are the same object with a different `origin` (`recorded`, `imported`, `replay`).
+- A **session** is one recorded run of that agent. Sessions arrive three ways: recorded live by an adapter, [imported](../getting-started/import-your-traces.md) from your existing traces, or produced by a replay. All three are the same object with a different `origin`: `recorded`, `imported`, or `replay`.
 
 ## Agents and agent versions
 
@@ -32,7 +32,7 @@ kitaru agent version register support-agent \
   --display-version "pr-1284"
 ```
 
-Register a new version when the code changes; an [experiment](experiments.md) is precisely "replay this cohort on that agent version and see what moved."
+Register a new version when the code changes. An [experiment](experiments.md) is precisely "replay this cohort on that agent version and see what moved."
 
 ## What a session records
 
@@ -51,11 +51,11 @@ Adapters record nodes automatically. The [PydanticAI adapter](../adapters/pydant
 
 ## One session is one end-to-end run
 
-This is the single most important thing to get right when you bring your own traces, and the easiest to get wrong.
+This is the most important thing to get right when you bring your own traces, and the easiest to get wrong.
 
 A session is **the whole run, from the request that started it to the answer that ended it**, including every model call, tool call and sub-agent hop in between. It is not one model call, and it is not one span. Replay re-executes a session from the top, so a session that holds half a run can only ever reproduce half a run, and a cohort of them measures nothing you care about.
 
-Adapters get this for free: the wrapper opens the session when your agent is invoked and closes it when the call returns. Importing is where it needs a decision from you, because observability tools do not agree on what a trace is:
+Adapters get this for free: the wrapper opens the session when your agent is invoked and closes it when the call returns. Importing needs a decision from you, because observability tools do not agree on what a trace is:
 
 - Some emit **one trace per run**, which maps to one session directly. Nothing to do.
 - Many emit **one trace per conversation turn**, so a five-turn support conversation arrives as five traces. If that is one run in your product, those five traces are one session.
@@ -63,7 +63,7 @@ Adapters get this for free: the wrapper opens the session when your agent is inv
 
 You do not have to reshape the export yourself. Importers group related traces into one session using the provider's own conversation or session identifier, and `--join-on` names the field to group on when the identity lives somewhere else. See [Join provider traces into sessions](../guides/importing-sessions.md). When no identifier is present, each trace becomes its own session, which is the safe default but rarely the one you want for multi-turn agents.
 
-So the question to answer before importing is not "what does my tool call a trace" but **"what does my product call one run"**, and then make the import produce that. If the answer is "it depends on how we configured tracing", it is worth resolving that upstream: consistent session identity in your traces is what makes everything downstream (cohorts, experiments, regression suites) mean the same thing every time.
+So the question before importing is not "what does my tool call a trace" but **"what does my product call one run"**. Then make the import produce that. If the answer is "it depends on how we configured tracing", resolve that upstream if you can: consistent session identity in your traces is what makes cohorts, experiments, and regression suites mean the same thing every time.
 
 If you are joining a format no importer understands, do the joining in your [custom importer](../guides/importing-sessions.md) rather than after the fact. Sessions are not merged once they land.
 
@@ -99,7 +99,7 @@ kitaru session list --agent support-agent --origin recorded
 kitaru session nodes <session-id> --include-payloads
 ```
 
-Sessions attach to the rest of the system by reference: a [cohort version](cohorts.md) pins a set of session ids, an [evaluation](evaluators.md) row scores one session, and a [replay](replay.md) points at its baseline session and produces a result session. **Tags** group resources ad hoc before they graduate into a cohort or another durable structure. A tag can link to a session, cohort, cohort version, agent version, experiment, or experiment run. Apply one to a whole import with `kitaru session import --tag ...`, then select on it anywhere that resource supports a `tag` filter, such as `kitaru session evaluate --tag ...`.
+Sessions attach to the rest of the system by reference: a [cohort version](cohorts.md) pins a set of session ids, an [evaluation](evaluators.md) row evaluates one session, and a [replay](replay.md) points at its baseline session and produces a result session. **Tags** group resources ad hoc before they graduate into a cohort or another durable structure. A tag can link to a session, cohort, cohort version, agent version, experiment, or experiment run. Apply one to a whole import with `kitaru session import --tag ...`, then select on it anywhere that resource supports a `tag` filter, such as `kitaru session evaluate --tag ...`.
 
 The native MCP server can list and filter tags, use existing filtered reads to rediscover tagged resources, and create, rename, link, unlink, or delete tags according to its capability mode. It cannot enumerate every link belonging to a tag. Deleting a tag removes all of its resource links; it does not delete the linked resources.
 

--- a/docs/book/concepts/cohorts.md
+++ b/docs/book/concepts/cohorts.md
@@ -9,7 +9,7 @@ One session answers "what happened on this run." A **cohort** answers questions 
 
 ## Versions are immutable
 
-A cohort itself is just a namespace. Membership lives on **cohort versions**, and a version's member list never changes after creation. To add or remove sessions you create a new version as a delta on the latest one:
+A cohort is a namespace. Membership lives on **cohort versions**, and a version's member list never changes after creation. To add or remove sessions, create a new version as a delta on the latest one:
 
 ```python
 import asyncio
@@ -35,7 +35,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-On the CLI, `cohort create` can snapshot a selection into version 1 in the same breath, by explicit IDs, a tag, a filter, or another cohort version:
+On the CLI, `cohort create` can snapshot a selection into version 1 at the same time, by explicit IDs, a tag, a filter, or another cohort version:
 
 ```bash
 kitaru cohort create refund-regression --agent support-agent \
@@ -59,14 +59,14 @@ kitaru cohort version create refund-regression \
 
 In the Python client and REST request, the same field is named `baseline_id`. Versions are server-numbered, `display_version` carries whatever you call the snapshot, and versions can be tagged and filtered by tag like sessions.
 
-Immutability is the point. When an experiment run reports "12 of 14 sessions improved," that claim stays checkable forever, because cohort version 3 will always contain exactly those 14 sessions. Re-running the experiment on the same version is an apples-to-apples comparison; adding this week's failures is a new version, and the numbers say which version they came from.
+Immutability is the point. When an experiment run reports "12 of 14 sessions improved," that claim stays checkable because cohort version 3 will always contain exactly those 14 sessions. Re-running the experiment on the same version is an apples-to-apples comparison; adding this week's failures is a new version, and the numbers say which version they came from.
 
 ## The lifecycle of a good cohort
 
 The pattern that pays off:
 
 1. **Triage:** a bad run surfaces (a complaint, an alert, an eyeball). You [replay it](replay.md), understand it, fix it.
-2. **Collect the population:** collect the runs like it into a cohort version. `client.sessions.list(...)` with filters, or tags you've been applying along the way, gives you the ids.
+2. **Collect the population:** collect the runs like it into a cohort version. `client.sessions.list(...)` with filters, or tags you have been applying along the way, gives you the ids.
 3. **Gate on it:** the [experiment](experiments.md) that verified your fix against that cohort becomes the regression suite that keeps the failure fixed. The cohort that caught the bug is the gate that keeps it caught.
 
 The full workflow, including CI wiring, is in [Build a regression suite from production](../guides/regression-suite.md).

--- a/docs/book/concepts/evaluators.md
+++ b/docs/book/concepts/evaluators.md
@@ -5,7 +5,7 @@ icon: chart-line
 
 # Evaluators & Evaluations
 
-Replay tells you what a change _did_; evaluators tell you whether it _helped_. An **evaluator** is a small piece of your code that reads one [session](agents-and-sessions.md) (the recording, node by node) and writes one or more **evaluations**: named, typed verdicts that Kitaru stores against the session.
+Replay tells you what a change _did_; evaluators tell you whether it _helped_. An **evaluator** is a small piece of your code that reads one [session](agents-and-sessions.md), node by node, and writes one or more **evaluations**: named, typed verdicts that Kitaru stores against the session.
 
 Because evaluators run against recorded sessions, they evaluate baselines, replays, and imported traces identically. The same evaluator you run over today's production traffic runs over the fork you're thinking about shipping.
 
@@ -14,7 +14,7 @@ Because evaluators run against recorded sessions, they evaluate baselines, repla
 An evaluator is a callable (a single Python file or an installable package) that receives the full session and returns results:
 
 ```python
-"""refund_check.py: did the agent actually issue the refund?"""
+"""refund_check.py: did the agent issue the refund?"""
 
 from kitaru.task.evaluator import EvaluationResult, SessionView
 
@@ -43,9 +43,9 @@ kitaru evaluator register refund-check \
   --script refund_check_evaluator.py --entrypoint evaluate
 ```
 
-Evaluators are versioned like agents: registering again with `kitaru evaluator version register` creates version 2, and every stored evaluation remembers exactly which evaluator version wrote it. An LLM judge is just an evaluator that calls a model inside `evaluate`: same contract, same rows. The walkthrough is in [Write an evaluator](../guides/write-an-evaluator.md).
+Evaluators are versioned like agents: registering again with `kitaru evaluator version register` creates version 2, and every stored evaluation remembers exactly which evaluator version wrote it. An LLM judge follows the same contract by calling a model inside `evaluate`. The walkthrough is in [Write an evaluator](../guides/write-an-evaluator.md).
 
-A suite of evaluators comes **built in**, registered at server startup under the `kitaru/` namespace: three cheap signals (`kitaru/cost`, `kitaru/latency`, `kitaru/tool-call-patterns`) plus ten deterministic checks over the recording itself, from `kitaru/output-contract` and `kitaru/tool-health` to `kitaru/timing-profile` and `kitaru/workflow-conformance`. None of them make model calls; they're the triage layer, available as `kitaru/cost@latest` before you've written anything.
+A suite of evaluators comes **built in**, registered at server startup under the `kitaru/` namespace: three cheap signals (`kitaru/cost`, `kitaru/latency`, `kitaru/tool-call-patterns`) plus ten deterministic checks over the recording itself, from `kitaru/output-contract` and `kitaru/tool-health` to `kitaru/timing-profile` and `kitaru/workflow-conformance`. None of them make model calls; they are the triage layer, available as `kitaru/cost@latest` before you have written anything.
 
 ## The evaluation row
 
@@ -58,7 +58,7 @@ One evaluation is one named result for one session. The data type is derived fro
 | `value="escalated"`         | `str`         | free text gets read            |
 | `score=0.9, value="polite"` | `categorical` | labels count, transitions diff |
 
-`passed` is an independent optional verdict (a threshold you decided in the evaluator, not something derived from `score`), and `explanation` says why, which is what you'll actually read when a regression gate goes red.
+`passed` is an independent optional verdict, based on a threshold you decided in the evaluator rather than something derived from `score`. `explanation` says why, which is the part you read when a regression gate goes red.
 
 ## Human labels are evaluations too
 
@@ -79,7 +79,7 @@ await client.sessions.merge_evaluations(
 )
 ```
 
-Manual evaluations upsert by name: re-sending `human_quality` overwrites the earlier verdict. Rows written by evaluator runs carry their evaluator version and task; manual rows carry neither, which is how you tell them apart. Comparing your evaluator's column against the human column on the same sessions is how you calibrate the evaluator before you let it gate anything. The human column typically comes out of [the interview](investigations.md): your coding assistant authors the investigation, and your answers land as annotations to calibrate against.
+Manual evaluations upsert by name: re-sending `human_quality` overwrites the earlier verdict. Rows written by evaluator runs carry their evaluator version and task; manual rows carry neither, which is how you tell them apart. Comparing your evaluator's column against the human column on the same sessions is how you calibrate the evaluator before you let it gate anything. The human column usually comes out of [the interview](investigations.md): your coding assistant authors the investigation, and your answers land as annotations to calibrate against.
 
 ## Running evaluators in batch
 
@@ -107,4 +107,4 @@ job = await client.evaluations.create(
 
 Each (session, evaluator) pair runs as its own task on a [worker](workers.md) (in your environment, next to your credentials), and one failed pair never cancels the rest. Read results back with `client.evaluations.list(...)`, filtered by session.
 
-Evaluators are also how [replays](replay.md) and [experiments](experiments.md) get their numbers: both require at least one evaluator, so a re-run is never just "it finished": it's evaluated the moment it lands.
+Evaluators are also how [replays](replay.md) and [experiments](experiments.md) get their numbers: both require at least one evaluator, so a re-run is evaluated the moment it lands.

--- a/docs/book/concepts/experiments.md
+++ b/docs/book/concepts/experiments.md
@@ -5,7 +5,7 @@ icon: vials
 
 # Experiments
 
-A [replay](replay.md) is one counterfactual. An **experiment** is that counterfactual at population scale: take a [cohort](cohorts.md) of real runs, apply one change to all of them, score every re-run with the same [evaluators](evaluators.md), and read what improved and what regressed.
+A [replay](replay.md) is one counterfactual. An **experiment** is that counterfactual at population scale: take a [cohort](cohorts.md) of real runs, apply one change to all of them, evaluate every re-run with the same [evaluators](evaluators.md), and read what improved and what regressed.
 
 The split of responsibilities is deliberate:
 
@@ -72,13 +72,13 @@ kitaru experiment run start cheaper-model \
   --evaluate-baselines --wait
 ```
 
-Starting a run fans out **one replay per session** in the cohort version. [Workers](workers.md) in your environment execute them; the run's `progress` counts replays through `pending → evaluating → completed` (plus `failed` / `canceled`), and the run settles when the last replay does. `evaluate_baselines=True` scores the original sessions too, so every replay has its baseline numbers to sit next to.
+Starting a run fans out **one replay per session** in the cohort version. [Workers](workers.md) in your environment execute them; the run's `progress` counts replays through `pending → evaluating → completed` (plus `failed` / `canceled`), and the run settles when the last replay does. `evaluate_baselines=True` evaluates the original sessions too, so every replay has its baseline numbers to sit next to.
 
 With a `history` tool policy scoped to `cohort_version`, replayed tool calls can be answered from any recording in the cohort (useful when runs share tool traffic), and `on_miss="fail"` keeps anything unrecorded from reaching a live system.
 
 ## Reading a run
 
-A run's output is deliberately raw: its replays, each with a result session, and the evaluation rows on both sides. Compare them by reading the evaluations:
+A run's output is intentionally plain: its replays, each with a result session, and the evaluation rows on both sides. Compare them by reading the evaluations:
 
 ```python
 from kitaru.api_models.v1.evaluation import EvaluationListParams

--- a/docs/book/concepts/investigations.md
+++ b/docs/book/concepts/investigations.md
@@ -5,27 +5,27 @@ icon: magnifying-glass-chart
 
 # Investigations and annotations
 
-Every eval system runs into the same wall: where do the criteria come from? You never wrote them down. The people who judge the agent, your support leads and domain experts, do it every day, in Slack threads and ticket comments, and every one of those corrections is a label nobody keeps.
+Every evaluation system hits the same wall: where do the criteria come from? You probably never wrote them down. The people who judge the agent, your support leads and domain experts, do it every day in Slack threads and ticket comments, and most of those corrections disappear.
 
-Investigations are how Kitaru captures them. An **investigation** organizes a review of recorded sessions: which sessions, in what order, what question each one raises, and what the reviewer concluded. By design, **a coding agent authors it, not you**. The LLM's job is to generate a good baseline investigation: pick the sessions worth your time, phrase the questions, and point at the evidence. Your job is the part no model can do: answering. An **annotation** is one answer, stored as JSON and pinned to the exact evidence that supports it: a session, a node inside it, a path inside a payload, even a character range. Together they are the ground truth everything downstream is calibrated against. Replay can tell you what a change did; only your recorded judgment can say whether it got better.
+Investigations are how Kitaru keeps them. An **investigation** organizes a review of recorded sessions: which sessions to inspect, in what order, what question each one raises, and what the reviewer concluded. By design, **a coding agent authors it, not you**. The LLM's job is to draft a useful investigation: pick the sessions worth your time, phrase the questions, and point at the evidence. Your job is the part no model can do: answer. An **annotation** is one answer, stored as JSON and pinned to the exact evidence that supports it: a session, a node inside it, a path inside a payload, even a character range. Together they are the ground truth everything downstream is calibrated against. Replay can tell you what a change did; only your recorded judgment can say whether it got better.
 
 ## The interview
 
-[Set up your coding agent](../agent-native/setup.md) and the `kitaru-investigation` skill runs the review as an interview. You never write questions or pick sessions; the assistant does, because a well-chosen worklist and well-phrased questions are exactly what LLMs are good at, and answering them is exactly what they are not:
+[Set up your coding agent](../agent-native/setup.md), then use the `kitaru-investigation` skill to run the review as an interview. You do not have to write questions or pick sessions; the assistant does that work because a well-chosen worklist and clear questions are a good use of an LLM. Answering those questions is not.
 
 1. **It maps the world first.** From one surprising failure, the assistant reads the session fully and builds a small worklist of related sessions plus at least one counterexample. From a vague "something is off," it samples a diverse population, normally 15 to 30 sessions, random picks alongside coverage-based ones.
 2. **It creates the investigation**, with a question for each session and highlights that point you at the evidence: the policy lookup that returned nothing, the refund that was accepted anyway.
-3. **It asks you, in context.** Not "write down your eval criteria" in the abstract, but "given this recorded policy result and this accepted refund, was escalation required?" Questions are asked against the trace, where you can answer them. This is the information Kitaru wants clarity on, extracted one concrete case at a time.
+3. **It asks you, in context.** Not "write down your evaluation criteria" in the abstract, but "given this recorded policy result and this accepted refund, was escalation required?" Questions are asked against the trace, where you can answer them. This gives Kitaru the missing judgment one concrete case at a time.
 4. **Your answers become annotations; your conclusions become verdicts.** Each reviewed session ends `acceptable`, `problematic`, or `uncertain`. The assistant selects, summarizes, and organizes the evidence; the judgment it records is yours, never its own suggestion.
 
-Two design choices keep the interview honest. Open observations come before proposed failure categories, so an early taxonomy doesn't bias what you look at. And observed behavior stays separate from expected behavior: the procedure distinguishes the agent's actions, dependency behavior, and product requirements instead of labeling every surprise an agent failure.
+Two design choices keep the interview honest. Open observations come before proposed failure categories, so an early taxonomy does not bias what you look at. Observed behavior also stays separate from expected behavior: the procedure distinguishes the agent's actions, dependency behavior, and product requirements instead of labeling every surprise an agent failure.
 
 ## What the answers are for
 
-Annotations are labels with addresses, and everything that gates a change is calibrated against them:
+Annotations are labels with addresses. Everything that gates a change is calibrated against them:
 
 - **Evaluators** are checked against them: run the evaluator over the reviewed sessions and [compare its evaluations with the human answers](../guides/write-an-evaluator.md) before the evaluator judges anything on its own.
-- **Cohorts** are justified by them: the sessions confirmed `problematic` become the [cohort](cohorts.md) a regression experiment replays, and the annotation trail is the auditable reason that cohort exists.
+- **Cohorts** are justified by them: the sessions confirmed `problematic` become the [cohort](cohorts.md) a regression experiment replays, and the annotation trail explains why that cohort exists.
 - **The next review** builds on them: verdicts and answers stay queryable, so a later investigation starts from what is already known instead of re-litigating it.
 
 An evaluator that gates a deploy should be able to show the human judgments it was calibrated against. Annotations are those judgments.
@@ -36,7 +36,7 @@ Everything below is what the assistant creates on your behalf during the intervi
 
 An investigation belongs to one agent. It contains linked sessions, each with a `position` that determines the review order.
 
-Questions belong to individual linked sessions rather than to the investigation as a whole, so the review can ask different questions about different runs. Each question has a `key`, unique within its session, and display text such as `refund_justified="Was the refund justified?"`. A question can include highlights: each has a selector and a description that point the reviewer at relevant evidence.
+Questions belong to individual linked sessions rather than to the investigation as a whole, so the review can ask different questions about different runs. Each question has a `key`, unique within its session, and display text such as `refund_justified="Was the refund justified?"`. A question can include highlights; each highlight has a selector and a description that point the reviewer at relevant evidence.
 
 The reviewer gives each linked session a verdict of `acceptable`, `problematic`, or `uncertain`. A session remains incomplete until it has a verdict; the investigation reports progress through `completed_sessions` and `total_sessions`, and tracks its own `status` as `pending`, `in_progress`, or `completed`.
 
@@ -91,4 +91,4 @@ kitaru investigation session verdict <investigation-id> <session-id> problematic
 
 Answers and verdicts are separate: answers record a value per question, the verdict records the conclusion about the session as a whole, and `completed_sessions` counts only sessions with a verdict. A session can have answers and still be incomplete.
 
-Over [MCP](../agent-native/setup.md), `kitaru_review_read` and `kitaru_review_manage` let a coding assistant read the review queue, answer questions, and create annotations. A human still decides which sessions to review and what verdict to assign. Before creating remote state or using worker or model compute, the skill explains the operation and asks for confirmation; if a required payload, permission, or worker is missing, it records a checkpoint so the interview can resume later. The client mirrors the surface: `client.investigations.*` and `client.annotations.*`.
+Over [MCP](../agent-native/setup.md), `kitaru_review_read` and `kitaru_review_manage` let a coding assistant read the review queue, answer questions, and create annotations. A human still decides which sessions to review and what verdict to assign. Before creating remote state or using worker or model compute, the skill explains the operation and asks for confirmation. If a required payload, permission, or worker is missing, it records a checkpoint so the interview can resume later. The client mirrors the surface: `client.investigations.*` and `client.annotations.*`.

--- a/docs/book/concepts/replay.md
+++ b/docs/book/concepts/replay.md
@@ -5,13 +5,13 @@ icon: rotate-left
 
 # Replay
 
-Replay is the verb the whole product hangs off. A [session](agents-and-sessions.md) is a recording; a **replay** re-executes it: your agent's real code runs again, and the recording answers for the world the original run saw. With a `history` [tool policy](#tool-policies), tool calls are served from the recorded session, so nothing touches your real systems.
+Replay is the verb the whole product hangs on. A [session](agents-and-sessions.md) is a recording; a **replay** re-executes it. Your agent's real code runs again, and the recording answers for the world the original run saw. With a `history` [tool policy](#tool-policies), tool calls are served from the recorded session, so nothing touches your real systems.
 
 The discipline comes first: **replay unchanged before you change anything.** An unchanged replay that reproduces the original is your faithful baseline. Fork from that baseline with exactly one thing different (a model, a prompt, a code change) and the diff you read is your change, not replay noise.
 
 ## What a replay is
 
-A replay names a **baseline session**, the **agent version** to run (by default, the version the baseline was recorded with), an optional **override**, a **tool policy**, and at least one [evaluator](evaluators.md). The server turns it into a job; a [worker](workers.md) in your environment starts your agent from its run spec, feeding it the baseline's inputs. The re-run records a fresh session (`origin: replay`), and the evaluators score it as soon as it completes.
+A replay names a **baseline session**, the **agent version** to run (by default, the version the baseline was recorded with), an optional **override**, a **tool policy**, and at least one [evaluator](evaluators.md). The server turns it into a job; a [worker](workers.md) in your environment starts your agent from its run spec, feeding it the baseline's inputs. The re-run records a fresh session (`origin: replay`), and the evaluators evaluate it as soon as it completes.
 
 For a one-off replay, the CLI exposes the same create, list, and get flow:
 
@@ -55,13 +55,13 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-`evaluate_baselines=True` scores the baseline session with the same evaluators, so the comparison you want, baseline evaluations next to replay evaluations, exists as soon as the replay settles. Watch the job with `kitaru job watch <job-id>`, then read `result_session_id` off the replay.
+`evaluate_baselines=True` evaluates the baseline session with the same evaluators, so the comparison you want, baseline evaluations next to replay evaluations, exists as soon as the replay settles. Watch the job with `kitaru job watch <job-id>`, then read `result_session_id` off the replay.
 
-A replay moves `pending → evaluating → completed` (or `failed` / `canceled`). Its output is deliberately plain: the result session plus its evaluation rows. You compare baseline and result by reading both sessions' evaluations, cost, and tokens. See [Replay a failure and fork it](../guides/replay-and-overrides.md) for the full loop.
+A replay moves `pending → evaluating → completed` (or `failed` / `canceled`). Its output is intentionally plain: the result session plus its evaluation rows. You compare baseline and result by reading both sessions' evaluations, cost, and tokens. See [Replay a failure and fork it](../guides/replay-and-overrides.md) for the full loop.
 
 ## Forking: the override
 
-There is no separate fork operation in the API; a "fork" is just a replay that carries an `override`. The word is shorthand for that, the way "baseline" is shorthand for a replay without one. Both are the same call.
+There is no separate fork operation in the API; a "fork" is a replay that carries an `override`. The word is shorthand for that, the way "baseline" is shorthand for a replay without one. Both are the same call.
 
 An override changes one thing about the re-run and leaves everything else alone:
 

--- a/docs/book/concepts/under-the-hood.md
+++ b/docs/book/concepts/under-the-hood.md
@@ -5,7 +5,7 @@ icon: sitemap
 
 # Under the Hood
 
-You can use Kitaru without reading this page. Read it when you want to know what actually happens between "start a replay" and "read the diff", or when you're deciding where Kitaru sits in your stack.
+You can use Kitaru without reading this page. Read it when you want to know what happens between "start a replay" and "read the diff", or when you are deciding where Kitaru sits in your stack.
 
 ## Two processes, one contract
 
@@ -15,17 +15,17 @@ The server is a single FastAPI service backed by Postgres. It stores every resou
 
 [Workers](workers.md) run in your environment and pull work from the server. Everything that executes (a replayed agent, an evaluator, an importer parsing a trace export) runs as a subprocess of a worker, next to your credentials, packages, and network. The server never needs access to your model providers or your tools.
 
-Between them sits the **job/task** layer. Commands like "replay this session," "import this export," or "score these sessions" create a job holding one or more tasks; every job carries its kind (`session_run`, `import`, `evaluation`, `replay`), so `kitaru job` listings filter cleanly. Workers claim tasks scoped by _task_ kind (`agent`, `evaluator`, `importer`, a different axis than job kinds) or by label, heartbeat while running them, and report results. Crashed workers lose their claim; the server requeues or fails the task, so no replay is ever silently stranded. `kitaru job watch <id>` follows any of it live.
+Between them sits the **job/task** layer. Commands like "replay this session," "import this export," or "evaluate these sessions" create a job holding one or more tasks; every job carries its kind (`session_run`, `import`, `evaluation`, `replay`), so `kitaru job` listings filter cleanly. Workers claim tasks scoped by _task_ kind (`agent`, `evaluator`, `importer`, a different axis than job kinds) or by label, heartbeat while running them, and report results. Crashed workers lose their claim; the server requeues or fails the task, so no replay is ever silently stranded. `kitaru job watch <id>` follows any of it live.
 
 Writes are safe to retry: the client stamps every create request with an idempotency key and reuses it across retries, and the server stores the outcome: a replay or evaluation request that times out on the wire and gets retried never becomes two replays.
 
-## How a replay actually works
+## How replay works
 
 1. `POST /api/v1/replays` stores the replay (baseline session, agent version, override, tool policy, evaluators) and creates its job with one agent task.
 2. A worker claims the task and starts your agent from the agent version's run spec command, with the baseline's inputs (rewritten by the override, if any) and `KITARU_REPLAY_ID` in the environment.
 3. Your agent runs for real. The adapter sees `KITARU_REPLAY_ID`, fetches the override and tool policy, applies model swaps at the model-call boundary, and answers tool calls per policy; a `history` policy looks up the recorded result by a hash of the tool name and arguments.
 4. The re-run records a fresh session, node by node, `origin: replay`.
-5. When the agent task completes, the server appends one evaluator task per configured evaluator; workers score the result session (and, with `evaluate_baselines`, the baseline).
+5. When the agent task completes, the server appends one evaluator task per configured evaluator; workers evaluate the result session and, with `evaluate_baselines`, the baseline.
 6. The job settles, the replay settles, and, inside an experiment run, the run's progress advances. Results are stored rows: the result session, its nodes, its evaluations.
 
 An [experiment run](experiments.md) is this pipeline fanned out once per session in a cohort version. Nothing about scale changes the mechanics.
@@ -38,7 +38,7 @@ Auth is deliberately simple: [API keys](../deploy/authentication.md) (`KITKEY_` 
 
 ## Where Kitaru sits in your stack
 
-Kitaru is a debugger with a memory, sitting **beside** your observability stack, not replacing it. Langfuse, LangSmith, or Braintrust remain your system of record for traces; Kitaru holds runnable copies of the runs you care about and the machinery to re-execute and score them. The [import path](../getting-started/import-your-traces.md) is exactly that bridge.
+Kitaru is a debugger with a memory, sitting **beside** your observability stack, not replacing it. Langfuse, LangSmith, Braintrust, and Logfire remain your system of record for traces; Kitaru holds runnable copies of the runs you care about and the machinery to re-execute and evaluate them. The [import path](../getting-started/import-your-traces.md) is that bridge.
 
 On the other side, Kitaru deliberately does **not** run your production agent. Your agent runs wherever it runs today; the adapter records it. Durable execution of agents in production is [ZenML](https://docs.zenml.io)'s job: ZenML runs agents durably; Kitaru replays and improves them.
 

--- a/docs/book/concepts/workers.md
+++ b/docs/book/concepts/workers.md
@@ -5,7 +5,7 @@ icon: gears
 
 # Workers
 
-Nothing in Kitaru executes on the server. Replays, imports, and evaluator runs are **tasks**; a **worker** is the process that claims tasks from the server and runs each one as a subprocess in _your_ environment, with _your_ virtualenv, credentials, and network. That is the data-privacy story in one sentence: the server coordinates, your infrastructure executes, and session payloads are read from the server your team already hosts.
+Nothing in Kitaru executes on the server. Replays, imports, and evaluator runs are **tasks**; a **worker** is the process that claims tasks from the server and runs each one as a subprocess in _your_ environment, with _your_ virtualenv, credentials, and network. The server coordinates, your infrastructure executes, and session payloads are read from the server your team already hosts.
 
 Start one wherever your agent's code can run:
 
@@ -25,7 +25,7 @@ The worker registers itself, polls for pending tasks, heartbeats while work is i
 
 Evaluator and importer plugins declare their own dependencies (PEP 723 inline metadata for script plugins, an exact pin for package plugins), and the worker builds each an isolated environment via `uv`. Agent tasks run your command as-is, in the working directory and environment the agent version declares, plus the [secrets](../deploy/secrets.md) it references.
 
-The worker hands each subprocess its context through environment variables: `KITARU_API_URL` and a `KITARU_API_TOKEN` (a bearer token scoped to that one task and attempt, with your broader `KITARU_API_KEY` deliberately stripped from the child environment), plus `KITARU_TASK_ID` to link the recorded session to the task, and `KITARU_REPLAY_ID` when the run is a replay, which is how the adapter knows to apply overrides and answer tool calls from the recording. The worker itself authenticates once with your API key and holds a worker-scoped token it renews on its own; see [Authentication & API keys](../deploy/authentication.md).
+The worker hands each subprocess its context through environment variables: `KITARU_API_URL` and a `KITARU_API_TOKEN`, a bearer token scoped to that one task and attempt, with your broader `KITARU_API_KEY` stripped from the child environment. It also provides `KITARU_TASK_ID` to link the recorded session to the task, and `KITARU_REPLAY_ID` when the run is a replay, which is how the adapter knows to apply overrides and answer tool calls from the recording. The worker itself authenticates once with your API key and holds a worker-scoped token it renews on its own; see [Authentication & API keys](../deploy/authentication.md).
 
 ## Scoping workers
 
@@ -42,7 +42,7 @@ kitaru worker start --claim agent=<AGENT_VERSION_ID>
 kitaru worker start --job-id <job-id>
 ```
 
-Every option is also an environment variable with the `KITARU_WORKER_` prefix (`KITARU_WORKER_CONCURRENCY`, `KITARU_WORKER_SCOPE__CLAIMS`, …), so a containerized worker is configured without flags. Deployment patterns (long-running workers on Kubernetes, one-shot workers in CI) are in [Workers in production](../deploy/workers.md).
+Every option is also an environment variable with the `KITARU_WORKER_` prefix (`KITARU_WORKER_CONCURRENCY`, `KITARU_WORKER_SCOPE__CLAIMS`, …), so a containerized worker can be configured without flags. Deployment patterns, including long-running workers on Kubernetes and one-shot workers in CI, are in [Workers in production](../deploy/workers.md).
 
 Check what's alive:
 

--- a/docs/book/getting-started/quickstart.md
+++ b/docs/book/getting-started/quickstart.md
@@ -5,9 +5,9 @@ icon: rocket
 
 # Quickstart
 
-**You probably already have an agent in production.** It serves real users, it occasionally does something wrong, and when it does, you read the trace, tweak a prompt, and hope. This page is the way out of that loop: get the agent's runs into Kitaru, judge one bad behavior, and test a fix against recorded evidence instead of a fresh demo prompt.
+**You probably already have an agent in production.** It serves real users. Sometimes it does the wrong thing. When that happens, the usual workflow is to read the trace, tweak a prompt, and hope the fix holds. This page gives you a better loop: bring the agent's runs into Kitaru, judge one bad behavior, and test a fix against recorded evidence instead of a fresh demo prompt.
 
-And you don't work Kitaru by memorizing commands. The product is built to be driven by your coding assistant: you ask, it operates Kitaru through the MCP server and the agent skills, and you keep the judgment calls. Every step below is a prompt first; the equivalent command exists when you want your hands on it.
+You do not need to memorize commands to start. Kitaru is built for your coding assistant to drive: you ask, it operates Kitaru through the MCP server and the agent skills, and you keep the judgment calls. Every step below starts as a prompt; the equivalent command is there when you want to run it yourself.
 
 {% hint style="info" %}
 **No agent in production yet?** Ask your assistant for the guided tour instead: the `kitaru-guided-tour` skill clones the public [`kitaru-template`](https://github.com/zenml-io/kitaru-template) (a ready agent with checked-in traces), prepares a three-session review for you to judge, turns one accepted finding into an evaluator without a paid model call, and ends with one approved replay experiment. Prefer to see every command yourself? The [returns-agent tutorial](../tutorials/returns-agent/README.md) walks the same ground manually.
@@ -17,7 +17,7 @@ Before starting, [install Kitaru and log in](installation.md), then [set up your
 
 ## First: get your runs into Kitaru
 
-Nothing else works until your agent's runs land in Kitaru as [sessions](../concepts/agents-and-sessions.md). Both ways in are one ask away:
+Nothing else works until your agent's runs land in Kitaru as [sessions](../concepts/agents-and-sessions.md). You have two ways in, and both can start with a prompt:
 
 {% tabs %}
 {% tab title="Import the traces you already have" %}
@@ -70,7 +70,7 @@ The whole method fits in one ask. `kitaru-investigation` is the skill that runs 
 Use kitaru-investigation to investigate this agent and help me test one meaningful improvement. Assume I am new to Kitaru. Show me the recorded evidence before asking for a judgment, and ask before creating resources, changing code, or starting paid replay.
 ```
 
-The assistant selects sessions, walks the review, drafts the evaluator, and runs the experiment. You supply the domain judgments and approve consequential actions. These five steps are the record → replay → improve loop in working form: recording already got you the sessions above, observing, judging, and defining are where improvement gets its criteria, and replaying and comparing close the loop. What follows is what the assistant is doing at each step, with a worked example from a support agent that refunds, replaces, or escalates return requests, and the prompt you would use to drive that step alone.
+The assistant selects sessions, walks the review, drafts the evaluator, and runs the experiment. You supply the domain judgments and approve consequential actions. These five steps are the record → replay → improve loop in working form: recording got you the sessions above; observing, judging, and defining turn evidence into criteria; replaying and comparing close the loop. The example below uses a support agent that refunds, replaces, or escalates return requests, and each step includes the prompt you would use to drive that step by itself.
 
 {% stepper %}
 {% step %}
@@ -80,7 +80,7 @@ The assistant selects sessions, walks the review, drafts the evaluator, and runs
 Run the deterministic evaluators over support-agent's recent sessions, show me which ones look worst and why, and walk me through the worst one node by node.
 ```
 
-Observation starts wide: sweep the whole history before you stare at any single trace. Kitaru ships ten [deterministic evaluators](../guides/deterministic-evaluations.md), covering session diagnostics, tool health, trajectory signals, timing, and LLM-call signals, that read stored sessions without running the agent or calling a model. The sweep is cheap and repeatable, and the failures, retries, and tool errors it surfaces tell you which sessions deserve a human look. One of the surfaced sessions contains this path:
+Observation starts wide: scan the history before you stare at one trace. Kitaru ships ten [deterministic evaluators](../guides/deterministic-evaluations.md), covering session diagnostics, tool health, trajectory signals, timing, and LLM-call signals, that read stored sessions without running the agent or calling a model. The sweep is cheap and repeatable, and the failures, retries, and tool errors it surfaces tell you which sessions deserve a human look. One surfaced session contains this path:
 
 | Session node | Result |
 | --- | --- |
@@ -100,13 +100,13 @@ Each model call, tool call, and result is a **session node**. The `issue_refund`
 Open an investigation on this session. I will give the verdicts; record each one as an annotation pinned to the exact nodes that support it.
 ```
 
-This is the interview, and it is the crucial step of the whole game. Your assistant has already mapped your sessions and built a worklist (related failures plus at least one counterexample); now it creates an [**investigation**](../concepts/investigations.md) and asks you, against the evidence on screen, the questions Kitaru needs clarity on. Not "write down your eval criteria," but "given this policy lookup that returned nothing and this refund that was accepted anyway, was escalation required?"
+This is the interview. Your assistant has already mapped your sessions and built a worklist: related failures plus at least one counterexample. Now it creates an [**investigation**](../concepts/investigations.md) and asks you, against the evidence on screen, the questions Kitaru needs answered. Not "write down your eval criteria," but "given this policy lookup that returned nothing and this refund that was accepted anyway, was escalation required?"
 
 The expert answers:
 
 > When the agent cannot establish whether approval is required, it should escalate instead of issuing the refund.
 
-Each answer is stored as an **annotation** pinned to the exact nodes that support it, and the conclusion becomes the session's verdict. Statistics can surface an unusual trace, but they cannot infer your business policy; every judgment recorded here is the ground truth the next three steps are calibrated against.
+Each answer is stored as an **annotation** pinned to the exact nodes that support it, and the conclusion becomes the session's verdict. Statistics can surface an unusual trace, but they cannot infer your business policy. The judgment you record here is the ground truth the next three steps use.
 {% endstep %}
 
 {% step %}
@@ -123,7 +123,7 @@ The accepted judgment becomes a reusable [**evaluator**](../concepts/evaluators.
 | Approval cannot be established | Escalate without a refund | **Target:** what should change. |
 | Valid low-risk refund | Issue the refund | **Counterexample:** what must not break. |
 
-Both are frozen into a [**cohort**](../concepts/cohorts.md) version. The target catches a change that does nothing; the counterexample catches a blunt one such as "never issue refunds."
+Both are frozen into a [**cohort**](../concepts/cohorts.md) version. The target catches a change that does not fix the failure; the counterexample catches a blunt fix such as "never issue refunds."
 {% endstep %}
 
 {% step %}
@@ -154,7 +154,7 @@ The same evaluator version checks the original and replayed sessions:
 | Approval cannot be established | Refund accepted, fail | Escalation, pass | The reviewed failure improved. |
 | Valid low-risk refund | Refund accepted, pass | Refund accepted, pass | The counterexample held. |
 
-Four honest outcomes stay available: **improved**, **regressed**, **trade-off**, and **inconclusive**. Inconclusive is information too; it names the missing evidence or execution control before you trust the change. The deployment decision stays with you.
+Four honest outcomes stay available: **improved**, **regressed**, **trade-off**, and **inconclusive**. Inconclusive is still useful: it names the missing evidence or execution control before you trust the change. The deployment decision stays with you.
 {% endstep %}
 {% endstepper %}
 

--- a/docs/book/guides/custom-importer.md
+++ b/docs/book/guides/custom-importer.md
@@ -5,7 +5,7 @@ icon: puzzle-piece
 
 # No importer for your format
 
-The built-in importers cover [Langfuse](import-langfuse-traces.md), [LangSmith](import-langsmith-traces.md), [Braintrust](import-braintrust-traces.md), [Logfire](import-logfire-traces.md), and the [Kitaru JSONL contract](importing-sessions.md). Any other trace store, or a homegrown logging format, comes in through a custom importer, and an importer is deliberately small: one callable that parses your export bytes into sessions, usually about a page of Python.
+The built-in importers cover [Langfuse](import-langfuse-traces.md), [LangSmith](import-langsmith-traces.md), [Braintrust](import-braintrust-traces.md), [Logfire](import-logfire-traces.md), and the [Kitaru JSONL contract](importing-sessions.md). Any other trace store, or a homegrown logging format, comes in through a custom importer. An importer is small by design: one callable that parses your export bytes into sessions, usually about a page of Python.
 
 There are two ways to get one, and the fast way is to not write it yourself: the `kitaru-importer-builder` [agent skill](../agent-native/setup.md) turns a representative export into a locally validated importer. It keeps the mapping from source evidence to normalized sessions explicit, so you can see what is preserved, approximated, or unavailable, and it finishes on your machine until you approve registration.
 
@@ -42,7 +42,7 @@ def parse(payload: bytes, params: dict[str, Any]) -> Iterator[ParsedSession | Im
         )
 ```
 
-Yield lazily; the import consumes one item at a time, so payload size is bounded by disk, not memory. Yield an `ImportFailure` for a bad record and the import counts it and moves on; only a crash of the parser itself fails the task (with partial stats preserved). The full field reference for `ParsedSession` and `ParsedNode` is the [portable session contract](importing-sessions.md).
+Yield lazily; the import consumes one item at a time, so payload size is bounded by disk, not memory. Yield an `ImportFailure` for a bad record and the import counts it and moves on. Only a crash of the parser itself fails the task, with partial stats preserved. The full field reference for `ParsedSession` and `ParsedNode` is the [portable session contract](importing-sessions.md).
 
 Set a stable `external_id` from your source system: together with the importer's provider name it is the dedup key, so re-importing an overlapping export skips what is already stored instead of duplicating it.
 
@@ -74,4 +74,4 @@ Imported payloads contain whatever your traces contain: prompts, customer data, 
 
 ## Next
 
-Score the history you just imported with [Write an evaluator](write-an-evaluator.md), then freeze the sessions that matter into a cohort and put a change to the test with [Build a regression suite from production](regression-suite.md).
+Evaluate the history you imported with [Write an evaluator](write-an-evaluator.md), then freeze the sessions that matter into a cohort and put a change to the test with [Build a regression suite from production](regression-suite.md).

--- a/docs/book/guides/deterministic-evaluations.md
+++ b/docs/book/guides/deterministic-evaluations.md
@@ -5,11 +5,11 @@ icon: gauge-high
 
 # Deterministic Evaluations
 
-The Kitaru repository includes ten deterministic evaluator plugins for recorded and imported sessions. They read stored session evidence and return repeatable diagnostics or policy results. They do not run the agent, call a model provider, replay a session, invoke a live tool, or read an external service.
+Kitaru includes ten deterministic evaluator plugins for recorded and imported sessions. They read stored session evidence and return repeatable diagnostics or policy results. They do not run the agent, call a model provider, replay a session, invoke a live tool, or read an external service.
 
 The default Kitaru server installation includes the `kitaru-evaluator` package. At startup, Kitaru registers its three basic evaluators and the ten deterministic evaluators below. A fresh workspace creates version 1 for each evaluator.
 
-You also start each evaluation explicitly. Importing, recording, or seeding a session does not start an evaluation Job automatically.
+You start each evaluation explicitly. Importing, recording, or seeding a session does not start an evaluation Job automatically.
 
 ## Start with the descriptive bundles
 

--- a/docs/book/guides/import-braintrust-traces.md
+++ b/docs/book/guides/import-braintrust-traces.md
@@ -5,7 +5,7 @@ icon: brain
 
 # Braintrust
 
-If your agent already logs to Braintrust, you don't need to instrument anything to start using Kitaru. Export the logs, run one import, and each trace lands as a [session](../concepts/agents-and-sessions.md): the same object a live-recorded run produces, ready to evaluate and replay.
+If your agent already logs to Braintrust, you do not need to instrument anything to start using Kitaru. Export the logs, run one import, and each trace lands as a [session](../concepts/agents-and-sessions.md): the same object a live-recorded run produces, ready to evaluate and replay.
 
 **Braintrust stays your system of record.** Kitaru takes a runnable copy of the runs you care about so that last Tuesday's incident becomes a test case and last month's traffic becomes a regression population.
 
@@ -13,7 +13,7 @@ Like every import, this one executes on a [worker](../concepts/workers.md) in yo
 
 ## 1. Export your Braintrust logs
 
-The importer is deliberately permissive about the container, because Braintrust logs reach you in more than one shape. It accepts a UTF-8 file that is any of:
+The importer is permissive about the container because Braintrust logs reach you in more than one shape. It accepts a UTF-8 file that is any of:
 
 - **JSONL**, one Braintrust event object per line.
 - **A JSON array** of event objects.
@@ -46,7 +46,7 @@ Rows that carry `span_id`, `root_span_id`, or `span_attributes` are treated as a
 
 ## 2. Import it
 
-Register the agent the traces belong to, if you haven't, and start a worker:
+Register the agent the traces belong to, if you have not, and start a worker:
 
 ```bash
 kitaru agent register support-agent --command "python support.py"
@@ -120,7 +120,7 @@ Session metadata records the provenance you'll want when reading the import back
 
 ## Re-runs skip what is already there
 
-Every imported session records its source identity: `imported_from` (`braintrust`) and an `external_id` of `<project>:<session>`. That pair is unique on the server, so re-importing an overlapping export **skips** what is already stored and reports it as `skipped`, not as an error. Exporting the last 24 hours every night is a safe cron job, not a duplication engine.
+Every imported session records its source identity: `imported_from` (`braintrust`) and an `external_id` of `<project>:<session>`. That pair is unique on the server, so re-importing an overlapping export **skips** what is already stored and reports it as `skipped`, not as an error. Exporting the last 24 hours every night is safe; it will not duplicate earlier sessions.
 
 ## Limitations
 
@@ -133,7 +133,7 @@ The importer is explicit about fidelity it cannot recover, and writes what it no
 
 Two more things worth knowing before you rely on an import:
 
-- Non-allowlisted `metadata` keys and Braintrust's own evaluations do not come across. Score imported sessions with Kitaru [evaluators](../concepts/evaluators.md) instead; backfilling your history is a single batch call.
+- Non-allowlisted `metadata` keys and Braintrust's own evaluations do not come across. Evaluate imported sessions with Kitaru [evaluators](../concepts/evaluators.md) instead; backfilling your history is a single batch call.
 - Replay re-runs your agent's real code, which no trace export contains. Register the agent version whose code produced these traces, with its run command, and imported sessions replay exactly like recorded ones.
 
 ### Lower-fidelity exports
@@ -144,4 +144,4 @@ A flat export (rows with `input`, `output`, `metadata`, and `metrics`, but no `s
 
 ## Next
 
-Score your imported history with [Write an evaluator](write-an-evaluator.md), then freeze the sessions that matter into a cohort and put a change to the test with [Build a regression suite from production](regression-suite.md).
+Evaluate your imported history with [Write an evaluator](write-an-evaluator.md), then freeze the sessions that matter into a cohort and put a change to the test with [Build a regression suite from production](regression-suite.md).

--- a/docs/book/guides/import-langfuse-traces.md
+++ b/docs/book/guides/import-langfuse-traces.md
@@ -5,7 +5,7 @@ icon: bolt
 
 # Langfuse
 
-[Import your traces](../getting-started/import-your-traces.md) covers the happy path: one `kitaru session import` against the built-in Langfuse importer. This guide is the full contract: what the importer understands, how re-runs dedup, and how to write an importer for any other format.
+[Import your traces](../getting-started/import-your-traces.md) covers the shortest path: one `kitaru session import` against the built-in Langfuse importer. This guide is the full contract: what the importer understands, how re-runs dedup, and how to write an importer for any other format.
 
 ## How an import executes
 
@@ -66,4 +66,4 @@ The importer contract is deliberately small, about a page of Python, and the shi
 
 ## After the import
 
-Imported sessions are full citizens: score them with [evaluators](write-an-evaluator.md) (backfilling your history is a single batch call), freeze them into [cohorts](../concepts/cohorts.md), and [replay](replay-and-overrides.md) them, provided the agent's code is registered as an agent version with a run command, since replay re-runs your code, which no trace export contains.
+Imported sessions are full Kitaru sessions: evaluate them with [evaluators](write-an-evaluator.md) (backfilling your history is a single batch call), freeze them into [cohorts](../concepts/cohorts.md), and [replay](replay-and-overrides.md) them. Replay re-runs your code, which no trace export contains, so the agent's code must be registered as an agent version with a run command.

--- a/docs/book/guides/import-langsmith-traces.md
+++ b/docs/book/guides/import-langsmith-traces.md
@@ -5,7 +5,7 @@ icon: hammer
 
 # LangSmith
 
-If your agent already reports to LangSmith, you don't need to re-instrument anything to start using Kitaru. Export the runs, import them, and each one lands as a [session](../concepts/agents-and-sessions.md) with `origin: imported`, the same object a live-recorded run produces. LangSmith stays your system of record; Kitaru takes a runnable copy of the runs you want to evaluate and replay.
+If your agent already reports to LangSmith, you do not need to re-instrument anything to start using Kitaru. Export the runs, import them, and each one lands as a [session](../concepts/agents-and-sessions.md) with `origin: imported`, the same object a live-recorded run produces. LangSmith stays your system of record; Kitaru takes a runnable copy of the runs you want to evaluate and replay.
 
 [Import your traces](../getting-started/import-your-traces.md) covers the shortest path. This guide is the LangSmith contract: what the built-in importer accepts, how it decides where one session ends and the next begins, and where it tells you it lost fidelity.
 
@@ -26,7 +26,7 @@ Each run record is read for the fields LangSmith already writes: `id`, `trace_id
 
 ## Import the export
 
-Register the agent these runs belong to, if you haven't, then start a [worker](../concepts/workers.md) in another terminal (`kitaru worker start`) and import:
+Register the agent these runs belong to, if you have not, then start a [worker](../concepts/workers.md) in another terminal (`kitaru worker start`) and import:
 
 ```bash
 kitaru agent register support-agent --command "python support.py"
@@ -83,11 +83,11 @@ At session level you get the thread's trace ids, the join paths used, the union 
 
 Every imported session records `imported_from: langsmith` plus an `external_id` of `<source_instance>:<thread>`. That pair is unique on the server, so re-importing an overlapping export **skips** what is already stored and reports it as `skipped`, not as an error. Nodes upsert by index within a session, so a re-parse restates each node's full content.
 
-This is what makes "export the last 24 hours every night" a safe cron job. It also means the grouping key matters: if you change `source_instance` or `join_on` between imports of the same runs, the same thread lands as a second session rather than deduping against the first.
+This is what makes "export the last 24 hours every night" safe. It also means the grouping key matters: if you change `source_instance` or `join_on` between imports of the same runs, the same thread lands as a second session rather than deduping against the first.
 
 ## Limitations
 
-- **Only what the export contains.** Anything LangSmith didn't record (intermediate state, code, environment) isn't recoverable from the file.
+- **Only what the export contains.** Anything LangSmith did not record (intermediate state, code, environment) is not recoverable from the file.
 - **Imported threads are frozen.** Once a thread is imported, later traces in the same thread are skipped by dedup rather than appended. Import a thread after it is finished, or scope `join_on` to something that closes.
 - **Partial graphs import with a warning.** A trace with more than one root run, a run whose parent is missing from the export, or model output containing `tool_calls` with no corresponding tool runs all set `source_completeness: partial` and add a line to `normalization_warnings`. The session still imports.
 - **A bad trace is isolated, not fatal.** A run with no trace id or run id, a trace with conflicting project identities or conflicting thread values, or a trace missing your chosen `join_on` value is reported as a failure and the rest of the file still imports. A malformed file (invalid JSON, non-UTF-8, empty, or over 50 MiB) fails the task as a whole.
@@ -97,4 +97,4 @@ This is what makes "export the last 24 hours every night" a safe cron job. It al
 
 ## Next
 
-Score the history you just imported with [Write an evaluator](write-an-evaluator.md), then freeze the sessions that matter into a cohort and put your next change to the test with [Build a regression suite from production](regression-suite.md).
+Evaluate the history you imported with [Write an evaluator](write-an-evaluator.md), then freeze the sessions that matter into a cohort and put your next change to the test with [Build a regression suite from production](regression-suite.md).

--- a/docs/book/guides/import-logfire-traces.md
+++ b/docs/book/guides/import-logfire-traces.md
@@ -5,7 +5,7 @@ icon: fire
 
 # Logfire
 
-If your agent already sends spans to Logfire, you don't need to instrument anything to start using Kitaru. Export the records, run one import, and each conversation lands as a [session](../concepts/agents-and-sessions.md): the same object a live-recorded run produces, ready to evaluate and replay.
+If your agent already sends spans to Logfire, you do not need to instrument anything to start using Kitaru. Export the records, run one import, and each conversation lands as a [session](../concepts/agents-and-sessions.md): the same object a live-recorded run produces, ready to evaluate and replay.
 
 **Logfire stays your system of record.** Kitaru takes a runnable copy of the runs you care about, so last Tuesday's incident becomes a test case and last month's traffic becomes a regression population.
 
@@ -56,7 +56,7 @@ Export whole traces rather than filtered subsets. A span whose parent is missing
 
 ## 2. Import it
 
-Register the agent the traces belong to, if you haven't, and start a worker:
+Register the agent the traces belong to, if you have not, and start a worker:
 
 ```bash
 kitaru agent register support-agent --command "python support.py"
@@ -143,7 +143,7 @@ Session metadata records the provenance you'll want when reading the import back
 
 ## Re-runs skip what is already there
 
-Every imported session records its source identity: `imported_from` (`logfire`) and an `external_id` of `<source_instance>:<session>`. That pair is unique on the server, so re-importing an overlapping export **skips** what is already stored and reports it as `skipped`, not as an error. Exporting the last 24 hours every night is a safe cron job, not a duplication engine.
+Every imported session records its source identity: `imported_from` (`logfire`) and an `external_id` of `<source_instance>:<session>`. That pair is unique on the server, so re-importing an overlapping export **skips** what is already stored and reports it as `skipped`, not as an error. Exporting the last 24 hours every night is safe; it will not duplicate earlier sessions.
 
 It also means the grouping key matters: if you change `source_instance` or `join_on` between imports of the same records, the same conversation lands as a second session rather than deduping against the first.
 
@@ -160,11 +160,11 @@ Some problems fail one session or one row rather than the file, and are reported
 
 Two more things worth knowing before you rely on an import:
 
-- Logfire's own evaluations and alerts do not come across, and neither do metrics or logs that are not span records. Score imported sessions with Kitaru [evaluators](../concepts/evaluators.md) instead; backfilling your history is a single batch call.
+- Logfire's own evaluations and alerts do not come across, and neither do metrics or logs that are not span records. Evaluate imported sessions with Kitaru [evaluators](../concepts/evaluators.md) instead; backfilling your history is a single batch call.
 - Replay re-runs your agent's real code, which no trace export contains. Register the agent version whose code produced these records, with its run command, and imported sessions replay exactly like recorded ones.
 
 {% hint style="warning" %} An import stores the parsed trace content, including prompts, tool arguments, and tool results, on your Kitaru server. The server is self-hosted, but check your own access and retention rules before importing exports that contain customer data. {% endhint %}
 
 ## Next
 
-Score your imported history with [Write an evaluator](write-an-evaluator.md), then freeze the sessions that matter into a cohort and put a change to the test with [Build a regression suite from production](regression-suite.md).
+Evaluate your imported history with [Write an evaluator](write-an-evaluator.md), then freeze the sessions that matter into a cohort and put a change to the test with [Build a regression suite from production](regression-suite.md).

--- a/docs/book/guides/importing-sessions.md
+++ b/docs/book/guides/importing-sessions.md
@@ -5,7 +5,7 @@ icon: file-import
 
 # Kitaru JSONL
 
-Kitaru importers convert exported trace data into one session graph. Provider importers decode source records, join related traces into sessions, order turns, reconstruct node relationships, and project common fields for the UI while preserving source inputs and outputs.
+Kitaru importers convert exported trace data into session graphs. Provider importers decode source records, join related traces into sessions, order turns, reconstruct node relationships, and project common fields for the UI while preserving source inputs and outputs.
 
 Use a provider importer for Langfuse, LangSmith, Braintrust, or Logfire data. Use the `kitaru-jsonl` importer when your producer already emits the Kitaru session and node contract.
 
@@ -53,7 +53,7 @@ Each node uses the fields below. Optional fields can be omitted or set to null.
 | `attributes` | any JSON value | Span attributes retained for diagnostics. |
 | `metadata` | JSON object | Bounded source metadata. |
 
-Text selectors avoid copying potentially large values into separate columns. A selector is present only when the importer can identify one relevant string in the corresponding payload. A client resolves that [RFC 6901 JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901.html) when it loads the node payload and can show the complete `inputs` or `outputs` value for inspection. The selectors remain available in node list responses without loading the payload columns. `system_prompt_selector` resolves against `inputs`. A null selector means that the importer could not choose one text value without guessing. The empty string is the JSON Pointer for the complete payload, which is useful when the payload itself is the selected string.
+Text selectors avoid copying potentially large values into separate columns. A selector is present only when the importer can identify one relevant string in the corresponding payload. A client resolves that [RFC 6901 JSON Pointer](https://www.rfc-editor.org/rfc/rfc6901.html) when it loads the node payload and can show the complete `inputs` or `outputs` value for inspection. The selectors remain available in node list responses without loading the payload columns. `system_prompt_selector` resolves against `inputs`. A null selector means the importer could not choose one text value without guessing. The empty string is the JSON Pointer for the complete payload, which is useful when the payload itself is the selected string.
 
 `reasoning` contains visible text only. Redacted, encrypted, or unavailable reasoning remains null, while the provider payload stays in `inputs` or `outputs`. Token usage can also include `reasoning_tokens` when a provider reports the count.
 
@@ -134,7 +134,7 @@ kitaru session import langfuse-observations.jsonl \
   --wait
 ```
 
-The example reads the scalar at `/metadata/customer/case_id`. Five traces with the value `case-42` become five ordered turns in the same Kitaru session. Traces with another value form another session.
+The example reads the scalar at `/metadata/customer/case_id`. Five traces with the value `case-42` become five ordered turns in the same Kitaru session. Traces with a different value form a different session.
 
 Escape source keys according to RFC 6901. Use `~1` for `/` and `~0` for `~`. For example, `/metadata/customer~1case~0id` selects the key `customer/case~id` inside `metadata`.
 
@@ -215,7 +215,7 @@ You have two ways in, and neither requires waiting for us to ship an importer.
 Parser = Callable[[bytes, dict[str, Any]], Iterator[ImportedSession | ImportFailure]]
 ```
 
-That is the whole interface. You receive the uploaded bytes and the `--params` object, and yield one `ImportedSession` per session you recognize, or an `ImportFailure` for a record you cannot parse, which isolates that record instead of failing the whole import:
+That is the whole interface. You receive the uploaded bytes and the `--params` object, then yield one `ImportedSession` per session you recognize, or an `ImportFailure` for a record you cannot parse. A yielded failure isolates that record instead of failing the whole import:
 
 ```python
 from kitaru.api_models.v1.imports import ImportFailure
@@ -229,7 +229,7 @@ def parse(content: bytes, params: dict[str, Any]) -> Iterator[ImportedSession | 
             yield ImportFailure(line=line_number, external_id=None, error=str(exc))
 ```
 
-Three things to get right, because they are where custom importers usually go wrong:
+Three things matter most because they are where custom importers usually go wrong:
 
 - **`external_id` is your identity, and it must be stable.** Kitaru deduplicates on `(imported_from, external_id)`, so a re-import is only safe if the id does not move between runs. Derive it from the source's own identifier, never from a row number or a timestamp.
 - **Decide session boundaries deliberately.** One `ImportedSession` should be one end-to-end run; see [what a session is](../concepts/agents-and-sessions.md). If your source splits a run across records, join them in the parser.

--- a/docs/book/guides/llm-calls.md
+++ b/docs/book/guides/llm-calls.md
@@ -5,7 +5,7 @@ icon: coins
 
 # Track cost and model usage
 
-Every model call in a recorded run lands as an `llm_call` node on the [session](../concepts/agents-and-sessions.md): the requested and resolved model, inputs and outputs, token usage (input, output, cached, reasoning), and cost. The session rolls them up as it goes, so the totals are already there when you read a run:
+Every model call in a recorded run lands as an `llm_call` node on the [session](../concepts/agents-and-sessions.md): the requested and resolved model, inputs and outputs, token usage (input, output, cached, reasoning), and cost. The session rolls those values up as it goes, so the totals are already there when you read a run:
 
 ```python
 session = await client.sessions.get(session_id)
@@ -31,7 +31,7 @@ for node in nodes.items:
         print(node.requested_model, node.model, node.tokens, node.cost)
 ```
 
-`requested_model` vs `model` is worth watching: it's how you see an alias or a replay [override](replay-and-overrides.md) resolving to the model that actually served the call.
+`requested_model` vs `model` is worth watching: it shows an alias or a replay [override](replay-and-overrides.md) resolving to the model that served the call.
 
 ## Cost as an experiment metric
 

--- a/docs/book/guides/regression-suite.md
+++ b/docs/book/guides/regression-suite.md
@@ -5,7 +5,7 @@ icon: vials
 
 # Build a regression suite from production
 
-Replaying a change against one session shows how it affects that case. A regression suite repeats the comparison across a fixed set of recorded or imported sessions. These sessions complement synthetic fixtures: they preserve inputs and behavior seen in real runs, while synthetic cases can cover conditions that have not occurred in production.
+Replaying a change against one session shows how it affects that case. A regression suite repeats the comparison across a fixed set of recorded or imported sessions. These sessions complement synthetic fixtures: they preserve inputs and behavior seen in real runs, while synthetic cases can cover conditions that have not happened in production.
 
 This guide selects a population, freezes it as a cohort version, defines a change as an experiment, and runs that experiment in CI.
 
@@ -56,7 +56,7 @@ version = await client.cohorts.create_version(
 )
 ```
 
-[Cohort versions are immutable](../concepts/cohorts.md). Version 1 therefore keeps the same 50 sessions. To add or remove sessions, create a new version so later comparisons show that the population changed.
+[Cohort versions are immutable](../concepts/cohorts.md). Version 1 keeps the same 50 sessions. To add or remove sessions, create a new version so later comparisons show that the population changed.
 
 ## 3. Make the change an experiment
 

--- a/docs/book/guides/replay-and-overrides.md
+++ b/docs/book/guides/replay-and-overrides.md
@@ -5,9 +5,9 @@ icon: rotate-left
 
 # Replay a failure and fork it
 
-Replay re-executes a recorded [session](../concepts/agents-and-sessions.md) to produce a **new session**: the same run, with exactly the changes you specify. One mechanism, two jobs:
+Replay re-executes a recorded [session](../concepts/agents-and-sessions.md) to produce a **new session**: the same run, with exactly the changes you specify. One mechanism covers two jobs:
 
-- **Debug a failure.** A production run went wrong. Replay it unchanged and you have the failure on your desk, reproducible, without touching production.
+- **Debug a failure.** A production run went wrong. Replay it unchanged and you have the failure on your desk, reproducible without touching production.
 - **Test a change.** You want to swap the model, tighten the prompt, or ship the code in your working tree. Fork the run with that one change and read what it did.
 
 This guide assumes you prepared the public [`kitaru-template`](https://github.com/zenml-io/kitaru-template) and completed the setup and Define phases of the [returns-agent tutorial](../tutorials/returns-agent/README.md): a registered agent with a run command, a registered [evaluator](../concepts/evaluators.md), and a [worker](../concepts/workers.md) running in the agent's environment.
@@ -39,7 +39,7 @@ Use `kitaru job get <job-id> --tasks` for task errors and `kitaru job cancel <jo
 Every trustworthy comparison involves three sessions:
 
 1. **Observed:** the original recording (recorded or imported).
-2. **Reproduced:** an unchanged replay of it. If this doesn't hold up (evaluations disagree, the path is wildly different), stop. Your run depends on something the recording doesn't answer (live tool traffic, nondeterminism you haven't pinned), and no fork from it can be trusted.
+2. **Reproduced:** an unchanged replay of it. If this does not hold up, because evaluations disagree or the path is wildly different, stop. Your run depends on something the recording does not answer, such as live tool traffic or nondeterminism you have not pinned, and no fork from it can be trusted.
 3. **Forked:** the replay with one thing changed. Because the baseline reproduced, the difference between it and the fork is your change.
 
 ## Anatomy of a replay
@@ -77,11 +77,11 @@ asyncio.run(main())
 Field by field:
 
 - `baseline_session_id`: the recording to re-run.
-- `agent_version_id`: which code runs. Omitted, it's the version the baseline was recorded with (the faithful choice). Point it at a newly registered version to replay old traffic **against your working tree**.
+- `agent_version_id`: which code runs. Omitted, it is the version the baseline was recorded with, which is the faithful choice. Point it at a newly registered version to replay old traffic **against your working tree**.
 - `override`: the fork. Omit it for a pure reproduction.
 - `tool_policy`: what tool calls hit. If omitted, the server applies its default, which currently passes calls through to live tools. For a replay that touches nothing real, set a `history` policy as above. Details in [Tool policies](tool-policies.md).
-- `evaluators`: at least one, always. A replay is never just "it ran"; it's evaluated on arrival.
-- `evaluate_baselines`: score the original session with the same evaluators, so the comparison exists as soon as the replay settles.
+- `evaluators`: at least one, always. A replay is evaluated on arrival.
+- `evaluate_baselines`: evaluate the original session with the same evaluators, so the comparison exists as soon as the replay settles.
 
 Watch it with `kitaru job watch <job-id>`; when the replay reads `completed`, `client.replays.get(replay.id)` carries the `result_session_id`.
 
@@ -123,16 +123,16 @@ for name, b in baseline_evals.items():
     print(name, "baseline:", b.score, "fork:", f.score if f else "-")
 ```
 
-Session rollups carry the operational deltas (`cost`, `tokens`, `llm_call_count`, `tool_call_count`), so "same pass rate, 40% cheaper, one extra model call" is three field reads. For node-level inspection, `list_nodes(include_payloads=True)` on both sessions shows you exactly where the paths diverged.
+Session rollups carry the operational deltas (`cost`, `tokens`, `llm_call_count`, `tool_call_count`), so "same pass rate, 40% cheaper, one extra model call" is three field reads. For node-level inspection, `list_nodes(include_payloads=True)` on both sessions shows where the paths diverged.
 
 ## When a replay fails
 
-A replay settles `failed` when its pipeline can't produce the comparison: the agent process exited nonzero, a tool call missed under `on_miss="fail"`, or an evaluator crashed. The job's tasks carry the error and a log tail; `kitaru job get <job-id>` and `kitaru job watch` surface them, and [Troubleshooting](../getting-started/troubleshooting.md) walks the diagnosis. The common causes:
+A replay settles `failed` when its pipeline cannot produce the comparison: the agent process exited nonzero, a tool call missed under `on_miss="fail"`, or an evaluator crashed. The job's tasks carry the error and a log tail; `kitaru job get <job-id>` and `kitaru job watch` surface them, and [Troubleshooting](../getting-started/troubleshooting.md) walks the diagnosis. The common causes:
 
 - **No run spec:** the agent version must carry a run command; registering with `--command` is what makes a session replayable.
 - **Worker environment:** the subprocess needs your agent's dependencies and provider keys; it inherits them from the worker's environment.
-- **Unrecorded tool call:** the fork took a path the baseline never took. That's information, not noise: widen the history scope, add a `static` case for it, or accept `error_result` and let the agent handle it.
+- **Unrecorded tool call:** the fork took a path the baseline never took. That is information: widen the history scope, add a `static` case for it, or accept `error_result` and let the agent handle it.
 
 ## From one replay to many
 
-The same request against many sessions is a [cohort](../concepts/cohorts.md) plus an [experiment](../concepts/experiments.md): one replay per session, fanned out and evaluated identically. That's the subject of [Build a regression suite from production](regression-suite.md).
+The same request against many sessions is a [cohort](../concepts/cohorts.md) plus an [experiment](../concepts/experiments.md): one replay per session, fanned out and evaluated identically. That is the subject of [Build a regression suite from production](regression-suite.md).

--- a/docs/book/guides/write-an-evaluator.md
+++ b/docs/book/guides/write-an-evaluator.md
@@ -5,11 +5,11 @@ icon: chart-line
 
 # Write an evaluator
 
-Your domain expert already knows what a good run looks like. An [evaluator](../concepts/evaluators.md) is that knowledge as code: a small Python callable that reads one recorded session and writes named, typed verdicts. This guide takes you from criteria to a registered, calibrated evaluator you can trust to gate a release.
+Your domain expert already knows what a good run looks like. An [evaluator](../concepts/evaluators.md) is that knowledge as code: a small Python callable that reads one recorded session and writes named, typed verdicts. This guide takes you from criteria to a registered, calibrated evaluator you can trust in a release gate.
 
 ## From criteria to code
 
-Start from what the expert actually says. "A good refund resolution issues exactly one refund, quotes the amount, and doesn't promise anything we don't do" is three checks:
+Start from what the expert says. "A good refund resolution issues exactly one refund, quotes the amount, and does not promise anything we do not do" is three checks:
 
 ```bash
 kitaru evaluator scaffold refund-quality
@@ -42,11 +42,11 @@ def evaluate(session: SessionView, **params) -> list[EvaluationResult]:
     ]
 ```
 
-`SessionView` is the whole recording: `session.session` is the [session](../concepts/agents-and-sessions.md) with its inputs, outputs, and rollups; `session.nodes` is every model call and tool call with payloads. Return one result or a list; each becomes one stored evaluation. Pick the type by how you'll read a thousand of them: **numbers average, booleans count, labels diff as transitions, free text gets read.** Use `passed` for the verdict and `explanation` for the sentence you'll want when a gate goes red.
+`SessionView` is the whole recording: `session.session` is the [session](../concepts/agents-and-sessions.md) with its inputs, outputs, and rollups; `session.nodes` is every model call and tool call with payloads. Return one result or a list; each becomes one stored evaluation. Pick the type by how you will read a thousand of them: **numbers average, booleans count, labels diff as transitions, free text gets read.** Use `passed` for the verdict and `explanation` for the sentence you will want when a gate goes red.
 
-## An LLM judge is just an evaluator
+## An LLM judge is an evaluator
 
-For criteria that need judgment (tone, helpfulness, "did it actually answer the question"), call a model inside `evaluate`. Declare the dependency inline (PEP 723) and the worker builds the environment:
+For criteria that need judgment, such as tone, helpfulness, or whether the reply answered the question, call a model inside `evaluate`. Declare the dependency inline (PEP 723) and the worker builds the environment:
 
 ```python
 # /// script
@@ -77,11 +77,11 @@ kitaru evaluator register refund-quality \
   --script refund_quality_evaluator.py --entrypoint evaluate
 ```
 
-Evaluators are versioned: re-registering with `kitaru evaluator version register refund-quality --script ...` creates version 2, and every evaluation row records exactly which version wrote it. Tightening a criterion never rewrites history: old rows keep their provenance, and you can re-score any population with the new version.
+Evaluators are versioned: re-registering with `kitaru evaluator version register refund-quality --script ...` creates version 2, and every evaluation row records exactly which version wrote it. Tightening a criterion never rewrites history: old rows keep their provenance, and you can evaluate any population again with the new version.
 
 ## Calibrate against human judgment
 
-Before an evaluator gates anything, check that it agrees with the human it's standing in for. The structured way to collect the human side is an [investigation](../concepts/investigations.md), and by design your coding assistant authors it for you: it picks the slice of sessions, poses the criteria as questions, and interviews you against the evidence. The answers land as annotations, one per session per question. Labels can also be written directly as evaluations:
+Before an evaluator gates anything, check that it agrees with the human it stands in for. The structured way to collect the human side is an [investigation](../concepts/investigations.md), and by design your coding assistant authors it for you: it picks the slice of sessions, poses the criteria as questions, and interviews you against the evidence. The answers land as annotations, one per session per question. Labels can also be written directly as evaluations:
 
 ```python
 from kitaru.api_models.v1.evaluation import EvaluationResult
@@ -95,7 +95,7 @@ await client.sessions.merge_evaluations(
 )
 ```
 
-Run the evaluator over the same slice, then compare the `tone` column against `human_tone` per session. Where they disagree, the explanation field tells you which side is confused. Fix the evaluator (new version) or the criteria, and repeat until the agreement rate earns your trust. The labeled slice is worth keeping as a [cohort](../concepts/cohorts.md): it's your calibration set for every future evaluator version.
+Run the evaluator over the same slice, then compare the `tone` column against `human_tone` per session. Where they disagree, the explanation field tells you which side is confused. Fix the evaluator (new version) or the criteria, and repeat until the agreement rate earns your trust. The labeled slice is worth keeping as a [cohort](../concepts/cohorts.md): it is your calibration set for every future evaluator version.
 
 ## Backfill your history
 


### PR DESCRIPTION
## Summary

This rewrites the reader-facing GitBook prose for voice and clarity without changing the docs structure, commands, prompts, links, or documented behavior.

The pass focuses on the launch-critical hand-written docs under `docs/book/`: the welcome page, quickstart, coding-agent setup, investigations, core concepts, and guides. It also replaces loose prose uses of "score" with evaluator/evaluation language while leaving API fields such as `score` unchanged.

## Reviewer Notes

The main review path is the docs reader path, not implementation behavior. Start with `docs/book/README.md`, then read `docs/book/getting-started/quickstart.md`, `docs/book/agent-native/setup.md`, and `docs/book/concepts/investigations.md`. Those pages carry the most visible voice changes and should still preserve the positioning that Kitaru is replay-based evals for AI agents, driven by coding assistants through MCP and skills.

The rest of the diff is a light consistency pass through `docs/book/concepts/` and `docs/book/guides/`. Check that facts, code snippets, importer limitations, worker semantics, and GitBook links are unchanged.

### Reproduction

1. Inspect the diff for `docs/book/README.md`, `docs/book/getting-started/quickstart.md`, `docs/book/agent-native/setup.md`, and `docs/book/concepts/investigations.md`.
2. Confirm the page structure and GitBook navigation are unchanged.
3. Run the GitBook audit used locally: validate Markdown frontmatter YAML, check no em dashes, check no cross-file `.md#` links, verify relative link targets, verify every page is in `toc.md`, verify every toc entry exists, and verify `.gitbook.yaml` redirect targets exist.

Local checks run:

- GitBook audit passed: 50 reader pages, 50 toc entries, 67 redirects
- `git diff --check`
- `rg -n "\.md#|—|captured|scorer|delve|leverage|robust|seamless|actually|genuinely" docs/book/README.md docs/book/getting-started docs/book/agent-native docs/book/concepts docs/book/guides`

Not run: `just check`, because `just` is not installed in this environment. `docs/worker` was not touched, so `node --test docs/worker/redirect.test.mjs` was not run.