### PR TITLE
Validate Kitaru release tags on main

### DIFF
--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -73,10 +73,10 @@ jobs:
       - name: Validate release source
         run: |
           set -euo pipefail
-          git fetch origin develop
+          git fetch origin main
           release_sha=$(git rev-parse HEAD)
-          if ! git merge-base --is-ancestor "$release_sha" origin/develop; then
-            echo "::error::$PACKAGE_TAG points to $release_sha, which is not on develop."
+          if ! git merge-base --is-ancestor "$release_sha" origin/main; then
+            echo "::error::$PACKAGE_TAG points to $release_sha, which is not on main."
             exit 1
           fi
       - name: Build plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,10 +77,10 @@ jobs:
       - name: Validate release source
         run: |
           set -euo pipefail
-          git fetch origin develop
+          git fetch origin main
           release_sha=$(git rev-parse HEAD)
-          if ! git merge-base --is-ancestor "$release_sha" origin/develop; then
-            echo "::error::$PACKAGE_TAG points to $release_sha, which is not on develop."
+          if ! git merge-base --is-ancestor "$release_sha" origin/main; then
+            echo "::error::$PACKAGE_TAG points to $release_sha, which is not on main."
             exit 1
           fi
       - name: Resolve exact frontend artifact


### PR DESCRIPTION
## What changed

Core and plugin release workflows now require the release tag to point to a commit reachable from `main`.

## Why

The release routines use `main` as the release branch; the workflows previously rejected those tags because they checked `develop`.

## Validation

- `git show --check HEAD`
- `git diff --check origin/main...HEAD`
- Confirmed both workflow guards now fetch and validate `origin/main`.