### PR TITLE
Mark stable GitHub releases as latest

### DIFF
--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -150,12 +150,15 @@ jobs:
             exit 0
           fi
           prerelease=()
+          latest=(--latest=false)
           if [ "$IS_PRERELEASE" = true ]; then
             prerelease+=(--prerelease)
+          else
+            latest=(--latest)
           fi
           gh release create "$PACKAGE_TAG" package-dist/* evidence/* \
             "${prerelease[@]}" \
             --verify-tag \
-            --latest=false \
+            "${latest[@]}" \
             --title "$DISTRIBUTION $VERSION" \
             --generate-notes

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -257,13 +257,16 @@ jobs:
         run: |-
           set -euo pipefail
           prerelease=()
+          latest=(--latest=false)
           if [ "$IS_PRERELEASE" = true ]; then
             prerelease+=(--prerelease)
+          else
+            latest=(--latest)
           fi
           if gh release view "$PACKAGE_TAG" >/dev/null 2>&1; then
             gh release upload "$PACKAGE_TAG" typescript-dist/*.tgz evidence/SHA256SUMS --clobber
             gh release edit "$PACKAGE_TAG" \
-              --latest=false \
+              "${latest[@]}" \
               --prerelease="$IS_PRERELEASE" \
               --title "Kitaru TypeScript $VERSION" \
               --verify-tag
@@ -271,7 +274,7 @@ jobs:
             gh release create "$PACKAGE_TAG" typescript-dist/*.tgz evidence/SHA256SUMS \
               "${prerelease[@]}" \
               --verify-tag \
-              --latest=false \
+              "${latest[@]}" \
               --title "Kitaru TypeScript $VERSION" \
               --generate-notes
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,12 +306,15 @@ jobs:
             exit 0
           fi
           prerelease=()
+          latest=(--latest=false)
           if [ "$IS_PRERELEASE" = true ]; then
             prerelease+=(--prerelease)
+          else
+            latest=(--latest)
           fi
           gh release create "$PACKAGE_TAG" package-dist/* evidence/* \
             "${prerelease[@]}" \
             --verify-tag \
-            --latest=false \
+            "${latest[@]}" \
             --title "kitaru $VERSION" \
             --generate-notes

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -352,6 +352,18 @@ def test_python_release_workflow_can_resume_after_partial_publication() -> None:
         assert "gh release upload" not in workflow
 
 
+def test_stable_github_releases_are_marked_latest() -> None:
+    workflows = [
+        (REPO_ROOT / ".github" / "workflows" / name).read_text()
+        for name in ("release.yml", "release-plugins.yml", "release-typescript.yml")
+    ]
+
+    for workflow in workflows:
+        assert "latest=(--latest=false)" in workflow
+        assert 'latest=(--latest)' in workflow
+        assert '"${latest[@]}"' in workflow
+
+
 def test_core_github_release_is_created_after_registry_publication() -> None:
     workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text()
 

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -360,7 +360,7 @@ def test_stable_github_releases_are_marked_latest() -> None:
 
     for workflow in workflows:
         assert "latest=(--latest=false)" in workflow
-        assert 'latest=(--latest)' in workflow
+        assert "latest=(--latest)" in workflow
         assert '"${latest[@]}"' in workflow
 
 


### PR DESCRIPTION
## Summary

Stable Kitaru, plugin, and TypeScript releases now pass `--latest` to GitHub CLI. Prereleases retain `--latest=false`.

The TypeScript release recovery path applies the same policy when reconciling an existing release.

## Root cause

Each workflow explicitly passed `--latest=false`, including stable releases.

## Validation

- `uv run pytest -q tests/scripts/test_release_units.py tests/scripts/test_typescript_packages.py` (50 passed)