### PR TITLE
Add guided tour video to docs

### DIFF
--- a/docs/book/agent-native/setup.md
+++ b/docs/book/agent-native/setup.md
@@ -74,6 +74,10 @@ Worker inspection is read-only by design. Use `kitaru_registry_read` with `kind:
 
 Skills ship separately from Kitaru as Markdown procedures in [`zenml-io/kitaru-skills`](https://github.com/zenml-io/kitaru-skills). A skill does not start another service or process; your assistant reads the document and follows its procedure with the tools already available in the host.
 
+{% hint style="info" %}
+**Want to see a Kitaru skill in action before installing it?** Watch the 26-minute [guided tour](https://youtu.be/aYLfzXEr2Rk). It follows the `kitaru-guided-tour` skill from a prepared session review through a deterministic evaluator, frozen cohort, replay experiment, and comparison.
+{% endhint %}
+
 {% tabs %}
 {% tab title="Any skill-aware host" %}
 ```bash

--- a/docs/book/getting-started/quickstart.md
+++ b/docs/book/getting-started/quickstart.md
@@ -10,7 +10,9 @@ icon: rocket
 You do not need to memorize commands to start. Kitaru is built for your coding assistant to drive: you ask, it operates Kitaru through the MCP server and the agent skills, and you keep the judgment calls. Every step below starts as a prompt; the equivalent command is there when you want to run it yourself.
 
 {% hint style="info" %}
-**No agent in production yet?** Ask your assistant for the guided tour instead: the `kitaru-guided-tour` skill clones the public [`kitaru-template`](https://github.com/zenml-io/kitaru-template) (a ready agent with checked-in traces), prepares a three-session review for you to judge, turns one accepted finding into an evaluator without a paid model call, and ends with one approved replay experiment. Prefer to see every command yourself? The [returns-agent tutorial](../tutorials/returns-agent/README.md) walks the same ground manually.
+**Want to see the complete loop before setting anything up?** Watch the 26-minute [Kitaru guided tour](https://youtu.be/aYLfzXEr2Rk). It starts with this Quickstart, then uses the `kitaru-guided-tour` skill to inspect recorded sessions, collect human judgments, define an evaluator and cohort, and test one improvement.
+
+**No agent in production yet?** When you are ready to try it yourself, ask your assistant for the guided tour. The skill clones the public [`kitaru-template`](https://github.com/zenml-io/kitaru-template), prepares a three-session review for you to judge, turns one accepted finding into an evaluator without a paid model call, and ends with one approved replay experiment. Prefer to see every command yourself? The [returns-agent tutorial](../tutorials/returns-agent/README.md) walks the same ground manually.
 {% endhint %}
 
 Before starting, [install Kitaru and log in](installation.md), then [set up your coding agent](../agent-native/setup.md): the MCP server gives it bounded Kitaru operations, and the skills teach it the procedures.


### PR DESCRIPTION
## What changed?

The Quickstart now offers the guided-tour video as a zero-setup way to see Kitaru's complete improvement loop. The coding-agent setup page also links to the walkthrough beside the skills installation instructions.

## Why?

People can understand how Kitaru works before installing it or running the public template themselves. The hands-on guided-tour skill remains the next step when they are ready to try the workflow.

## Reviewer Notes

Start with the info callout near the top of the Quickstart. Then check the smaller callout under “Install the agent skills” and confirm that both links clearly distinguish watching the workflow from running it.

This is one of three coordinated documentation updates across the core docs, public template, and skills repository.

## Reproduction

Render the Quickstart and coding-agent setup pages. Follow either guided-tour link and confirm that it opens the 26-minute YouTube walkthrough.

## Local checks run

- `git diff --check`
- `just check`
