### PR TITLE
Enable Ruff pydocstyle (`D`) rules for Google-style docstrings

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -72,11 +72,11 @@ audit:
 # Source MDX uses docs-app-root routes such as /guides/...; site-build validates
 # those after materializing public /docs/... links, where lychee can resolve them.
 links:
-    lychee --offline --root-dir . --exclude-path '.venv' --exclude-path 'docs/node_modules' --exclude-path 'docs/out' --exclude-path 'design' './**/*.md'
+    lychee --offline --root-dir . --exclude-path '.venv' --exclude-path 'node_modules' --exclude-path 'docs/out' --exclude-path 'design' './**/*.md'
 
 # Check raw Markdown links including external URLs (slow, used in CI)
 links-external:
-    lychee --root-dir . --exclude-path '.venv' --exclude-path 'docs/node_modules' --exclude-path 'docs/out' --exclude-path 'design' './**/*.md'
+    lychee --root-dir . --exclude-path '.venv' --exclude-path 'node_modules' --exclude-path 'docs/out' --exclude-path 'design' './**/*.md'
 
 # Auto-fix formatting, lint issues, and YAML
 fix:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,16 @@ select = [
     "B",    # bugbear
     "SIM",  # simplify
     "RUF",  # ruff-specific rules
+    "D",    # pydocstyle (Google convention, see [tool.ruff.lint.pydocstyle])
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests may omit docstrings (D1xx), but any docstring they do have must still
+# follow the Google formatting rules (D2xx and up).
+"tests/**" = ["D1"]
+# Test doubles whose methods only mirror the real ADK surface; class-level
+# docstrings already say what each fake stands in for.
+"scripts/google_adk_fakes.py" = ["D1"]
 
 [tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["fastapi.Depends"]

--- a/scripts/audit-example-coverage.py
+++ b/scripts/audit-example-coverage.py
@@ -53,6 +53,7 @@ SHELL_PLACEHOLDER_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=<[^<>\s]+
 
 
 def main() -> int:
+    """Run the example coverage audit and return a process exit code."""
     errors = audit_manifest()
     if errors:
         print("Example coverage audit failed:", file=sys.stderr)
@@ -64,6 +65,7 @@ def main() -> int:
 
 
 def audit_manifest() -> list[str]:
+    """Check the example coverage manifest and return the problems found."""
     data = _load_yaml(MANIFEST_PATH)
     errors: list[str] = []
 

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -61,14 +61,17 @@ class CommandDoc:
 
     @property
     def slug(self) -> str:
+        """Return the final path segment of the command."""
         return self.path[-1]
 
     @property
     def invocation(self) -> str:
+        """Return the full command line used to invoke the command."""
         return " ".join(("kitaru", *self.path))
 
     @property
     def docs_url(self) -> str:
+        """Return the docs site path for the command's page."""
         return f"/cli/{'/'.join(self.path)}/"
 
 
@@ -86,14 +89,17 @@ class GroupDoc:
 
     @property
     def slug(self) -> str:
+        """Return the final path segment of the group."""
         return self.path[-1]
 
     @property
     def invocation(self) -> str:
+        """Return the full command line prefix for the group."""
         return " ".join(("kitaru", *self.path))
 
     @property
     def docs_url(self) -> str:
+        """Return the docs site path for the group's index page."""
         return f"/cli/{'/'.join(self.path)}/" if self.path else "/cli/"
 
     @property

--- a/scripts/probe_mcp_wheel.py
+++ b/scripts/probe_mcp_wheel.py
@@ -176,6 +176,7 @@ async def _run(console: Path) -> None:
 
 
 def main() -> int:
+    """Probe the installed MCP server in every capability mode."""
     parser = argparse.ArgumentParser()
     parser.add_argument("console", type=Path)
     arguments = parser.parse_args()

--- a/scripts/smoke_mcp_wheel.py
+++ b/scripts/smoke_mcp_wheel.py
@@ -103,6 +103,7 @@ def _smoke_mcp(uv: str, root: Path, wheel: Path, repository: Path) -> None:
 
 
 def main() -> int:
+    """Smoke test a built wheel's base and MCP installations."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "wheel",

--- a/scripts/summarize_pytest_speed.py
+++ b/scripts/summarize_pytest_speed.py
@@ -224,6 +224,7 @@ def _print_worker_tail(events: Iterable[dict[str, Any]]) -> None:
 
 
 def main(argv: list[str]) -> int:
+    """Print a speed summary for the probe events in the given report directory."""
     if len(argv) != 2:
         print("Usage: summarize_pytest_speed.py REPORT_DIR", file=sys.stderr)
         return 2

--- a/scripts/verify-ui-wheel.py
+++ b/scripts/verify-ui-wheel.py
@@ -29,6 +29,7 @@ def _missing_ui_files(names: set[str]) -> list[str]:
 
 
 def main() -> int:
+    """Verify the wheel contains the packaged UI assets and report the result."""
     args = _parse_args()
     wheel = args.wheel
     if not wheel.is_file():

--- a/src/kitaru/mcp/connection.py
+++ b/src/kitaru/mcp/connection.py
@@ -22,6 +22,7 @@ class ConnectionConfigurationError(Exception):
     hint: str | None = None
 
     def __post_init__(self) -> None:
+        """Initialize the `Exception` base with the error message."""
         Exception.__init__(self, self.message)
 
 

--- a/src/kitaru/mcp/errors.py
+++ b/src/kitaru/mcp/errors.py
@@ -31,6 +31,7 @@ class MCPToolError(Exception):
     recovery: str | None = None
 
     def __post_init__(self) -> None:
+        """Initialize the `Exception` base with the error message."""
         Exception.__init__(self, self.message)
 
 
@@ -41,6 +42,7 @@ class MCPOutputValidationError(Exception):
     validation_error: ValidationError
 
     def __post_init__(self) -> None:
+        """Initialize the `Exception` base with a fixed validation message."""
         Exception.__init__(self, "MCP handler output validation failed")
 
 

--- a/src/kitaru/mcp/lifecycle.py
+++ b/src/kitaru/mcp/lifecycle.py
@@ -24,6 +24,7 @@ class MCPServerState:
     _closed: bool = field(default=False, init=False)
 
     def __post_init__(self) -> None:
+        """Create the semaphore from the configured maximum concurrency."""
         self.semaphore = asyncio.Semaphore(self.settings.max_concurrency)
 
     async def execute(self, operation: Callable[[], Awaitable[ResultT]]) -> ResultT:

--- a/src/kitaru/mcp/models/activity.py
+++ b/src/kitaru/mcp/models/activity.py
@@ -31,6 +31,8 @@ class ActivityGetRequest(MCPModel):
 
 
 class SessionNodesRequest(MCPModel):
+    """List a session's child nodes."""
+
     operation: Literal["list_children"]
     kind: Literal["session_nodes"]
     parent_id: uuid.UUID
@@ -40,6 +42,8 @@ class SessionNodesRequest(MCPModel):
 
 
 class SortedChildrenRequest(PageOptions):
+    """List an experiment run's jobs or a job's tasks, sorted."""
+
     operation: Literal["list_children"]
     kind: Literal["experiment_run_jobs", "job_tasks"]
     parent_id: uuid.UUID

--- a/src/kitaru/mcp/references.py
+++ b/src/kitaru/mcp/references.py
@@ -59,6 +59,7 @@ class ReferenceResolutionError(Exception):
     details: dict[str, JsonValue] | None = None
 
     def __post_init__(self) -> None:
+        """Initialize the `Exception` base with the error message."""
         Exception.__init__(self, self.message)
 
 

--- a/tests/client/test_experiment_runs.py
+++ b/tests/client/test_experiment_runs.py
@@ -114,8 +114,10 @@ async def agent_id(services: ReplayServices) -> uuid.UUID:
 async def run_request(
     services: ReplayServices, agent_id: uuid.UUID
 ) -> ExperimentRunCreateRequest:
-    """Provide a run request naming a non-empty cohort version and a runnable
-    version."""
+    """Provide a run request for an experiment run.
+
+    The request names a non-empty cohort version and a runnable version.
+    """
     version = await create_agent_version(
         services.agent_versions,
         agent_id=agent_id,

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -2510,6 +2510,7 @@
         },
         "SessionNodesRequest": {
           "additionalProperties": false,
+          "description": "List a session's child nodes.",
           "properties": {
             "cursor": {
               "anyOf": [
@@ -2561,6 +2562,7 @@
         },
         "SortedChildrenRequest": {
           "additionalProperties": false,
+          "description": "List an experiment run's jobs or a job's tasks, sorted.",
           "properties": {
             "cursor": {
               "anyOf": [

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,13 +6,13 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 151641,
+      "discovery_response_bytes": 151759,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
           "$defs_count": 43,
-          "combined_bytes": 33543,
-          "input_bytes": 5090,
+          "combined_bytes": 33661,
+          "input_bytes": 5208,
           "maximum_nesting_depth": 8,
           "output_bytes": 28453
         },
@@ -89,13 +89,13 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 78003,
+      "discovery_response_bytes": 78121,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
           "$defs_count": 43,
-          "combined_bytes": 33543,
-          "input_bytes": 5090,
+          "combined_bytes": 33661,
+          "input_bytes": 5208,
           "maximum_nesting_depth": 8,
           "output_bytes": 28453
         },
@@ -116,13 +116,13 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 140249,
+      "discovery_response_bytes": 140367,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
           "$defs_count": 43,
-          "combined_bytes": 33543,
-          "input_bytes": 5090,
+          "combined_bytes": 33661,
+          "input_bytes": 5208,
           "maximum_nesting_depth": 8,
           "output_bytes": 28453
         },

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -2510,6 +2510,7 @@
         },
         "SessionNodesRequest": {
           "additionalProperties": false,
+          "description": "List a session's child nodes.",
           "properties": {
             "cursor": {
               "anyOf": [
@@ -2561,6 +2562,7 @@
         },
         "SortedChildrenRequest": {
           "additionalProperties": false,
+          "description": "List an experiment run's jobs or a job's tasks, sorted.",
           "properties": {
             "cursor": {
               "anyOf": [

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -2510,6 +2510,7 @@
         },
         "SessionNodesRequest": {
           "additionalProperties": false,
+          "description": "List a session's child nodes.",
           "properties": {
             "cursor": {
               "anyOf": [
@@ -2561,6 +2562,7 @@
         },
         "SortedChildrenRequest": {
           "additionalProperties": false,
+          "description": "List an experiment run's jobs or a job's tasks, sorted.",
           "properties": {
             "cursor": {
               "anyOf": [

--- a/tests/server/test_agent_repository.py
+++ b/tests/server/test_agent_repository.py
@@ -52,8 +52,11 @@ Setup = tuple[AgentRepository, uuid.UUID, Callable[[], AgentVersionRepository]]
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
-    """Provide each agent repository implementation, an owner id, and a
-    version repository factory sharing the same backing store."""
+    """Provide each agent repository implementation and its collaborators.
+
+    Yields the repository, an owner id, and a version repository factory
+    sharing the same backing store.
+    """
     if request.param == "fake":
         agents = FakeAgentRepository()
         yield agents, uuid.uuid4(), lambda: FakeAgentVersionRepository(agents)

--- a/tests/server/test_agent_version_repository.py
+++ b/tests/server/test_agent_version_repository.py
@@ -70,10 +70,12 @@ Setup = tuple[
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
-    """Provide each agent version repository implementation, an owner id, an
-    agent id to attach versions to, factories for further agent ids and
-    secret ids a run spec can reference, and a tag repository sharing the
-    backend."""
+    """Provide each agent version repository implementation and its collaborators.
+
+    Yields the repository, an owner id, an agent id to attach versions to,
+    factories for further agent ids and secret ids a run spec can reference,
+    and a tag repository sharing the backend.
+    """
     if request.param == "fake":
         agents = FakeAgentRepository()
         secrets = FakeSecretRepository()

--- a/tests/server/test_annotation_repository.py
+++ b/tests/server/test_annotation_repository.py
@@ -117,9 +117,12 @@ async def _link_investigation_session(
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
-    """Provide each annotation repository implementation, an investigation
-    repository sharing its backend, an owner id, a factory for session ids,
-    and a factory linking a session into a fresh one-question investigation."""
+    """Provide each annotation repository implementation and its collaborators.
+
+    Yields the repository, an investigation repository sharing its backend, an
+    owner id, a factory for session ids, and a factory linking a session into a
+    fresh one-question investigation.
+    """
     if request.param == "fake":
         investigations = FakeInvestigationRepository()
         annotations = FakeAnnotationRepository(investigations=investigations)

--- a/tests/server/test_cohort_repository.py
+++ b/tests/server/test_cohort_repository.py
@@ -48,8 +48,11 @@ Setup = tuple[CohortRepository, uuid.UUID, uuid.UUID, TagRepository]
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
-    """Provide each cohort repository implementation, an owner id, an agent
-    id to attach cohorts to, and a tag repository sharing the backend."""
+    """Provide each cohort repository implementation and its collaborators.
+
+    Yields the repository, an owner id, an agent id to attach cohorts to, and
+    a tag repository sharing the backend.
+    """
     if request.param == "fake":
         tags = FakeTagRepository()
         yield FakeCohortRepository(tags=tags), uuid.uuid4(), uuid.uuid4(), tags

--- a/tests/server/test_cohort_version_repository.py
+++ b/tests/server/test_cohort_version_repository.py
@@ -97,12 +97,14 @@ Setup = tuple[
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
-    """Provide each cohort version repository implementation, a session
-    repository sharing its backend, an owner id, a cohort id to attach
-    versions to, a factory for further cohort ids, a factory for further
-    session ids on the cohort's agent, a factory attaching an experiment
-    run to a given cohort version id, and a tag repository sharing the
-    backend."""
+    """Provide each cohort version repository implementation and its collaborators.
+
+    Yields the repository, a session repository sharing its backend, an owner
+    id, a cohort id to attach versions to, a factory for further cohort ids, a
+    factory for further session ids on the cohort's agent, a factory attaching
+    an experiment run to a given cohort version id, and a tag repository
+    sharing the backend.
+    """
     if request.param == "fake":
         sessions = FakeSessionRepository()
         cohorts = FakeCohortRepository()

--- a/tests/server/test_evaluation_repository.py
+++ b/tests/server/test_evaluation_repository.py
@@ -160,8 +160,11 @@ async def _create_session_row(
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
-    """Provide each evaluation repository implementation, an owner id, and a
-    session id to attach evaluations to."""
+    """Provide each evaluation repository implementation and its collaborators.
+
+    Yields the repository, an owner id, and a session id to attach
+    evaluations to.
+    """
     if request.param == "fake":
         yield FakeEvaluationRepository(), uuid.uuid4(), uuid.uuid4()
         return
@@ -191,8 +194,10 @@ async def test_merge_inserts_new_evaluations(setup: Setup) -> None:
 
 
 async def test_merge_overwrites_matching_name_and_keeps_id(setup: Setup) -> None:
-    """Resending a name overwrites its score, value, data type, and
-    explanation, while keeping the row id, owner, and creation time."""
+    """Resending a name overwrites its score, value, data type, and explanation.
+
+    The row id, owner, and creation time are kept.
+    """
     repository, owner_id, session_id = setup
     first = await repository.merge_session_evaluations(
         session_id,
@@ -309,8 +314,10 @@ async def test_get_not_found(setup: Setup) -> None:
 async def session_pair(
     request: pytest.FixtureRequest,
 ) -> AsyncGenerator[tuple[EvaluationRepository, uuid.UUID, uuid.UUID, uuid.UUID], None]:
-    """Provide an evaluation repository, an owner id, and two distinct
-    session ids to score."""
+    """Provide an evaluation repository and its collaborators.
+
+    Yields the repository, an owner id, and two distinct session ids to score.
+    """
     if request.param == "fake":
         yield FakeEvaluationRepository(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
         return
@@ -425,8 +432,11 @@ async def test_query_task_id_filter(setup: Setup) -> None:
 async def plugin_setup(
     request: pytest.FixtureRequest,
 ) -> AsyncGenerator[PluginSetup, None]:
-    """Provide a plugin repository and an evaluation repository sharing one
-    backend, an owner id, and a session id."""
+    """Provide plugin and evaluation repositories and their collaborators.
+
+    Yields a plugin repository and an evaluation repository sharing one
+    backend, an owner id, and a session id.
+    """
     if request.param == "fake":
         plugin_repository = FakePluginRepository()
         evaluation_repository = FakeEvaluationRepository(

--- a/tests/server/test_experiment_run_repository.py
+++ b/tests/server/test_experiment_run_repository.py
@@ -81,8 +81,11 @@ Setup = tuple[
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
-    """Provide each run repository implementation, an owner id, and factories
-    for a fresh experiment id, cohort version id, and agent version id."""
+    """Provide each run repository implementation and its collaborators.
+
+    Yields the repository, an owner id, and factories for a fresh experiment
+    id, cohort version id, and agent version id.
+    """
     if request.param == "fake":
         owner_id = uuid.uuid4()
 

--- a/tests/server/test_investigation_repository.py
+++ b/tests/server/test_investigation_repository.py
@@ -75,9 +75,12 @@ Setup = tuple[
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
-    """Provide each investigation repository implementation, an owner id, an
-    agent id, a factory for further session ids on that agent, and a factory
-    for further agent ids under the same owner."""
+    """Provide each investigation repository implementation and its collaborators.
+
+    Yields the repository, an owner id, an agent id, a factory for further
+    session ids on that agent, and a factory for further agent ids under the
+    same owner.
+    """
     if request.param == "fake":
         investigations = FakeInvestigationRepository()
         sessions = FakeSessionRepository()

--- a/tests/server/test_replay_repository.py
+++ b/tests/server/test_replay_repository.py
@@ -73,8 +73,11 @@ Setup = tuple[
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
-    """Provide each replay repository implementation, an owner id, and factories
-    for a fresh job id, replay config id, and baseline session id."""
+    """Provide each replay repository implementation and its collaborators.
+
+    Yields the repository, an owner id, and factories for a fresh job id,
+    replay config id, and baseline session id.
+    """
     if request.param == "fake":
         owner_id = uuid.uuid4()
         jobs = FakeJobRepository()

--- a/tests/server/test_session_node_repository.py
+++ b/tests/server/test_session_node_repository.py
@@ -75,8 +75,11 @@ ScopedSetup = tuple[
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
-    """Provide each session node repository implementation, a session id to
-    attach nodes to, and a factory for further session ids."""
+    """Provide each session node repository implementation and its collaborators.
+
+    Yields the repository, a session id to attach nodes to, and a factory for
+    further session ids.
+    """
     if request.param == "fake":
         sessions = FakeSessionRepository()
         owner_id = uuid.uuid4()
@@ -117,10 +120,13 @@ async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
 async def scoped_setup(
     request: pytest.FixtureRequest,
 ) -> AsyncGenerator[ScopedSetup, None]:
-    """Provide a session node repository wired to sessions and cohort versions
+    """Provide a cohort-scoped session node repository and its collaborators.
+
+    Yields a session node repository wired to sessions and cohort versions
     sharing its backend, a cohort repository, a cohort version repository, an
     owner id, a factory for agent ids, and a factory for session ids on a
-    given agent."""
+    given agent.
+    """
     if request.param == "fake":
         sessions = FakeSessionRepository()
         cohorts = FakeCohortRepository()

--- a/tests/server/test_session_repository.py
+++ b/tests/server/test_session_repository.py
@@ -126,9 +126,12 @@ CohortSetup = tuple[
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
-    """Provide each session repository implementation, an owner id, an agent
-    id to attach sessions to, a tag repository, and an evaluation repository,
-    the last two sharing the session repository's backend."""
+    """Provide each session repository implementation and its collaborators.
+
+    Yields the repository, an owner id, an agent id to attach sessions to, a
+    tag repository, and an evaluation repository, the last two sharing the
+    session repository's backend.
+    """
     if request.param == "fake":
         tags = FakeTagRepository()
         evaluations = FakeEvaluationRepository()
@@ -160,8 +163,11 @@ async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
 async def cohort_setup(
     request: pytest.FixtureRequest,
 ) -> AsyncGenerator[CohortSetup, None]:
-    """Provide a session repository wired to cohort and cohort version
-    repositories sharing its backend, an owner id, and an agent id."""
+    """Provide a cohort-aware session repository and its collaborators.
+
+    Yields a session repository wired to cohort and cohort version
+    repositories sharing its backend, an owner id, and an agent id.
+    """
     if request.param == "fake":
         sessions = FakeSessionRepository()
         cohorts = FakeCohortRepository()
@@ -610,8 +616,7 @@ async def test_update_not_found(setup: Setup) -> None:
 
 
 async def test_update_duplicate_external_id(setup: Setup) -> None:
-    """Reject an update that collides with another session's imported_from and
-    external id."""
+    """Reject an update colliding on another session's imported_from + external id."""
     repository, owner_id, agent_id, _, _ = setup
     await repository.create(
         Session(
@@ -1261,8 +1266,10 @@ async def test_query_filters_by_in_expression(setup: Setup) -> None:
 
 
 async def test_query_filters_by_string_ops_on_name(setup: Setup) -> None:
-    """Match name with startswith, endswith, and contains, autoescaping SQL
-    wildcards in the contains value."""
+    """Match name with startswith, endswith, and contains.
+
+    SQL wildcards in the contains value are autoescaped.
+    """
     repository, owner_id, agent_id, _, _ = setup
     web_run = await repository.create(
         Session(

--- a/tests/server/test_sessions_api.py
+++ b/tests/server/test_sessions_api.py
@@ -83,8 +83,7 @@ def session_repository(
     tag_repository: FakeTagRepository,
     evaluation_repository: FakeEvaluationRepository,
 ) -> FakeSessionRepository:
-    """Provide the fake session repository backing the app, tag- and
-    evaluation-aware."""
+    """Provide the tag- and evaluation-aware fake session repository for the app."""
     return FakeSessionRepository(tags=tag_repository, evaluations=evaluation_repository)
 
 
@@ -105,8 +104,10 @@ def cohort_version_repository(
     cohort_repository: FakeCohortRepository,
     session_repository: FakeSessionRepository,
 ) -> FakeCohortVersionRepository:
-    """Provide the fake cohort version repository wired to the session
-    repository backing the app."""
+    """Provide the fake cohort version repository backing the app.
+
+    The repository is wired to the fake session repository.
+    """
     return FakeCohortVersionRepository(
         cohorts=cohort_repository, sessions=session_repository
     )
@@ -624,8 +625,7 @@ async def test_update_session_status_cannot_be_cleared(
 async def test_update_session_rejects_terminal_back_to_in_progress(
     client: httpx.AsyncClient,
 ) -> None:
-    """Observe HTTP 409 when the update moves a terminal session back to
-    in_progress."""
+    """Return HTTP 409 when an update moves a terminal session to in_progress."""
     created = (await client.post("/api/v1/sessions", json=_session_body())).json()
     await client.patch(f"/api/v1/sessions/{created['id']}", json={"status": "failed"})
     response = await client.patch(

--- a/tests/server/test_ui_api.py
+++ b/tests/server/test_ui_api.py
@@ -72,8 +72,7 @@ def session_repository(
     tag_repository: FakeTagRepository,
     evaluation_repository: FakeEvaluationRepository,
 ) -> FakeSessionRepository:
-    """Provide the fake session repository backing the app, tag- and
-    evaluation-aware."""
+    """Provide the tag- and evaluation-aware fake session repository for the app."""
     return FakeSessionRepository(tags=tag_repository, evaluations=evaluation_repository)
 
 
@@ -94,8 +93,10 @@ def cohort_version_repository(
     cohort_repository: FakeCohortRepository,
     session_repository: FakeSessionRepository,
 ) -> FakeCohortVersionRepository:
-    """Provide the fake cohort version repository wired to the session
-    repository backing the app."""
+    """Provide the fake cohort version repository backing the app.
+
+    The repository is wired to the fake session repository.
+    """
     return FakeCohortVersionRepository(
         cohorts=cohort_repository, sessions=session_repository
     )


### PR DESCRIPTION
Closes #809.

## What this does

`pyproject.toml` has declared `convention = "google"` under `[tool.ruff.lint.pydocstyle]` for a while, but the `D` rule family was never in the `select` list, so the convention was configured yet unenforced — `ruff check .` (and therefore `just check` and CI lint) passed regardless of docstring state. When the issue was filed the audit showed 228 violations; by the time of this branch it had grown to 310, which is the problem in miniature: without the rule enabled, the backlog only grows.

This PR enables `D` and clears the baseline:

- **Enforcement scope:** full `D` enforcement on `src/` and `scripts/`. `tests/**` gets a per-file-ignore for the missing-docstring rules only (`D1`), so test helpers may omit docstrings, but any docstring a test *does* have must still satisfy the Google formatting rules (`D2xx` and up). `scripts/google_adk_fakes.py` also skips `D1`: it is a file of test doubles whose methods only mirror the real ADK surface, and the class-level docstrings already say what each fake stands in for. Both exemptions are commented in `pyproject.toml`.
- **Baseline fixes:** 24 auto-fixed `D209` closing-quote placements, 24 `D205` summary/description reflows in `tests/`, missing docstrings added across `scripts/` and `src/kitaru/mcp/`.
- **MCP schema snapshots regenerated:** two of the new docstrings sit on Pydantic models in `src/kitaru/mcp/models/activity.py`, and Pydantic publishes a model's docstring as the `description` field of its JSON schema, so the committed MCP tool-schema snapshots changed.
- **Lychee exclusion widened:** the offline link check previously excluded only `docs/node_modules`, so running the TypeScript tests locally (which installs `v2_examples/*/node_modules`) made a subsequent `just check` fail on third-party package READMEs. The recipe now excludes all `node_modules` directories; the scanned-file count for tracked docs is unchanged (515 before and after).

The `plugins/` tree is intentionally untouched — it is already excluded from this Ruff configuration and keeps its own lint setup.

## Reviewer Notes

The riskiest part of this PR is not the docstrings, it is the two places where a docstring is *not* just documentation:

1. **`src/kitaru/mcp/models/activity.py` + `tests/mcp/snapshots/*.json`** — the docstrings on `SessionNodesRequest` and `SortedChildrenRequest` become part of the published MCP tool schemas. The snapshot diff is small (two `description` fields plus updated byte counts in `metrics.json`), but it is real API surface. The wording was deliberately kept short because `kitaru_activity_read` sits close to its per-tool schema-size budget in `tests/mcp/test_registry_runtime.py`; after this change it is 33661 bytes against a 33792-byte budget. If you would rather keep these models out of the schema entirely, the alternative is dropping the two docstrings and their snapshot changes.
2. **`pyproject.toml`** — the shape of the per-file-ignores decides what CI enforces forever after. `"tests/**" = ["D1"]` is prefix-granular on purpose: listing `D100`–`D107` individually would silently miss future rules in that family.

Everything else is mechanical: the `tests/` changes only reshape existing docstrings (summary line, blank line, description — no test logic touched), and the `scripts/`/`src/kitaru/mcp/` changes only add docstrings. The `Justfile` change affects the local `links`/`links-external` recipes only, not what CI installs.

### Reproduction

```bash
# On develop: the convention is configured but nothing enforces it
git checkout develop && uv run ruff check --select D . | tail -1   # ~310 errors
uv run ruff check . | tail -1                                       # passes anyway

# On this branch: the same command now enforces docstrings
git checkout feat/enable-pydocstyle && uv run ruff check . | tail -1  # passes, D active
# Delete any docstring in src/kitaru/ and rerun — ruff now fails with a D1xx error.
```

Local checks run: `just check` and `just test` (3577 passed, 16 skipped) both green, including the MCP schema-budget tests after snapshot regeneration.