### PR TITLE
Register a new worker on every start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - Every worker start now registers a new worker, worker names are labels and no longer need to be unique. Worker listings leave stale workers out unless `include_stale` is set. `kitaru worker get` takes a worker id, the name lookup it also accepted is gone.
+- Server analytics events now carry the reporting client in `client_version`, as the client name and the version it reported. Each client versions on its own series, so a bare version says nothing without the client that sent it.
 - Registering a worker from the Kitaru 0.22.2 Python SDK or older is rejected with HTTP 426. Those versions renew a worker token by registering again, which a server that gives every registration its own id cannot serve: the worker goes on heartbeating an id its token no longer names, and the tasks it is running get swept away from it. Upgrade workers along with the server. Every other caller is unaffected.
 
 ## [0.22.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `POST /api/v1/workers/{worker_id}/token` to renew a worker token, and `kitaru worker list --include-stale` to list workers past the liveness window.
+
+### Changed
+
+- Every worker start now registers a new worker, worker names are labels and no longer need to be unique. Worker listings leave stale workers out unless `include_stale` is set. `kitaru worker get` takes a worker id, the name lookup it also accepted is gone.
+- Registering a worker from the Kitaru 0.22.2 Python SDK or older is rejected with HTTP 426. Those versions renew a worker token by registering again, which a server that gives every registration its own id cannot serve: the worker goes on heartbeating an id its token no longer names, and the tasks it is running get swept away from it. Upgrade workers along with the server. Every other caller is unaffected.
+
 ## [0.22.2]
 
 ### Changed

--- a/docs/book/concepts/workers.md
+++ b/docs/book/concepts/workers.md
@@ -51,6 +51,6 @@ kitaru worker list
 kitaru worker get <worker-id>
 ```
 
-A worker record exposes `last_seen_at`, the time of its last observed heartbeat, and `live`, the server's current liveness calculation. These are observations, not assignment guarantees: a worker can become unavailable after its last heartbeat, and a live worker may not match a task's scope or win its claim. The native MCP server exposes the same list and exact-UUID get operations through the read-only `kitaru_registry_read` tool. It cannot register, update, delete, or control workers.
+`kitaru worker list` shows live workers, add `--include-stale` for the rest. Names are labels shared by any number of workers, so `kitaru worker get` takes an id from that listing. A worker record exposes `last_seen_at`, the time of its last observed heartbeat, and `live`, the server's current liveness calculation. These are observations, not assignment guarantees: a worker can become unavailable after its last heartbeat, and a live worker may not match a task's scope or win its claim. The native MCP server exposes the same list and exact-UUID get operations through the read-only `kitaru_registry_read` tool. It cannot register, update, delete, or control workers.
 
 A worker that stops heartbeating loses its tasks: the server requeues them for the next worker (or fails them at the retry cap), so a crashed pod never strands a replay.

--- a/docs/book/deploy/authentication.md
+++ b/docs/book/deploy/authentication.md
@@ -64,9 +64,9 @@ This is intended for local developer workflows. It reads the CLI store without m
 
 ## Workers and tasks get scoped tokens
 
-An API key is the only long-lived credential a worker holds. It uses the key to register and again whenever it re-registers to renew its worker token. Credentials narrow for task execution:
+An API key is the only long-lived credential a worker holds. It uses the key to register and again whenever it renews its worker token. Credentials narrow for task execution:
 
-- Registering (`kitaru worker start`) returns a **worker token**, a bearer token scoped to that one worker, which the worker renews on its own by re-registering under the same name.
+- Registering (`kitaru worker start`) returns a **worker token**, a bearer token scoped to that one worker, which the worker renews on its own through `POST /api/v1/workers/{worker_id}/token`.
 - Each claimed task comes with a **task token** scoped to that single task and attempt, carrying an explicit allowlist of the sessions and blobs the task may touch. The worker hands _that_ to your agent subprocess as `KITARU_API_TOKEN`, and your broad API key is stripped from the child environment.
 
 Clients that consume `KITARU_API_TOKEN`, including `KitaruAPIClient`, use the task-scoped credential. Its expiry is set when the task is claimed to the task's execution timeout plus a server-configured leeway; completing the attempt does not revoke it immediately. The CLI does not currently consume that variable and may fall back to a stored login credential. Run workers under a dedicated OS or container identity with no broader stored Kitaru credentials when agent code can invoke the CLI.

--- a/docs/book/deploy/workers.md
+++ b/docs/book/deploy/workers.md
@@ -24,7 +24,7 @@ kitaru worker start
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `KITARU_WORKER_NAME` | hostname-pid | Stable name; restarts reuse the worker registration. In Kubernetes the pod name works out of the box. |
+| `KITARU_WORKER_NAME` | hostname-pid | Label shown in worker listings. Every start registers a new worker, names need not be unique. |
 | `KITARU_WORKER_CONCURRENCY` | 10 | Tasks run in parallel |
 | `KITARU_WORKER_SCOPE__CLAIMS` | all | JSON list of claims, such as `{"kind":"agent"}` or `{"kind":"agent","agent_version_id":"<UUID>"}` |
 | `KITARU_WORKER_SCOPE__SELECTORS` | none | JSON label selectors (e.g. limit to one agent version's environment) |
@@ -64,5 +64,5 @@ This is the pattern for [CI regression gates](../guides/regression-suite.md): th
 
 - **Draining**: SIGINT/SIGTERM stops claiming and finishes in-flight tasks; a second signal exits immediately. Per-task timeouts (set server-side and on agent versions) bound the wait.
 - **Crash safety**: a worker that dies stops heartbeating; the server requeues its tasks to the next worker (up to the retry limit). No replay is lost to a pod eviction.
-- **Liveness**: `kitaru worker list` shows the fleet and when each worker was last seen.
+- **Liveness**: `kitaru worker list` shows the live fleet and when each worker was last seen. Add `--include-stale` to see workers past the liveness window.
 - **Subprocess environments**: evaluator and importer plugins run via `uv` in isolated per-plugin environments, cached by content hash; agent tasks run the agent version's command in the worker's own environment plus the version's [secrets](secrets.md). The default plugins (the five `kitaru/` importers and the built-in evaluator suite) run under the same isolation as plugins you write yourself.

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8632,7 +8632,7 @@
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.22.1+dev"
+    "version": "0.22.2+dev"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -16259,7 +16259,7 @@
         ]
       },
       "post": {
-        "description": "Register a worker.\n\nEvery registration creates a new worker, names are labels and need not\nbe unique. Clients observe HTTP 200 on success, 426 from a Kitaru client\nthat renews by re-registering, and 422 on invalid input.\n\nArgs:\n    body: Worker create request.\n    service: Worker service.\n    auth_service: Authentication service for the current request.\n    actor: Caller context.\n    settings: API settings for this process.\n    client: Client identification header value.\n\nReturns:\n    Stored worker with a bearer token scoped to it.",
+        "description": "Register a worker.\n\nEvery registration creates a new worker, names are labels and need not\nbe unique. Clients observe HTTP 200 on success, 426 from an SDK that\nrenews by re-registering, and 422 on invalid input.\n\nArgs:\n    body: Worker create request.\n    service: Worker service.\n    auth_service: Authentication service for the current request.\n    actor: Caller context.\n    settings: API settings for this process.\n    client: Client identification header value.\n\nReturns:\n    Stored worker with a bearer token scoped to it.",
         "operationId": "register_worker_api_v1_workers_post",
         "parameters": [
           {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8373,9 +8373,9 @@
           }
         },
         "required": [
-          "worker",
           "token",
-          "token_expires_at"
+          "token_expires_at",
+          "worker"
         ],
         "title": "WorkerRegistrationResponse",
         "type": "object"
@@ -8603,12 +8603,36 @@
         ],
         "title": "WorkerScope",
         "type": "object"
+      },
+      "WorkerTokenResponse": {
+        "description": "Worker token response.",
+        "properties": {
+          "token": {
+            "description": "Bearer token scoped to this worker.",
+            "format": "password",
+            "title": "Token",
+            "type": "string",
+            "writeOnly": true
+          },
+          "token_expires_at": {
+            "description": "Time the token expires.",
+            "format": "date-time",
+            "title": "Token Expires At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "token_expires_at"
+        ],
+        "title": "WorkerTokenResponse",
+        "type": "object"
       }
     }
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.22.2"
+    "version": "0.22.1+dev"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -16119,7 +16143,7 @@
     },
     "/api/v1/workers": {
       "get": {
-        "description": "List workers.\n\nClients observe HTTP 200 on success and 422 on invalid pagination\nparameters.\n\nArgs:\n    service: Worker service.\n    actor: Caller context.\n    settings: API settings for this process.\n    params: Worker list params.\n\nReturns:\n    Page of workers.",
+        "description": "List workers.\n\nWorkers past the liveness window are left out unless include_stale is\nset. Clients observe HTTP 200 on success and 422 on invalid pagination\nparameters.\n\nArgs:\n    service: Worker service.\n    actor: Caller context.\n    settings: API settings for this process.\n    params: Worker list params.\n\nReturns:\n    Page of workers.",
         "operationId": "list_workers_api_v1_workers_get",
         "parameters": [
           {
@@ -16193,6 +16217,18 @@
               "description": "Filter expression, JSON-encoded in the query string.",
               "title": "Filter"
             }
+          },
+          {
+            "description": "Include workers past the liveness window.",
+            "in": "query",
+            "name": "include_stale",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Include workers past the liveness window.",
+              "title": "Include Stale",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -16223,8 +16259,20 @@
         ]
       },
       "post": {
-        "description": "Register a worker, upserting by name.\n\nRe-registration refreshes the scope, runtime, and metadata, stamps\nlast_seen_at, and mints a fresh token, keeping the id and created time.\nRe-registering with a fresh token is how a worker renews before its\ncurrent token expires. Clients observe HTTP 200 on both the first\nregistration and every re-registration, and 422 on invalid input.\n\nArgs:\n    body: Worker create request.\n    service: Worker service.\n    auth_service: Authentication service for the current request.\n    actor: Caller context.\n    settings: API settings for this process.\n\nReturns:\n    Stored worker with a bearer token scoped to it.",
+        "description": "Register a worker.\n\nEvery registration creates a new worker, names are labels and need not\nbe unique. Clients observe HTTP 200 on success, 426 from a Kitaru client\nthat renews by re-registering, and 422 on invalid input.\n\nArgs:\n    body: Worker create request.\n    service: Worker service.\n    auth_service: Authentication service for the current request.\n    actor: Caller context.\n    settings: API settings for this process.\n    client: Client identification header value.\n\nReturns:\n    Stored worker with a bearer token scoped to it.",
         "operationId": "register_worker_api_v1_workers_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Kitaru-Client",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "X-Kitaru-Client",
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -16391,6 +16439,50 @@
           }
         },
         "summary": "Heartbeat Worker",
+        "tags": [
+          "workers"
+        ]
+      }
+    },
+    "/api/v1/workers/{worker_id}/token": {
+      "post": {
+        "description": "Issue a fresh token for a registered worker.\n\nRenewal stamps last_seen_at. Clients observe HTTP 200 on success, 403\nwhen the worker belongs to another account, and 404 when no worker has\nthis id.\n\nArgs:\n    worker_id: Id of the worker.\n    service: Worker service.\n    auth_service: Authentication service for the current request.\n    actor: Caller context.\n\nReturns:\n    Bearer token scoped to the worker.",
+        "operationId": "renew_worker_token_api_v1_workers__worker_id__token_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "worker_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Worker Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkerTokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Renew Worker Token",
         "tags": [
           "workers"
         ]

--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -3335,7 +3335,8 @@ export interface paths {
          * List Workers
          * @description List workers.
          *
-         *     Clients observe HTTP 200 on success and 422 on invalid pagination
+         *     Workers past the liveness window are left out unless include_stale is
+         *     set. Clients observe HTTP 200 on success and 422 on invalid pagination
          *     parameters.
          *
          *     Args:
@@ -3351,13 +3352,11 @@ export interface paths {
         put?: never;
         /**
          * Register Worker
-         * @description Register a worker, upserting by name.
+         * @description Register a worker.
          *
-         *     Re-registration refreshes the scope, runtime, and metadata, stamps
-         *     last_seen_at, and mints a fresh token, keeping the id and created time.
-         *     Re-registering with a fresh token is how a worker renews before its
-         *     current token expires. Clients observe HTTP 200 on both the first
-         *     registration and every re-registration, and 422 on invalid input.
+         *     Every registration creates a new worker, names are labels and need not
+         *     be unique. Clients observe HTTP 200 on success, 426 from a Kitaru client
+         *     that renews by re-registering, and 422 on invalid input.
          *
          *     Args:
          *         body: Worker create request.
@@ -3365,6 +3364,7 @@ export interface paths {
          *         auth_service: Authentication service for the current request.
          *         actor: Caller context.
          *         settings: API settings for this process.
+         *         client: Client identification header value.
          *
          *     Returns:
          *         Stored worker with a bearer token scoped to it.
@@ -3445,6 +3445,39 @@ export interface paths {
          *         Held tasks the worker should stop running.
          */
         post: operations["heartbeat_worker_api_v1_workers__worker_id__heartbeat_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/workers/{worker_id}/token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Renew Worker Token
+         * @description Issue a fresh token for a registered worker.
+         *
+         *     Renewal stamps last_seen_at. Clients observe HTTP 200 on success, 403
+         *     when the worker belongs to another account, and 404 when no worker has
+         *     this id.
+         *
+         *     Args:
+         *         worker_id: Id of the worker.
+         *         service: Worker service.
+         *         auth_service: Authentication service for the current request.
+         *         actor: Caller context.
+         *
+         *     Returns:
+         *         Bearer token scoped to the worker.
+         */
+        post: operations["renew_worker_token_api_v1_workers__worker_id__token_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -8238,6 +8271,24 @@ export interface components {
              */
             selectors?: components["schemas"]["LabelSelector"][] | null;
         };
+        /**
+         * WorkerTokenResponse
+         * @description Worker token response.
+         */
+        WorkerTokenResponse: {
+            /**
+             * Token
+             * Format: password
+             * @description Bearer token scoped to this worker.
+             */
+            token: string;
+            /**
+             * Token Expires At
+             * Format: date-time
+             * @description Time the token expires.
+             */
+            token_expires_at: string;
+        };
     };
     responses: never;
     parameters: never;
@@ -12633,6 +12684,8 @@ export interface operations {
                 sort?: string;
                 /** @description Filter expression, JSON-encoded in the query string. */
                 filter?: components["schemas"]["FilterCondition"] | components["schemas"]["AndFilter"] | components["schemas"]["OrFilter"] | components["schemas"]["NotFilter"] | null;
+                /** @description Include workers past the liveness window. */
+                include_stale?: boolean;
             };
             header?: never;
             path?: never;
@@ -12663,7 +12716,9 @@ export interface operations {
     register_worker_api_v1_workers_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-Kitaru-Client"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -12775,6 +12830,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WorkerHeartbeatResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    renew_worker_token_api_v1_workers__worker_id__token_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                worker_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkerTokenResponse"];
                 };
             };
             /** @description Validation Error */

--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -3355,8 +3355,8 @@ export interface paths {
          * @description Register a worker.
          *
          *     Every registration creates a new worker, names are labels and need not
-         *     be unique. Clients observe HTTP 200 on success, 426 from a Kitaru client
-         *     that renews by re-registering, and 422 on invalid input.
+         *     be unique. Clients observe HTTP 200 on success, 426 from an SDK that
+         *     renews by re-registering, and 422 on invalid input.
          *
          *     Args:
          *         body: Worker create request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.22.2"
+version = "0.22.2+dev"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/release_units.py
+++ b/scripts/release_units.py
@@ -89,6 +89,22 @@ class ReleaseInventory:
         return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
 
 
+def validate_canonical_version(value: str) -> str:
+    """Validate and return a canonical PEP 440 version."""
+    try:
+        version = Version(value)
+    except InvalidVersion as error:
+        raise ReleaseInventoryError(
+            f"version must be canonical PEP 440: {value}"
+        ) from error
+    canonical = str(version)
+    if canonical != value:
+        raise ReleaseInventoryError(
+            f"version must be canonical PEP 440: {value} normalizes to {canonical}"
+        )
+    return canonical
+
+
 def validate_version(value: str) -> str:
     """Validate and return a canonical PEP 440 public version."""
     try:
@@ -158,7 +174,7 @@ def _parse_manifest(
     if not isinstance(project, dict):
         raise ReleaseInventoryError(f"{context}: version source has no [project] table")
     name = _get_string(project, "name", context)
-    version = validate_version(_get_string(project, "version", context))
+    version = validate_canonical_version(_get_string(project, "version", context))
     return name, version, project
 
 

--- a/src/kitaru/analytics/source.py
+++ b/src/kitaru/analytics/source.py
@@ -16,7 +16,6 @@
 from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import StrEnum
-from importlib.metadata import version
 
 
 class AnalyticsSource(StrEnum):
@@ -44,15 +43,3 @@ _DEFAULT_ATTRIBUTION = AnalyticsAttribution()
 current_attribution: ContextVar[AnalyticsAttribution] = ContextVar(
     "kitaru_analytics_attribution", default=_DEFAULT_ATTRIBUTION
 )
-
-
-def format_client_header(source: AnalyticsSource) -> str:
-    """Format the client identification header value.
-
-    Args:
-        source: Client sending the requests.
-
-    Returns:
-        ``<source>/<version>`` header value.
-    """
-    return f"{source.value}/{version('kitaru')}"

--- a/src/kitaru/analytics/source.py
+++ b/src/kitaru/analytics/source.py
@@ -18,9 +18,6 @@ from dataclasses import dataclass
 from enum import StrEnum
 from importlib.metadata import version
 
-CLIENT_HEADER = "X-Kitaru-Client"
-SKILL_HEADER = "X-Kitaru-Skill"
-
 
 class AnalyticsSource(StrEnum):
     """Analytics event source."""
@@ -38,6 +35,7 @@ class AnalyticsAttribution:
     """Analytics attribution."""
 
     source: AnalyticsSource = AnalyticsSource.PYTHON
+    version: str | None = None
     skill: str | None = None
 
 
@@ -58,21 +56,3 @@ def format_client_header(source: AnalyticsSource) -> str:
         ``<source>/<version>`` header value.
     """
     return f"{source.value}/{version('kitaru')}"
-
-
-def parse_client_header(value: str) -> AnalyticsSource | None:
-    """Parse the source from a client identification header value.
-
-    Args:
-        value: ``<source>/<version>`` header value.
-
-    Returns:
-        Parsed source, or None for an unknown client.
-    """
-    if not value:
-        return None
-    name, _, _ = value.partition("/")
-    try:
-        return AnalyticsSource(name)
-    except ValueError:
-        return None

--- a/src/kitaru/api_models/v1/worker.py
+++ b/src/kitaru/api_models/v1/worker.py
@@ -161,6 +161,10 @@ class WorkerCreateRequest(RequestModel):
 class WorkerListParams(FilterableListParams):
     """Worker list params."""
 
+    include_stale: bool = Field(
+        default=False, description="Include workers past the liveness window."
+    )
+
 
 class WorkerHeartbeatRequest(RequestModel):
     """Worker heartbeat request."""
@@ -188,11 +192,16 @@ class WorkerResponse(OwnedResponseModel):
     metadata: dict[str, str] = Field(description="Arbitrary metadata.")
 
 
-class WorkerRegistrationResponse(ResponseModel):
-    """Worker registration response."""
+class WorkerTokenResponse(ResponseModel):
+    """Worker token response."""
 
-    worker: WorkerResponse = Field(description="Registered worker.")
     token: PlainSerializedSecretStr = Field(
         description="Bearer token scoped to this worker."
     )
     token_expires_at: datetime = Field(description="Time the token expires.")
+
+
+class WorkerRegistrationResponse(WorkerTokenResponse):
+    """Worker registration response."""
+
+    worker: WorkerResponse = Field(description="Registered worker.")

--- a/src/kitaru/cli/app.py
+++ b/src/kitaru/cli/app.py
@@ -3852,7 +3852,7 @@ _WORKER_START_PARAMETERS = (
             "creates_remote_state",
             "executes_local_code",
         ),
-        idempotency="runtime_registration_upsert_by_name",
+        idempotency="non_idempotent_remote_create",
         errors=_ASSET_READ_ERRORS,
         streams=True,
     ),
@@ -3908,8 +3908,17 @@ async def worker_start(
     worker_app,
     _spec(
         ("worker", "list"),
-        "List workers, describing each server record as live or stale.",
-        parameters=_LIST_PARAMETERS,
+        "List live workers, or every server record with --include-stale.",
+        parameters=(
+            *_LIST_PARAMETERS,
+            ParameterSpec(
+                "--include-stale",
+                "boolean",
+                "option",
+                False,
+                "Include workers past the liveness window.",
+            ),
+        ),
         errors=_ASSET_READ_ERRORS,
     ),
 )
@@ -3919,11 +3928,19 @@ async def worker_list(
     cursor: str | None = None,
     sort: str = "created:desc",
     filter: str | None = None,
+    include_stale: Annotated[
+        bool, Parameter(name="--include-stale", negative=False)
+    ] = False,
 ) -> CommandResult:
     """List one server page of worker records."""
     async with _open_asset_client() as client:
         return await workers.list_workers(
-            client, size=size, cursor=cursor, sort=sort, filter=filter
+            client,
+            size=size,
+            cursor=cursor,
+            sort=sort,
+            filter=filter,
+            include_stale=include_stale,
         )
 
 
@@ -3931,16 +3948,12 @@ async def worker_list(
     worker_app,
     _spec(
         ("worker", "get"),
-        "Get a worker by exact UUID or case-sensitive name.",
-        parameters=(
-            ParameterSpec(
-                "WORKER", "reference", "argument", True, "Worker UUID or exact name."
-            ),
-        ),
-        errors=_ASSET_READ_ERRORS,
+        "Get a worker by exact UUID.",
+        parameters=(ParameterSpec("WORKER", "UUID", "argument", True, "Worker ID."),),
+        errors=_UUID_READ_ERRORS,
     ),
 )
-async def worker_get(worker: str, /) -> CommandResult:
+async def worker_get(worker: uuid.UUID, /) -> CommandResult:
     """Get one exact worker record."""
     async with _open_asset_client() as client:
         return await workers.get_worker(client, worker)

--- a/src/kitaru/cli/workers.py
+++ b/src/kitaru/cli/workers.py
@@ -25,7 +25,6 @@ from typing import Any, Literal, Protocol
 
 from pydantic import ValidationError
 
-from kitaru.api_models.v1.filter import FilterCondition, FilterOp
 from kitaru.api_models.v1.task import TaskKind
 from kitaru.api_models.v1.worker import (
     LabelSelector,
@@ -367,6 +366,7 @@ async def list_workers(
     cursor: str | None,
     sort: str,
     filter: str | None,
+    include_stale: bool = False,
 ) -> CommandResult:
     """List one server page of workers with explicit live/stale wording."""
     params = build_list_params(
@@ -376,6 +376,10 @@ async def list_workers(
         sort=sort,
         filter=filter,
     )
+    # Leave include_stale unset unless it was asked for, so the default
+    # listing stays a request a server without the parameter still accepts.
+    if include_stale:
+        params = params.model_copy(update={"include_stale": True})
     page = await client.workers.list(params)
     return CommandResult(
         items=[_worker_item(item) for item in page.items],
@@ -387,34 +391,10 @@ async def list_workers(
     )
 
 
-async def get_worker(client: Any, reference: str) -> CommandResult:
-    """Get a worker by exact UUID or one bounded exact-name lookup."""
-    normalized = reference.strip()
-    if not normalized:
-        raise CLIError("invalid_arguments", "Worker reference cannot be blank.")
-    try:
-        worker_id = uuid.UUID(normalized)
-    except ValueError:
-        worker_id = None
-    if worker_id is not None:
-        item = await client.workers.get(worker_id)
-        return CommandResult(item=_worker_item(item))
-
-    params = WorkerListParams(
-        size=2,
-        filter=FilterCondition(field="name", op=FilterOp.EQ, value=normalized),
-    )
-    page = await client.workers.list(params)
-    matches = [worker for worker in page.items if worker.name == normalized]
-    if not matches:
-        raise CLIError("not_found", f"Worker {normalized!r} was not found.")
-    if len(matches) > 1:
-        raise CLIError(
-            "conflict",
-            f"More than one worker has the exact name {normalized!r}.",
-            details={"ids": [str(worker.id) for worker in matches[:2]]},
-        )
-    return CommandResult(item=_worker_item(matches[0]))
+async def get_worker(client: Any, worker_id: uuid.UUID) -> CommandResult:
+    """Get one worker by id."""
+    item = await client.workers.get(worker_id)
+    return CommandResult(item=_worker_item(item))
 
 
 def _worker_item(worker: Any) -> dict[str, Any]:

--- a/src/kitaru/client/api_client.py
+++ b/src/kitaru/client/api_client.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import httpx
 
-from kitaru.analytics.source import AnalyticsSource, format_client_header
+from kitaru.analytics.source import AnalyticsSource
 from kitaru.api_models.v1.auth import CONTROL_PLANE_API_KEY_PREFIX
 from kitaru.client.auth import (
     CredentialStoreTokenSource,
@@ -63,7 +63,7 @@ from kitaru.client.resources.tags import TagsResource
 from kitaru.client.resources.tasks import TasksResource
 from kitaru.client.resources.users import UsersResource
 from kitaru.client.resources.workers import WorkersResource
-from kitaru.headers import CLIENT_HEADER, SKILL_HEADER
+from kitaru.headers import CLIENT_HEADER, SKILL_HEADER, format_client_header
 from kitaru.transport import build_async_client
 
 

--- a/src/kitaru/client/api_client.py
+++ b/src/kitaru/client/api_client.py
@@ -21,12 +21,7 @@ from typing import Any
 
 import httpx
 
-from kitaru.analytics.source import (
-    CLIENT_HEADER,
-    SKILL_HEADER,
-    AnalyticsSource,
-    format_client_header,
-)
+from kitaru.analytics.source import AnalyticsSource, format_client_header
 from kitaru.api_models.v1.auth import CONTROL_PLANE_API_KEY_PREFIX
 from kitaru.client.auth import (
     CredentialStoreTokenSource,
@@ -68,6 +63,7 @@ from kitaru.client.resources.tags import TagsResource
 from kitaru.client.resources.tasks import TasksResource
 from kitaru.client.resources.users import UsersResource
 from kitaru.client.resources.workers import WorkersResource
+from kitaru.headers import CLIENT_HEADER, SKILL_HEADER
 from kitaru.transport import build_async_client
 
 

--- a/src/kitaru/client/resources/workers.py
+++ b/src/kitaru/client/resources/workers.py
@@ -25,6 +25,7 @@ from kitaru.api_models.v1.worker import (
     WorkerListParams,
     WorkerRegistrationResponse,
     WorkerResponse,
+    WorkerTokenResponse,
 )
 from kitaru.client.resources.pagination import iterate_pages
 
@@ -44,7 +45,7 @@ class WorkersResource:
         self._client = client
 
     async def create(self, request: WorkerCreateRequest) -> WorkerRegistrationResponse:
-        """Register a worker, upserting by name.
+        """Register a worker.
 
         Args:
             request: Worker create request.
@@ -61,6 +62,23 @@ class WorkersResource:
             json=request.model_dump(mode="json", exclude_unset=True),
         )
         return WorkerRegistrationResponse.model_validate(response.json())
+
+    async def renew_token(self, worker_id: uuid.UUID) -> WorkerTokenResponse:
+        """Issue a fresh token for a registered worker.
+
+        Args:
+            worker_id: Id of the worker.
+
+        Raises:
+            APIError: The request failed, including 404 for a missing worker.
+
+        Returns:
+            Worker token and its expiry.
+        """
+        response = await self._client.request(
+            "POST", f"/api/v1/workers/{worker_id}/token"
+        )
+        return WorkerTokenResponse.model_validate(response.json())
 
     async def heartbeat(
         self, worker_id: uuid.UUID, request: WorkerHeartbeatRequest

--- a/src/kitaru/headers.py
+++ b/src/kitaru/headers.py
@@ -11,7 +11,23 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Kitaru request header names."""
+"""Kitaru request headers."""
+
+from importlib.metadata import version
+
+from kitaru.analytics.source import AnalyticsSource
 
 CLIENT_HEADER = "X-Kitaru-Client"
 SKILL_HEADER = "X-Kitaru-Skill"
+
+
+def format_client_header(source: AnalyticsSource) -> str:
+    """Format the client identification header value.
+
+    Args:
+        source: Client sending the requests.
+
+    Returns:
+        ``<source>/<version>`` header value.
+    """
+    return f"{source.value}/{version('kitaru')}"

--- a/src/kitaru/headers.py
+++ b/src/kitaru/headers.py
@@ -11,18 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Tests for the analytics source helpers."""
+"""Kitaru request header names."""
 
-from importlib.metadata import version
-
-from kitaru.analytics.source import (
-    AnalyticsSource,
-    format_client_header,
-)
-
-
-def test_format_client_header() -> None:
-    """Format the source and package version into the header value."""
-    assert format_client_header(AnalyticsSource.PYTHON) == (
-        f"kitaru-python/{version('kitaru')}"
-    )
+CLIENT_HEADER = "X-Kitaru-Client"
+SKILL_HEADER = "X-Kitaru-Skill"

--- a/src/kitaru/server/adapters/db/orm/worker.py
+++ b/src/kitaru/server/adapters/db/orm/worker.py
@@ -16,7 +16,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKeyConstraint, Index, String, UniqueConstraint
+from sqlalchemy import DateTime, ForeignKeyConstraint, Index, String
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -26,17 +26,13 @@ from kitaru.server.adapters.db.orm.base import (
     TimestampMixin,
     UUIDPrimaryKeyMixin,
 )
-from kitaru.server.adapters.db.orm.orm_utils import (
-    foreign_key_name,
-    index_name,
-    unique_constraint_name,
-)
+from kitaru.server.adapters.db.orm.orm_utils import foreign_key_name, index_name
 from kitaru.server.domain.names import MAX_NAME_LENGTH
 from kitaru.server.domain.worker import Worker
 
-WORKER_NAME_UNIQUE_CONSTRAINT = unique_constraint_name("worker", ["name"])
 WORKER_OWNER_ID_FOREIGN_KEY = foreign_key_name("worker", ["owner_id"])
 WORKER_OWNER_ID_INDEX = index_name("worker", ["owner_id"])
+WORKER_LAST_SEEN_AT_INDEX = index_name("worker", ["last_seen_at", "id"])
 
 
 class WorkerORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -44,11 +40,11 @@ class WorkerORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     __tablename__ = "worker"
     __table_args__ = (
-        UniqueConstraint("name", name=WORKER_NAME_UNIQUE_CONSTRAINT),
         ForeignKeyConstraint(
             ["owner_id"], ["account.id"], name=WORKER_OWNER_ID_FOREIGN_KEY
         ),
         Index(WORKER_OWNER_ID_INDEX, "owner_id"),
+        Index(WORKER_LAST_SEEN_AT_INDEX, "last_seen_at", "id"),
     )
 
     owner_id: Mapped[uuid.UUID]
@@ -57,29 +53,6 @@ class WorkerORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     runtime: Mapped[dict] = mapped_column(JSONB)
     last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     metadata_: Mapped[dict[str, str]] = mapped_column("metadata", JSONB)
-
-    @classmethod
-    def column_values(cls, worker: Worker) -> dict[str, object]:
-        """Map a domain worker to its column values, id included.
-
-        Shared by `from_domain` and the upsert statement in
-        `SQLWorkerRepository.register`, so the field list is written once.
-
-        Args:
-            worker: Worker to store.
-
-        Returns:
-            Column values keyed by column name.
-        """
-        return {
-            "id": worker.id,
-            "owner_id": worker.owner_id,
-            "name": worker.name,
-            "scope": worker.scope.model_dump(mode="json"),
-            "runtime": worker.runtime.model_dump(mode="json"),
-            "last_seen_at": worker.last_seen_at,
-            "metadata_": worker.metadata,
-        }
 
     @classmethod
     def from_domain(cls, worker: Worker) -> "WorkerORM":
@@ -91,7 +64,15 @@ class WorkerORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         Returns:
             Row without timestamps set.
         """
-        return cls(**cls.column_values(worker))
+        return cls(
+            id=worker.id,
+            owner_id=worker.owner_id,
+            name=worker.name,
+            scope=worker.scope.model_dump(mode="json"),
+            runtime=worker.runtime.model_dump(mode="json"),
+            last_seen_at=worker.last_seen_at,
+            metadata_=worker.metadata,
+        )
 
     def to_domain(self) -> Worker:
         """Build a domain worker from this row.

--- a/src/kitaru/server/adapters/db/repositories/worker_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/worker_repository.py
@@ -15,16 +15,12 @@
 
 import uuid
 from collections.abc import Mapping
-from datetime import UTC, datetime
+from datetime import datetime
 
 from sqlalchemy import select, update
-from sqlalchemy.dialects.postgresql import insert
 
 from kitaru.server.adapters.db.filtering import FilterBinding, compile_filter_expression
-from kitaru.server.adapters.db.orm.worker import (
-    WORKER_NAME_UNIQUE_CONSTRAINT,
-    WorkerORM,
-)
+from kitaru.server.adapters.db.orm.worker import WorkerORM
 from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.worker import WorkerFilter
@@ -54,39 +50,16 @@ class SQLWorkerRepository(BaseSQLRepository[WorkerORM]):
         return WorkerNotFound(entity_id)
 
     async def register(self, worker: Worker) -> Worker:
-        """Persist a worker, refreshing an existing row with the same name.
-
-        The insert races no fallback lookup: a concurrent registration under
-        the same name resolves through the database's own conflict handling,
-        never through a read-then-write from this repository.
+        """Persist a new worker.
 
         Args:
-            worker: Worker to store or refresh.
+            worker: Worker to store.
 
         Returns:
             Stored worker with its id, created, and updated timestamp set.
         """
-        now = datetime.now(UTC)
-        statement = insert(WorkerORM).values(**WorkerORM.column_values(worker))
-        # The client-side onupdate hook on TimestampMixin.updated never fires
-        # for this Core-level statement, so the conflict branch renews it
-        # explicitly. owner_id, id, and created stay out of the SET clause so
-        # re-registration keeps the original owner and creation time.
-        statement = statement.on_conflict_do_update(
-            constraint=WORKER_NAME_UNIQUE_CONSTRAINT,
-            set_={
-                "scope": statement.excluded.scope,
-                "runtime": statement.excluded.runtime,
-                "last_seen_at": statement.excluded.last_seen_at,
-                "metadata": statement.excluded["metadata"],
-                "updated": now,
-            },
-        ).returning(WorkerORM)
-        row = (
-            await self._session.scalars(
-                statement, execution_options={"populate_existing": True}
-            )
-        ).one()
+        row = WorkerORM.from_domain(worker)
+        await self._add(row)
         return row.to_domain()
 
     async def get(self, worker_id: uuid.UUID) -> Worker:
@@ -131,21 +104,21 @@ class SQLWorkerRepository(BaseSQLRepository[WorkerORM]):
         await self._session.flush()
 
     async def query(
-        self, worker_filter: WorkerFilter
+        self, worker_filter: WorkerFilter, live_cutoff: datetime | None
     ) -> tuple[list[Worker], str | None]:
         """Query workers matching a filter.
 
         Args:
             worker_filter: Filter and pagination parameters.
+            live_cutoff: Bound the last heartbeat must be at or after, None
+                keeps stale workers.
 
         Returns:
             Page of matching workers and the next cursor.
         """
         statement = select(WorkerORM)
-        if worker_filter.seen_after is not None:
-            statement = statement.where(
-                WorkerORM.last_seen_at >= worker_filter.seen_after
-            )
+        if live_cutoff is not None:
+            statement = statement.where(WorkerORM.last_seen_at >= live_cutoff)
         if worker_filter.expression is not None:
             statement = statement.where(
                 compile_filter_expression(

--- a/src/kitaru/server/adapters/rest/dependencies.py
+++ b/src/kitaru/server/adapters/rest/dependencies.py
@@ -820,18 +820,24 @@ def get_tag_service(
 
 def get_worker_service(
     session: Annotated[AsyncSession, Depends(get_session)],
+    settings: Annotated[APISettings, Depends(get_app_settings)],
     analytics: Annotated[ServerAnalytics, Depends(get_server_analytics)],
 ) -> WorkerService:
     """Return a worker service for the current request.
 
     Args:
         session: Request-scoped database session.
+        settings: API settings for this process.
         analytics: Analytics tracker for the current request.
 
     Returns:
         Worker service bound to the SQL repository.
     """
-    return WorkerService(repository=SQLWorkerRepository(session), analytics=analytics)
+    return WorkerService(
+        repository=SQLWorkerRepository(session),
+        liveness_timeout_seconds=settings.WORKER_LIVENESS_TIMEOUT_SECONDS,
+        analytics=analytics,
+    )
 
 
 def get_idempotency_key_repository(

--- a/src/kitaru/server/adapters/rest/mapping/workers.py
+++ b/src/kitaru/server/adapters/rest/mapping/workers.py
@@ -63,6 +63,7 @@ def worker_list_params_to_filter(params: WorkerListParams) -> WorkerFilter:
         expression=filter_to_expression(params.filter)
         if params.filter is not None
         else None,
+        include_stale=params.include_stale,
         cursor=params.cursor,
         size=params.size,
         sort=params.sort,

--- a/src/kitaru/server/adapters/rest/routers/workers.py
+++ b/src/kitaru/server/adapters/rest/routers/workers.py
@@ -20,6 +20,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Header, Query, status
 from packaging.version import InvalidVersion, Version
 
+from kitaru.analytics.source import AnalyticsSource
 from kitaru.api_models.v1.base import Page
 from kitaru.api_models.v1.worker import (
     WorkerCreateRequest,
@@ -55,18 +56,14 @@ from kitaru.server.domain.worker import WorkerClientUnsupported
 
 router = APIRouter(route_class=KitaruAPIRoute)
 
-# Newest release that renews a worker token by registering again rather than
-# through the token endpoint. Those releases go on heartbeating the id they
-# registered with first, which the token they now hold does not name, so the
-# tasks they are running stop being stamped and get swept away from them.
-LAST_UNSUPPORTED_WORKER_CLIENT_VERSION = "0.22.1"
+LAST_UNSUPPORTED_WORKER_CLIENT_VERSION = "0.22.2"
 
 
 def _check_worker_client(client: str) -> None:
-    """Reject a client older than the oldest version that renews its token.
+    """Reject an SDK older than the oldest version that renews its token.
 
-    A caller that does not identify itself as a Kitaru client, or reports no
-    readable version, is left alone.
+    A caller that is not the Python SDK, or reports no readable version, is
+    left alone.
 
     Args:
         client: Client identification header value.
@@ -75,7 +72,11 @@ def _check_worker_client(client: str) -> None:
         WorkerClientUnsupported: The client predates token renewal.
     """
     identity = parse_client_identity(client)
-    if identity is None or identity.version is None:
+    if (
+        identity is None
+        or identity.source is not AnalyticsSource.PYTHON
+        or identity.version is None
+    ):
         return
     try:
         client_version = Version(identity.version)
@@ -99,8 +100,8 @@ async def register_worker(
     """Register a worker.
 
     Every registration creates a new worker, names are labels and need not
-    be unique. Clients observe HTTP 200 on success, 426 from a Kitaru client
-    that renews by re-registering, and 422 on invalid input.
+    be unique. Clients observe HTTP 200 on success, 426 from an SDK that
+    renews by re-registering, and 422 on invalid input.
 
     Args:
         body: Worker create request.

--- a/src/kitaru/server/adapters/rest/routers/workers.py
+++ b/src/kitaru/server/adapters/rest/routers/workers.py
@@ -17,7 +17,8 @@ import uuid
 from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, Header, Query, status
+from packaging.version import InvalidVersion, Version
 
 from kitaru.api_models.v1.base import Page
 from kitaru.api_models.v1.worker import (
@@ -27,7 +28,9 @@ from kitaru.api_models.v1.worker import (
     WorkerListParams,
     WorkerRegistrationResponse,
     WorkerResponse,
+    WorkerTokenResponse,
 )
+from kitaru.headers import CLIENT_HEADER
 from kitaru.server.adapters.auth.auth_service import AuthService
 from kitaru.server.adapters.rest.dependencies import (
     authorize,
@@ -47,8 +50,41 @@ from kitaru.server.api.config import APISettings
 from kitaru.server.application.models.auth import AuthContext, WorkerAuthContext
 from kitaru.server.application.services.task_service import TaskService
 from kitaru.server.application.services.worker_service import WorkerService
+from kitaru.server.client_identity import parse_client_identity
+from kitaru.server.domain.worker import WorkerClientUnsupported
 
 router = APIRouter(route_class=KitaruAPIRoute)
+
+# Newest release that renews a worker token by registering again rather than
+# through the token endpoint. Those releases go on heartbeating the id they
+# registered with first, which the token they now hold does not name, so the
+# tasks they are running stop being stamped and get swept away from them.
+LAST_UNSUPPORTED_WORKER_CLIENT_VERSION = "0.22.1"
+
+
+def _check_worker_client(client: str) -> None:
+    """Reject a client older than the oldest version that renews its token.
+
+    A caller that does not identify itself as a Kitaru client, or reports no
+    readable version, is left alone.
+
+    Args:
+        client: Client identification header value.
+
+    Raises:
+        WorkerClientUnsupported: The client predates token renewal.
+    """
+    identity = parse_client_identity(client)
+    if identity is None or identity.version is None:
+        return
+    try:
+        client_version = Version(identity.version)
+    except InvalidVersion:
+        return
+    if client_version <= Version(LAST_UNSUPPORTED_WORKER_CLIENT_VERSION):
+        raise WorkerClientUnsupported(
+            identity.version, LAST_UNSUPPORTED_WORKER_CLIENT_VERSION
+        )
 
 
 @router.post("")
@@ -58,14 +94,13 @@ async def register_worker(
     auth_service: Annotated[AuthService, Depends(get_auth_service)],
     actor: Annotated[AuthContext, Depends(authorize)],
     settings: Annotated[APISettings, Depends(get_app_settings)],
+    client: Annotated[str, Header(alias=CLIENT_HEADER)] = "",
 ) -> WorkerRegistrationResponse:
-    """Register a worker, upserting by name.
+    """Register a worker.
 
-    Re-registration refreshes the scope, runtime, and metadata, stamps
-    last_seen_at, and mints a fresh token, keeping the id and created time.
-    Re-registering with a fresh token is how a worker renews before its
-    current token expires. Clients observe HTTP 200 on both the first
-    registration and every re-registration, and 422 on invalid input.
+    Every registration creates a new worker, names are labels and need not
+    be unique. Clients observe HTTP 200 on success, 426 from a Kitaru client
+    that renews by re-registering, and 422 on invalid input.
 
     Args:
         body: Worker create request.
@@ -73,10 +108,12 @@ async def register_worker(
         auth_service: Authentication service for the current request.
         actor: Caller context.
         settings: API settings for this process.
+        client: Client identification header value.
 
     Returns:
         Stored worker with a bearer token scoped to it.
     """
+    _check_worker_client(client)
     worker = await service.register_worker(
         name=body.name,
         scope=body.scope,
@@ -96,6 +133,35 @@ async def register_worker(
     )
 
 
+@router.post("/{worker_id}/token")
+async def renew_worker_token(
+    worker_id: uuid.UUID,
+    service: Annotated[WorkerService, Depends(get_worker_service)],
+    auth_service: Annotated[AuthService, Depends(get_auth_service)],
+    actor: Annotated[AuthContext, Depends(authorize)],
+) -> WorkerTokenResponse:
+    """Issue a fresh token for a registered worker.
+
+    Renewal stamps last_seen_at. Clients observe HTTP 200 on success, 403
+    when the worker belongs to another account, and 404 when no worker has
+    this id.
+
+    Args:
+        worker_id: Id of the worker.
+        service: Worker service.
+        auth_service: Authentication service for the current request.
+        actor: Caller context.
+
+    Returns:
+        Bearer token scoped to the worker.
+    """
+    await service.renew_worker(worker_id, actor=actor)
+    issued = auth_service.issue_worker_token(
+        worker_id=worker_id, account_id=actor.account.id
+    )
+    return WorkerTokenResponse(token=issued.token, token_expires_at=issued.expires_at)
+
+
 @router.get("")
 async def list_workers(
     service: Annotated[WorkerService, Depends(get_worker_service)],
@@ -105,7 +171,8 @@ async def list_workers(
 ) -> Page[WorkerResponse]:
     """List workers.
 
-    Clients observe HTTP 200 on success and 422 on invalid pagination
+    Workers past the liveness window are left out unless include_stale is
+    set. Clients observe HTTP 200 on success and 422 on invalid pagination
     parameters.
 
     Args:

--- a/src/kitaru/server/api/app.py
+++ b/src/kitaru/server/api/app.py
@@ -25,14 +25,12 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
 from kitaru.analytics.client import AnalyticsClient
 from kitaru.analytics.source import (
-    CLIENT_HEADER,
-    SKILL_HEADER,
     AnalyticsAttribution,
     AnalyticsSource,
     current_attribution,
-    parse_client_header,
 )
 from kitaru.api_models.v1.info import AuthScheme
+from kitaru.headers import CLIENT_HEADER, SKILL_HEADER
 from kitaru.server.adapters.auth.control_plane import ControlPlaneClient
 from kitaru.server.adapters.db.errors import is_connection_unavailable, is_deadlock
 from kitaru.server.adapters.db.repositories.account_repository import (
@@ -90,6 +88,7 @@ from kitaru.server.application.services.server_analytics import (
     ServerAnalytics,
     build_analytics_context,
 )
+from kitaru.server.client_identity import parse_client_identity
 from kitaru.server.database.service import DatabaseService
 from kitaru.server.domain.base import (
     ConflictError,
@@ -98,6 +97,7 @@ from kitaru.server.domain.base import (
     NotFoundError,
     PayloadTooLargeError,
     QueryTimeoutError,
+    UpgradeRequiredError,
     ValidationError,
 )
 
@@ -107,8 +107,9 @@ def _register_domain_exception_handlers(app: FastAPI) -> None:
 
     Clients receive HTTP 403 for ``ForbiddenError``, 404 for ``NotFoundError``,
     409 for ``ConflictError``, 413 for ``PayloadTooLargeError``, 422 for
-    ``ValidationError``, 503 for ``QueryTimeoutError``, and 500 for other
-    ``DomainError`` subclasses. Each body is ``{"detail": "<message>"}``.
+    ``ValidationError``, 426 for ``UpgradeRequiredError``, 503 for
+    ``QueryTimeoutError``, and 500 for other ``DomainError`` subclasses. Each
+    body is ``{"detail": "<message>"}``.
 
     Args:
         app: FastAPI application that will serve the v1 API.
@@ -128,6 +129,13 @@ def _register_domain_exception_handlers(app: FastAPI) -> None:
     async def conflict(request: Request, exc: ConflictError) -> JSONResponse:
         _ = request
         return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+    @app.exception_handler(UpgradeRequiredError)
+    async def upgrade_required(
+        request: Request, exc: UpgradeRequiredError
+    ) -> JSONResponse:
+        _ = request
+        return JSONResponse(status_code=426, content={"detail": str(exc)})
 
     @app.exception_handler(PayloadTooLargeError)
     async def payload_too_large(
@@ -227,10 +235,11 @@ async def _set_analytics_attribution(
     Returns:
         HTTP response.
     """
-    source = parse_client_header(request.headers.get(CLIENT_HEADER, ""))
+    identity = parse_client_identity(request.headers.get(CLIENT_HEADER, ""))
     token = current_attribution.set(
         AnalyticsAttribution(
-            source=source or AnalyticsSource.API,
+            source=identity.source if identity else AnalyticsSource.API,
+            version=identity.version if identity else None,
             skill=request.headers.get(SKILL_HEADER) or None,
         )
     )

--- a/src/kitaru/server/application/interfaces/worker_repository.py
+++ b/src/kitaru/server/application/interfaces/worker_repository.py
@@ -25,10 +25,10 @@ class WorkerRepository(Protocol):
     """Worker persistence operations."""
 
     async def register(self, worker: Worker) -> Worker:
-        """Persist a worker, refreshing an existing row with the same name.
+        """Persist a new worker.
 
         Args:
-            worker: Worker to store or refresh.
+            worker: Worker to store.
 
         Returns:
             Stored worker with its id, created, and updated timestamp set.
@@ -62,12 +62,14 @@ class WorkerRepository(Protocol):
         ...
 
     async def query(
-        self, worker_filter: WorkerFilter
+        self, worker_filter: WorkerFilter, live_cutoff: datetime | None
     ) -> tuple[list[Worker], str | None]:
         """Query workers matching a filter.
 
         Args:
             worker_filter: Filter and pagination parameters.
+            live_cutoff: Bound the last heartbeat must be at or after, None
+                keeps stale workers.
 
         Returns:
             Page of matching workers and the next cursor.

--- a/src/kitaru/server/application/models/worker.py
+++ b/src/kitaru/server/application/models/worker.py
@@ -17,8 +17,6 @@ import uuid
 from collections.abc import Mapping
 from typing import ClassVar
 
-from pydantic import AwareDatetime
-
 from kitaru.server.base import ListFilter
 from kitaru.server.filtering import EQUALITY_OPS, STRING_OPS, FilterField
 
@@ -31,4 +29,4 @@ class WorkerFilter(ListFilter):
         "name": FilterField(value_type=str, ops=STRING_OPS),
     }
 
-    seen_after: AwareDatetime | None = None
+    include_stale: bool = False

--- a/src/kitaru/server/application/services/server_analytics.py
+++ b/src/kitaru/server/application/services/server_analytics.py
@@ -152,11 +152,10 @@ class ServerAnalytics:
         attribution = current_attribution.get()
         # Each client versions on its own series, so the version is only
         # readable attached to the client that reported it.
-        properties["client_version"] = (
-            f"{attribution.source.value}/{attribution.version}"
-            if attribution.version is not None
-            else attribution.source.value
-        )
+        if attribution.version is not None:
+            properties["client_version"] = (
+                f"{attribution.source.value}/{attribution.version}"
+            )
         if attribution.skill is not None:
             properties["skill"] = attribution.skill
         self._get_buffer().messages.append(

--- a/src/kitaru/server/application/services/server_analytics.py
+++ b/src/kitaru/server/application/services/server_analytics.py
@@ -149,9 +149,11 @@ class ServerAnalytics:
             properties["service_account"] = actor.is_service_account
             if actor.external_id is not None:
                 properties["control_plane_user_id"] = actor.external_id
-        skill = current_attribution.get().skill
-        if skill is not None:
-            properties["skill"] = skill
+        attribution = current_attribution.get()
+        if attribution.version is not None:
+            properties["client_version"] = attribution.version
+        if attribution.skill is not None:
+            properties["skill"] = attribution.skill
         self._get_buffer().messages.append(
             _BufferedTrack(user_id=user_id, event=event, properties=properties)
         )

--- a/src/kitaru/server/application/services/server_analytics.py
+++ b/src/kitaru/server/application/services/server_analytics.py
@@ -150,8 +150,13 @@ class ServerAnalytics:
             if actor.external_id is not None:
                 properties["control_plane_user_id"] = actor.external_id
         attribution = current_attribution.get()
-        if attribution.version is not None:
-            properties["client_version"] = attribution.version
+        # Each client versions on its own series, so the version is only
+        # readable attached to the client that reported it.
+        properties["client_version"] = (
+            f"{attribution.source.value}/{attribution.version}"
+            if attribution.version is not None
+            else attribution.source.value
+        )
         if attribution.skill is not None:
             properties["skill"] = attribution.skill
         self._get_buffer().messages.append(

--- a/src/kitaru/server/application/services/worker_service.py
+++ b/src/kitaru/server/application/services/worker_service.py
@@ -14,7 +14,7 @@
 """Worker use cases."""
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from kitaru.analytics.events import AnalyticsEvent
 from kitaru.api_models.v1.worker import WorkerRuntime, WorkerScope
@@ -34,15 +34,18 @@ class WorkerService:
     def __init__(
         self,
         repository: WorkerRepository,
+        liveness_timeout_seconds: int,
         analytics: ServerAnalytics | None = None,
     ) -> None:
         """Initialize the service.
 
         Args:
             repository: Worker repository.
+            liveness_timeout_seconds: Liveness window in seconds.
             analytics: Analytics tracker, None skips tracking.
         """
         self._repository = repository
+        self._liveness_timeout_seconds = liveness_timeout_seconds
         self._analytics = analytics
 
     async def register_worker(
@@ -53,7 +56,7 @@ class WorkerService:
         metadata: dict[str, str],
         actor: AuthContext,
     ) -> Worker:
-        """Register a worker, refreshing an existing row with the same name.
+        """Register a worker.
 
         Args:
             name: Worker name.
@@ -74,9 +77,7 @@ class WorkerService:
             last_seen_at=datetime.now(UTC),
         )
         stored = await self._repository.register(worker)
-        # A refresh keeps the existing row's id, so a returned row carrying
-        # the requested id is a new registration.
-        if self._analytics is not None and stored.id == worker.id:
+        if self._analytics is not None:
             self._analytics.track(
                 actor.account.id,
                 AnalyticsEvent.WORKER_REGISTERED,
@@ -108,6 +109,22 @@ class WorkerService:
             raise WorkerAccessDenied(worker_id)
         return await self._repository.get(worker_id)
 
+    async def renew_worker(self, worker_id: uuid.UUID, actor: AuthContext) -> None:
+        """Stamp a worker as seen ahead of issuing it a fresh token.
+
+        Args:
+            worker_id: Id of the worker.
+            actor: Caller context.
+
+        Raises:
+            WorkerAccessDenied: The worker belongs to another account.
+            WorkerNotFound: No worker has this id.
+        """
+        worker = await self._repository.get(worker_id)
+        if worker.owner_id != actor.account.id:
+            raise WorkerAccessDenied(worker_id)
+        await self._repository.update_last_seen_at(worker_id, datetime.now(UTC))
+
     async def list_workers(
         self, worker_filter: WorkerFilter, actor: AuthContext
     ) -> tuple[list[Worker], str | None]:
@@ -121,7 +138,12 @@ class WorkerService:
             Page of matching workers and the next cursor.
         """
         _ = actor
-        return await self._repository.query(worker_filter)
+        live_cutoff = None
+        if not worker_filter.include_stale:
+            live_cutoff = datetime.now(UTC) - timedelta(
+                seconds=self._liveness_timeout_seconds
+            )
+        return await self._repository.query(worker_filter, live_cutoff)
 
     async def delete_worker(self, worker_id: uuid.UUID, actor: AuthContext) -> None:
         """Delete a worker.

--- a/src/kitaru/server/client_identity.py
+++ b/src/kitaru/server/client_identity.py
@@ -1,0 +1,43 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Client identification parsed from request headers."""
+
+from dataclasses import dataclass
+
+from kitaru.analytics.source import AnalyticsSource
+
+
+@dataclass(frozen=True)
+class ClientIdentity:
+    """Client identity."""
+
+    source: AnalyticsSource
+    version: str | None
+
+
+def parse_client_identity(value: str) -> ClientIdentity | None:
+    """Parse a client identification header value.
+
+    Args:
+        value: ``<source>/<version>`` header value.
+
+    Returns:
+        Parsed identity, or None for an unknown client.
+    """
+    name, _, client_version = value.partition("/")
+    try:
+        source = AnalyticsSource(name)
+    except ValueError:
+        return None
+    return ClientIdentity(source=source, version=client_version or None)

--- a/src/kitaru/server/database/migrations/versions/003_worker_liveness_index.py
+++ b/src/kitaru/server/database/migrations/versions/003_worker_liveness_index.py
@@ -1,0 +1,50 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Drop the worker name unique constraint and index the liveness cutoff.
+
+Revision ID: 003_worker_liveness_index
+Revises: 002_idempotency_key
+Create Date: 2026-08-19
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "003_worker_liveness_index"
+down_revision = "002_idempotency_key"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    with op.batch_alter_table("worker", schema=None) as batch_op:
+        batch_op.drop_constraint("uq_worker_name", type_="unique")
+        batch_op.create_index(
+            "ix_worker_last_seen_at_id", ["last_seen_at", "id"], unique=False
+        )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    # Registrations under a shared name are what this revision allows, so the
+    # rows the unique constraint would reject are deleted before it comes back.
+    op.execute(
+        "DELETE FROM worker WHERE id NOT IN "
+        "(SELECT DISTINCT ON (name) id FROM worker ORDER BY name, last_seen_at DESC)"
+    )
+    with op.batch_alter_table("worker", schema=None) as batch_op:
+        batch_op.drop_index("ix_worker_last_seen_at_id")
+        batch_op.create_unique_constraint("uq_worker_name", ["name"])

--- a/src/kitaru/server/domain/base.py
+++ b/src/kitaru/server/domain/base.py
@@ -38,6 +38,10 @@ class ConflictError(DomainError):
     """Raised when an operation conflicts with existing state."""
 
 
+class UpgradeRequiredError(DomainError):
+    """Raised when the caller must upgrade before performing an operation."""
+
+
 class PayloadTooLargeError(DomainError):
     """Raised when a request payload exceeds a size limit."""
 

--- a/src/kitaru/server/domain/worker.py
+++ b/src/kitaru/server/domain/worker.py
@@ -19,7 +19,12 @@ from datetime import datetime
 from pydantic import Field
 
 from kitaru.api_models.v1.worker import WorkerRuntime, WorkerScope
-from kitaru.server.domain.base import DomainModel, ForbiddenError, NotFoundError
+from kitaru.server.domain.base import (
+    DomainModel,
+    ForbiddenError,
+    NotFoundError,
+    UpgradeRequiredError,
+)
 from kitaru.server.domain.ids import uuid7
 from kitaru.server.domain.names import Name
 
@@ -42,6 +47,23 @@ class WorkerCredentialRequired(ForbiddenError):
     def __init__(self) -> None:
         """Initialize the error."""
         super().__init__("This operation requires a worker credential")
+
+
+class WorkerClientUnsupported(UpgradeRequiredError):
+    """Raised when a worker registers from a client below the supported version."""
+
+    def __init__(self, client_version: str, last_unsupported_version: str) -> None:
+        """Initialize the error.
+
+        Args:
+            client_version: Version the client reported.
+            last_unsupported_version: Newest version not allowed to register.
+        """
+        super().__init__(
+            f"Registering a worker requires kitaru newer than "
+            f"{last_unsupported_version}, this client reports {client_version}. "
+            "Upgrade the worker"
+        )
 
 
 class WorkerAccessDenied(ForbiddenError):
@@ -68,26 +90,6 @@ class Worker(DomainModel):
     metadata: dict[str, str] = Field(default_factory=dict)
     created: datetime | None = None
     updated: datetime | None = None
-
-    def refresh(
-        self,
-        scope: WorkerScope,
-        runtime: WorkerRuntime,
-        metadata: dict[str, str],
-        now: datetime,
-    ) -> None:
-        """Replace the reported scope, runtime, and metadata, and stamp last_seen_at.
-
-        Args:
-            scope: New claim scope.
-            runtime: New reported runtime.
-            metadata: New metadata.
-            now: Current time.
-        """
-        self.scope = scope
-        self.runtime = runtime
-        self.metadata = metadata
-        self.last_seen_at = now
 
     def is_live(self, now: datetime, timeout_seconds: int) -> bool:
         """Report whether the worker was seen within the liveness window.

--- a/src/kitaru/worker/auth.py
+++ b/src/kitaru/worker/auth.py
@@ -11,32 +11,33 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Worker bearer token renewal through re-registration."""
+"""Worker bearer token renewal."""
 
-from kitaru.api_models.v1.worker import WorkerCreateRequest
+import uuid
+
 from kitaru.client.api_client import KitaruAPIClient
 
 
 class WorkerTokenSource:
-    """Worker token renewed by re-registering through an API key client."""
+    """Worker token renewed through an API key client."""
 
     def __init__(
-        self, client: KitaruAPIClient, request: WorkerCreateRequest, token: str
+        self, client: KitaruAPIClient, worker_id: uuid.UUID, token: str
     ) -> None:
         """Initialize the source.
 
         Args:
             client: Client authenticating with the account API key, used to
-                re-register the worker.
-            request: Worker registration request sent on every registration.
-            token: Worker token issued by the initial registration.
+                renew the worker token.
+            worker_id: Id of the registered worker.
+            token: Worker token issued by the registration.
         """
         self._client = client
-        self._request = request
+        self._worker_id = worker_id
         self._token = token
 
     def get_cached_token(self) -> str | None:
-        """Return the worker token issued by the last registration.
+        """Return the worker token issued last.
 
         Returns:
             Worker token.
@@ -44,20 +45,17 @@ class WorkerTokenSource:
         return self._token
 
     async def fetch_token(self) -> str | None:
-        """Re-register the worker and return the freshly issued token.
-
-        Registering is an upsert by worker name, so re-registering only
-        refreshes the token rather than creating a second worker.
+        """Renew the worker token and return it.
 
         Raises:
-            APIError: The registration request failed.
+            APIError: The renewal request failed.
 
         Returns:
-            Worker token issued by the fresh registration.
+            Freshly issued worker token.
         """
-        response = await self._client.workers.create(self._request)
+        response = await self._client.workers.renew_token(self._worker_id)
         self._token = response.token.get_secret_value()
         return self._token
 
     async def close(self) -> None:
-        """Close no resources, since the registration client has its own owner."""
+        """Close no resources, since the API key client has its own owner."""

--- a/src/kitaru/worker/worker.py
+++ b/src/kitaru/worker/worker.py
@@ -174,7 +174,7 @@ class Worker:
             worker = response.worker
             logger.info("Registered worker %s (%s).", name, worker.id)
             source = WorkerTokenSource(
-                registration_client, registration, response.token.get_secret_value()
+                registration_client, worker.id, response.token.get_secret_value()
             )
             client = registration_client.with_auth(RenewingTokenAuth(source))
             ctx = ExecutionContext(

--- a/tests/cli/test_workers.py
+++ b/tests/cli/test_workers.py
@@ -72,7 +72,7 @@ class DrainWorker:
 
 @dataclass
 class StubWorkers:
-    """Worker resource fake for list and exact-name lookup."""
+    """Worker resource fake for list and exact-id lookup."""
 
     items: list[WorkerResponse]
     list_calls: list[Any] = field(default_factory=list)
@@ -487,7 +487,7 @@ async def test_list_and_get_report_live_or_stale() -> None:
     )
     assert [item["status"] for item in listed.items or []] == ["live", "stale"]
 
-    fetched = await workers.get_worker(client, "old")
+    fetched = await workers.get_worker(client, stale.id)
     assert fetched.item["id"] == str(stale.id)
     assert fetched.item["status"] == "stale"
 
@@ -517,16 +517,14 @@ def test_worker_list_defaults_to_newest_first() -> None:
     assert WorkerListParams(sort=default_sort).sort == "created:desc"
 
 
-async def test_exact_worker_name_conflicts_before_returning_a_record() -> None:
-    """Duplicate exact names remain a stable conflict instead of guessing."""
-    client = SimpleNamespace(
-        workers=StubWorkers(
-            [_response("duplicate", live=True), _response("duplicate", live=False)]
-        )
-    )
-    with pytest.raises(CLIError) as error:
-        await workers.get_worker(client, "duplicate")
-    assert error.value.kind == "conflict"
+async def test_worker_get_reads_one_record_by_id_among_shared_names() -> None:
+    """Workers sharing a name stay individually addressable by id."""
+    first = _response("duplicate", live=True)
+    second = _response("duplicate", live=False)
+    client = SimpleNamespace(workers=StubWorkers([first, second]))
+
+    assert (await workers.get_worker(client, first.id)).item["id"] == str(first.id)
+    assert (await workers.get_worker(client, second.id)).item["id"] == str(second.id)
 
 
 def test_missing_worker_extra_has_actionable_hint(

--- a/tests/client/test_workers.py
+++ b/tests/client/test_workers.py
@@ -129,7 +129,10 @@ async def api_client(
 ) -> AsyncGenerator[KitaruAPIClient, None]:
     """Provide an API client authenticated as the fixture account by default."""
     app = create_app(local_settings())
-    service = WorkerService(repository=worker_repository)
+    service = WorkerService(
+        repository=worker_repository,
+        liveness_timeout_seconds=local_settings().WORKER_LIVENESS_TIMEOUT_SECONDS,
+    )
     agents = FakeAgentRepository()
     transitions = TaskTransitions(
         task_repository=task_repository,
@@ -175,8 +178,8 @@ async def test_create(api_client: KitaruAPIClient, account: Account) -> None:
     assert registered.token.get_secret_value()
 
 
-async def test_create_upsert(api_client: KitaruAPIClient) -> None:
-    """Re-registering under the same name keeps the id through the SDK."""
+async def test_create_same_name(api_client: KitaruAPIClient) -> None:
+    """Registering under an existing name creates a second worker through the SDK."""
     first = await api_client.workers.create(
         WorkerCreateRequest(
             name="worker-1",
@@ -193,10 +196,28 @@ async def test_create_upsert(api_client: KitaruAPIClient) -> None:
             metadata={},
         )
     )
-    assert second.worker.id == first.worker.id
-    assert second.worker.scope == WorkerScope(
-        claims=[WorkerClaim(kind=TaskKind.IMPORTER)]
+    assert second.worker.id != first.worker.id
+    assert (await api_client.workers.get(first.worker.id)).scope == WorkerScope(
+        claims=[WorkerClaim(kind=TaskKind.AGENT)]
     )
+
+
+async def test_renew_token(api_client: KitaruAPIClient) -> None:
+    """Renew a worker token through the SDK."""
+    registered = await api_client.workers.create(
+        WorkerCreateRequest(
+            name="worker-1", scope=UNSCOPED_WORKER_SCOPE, runtime=RUNTIME, metadata={}
+        )
+    )
+    renewed = await api_client.workers.renew_token(registered.worker.id)
+    assert renewed.token.get_secret_value()
+    assert renewed.token_expires_at
+
+
+async def test_renew_token_not_found(api_client: KitaruAPIClient) -> None:
+    """Observe NotFoundError when renewing an unknown worker."""
+    with pytest.raises(NotFoundError):
+        await api_client.workers.renew_token(uuid.uuid4())
 
 
 async def test_get(api_client: KitaruAPIClient) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3326,25 +3326,14 @@ class FakeWorkerRepository:
         self._workers: dict[uuid.UUID, Worker] = {}
 
     async def register(self, worker: Worker) -> Worker:
-        """Persist a worker, refreshing an existing row with the same name.
+        """Persist a new worker.
 
         Args:
-            worker: Worker to store or refresh.
+            worker: Worker to store.
 
         Returns:
             Stored worker with its id, created, and updated timestamp set.
         """
-        for stored in self._workers.values():
-            if stored.name == worker.name:
-                refreshed = stored.model_copy()
-                refreshed.refresh(
-                    worker.scope, worker.runtime, worker.metadata, worker.last_seen_at
-                )
-                refreshed = refreshed.model_copy(
-                    update={"updated": _renewed_timestamp(stored.updated)}
-                )
-                self._workers[stored.id] = refreshed
-                return refreshed.model_copy()
         now = datetime.now(UTC)
         stored = worker.model_copy(update={"created": now, "updated": now})
         self._workers[stored.id] = stored
@@ -3388,22 +3377,22 @@ class FakeWorkerRepository:
         )
 
     async def query(
-        self, worker_filter: WorkerFilter
+        self, worker_filter: WorkerFilter, live_cutoff: datetime | None
     ) -> tuple[list[Worker], str | None]:
         """Query workers matching a filter.
 
         Args:
             worker_filter: Filter and pagination parameters.
+            live_cutoff: Bound the last heartbeat must be at or after, None
+                keeps stale workers.
 
         Returns:
             Page of matching workers and the next cursor.
         """
         workers = list(self._workers.values())
-        if worker_filter.seen_after is not None:
+        if live_cutoff is not None:
             workers = [
-                worker
-                for worker in workers
-                if worker.last_seen_at >= worker_filter.seen_after
+                worker for worker in workers if worker.last_seen_at >= live_cutoff
             ]
         if worker_filter.expression is not None:
             workers = [

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -6,12 +6,14 @@ import sys
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 from scripts.release_units import (
     ReleaseInventoryError,
     build_plugin_matrix,
     format_inventory,
     load_inventory,
     parse_package_tag,
+    validate_canonical_version,
     validate_version,
 )
 
@@ -83,9 +85,12 @@ def test_inventory_versions_and_tags_match_project_manifests() -> None:
     inventory = load_inventory()
 
     for unit in inventory.units:
-        resolved = parse_package_tag(unit.tag, inventory)
-        assert resolved == unit
         assert unit.tag == f"python/{unit.distribution}/v{unit.version}"
+        if Version(unit.version).local is not None:
+            with pytest.raises(ReleaseInventoryError, match="local segment"):
+                parse_package_tag(unit.tag, inventory)
+            continue
+        assert parse_package_tag(unit.tag, inventory) == unit
 
 
 @pytest.mark.parametrize("version", ["0.22.0rc1", "0.22.0", "1.0.dev1"])
@@ -105,6 +110,21 @@ def test_noncanonical_python_versions_are_rejected(version: str) -> None:
 def test_local_python_versions_are_rejected_for_pypi() -> None:
     with pytest.raises(ReleaseInventoryError, match="local segment"):
         validate_version("1.0+build.1")
+
+
+@pytest.mark.parametrize("version", ["0.22.2+dev", "0.22.0rc1", "1.0.dev1"])
+def test_manifest_versions_keep_their_local_segment(version: str) -> None:
+    assert validate_canonical_version(version) == version
+
+
+def test_noncanonical_manifest_versions_are_rejected() -> None:
+    with pytest.raises(ReleaseInventoryError, match="canonical PEP 440"):
+        validate_canonical_version("v0.22.0")
+
+
+def test_local_package_tags_are_rejected_for_pypi() -> None:
+    with pytest.raises(ReleaseInventoryError, match="local segment"):
+        parse_package_tag("python/kitaru/v0.22.2+dev", load_inventory())
 
 
 def test_core_release_publishes_deployables_without_waiting_for_plugins() -> None:
@@ -557,12 +577,23 @@ def test_cli_json_commands_succeed(arguments: list[str], expected_key: str) -> N
 
 
 def test_cli_resolves_the_current_package_tag() -> None:
-    tag = load_inventory().units[0].tag
+    tag = next(
+        unit.tag
+        for unit in load_inventory().units
+        if Version(unit.version).local is None
+    )
     result = _run_cli("resolve", "--tag", tag, "--format", "json")
 
     assert result.returncode == 0
     assert json.loads(result.stdout)["unit"]["tag"] == tag
     assert result.stderr == ""
+
+
+def test_cli_refuses_to_release_a_local_version_tag() -> None:
+    result = _run_cli("resolve", "--tag", "python/kitaru/v0.22.2+dev")
+
+    assert result.returncode == 2
+    assert "local segment" in result.stderr
 
 
 def test_cli_json_errors_are_structured() -> None:

--- a/tests/server/test_analytics_attribution.py
+++ b/tests/server/test_analytics_attribution.py
@@ -14,6 +14,7 @@
 """Tests for the analytics attribution middleware."""
 
 from collections.abc import AsyncGenerator
+from importlib.metadata import version as package_version
 
 import httpx
 import pytest
@@ -31,7 +32,11 @@ def create_app_with_attribution_probe() -> FastAPI:
     async def read_attribution() -> dict[str, str | None]:
         """Return the analytics attribution seen by the route handler."""
         attribution = current_attribution.get()
-        return {"source": attribution.source.value, "skill": attribution.skill}
+        return {
+            "source": attribution.source.value,
+            "version": attribution.version,
+            "skill": attribution.skill,
+        }
 
     # Register the probe ahead of the UI catch-all route so it stays
     # reachable when a UI bundle is present.
@@ -51,24 +56,28 @@ async def client() -> AsyncGenerator[httpx.AsyncClient, None]:
 async def test_source_defaults_to_api(client: httpx.AsyncClient) -> None:
     """Attribute requests without a client header to the API source."""
     response = await client.get("/probe-attribution")
-    assert response.json() == {"source": "kitaru-api", "skill": None}
+    assert response.json() == {"source": "kitaru-api", "version": None, "skill": None}
 
 
 @pytest.mark.parametrize(
-    ("header", "source"),
+    ("header", "source", "client_version"),
     [
-        ("kitaru-ui/0.3.0", "kitaru-ui"),
-        ("kitaru-typescript", "kitaru-typescript"),
+        ("kitaru-ui/0.3.0", "kitaru-ui", "0.3.0"),
+        ("kitaru-typescript", "kitaru-typescript", None),
     ],
 )
 async def test_source_parsed_from_client_header(
-    client: httpx.AsyncClient, header: str, source: str
+    client: httpx.AsyncClient, header: str, source: str, client_version: str | None
 ) -> None:
     """Attribute requests to the source named in the client header."""
     response = await client.get(
         "/probe-attribution", headers={"X-Kitaru-Client": header}
     )
-    assert response.json() == {"source": source, "skill": None}
+    assert response.json() == {
+        "source": source,
+        "version": client_version,
+        "skill": None,
+    }
 
 
 async def test_unknown_client_header_falls_back_to_api(
@@ -78,7 +87,7 @@ async def test_unknown_client_header_falls_back_to_api(
     response = await client.get(
         "/probe-attribution", headers={"X-Kitaru-Client": "curl/8.0"}
     )
-    assert response.json() == {"source": "kitaru-api", "skill": None}
+    assert response.json() == {"source": "kitaru-api", "version": None, "skill": None}
 
 
 async def test_skill_parsed_from_skill_header(client: httpx.AsyncClient) -> None:
@@ -86,7 +95,11 @@ async def test_skill_parsed_from_skill_header(client: httpx.AsyncClient) -> None
     response = await client.get(
         "/probe-attribution", headers={"X-Kitaru-Skill": "data-analysis"}
     )
-    assert response.json() == {"source": "kitaru-api", "skill": "data-analysis"}
+    assert response.json() == {
+        "source": "kitaru-api",
+        "version": None,
+        "skill": "data-analysis",
+    }
 
 
 async def test_empty_skill_header_reads_as_no_skill(
@@ -94,14 +107,18 @@ async def test_empty_skill_header_reads_as_no_skill(
 ) -> None:
     """Attribute requests with an empty skill header to no skill."""
     response = await client.get("/probe-attribution", headers={"X-Kitaru-Skill": ""})
-    assert response.json() == {"source": "kitaru-api", "skill": None}
+    assert response.json() == {"source": "kitaru-api", "version": None, "skill": None}
 
 
 async def test_sdk_client_reports_python_source() -> None:
     """Attribute SDK requests to the Python source via the default headers."""
     api_client = asgi_api_client(create_app_with_attribution_probe())
     response = await api_client.request("GET", "/probe-attribution")
-    assert response.json() == {"source": "kitaru-python", "skill": None}
+    assert response.json() == {
+        "source": "kitaru-python",
+        "version": package_version("kitaru"),
+        "skill": None,
+    }
     await api_client.close()
 
 
@@ -111,7 +128,11 @@ async def test_sdk_client_reports_configured_source() -> None:
         create_app_with_attribution_probe(), analytics_source=AnalyticsSource.CLI
     )
     response = await api_client.request("GET", "/probe-attribution")
-    assert response.json() == {"source": "kitaru-cli", "skill": None}
+    assert response.json() == {
+        "source": "kitaru-cli",
+        "version": package_version("kitaru"),
+        "skill": None,
+    }
     await api_client.close()
 
 
@@ -122,5 +143,23 @@ async def test_sdk_client_reports_active_skill(
     monkeypatch.setenv("KITARU_ACTIVE_SKILL", "data-analysis")
     api_client = asgi_api_client(create_app_with_attribution_probe())
     response = await api_client.request("GET", "/probe-attribution")
-    assert response.json() == {"source": "kitaru-python", "skill": "data-analysis"}
+    assert response.json() == {
+        "source": "kitaru-python",
+        "version": package_version("kitaru"),
+        "skill": "data-analysis",
+    }
     await api_client.close()
+
+
+async def test_client_version_parsed_from_client_header(
+    client: httpx.AsyncClient,
+) -> None:
+    """Attribute requests to the version the client header reports."""
+    response = await client.get(
+        "/probe-attribution", headers={"X-Kitaru-Client": "kitaru-cli/1.2.3"}
+    )
+    assert response.json() == {
+        "source": "kitaru-cli",
+        "version": "1.2.3",
+        "skill": None,
+    }

--- a/tests/server/test_client_identity.py
+++ b/tests/server/test_client_identity.py
@@ -1,0 +1,40 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for client identification parsing."""
+
+from kitaru.analytics.source import AnalyticsSource
+from kitaru.server.client_identity import parse_client_identity
+
+
+def test_parse_client_identity() -> None:
+    """Read the source and the version out of the header."""
+    identity = parse_client_identity("kitaru-python/0.21.0")
+    assert identity is not None
+    assert identity.source is AnalyticsSource.PYTHON
+    assert identity.version == "0.21.0"
+
+
+def test_parse_client_identity_without_a_version() -> None:
+    """Read a source reported without a version."""
+    identity = parse_client_identity("kitaru-cli")
+    assert identity is not None
+    assert identity.source is AnalyticsSource.CLI
+    assert identity.version is None
+
+
+def test_parse_client_identity_rejects_unknown_clients() -> None:
+    """Report no identity for a caller that is not a Kitaru client."""
+    assert parse_client_identity("") is None
+    assert parse_client_identity("curl/8.0") is None
+    assert parse_client_identity("python-httpx/0.27.0") is None

--- a/tests/server/test_route_manifest.py
+++ b/tests/server/test_route_manifest.py
@@ -113,5 +113,6 @@ def test_route_manifest_is_registered() -> None:
         "/api/v1/workers",
         "/api/v1/workers/{worker_id}",
         "/api/v1/workers/{worker_id}/heartbeat",
+        "/api/v1/workers/{worker_id}/token",
     }
     assert paths == expected

--- a/tests/server/test_server_analytics_pg.py
+++ b/tests/server/test_server_analytics_pg.py
@@ -302,8 +302,8 @@ async def test_track_merges_the_client_with_its_version() -> None:
     assert properties["client_version"] == "kitaru-ui/0.2.2"
 
 
-async def test_track_merges_the_client_without_a_version() -> None:
-    """A client that reports no version lands under its source alone."""
+async def test_track_omits_the_client_without_a_version() -> None:
+    """A client that reports no version contributes no client property."""
     if not await postgres_available():
         pytest.skip("PostgreSQL is not reachable")
 
@@ -321,7 +321,7 @@ async def test_track_merges_the_client_without_a_version() -> None:
         current_attribution.reset(token)
 
     _, _, properties = client.tracked[0]
-    assert properties["client_version"] == "kitaru-api"
+    assert "client_version" not in properties
 
 
 async def test_track_omits_control_plane_user_id_without_external_id() -> None:

--- a/tests/server/test_server_analytics_pg.py
+++ b/tests/server/test_server_analytics_pg.py
@@ -21,7 +21,11 @@ import pytest
 from conftest import pg_session, postgres_available
 from kitaru.analytics.client import AnalyticsClient
 from kitaru.analytics.events import AnalyticsEvent
-from kitaru.analytics.source import AnalyticsAttribution, current_attribution
+from kitaru.analytics.source import (
+    AnalyticsAttribution,
+    AnalyticsSource,
+    current_attribution,
+)
 from kitaru.server.adapters.db.analytics import register_analytics_listeners
 from kitaru.server.application.services.server_analytics import (
     ServerAnalytics,
@@ -274,6 +278,50 @@ async def test_track_merges_the_current_skill() -> None:
     assert properties["skill"] == "data-analysis"
     _, traits = client.identified[0]
     assert "skill" not in traits
+
+
+async def test_track_merges_the_client_with_its_version() -> None:
+    """A client that reports a version lands under source and version."""
+    if not await postgres_available():
+        pytest.skip("PostgreSQL is not reachable")
+
+    client = _RecordingAnalyticsClient()
+    user_id = uuid.uuid4()
+    token = current_attribution.set(
+        AnalyticsAttribution(source=AnalyticsSource.UI, version="0.2.2")
+    )
+    try:
+        async with pg_session() as session:
+            analytics = ServerAnalytics(client=client, session=session)
+            analytics.track(user_id, AnalyticsEvent.SESSION_COMPLETED)
+            await session.commit()
+    finally:
+        current_attribution.reset(token)
+
+    _, _, properties = client.tracked[0]
+    assert properties["client_version"] == "kitaru-ui/0.2.2"
+
+
+async def test_track_merges_the_client_without_a_version() -> None:
+    """A client that reports no version lands under its source alone."""
+    if not await postgres_available():
+        pytest.skip("PostgreSQL is not reachable")
+
+    client = _RecordingAnalyticsClient()
+    user_id = uuid.uuid4()
+    token = current_attribution.set(
+        AnalyticsAttribution(source=AnalyticsSource.API, version=None)
+    )
+    try:
+        async with pg_session() as session:
+            analytics = ServerAnalytics(client=client, session=session)
+            analytics.track(user_id, AnalyticsEvent.SESSION_COMPLETED)
+            await session.commit()
+    finally:
+        current_attribution.reset(token)
+
+    _, _, properties = client.tracked[0]
+    assert properties["client_version"] == "kitaru-api"
 
 
 async def test_track_omits_control_plane_user_id_without_external_id() -> None:

--- a/tests/server/test_worker_repository.py
+++ b/tests/server/test_worker_repository.py
@@ -48,6 +48,8 @@ from kitaru.server.filtering import FilterCondition
 
 Setup = tuple[WorkerRepository, uuid.UUID]
 
+_CUTOFF = datetime.now(UTC) - timedelta(minutes=1)
+
 
 @pytest.fixture(params=["fake", "postgres"])
 async def setup(request: pytest.FixtureRequest) -> AsyncGenerator[Setup, None]:
@@ -104,8 +106,8 @@ async def test_register_sets_timestamps(setup: Setup) -> None:
     assert worker.updated is not None
 
 
-async def test_register_upsert_keeps_id_and_created(setup: Setup) -> None:
-    """Re-registering under the same name keeps the id and created time."""
+async def test_register_same_name_creates_a_second_worker(setup: Setup) -> None:
+    """Registering under an existing name creates a separate worker."""
     repository, owner_id = setup
     first = await repository.register(
         _worker(owner_id, scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)]))
@@ -115,56 +117,9 @@ async def test_register_upsert_keeps_id_and_created(setup: Setup) -> None:
             owner_id, scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)])
         )
     )
-    assert second.id == first.id
-    assert second.created == first.created
-    assert second.scope == WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)])
-
-
-async def test_register_upsert_renews_updated_and_last_seen_at(setup: Setup) -> None:
-    """Re-registering renews the updated timestamp and last_seen_at."""
-    repository, owner_id = setup
-    first = await repository.register(_worker(owner_id))
-    second = await repository.register(
-        _worker(owner_id, last_seen_at=datetime.now(UTC) + timedelta(seconds=1))
-    )
-    assert second.updated is not None
-    assert first.updated is not None
-    assert second.updated > first.updated
-    assert second.last_seen_at > first.last_seen_at
-
-
-async def test_register_upsert_refreshes_scope_runtime_and_metadata(
-    setup: Setup,
-) -> None:
-    """Re-registering replaces the scope, runtime, and metadata."""
-    repository, owner_id = setup
-    await repository.register(
-        _worker(
-            owner_id,
-            scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)]),
-            runtime=WorkerRuntime(platform="bare"),
-            metadata={"region": "eu"},
-        )
-    )
-    second = await repository.register(
-        _worker(
-            owner_id,
-            scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)]),
-            runtime=WorkerRuntime(platform="docker", hostname="worker-a"),
-            metadata={"region": "us"},
-        )
-    )
-    assert second.scope == WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)])
-    assert second.runtime == WorkerRuntime(platform="docker", hostname="worker-a")
-    assert second.metadata == {"region": "us"}
-
-
-async def test_register_upsert_distinct_names_coexist(setup: Setup) -> None:
-    """Registering under a different name creates a separate worker."""
-    repository, owner_id = setup
-    first = await repository.register(_worker(owner_id, name="worker-1"))
-    second = await repository.register(_worker(owner_id, name="worker-2"))
-    assert first.id != second.id
+    assert second.id != first.id
+    assert (await repository.get(first.id)).scope == first.scope
+    assert (await repository.get(second.id)).scope == second.scope
 
 
 async def test_get(setup: Setup) -> None:
@@ -190,14 +145,15 @@ async def test_query(setup: Setup) -> None:
     await repository.register(_worker(owner_id, name="worker-2"))
     third = await repository.register(_worker(owner_id, name="worker-3"))
 
-    workers, next_cursor = await repository.query(WorkerFilter())
+    workers, next_cursor = await repository.query(WorkerFilter(), _CUTOFF)
     assert next_cursor is None
     assert [worker.name for worker in workers] == ["worker-3", "worker-2", "worker-1"]
 
     workers, next_cursor = await repository.query(
         WorkerFilter(
             expression=FilterCondition(field="name", op=FilterOp.EQ, value="worker-1")
-        )
+        ),
+        _CUTOFF,
     )
     assert next_cursor is None
     assert workers[0] == first
@@ -205,27 +161,30 @@ async def test_query(setup: Setup) -> None:
     workers, next_cursor = await repository.query(
         WorkerFilter(
             expression=FilterCondition(field="name", op=FilterOp.EQ, value="missing")
-        )
+        ),
+        _CUTOFF,
     )
     assert next_cursor is None
     assert workers == []
     assert third.name == "worker-3"
 
 
-async def test_query_seen_after(setup: Setup) -> None:
-    """Filter workers by last_seen_at, an internal filter field."""
+async def test_query_hides_stale_unless_included(setup: Setup) -> None:
+    """Leave workers past the cutoff out unless no cutoff is given."""
     repository, owner_id = setup
     now = datetime.now(UTC)
-    await repository.register(
+    stale = await repository.register(
         _worker(owner_id, name="stale", last_seen_at=now - timedelta(hours=1))
     )
     fresh = await repository.register(_worker(owner_id, name="fresh", last_seen_at=now))
+    cutoff = now - timedelta(minutes=1)
 
-    workers, next_cursor = await repository.query(
-        WorkerFilter(seen_after=now - timedelta(minutes=1))
-    )
+    workers, next_cursor = await repository.query(WorkerFilter(), cutoff)
     assert next_cursor is None
     assert [worker.id for worker in workers] == [fresh.id]
+
+    workers, _ = await repository.query(WorkerFilter(), None)
+    assert {worker.id for worker in workers} == {stale.id, fresh.id}
 
 
 async def test_query_walks_pages(setup: Setup) -> None:
@@ -241,7 +200,7 @@ async def test_query_walks_pages(setup: Setup) -> None:
     cursor = None
     while True:
         workers, next_cursor = await repository.query(
-            WorkerFilter(cursor=cursor, size=2)
+            WorkerFilter(cursor=cursor, size=2), _CUTOFF
         )
         collected.extend(workers)
         if next_cursor is None:
@@ -256,7 +215,7 @@ async def test_query_invalid_cursor(setup: Setup) -> None:
     """Raise for a cursor string that fails to decode."""
     repository, _ = setup
     with pytest.raises(ValidationError):
-        await repository.query(WorkerFilter(cursor="not-a-valid-cursor"))
+        await repository.query(WorkerFilter(cursor="not-a-valid-cursor"), _CUTOFF)
 
 
 async def test_delete(setup: Setup) -> None:

--- a/tests/server/test_worker_service.py
+++ b/tests/server/test_worker_service.py
@@ -34,7 +34,7 @@ from kitaru.server.application.models.worker import WorkerFilter
 from kitaru.server.application.services.server_analytics import ServerAnalytics
 from kitaru.server.application.services.worker_service import WorkerService
 from kitaru.server.domain.account import Account
-from kitaru.server.domain.worker import WorkerNotFound
+from kitaru.server.domain.worker import WorkerAccessDenied, WorkerNotFound
 from kitaru.server.filtering import FilterCondition
 
 ACTOR = AuthContext(account=Account(id=uuid.uuid4(), name="ann"))
@@ -72,7 +72,7 @@ def repository() -> FakeWorkerRepository:
 @pytest.fixture
 def service(repository: FakeWorkerRepository) -> WorkerService:
     """Provide a worker service backed by the fake repository."""
-    return WorkerService(repository=repository)
+    return WorkerService(repository=repository, liveness_timeout_seconds=60)
 
 
 async def test_register_worker(service: WorkerService) -> None:
@@ -91,12 +91,14 @@ async def test_register_worker(service: WorkerService) -> None:
     assert worker.updated is not None
 
 
-async def test_register_worker_tracks_only_new_registrations(
+async def test_register_worker_tracks_every_registration(
     repository: FakeWorkerRepository,
 ) -> None:
-    """Track the worker registered event on creation but not on a refresh."""
+    """Track the worker registered event on every registration."""
     analytics = _RecordingAnalytics()
-    service = WorkerService(repository=repository, analytics=analytics)
+    service = WorkerService(
+        repository=repository, liveness_timeout_seconds=60, analytics=analytics
+    )
 
     for _ in range(2):
         await service.register_worker(
@@ -107,19 +109,23 @@ async def test_register_worker_tracks_only_new_registrations(
             actor=ACTOR,
         )
 
-    assert analytics.tracked == [
-        (
-            ACTOR.account.id,
-            AnalyticsEvent.WORKER_REGISTERED,
-            {"worker_platform": "docker"},
-        )
-    ]
+    assert (
+        analytics.tracked
+        == [
+            (
+                ACTOR.account.id,
+                AnalyticsEvent.WORKER_REGISTERED,
+                {"worker_platform": "docker"},
+            )
+        ]
+        * 2
+    )
 
 
-async def test_register_worker_upsert_keeps_id_and_renews_timestamps(
+async def test_register_worker_same_name_creates_a_second_worker(
     service: WorkerService,
 ) -> None:
-    """Re-registering under the same name keeps id and created, renews updated."""
+    """Registering under an existing name creates a separate worker."""
     first = await service.register_worker(
         name="worker-1",
         scope=WorkerScope(claims=[WorkerClaim(kind=TaskKind.AGENT)]),
@@ -134,15 +140,43 @@ async def test_register_worker_upsert_keeps_id_and_renews_timestamps(
         metadata={"region": "us"},
         actor=ACTOR,
     )
-    assert second.id == first.id
-    assert second.created == first.created
-    assert second.scope == WorkerScope(claims=[WorkerClaim(kind=TaskKind.IMPORTER)])
-    assert second.runtime.platform == "docker"
-    assert second.metadata == {"region": "us"}
-    assert second.last_seen_at >= first.last_seen_at
-    assert second.updated is not None
-    assert first.updated is not None
-    assert second.updated > first.updated
+    assert second.id != first.id
+    assert (await service.get_worker(first.id, actor=ACTOR)).scope == first.scope
+    assert (await service.get_worker(second.id, actor=ACTOR)).scope == second.scope
+
+
+async def test_renew_worker_stamps_last_seen_at(service: WorkerService) -> None:
+    """Renewing a worker stamps it as seen."""
+    created = await service.register_worker(
+        name="worker-1",
+        scope=UNSCOPED_WORKER_SCOPE,
+        runtime=WorkerRuntime(platform="bare"),
+        metadata={},
+        actor=ACTOR,
+    )
+    await service.renew_worker(created.id, actor=ACTOR)
+    reloaded = await service.get_worker(created.id, actor=ACTOR)
+    assert reloaded.last_seen_at >= created.last_seen_at
+
+
+async def test_renew_worker_not_found(service: WorkerService) -> None:
+    """Renewing an unknown worker raises WorkerNotFound."""
+    with pytest.raises(WorkerNotFound):
+        await service.renew_worker(uuid.uuid4(), actor=ACTOR)
+
+
+async def test_renew_worker_of_another_account(service: WorkerService) -> None:
+    """Renewing a worker of another account raises WorkerAccessDenied."""
+    created = await service.register_worker(
+        name="worker-1",
+        scope=UNSCOPED_WORKER_SCOPE,
+        runtime=WorkerRuntime(platform="bare"),
+        metadata={},
+        actor=ACTOR,
+    )
+    other = AuthContext(account=Account(id=uuid.uuid4(), name="bob"))
+    with pytest.raises(WorkerAccessDenied):
+        await service.renew_worker(created.id, actor=other)
 
 
 async def test_get_worker(service: WorkerService) -> None:
@@ -190,10 +224,10 @@ async def test_list_workers(service: WorkerService) -> None:
     assert workers[0].name == "worker-2"
 
 
-async def test_list_workers_seen_after(
+async def test_list_workers_hides_stale_unless_included(
     service: WorkerService, repository: FakeWorkerRepository
 ) -> None:
-    """Filter workers by last_seen_at, an internal filter field."""
+    """Leave workers past the liveness window out unless the filter includes them."""
     now = datetime.now(UTC)
     stale = await create_worker(
         repository,
@@ -205,12 +239,14 @@ async def test_list_workers_seen_after(
         repository, ACTOR.account.id, name="fresh", last_seen_at=now
     )
 
-    workers, next_cursor = await service.list_workers(
-        WorkerFilter(seen_after=now - timedelta(minutes=1)), actor=ACTOR
-    )
+    workers, next_cursor = await service.list_workers(WorkerFilter(), actor=ACTOR)
     assert next_cursor is None
     assert [worker.id for worker in workers] == [fresh.id]
-    assert stale.id not in [worker.id for worker in workers]
+
+    workers, _ = await service.list_workers(
+        WorkerFilter(include_stale=True), actor=ACTOR
+    )
+    assert {worker.id for worker in workers} == {stale.id, fresh.id}
 
 
 async def test_delete_worker(service: WorkerService) -> None:

--- a/tests/server/test_workers_api.py
+++ b/tests/server/test_workers_api.py
@@ -244,12 +244,12 @@ async def test_renew_worker_token_of_another_account(
 
 @pytest.mark.parametrize(
     "client_header",
-    ["kitaru-python/0.22.1", "kitaru-cli/0.22.0rc10", "kitaru-mcp/0.9"],
+    ["kitaru-python/0.22.2", "kitaru-python/0.22.0rc10", "kitaru-python/0.9"],
 )
 async def test_register_worker_rejects_reregistering_client(
     client: httpx.AsyncClient, client_header: str
 ) -> None:
-    """Observe HTTP 426 for a Kitaru client that renews by re-registering."""
+    """Observe HTTP 426 for an SDK version that renews by re-registering."""
     response = await client.post(
         "/api/v1/workers",
         json={"name": "worker-1", "scope": SCOPE, "runtime": RUNTIME, "metadata": {}},
@@ -262,10 +262,13 @@ async def test_register_worker_rejects_reregistering_client(
 @pytest.mark.parametrize(
     "client_header",
     [
-        "kitaru-cli/0.22.2",
-        "kitaru-python/0.22.2.dev0",
+        "kitaru-python/0.22.3.dev0",
         "kitaru-python/0.23.0.dev0",
         "kitaru-python/1.0.0",
+        "kitaru-cli/0.22.2",
+        "kitaru-mcp/0.9",
+        "kitaru-ui/0.9",
+        "kitaru-typescript/0.1.1",
         "curl/8.4.0",
         "kitaru-python",
         "kitaru-python/not-a-version",
@@ -275,7 +278,7 @@ async def test_register_worker_rejects_reregistering_client(
 async def test_register_worker_admits_supported_client(
     client: httpx.AsyncClient, client_header: str
 ) -> None:
-    """Admit anything at or above the minimum client version."""
+    """Admit any non-SDK client and every SDK at or above the minimum."""
     response = await client.post(
         "/api/v1/workers",
         json={"name": "worker-1", "scope": SCOPE, "runtime": RUNTIME, "metadata": {}},

--- a/tests/server/test_workers_api.py
+++ b/tests/server/test_workers_api.py
@@ -256,7 +256,7 @@ async def test_register_worker_rejects_reregistering_client(
         headers={CLIENT_HEADER: client_header},
     )
     assert response.status_code == 426
-    assert "0.22.2 or newer" in response.json()["detail"]
+    assert "newer than 0.22.2" in response.json()["detail"]
 
 
 @pytest.mark.parametrize(

--- a/tests/server/test_workers_api.py
+++ b/tests/server/test_workers_api.py
@@ -22,6 +22,7 @@ import httpx
 import pytest
 
 from conftest import (
+    FakeAccountRepository,
     FakeAgentRepository,
     FakeAgentVersionRepository,
     FakeBlobRepository,
@@ -38,6 +39,7 @@ from conftest import (
     local_settings,
     mint_worker_token,
 )
+from kitaru.headers import CLIENT_HEADER
 from kitaru.server.adapters.auth.auth_service import AuthService
 from kitaru.server.adapters.rest.dependencies import (
     get_auth_service,
@@ -92,7 +94,10 @@ async def client(
 ) -> AsyncGenerator[httpx.AsyncClient, None]:
     """Provide an HTTP client authenticated as the fixture account by default."""
     app = create_app(local_settings())
-    service = WorkerService(repository=repository)
+    service = WorkerService(
+        repository=repository,
+        liveness_timeout_seconds=local_settings().WORKER_LIVENESS_TIMEOUT_SECONDS,
+    )
     transitions = TaskTransitions(
         task_repository=task_repository,
         job_repository=job_repository,
@@ -151,8 +156,8 @@ async def test_register_worker(client: httpx.AsyncClient, account: Account) -> N
     assert body["token_expires_at"]
 
 
-async def test_register_worker_upsert(client: httpx.AsyncClient) -> None:
-    """Re-registering under the same name keeps the id and renews the state."""
+async def test_register_worker_same_name(client: httpx.AsyncClient) -> None:
+    """Registering under an existing name creates a separate worker."""
     first = (
         await client.post(
             "/api/v1/workers",
@@ -175,15 +180,108 @@ async def test_register_worker_upsert(client: httpx.AsyncClient) -> None:
             },
         )
     ).json()
-    assert second["worker"]["id"] == first["worker"]["id"]
-    assert second["worker"]["created"] == first["worker"]["created"]
-    assert second["worker"]["scope"]["claims"] == [
-        {"kind": "importer", "agent_version_id": None}
-    ]
-    assert second["worker"]["runtime"]["platform"] == "docker"
-    assert second["worker"]["metadata"] == {"region": "us"}
-    assert second["worker"]["updated"] > first["worker"]["updated"]
+    assert second["worker"]["id"] != first["worker"]["id"]
     assert isinstance(second["token"], str) and second["token"]
+    response = await client.get(f"/api/v1/workers/{first['worker']['id']}")
+    assert response.json()["scope"]["claims"] == [
+        {"kind": "agent", "agent_version_id": None}
+    ]
+
+
+async def test_renew_worker_token(client: httpx.AsyncClient) -> None:
+    """Renew a worker token and observe a fresh token plus a seen stamp."""
+    created = (
+        await client.post(
+            "/api/v1/workers",
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
+        )
+    ).json()
+    response = await client.post(f"/api/v1/workers/{created['worker']['id']}/token")
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body["token"], str) and body["token"]
+    assert body["token_expires_at"]
+    response = await client.get(f"/api/v1/workers/{created['worker']['id']}")
+    assert response.json()["last_seen_at"] >= created["worker"]["last_seen_at"]
+
+
+async def test_renew_worker_token_not_found(client: httpx.AsyncClient) -> None:
+    """Observe HTTP 404 when renewing an unknown worker."""
+    response = await client.post(f"/api/v1/workers/{uuid.uuid4()}/token")
+    assert response.status_code == 404
+
+
+async def test_renew_worker_token_of_another_account(
+    client: httpx.AsyncClient,
+    auth_service: AuthService,
+    account_repository: FakeAccountRepository,
+) -> None:
+    """Observe HTTP 403 when renewing a worker owned by another account."""
+    created = (
+        await client.post(
+            "/api/v1/workers",
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
+        )
+    ).json()
+    other = await account_repository.create(Account(name="bob"))
+    token = auth_service.issue_token(AuthContext(account=other)).token
+    response = await client.post(
+        f"/api/v1/workers/{created['worker']['id']}/token",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "client_header",
+    ["kitaru-python/0.22.1", "kitaru-cli/0.22.0rc10", "kitaru-mcp/0.9"],
+)
+async def test_register_worker_rejects_reregistering_client(
+    client: httpx.AsyncClient, client_header: str
+) -> None:
+    """Observe HTTP 426 for a Kitaru client that renews by re-registering."""
+    response = await client.post(
+        "/api/v1/workers",
+        json={"name": "worker-1", "scope": SCOPE, "runtime": RUNTIME, "metadata": {}},
+        headers={CLIENT_HEADER: client_header},
+    )
+    assert response.status_code == 426
+    assert "0.22.2 or newer" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "client_header",
+    [
+        "kitaru-cli/0.22.2",
+        "kitaru-python/0.22.2.dev0",
+        "kitaru-python/0.23.0.dev0",
+        "kitaru-python/1.0.0",
+        "curl/8.4.0",
+        "kitaru-python",
+        "kitaru-python/not-a-version",
+        "",
+    ],
+)
+async def test_register_worker_admits_supported_client(
+    client: httpx.AsyncClient, client_header: str
+) -> None:
+    """Admit anything at or above the minimum client version."""
+    response = await client.post(
+        "/api/v1/workers",
+        json={"name": "worker-1", "scope": SCOPE, "runtime": RUNTIME, "metadata": {}},
+        headers={CLIENT_HEADER: client_header},
+    )
+    assert response.status_code == 200
 
 
 async def test_register_worker_invalid_name(client: httpx.AsyncClient) -> None:
@@ -304,6 +402,25 @@ async def test_list_workers(client: httpx.AsyncClient) -> None:
     )
     assert response.status_code == 200
     assert response.json()["items"][0]["name"] == "worker-2"
+
+
+async def test_list_workers_hides_stale_unless_asked(
+    client: httpx.AsyncClient, repository: FakeWorkerRepository, account: Account
+) -> None:
+    """Leave stale workers out of the list unless include_stale is set."""
+    await create_worker(repository, account.id, name="live")
+    await create_worker(
+        repository,
+        account.id,
+        name="stale",
+        last_seen_at=datetime.now(UTC) - timedelta(minutes=5),
+    )
+
+    response = await client.get("/api/v1/workers")
+    assert [item["name"] for item in response.json()["items"]] == ["live"]
+
+    response = await client.get("/api/v1/workers", params={"include_stale": "true"})
+    assert [item["name"] for item in response.json()["items"]] == ["stale", "live"]
 
 
 async def test_delete_worker(client: httpx.AsyncClient) -> None:

--- a/tests/server/test_workers_api_pg.py
+++ b/tests/server/test_workers_api_pg.py
@@ -56,8 +56,8 @@ async def test_workers_persist_across_requests(client: httpx.AsyncClient) -> Non
     assert body["items"][0] == created
 
 
-async def test_upsert_persists_across_requests(client: httpx.AsyncClient) -> None:
-    """Persist a re-registration across requests, keeping id and created."""
+async def test_same_name_registers_a_second_worker(client: httpx.AsyncClient) -> None:
+    """Persist two workers registered under one name across requests."""
     first = (
         await client.post(
             "/api/v1/workers",
@@ -82,16 +82,38 @@ async def test_upsert_persists_across_requests(client: httpx.AsyncClient) -> Non
         )
     ).json()["worker"]
 
-    assert second["id"] == first["id"]
-    assert second["created"] == first["created"]
-    assert second["updated"] > first["updated"]
+    assert second["id"] != first["id"]
 
     response = await client.get(f"/api/v1/workers/{first['id']}")
     assert response.status_code == 200
     body = response.json()
-    assert body["scope"]["claims"] == [{"kind": "importer", "agent_version_id": None}]
-    assert body["runtime"]["platform"] == "docker"
-    assert body["metadata"] == {"region": "us"}
+    assert body["scope"]["claims"] == [{"kind": "agent", "agent_version_id": None}]
+    assert body["runtime"]["platform"] == "bare"
+    assert body["metadata"] == {"region": "eu"}
+
+
+async def test_token_renewal_persists_across_requests(
+    client: httpx.AsyncClient,
+) -> None:
+    """Renew a worker token and observe the seen stamp on a later read."""
+    created = (
+        await client.post(
+            "/api/v1/workers",
+            json={
+                "name": "worker-1",
+                "scope": SCOPE,
+                "runtime": RUNTIME,
+                "metadata": {},
+            },
+        )
+    ).json()["worker"]
+
+    response = await client.post(f"/api/v1/workers/{created['id']}/token")
+    assert response.status_code == 200
+    assert response.json()["token"]
+
+    response = await client.get(f"/api/v1/workers/{created['id']}")
+    assert response.json()["last_seen_at"] >= created["last_seen_at"]
 
 
 async def test_delete_persists_across_requests(client: httpx.AsyncClient) -> None:

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -11,14 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Tests for the analytics source helpers."""
+"""Tests for the request header helpers."""
 
 from importlib.metadata import version
 
-from kitaru.analytics.source import (
-    AnalyticsSource,
-    format_client_header,
-)
+from kitaru.analytics.source import AnalyticsSource
+from kitaru.headers import format_client_header
 
 
 def test_format_client_header() -> None:

--- a/tests/worker/test_worker_auth.py
+++ b/tests/worker/test_worker_auth.py
@@ -11,8 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Tests for the worker registration token source."""
+"""Tests for the worker token source."""
 
+import uuid
+from datetime import datetime
+
+import pytest
 from fastapi import FastAPI
 
 from conftest import (
@@ -25,6 +29,7 @@ from conftest import (
     local_settings,
 )
 from kitaru.api_models.v1.worker import WorkerCreateRequest, WorkerRuntime
+from kitaru.client.exceptions import NotFoundError
 from kitaru.server.adapters.auth.auth_service import AuthService
 from kitaru.server.adapters.rest.dependencies import (
     get_auth_service,
@@ -41,17 +46,23 @@ RUNTIME = WorkerRuntime(platform="bare")
 
 
 class _CountingWorkerRepository(FakeWorkerRepository):
-    """Fake worker repository counting the registration calls it received."""
+    """Fake worker repository counting the registration and renewal calls."""
 
     def __init__(self) -> None:
         """Initialize the repository with no recorded calls."""
         super().__init__()
         self.register_calls = 0
+        self.renewal_calls = 0
 
     async def register(self, worker: Worker) -> Worker:
-        """Record the call and delegate to the fake upsert-by-name behavior."""
+        """Record the call and delegate to the fake insert."""
         self.register_calls += 1
         return await super().register(worker)
+
+    async def update_last_seen_at(self, worker_id: uuid.UUID, now: datetime) -> None:
+        """Record the call and delegate to the fake stamp."""
+        self.renewal_calls += 1
+        await super().update_last_seen_at(worker_id, now)
 
 
 async def _registration_app() -> tuple[FastAPI, _CountingWorkerRepository, str]:
@@ -73,7 +84,7 @@ async def _registration_app() -> tuple[FastAPI, _CountingWorkerRepository, str]:
     repository = _CountingWorkerRepository()
     app = create_app(local_settings())
     app.dependency_overrides[get_worker_service] = lambda: WorkerService(
-        repository=repository
+        repository=repository, liveness_timeout_seconds=60
     )
     app.dependency_overrides[get_auth_service] = lambda: auth_service
     return app, repository, account_token
@@ -93,39 +104,43 @@ def _registration_request(name: str = "worker-1") -> WorkerCreateRequest:
     )
 
 
-async def test_initial_token_is_served_without_registering() -> None:
-    """Return the token from the initial registration without a new registration."""
+async def test_initial_token_is_served_without_renewing() -> None:
+    """Return the token from the registration without a renewal request."""
     app, repository, account_token = await _registration_app()
     client = asgi_api_client(app, api_key=account_token)
-    source = WorkerTokenSource(client, _registration_request(), "initial-token")
+    registered = await client.workers.create(_registration_request())
+    source = WorkerTokenSource(client, registered.worker.id, "initial-token")
 
     token = source.get_cached_token()
 
     assert token == "initial-token"
-    assert repository.register_calls == 0
+    assert repository.renewal_calls == 0
 
 
-async def test_fetch_reregisters_and_caches_the_fresh_token() -> None:
-    """Re-register the worker and serve the freshly issued token from the cache."""
+async def test_fetch_renews_and_caches_the_fresh_token() -> None:
+    """Renew the worker token and serve the freshly issued token from the cache."""
     app, repository, account_token = await _registration_app()
     client = asgi_api_client(app, api_key=account_token)
-    source = WorkerTokenSource(client, _registration_request(), "initial-token")
+    registered = await client.workers.create(_registration_request())
+    source = WorkerTokenSource(client, registered.worker.id, "initial-token")
 
     token = await source.fetch_token()
 
     assert isinstance(token, str) and token != "initial-token"
     assert repository.register_calls == 1
+    assert repository.renewal_calls == 1
     assert source.get_cached_token() == token
 
 
-async def test_reregistration_upserts_by_name() -> None:
-    """Keep the same worker id when re-registering under the same worker name."""
-    app, repository, account_token = await _registration_app()
+async def test_fetch_fails_for_a_deleted_worker() -> None:
+    """Raise when the worker the source renews for no longer exists."""
+    app, _, account_token = await _registration_app()
     client = asgi_api_client(app, api_key=account_token)
-    request = _registration_request(name="shared-worker")
+    registered = await client.workers.create(_registration_request())
+    await client.workers.delete(registered.worker.id)
+    source = WorkerTokenSource(client, registered.worker.id, "initial-token")
 
-    first = await client.workers.create(request)
-    second = await client.workers.create(request)
+    with pytest.raises(NotFoundError):
+        await source.fetch_token()
 
-    assert first.worker.id == second.worker.id
-    assert repository.register_calls == 2
+    assert source.get_cached_token() == "initial-token"

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-17T13:35:55.994919Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -907,7 +907,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.2"
+version = "0.22.2+dev"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Worker names are labels now, every start registers a new worker, tokens renew through POST /api/v1/workers/{worker_id}/token, and listings hide stale workers unless include_stale is set.