### PR TITLE
Return the linked session on a retried task session create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Repeated identical tool calls with baseline-scoped history replay their distinct recorded results in baseline order instead of all resolving to the newest match. Replayed calls past the last recorded occurrence follow the configured `on_miss` behavior.
+- Session creation by a task retried after a lost response now returns the already linked session instead of a 409.
+
 ### Changed
 
 - Unified all runnable examples under a single `examples/` tree: the Python adapter examples moved from `examples/integrations/` to `examples/python/`, and the TypeScript examples moved from `v2_examples/` to `examples/typescript/`. The `examples/v2/mcp` configuration example was removed in favor of the MCP setup documentation.

--- a/src/kitaru/server/application/services/session_service.py
+++ b/src/kitaru/server/application/services/session_service.py
@@ -105,7 +105,7 @@ class SessionService:
             TaskAttemptMismatch: The principal's token is fenced by an attempt
                 the task has moved past.
             TaskResultSessionAlreadyLinked: The principal's agent task already
-                links a session.
+                links a session that differs from the command.
             SessionAgentVersionMismatch: The command names a different agent
                 version than the task runs.
             SessionAgentMismatch: The command names a different agent than the
@@ -131,8 +131,6 @@ class SessionService:
             # Check the attempt on the locked task so a requeue cannot race
             # the result link.
             task.check_attempt(actor.principal.attempt)
-            if isinstance(task, AgentTask) and task.result_session_id is not None:
-                raise TaskResultSessionAlreadyLinked(task.id)
         agent_id, agent_version_id = await self._resolve_agent(command, task)
         number = await self._repository.allocate_session_number(agent_id)
         session = Session(
@@ -157,6 +155,14 @@ class SessionService:
             framework=command.framework,
             adapter_version=command.adapter_version,
         )
+        if isinstance(task, AgentTask) and task.result_session_id is not None:
+            # check_attempt above pins this call to the task's attempt, and claim
+            # bumps it while requeue clears the link, so an identical session
+            # is a retry of the create that linked it.
+            linked = await self._repository.get(task.result_session_id)
+            if not linked.is_same_create(session):
+                raise TaskResultSessionAlreadyLinked(task.id)
+            return linked
         stored = await self._repository.create(session)
         if isinstance(task, AgentTask):
             task.link_result_session(stored.id)

--- a/src/kitaru/server/domain/session.py
+++ b/src/kitaru/server/domain/session.py
@@ -323,6 +323,28 @@ class Session(DomainModel):
         """Clear the task this session was produced by."""
         self.task_id = None
 
+    def is_same_create(self, other: "Session") -> bool:
+        """Report whether another session carries the same created fields.
+
+        Args:
+            other: Session to compare against.
+
+        Returns:
+            Whether every field a create sets is equal, ignoring identity,
+            number, timestamps, and counters.
+        """
+        exclude = {
+            "id",
+            "number",
+            "created",
+            "updated",
+            "cost",
+            "tokens",
+            "llm_call_count",
+            "tool_call_count",
+        }
+        return self.model_dump(exclude=exclude) == other.model_dump(exclude=exclude)
+
     def check_node_ingest(self) -> None:
         """Require the session to currently accept node ingestion.
 

--- a/tests/server/test_session_service.py
+++ b/tests/server/test_session_service.py
@@ -779,23 +779,51 @@ async def test_create_session_links_an_agent_tasks_result_session(
     assert stored_task.result_session_id == session.id
 
 
-async def test_create_session_rejects_a_second_link_to_an_agent_task(
+async def test_create_session_returns_the_existing_link_on_a_retry(
     service: SessionService,
     task_repository: FakeTaskRepository,
     agent_repository: FakeAgentRepository,
     agent_version_repository: FakeAgentVersionRepository,
 ) -> None:
-    """A second session cannot link to an agent task that already has one."""
+    """A retried create for an already-linked agent task returns that session."""
+    version = await _stored_agent_version(agent_repository, agent_version_repository)
+    task = await _running_agent_task(task_repository, version.id)
+    actor = _task_principal(task.id)
+    first = await service.create_session(
+        SessionCreate(origin=SessionOrigin.RECORDED),
+        actor=actor,
+    )
+    second = await service.create_session(
+        SessionCreate(origin=SessionOrigin.RECORDED),
+        actor=actor,
+    )
+    assert second.id == first.id
+    sessions, _ = await service.list_sessions(
+        SessionFilter(
+            expression=FilterCondition(field="task_id", op=FilterOp.EQ, value=task.id)
+        ),
+        actor=actor,
+    )
+    assert len(sessions) == 1
+
+
+async def test_create_session_rejects_a_differing_second_link_to_an_agent_task(
+    service: SessionService,
+    task_repository: FakeTaskRepository,
+    agent_repository: FakeAgentRepository,
+    agent_version_repository: FakeAgentVersionRepository,
+) -> None:
+    """A second, differing session cannot link to an agent task that already has one."""
     version = await _stored_agent_version(agent_repository, agent_version_repository)
     task = await _running_agent_task(task_repository, version.id)
     actor = _task_principal(task.id)
     await service.create_session(
-        SessionCreate(origin=SessionOrigin.RECORDED),
+        SessionCreate(origin=SessionOrigin.RECORDED, name="first"),
         actor=actor,
     )
     with pytest.raises(TaskResultSessionAlreadyLinked):
         await service.create_session(
-            SessionCreate(origin=SessionOrigin.RECORDED),
+            SessionCreate(origin=SessionOrigin.RECORDED, name="second"),
             actor=actor,
         )
 


### PR DESCRIPTION
A session create from a task token whose task already links a result session now returns that session instead of a 409, so a client retry after a lost response no longer kills the agent process.