### PR TITLE
Send baseline `occurrence` in TypeScript history lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Repeated identical tool calls with baseline-scoped history replay their distinct recorded results in baseline order instead of all resolving to the newest match. Replayed calls past the last recorded occurrence follow the configured `on_miss` behavior.
+- The TypeScript adapters (Mastra and Vercel AI SDK) now apply the same baseline occurrence ordering: repeated identical tool calls send a zero-based `occurrence` with each history lookup and advance it only on a found result.
+
 ### Changed
 
 - Unified all runnable examples under a single `examples/` tree: the Python adapter examples moved from `examples/integrations/` to `examples/python/`, and the TypeScript examples moved from `v2_examples/` to `examples/typescript/`. The `examples/v2/mcp` configuration example was removed in favor of the MCP setup documentation.

--- a/docs/book/guides/tool-policies.md
+++ b/docs/book/guides/tool-policies.md
@@ -78,7 +78,7 @@ History matching is guaranteed only within the same TypeScript adapter. Differen
 
 A recorded `tool_call` node has a cache key derived from the tool name and its canonical JSON arguments. During replay, the adapter computes the same key for the attempted call and asks the server for a match within the policy's scope. Calls with different arguments have different keys and do not match.
 
-A baseline can call the same tool with identical arguments more than once and receive different results. With `baseline` scope, the PydanticAI and LangGraph adapters consume those recorded results in their original order: the first replayed call gets the first recorded result, the second gets the second, and so on. A replayed call past the last recorded occurrence is a miss and follows the configured `on_miss` behavior. With `cohort_version` and `agent` scope, the newest matching recording answers every call.
+A baseline can call the same tool with identical arguments more than once and receive different results. With `baseline` scope, the PydanticAI, LangGraph, and TypeScript (Mastra and Vercel AI SDK) adapters consume those recorded results in their original order: the first replayed call gets the first recorded result, the second gets the second, and so on. A replayed call past the last recorded occurrence is a miss and follows the configured `on_miss` behavior. With `cohort_version` and `agent` scope, the newest matching recording answers every call.
 
 If a tool call's arguments cannot be serialized to canonical JSON, the call has no cache key. A history lookup cannot match it, so replay follows the configured `on_miss` behavior. Keep tool arguments JSON-serializable if you plan to replay them from history.
 

--- a/packages/core/src/adapter/run-state.ts
+++ b/packages/core/src/adapter/run-state.ts
@@ -45,11 +45,13 @@ export interface AdapterRunState {
   readonly rootIndex: number;
   readonly sessionId: string;
   readonly spec?: ReplaySpec;
+  advanceHistoryOccurrence(cacheKey: string, usedOccurrence: number): void;
   allocateNode(): { index: number };
   awaitSteps(): Promise<void>;
   clearLedger(callIds: readonly string[]): void;
   enqueueStep(operation: () => Promise<void>): Promise<void>;
   failedLedgerEntries(): ToolLedgerEntry[];
+  getHistoryOccurrence(cacheKey: string): number;
   getToolCall(callId: string): ToolLedgerEntry | undefined;
   setToolCall(entry: ToolLedgerEntry): void;
   storeFailure(error: unknown): void;
@@ -67,6 +69,10 @@ export class RunState implements AdapterRunState {
   readonly spec?: ReplaySpec;
 
   #failure: unknown;
+  // Repeated baseline-history calls with identical arguments share a cache
+  // key; this counter walks them through the recorded occurrences in order
+  // instead of replaying the newest match every time.
+  #historyOccurrences = new Map<string, number>();
   #ledger = new Map<string, ToolLedgerEntry>();
   #nextIndex: number;
   #stepBoundary: string = new Date().toISOString();
@@ -83,6 +89,13 @@ export class RunState implements AdapterRunState {
     this.#nextIndex = this.rootIndex + 1;
     this.sessionId = options.sessionId;
     this.spec = options.spec;
+  }
+
+  advanceHistoryOccurrence(cacheKey: string, usedOccurrence: number): void {
+    // Write back from the occurrence this call consumed rather than
+    // re-reading the counter, so overlapping identical calls that both read
+    // the same occurrence cannot advance it twice.
+    this.#historyOccurrences.set(cacheKey, usedOccurrence + 1);
   }
 
   allocateNode(): { index: number } {
@@ -132,6 +145,10 @@ export class RunState implements AdapterRunState {
 
   get failure(): unknown {
     return this.#failure;
+  }
+
+  getHistoryOccurrence(cacheKey: string): number {
+    return this.#historyOccurrences.get(cacheKey) ?? 0;
   }
 
   getToolCall(callId: string): ToolLedgerEntry | undefined {

--- a/packages/core/src/adapter/tool-policy.ts
+++ b/packages/core/src/adapter/tool-policy.ts
@@ -1,7 +1,7 @@
 import { historyCacheKey } from "../cache-key.js";
 import { ToolPolicyError, ToolPolicyMissError } from "../errors.js";
 import { recorderError, toRecorderJson } from "../json.js";
-import type { JsonValue, ToolPolicy } from "../types.js";
+import type { JsonValue, ToolLookupRequest, ToolPolicy } from "../types.js";
 import { isRecord } from "../validation.js";
 import { recordedToolPayloadJson } from "./recorded-json.js";
 import type { AdapterRunState } from "./run-state.js";
@@ -234,10 +234,27 @@ export async function decideToolCall(
     if (!state.replayId) {
       throw new ToolPolicyError("History policy requires a replay ID");
     }
-    const lookup = await state.client.lookupToolResult(state.replayId, {
+    const request: ToolLookupRequest = {
       cache_key: cacheKey,
       tool_name: input.toolName,
-    });
+    };
+    // Baseline lookups walk repeated identical calls through the recorded
+    // occurrences in order; other scopes have no stable per-run ordering, so
+    // they take the server's default (newest match) instead.
+    const occurrence =
+      policy.scope === "baseline"
+        ? state.getHistoryOccurrence(cacheKey)
+        : undefined;
+    if (occurrence !== undefined) {
+      request.occurrence = occurrence;
+    }
+    const lookup = await state.client.lookupToolResult(state.replayId, request);
+    // Any hit consumes its recorded occurrence, even one the ambiguity guard
+    // below rejects, matching the Python adapters; a miss keeps the counter
+    // still so a later identical call can retry the same recorded position.
+    if (lookup.found && occurrence !== undefined) {
+      state.advanceHistoryOccurrence(cacheKey, occurrence);
+    }
     if (lookup.found && lookup.result === null) {
       throw new ToolPolicyError(
         `History lookup for tool '${input.toolName}' cannot distinguish a ` +

--- a/packages/core/test/adapter/tool-policy.test.ts
+++ b/packages/core/test/adapter/tool-policy.test.ts
@@ -203,6 +203,106 @@ describe("normalized replay policy decisions", () => {
     expect(run.failure).toBeUndefined();
   });
 
+  const baselineHistory = (onMiss: "fail" | "passthrough") =>
+    ({
+      default: { on_miss: onMiss, scope: "baseline", type: "history" },
+      tools: {},
+    }) as const;
+  const weatherDelft = { inputs: { city: "Delft" }, toolName: "weather" };
+
+  it("replays repeated identical baseline calls in recorded order", async () => {
+    const recorded = ["first", "second", "third"];
+    const { client, run } = runState(baselineHistory("fail"), (request) => ({
+      found: true,
+      result: { value: recorded[request.occurrence ?? 0] },
+    }));
+
+    for (const [index, value] of recorded.entries()) {
+      await expect(
+        decideToolCall(run, { callId: `call-${index}`, ...weatherDelft }),
+      ).resolves.toEqual({ output: { value }, type: "mocked_result" });
+    }
+    expect(client.lookups.map((lookup) => lookup.occurrence)).toEqual([
+      0, 1, 2,
+    ]);
+  });
+
+  it("counts baseline occurrences per cache key, not per run", async () => {
+    const { client, run } = runState(baselineHistory("fail"), (request) => ({
+      found: true,
+      result: { value: request.occurrence ?? 0 },
+    }));
+
+    await decideToolCall(run, { callId: "call-1", ...weatherDelft });
+    await decideToolCall(run, {
+      callId: "call-2",
+      inputs: { city: "Rotterdam" },
+      toolName: "weather",
+    });
+    await decideToolCall(run, { callId: "call-3", ...weatherDelft });
+    // A shared per-run counter would send [0, 1, 2] here.
+    expect(client.lookups.map((lookup) => lookup.occurrence)).toEqual([
+      0, 0, 1,
+    ]);
+  });
+
+  it("keeps the baseline occurrence counter still on a miss", async () => {
+    let firstCall = true;
+    const { client, run } = runState(baselineHistory("passthrough"), () => {
+      if (firstCall) {
+        firstCall = false;
+        return { found: false, result: null };
+      }
+      return { found: true, result: { value: "recorded" } };
+    });
+
+    await expect(
+      decideToolCall(run, { callId: "call-1", ...weatherDelft }),
+    ).resolves.toEqual({ type: "execute" });
+    await expect(
+      decideToolCall(run, { callId: "call-2", ...weatherDelft }),
+    ).resolves.toEqual({
+      output: { value: "recorded" },
+      type: "mocked_result",
+    });
+    expect(client.lookups.map((lookup) => lookup.occurrence)).toEqual([0, 0]);
+  });
+
+  it.each([
+    "agent",
+    "cohort_version",
+  ] as const)("sends no occurrence for the %s scope", async (scope) => {
+    const { client, run } = runState(
+      {
+        default: { on_miss: "fail", scope, type: "history" },
+        tools: {},
+      },
+      () => ({ found: true, result: { value: "recorded" } }),
+    );
+    await decideToolCall(run, { callId: "call-1", ...weatherDelft });
+    await decideToolCall(run, { callId: "call-2", ...weatherDelft });
+    expect(client.lookups).toHaveLength(2);
+    for (const lookup of client.lookups) {
+      expect(lookup).not.toHaveProperty("occurrence");
+    }
+  });
+
+  it("follows on_miss for a call past the last recorded occurrence", async () => {
+    const { client, run } = runState(baselineHistory("fail"), (request) =>
+      (request.occurrence ?? 0) < 1
+        ? { found: true, result: { value: "only" } }
+        : { found: false, result: null },
+    );
+
+    await expect(
+      decideToolCall(run, { callId: "call-1", ...weatherDelft }),
+    ).resolves.toEqual({ output: { value: "only" }, type: "mocked_result" });
+    await expect(
+      decideToolCall(run, { callId: "call-2", ...weatherDelft }),
+    ).rejects.toBeInstanceOf(ToolPolicyMissError);
+    expect(client.lookups.map((lookup) => lookup.occurrence)).toEqual([0, 1]);
+  });
+
   it("refuses a later tool once a policy has already failed", async () => {
     const run = state({ default: { type: "passthrough" }, tools: {} });
     const failure = new ToolPolicyMissError("No static result for 'normalize'");

--- a/packages/mastra/test/tool-policies.test.ts
+++ b/packages/mastra/test/tool-policies.test.ts
@@ -160,6 +160,7 @@ describe("replay tool policies", () => {
     const lookup = api.calls.find((call) => call.path.endsWith("/tool-lookup"));
     expect(lookup?.body).toEqual({
       cache_key: computeToolCacheKey("normalize", rawInput as never),
+      occurrence: 0,
       tool_name: "normalize",
     });
   });


### PR DESCRIPTION
## What this does

PR #807 taught the server's replay tool-lookup endpoint to take a zero-based `occurrence`, so repeated identical tool calls replay their distinct recorded results in baseline order, and updated the PydanticAI and LangGraph adapters to use it. This PR ports the same behavior to the TypeScript SDK.

For baseline-scoped history policies, `decideToolCall` in `packages/core` now keeps a per-cache-key counter on `RunState`, sends it as `occurrence` with each lookup, and advances it only on a hit. Non-baseline scopes (`cohort_version`, `agent`) omit the field, which the server requires. Both TypeScript adapters (Mastra and Vercel AI SDK) inherit the behavior through the shared core implementation with no adapter-side changes.

Closes #844 for the TypeScript surfaces. The OpenAI Agents adapter is the deliberate remainder: it does not implement the `history` tool policy at all (it rejects anything but `passthrough` and `static`), so there is no lookup to attach a counter to. That prerequisite feature is tracked separately in #846.

## Reviewer Notes

The story is small but the two subtle spots are both in the lookup path of `packages/core/src/adapter/tool-policy.ts`:

- **The counter advances on any hit, before the null-result ambiguity guard.** A recorded occurrence whose stored result is null still gets consumed, matching the Python adapters (`_history_result` in `kitaru_langgraph/langchain.py`). If the advance sat after the guard, a broken recording would pin the counter and every later identical call would re-fetch the same broken occurrence. A miss never advances, so a later identical call can retry the same recorded position after its `on_miss` path runs.
- **`advanceHistoryOccurrence(cacheKey, usedOccurrence)` writes back `usedOccurrence + 1` instead of re-reading the map.** With re-read-and-increment, two overlapping identical calls that both read occurrence 0 would advance the counter twice and silently skip recording #1. With write-back, both store 1 — the same semantics as the Python adapters' `history_occurrences[cache_key] = occurrence + 1`. If this is wrong, replays of runs with parallel identical tool calls would skip recorded results or spuriously trigger `on_miss` (which, under a passthrough miss policy, means re-firing a live side effect during replay).

If the implementation were wrong more broadly, the failure mode is the pre-#807 one: a baseline that called the same tool three times with identical arguments and got A, B, C would replay as C, C, C, and the replayed agent's trajectory silently drifts from the recording.

Everything else is mechanical: the generated `ToolLookupRequest` type already had `occurrence` from #807, the request omits the key entirely for non-baseline scopes (the server rejects `occurrence` there), and the Mastra test's serialized-body assertion now expects `occurrence: 0`, confirming the adapters pick this up with zero changes of their own.

Tests in `packages/core/test/adapter/tool-policy.test.ts` cover: three identical calls sending occurrences 0/1/2 and receiving distinct results in order, a miss not advancing the counter, per-cache-key (not per-run) counting via interleaved inputs asserting `[0, 0, 1]`, both non-baseline scopes omitting the field, and a call past the last recorded occurrence following `on_miss`.

### Reproduction

Unit-level: `cd packages/core && pnpm test -- test/adapter/tool-policy.test.ts` — the ordered-replay test fails on the pre-PR code with lookups `[undefined, undefined, undefined]` and every call resolving to the newest match.

End-to-end, this was proven live against a real server and real OpenAI (`gpt-5-nano`) through the full job pipeline: a Vercel AI agent with a no-argument `popNextTicket` tool recorded a baseline returning TICKET-A, TICKET-B, TICKET-C on three identical calls. The live queue was then replaced with WRONG-1/2/3 and the session replayed with `popNextTicket` under a baseline-scoped history policy (`on_miss: fail`). The replay's tool nodes and final answer came back `TICKET-A, TICKET-B, TICKET-C` in baseline order; without this change the same replay answers TICKET-C three times. The cross-language integration suite (`uv run pytest tests/typescript/`, 15 tests, needs the compose `db`) exercises the same record → history-replay path with the compiled packages.

Local checks run: `just check`, `just test` (3583 passed), `pnpm typecheck && pnpm lint && pnpm test` in `packages/core`, `packages/mastra`, and `packages/vercel-ai`.