### PR TITLE
Default `KITARU_SERVER_ANALYTICS_OPT_IN` to false in the dev `docker-compose.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Repeated identical tool calls with baseline-scoped history replay their distinct recorded results in baseline order instead of all resolving to the newest match. Replayed calls past the last recorded occurrence follow the configured `on_miss` behavior.
 ### Changed
 
+- The repository's development `docker-compose.yml` now defaults `KITARU_SERVER_ANALYTICS_OPT_IN` to `false`, so servers spun up from a source checkout stop emitting product analytics unless the variable is exported. The CLI-managed local deployment (`kitaru login --local`) and the published server image keep their existing opt-in default.
 - Unified all runnable examples under a single `examples/` tree: the Python adapter examples moved from `examples/integrations/` to `examples/python/`, and the TypeScript examples moved from `v2_examples/` to `examples/typescript/`. The `examples/v2/mcp` configuration example was removed in favor of the MCP setup documentation.
 
 ## [0.22.1]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       KITARU_SERVER_SECRET_ENCRYPTION_KEY: dev
       KITARU_SERVER_DEFAULT_ACCOUNT_PASSWORD: password
       KITARU_SERVER_ANALYTICS_DEBUG: true
+      KITARU_SERVER_ANALYTICS_OPT_IN: "${KITARU_SERVER_ANALYTICS_OPT_IN:-false}"
     volumes: [./src:/app/src]
     healthcheck:
       test: [CMD, curl, -f, http://localhost:8000/health/live]


### PR DESCRIPTION
## What and why

The repository's root `docker-compose.yml` is the development Compose file: it builds the server from source via `docker/dev-server.Dockerfile`, mounts `./src` live, and runs with dev secrets and `KITARU_SERVER_AUTH_SCHEME: none`. Servers started this way are development instances (contributors and their coding agents spinning up a stack to work against), not real product usage — but until now they emitted product analytics like any other server, since the server-side default is `ANALYTICS_OPT_IN = True`.

This PR adds one line to the dev Compose file:

```yaml
KITARU_SERVER_ANALYTICS_OPT_IN: "${KITARU_SERVER_ANALYTICS_OPT_IN:-false}"
```

Compose resolves the default on the host, so dev servers now start with analytics off, and anyone who needs to test the analytics path can flip it back on for a single run with `KITARU_SERVER_ANALYTICS_OPT_IN=true docker compose up`.

## What this does NOT change

- **`kitaru login --local`** uses the CLI's bundled template (`src/kitaru/cli/resources/local-compose.yaml`), which already declares this variable with the opposite default (`:-true`). End users keep analytics on unless they opt out.
- **The published image / Helm** paths set no value and keep the code default of `True` (`src/kitaru/server/api/config.py`).
- The existing `KITARU_SERVER_ANALYTICS_DEBUG: true` line stays: debug only tags messages with a `debug` field, it does not stop them from being sent — which is why this new line is needed at all.

## Reviewer Notes

The whole behavior change is the one line in `docker-compose.yml`; `CHANGELOG.md` gets a matching entry under `[Unreleased]`. The one judgment call worth reviewing: the manually managed clone-and-compose deployment documented in `docs/book/deploy/docker.md` uses this same file, so people on that path also get analytics defaulted off. That population is building from source with the dev Dockerfile and auth disabled, so treating them like developers rather than end users seemed right — flag it if you disagree, in which case the alternative is a separate compose override file for dev use.

If the implementation were wrong in the risky direction — a typo in the variable name or the interpolation syntax — the flag would silently not reach the server and dev events would keep flowing, so the reproduction below checks the effective config rather than trusting the YAML.

### Reproduction

```bash
docker compose up -d
docker inspect kitaru_server --format '{{range .Config.Env}}{{println .}}{{end}}' | grep ANALYTICS
```

Expect `KITARU_SERVER_ANALYTICS_OPT_IN=false` (and `KITARU_SERVER_ANALYTICS_DEBUG=true`). Then rerun with the override:

```bash
KITARU_SERVER_ANALYTICS_OPT_IN=true docker compose up -d
docker inspect kitaru_server --format '{{range .Config.Env}}{{println .}}{{end}}' | grep ANALYTICS
```

Expect `KITARU_SERVER_ANALYTICS_OPT_IN=true`, confirming the host-environment escape hatch works.

Local checks run: `just check` and `just test` (3583 passed, 16 skipped).