### PR TITLE
Prepare Kitaru 0.22.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.22.2]
+
+### Changed
+
+- Updated the bundled frontend to `kitaru-ui-v0.2.2`.
+
 ### Added
 
 - Added user-facing methods to `KitaruClient` and `KitaruSyncClient`: get agents and experiments by name or id, list sessions and session nodes, replay a session or start an experiment run and wait for the result. The one-method-per-endpoint API client stays reachable as `client.api`.

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8608,7 +8608,7 @@
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.22.1"
+    "version": "0.22.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.22.1"
+version = "0.22.2"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/releases/python/kitaru/0.22.2.toml
+++ b/releases/python/kitaru/0.22.2.toml
@@ -1,0 +1,3 @@
+schema-version = 1
+kitaru-version = "0.22.2"
+ui-tag = "kitaru-ui-v0.2.2"

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -239,7 +239,7 @@ def test_release_wheel_install_fails_after_the_attempt_limit(
         ("kitaru-v0.21.0", "package tag"),
         ("python/unknown/v0.1.0", "unknown distribution"),
         ("python/kitaru/v0.22.0-rc.1", "canonical PEP 440"),
-        ("python/kitaru/v0.22.2", "does not match manifest version"),
+        ("python/kitaru/v0.22.3", "does not match manifest version"),
     ],
 )
 def test_invalid_or_mismatched_package_tags_are_rejected(

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-17T13:35:55.994919Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -907,7 +907,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.22.1"
+version = "0.22.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Release preparation

- Core: `kitaru` `0.22.2`
- Frontend: `kitaru-ui-v0.2.2`
- Importer releases queued after core: `kitaru-langfuse-importer` `0.1.1`, `kitaru-logfire-importer` `0.1.1`, and `kitaru-phoenix-importer` `0.1.0`

## Frontend readiness

The selected UI release has both required assets, but GitHub currently marks `kitaru-ui-v0.2.2` as a prerelease. The stable core workflow will reject it until that release is promoted to stable.

## Validation

- `git diff --check`
- `just check`
- `uv run pytest -q tests/scripts/test_release_ui.py tests/scripts/test_release_units.py` (45 passed)
- `uv run --no-project --with packaging==26.2 python scripts/release_units.py validate` (11 units)
- `uv run python scripts/release_ui.py --version 0.22.2`

## Publication order

1. Promote and verify `kitaru-ui-v0.2.2` as a stable frontend release.
2. Merge and publish the core from `python/kitaru/v0.22.2`.
3. Publish the queued Langfuse, Logfire, and Phoenix importer releases.

## Reviewer Notes

Review `pyproject.toml`, `CHANGELOG.md`, `releases/python/kitaru/0.22.2.toml`, `uv.lock`, and `openapi/openapi.json`. Confirm the frontend tag is stable before removing draft status; no tag, workflow dispatch, or artifact publication is included in this PR.