### PR TITLE
Add metadata to plugin packages

### DIFF
--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -81,6 +81,15 @@ jobs:
           fi
       - name: Build plugin
         run: uv build --project "$PROJECT_DIR" --out-dir package-dist
+      - name: Validate distribution metadata
+        run: |
+          set -euo pipefail
+          wheel=$(find package-dist -maxdepth 1 -name '*.whl' -print -quit)
+          test -n "$wheel"
+          python scripts/smoke_plugin_artifacts.py \
+            --validate-wheel "$wheel" \
+            --distribution "$DISTRIBUTION" \
+            --version "$VERSION"
       - name: Test installed distribution
         run: |
           set -euo pipefail

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -14,7 +14,9 @@ Kitaru keeps the default catalog in `src/kitaru/server/api/bootstrap.py`. At sta
 | `langfuse-importer` | `kitaru-langfuse-importer` | Langfuse importer |
 | `langgraph` | `kitaru-langgraph` | LangGraph recording and replay adapter |
 | `langsmith-importer` | `kitaru-langsmith-importer` | LangSmith importer |
+| `logfire-importer` | `kitaru-logfire-importer` | Logfire importer |
 | `openai-agents` | `kitaru-openai-agents` | OpenAI Agents SDK recording adapter |
+| `phoenix-importer` | `kitaru-phoenix-importer` | Arize Phoenix importer |
 | `pydantic-ai` | `kitaru-pydantic-ai` | PydanticAI recording and replay adapter |
 
 ## Development and releases

--- a/plugins/packages/braintrust-importer/README.md
+++ b/plugins/packages/braintrust-importer/README.md
@@ -1,0 +1,24 @@
+# Kitaru Braintrust importer
+
+Import Braintrust project-log and UI exports as Kitaru sessions. This package backs the built-in `kitaru/braintrust` importer and runs on a Kitaru worker, so the export is parsed in your environment.
+
+Most users do not install or call this package directly. Start a Kitaru worker, then select the built-in importer:
+
+```bash
+kitaru session import braintrust-logs.jsonl \
+  --importer kitaru/braintrust@latest \
+  --agent support-agent@latest \
+  --wait
+```
+
+The importer accepts Braintrust JSON and JSONL export shapes, preserves source hierarchy and evidence when present, and records fidelity warnings for incomplete exports. Re-importing the same source identity skips sessions that Kitaru already stores.
+
+See the [Braintrust import guide](https://docs.zenml.io/kitaru/guides/import-braintrust-traces) for accepted formats, grouping parameters, deduplication behavior, and fidelity limits.
+
+## Links
+
+- [Kitaru documentation](https://docs.zenml.io/kitaru)
+- [Source code](https://github.com/zenml-io/kitaru)
+- [Issue tracker](https://github.com/zenml-io/kitaru/issues)
+
+Licensed under Apache-2.0.

--- a/plugins/packages/braintrust-importer/pyproject.toml
+++ b/plugins/packages/braintrust-importer/pyproject.toml
@@ -2,9 +2,34 @@
 name = "kitaru-braintrust-importer"
 version = "0.1.0"
 description = "Braintrust trace importer for Kitaru."
+readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
+authors = [
+    { name = "ZenML GmbH", email = "info@zenml.io" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["ai-agents", "braintrust", "kitaru", "observability", "traces"]
 dependencies = ["kitaru>=0.22.0"]
+
+[project.urls]
+Homepage = "https://kitaru.ai"
+Documentation = "https://docs.zenml.io/kitaru/guides/import-braintrust-traces"
+Repository = "https://github.com/zenml-io/kitaru"
+Issues = "https://github.com/zenml-io/kitaru/issues"
+Changelog = "https://github.com/zenml-io/kitaru/blob/develop/plugins/packages/braintrust-importer/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling==1.32.0"]

--- a/plugins/packages/evaluator/README.md
+++ b/plugins/packages/evaluator/README.md
@@ -1,0 +1,24 @@
+# Kitaru built-in evaluators
+
+Run offline evaluations over recorded and imported Kitaru sessions. This package contains the evaluator implementations registered under the `kitaru/` namespace by the default server and resolved by Kitaru workers.
+
+Most users do not install or call this package directly. Select one or more registered evaluators from the CLI:
+
+```bash
+kitaru session evaluate "$SESSION_ID" \
+  --evaluator kitaru/session-diagnostics@latest \
+  --evaluator kitaru/tool-health@latest \
+  --wait
+```
+
+The evaluators read stored session evidence. They do not run the agent, call a model provider, invoke a live tool, replay a session, or query an external service. Descriptive evaluators report findings without forcing a pass/fail judgment; configured policy evaluators can pass, fail, or hold when evidence is insufficient.
+
+See the [deterministic evaluations guide](https://docs.zenml.io/kitaru/guides/deterministic-evaluations) for the evaluator catalog, parameters, evidence semantics, and versioning guidance.
+
+## Links
+
+- [Kitaru documentation](https://docs.zenml.io/kitaru)
+- [Source code](https://github.com/zenml-io/kitaru)
+- [Issue tracker](https://github.com/zenml-io/kitaru/issues)
+
+Licensed under Apache-2.0.

--- a/plugins/packages/evaluator/pyproject.toml
+++ b/plugins/packages/evaluator/pyproject.toml
@@ -1,10 +1,35 @@
 [project]
 name = "kitaru-evaluator"
 version = "0.1.0"
-description = "Built-in deterministic evaluators for Kitaru."
+description = "Built-in offline evaluators for Kitaru."
+readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
+authors = [
+    { name = "ZenML GmbH", email = "info@zenml.io" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["ai-agents", "evaluation", "kitaru", "llm", "testing"]
 dependencies = ["kitaru>=0.22.0"]
+
+[project.urls]
+Homepage = "https://kitaru.ai"
+Documentation = "https://docs.zenml.io/kitaru/guides/deterministic-evaluations"
+Repository = "https://github.com/zenml-io/kitaru"
+Issues = "https://github.com/zenml-io/kitaru/issues"
+Changelog = "https://github.com/zenml-io/kitaru/blob/develop/plugins/packages/evaluator/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling==1.32.0"]

--- a/plugins/packages/jsonl-importer/README.md
+++ b/plugins/packages/jsonl-importer/README.md
@@ -1,0 +1,24 @@
+# Kitaru JSONL importer
+
+Import sessions that already match Kitaru's canonical JSONL session contract. This package backs the built-in `kitaru/kitaru-jsonl` importer and validates each line independently on a Kitaru worker.
+
+Most users do not install or call this package directly. Start a Kitaru worker, then select the built-in importer:
+
+```bash
+kitaru session import sessions.jsonl \
+  --importer kitaru/kitaru-jsonl@latest \
+  --agent support-agent@latest \
+  --wait
+```
+
+Write one complete Kitaru session object per line. Unknown fields and invalid records are rejected independently, so valid lines in the same upload can still import. Use a provider-specific importer when the input is a raw observability export rather than canonical Kitaru JSONL.
+
+See the [Kitaru JSONL guide](https://docs.zenml.io/kitaru/guides/importing-sessions) for the full session and node schema.
+
+## Links
+
+- [Kitaru documentation](https://docs.zenml.io/kitaru)
+- [Source code](https://github.com/zenml-io/kitaru)
+- [Issue tracker](https://github.com/zenml-io/kitaru/issues)
+
+Licensed under Apache-2.0.

--- a/plugins/packages/jsonl-importer/pyproject.toml
+++ b/plugins/packages/jsonl-importer/pyproject.toml
@@ -2,9 +2,34 @@
 name = "kitaru-jsonl-importer"
 version = "0.1.0"
 description = "Canonical JSONL session importer for Kitaru."
+readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
+authors = [
+    { name = "ZenML GmbH", email = "info@zenml.io" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["ai-agents", "jsonl", "kitaru", "observability", "traces"]
 dependencies = ["kitaru>=0.22.0"]
+
+[project.urls]
+Homepage = "https://kitaru.ai"
+Documentation = "https://docs.zenml.io/kitaru/guides/importing-sessions"
+Repository = "https://github.com/zenml-io/kitaru"
+Issues = "https://github.com/zenml-io/kitaru/issues"
+Changelog = "https://github.com/zenml-io/kitaru/blob/develop/plugins/packages/jsonl-importer/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling==1.32.0"]

--- a/plugins/packages/langfuse-importer/README.md
+++ b/plugins/packages/langfuse-importer/README.md
@@ -1,0 +1,24 @@
+# Kitaru Langfuse importer
+
+Import Langfuse JSON and JSONL trace exports as Kitaru sessions. This package backs the built-in `kitaru/langfuse` importer and runs on a Kitaru worker, so the export is parsed in your environment.
+
+Most users do not install or call this package directly. Start a Kitaru worker, then select the built-in importer:
+
+```bash
+kitaru session import langfuse-export.jsonl \
+  --importer kitaru/langfuse@latest \
+  --agent support-agent@latest \
+  --wait
+```
+
+The importer understands Langfuse trace, observation, and ingestion-event records. It preserves hierarchy, timing, models, token usage, cost, and source payloads when the export provides them. Re-importing the same source identity skips sessions that Kitaru already stores.
+
+See the [Langfuse import guide](https://docs.zenml.io/kitaru/guides/import-langfuse-traces) for accepted formats, parameters, deduplication behavior, and fidelity limits.
+
+## Links
+
+- [Kitaru documentation](https://docs.zenml.io/kitaru)
+- [Source code](https://github.com/zenml-io/kitaru)
+- [Issue tracker](https://github.com/zenml-io/kitaru/issues)
+
+Licensed under Apache-2.0.

--- a/plugins/packages/langfuse-importer/pyproject.toml
+++ b/plugins/packages/langfuse-importer/pyproject.toml
@@ -2,9 +2,34 @@
 name = "kitaru-langfuse-importer"
 version = "0.1.1"
 description = "Langfuse trace importer for Kitaru."
+readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
+authors = [
+    { name = "ZenML GmbH", email = "info@zenml.io" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["ai-agents", "kitaru", "langfuse", "observability", "traces"]
 dependencies = ["kitaru>=0.22.0"]
+
+[project.urls]
+Homepage = "https://kitaru.ai"
+Documentation = "https://docs.zenml.io/kitaru/guides/import-langfuse-traces"
+Repository = "https://github.com/zenml-io/kitaru"
+Issues = "https://github.com/zenml-io/kitaru/issues"
+Changelog = "https://github.com/zenml-io/kitaru/blob/develop/plugins/packages/langfuse-importer/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling==1.32.0"]

--- a/plugins/packages/langgraph/README.md
+++ b/plugins/packages/langgraph/README.md
@@ -33,3 +33,13 @@ print(result)
 ```
 
 Wrap an existing compiled graph directly with `KitaruGraphRunner(graph)` when you build the graph yourself. The runner accepts the same invocation arguments as the wrapped runnable. Kitaru workers provide task, replay, and authentication context through the standard task environment.
+
+Replay support depends on how the graph was constructed. See the [LangGraph adapter guide and capability matrix](https://docs.zenml.io/kitaru/adapters/langgraph) for supported invocation methods, overrides, tool policies, interrupts, and failure behavior.
+
+## Links
+
+- [Kitaru documentation](https://docs.zenml.io/kitaru)
+- [Source code](https://github.com/zenml-io/kitaru)
+- [Issue tracker](https://github.com/zenml-io/kitaru/issues)
+
+Licensed under Apache-2.0.

--- a/plugins/packages/langgraph/pyproject.toml
+++ b/plugins/packages/langgraph/pyproject.toml
@@ -5,6 +5,23 @@ description = "LangGraph recording and replay adapter for Kitaru."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
+authors = [
+    { name = "ZenML GmbH", email = "info@zenml.io" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["ai-agents", "kitaru", "langgraph", "recording", "replay"]
 dependencies = [
     "kitaru>=0.22.0",
     "langchain>=1.3.14,<2",
@@ -14,6 +31,13 @@ dependencies = [
 
 [project.optional-dependencies]
 deepagents = ["deepagents>=0.7.4,<0.8"]
+
+[project.urls]
+Homepage = "https://kitaru.ai"
+Documentation = "https://docs.zenml.io/kitaru/adapters/langgraph"
+Repository = "https://github.com/zenml-io/kitaru"
+Issues = "https://github.com/zenml-io/kitaru/issues"
+Changelog = "https://github.com/zenml-io/kitaru/blob/develop/plugins/packages/langgraph/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling==1.32.0"]

--- a/plugins/packages/langsmith-importer/README.md
+++ b/plugins/packages/langsmith-importer/README.md
@@ -1,0 +1,24 @@
+# Kitaru LangSmith importer
+
+Import LangSmith run-query and bulk-export records as Kitaru sessions. This package backs the built-in `kitaru/langsmith` importer and runs on a Kitaru worker, so the export is parsed in your environment.
+
+Most users do not install or call this package directly. Start a Kitaru worker, then select the built-in importer:
+
+```bash
+kitaru session import langsmith-runs.jsonl \
+  --importer kitaru/langsmith@latest \
+  --agent support-agent@latest \
+  --wait
+```
+
+The importer accepts LangSmith JSON and JSONL export shapes, reconstructs run hierarchy, and groups traces using thread-like metadata or an explicit grouping path. Re-importing the same source identity skips sessions that Kitaru already stores.
+
+See the [LangSmith import guide](https://docs.zenml.io/kitaru/guides/import-langsmith-traces) for accepted formats, grouping parameters, deduplication behavior, and fidelity limits.
+
+## Links
+
+- [Kitaru documentation](https://docs.zenml.io/kitaru)
+- [Source code](https://github.com/zenml-io/kitaru)
+- [Issue tracker](https://github.com/zenml-io/kitaru/issues)
+
+Licensed under Apache-2.0.

--- a/plugins/packages/langsmith-importer/pyproject.toml
+++ b/plugins/packages/langsmith-importer/pyproject.toml
@@ -2,9 +2,34 @@
 name = "kitaru-langsmith-importer"
 version = "0.1.0"
 description = "LangSmith trace importer for Kitaru."
+readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
+authors = [
+    { name = "ZenML GmbH", email = "info@zenml.io" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["ai-agents", "kitaru", "langsmith", "observability", "traces"]
 dependencies = ["kitaru>=0.22.0"]
+
+[project.urls]
+Homepage = "https://kitaru.ai"
+Documentation = "https://docs.zenml.io/kitaru/guides/import-langsmith-traces"
+Repository = "https://github.com/zenml-io/kitaru"
+Issues = "https://github.com/zenml-io/kitaru/issues"
+Changelog = "https://github.com/zenml-io/kitaru/blob/develop/plugins/packages/langsmith-importer/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling==1.32.0"]

--- a/plugins/packages/logfire-importer/README.md
+++ b/plugins/packages/logfire-importer/README.md
@@ -1,0 +1,24 @@
+# Kitaru Logfire importer
+
+Import Logfire records-query JSON and NDJSON exports as Kitaru sessions. This package backs the built-in `kitaru/logfire` importer and runs on a Kitaru worker, so the export is parsed in your environment.
+
+Most users do not install or call this package directly. Start a Kitaru worker, then select the built-in importer:
+
+```bash
+kitaru session import logfire-records.jsonl \
+  --importer kitaru/logfire@latest \
+  --agent support-agent@latest \
+  --wait
+```
+
+The importer rebuilds span hierarchy and conservatively identifies model and tool calls from OpenTelemetry attributes. Supply a stable source identity when an export does not contain one, especially when importing from more than one Logfire project.
+
+See the [Logfire import guide](https://docs.zenml.io/kitaru/guides/import-logfire-traces) for accepted formats, parameters, deduplication behavior, and fidelity limits.
+
+## Links
+
+- [Kitaru documentation](https://docs.zenml.io/kitaru)
+- [Source code](https://github.com/zenml-io/kitaru)
+- [Issue tracker](https://github.com/zenml-io/kitaru/issues)
+
+Licensed under Apache-2.0.

--- a/plugins/packages/logfire-importer/pyproject.toml
+++ b/plugins/packages/logfire-importer/pyproject.toml
@@ -2,9 +2,34 @@
 name = "kitaru-logfire-importer"
 version = "0.1.1"
 description = "Logfire records-query importer for Kitaru."
+readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
+authors = [
+    { name = "ZenML GmbH", email = "info@zenml.io" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["ai-agents", "kitaru", "logfire", "observability", "traces"]
 dependencies = ["kitaru>=0.22.0"]
+
+[project.urls]
+Homepage = "https://kitaru.ai"
+Documentation = "https://docs.zenml.io/kitaru/guides/import-logfire-traces"
+Repository = "https://github.com/zenml-io/kitaru"
+Issues = "https://github.com/zenml-io/kitaru/issues"
+Changelog = "https://github.com/zenml-io/kitaru/blob/develop/plugins/packages/logfire-importer/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling==1.32.0"]

--- a/plugins/packages/openai-agents/README.md
+++ b/plugins/packages/openai-agents/README.md
@@ -31,3 +31,13 @@ print(result.final_output)
 ```
 
 `KitaruRunner.run()` and `KitaruRunner.run_sync()` accept the same run arguments as the OpenAI Agents SDK `Runner`. Kitaru workers provide task, replay, and authentication context through the standard task environment.
+
+The adapter supports bounded replay of non-streaming runs. See the [OpenAI Agents SDK adapter guide](https://docs.zenml.io/kitaru/adapters/openai-agents) for supported overrides and tool policies, capture limits, approval and resume boundaries, and recording-failure behavior.
+
+## Links
+
+- [Kitaru documentation](https://docs.zenml.io/kitaru)
+- [Source code](https://github.com/zenml-io/kitaru)
+- [Issue tracker](https://github.com/zenml-io/kitaru/issues)
+
+Licensed under Apache-2.0.

--- a/plugins/packages/openai-agents/pyproject.toml
+++ b/plugins/packages/openai-agents/pyproject.toml
@@ -5,10 +5,34 @@ description = "OpenAI Agents SDK recording adapter for Kitaru."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
+authors = [
+    { name = "ZenML GmbH", email = "info@zenml.io" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["ai-agents", "kitaru", "openai-agents", "recording", "replay"]
 dependencies = [
     "kitaru>=0.22.0",
     "openai-agents>=0.19.3,<0.20",
 ]
+
+[project.urls]
+Homepage = "https://kitaru.ai"
+Documentation = "https://docs.zenml.io/kitaru/adapters/openai-agents"
+Repository = "https://github.com/zenml-io/kitaru"
+Issues = "https://github.com/zenml-io/kitaru/issues"
+Changelog = "https://github.com/zenml-io/kitaru/blob/develop/plugins/packages/openai-agents/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling==1.32.0"]

--- a/plugins/packages/phoenix-importer/README.md
+++ b/plugins/packages/phoenix-importer/README.md
@@ -1,0 +1,24 @@
+# Kitaru Arize Phoenix importer
+
+Import Arize Phoenix JSON and JSONL trace exports as Kitaru sessions. This package backs the built-in `kitaru/phoenix` importer and runs on a Kitaru worker, so the export is parsed in your environment.
+
+Most users do not install or call this package directly. Start a Kitaru worker, then select the built-in importer:
+
+```bash
+kitaru session import phoenix-traces.jsonl \
+  --importer kitaru/phoenix@latest \
+  --agent support-agent@latest \
+  --wait
+```
+
+The importer accepts Phoenix UI and CLI export shapes, preserves trace hierarchy and source evidence, and maps model and tool spans to Kitaru node types. Each Phoenix trace becomes one Kitaru session.
+
+See [Import your traces](https://docs.zenml.io/kitaru/getting-started/import-your-traces) for the live import workflow. The [provider-specific guide in the Kitaru repository](https://github.com/zenml-io/kitaru/blob/develop/docs/book/guides/import-phoenix-traces.md) documents accepted Phoenix formats, deduplication behavior, and fidelity limits.
+
+## Links
+
+- [Kitaru documentation](https://docs.zenml.io/kitaru)
+- [Source code](https://github.com/zenml-io/kitaru)
+- [Issue tracker](https://github.com/zenml-io/kitaru/issues)
+
+Licensed under Apache-2.0.

--- a/plugins/packages/phoenix-importer/pyproject.toml
+++ b/plugins/packages/phoenix-importer/pyproject.toml
@@ -2,9 +2,34 @@
 name = "kitaru-phoenix-importer"
 version = "0.1.0"
 description = "Arize Phoenix trace importer for Kitaru."
+readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
+authors = [
+    { name = "ZenML GmbH", email = "info@zenml.io" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["ai-agents", "arize-phoenix", "kitaru", "observability", "traces"]
 dependencies = ["kitaru>=0.22.0"]
+
+[project.urls]
+Homepage = "https://kitaru.ai"
+Documentation = "https://docs.zenml.io/kitaru/getting-started/import-your-traces"
+Repository = "https://github.com/zenml-io/kitaru"
+Issues = "https://github.com/zenml-io/kitaru/issues"
+Changelog = "https://github.com/zenml-io/kitaru/blob/develop/plugins/packages/phoenix-importer/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling==1.32.0"]

--- a/plugins/packages/pydantic-ai/README.md
+++ b/plugins/packages/pydantic-ai/README.md
@@ -54,3 +54,13 @@ agent = KitaruAgent(pydantic_agent, cost_calculator=calculate_cost)
 ```
 
 Set `estimate_costs=False` when cost estimation should be disabled. This does not disable a supplied `cost_calculator`.
+
+See the [PydanticAI adapter guide](https://docs.zenml.io/kitaru/adapters/pydantic-ai) for the recording lifecycle, replay overrides, tool policies, payload handling, and failure behavior.
+
+## Links
+
+- [Kitaru documentation](https://docs.zenml.io/kitaru)
+- [Source code](https://github.com/zenml-io/kitaru)
+- [Issue tracker](https://github.com/zenml-io/kitaru/issues)
+
+Licensed under Apache-2.0.

--- a/plugins/packages/pydantic-ai/pyproject.toml
+++ b/plugins/packages/pydantic-ai/pyproject.toml
@@ -5,6 +5,25 @@ description = "PydanticAI recording and replay adapter for Kitaru."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
+authors = [
+    { name = "ZenML GmbH", email = "info@zenml.io" },
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Framework :: Pydantic",
+    "Framework :: Pydantic :: 2",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["ai-agents", "kitaru", "pydantic-ai", "recording", "replay"]
 dependencies = [
     "genai-prices>=0.1.1,<0.2",
     "kitaru>=0.22.0",
@@ -13,6 +32,13 @@ dependencies = [
 
 [project.optional-dependencies]
 openai = ["pydantic-ai-slim[openai]>=2.14.1,<2.23"]
+
+[project.urls]
+Homepage = "https://kitaru.ai"
+Documentation = "https://docs.zenml.io/kitaru/adapters/pydantic-ai"
+Repository = "https://github.com/zenml-io/kitaru"
+Issues = "https://github.com/zenml-io/kitaru/issues"
+Changelog = "https://github.com/zenml-io/kitaru/blob/develop/plugins/packages/pydantic-ai/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling==1.32.0"]

--- a/scripts/release_units.py
+++ b/scripts/release_units.py
@@ -19,6 +19,9 @@ PACKAGE_TAG_PATTERN = re.compile(
     r"python/(?P<distribution>[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?)/v(?P<version>[^/]+)"
 )
 SLUG_PATTERN = re.compile(r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
+REQUIRED_PLUGIN_PROJECT_URLS = frozenset(
+    {"Homepage", "Documentation", "Repository", "Issues", "Changelog"}
+)
 
 
 class ReleaseInventoryError(ValueError):
@@ -146,7 +149,7 @@ def _resolve_repo_path(repo_root: Path, value: str, context: str) -> Path:
 
 def _parse_manifest(
     repo_root: Path, project_path: Path, version_source: str, context: str
-) -> tuple[str, str]:
+) -> tuple[str, str, dict[str, Any]]:
     manifest_path = _resolve_repo_path(repo_root, version_source, context)
     if not manifest_path.is_relative_to(project_path):
         raise ReleaseInventoryError(f"{context}: version source is outside the project")
@@ -156,7 +159,64 @@ def _parse_manifest(
         raise ReleaseInventoryError(f"{context}: version source has no [project] table")
     name = _get_string(project, "name", context)
     version = validate_version(_get_string(project, "version", context))
-    return name, version
+    return name, version, project
+
+
+def _validate_plugin_project_metadata(
+    project_path: Path, project: dict[str, Any], context: str
+) -> None:
+    """Require the metadata rendered on each plugin's PyPI page."""
+    _get_string(project, "description", context)
+    if _get_string(project, "license", context) != "Apache-2.0":
+        raise ReleaseInventoryError(f"{context}: license must be Apache-2.0")
+
+    readme_value = _get_string(project, "readme", context)
+    readme_path = Path(readme_value)
+    if readme_path.is_absolute():
+        raise ReleaseInventoryError(f"{context}: readme must be project-relative")
+    resolved_readme = (project_path / readme_path).resolve()
+    if not resolved_readme.is_relative_to(project_path.resolve()):
+        raise ReleaseInventoryError(f"{context}: readme escapes the project")
+    if not resolved_readme.is_file() or not resolved_readme.read_text().strip():
+        raise ReleaseInventoryError(
+            f"{context}: readme must reference a non-empty file"
+        )
+
+    authors = project.get("authors")
+    if not isinstance(authors, list) or not authors:
+        raise ReleaseInventoryError(f"{context}: authors must be a non-empty list")
+    for author in authors:
+        if not isinstance(author, dict):
+            raise ReleaseInventoryError(f"{context}: each author must be a table")
+        _get_string(author, "name", f"{context} author")
+        _get_string(author, "email", f"{context} author")
+
+    for key in ("classifiers", "keywords"):
+        values = _get_string_list(project, key, context)
+        if not values:
+            raise ReleaseInventoryError(f"{context}: {key} must not be empty")
+        if any(value != value.strip() for value in values):
+            raise ReleaseInventoryError(
+                f"{context}: {key} values must not contain outer whitespace"
+            )
+
+    urls = project.get("urls")
+    if not isinstance(urls, dict):
+        raise ReleaseInventoryError(f"{context}: [project.urls] must be a table")
+    missing_urls = sorted(REQUIRED_PLUGIN_PROJECT_URLS - urls.keys())
+    if missing_urls:
+        raise ReleaseInventoryError(
+            f"{context}: missing project URL: {missing_urls[0]}"
+        )
+    for label, value in urls.items():
+        if not isinstance(label, str) or not label:
+            raise ReleaseInventoryError(
+                f"{context}: project URL labels must be non-empty strings"
+            )
+        if not isinstance(value, str) or not value.startswith("https://"):
+            raise ReleaseInventoryError(
+                f"{context}: project URL {label} must be an HTTPS URL"
+            )
 
 
 def _parse_requirement(value: str, context: str) -> Requirement:
@@ -328,13 +388,17 @@ def load_inventory(
         if registry != "pypi":
             raise ReleaseInventoryError(f"{context}: unsupported registry {registry}")
         version_source = _get_string(raw_unit, "version-source", context)
-        manifest_name, version = _parse_manifest(
+        manifest_name, version, project_metadata = _parse_manifest(
             root, resolved_project, version_source, context
         )
         if manifest_name != distribution:
             raise ReleaseInventoryError(
                 f"{context}: manifest name {manifest_name} does not match "
                 f"{distribution}"
+            )
+        if slug != "kitaru":
+            _validate_plugin_project_metadata(
+                resolved_project, project_metadata, context
             )
 
         default_catalog = raw_unit.get("default-catalog")

--- a/scripts/smoke_plugin_artifacts.py
+++ b/scripts/smoke_plugin_artifacts.py
@@ -9,7 +9,10 @@ import subprocess
 import sys
 import tempfile
 import tomllib
+from email.parser import BytesParser
+from email.policy import default
 from pathlib import Path
+from zipfile import BadZipFile, ZipFile
 
 _SUBPROCESS_TIMEOUT_SECONDS = 300
 _SCRUBBED_ENVIRONMENT_VARIABLES = {
@@ -24,6 +27,9 @@ _SCRUBBED_ENVIRONMENT_VARIABLES = {
     "VIRTUAL_ENV",
     "VIRTUAL_ENV_PROMPT",
 }
+_REQUIRED_PROJECT_URLS = frozenset(
+    {"Homepage", "Documentation", "Repository", "Issues", "Changelog"}
+)
 
 
 class SmokeFailure(RuntimeError):
@@ -162,6 +168,58 @@ def _find_wheel(directory: Path, name: str, version: str) -> Path:
             f"Expected one wheel for {name}=={version}, found {len(matches)}"
         )
     return matches[0].resolve()
+
+
+def _validate_wheel_metadata(wheel: Path, name: str, version: str) -> None:
+    """Require the metadata that PyPI renders for one plugin wheel."""
+    try:
+        with ZipFile(wheel) as archive:
+            metadata_files = [
+                path
+                for path in archive.namelist()
+                if path.endswith(".dist-info/METADATA")
+            ]
+            if len(metadata_files) != 1:
+                raise SmokeFailure(
+                    f"{name}=={version}: expected one wheel METADATA file, "
+                    f"found {len(metadata_files)}"
+                )
+            message = BytesParser(policy=default).parsebytes(
+                archive.read(metadata_files[0])
+            )
+    except (BadZipFile, OSError) as error:
+        raise SmokeFailure(f"{name}=={version}: invalid wheel: {error}") from error
+
+    required_headers = {
+        "Name": name,
+        "Version": version,
+        "Description-Content-Type": "text/markdown",
+        "License-Expression": "Apache-2.0",
+    }
+    for header, expected in required_headers.items():
+        if message.get(header) != expected:
+            raise SmokeFailure(f"{name}=={version}: {header} must be {expected!r}")
+
+    for header in ("Summary", "Author-email", "Keywords"):
+        value = message.get(header)
+        if value is None or not str(value).strip():
+            raise SmokeFailure(f"{name}=={version}: missing {header}")
+    if not message.get_all("Classifier"):
+        raise SmokeFailure(f"{name}=={version}: missing Classifier")
+
+    payload = message.get_payload()
+    if not isinstance(payload, str) or not payload.strip():
+        raise SmokeFailure(f"{name}=={version}: wheel description is empty")
+
+    project_urls: set[str] = set()
+    for value in message.get_all("Project-URL", []):
+        label, separator, url = str(value).partition(",")
+        if not separator or not label.strip() or not url.strip().startswith("https://"):
+            raise SmokeFailure(f"{name}=={version}: invalid Project-URL {value!r}")
+        project_urls.add(label.strip())
+    missing_urls = sorted(_REQUIRED_PROJECT_URLS - project_urls)
+    if missing_urls:
+        raise SmokeFailure(f"{name}=={version}: missing Project-URL {missing_urls[0]}")
 
 
 def _build_wheel(
@@ -318,6 +376,19 @@ def main() -> int:
     """Build plugin wheels and validate their installed contracts."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--validate-wheel",
+        type=Path,
+        help="Validate one existing plugin wheel and exit.",
+    )
+    parser.add_argument(
+        "--distribution",
+        help="Expected distribution name for --validate-wheel.",
+    )
+    parser.add_argument(
+        "--version",
+        help="Expected distribution version for --validate-wheel.",
+    )
+    parser.add_argument(
         "--package",
         action="append",
         default=[],
@@ -336,6 +407,24 @@ def main() -> int:
         help="Existing Kitaru wheel or directory containing one candidate wheel.",
     )
     arguments = parser.parse_args()
+
+    if arguments.validate_wheel is not None:
+        if arguments.distribution is None or arguments.version is None:
+            parser.error("--validate-wheel requires --distribution and --version")
+        try:
+            _validate_wheel_metadata(
+                arguments.validate_wheel,
+                arguments.distribution,
+                arguments.version,
+            )
+        except SmokeFailure as error:
+            print(f"Plugin artifact smoke failed: {error}", file=sys.stderr)
+            return 1
+        print(
+            "Validated plugin wheel metadata: "
+            f"{arguments.distribution}=={arguments.version}"
+        )
+        return 0
 
     uv = shutil.which("uv")
     if uv is None:
@@ -380,11 +469,11 @@ def main() -> int:
                     raise SmokeFailure(
                         f"{name}=={version} is not pinned in default-requirements.txt"
                     )
-                plugin_wheels.append(
-                    _build_wheel(
-                        uv, repository, project, candidate_directory, environment
-                    )
+                wheel = _build_wheel(
+                    uv, repository, project, candidate_directory, environment
                 )
+                _validate_wheel_metadata(wheel, name, version)
+                plugin_wheels.append(wheel)
                 if requirement is not None:
                     requirements.append(requirement)
                 if import_module is not None:

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -56,16 +56,18 @@ def release_repo(tmp_path: Path) -> Path:
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, destination)
 
-    for manifest in (REPO_ROOT / "plugins" / "packages").glob("*/pyproject.toml"):
-        relative_path = manifest.relative_to(REPO_ROOT)
-        destination = tmp_path / relative_path
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(manifest, destination)
+    for project in (REPO_ROOT / "plugins" / "packages").iterdir():
+        for filename in ("pyproject.toml", "README.md"):
+            source = project / filename
+            relative_path = source.relative_to(REPO_ROOT)
+            destination = tmp_path / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
 
     return tmp_path
 
 
-def test_inventory_describes_exactly_the_ten_python_distributions() -> None:
+def test_inventory_describes_core_and_ten_plugin_distributions() -> None:
     inventory = load_inventory()
 
     assert {unit.slug: unit.distribution for unit in inventory.units} == EXPECTED_UNITS
@@ -282,6 +284,64 @@ def test_inventory_rejects_a_missing_plugin_project(release_repo: Path) -> None:
         load_inventory(release_repo)
 
 
+def test_inventory_rejects_plugin_metadata_without_a_readme(
+    release_repo: Path,
+) -> None:
+    manifest = (
+        release_repo / "plugins" / "packages" / "langfuse-importer" / "pyproject.toml"
+    )
+    manifest.write_text(manifest.read_text().replace('readme = "README.md"\n', ""))
+
+    with pytest.raises(ReleaseInventoryError, match="readme must be"):
+        load_inventory(release_repo)
+
+
+def test_inventory_rejects_plugin_metadata_with_a_missing_readme_file(
+    release_repo: Path,
+) -> None:
+    readme = release_repo / "plugins" / "packages" / "langfuse-importer" / "README.md"
+    readme.unlink()
+
+    with pytest.raises(ReleaseInventoryError, match="non-empty file"):
+        load_inventory(release_repo)
+
+
+def test_inventory_rejects_plugin_metadata_without_project_urls(
+    release_repo: Path,
+) -> None:
+    manifest = (
+        release_repo / "plugins" / "packages" / "langfuse-importer" / "pyproject.toml"
+    )
+    manifest.write_text(
+        manifest.read_text().replace(
+            'Documentation = "https://docs.zenml.io/kitaru/guides/import-langfuse-traces"\n',
+            "",
+        )
+    )
+
+    with pytest.raises(
+        ReleaseInventoryError, match="missing project URL: Documentation"
+    ):
+        load_inventory(release_repo)
+
+
+def test_inventory_rejects_plugin_metadata_without_keywords(
+    release_repo: Path,
+) -> None:
+    manifest = (
+        release_repo / "plugins" / "packages" / "langfuse-importer" / "pyproject.toml"
+    )
+    manifest.write_text(
+        manifest.read_text().replace(
+            'keywords = ["ai-agents", "kitaru", "langfuse", "observability", "traces"]',
+            "keywords = []",
+        )
+    )
+
+    with pytest.raises(ReleaseInventoryError, match="keywords must not be empty"):
+        load_inventory(release_repo)
+
+
 def test_inventory_rejects_an_adapter_in_the_default_catalog(
     release_repo: Path,
 ) -> None:
@@ -314,7 +374,7 @@ def test_text_and_json_outputs_contain_the_same_unit_identities() -> None:
     assert all(unit.distribution in text_output for unit in inventory.units)
 
 
-def test_plugin_matrix_is_generated_from_the_nine_plugin_units() -> None:
+def test_plugin_matrix_is_generated_from_the_ten_plugin_units() -> None:
     matrix = build_plugin_matrix(load_inventory())
 
     assert matrix == {
@@ -338,6 +398,21 @@ def test_plugin_release_workflow_resolves_plugin_tags_from_the_inventory() -> No
     assert "scripts/release_ui.py --version" not in workflow
     assert "uv version" not in workflow
     assert "name: pypi-${{ needs.build.outputs.distribution }}" in workflow
+
+
+def test_plugin_release_workflow_validates_wheel_metadata_before_publish() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release-plugins.yml").read_text()
+    build_job = workflow.split("\n  publish-python:\n", maxsplit=1)[0]
+
+    build_step = build_job.index("      - name: Build plugin\n")
+    metadata_step = build_job.index("      - name: Validate distribution metadata\n")
+    checksum_step = build_job.index("      - name: Record artifact checksums\n")
+
+    assert build_step < metadata_step < checksum_step
+    assert "scripts/smoke_plugin_artifacts.py" in build_job
+    assert '--validate-wheel "$wheel"' in build_job
+    assert '--distribution "$DISTRIBUTION"' in build_job
+    assert '--version "$VERSION"' in build_job
 
 
 def test_python_release_workflow_can_resume_after_partial_publication() -> None:

--- a/tests/scripts/test_smoke_plugin_artifacts.py
+++ b/tests/scripts/test_smoke_plugin_artifacts.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+from scripts.smoke_plugin_artifacts import SmokeFailure, _validate_wheel_metadata
+
+VALID_METADATA = """Metadata-Version: 2.4
+Name: kitaru-example
+Version: 1.0.0
+Summary: Example Kitaru package.
+Author-email: ZenML GmbH <info@zenml.io>
+License-Expression: Apache-2.0
+Keywords: ai-agents,kitaru
+Classifier: Development Status :: 3 - Alpha
+Description-Content-Type: text/markdown
+Project-URL: Homepage, https://kitaru.ai
+Project-URL: Documentation, https://docs.zenml.io/kitaru
+Project-URL: Repository, https://github.com/zenml-io/kitaru
+Project-URL: Issues, https://github.com/zenml-io/kitaru/issues
+Project-URL: Changelog, https://github.com/zenml-io/kitaru/blob/develop/CHANGELOG.md
+
+# Kitaru example
+
+Package description.
+"""
+
+
+def _write_wheel(tmp_path: Path, metadata: str) -> Path:
+    wheel = tmp_path / "kitaru_example-1.0.0-py3-none-any.whl"
+    with ZipFile(wheel, "w") as archive:
+        archive.writestr("kitaru_example-1.0.0.dist-info/METADATA", metadata)
+    return wheel
+
+
+def test_wheel_metadata_accepts_complete_pypi_metadata(tmp_path: Path) -> None:
+    wheel = _write_wheel(tmp_path, VALID_METADATA)
+
+    _validate_wheel_metadata(wheel, "kitaru-example", "1.0.0")
+
+
+def test_wheel_metadata_rejects_an_empty_description(tmp_path: Path) -> None:
+    headers = VALID_METADATA.split("\n\n", maxsplit=1)[0]
+    wheel = _write_wheel(tmp_path, f"{headers}\n\n")
+
+    with pytest.raises(SmokeFailure, match="wheel description is empty"):
+        _validate_wheel_metadata(wheel, "kitaru-example", "1.0.0")
+
+
+def test_wheel_metadata_rejects_a_missing_project_url(tmp_path: Path) -> None:
+    metadata = VALID_METADATA.replace(
+        "Project-URL: Documentation, https://docs.zenml.io/kitaru\n", ""
+    )
+    wheel = _write_wheel(tmp_path, metadata)
+
+    with pytest.raises(SmokeFailure, match="missing Project-URL Documentation"):
+        _validate_wheel_metadata(wheel, "kitaru-example", "1.0.0")
+
+
+def test_wheel_metadata_rejects_an_invalid_project_url(tmp_path: Path) -> None:
+    metadata = VALID_METADATA.replace(
+        "Project-URL: Homepage, https://kitaru.ai",
+        "Project-URL: Homepage, http://kitaru.ai",
+    )
+    wheel = _write_wheel(tmp_path, metadata)
+
+    with pytest.raises(SmokeFailure, match="invalid Project-URL"):
+        _validate_wheel_metadata(wheel, "kitaru-example", "1.0.0")


### PR DESCRIPTION
## What changed?

- Added complete PyPI metadata and package-level READMEs for all ten non-core Python distributions.
- Added release-inventory validation for the source metadata each distribution must declare.
- Added wheel metadata validation to plugin artifact CI and the tag-triggered publish workflow.

No package versions, default pins, changelogs, or existing PyPI releases change. The improved metadata will appear with each package's next ordinary release.

## Why?

PyPI renders each distribution from the metadata embedded in that distribution's uploaded artifact. Seven plugin packages did not declare a README at all, and all ten omitted shared metadata such as authors, classifiers, keywords, and project URLs. The release workflow faithfully published those omissions and only checked the installed version.

This change fixes the package sources and guards both representations: inventory validation catches incomplete `pyproject.toml` metadata, while wheel validation catches build-backend or release-workflow drift before publication.

## Reviewer Notes

Each package declares its metadata directly because PEP 621 does not define inheritance between project manifests. The important behavior lives in `scripts/release_units.py`, which is already called while resolving any plugin release tag, and `scripts/smoke_plugin_artifacts.py`, which checks the metadata PyPI will actually receive. The release workflow invokes the same wheel gate before checksums, artifact upload, and publication.

The final review specifically checked that a tag-triggered release cannot bypass the wheel metadata validation. If either gate is wrong, an immutable release could still reach PyPI with an empty or incomplete project page.

## Reproduction

1. Build one plugin wheel:

   ```bash
   uv build --wheel --project plugins/packages/langfuse-importer --out-dir /tmp/kitaru-plugin-metadata
   ```

2. Validate the exact artifact as the release workflow does:

   ```bash
   python scripts/smoke_plugin_artifacts.py \
     --validate-wheel /tmp/kitaru-plugin-metadata/kitaru_langfuse_importer-0.1.1-py3-none-any.whl \
     --distribution kitaru-langfuse-importer \
     --version 0.1.1
   ```

3. Observe `Validated plugin wheel metadata: kitaru-langfuse-importer==0.1.1`. Removing a required project URL or the README declaration makes the corresponding source or artifact gate fail.

## Local checks run

- `uv run --extra server pytest -q tests/scripts/test_release_units.py tests/scripts/test_smoke_plugin_artifacts.py` (51 passed)
- `uv run --no-project --with packaging==26.2 python scripts/release_units.py validate` (11 release units validated)
- `just plugin-artifact-smoke` (all 10 plugin wheels built, metadata-validated, installed, and probed)
- Plugin workspace checks (418 tests passed)
- `just check`
