### PR TITLE
Clear stale entries from `pip-audit-ignored.txt` and make empty-list audits robust

### DIFF
--- a/.github/pip-audit-ignored.txt
+++ b/.github/pip-audit-ignored.txt
@@ -10,26 +10,7 @@
 # To re-verify this list, run `uv run pip-audit` with no ignore flags and
 # compare the reported IDs against the entries below. Anything listed here
 # that pip-audit no longer reports is stale and should be deleted.
-
-# --- Blocked by zenml's `click<=8.2.1` cap. --------------------------------
-# zenml declares `click>=8.0.1,<=8.2.1`. The ceiling is inclusive and sits on
-# the vulnerable version itself, so no lockfile refresh can reach the 8.3.3
-# fix while we depend on zenml.
 #
-# Not exploitable here: the advisory is a command injection in `click.edit()`,
-# the helper that shells out to `$EDITOR`. Kitaru never calls it (our only
-# click usage is `click.get_app_dir()` and catching `click.ClickException`),
-# and neither does zenml. The CVSS vector is local-only and already requires
-# high privileges (AV:L/AC:H/PR:H/UI:R).
-# Tracked upstream: https://github.com/zenml-io/zenml/issues/5077
-PYSEC-2026-2132  # click 8.2.1 -> 8.3.3 (CVE-2026-7246, `click.edit()` injection)
-
-# --- Blocked by the fastapi pin in zenml's [server] extra. -----------------
-# zenml pins `fastapi>=0.120.1,<0.121.0`, and fastapi 0.120.x in turn requires
-# `starlette<0.50.0`. The fixes below all land in starlette 1.x, so they are
-# unreachable until zenml widens its server-stack constraints.
-PYSEC-2026-161  # starlette -> 1.0.1 (above fastapi's <0.50.0 ceiling)
-CVE-2026-48817  # starlette -> 1.1.0 (above fastapi's <0.50.0 ceiling)
-CVE-2026-48818  # starlette -> 1.1.0 (above fastapi's <0.50.0 ceiling)
-CVE-2026-54282  # starlette -> 1.3.0 (above fastapi's <0.50.0 ceiling)
-CVE-2026-54283  # starlette -> 1.3.1 (above fastapi's <0.50.0 ceiling)
+# The list is currently empty: the click and starlette entries were removed
+# when the zenml dependency (whose pins blocked the fixed versions) was
+# dropped and a bare `uv run pip-audit` came back clean.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,9 +168,13 @@ jobs:
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
       - run: uv sync --frozen --all-extras
       - name: Run pip-audit (with documented ignore list)
+        # Build the flags as an array instead of piping into xargs so an empty
+        # ignore list still runs the audit (BSD xargs skips the command
+        # entirely on empty input, and quoting keeps shellcheck happy).
         run: |
-          awk '/^(CVE|GHSA|PYSEC)-/ {printf "--ignore-vuln %s ", $1}' \
-            .github/pip-audit-ignored.txt | xargs uv run pip-audit
+          readarray -t ignore_flags < <(awk '/^(CVE|GHSA|PYSEC)-/ {print "--ignore-vuln"; print $1}' \
+            .github/pip-audit-ignored.txt)
+          uv run pip-audit "${ignore_flags[@]}"
   public-template-contract:
     name: Public template against current Kitaru
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}

--- a/Justfile
+++ b/Justfile
@@ -65,8 +65,10 @@ zizmor:
     uvx zizmor --config=.github/zizmor.yml .github/workflows/ .github/dependabot.yml
 
 # Audit Python dependencies for known vulnerabilities (honors .github/pip-audit-ignored.txt)
+# Command substitution instead of xargs: BSD xargs skips the command entirely
+# on empty input, which would turn an empty ignore list into a no-op audit.
 audit:
-    awk '/^(CVE|GHSA|PYSEC)-/ {printf "--ignore-vuln %s ", $1}' .github/pip-audit-ignored.txt | xargs uv run pip-audit
+    uv run pip-audit $(awk '/^(CVE|GHSA|PYSEC)-/ {printf "--ignore-vuln %s ", $1}' .github/pip-audit-ignored.txt)
 
 # Check raw Markdown links — offline only (requires lychee: brew install lychee).
 # Source MDX uses docs-app-root routes such as /guides/...; site-build validates


### PR DESCRIPTION
## What

Empties the pip-audit suppression list (`.github/pip-audit-ignored.txt`) and hardens the `just audit` recipe plus the CI pip-audit step so they still run when the list is empty.

## Why

Every suppressed advisory was justified by version pins in the `zenml` dependency: `click<=8.2.1` (PYSEC-2026-2132) and `fastapi<0.121` → `starlette<0.50` (the five starlette advisories). `zenml` is no longer a dependency, so those ceilings are gone: the lockfile now resolves `click 8.4.2` and `starlette 1.3.1`, both past the fixed versions. A bare `uv run pip-audit` (no ignore flags) reports **no known vulnerabilities**, which makes all six entries stale. A stale suppression is worse than noise: if any of those IDs ever resurfaced through a downgrade, the list would silently hide it.

## Reviewer Notes

The risky part is not the deletion, it's the emptiness. Both audit entry points fed the ignore flags through `awk ... | xargs uv run pip-audit`. BSD xargs (macOS) does not run the command at all when its input is empty, so with an empty list `just audit` would exit 0 having scanned nothing. GNU xargs on the CI runners runs the command once, so CI happened to be safe — but only by xargs flavor. The Justfile recipe now uses command substitution and the CI step builds the flags with `readarray` into a quoted bash array (shellcheck-clean), so `pip-audit` always executes regardless of list length. If either of those rewrites is wrong, the failure mode is an audit that never runs — which is exactly what they exist to prevent, so please eyeball the two shell fragments.

`.github/workflows/ci.yml` is touched, so the path-filtered zizmor workflow will run on this PR.

### Reproduction

```sh
uv run pip-audit          # no ignore flags: reports "No known vulnerabilities found"
just audit                # empty list, still runs pip-audit and prints the same
```

On macOS before this change, `just audit` with the empty list printed nothing and exited 0 (BSD xargs skipped the command).

Local checks run: `just check`, `just test` (3638 passed, 16 skipped), `just zizmor` (no findings).