### PR TITLE
Require human review before merging any PR (`CLAUDE.md`, `AGENTS.md`)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,11 +113,7 @@ The canonical returns implementation lives in the public [`zenml-io/kitaru-templ
 - Link related issues when applicable.
 - Every PR description should include a `Reviewer Notes` H2 or H3 section with
   a concrete reproduction path for reviewers.
-- Never merge a PR that has not received an approving human review — this
-  includes dependabot bumps and trivial changes, and it must not be bypassed
-  with `gh pr merge --admin` or similar. Documented review of every change is
-  part of our change-management controls (relevant to compliance frameworks
-  such as SOC 2). Prepare the PR, request review, and wait.
+- Never merge a PR that has not received an approving human review — this includes dependabot bumps and trivial changes, and it must not be bypassed with `gh pr merge --admin` or similar. Documented review of every change is part of our change-management controls (relevant to compliance frameworks such as SOC 2). Prepare the PR, request review, and wait.
 
 ## CI/CD
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,11 @@ The canonical returns implementation lives in the public [`zenml-io/kitaru-templ
 - Link related issues when applicable.
 - Every PR description should include a `Reviewer Notes` H2 or H3 section with
   a concrete reproduction path for reviewers.
+- Never merge a PR that has not received an approving human review — this
+  includes dependabot bumps and trivial changes, and it must not be bypassed
+  with `gh pr merge --admin` or similar. Documented review of every change is
+  part of our change-management controls (relevant to compliance frameworks
+  such as SOC 2). Prepare the PR, request review, and wait.
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ For adapter, importer, specialized UI API, docs, CI, and release work, load the 
 
 ## Commits and PRs
 
+- **Never merge a PR that has not been human-reviewed.** Every PR — including dependabot bumps and small hygiene changes — needs an approving review from a human before it merges. Do not bypass the review requirement with `gh pr merge --admin` or any other mechanism, even when all checks are green and the change looks trivial. Documented review of every change is part of our change-management controls (relevant to compliance frameworks such as SOC 2), so an unreviewed merge is a process violation, not just a style issue. Prepare the PR, request review, and wait.
 - **Run CI checks locally before committing/pushing.** Always run `just check` and `just test` before pushing to `develop`. All checks must pass locally — do not rely on CI to catch failures. This includes format, lint, typecheck, typos, yaml, actions lint, links, and tests.
 - **Keep pre-existing failures separate.** If `just check` or `just test` surfaces a failure unrelated to the requested change, diagnose and report it. Fix it only when it blocks the scoped change or the user explicitly approves expanding the task; do not absorb another contributor's work into the current commit by default.
 - **Commits:** Imperative mood, concise summary (50 chars or less): "Add feature" not "Added feature". Explain *why* in the body (blank line after summary), reference issues when applicable (`Fixes #1234`).


### PR DESCRIPTION
## What

Adds an explicit rule to both agent-instruction files (`CLAUDE.md` and `AGENTS.md`): never merge a PR that has not received an approving human review, and never bypass the review requirement with `gh pr merge --admin` — including for dependabot bumps and trivial changes with green checks.

## Why

An AI coding agent working in this repo merged a small hygiene PR (#860) with `--admin` after all checks passed, without any human having reviewed it. The branch ruleset requires a review, but admin rights can bypass it, and nothing in the agent instructions said not to. Documented review of every change is part of our change-management controls (relevant to compliance frameworks such as SOC 2), so the instructions should state the rule explicitly rather than relying on the ruleset alone.

## Reviewer Notes

Two prose-only additions, one per file, both in the existing commits/PRs sections: `CLAUDE.md` under "Commits and PRs" and `AGENTS.md` under "Git, Commits, and PRs". The wording is the substance here — please check that the rule is stated the way you want agents to read it, including the compliance framing. If the SOC 2 mention is more than we want in a public repo, it can be trimmed to "our change-management controls" without losing the teeth.

### Reproduction

Not applicable (documentation-only). To see the rendered result: read the first bullet of "Commits and PRs" in `CLAUDE.md` and the last bullet of "Git, Commits, and PRs" in `AGENTS.md` on this branch.

Local checks run: `just check`, `just test` (3638 passed, 16 skipped).