### PR TITLE
Task hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Added `DELETE /api/v1/replays/{replay_id}` to delete a standalone replay. A replay that belongs to an experiment run returns HTTP 409, since deleting the run removes its replays.
+- Added `POST /api/v1/workers/{worker_id}/token` to renew a worker token, and `kitaru worker list --include-stale` to list workers past the liveness window.
+- Added task hooks to the agent version run spec: `copy_workdir` runs the agent in a fresh copy of the working directory, `git_clone` clones a repository and runs the agent from the clone, and `git_push` commits and pushes the working directory's changes after a successful run. Hooks run in the declared order before the agent process, and their teardowns run in reverse order after it.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Added `DELETE /api/v1/replays/{replay_id}` to delete a standalone replay. A replay that belongs to an experiment run returns HTTP 409, since deleting the run removes its replays.
 - Added `POST /api/v1/workers/{worker_id}/token` to renew a worker token, and `kitaru worker list --include-stale` to list workers past the liveness window.
-- Added task hooks to the agent version run spec: `copy_workdir` runs the agent in a fresh copy of the working directory, and `command` runs a shell command in the working directory before or after the agent process. Hooks run in the declared order before the agent process, and their teardowns run in reverse order after it.
+- Added task hooks to the agent version run spec: `copy_workdir` runs the agent in a fresh copy of the working directory, `setup_command` runs a shell command in the working directory before the agent process, and `teardown_command` runs one after it based on the task outcome. Hooks run in the declared order before the agent process, and their teardowns run in reverse order after it.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Added `DELETE /api/v1/replays/{replay_id}` to delete a standalone replay. A replay that belongs to an experiment run returns HTTP 409, since deleting the run removes its replays.
 - Added `POST /api/v1/workers/{worker_id}/token` to renew a worker token, and `kitaru worker list --include-stale` to list workers past the liveness window.
-- Added task hooks to the agent version run spec: `copy_workdir` runs the agent in a fresh copy of the working directory, `git_clone` clones a repository and runs the agent from the clone, and `git_push` commits and pushes the working directory's changes after a successful run. Hooks run in the declared order before the agent process, and their teardowns run in reverse order after it.
+- Added task hooks to the agent version run spec: `copy_workdir` runs the agent in a fresh copy of the working directory, and `command` runs a shell command in the working directory before or after the agent process. Hooks run in the declared order before the agent process, and their teardowns run in reverse order after it.
 
 ### Changed
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1349,44 +1349,6 @@
         "title": "CohortVersionUpdateRequest",
         "type": "object"
       },
-      "CommandHook": {
-        "additionalProperties": false,
-        "description": "Command hook.",
-        "properties": {
-          "command": {
-            "description": "Shell command to run.",
-            "title": "Command",
-            "type": "string"
-          },
-          "run_on_failure": {
-            "default": false,
-            "description": "Whether a teardown command runs when the task process failed.",
-            "title": "Run On Failure",
-            "type": "boolean"
-          },
-          "type": {
-            "const": "command",
-            "default": "command",
-            "title": "Type",
-            "type": "string"
-          },
-          "when": {
-            "description": "Phase the command runs in.",
-            "enum": [
-              "setup",
-              "teardown"
-            ],
-            "title": "When",
-            "type": "string"
-          }
-        },
-        "required": [
-          "command",
-          "when"
-        ],
-        "title": "CommandHook",
-        "type": "object"
-      },
       "CopyWorkdirHook": {
         "additionalProperties": false,
         "description": "Copy workdir hook.",
@@ -5471,8 +5433,9 @@
             "items": {
               "discriminator": {
                 "mapping": {
-                  "command": "#/components/schemas/CommandHook",
-                  "copy_workdir": "#/components/schemas/CopyWorkdirHook"
+                  "copy_workdir": "#/components/schemas/CopyWorkdirHook",
+                  "setup_command": "#/components/schemas/SetupCommandHook",
+                  "teardown_command": "#/components/schemas/TeardownCommandHook"
                 },
                 "propertyName": "type"
               },
@@ -5481,7 +5444,10 @@
                   "$ref": "#/components/schemas/CopyWorkdirHook"
                 },
                 {
-                  "$ref": "#/components/schemas/CommandHook"
+                  "$ref": "#/components/schemas/SetupCommandHook"
+                },
+                {
+                  "$ref": "#/components/schemas/TeardownCommandHook"
                 }
               ]
             },
@@ -7501,6 +7467,28 @@
         "title": "SessionWithNodesResponse",
         "type": "object"
       },
+      "SetupCommandHook": {
+        "additionalProperties": false,
+        "description": "Setup command hook.",
+        "properties": {
+          "command": {
+            "description": "Shell command to run.",
+            "title": "Command",
+            "type": "string"
+          },
+          "type": {
+            "const": "setup_command",
+            "default": "setup_command",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "command"
+        ],
+        "title": "SetupCommandHook",
+        "type": "object"
+      },
       "StaticCase": {
         "additionalProperties": false,
         "description": "Static tool call case.",
@@ -8086,8 +8074,9 @@
             "items": {
               "discriminator": {
                 "mapping": {
-                  "command": "#/components/schemas/CommandHook",
-                  "copy_workdir": "#/components/schemas/CopyWorkdirHook"
+                  "copy_workdir": "#/components/schemas/CopyWorkdirHook",
+                  "setup_command": "#/components/schemas/SetupCommandHook",
+                  "teardown_command": "#/components/schemas/TeardownCommandHook"
                 },
                 "propertyName": "type"
               },
@@ -8096,7 +8085,10 @@
                   "$ref": "#/components/schemas/CopyWorkdirHook"
                 },
                 {
-                  "$ref": "#/components/schemas/CommandHook"
+                  "$ref": "#/components/schemas/SetupCommandHook"
+                },
+                {
+                  "$ref": "#/components/schemas/TeardownCommandHook"
                 }
               ]
             },
@@ -8230,6 +8222,39 @@
           "token"
         ],
         "title": "TaskWithSpec",
+        "type": "object"
+      },
+      "TeardownCommandHook": {
+        "additionalProperties": false,
+        "description": "Teardown command hook.",
+        "properties": {
+          "command": {
+            "description": "Shell command to run.",
+            "title": "Command",
+            "type": "string"
+          },
+          "on": {
+            "default": "success",
+            "description": "Task process outcome the command runs on.",
+            "enum": [
+              "success",
+              "failure",
+              "always"
+            ],
+            "title": "On",
+            "type": "string"
+          },
+          "type": {
+            "const": "teardown_command",
+            "default": "teardown_command",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "command"
+        ],
+        "title": "TeardownCommandHook",
         "type": "object"
       },
       "TokenErrorCode": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1349,6 +1349,20 @@
         "title": "CohortVersionUpdateRequest",
         "type": "object"
       },
+      "CopyWorkdirHook": {
+        "additionalProperties": false,
+        "description": "Copy workdir hook.",
+        "properties": {
+          "type": {
+            "const": "copy_workdir",
+            "default": "copy_workdir",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "title": "CopyWorkdirHook",
+        "type": "object"
+      },
       "DeviceAuthorizationResponse": {
         "description": "Device authorization response.",
         "properties": {
@@ -2940,6 +2954,66 @@
         ],
         "title": "FilterOp",
         "type": "string"
+      },
+      "GitCloneHook": {
+        "additionalProperties": false,
+        "description": "Git clone hook.",
+        "properties": {
+          "ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Ref checked out after the clone.",
+            "title": "Ref"
+          },
+          "type": {
+            "const": "git_clone",
+            "default": "git_clone",
+            "title": "Type",
+            "type": "string"
+          },
+          "url": {
+            "description": "Repository to clone.",
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "title": "GitCloneHook",
+        "type": "object"
+      },
+      "GitPushHook": {
+        "additionalProperties": false,
+        "description": "Git push hook.",
+        "properties": {
+          "branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Branch pushed to.",
+            "title": "Branch"
+          },
+          "type": {
+            "const": "git_push",
+            "default": "git_push",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "title": "GitPushHook",
+        "type": "object"
       },
       "HTTPValidationError": {
         "properties": {
@@ -5413,6 +5487,32 @@
             "description": "Process environment.",
             "title": "Env",
             "type": "object"
+          },
+          "hooks": {
+            "description": "Hooks run around the task process.",
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "copy_workdir": "#/components/schemas/CopyWorkdirHook",
+                  "git_clone": "#/components/schemas/GitCloneHook",
+                  "git_push": "#/components/schemas/GitPushHook"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/CopyWorkdirHook"
+                },
+                {
+                  "$ref": "#/components/schemas/GitCloneHook"
+                },
+                {
+                  "$ref": "#/components/schemas/GitPushHook"
+                }
+              ]
+            },
+            "title": "Hooks",
+            "type": "array"
           },
           "secret_ids": {
             "description": "Secrets merged into the process environment.",
@@ -8006,6 +8106,32 @@
             "description": "Creator-set process environment extras.",
             "title": "Env",
             "type": "object"
+          },
+          "hooks": {
+            "description": "Hooks run around the task process.",
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "copy_workdir": "#/components/schemas/CopyWorkdirHook",
+                  "git_clone": "#/components/schemas/GitCloneHook",
+                  "git_push": "#/components/schemas/GitPushHook"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/CopyWorkdirHook"
+                },
+                {
+                  "$ref": "#/components/schemas/GitCloneHook"
+                },
+                {
+                  "$ref": "#/components/schemas/GitPushHook"
+                }
+              ]
+            },
+            "title": "Hooks",
+            "type": "array"
           },
           "kind": {
             "$ref": "#/components/schemas/TaskKind",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1349,6 +1349,44 @@
         "title": "CohortVersionUpdateRequest",
         "type": "object"
       },
+      "CommandHook": {
+        "additionalProperties": false,
+        "description": "Command hook.",
+        "properties": {
+          "command": {
+            "description": "Shell command to run.",
+            "title": "Command",
+            "type": "string"
+          },
+          "run_on_failure": {
+            "default": false,
+            "description": "Whether a teardown command runs when the task process failed.",
+            "title": "Run On Failure",
+            "type": "boolean"
+          },
+          "type": {
+            "const": "command",
+            "default": "command",
+            "title": "Type",
+            "type": "string"
+          },
+          "when": {
+            "description": "Phase the command runs in.",
+            "enum": [
+              "setup",
+              "teardown"
+            ],
+            "title": "When",
+            "type": "string"
+          }
+        },
+        "required": [
+          "command",
+          "when"
+        ],
+        "title": "CommandHook",
+        "type": "object"
+      },
       "CopyWorkdirHook": {
         "additionalProperties": false,
         "description": "Copy workdir hook.",
@@ -2954,66 +2992,6 @@
         ],
         "title": "FilterOp",
         "type": "string"
-      },
-      "GitCloneHook": {
-        "additionalProperties": false,
-        "description": "Git clone hook.",
-        "properties": {
-          "ref": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Ref checked out after the clone.",
-            "title": "Ref"
-          },
-          "type": {
-            "const": "git_clone",
-            "default": "git_clone",
-            "title": "Type",
-            "type": "string"
-          },
-          "url": {
-            "description": "Repository to clone.",
-            "title": "Url",
-            "type": "string"
-          }
-        },
-        "required": [
-          "url"
-        ],
-        "title": "GitCloneHook",
-        "type": "object"
-      },
-      "GitPushHook": {
-        "additionalProperties": false,
-        "description": "Git push hook.",
-        "properties": {
-          "branch": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Branch pushed to.",
-            "title": "Branch"
-          },
-          "type": {
-            "const": "git_push",
-            "default": "git_push",
-            "title": "Type",
-            "type": "string"
-          }
-        },
-        "title": "GitPushHook",
-        "type": "object"
       },
       "HTTPValidationError": {
         "properties": {
@@ -5493,9 +5471,8 @@
             "items": {
               "discriminator": {
                 "mapping": {
-                  "copy_workdir": "#/components/schemas/CopyWorkdirHook",
-                  "git_clone": "#/components/schemas/GitCloneHook",
-                  "git_push": "#/components/schemas/GitPushHook"
+                  "command": "#/components/schemas/CommandHook",
+                  "copy_workdir": "#/components/schemas/CopyWorkdirHook"
                 },
                 "propertyName": "type"
               },
@@ -5504,10 +5481,7 @@
                   "$ref": "#/components/schemas/CopyWorkdirHook"
                 },
                 {
-                  "$ref": "#/components/schemas/GitCloneHook"
-                },
-                {
-                  "$ref": "#/components/schemas/GitPushHook"
+                  "$ref": "#/components/schemas/CommandHook"
                 }
               ]
             },
@@ -8112,9 +8086,8 @@
             "items": {
               "discriminator": {
                 "mapping": {
-                  "copy_workdir": "#/components/schemas/CopyWorkdirHook",
-                  "git_clone": "#/components/schemas/GitCloneHook",
-                  "git_push": "#/components/schemas/GitPushHook"
+                  "command": "#/components/schemas/CommandHook",
+                  "copy_workdir": "#/components/schemas/CopyWorkdirHook"
                 },
                 "propertyName": "type"
               },
@@ -8123,10 +8096,7 @@
                   "$ref": "#/components/schemas/CopyWorkdirHook"
                 },
                 {
-                  "$ref": "#/components/schemas/GitCloneHook"
-                },
-                {
-                  "$ref": "#/components/schemas/GitPushHook"
+                  "$ref": "#/components/schemas/CommandHook"
                 }
               ]
             },

--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -4378,6 +4378,34 @@ export interface components {
             display_version?: string | null;
         };
         /**
+         * CommandHook
+         * @description Command hook.
+         */
+        CommandHook: {
+            /**
+             * Command
+             * @description Shell command to run.
+             */
+            command: string;
+            /**
+             * Run On Failure
+             * @description Whether a teardown command runs when the task process failed.
+             * @default false
+             */
+            run_on_failure: boolean;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "command";
+            /**
+             * When
+             * @description Phase the command runs in.
+             * @enum {string}
+             */
+            when: "setup" | "teardown";
+        };
+        /**
          * CopyWorkdirHook
          * @description Copy workdir hook.
          */
@@ -5281,43 +5309,6 @@ export interface components {
          * @enum {string}
          */
         FilterOp: "eq" | "ne" | "lt" | "le" | "gt" | "ge" | "in" | "is_null" | "startswith" | "endswith" | "contains";
-        /**
-         * GitCloneHook
-         * @description Git clone hook.
-         */
-        GitCloneHook: {
-            /**
-             * Ref
-             * @description Ref checked out after the clone.
-             */
-            ref?: string | null;
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            type: "git_clone";
-            /**
-             * Url
-             * @description Repository to clone.
-             */
-            url: string;
-        };
-        /**
-         * GitPushHook
-         * @description Git push hook.
-         */
-        GitPushHook: {
-            /**
-             * Branch
-             * @description Branch pushed to.
-             */
-            branch?: string | null;
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            type: "git_push";
-        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -6623,7 +6614,7 @@ export interface components {
              * Hooks
              * @description Hooks run around the task process.
              */
-            hooks?: (components["schemas"]["CopyWorkdirHook"] | components["schemas"]["GitCloneHook"] | components["schemas"]["GitPushHook"])[];
+            hooks?: (components["schemas"]["CopyWorkdirHook"] | components["schemas"]["CommandHook"])[];
             /**
              * Secret Ids
              * @description Secrets merged into the process environment.
@@ -8037,7 +8028,7 @@ export interface components {
              * Hooks
              * @description Hooks run around the task process.
              */
-            hooks?: (components["schemas"]["CopyWorkdirHook"] | components["schemas"]["GitCloneHook"] | components["schemas"]["GitPushHook"])[];
+            hooks?: (components["schemas"]["CopyWorkdirHook"] | components["schemas"]["CommandHook"])[];
             /** @description Kind of work the task runs. */
             kind: components["schemas"]["TaskKind"];
             /** @description Command to run, unset for evaluator and importer tasks. */

--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -4378,34 +4378,6 @@ export interface components {
             display_version?: string | null;
         };
         /**
-         * CommandHook
-         * @description Command hook.
-         */
-        CommandHook: {
-            /**
-             * Command
-             * @description Shell command to run.
-             */
-            command: string;
-            /**
-             * Run On Failure
-             * @description Whether a teardown command runs when the task process failed.
-             * @default false
-             */
-            run_on_failure: boolean;
-            /**
-             * @description discriminator enum property added by openapi-typescript
-             * @enum {string}
-             */
-            type: "command";
-            /**
-             * When
-             * @description Phase the command runs in.
-             * @enum {string}
-             */
-            when: "setup" | "teardown";
-        };
-        /**
          * CopyWorkdirHook
          * @description Copy workdir hook.
          */
@@ -6614,7 +6586,7 @@ export interface components {
              * Hooks
              * @description Hooks run around the task process.
              */
-            hooks?: (components["schemas"]["CopyWorkdirHook"] | components["schemas"]["CommandHook"])[];
+            hooks?: (components["schemas"]["CopyWorkdirHook"] | components["schemas"]["SetupCommandHook"] | components["schemas"]["TeardownCommandHook"])[];
             /**
              * Secret Ids
              * @description Secrets merged into the process environment.
@@ -7682,6 +7654,22 @@ export interface components {
             session: components["schemas"]["SessionDetailResponse"];
         };
         /**
+         * SetupCommandHook
+         * @description Setup command hook.
+         */
+        SetupCommandHook: {
+            /**
+             * Command
+             * @description Shell command to run.
+             */
+            command: string;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "setup_command";
+        };
+        /**
          * StaticCase
          * @description Static tool call case.
          */
@@ -8028,7 +8016,7 @@ export interface components {
              * Hooks
              * @description Hooks run around the task process.
              */
-            hooks?: (components["schemas"]["CopyWorkdirHook"] | components["schemas"]["CommandHook"])[];
+            hooks?: (components["schemas"]["CopyWorkdirHook"] | components["schemas"]["SetupCommandHook"] | components["schemas"]["TeardownCommandHook"])[];
             /** @description Kind of work the task runs. */
             kind: components["schemas"]["TaskKind"];
             /** @description Command to run, unset for evaluator and importer tasks. */
@@ -8091,6 +8079,29 @@ export interface components {
              * @description Bearer token scoped to this task and attempt.
              */
             token: string;
+        };
+        /**
+         * TeardownCommandHook
+         * @description Teardown command hook.
+         */
+        TeardownCommandHook: {
+            /**
+             * Command
+             * @description Shell command to run.
+             */
+            command: string;
+            /**
+             * On
+             * @description Task process outcome the command runs on.
+             * @default success
+             * @enum {string}
+             */
+            on: "success" | "failure" | "always";
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "teardown_command";
         };
         /**
          * TokenErrorCode

--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -4378,6 +4378,17 @@ export interface components {
             display_version?: string | null;
         };
         /**
+         * CopyWorkdirHook
+         * @description Copy workdir hook.
+         */
+        CopyWorkdirHook: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "copy_workdir";
+        };
+        /**
          * DeviceAuthorizationResponse
          * @description Device authorization response.
          */
@@ -5270,6 +5281,43 @@ export interface components {
          * @enum {string}
          */
         FilterOp: "eq" | "ne" | "lt" | "le" | "gt" | "ge" | "in" | "is_null" | "startswith" | "endswith" | "contains";
+        /**
+         * GitCloneHook
+         * @description Git clone hook.
+         */
+        GitCloneHook: {
+            /**
+             * Ref
+             * @description Ref checked out after the clone.
+             */
+            ref?: string | null;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "git_clone";
+            /**
+             * Url
+             * @description Repository to clone.
+             */
+            url: string;
+        };
+        /**
+         * GitPushHook
+         * @description Git push hook.
+         */
+        GitPushHook: {
+            /**
+             * Branch
+             * @description Branch pushed to.
+             */
+            branch?: string | null;
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "git_push";
+        };
         /** HTTPValidationError */
         HTTPValidationError: {
             /** Detail */
@@ -6571,6 +6619,11 @@ export interface components {
             env?: {
                 [key: string]: string;
             };
+            /**
+             * Hooks
+             * @description Hooks run around the task process.
+             */
+            hooks?: (components["schemas"]["CopyWorkdirHook"] | components["schemas"]["GitCloneHook"] | components["schemas"]["GitPushHook"])[];
             /**
              * Secret Ids
              * @description Secrets merged into the process environment.
@@ -7980,6 +8033,11 @@ export interface components {
             env: {
                 [key: string]: string;
             };
+            /**
+             * Hooks
+             * @description Hooks run around the task process.
+             */
+            hooks?: (components["schemas"]["CopyWorkdirHook"] | components["schemas"]["GitCloneHook"] | components["schemas"]["GitPushHook"])[];
             /** @description Kind of work the task runs. */
             kind: components["schemas"]["TaskKind"];
             /** @description Command to run, unset for evaluator and importer tasks. */

--- a/src/kitaru/api_models/v1/agent_version.py
+++ b/src/kitaru/api_models/v1/agent_version.py
@@ -19,6 +19,7 @@ from pydantic import Field, PositiveInt
 
 from kitaru.api_models.v1.base import OwnedResponseModel, RequestModel
 from kitaru.api_models.v1.filter import FilterableListParams
+from kitaru.api_models.v1.hook import TaskHook
 
 
 class RunSpec(RequestModel):
@@ -31,6 +32,9 @@ class RunSpec(RequestModel):
     )
     secret_ids: list[uuid.UUID] = Field(
         default_factory=list, description="Secrets merged into the process environment."
+    )
+    hooks: list[TaskHook] = Field(
+        default_factory=list, description="Hooks run around the task process."
     )
     timeout_seconds: PositiveInt = Field(default=3600, description="Process timeout.")
 

--- a/src/kitaru/api_models/v1/hook.py
+++ b/src/kitaru/api_models/v1/hook.py
@@ -26,23 +26,16 @@ class CopyWorkdirHook(DiscriminatedRequestModel):
     type: Literal["copy_workdir"] = Field(default="copy_workdir")
 
 
-class GitCloneHook(DiscriminatedRequestModel):
-    """Git clone hook."""
+class CommandHook(DiscriminatedRequestModel):
+    """Command hook."""
 
-    type: Literal["git_clone"] = Field(default="git_clone")
-    url: str = Field(description="Repository to clone.")
-    ref: str | None = Field(
-        default=None, description="Ref checked out after the clone."
+    type: Literal["command"] = Field(default="command")
+    command: str = Field(description="Shell command to run.")
+    when: Literal["setup", "teardown"] = Field(description="Phase the command runs in.")
+    run_on_failure: bool = Field(
+        default=False,
+        description="Whether a teardown command runs when the task process failed.",
     )
 
 
-class GitPushHook(DiscriminatedRequestModel):
-    """Git push hook."""
-
-    type: Literal["git_push"] = Field(default="git_push")
-    branch: str | None = Field(default=None, description="Branch pushed to.")
-
-
-TaskHook = Annotated[
-    CopyWorkdirHook | GitCloneHook | GitPushHook, Field(discriminator="type")
-]
+TaskHook = Annotated[CopyWorkdirHook | CommandHook, Field(discriminator="type")]

--- a/src/kitaru/api_models/v1/hook.py
+++ b/src/kitaru/api_models/v1/hook.py
@@ -1,0 +1,48 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Task hook API models."""
+
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from kitaru.api_models.v1.base import DiscriminatedRequestModel
+
+
+class CopyWorkdirHook(DiscriminatedRequestModel):
+    """Copy workdir hook."""
+
+    type: Literal["copy_workdir"] = Field(default="copy_workdir")
+
+
+class GitCloneHook(DiscriminatedRequestModel):
+    """Git clone hook."""
+
+    type: Literal["git_clone"] = Field(default="git_clone")
+    url: str = Field(description="Repository to clone.")
+    ref: str | None = Field(
+        default=None, description="Ref checked out after the clone."
+    )
+
+
+class GitPushHook(DiscriminatedRequestModel):
+    """Git push hook."""
+
+    type: Literal["git_push"] = Field(default="git_push")
+    branch: str | None = Field(default=None, description="Branch pushed to.")
+
+
+TaskHook = Annotated[
+    CopyWorkdirHook | GitCloneHook | GitPushHook, Field(discriminator="type")
+]

--- a/src/kitaru/api_models/v1/hook.py
+++ b/src/kitaru/api_models/v1/hook.py
@@ -26,16 +26,24 @@ class CopyWorkdirHook(DiscriminatedRequestModel):
     type: Literal["copy_workdir"] = Field(default="copy_workdir")
 
 
-class CommandHook(DiscriminatedRequestModel):
-    """Command hook."""
+class SetupCommandHook(DiscriminatedRequestModel):
+    """Setup command hook."""
 
-    type: Literal["command"] = Field(default="command")
+    type: Literal["setup_command"] = Field(default="setup_command")
     command: str = Field(description="Shell command to run.")
-    when: Literal["setup", "teardown"] = Field(description="Phase the command runs in.")
-    run_on_failure: bool = Field(
-        default=False,
-        description="Whether a teardown command runs when the task process failed.",
+
+
+class TeardownCommandHook(DiscriminatedRequestModel):
+    """Teardown command hook."""
+
+    type: Literal["teardown_command"] = Field(default="teardown_command")
+    command: str = Field(description="Shell command to run.")
+    on: Literal["success", "failure", "always"] = Field(
+        default="success", description="Task process outcome the command runs on."
     )
 
 
-TaskHook = Annotated[CopyWorkdirHook | CommandHook, Field(discriminator="type")]
+TaskHook = Annotated[
+    CopyWorkdirHook | SetupCommandHook | TeardownCommandHook,
+    Field(discriminator="type"),
+]

--- a/src/kitaru/api_models/v1/task.py
+++ b/src/kitaru/api_models/v1/task.py
@@ -28,6 +28,7 @@ from kitaru.api_models.v1.base import (
     TimestampedResponseModel,
 )
 from kitaru.api_models.v1.filter import FilterableListParams
+from kitaru.api_models.v1.hook import TaskHook
 
 
 class TaskKind(StrEnum):
@@ -225,6 +226,9 @@ class TaskSpecResponse(ResponseModel):
     env: dict[str, str] = Field(description="Creator-set process environment extras.")
     secret_env: dict[str, str] = Field(
         description="Secrets merged into the process environment."
+    )
+    hooks: list[TaskHook] = Field(
+        default_factory=list, description="Hooks run around the task process."
     )
     details: TaskDetails = Field(description="Kind-specific task details.")
 

--- a/src/kitaru/server/adapters/db/orm/agent_version.py
+++ b/src/kitaru/server/adapters/db/orm/agent_version.py
@@ -14,7 +14,9 @@
 """Agent version ORM table."""
 
 import uuid
+from typing import Any
 
+from pydantic import TypeAdapter
 from sqlalchemy import ForeignKeyConstraint, Index, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
@@ -34,6 +36,9 @@ from kitaru.server.domain.agent_version import (
     AgentVersion,
     RunSpec,
 )
+from kitaru.server.domain.hook import TaskHook
+
+_TASK_HOOKS_ADAPTER: TypeAdapter[list[TaskHook]] = TypeAdapter(list[TaskHook])
 
 AGENT_VERSION_AGENT_ID_VERSION_UNIQUE_CONSTRAINT = unique_constraint_name(
     "agent_version", ["agent_id", "version"]
@@ -71,6 +76,9 @@ class AgentVersionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     run_command: Mapped[str | None] = mapped_column(Text)
     run_working_dir: Mapped[str | None] = mapped_column(Text)
     run_env: Mapped[dict[str, str] | None] = mapped_column(JSONB(none_as_null=True))
+    run_hooks: Mapped[list[dict[str, Any]] | None] = mapped_column(
+        JSONB(none_as_null=True)
+    )
     run_timeout_seconds: Mapped[int | None]
     capabilities: Mapped[dict[str, list[str]]] = mapped_column(JSONB)
 
@@ -99,6 +107,11 @@ class AgentVersionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             run_command=run_spec.command if run_spec is not None else None,
             run_working_dir=run_spec.working_dir if run_spec is not None else None,
             run_env=run_spec.env if run_spec is not None else None,
+            run_hooks=(
+                [hook.model_dump(mode="json") for hook in run_spec.hooks]
+                if run_spec is not None
+                else None
+            ),
             run_timeout_seconds=(
                 run_spec.timeout_seconds if run_spec is not None else None
             ),
@@ -122,6 +135,11 @@ class AgentVersionORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
                 working_dir=self.run_working_dir,
                 env=self.run_env if self.run_env is not None else {},
                 secret_ids=secret_ids,
+                hooks=(
+                    _TASK_HOOKS_ADAPTER.validate_python(self.run_hooks)
+                    if self.run_hooks is not None
+                    else []
+                ),
                 timeout_seconds=self.run_timeout_seconds,
             )
         return AgentVersion(

--- a/src/kitaru/server/adapters/db/repositories/agent_version_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/agent_version_repository.py
@@ -331,6 +331,11 @@ class SQLAgentVersionRepository(BaseSQLRepository[AgentVersionORM]):
         row.run_command = run_spec.command if run_spec is not None else None
         row.run_working_dir = run_spec.working_dir if run_spec is not None else None
         row.run_env = run_spec.env if run_spec is not None else None
+        row.run_hooks = (
+            [hook.model_dump(mode="json") for hook in run_spec.hooks]
+            if run_spec is not None
+            else None
+        )
         row.run_timeout_seconds = (
             run_spec.timeout_seconds if run_spec is not None else None
         )

--- a/src/kitaru/server/adapters/rest/mapping/agent_versions.py
+++ b/src/kitaru/server/adapters/rest/mapping/agent_versions.py
@@ -25,16 +25,8 @@ from kitaru.api_models.v1.agent_version import (
     AgentVersionUpdateRequest,
 )
 from kitaru.api_models.v1.agent_version import RunSpec as WireRunSpec
-from kitaru.api_models.v1.hook import (
-    CommandHook as WireCommandHook,
-)
-from kitaru.api_models.v1.hook import (
-    CopyWorkdirHook as WireCopyWorkdirHook,
-)
-from kitaru.api_models.v1.hook import (
-    TaskHook as WireTaskHook,
-)
 from kitaru.server.adapters.rest.mapping.filtering import filter_to_expression
+from kitaru.server.adapters.rest.mapping.hooks import hook_to_domain, hook_to_response
 from kitaru.server.application.models.agent_version import (
     AgentVersionFilter,
     AgentVersionUpdate,
@@ -44,43 +36,6 @@ from kitaru.server.domain.agent_version import (
     AgentVersion,
     RunSpec,
 )
-from kitaru.server.domain.hook import (
-    CommandHook,
-    CopyWorkdirHook,
-    TaskHook,
-)
-
-
-def _hook_to_domain(hook: WireTaskHook) -> TaskHook:
-    """Convert a wire task hook to its domain value object.
-
-    Args:
-        hook: Wire task hook.
-
-    Returns:
-        Domain task hook.
-    """
-    if isinstance(hook, WireCopyWorkdirHook):
-        return CopyWorkdirHook()
-    return CommandHook(
-        command=hook.command, when=hook.when, run_on_failure=hook.run_on_failure
-    )
-
-
-def _hook_to_response(hook: TaskHook) -> WireTaskHook:
-    """Convert a domain task hook to its wire value object.
-
-    Args:
-        hook: Domain task hook.
-
-    Returns:
-        Wire task hook.
-    """
-    if isinstance(hook, CopyWorkdirHook):
-        return WireCopyWorkdirHook()
-    return WireCommandHook(
-        command=hook.command, when=hook.when, run_on_failure=hook.run_on_failure
-    )
 
 
 def run_spec_to_domain(run_spec: WireRunSpec) -> RunSpec:
@@ -97,7 +52,7 @@ def run_spec_to_domain(run_spec: WireRunSpec) -> RunSpec:
         working_dir=run_spec.working_dir,
         env=run_spec.env,
         secret_ids=run_spec.secret_ids,
-        hooks=[_hook_to_domain(hook) for hook in run_spec.hooks],
+        hooks=[hook_to_domain(hook) for hook in run_spec.hooks],
         timeout_seconds=run_spec.timeout_seconds,
     )
 
@@ -116,7 +71,7 @@ def _run_spec_to_response(run_spec: RunSpec) -> WireRunSpec:
         working_dir=run_spec.working_dir,
         env=run_spec.env,
         secret_ids=run_spec.secret_ids,
-        hooks=[_hook_to_response(hook) for hook in run_spec.hooks],
+        hooks=[hook_to_response(hook) for hook in run_spec.hooks],
         timeout_seconds=run_spec.timeout_seconds,
     )
 

--- a/src/kitaru/server/adapters/rest/mapping/agent_versions.py
+++ b/src/kitaru/server/adapters/rest/mapping/agent_versions.py
@@ -25,6 +25,18 @@ from kitaru.api_models.v1.agent_version import (
     AgentVersionUpdateRequest,
 )
 from kitaru.api_models.v1.agent_version import RunSpec as WireRunSpec
+from kitaru.api_models.v1.hook import (
+    CopyWorkdirHook as WireCopyWorkdirHook,
+)
+from kitaru.api_models.v1.hook import (
+    GitCloneHook as WireGitCloneHook,
+)
+from kitaru.api_models.v1.hook import (
+    GitPushHook as WireGitPushHook,
+)
+from kitaru.api_models.v1.hook import (
+    TaskHook as WireTaskHook,
+)
 from kitaru.server.adapters.rest.mapping.filtering import filter_to_expression
 from kitaru.server.application.models.agent_version import (
     AgentVersionFilter,
@@ -35,6 +47,44 @@ from kitaru.server.domain.agent_version import (
     AgentVersion,
     RunSpec,
 )
+from kitaru.server.domain.hook import (
+    CopyWorkdirHook,
+    GitCloneHook,
+    GitPushHook,
+    TaskHook,
+)
+
+
+def _hook_to_domain(hook: WireTaskHook) -> TaskHook:
+    """Convert a wire task hook to its domain value object.
+
+    Args:
+        hook: Wire task hook.
+
+    Returns:
+        Domain task hook.
+    """
+    if isinstance(hook, WireCopyWorkdirHook):
+        return CopyWorkdirHook()
+    if isinstance(hook, WireGitCloneHook):
+        return GitCloneHook(url=hook.url, ref=hook.ref)
+    return GitPushHook(branch=hook.branch)
+
+
+def _hook_to_response(hook: TaskHook) -> WireTaskHook:
+    """Convert a domain task hook to its wire value object.
+
+    Args:
+        hook: Domain task hook.
+
+    Returns:
+        Wire task hook.
+    """
+    if isinstance(hook, CopyWorkdirHook):
+        return WireCopyWorkdirHook()
+    if isinstance(hook, GitCloneHook):
+        return WireGitCloneHook(url=hook.url, ref=hook.ref)
+    return WireGitPushHook(branch=hook.branch)
 
 
 def run_spec_to_domain(run_spec: WireRunSpec) -> RunSpec:
@@ -51,6 +101,7 @@ def run_spec_to_domain(run_spec: WireRunSpec) -> RunSpec:
         working_dir=run_spec.working_dir,
         env=run_spec.env,
         secret_ids=run_spec.secret_ids,
+        hooks=[_hook_to_domain(hook) for hook in run_spec.hooks],
         timeout_seconds=run_spec.timeout_seconds,
     )
 
@@ -69,6 +120,7 @@ def _run_spec_to_response(run_spec: RunSpec) -> WireRunSpec:
         working_dir=run_spec.working_dir,
         env=run_spec.env,
         secret_ids=run_spec.secret_ids,
+        hooks=[_hook_to_response(hook) for hook in run_spec.hooks],
         timeout_seconds=run_spec.timeout_seconds,
     )
 

--- a/src/kitaru/server/adapters/rest/mapping/agent_versions.py
+++ b/src/kitaru/server/adapters/rest/mapping/agent_versions.py
@@ -26,13 +26,10 @@ from kitaru.api_models.v1.agent_version import (
 )
 from kitaru.api_models.v1.agent_version import RunSpec as WireRunSpec
 from kitaru.api_models.v1.hook import (
+    CommandHook as WireCommandHook,
+)
+from kitaru.api_models.v1.hook import (
     CopyWorkdirHook as WireCopyWorkdirHook,
-)
-from kitaru.api_models.v1.hook import (
-    GitCloneHook as WireGitCloneHook,
-)
-from kitaru.api_models.v1.hook import (
-    GitPushHook as WireGitPushHook,
 )
 from kitaru.api_models.v1.hook import (
     TaskHook as WireTaskHook,
@@ -48,9 +45,8 @@ from kitaru.server.domain.agent_version import (
     RunSpec,
 )
 from kitaru.server.domain.hook import (
+    CommandHook,
     CopyWorkdirHook,
-    GitCloneHook,
-    GitPushHook,
     TaskHook,
 )
 
@@ -66,9 +62,9 @@ def _hook_to_domain(hook: WireTaskHook) -> TaskHook:
     """
     if isinstance(hook, WireCopyWorkdirHook):
         return CopyWorkdirHook()
-    if isinstance(hook, WireGitCloneHook):
-        return GitCloneHook(url=hook.url, ref=hook.ref)
-    return GitPushHook(branch=hook.branch)
+    return CommandHook(
+        command=hook.command, when=hook.when, run_on_failure=hook.run_on_failure
+    )
 
 
 def _hook_to_response(hook: TaskHook) -> WireTaskHook:
@@ -82,9 +78,9 @@ def _hook_to_response(hook: TaskHook) -> WireTaskHook:
     """
     if isinstance(hook, CopyWorkdirHook):
         return WireCopyWorkdirHook()
-    if isinstance(hook, GitCloneHook):
-        return WireGitCloneHook(url=hook.url, ref=hook.ref)
-    return WireGitPushHook(branch=hook.branch)
+    return WireCommandHook(
+        command=hook.command, when=hook.when, run_on_failure=hook.run_on_failure
+    )
 
 
 def run_spec_to_domain(run_spec: WireRunSpec) -> RunSpec:

--- a/src/kitaru/server/adapters/rest/mapping/hooks.py
+++ b/src/kitaru/server/adapters/rest/mapping/hooks.py
@@ -1,0 +1,61 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Task hook DTO conversions."""
+
+from kitaru.api_models.v1.hook import (
+    CommandHook as WireCommandHook,
+)
+from kitaru.api_models.v1.hook import (
+    CopyWorkdirHook as WireCopyWorkdirHook,
+)
+from kitaru.api_models.v1.hook import (
+    TaskHook as WireTaskHook,
+)
+from kitaru.server.domain.hook import (
+    CommandHook,
+    CopyWorkdirHook,
+    TaskHook,
+)
+
+
+def hook_to_domain(hook: WireTaskHook) -> TaskHook:
+    """Convert a wire task hook to its domain value object.
+
+    Args:
+        hook: Wire task hook.
+
+    Returns:
+        Domain task hook.
+    """
+    if isinstance(hook, WireCopyWorkdirHook):
+        return CopyWorkdirHook()
+    return CommandHook(
+        command=hook.command, when=hook.when, run_on_failure=hook.run_on_failure
+    )
+
+
+def hook_to_response(hook: TaskHook) -> WireTaskHook:
+    """Convert a domain task hook to its wire value object.
+
+    Args:
+        hook: Domain task hook.
+
+    Returns:
+        Wire task hook.
+    """
+    if isinstance(hook, CopyWorkdirHook):
+        return WireCopyWorkdirHook()
+    return WireCommandHook(
+        command=hook.command, when=hook.when, run_on_failure=hook.run_on_failure
+    )

--- a/src/kitaru/server/adapters/rest/mapping/hooks.py
+++ b/src/kitaru/server/adapters/rest/mapping/hooks.py
@@ -14,18 +14,22 @@
 """Task hook DTO conversions."""
 
 from kitaru.api_models.v1.hook import (
-    CommandHook as WireCommandHook,
+    CopyWorkdirHook as WireCopyWorkdirHook,
 )
 from kitaru.api_models.v1.hook import (
-    CopyWorkdirHook as WireCopyWorkdirHook,
+    SetupCommandHook as WireSetupCommandHook,
 )
 from kitaru.api_models.v1.hook import (
     TaskHook as WireTaskHook,
 )
+from kitaru.api_models.v1.hook import (
+    TeardownCommandHook as WireTeardownCommandHook,
+)
 from kitaru.server.domain.hook import (
-    CommandHook,
     CopyWorkdirHook,
+    SetupCommandHook,
     TaskHook,
+    TeardownCommandHook,
 )
 
 
@@ -40,9 +44,9 @@ def hook_to_domain(hook: WireTaskHook) -> TaskHook:
     """
     if isinstance(hook, WireCopyWorkdirHook):
         return CopyWorkdirHook()
-    return CommandHook(
-        command=hook.command, when=hook.when, run_on_failure=hook.run_on_failure
-    )
+    if isinstance(hook, WireSetupCommandHook):
+        return SetupCommandHook(command=hook.command)
+    return TeardownCommandHook(command=hook.command, on=hook.on)
 
 
 def hook_to_response(hook: TaskHook) -> WireTaskHook:
@@ -56,6 +60,6 @@ def hook_to_response(hook: TaskHook) -> WireTaskHook:
     """
     if isinstance(hook, CopyWorkdirHook):
         return WireCopyWorkdirHook()
-    return WireCommandHook(
-        command=hook.command, when=hook.when, run_on_failure=hook.run_on_failure
-    )
+    if isinstance(hook, SetupCommandHook):
+        return WireSetupCommandHook(command=hook.command)
+    return WireTeardownCommandHook(command=hook.command, on=hook.on)

--- a/src/kitaru/server/adapters/rest/mapping/tasks.py
+++ b/src/kitaru/server/adapters/rest/mapping/tasks.py
@@ -16,9 +16,8 @@
 import uuid
 
 from kitaru.api_models.v1.hook import (
+    CommandHook,
     CopyWorkdirHook,
-    GitCloneHook,
-    GitPushHook,
     TaskHook,
 )
 from kitaru.api_models.v1.task import (
@@ -42,9 +41,6 @@ from kitaru.server.adapters.rest.mapping.filtering import filter_to_expression
 from kitaru.server.application.models.task import ClaimedTask, TaskFilter, TaskUpdate
 from kitaru.server.domain.hook import (
     CopyWorkdirHook as DomainCopyWorkdirHook,
-)
-from kitaru.server.domain.hook import (
-    GitCloneHook as DomainGitCloneHook,
 )
 from kitaru.server.domain.hook import (
     TaskHook as DomainTaskHook,
@@ -179,9 +175,9 @@ def _hook_to_response(hook: DomainTaskHook) -> TaskHook:
     """
     if isinstance(hook, DomainCopyWorkdirHook):
         return CopyWorkdirHook()
-    if isinstance(hook, DomainGitCloneHook):
-        return GitCloneHook(url=hook.url, ref=hook.ref)
-    return GitPushHook(branch=hook.branch)
+    return CommandHook(
+        command=hook.command, when=hook.when, run_on_failure=hook.run_on_failure
+    )
 
 
 def _details_to_response(spec: TaskSpec) -> TaskDetails:

--- a/src/kitaru/server/adapters/rest/mapping/tasks.py
+++ b/src/kitaru/server/adapters/rest/mapping/tasks.py
@@ -15,6 +15,12 @@
 
 import uuid
 
+from kitaru.api_models.v1.hook import (
+    CopyWorkdirHook,
+    GitCloneHook,
+    GitPushHook,
+    TaskHook,
+)
 from kitaru.api_models.v1.task import (
     AgentTaskDetails,
     EvaluationTaskDetails,
@@ -34,6 +40,15 @@ from kitaru.api_models.v1.task import (
 )
 from kitaru.server.adapters.rest.mapping.filtering import filter_to_expression
 from kitaru.server.application.models.task import ClaimedTask, TaskFilter, TaskUpdate
+from kitaru.server.domain.hook import (
+    CopyWorkdirHook as DomainCopyWorkdirHook,
+)
+from kitaru.server.domain.hook import (
+    GitCloneHook as DomainGitCloneHook,
+)
+from kitaru.server.domain.hook import (
+    TaskHook as DomainTaskHook,
+)
 from kitaru.server.domain.task import (
     AgentTask,
     EvaluationTask,
@@ -153,6 +168,22 @@ def _run_spec_to_response(run_spec: DomainTaskRunSpec) -> TaskRunSpec:
     )
 
 
+def _hook_to_response(hook: DomainTaskHook) -> TaskHook:
+    """Convert a task hook value object to its response DTO.
+
+    Args:
+        hook: Hook the worker runs around the task process.
+
+    Returns:
+        Task hook DTO.
+    """
+    if isinstance(hook, DomainCopyWorkdirHook):
+        return CopyWorkdirHook()
+    if isinstance(hook, DomainGitCloneHook):
+        return GitCloneHook(url=hook.url, ref=hook.ref)
+    return GitPushHook(branch=hook.branch)
+
+
 def _details_to_response(spec: TaskSpec) -> TaskDetails:
     """Convert the kind-specific details of a task spec to their response DTO.
 
@@ -204,6 +235,7 @@ def spec_to_response(spec: TaskSpec) -> TaskSpecResponse:
         ),
         env=spec.env,
         secret_env=spec.secret_env,
+        hooks=[_hook_to_response(hook) for hook in spec.hooks],
         details=_details_to_response(spec),
     )
 

--- a/src/kitaru/server/adapters/rest/mapping/tasks.py
+++ b/src/kitaru/server/adapters/rest/mapping/tasks.py
@@ -15,11 +15,6 @@
 
 import uuid
 
-from kitaru.api_models.v1.hook import (
-    CommandHook,
-    CopyWorkdirHook,
-    TaskHook,
-)
 from kitaru.api_models.v1.task import (
     AgentTaskDetails,
     EvaluationTaskDetails,
@@ -38,13 +33,8 @@ from kitaru.api_models.v1.task import (
     TaskWithSpec,
 )
 from kitaru.server.adapters.rest.mapping.filtering import filter_to_expression
+from kitaru.server.adapters.rest.mapping.hooks import hook_to_response
 from kitaru.server.application.models.task import ClaimedTask, TaskFilter, TaskUpdate
-from kitaru.server.domain.hook import (
-    CopyWorkdirHook as DomainCopyWorkdirHook,
-)
-from kitaru.server.domain.hook import (
-    TaskHook as DomainTaskHook,
-)
 from kitaru.server.domain.task import (
     AgentTask,
     EvaluationTask,
@@ -164,22 +154,6 @@ def _run_spec_to_response(run_spec: DomainTaskRunSpec) -> TaskRunSpec:
     )
 
 
-def _hook_to_response(hook: DomainTaskHook) -> TaskHook:
-    """Convert a task hook value object to its response DTO.
-
-    Args:
-        hook: Hook the worker runs around the task process.
-
-    Returns:
-        Task hook DTO.
-    """
-    if isinstance(hook, DomainCopyWorkdirHook):
-        return CopyWorkdirHook()
-    return CommandHook(
-        command=hook.command, when=hook.when, run_on_failure=hook.run_on_failure
-    )
-
-
 def _details_to_response(spec: TaskSpec) -> TaskDetails:
     """Convert the kind-specific details of a task spec to their response DTO.
 
@@ -231,7 +205,7 @@ def spec_to_response(spec: TaskSpec) -> TaskSpecResponse:
         ),
         env=spec.env,
         secret_env=spec.secret_env,
-        hooks=[_hook_to_response(hook) for hook in spec.hooks],
+        hooks=[hook_to_response(hook) for hook in spec.hooks],
         details=_details_to_response(spec),
     )
 

--- a/src/kitaru/server/application/services/task_spec.py
+++ b/src/kitaru/server/application/services/task_spec.py
@@ -128,6 +128,7 @@ class TaskSpecBuilder:
             ),
             env=task.env,
             secret_env=secret_env,
+            hooks=run_spec.hooks,
             details=AgentTaskDetails(
                 inputs=task.inputs,
                 replay_id=replay.id if replay is not None else None,

--- a/src/kitaru/server/database/migrations/versions/005_agent_version_run_hooks.py
+++ b/src/kitaru/server/database/migrations/versions/005_agent_version_run_hooks.py
@@ -1,0 +1,48 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Agent version run hooks Alembic revision.
+
+Revision ID: 005_agent_version_run_hooks
+Revises: 004_replay_result_session_id
+Create Date: 2026-08-21
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "005_agent_version_run_hooks"
+down_revision = "004_replay_result_session_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    with op.batch_alter_table("agent_version", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "run_hooks",
+                postgresql.JSONB(none_as_null=True, astext_type=sa.Text()),
+                nullable=True,
+            )
+        )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    with op.batch_alter_table("agent_version", schema=None) as batch_op:
+        batch_op.drop_column("run_hooks")

--- a/src/kitaru/server/database/migrations/versions/008_agent_version_run_hooks.py
+++ b/src/kitaru/server/database/migrations/versions/008_agent_version_run_hooks.py
@@ -13,8 +13,8 @@
 #  permissions and limitations under the License.
 """Agent version run hooks Alembic revision.
 
-Revision ID: 005_agent_version_run_hooks
-Revises: 004_replay_result_session_id
+Revision ID: 008_agent_version_run_hooks
+Revises: 007_payload_blob_offload
 Create Date: 2026-08-21
 
 """
@@ -24,8 +24,8 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = "005_agent_version_run_hooks"
-down_revision = "004_replay_result_session_id"
+revision = "008_agent_version_run_hooks"
+down_revision = "007_payload_blob_offload"
 branch_labels = None
 depends_on = None
 

--- a/src/kitaru/server/database/migrations/versions/009_agent_version_run_hooks.py
+++ b/src/kitaru/server/database/migrations/versions/009_agent_version_run_hooks.py
@@ -13,8 +13,8 @@
 #  permissions and limitations under the License.
 """Agent version run hooks Alembic revision.
 
-Revision ID: 008_agent_version_run_hooks
-Revises: 007_payload_blob_offload
+Revision ID: 009_agent_version_run_hooks
+Revises: 008_session_text_selectors
 Create Date: 2026-08-21
 
 """
@@ -24,8 +24,8 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = "008_agent_version_run_hooks"
-down_revision = "007_payload_blob_offload"
+revision = "009_agent_version_run_hooks"
+down_revision = "008_session_text_selectors"
 branch_labels = None
 depends_on = None
 

--- a/src/kitaru/server/domain/agent_version.py
+++ b/src/kitaru/server/domain/agent_version.py
@@ -26,6 +26,7 @@ from kitaru.server.domain.base import (
     NotFoundError,
     ValidationError,
 )
+from kitaru.server.domain.hook import TaskHook
 from kitaru.server.domain.ids import uuid7
 from kitaru.server.domain.names import VersionName
 
@@ -114,6 +115,7 @@ class RunSpec(FrozenModel):
     working_dir: str | None = None
     env: dict[str, str] = Field(default_factory=dict)
     secret_ids: list[uuid.UUID] = Field(default_factory=list)
+    hooks: list[TaskHook] = Field(default_factory=list)
     timeout_seconds: TimeoutSeconds = 3600
 
 

--- a/src/kitaru/server/domain/hook.py
+++ b/src/kitaru/server/domain/hook.py
@@ -26,13 +26,22 @@ class CopyWorkdirHook(FrozenModel):
     type: Literal["copy_workdir"] = "copy_workdir"
 
 
-class CommandHook(FrozenModel):
-    """Command hook."""
+class SetupCommandHook(FrozenModel):
+    """Setup command hook."""
 
-    type: Literal["command"] = "command"
+    type: Literal["setup_command"] = "setup_command"
     command: str
-    when: Literal["setup", "teardown"]
-    run_on_failure: bool = False
 
 
-TaskHook = Annotated[CopyWorkdirHook | CommandHook, Field(discriminator="type")]
+class TeardownCommandHook(FrozenModel):
+    """Teardown command hook."""
+
+    type: Literal["teardown_command"] = "teardown_command"
+    command: str
+    on: Literal["success", "failure", "always"] = "success"
+
+
+TaskHook = Annotated[
+    CopyWorkdirHook | SetupCommandHook | TeardownCommandHook,
+    Field(discriminator="type"),
+]

--- a/src/kitaru/server/domain/hook.py
+++ b/src/kitaru/server/domain/hook.py
@@ -1,0 +1,46 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Task hook value objects."""
+
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from kitaru.base import FrozenModel
+
+
+class CopyWorkdirHook(FrozenModel):
+    """Copy workdir hook."""
+
+    type: Literal["copy_workdir"] = "copy_workdir"
+
+
+class GitCloneHook(FrozenModel):
+    """Git clone hook."""
+
+    type: Literal["git_clone"] = "git_clone"
+    url: str
+    ref: str | None = None
+
+
+class GitPushHook(FrozenModel):
+    """Git push hook."""
+
+    type: Literal["git_push"] = "git_push"
+    branch: str | None = None
+
+
+TaskHook = Annotated[
+    CopyWorkdirHook | GitCloneHook | GitPushHook, Field(discriminator="type")
+]

--- a/src/kitaru/server/domain/hook.py
+++ b/src/kitaru/server/domain/hook.py
@@ -26,21 +26,13 @@ class CopyWorkdirHook(FrozenModel):
     type: Literal["copy_workdir"] = "copy_workdir"
 
 
-class GitCloneHook(FrozenModel):
-    """Git clone hook."""
+class CommandHook(FrozenModel):
+    """Command hook."""
 
-    type: Literal["git_clone"] = "git_clone"
-    url: str
-    ref: str | None = None
-
-
-class GitPushHook(FrozenModel):
-    """Git push hook."""
-
-    type: Literal["git_push"] = "git_push"
-    branch: str | None = None
+    type: Literal["command"] = "command"
+    command: str
+    when: Literal["setup", "teardown"]
+    run_on_failure: bool = False
 
 
-TaskHook = Annotated[
-    CopyWorkdirHook | GitCloneHook | GitPushHook, Field(discriminator="type")
-]
+TaskHook = Annotated[CopyWorkdirHook | CommandHook, Field(discriminator="type")]

--- a/src/kitaru/server/domain/task.py
+++ b/src/kitaru/server/domain/task.py
@@ -35,6 +35,7 @@ from kitaru.server.domain.base import (
     PayloadTooLargeError,
     ValidationError,
 )
+from kitaru.server.domain.hook import TaskHook
 from kitaru.server.domain.ids import uuid7
 
 __all__ = [
@@ -749,4 +750,5 @@ class TaskSpec(FrozenModel):
     run_spec: TaskRunSpec | None = None
     env: dict[str, str] = Field(default_factory=dict)
     secret_env: dict[str, str] = Field(default_factory=dict)
+    hooks: list[TaskHook] = Field(default_factory=list)
     details: TaskDetails

--- a/src/kitaru/worker/hooks.py
+++ b/src/kitaru/worker/hooks.py
@@ -20,18 +20,15 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from kitaru.api_models.v1.hook import (
+    CommandHook as CommandHookSpec,
+)
+from kitaru.api_models.v1.hook import (
     CopyWorkdirHook as CopyWorkdirHookSpec,
-)
-from kitaru.api_models.v1.hook import (
-    GitCloneHook as GitCloneHookSpec,
-)
-from kitaru.api_models.v1.hook import (
-    GitPushHook as GitPushHookSpec,
 )
 from kitaru.api_models.v1.hook import TaskHook
 from kitaru.worker.process import TaskProcess, run_task_process
 
-# Bound on each git command a hook runs.
+# Bound on each command a hook runs.
 HOOK_TIMEOUT_SECONDS = 600
 
 
@@ -97,96 +94,45 @@ class CopyWorkdirHook(Hook):
         ctx.process = ctx.process._replace(working_dir=str(dest))
 
 
-class GitCloneHook(Hook):
-    """Git clone hook."""
+class CommandHook(Hook):
+    """Command hook."""
 
-    def __init__(self, spec: GitCloneHookSpec, index: int) -> None:
+    def __init__(self, spec: CommandHookSpec) -> None:
         """Initialize the hook.
 
         Args:
             spec: Hook spec.
-            index: Position of the hook in the spec's hook list.
         """
         self._spec = spec
-        self._index = index
 
     async def setup(self, ctx: HookContext) -> None:
-        """Clone the repository and point the process at the clone.
+        """Run a setup command before the task process starts.
 
         Args:
             ctx: Hook context.
 
         Raises:
-            HookError: A git command did not exit successfully.
+            HookError: The command did not exit successfully.
         """
-        dest = ctx.scratch_dir / f"hook-{self._index}-clone"
-        await _run_git_command(
-            ctx,
-            ["git", "clone", self._spec.url, str(dest)],
-            None,
-            "clone the repository",
-        )
-        if self._spec.ref is not None:
-            await _run_git_command(
-                ctx,
-                ["git", "checkout", self._spec.ref],
-                str(dest),
-                "check out the ref",
-            )
-        ctx.process = ctx.process._replace(working_dir=str(dest))
-
-
-class GitPushHook(Hook):
-    """Git push hook."""
-
-    def __init__(self, spec: GitPushHookSpec) -> None:
-        """Initialize the hook.
-
-        Args:
-            spec: Hook spec.
-        """
-        self._spec = spec
+        if self._spec.when != "setup":
+            return
+        await _run_command(ctx, self._spec.command)
 
     async def teardown(self, ctx: HookContext, success: bool) -> None:
-        """Commit and push the working directory changes on success.
+        """Run a teardown command after the task process exits.
 
         Args:
             ctx: Hook context.
             success: Whether the task process exited with code 0.
 
         Raises:
-            HookError: A git command did not exit successfully.
+            HookError: The command did not exit successfully.
         """
-        if not success:
+        if self._spec.when != "teardown":
             return
-        working_dir = ctx.process.working_dir
-        await _run_git_command(
-            ctx, ["git", "add", "-A"], working_dir, "stage the changes"
-        )
-        staged = await _run_git_command(
-            ctx,
-            ["git", "diff", "--cached", "--quiet"],
-            working_dir,
-            "check for staged changes",
-            expected_returncodes=(0, 1),
-        )
-        if staged == 0:
+        if not success and not self._spec.run_on_failure:
             return
-        branch = self._spec.branch or f"kitaru/task-{ctx.task_id}"
-        await _run_git_command(
-            ctx,
-            ["git", "commit", "-m", f"Kitaru task {ctx.task_id}"],
-            working_dir,
-            "commit the changes",
-        )
-        # Qualify the destination because a detached HEAD, left behind by a
-        # ref checkout, cannot resolve an unqualified new branch name.
-        await _run_git_command(
-            ctx,
-            ["git", "push", "origin", f"HEAD:refs/heads/{branch}"],
-            working_dir,
-            "push the changes",
-        )
+        await _run_command(ctx, self._spec.command)
 
 
 def build_hooks(specs: list[TaskHook]) -> list[Hook]:
@@ -202,49 +148,34 @@ def build_hooks(specs: list[TaskHook]) -> list[Hook]:
     for index, spec in enumerate(specs):
         if isinstance(spec, CopyWorkdirHookSpec):
             hooks.append(CopyWorkdirHook(index))
-        elif isinstance(spec, GitCloneHookSpec):
-            hooks.append(GitCloneHook(spec, index))
         else:
-            hooks.append(GitPushHook(spec))
+            hooks.append(CommandHook(spec))
     return hooks
 
 
-async def _run_git_command(
-    ctx: HookContext,
-    command: list[str],
-    working_dir: str | None,
-    purpose: str,
-    expected_returncodes: tuple[int, ...] = (0,),
-) -> int:
-    """Run a git command, raising on an unexpected outcome.
+async def _run_command(ctx: HookContext, command: str) -> None:
+    """Run a hook command in the task process's working directory.
 
     Args:
         ctx: Hook context.
-        command: Command to run.
-        working_dir: Directory the command runs in.
-        purpose: Action named in the error message.
-        expected_returncodes: Exit codes that are not an error.
+        command: Shell command to run.
 
     Raises:
-        HookError: The command was canceled, timed out, or exited with an
-            unexpected code.
-
-    Returns:
-        Exit code.
+        HookError: The command was canceled, timed out, or exited with a
+            nonzero code.
     """
     process = TaskProcess(
         command=command,
-        working_dir=working_dir,
+        working_dir=ctx.process.working_dir,
         env=ctx.process.env,
         timeout_seconds=HOOK_TIMEOUT_SECONDS,
     )
     result = await run_task_process(process, ctx.canceled)
     if result.returncode is None:
         outcome = "was canceled" if ctx.canceled.is_set() else "timed out"
-        raise HookError(f"Command to {purpose} {outcome}.")
-    if result.returncode not in expected_returncodes:
-        message = f"Command to {purpose} exited with code {result.returncode}."
+        raise HookError(f"Command {outcome}.")
+    if result.returncode != 0:
+        message = f"Command exited with code {result.returncode}."
         if result.tail:
             message = f"{message}\n\n{result.tail}"
         raise HookError(message)
-    return result.returncode

--- a/src/kitaru/worker/hooks.py
+++ b/src/kitaru/worker/hooks.py
@@ -20,12 +20,15 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from kitaru.api_models.v1.hook import (
-    CommandHook as CommandHookSpec,
-)
-from kitaru.api_models.v1.hook import (
     CopyWorkdirHook as CopyWorkdirHookSpec,
 )
+from kitaru.api_models.v1.hook import (
+    SetupCommandHook as SetupCommandHookSpec,
+)
 from kitaru.api_models.v1.hook import TaskHook
+from kitaru.api_models.v1.hook import (
+    TeardownCommandHook as TeardownCommandHookSpec,
+)
 from kitaru.worker.process import TaskProcess, run_task_process
 
 # Bound on each command a hook runs.
@@ -94,10 +97,10 @@ class CopyWorkdirHook(Hook):
         ctx.process = ctx.process._replace(working_dir=str(dest))
 
 
-class CommandHook(Hook):
-    """Command hook."""
+class SetupCommandHook(Hook):
+    """Setup command hook."""
 
-    def __init__(self, spec: CommandHookSpec) -> None:
+    def __init__(self, spec: SetupCommandHookSpec) -> None:
         """Initialize the hook.
 
         Args:
@@ -106,7 +109,7 @@ class CommandHook(Hook):
         self._spec = spec
 
     async def setup(self, ctx: HookContext) -> None:
-        """Run a setup command before the task process starts.
+        """Run the command before the task process starts.
 
         Args:
             ctx: Hook context.
@@ -114,12 +117,22 @@ class CommandHook(Hook):
         Raises:
             HookError: The command did not exit successfully.
         """
-        if self._spec.when != "setup":
-            return
         await _run_command(ctx, self._spec.command)
 
+
+class TeardownCommandHook(Hook):
+    """Teardown command hook."""
+
+    def __init__(self, spec: TeardownCommandHookSpec) -> None:
+        """Initialize the hook.
+
+        Args:
+            spec: Hook spec.
+        """
+        self._spec = spec
+
     async def teardown(self, ctx: HookContext, success: bool) -> None:
-        """Run a teardown command after the task process exits.
+        """Run the command after the task process exits on a matching outcome.
 
         Args:
             ctx: Hook context.
@@ -128,9 +141,9 @@ class CommandHook(Hook):
         Raises:
             HookError: The command did not exit successfully.
         """
-        if self._spec.when != "teardown":
+        if success and self._spec.on == "failure":
             return
-        if not success and not self._spec.run_on_failure:
+        if not success and self._spec.on == "success":
             return
         await _run_command(ctx, self._spec.command)
 
@@ -148,8 +161,10 @@ def build_hooks(specs: list[TaskHook]) -> list[Hook]:
     for index, spec in enumerate(specs):
         if isinstance(spec, CopyWorkdirHookSpec):
             hooks.append(CopyWorkdirHook(index))
+        elif isinstance(spec, SetupCommandHookSpec):
+            hooks.append(SetupCommandHook(spec))
         else:
-            hooks.append(CommandHook(spec))
+            hooks.append(TeardownCommandHook(spec))
     return hooks
 
 

--- a/src/kitaru/worker/hooks.py
+++ b/src/kitaru/worker/hooks.py
@@ -1,0 +1,250 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Task hook execution around the task process."""
+
+import asyncio
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from kitaru.api_models.v1.hook import (
+    CopyWorkdirHook as CopyWorkdirHookSpec,
+)
+from kitaru.api_models.v1.hook import (
+    GitCloneHook as GitCloneHookSpec,
+)
+from kitaru.api_models.v1.hook import (
+    GitPushHook as GitPushHookSpec,
+)
+from kitaru.api_models.v1.hook import TaskHook
+from kitaru.worker.process import TaskProcess, run_task_process
+
+# Bound on each git command a hook runs.
+HOOK_TIMEOUT_SECONDS = 600
+
+
+class HookError(Exception):
+    """Hook execution error."""
+
+
+@dataclass
+class HookContext:
+    """Hook context."""
+
+    task_id: uuid.UUID
+    scratch_dir: Path
+    canceled: asyncio.Event
+    process: TaskProcess
+
+
+class Hook:
+    """Task hook."""
+
+    async def setup(self, ctx: HookContext) -> None:
+        """Run before the task process starts.
+
+        Args:
+            ctx: Hook context.
+        """
+
+    async def teardown(self, ctx: HookContext, success: bool) -> None:
+        """Run after the task process exits.
+
+        Args:
+            ctx: Hook context.
+            success: Whether the task process exited with code 0.
+        """
+
+
+class CopyWorkdirHook(Hook):
+    """Copy workdir hook."""
+
+    def __init__(self, index: int) -> None:
+        """Initialize the hook.
+
+        Args:
+            index: Position of the hook in the spec's hook list.
+        """
+        self._index = index
+
+    async def setup(self, ctx: HookContext) -> None:
+        """Copy the working directory and point the process at the copy.
+
+        Args:
+            ctx: Hook context.
+
+        Raises:
+            HookError: The task process has no working directory.
+        """
+        if ctx.process.working_dir is None:
+            raise HookError("The task process has no working directory to copy.")
+        dest = ctx.scratch_dir / f"hook-{self._index}-workdir"
+        await asyncio.to_thread(
+            shutil.copytree, ctx.process.working_dir, dest, symlinks=True
+        )
+        ctx.process = ctx.process._replace(working_dir=str(dest))
+
+
+class GitCloneHook(Hook):
+    """Git clone hook."""
+
+    def __init__(self, spec: GitCloneHookSpec, index: int) -> None:
+        """Initialize the hook.
+
+        Args:
+            spec: Hook spec.
+            index: Position of the hook in the spec's hook list.
+        """
+        self._spec = spec
+        self._index = index
+
+    async def setup(self, ctx: HookContext) -> None:
+        """Clone the repository and point the process at the clone.
+
+        Args:
+            ctx: Hook context.
+
+        Raises:
+            HookError: A git command did not exit successfully.
+        """
+        dest = ctx.scratch_dir / f"hook-{self._index}-clone"
+        await _run_git_command(
+            ctx,
+            ["git", "clone", self._spec.url, str(dest)],
+            None,
+            "clone the repository",
+        )
+        if self._spec.ref is not None:
+            await _run_git_command(
+                ctx,
+                ["git", "checkout", self._spec.ref],
+                str(dest),
+                "check out the ref",
+            )
+        ctx.process = ctx.process._replace(working_dir=str(dest))
+
+
+class GitPushHook(Hook):
+    """Git push hook."""
+
+    def __init__(self, spec: GitPushHookSpec) -> None:
+        """Initialize the hook.
+
+        Args:
+            spec: Hook spec.
+        """
+        self._spec = spec
+
+    async def teardown(self, ctx: HookContext, success: bool) -> None:
+        """Commit and push the working directory changes on success.
+
+        Args:
+            ctx: Hook context.
+            success: Whether the task process exited with code 0.
+
+        Raises:
+            HookError: A git command did not exit successfully.
+        """
+        if not success:
+            return
+        working_dir = ctx.process.working_dir
+        await _run_git_command(
+            ctx, ["git", "add", "-A"], working_dir, "stage the changes"
+        )
+        staged = await _run_git_command(
+            ctx,
+            ["git", "diff", "--cached", "--quiet"],
+            working_dir,
+            "check for staged changes",
+            expected_returncodes=(0, 1),
+        )
+        if staged == 0:
+            return
+        branch = self._spec.branch or f"kitaru/task-{ctx.task_id}"
+        await _run_git_command(
+            ctx,
+            ["git", "commit", "-m", f"Kitaru task {ctx.task_id}"],
+            working_dir,
+            "commit the changes",
+        )
+        # Qualify the destination because a detached HEAD, left behind by a
+        # ref checkout, cannot resolve an unqualified new branch name.
+        await _run_git_command(
+            ctx,
+            ["git", "push", "origin", f"HEAD:refs/heads/{branch}"],
+            working_dir,
+            "push the changes",
+        )
+
+
+def build_hooks(specs: list[TaskHook]) -> list[Hook]:
+    """Build the hook implementations for a task's hook specs.
+
+    Args:
+        specs: Hook specs in declared order.
+
+    Returns:
+        Hook implementations in declared order.
+    """
+    hooks: list[Hook] = []
+    for index, spec in enumerate(specs):
+        if isinstance(spec, CopyWorkdirHookSpec):
+            hooks.append(CopyWorkdirHook(index))
+        elif isinstance(spec, GitCloneHookSpec):
+            hooks.append(GitCloneHook(spec, index))
+        else:
+            hooks.append(GitPushHook(spec))
+    return hooks
+
+
+async def _run_git_command(
+    ctx: HookContext,
+    command: list[str],
+    working_dir: str | None,
+    purpose: str,
+    expected_returncodes: tuple[int, ...] = (0,),
+) -> int:
+    """Run a git command, raising on an unexpected outcome.
+
+    Args:
+        ctx: Hook context.
+        command: Command to run.
+        working_dir: Directory the command runs in.
+        purpose: Action named in the error message.
+        expected_returncodes: Exit codes that are not an error.
+
+    Raises:
+        HookError: The command was canceled, timed out, or exited with an
+            unexpected code.
+
+    Returns:
+        Exit code.
+    """
+    process = TaskProcess(
+        command=command,
+        working_dir=working_dir,
+        env=ctx.process.env,
+        timeout_seconds=HOOK_TIMEOUT_SECONDS,
+    )
+    result = await run_task_process(process, ctx.canceled)
+    if result.returncode is None:
+        outcome = "was canceled" if ctx.canceled.is_set() else "timed out"
+        raise HookError(f"Command to {purpose} {outcome}.")
+    if result.returncode not in expected_returncodes:
+        message = f"Command to {purpose} exited with code {result.returncode}."
+        if result.tail:
+            message = f"{message}\n\n{result.tail}"
+        raise HookError(message)
+    return result.returncode

--- a/src/kitaru/worker/task_runner.py
+++ b/src/kitaru/worker/task_runner.py
@@ -24,6 +24,7 @@ from typing import Any
 import httpx
 
 from kitaru.api_models.v1.filter import FilterCondition, FilterOp
+from kitaru.api_models.v1.hook import TaskHook
 from kitaru.api_models.v1.session import SessionListParams, SessionStatus
 from kitaru.api_models.v1.task import (
     TaskKind,
@@ -41,6 +42,7 @@ from kitaru.client.exceptions import (
 )
 from kitaru.worker.context import ExecutionContext
 from kitaru.worker.handlers import HANDLERS
+from kitaru.worker.hooks import Hook, HookContext, build_hooks
 from kitaru.worker.process import run_task_process
 
 logger = logging.getLogger(__name__)
@@ -114,9 +116,24 @@ class TaskRunner:
             process = process._replace(
                 env={**process.env, "KITARU_TASK_RESULT_PATH": str(result_path)}
             )
-            result = await run_task_process(process, canceled)
+            hooks = build_hooks(spec.hooks)
+            hook_ctx = HookContext(
+                task_id=task.id,
+                scratch_dir=Path(work_dir),
+                canceled=canceled,
+                process=process,
+            )
+            error = await _run_hook_setups(hook_ctx, spec.hooks, hooks)
+            if error is not None:
+                return await self._fail(client, task, attempt, error)
+            result = await run_task_process(hook_ctx.process, canceled)
+            hook_error = await _run_hook_teardowns(
+                hook_ctx, spec.hooks, hooks, result.returncode == 0
+            )
 
             if result.returncode == 0:
+                if hook_error is not None:
+                    return await self._fail(client, task, attempt, hook_error)
                 return await self._succeed(
                     client, task, spec, attempt, label, result_path
                 )
@@ -448,6 +465,55 @@ class TaskRunner:
                 "Failed to update task %s to %s: %s", task_id, request.status, exc
             )
             return None
+
+
+async def _run_hook_setups(
+    ctx: HookContext, specs: list[TaskHook], hooks: list[Hook]
+) -> str | None:
+    """Run hook setups in order, tearing down the completed ones on failure.
+
+    Args:
+        ctx: Hook context.
+        specs: Hook specs in declared order.
+        hooks: Hook implementations in declared order.
+
+    Returns:
+        Error message of the failed setup, or None when every setup succeeded.
+    """
+    for index, (hook_spec, hook) in enumerate(zip(specs, hooks, strict=True)):
+        try:
+            await hook.setup(ctx)
+        except Exception as exc:
+            await _run_hook_teardowns(ctx, specs[:index], hooks[:index], False)
+            return f"Hook {hook_spec.type} failed: {exc}"
+    return None
+
+
+async def _run_hook_teardowns(
+    ctx: HookContext, specs: list[TaskHook], hooks: list[Hook], success: bool
+) -> str | None:
+    """Run hook teardowns in reverse declared order.
+
+    Args:
+        ctx: Hook context.
+        specs: Hook specs in declared order.
+        hooks: Hook implementations in declared order.
+        success: Whether the task process exited with code 0.
+
+    Returns:
+        Error message of the first failed teardown when success is set, None
+        otherwise.
+    """
+    error: str | None = None
+    for hook_spec, hook in zip(reversed(specs), reversed(hooks), strict=True):
+        try:
+            await hook.teardown(ctx, success)
+        except Exception as exc:
+            if success and error is None:
+                error = f"Hook {hook_spec.type} failed: {exc}"
+            else:
+                logger.warning("Hook %s teardown failed: %s", hook_spec.type, exc)
+    return error
 
 
 def _read_diagnostic_result(result_path: Path) -> Any:

--- a/tests/api_models/test_hook.py
+++ b/tests/api_models/test_hook.py
@@ -16,7 +16,7 @@
 import uuid
 
 from kitaru.api_models.v1.agent_version import RunSpec
-from kitaru.api_models.v1.hook import CopyWorkdirHook, GitCloneHook, GitPushHook
+from kitaru.api_models.v1.hook import CommandHook, CopyWorkdirHook
 from kitaru.api_models.v1.task import (
     AgentTaskDetails,
     TaskKind,
@@ -31,18 +31,21 @@ def test_run_spec_hooks_round_trip_json() -> None:
         command="run.sh",
         hooks=[
             CopyWorkdirHook(),
-            GitCloneHook(url="https://example.com/repo.git", ref="main"),
-            GitPushHook(branch="results"),
+            CommandHook(command="setup.sh", when="setup"),
+            CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
         ],
     )
     restored = RunSpec.model_validate_json(spec.model_dump_json())
     assert restored == spec
     assert isinstance(restored.hooks[0], CopyWorkdirHook)
-    assert isinstance(restored.hooks[1], GitCloneHook)
-    assert restored.hooks[1].url == "https://example.com/repo.git"
-    assert restored.hooks[1].ref == "main"
-    assert isinstance(restored.hooks[2], GitPushHook)
-    assert restored.hooks[2].branch == "results"
+    assert isinstance(restored.hooks[1], CommandHook)
+    assert restored.hooks[1].command == "setup.sh"
+    assert restored.hooks[1].when == "setup"
+    assert restored.hooks[1].run_on_failure is False
+    assert isinstance(restored.hooks[2], CommandHook)
+    assert restored.hooks[2].command == "teardown.sh"
+    assert restored.hooks[2].when == "teardown"
+    assert restored.hooks[2].run_on_failure is True
 
 
 def test_task_spec_response_hooks_round_trip_json() -> None:
@@ -56,15 +59,12 @@ def test_task_spec_response_hooks_round_trip_json() -> None:
         secret_env={},
         hooks=[
             CopyWorkdirHook(),
-            GitCloneHook(url="https://example.com/repo.git"),
-            GitPushHook(),
+            CommandHook(command="teardown.sh", when="teardown"),
         ],
         details=AgentTaskDetails(inputs=None),
     )
     restored = TaskSpecResponse.model_validate_json(spec.model_dump_json())
     assert restored == spec
     assert isinstance(restored.hooks[0], CopyWorkdirHook)
-    assert isinstance(restored.hooks[1], GitCloneHook)
-    assert restored.hooks[1].ref is None
-    assert isinstance(restored.hooks[2], GitPushHook)
-    assert restored.hooks[2].branch is None
+    assert isinstance(restored.hooks[1], CommandHook)
+    assert restored.hooks[1].run_on_failure is False

--- a/tests/api_models/test_hook.py
+++ b/tests/api_models/test_hook.py
@@ -16,7 +16,11 @@
 import uuid
 
 from kitaru.api_models.v1.agent_version import RunSpec
-from kitaru.api_models.v1.hook import CommandHook, CopyWorkdirHook
+from kitaru.api_models.v1.hook import (
+    CopyWorkdirHook,
+    SetupCommandHook,
+    TeardownCommandHook,
+)
 from kitaru.api_models.v1.task import (
     AgentTaskDetails,
     TaskKind,
@@ -31,21 +35,18 @@ def test_run_spec_hooks_round_trip_json() -> None:
         command="run.sh",
         hooks=[
             CopyWorkdirHook(),
-            CommandHook(command="setup.sh", when="setup"),
-            CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
+            SetupCommandHook(command="setup.sh"),
+            TeardownCommandHook(command="teardown.sh", on="always"),
         ],
     )
     restored = RunSpec.model_validate_json(spec.model_dump_json())
     assert restored == spec
     assert isinstance(restored.hooks[0], CopyWorkdirHook)
-    assert isinstance(restored.hooks[1], CommandHook)
+    assert isinstance(restored.hooks[1], SetupCommandHook)
     assert restored.hooks[1].command == "setup.sh"
-    assert restored.hooks[1].when == "setup"
-    assert restored.hooks[1].run_on_failure is False
-    assert isinstance(restored.hooks[2], CommandHook)
+    assert isinstance(restored.hooks[2], TeardownCommandHook)
     assert restored.hooks[2].command == "teardown.sh"
-    assert restored.hooks[2].when == "teardown"
-    assert restored.hooks[2].run_on_failure is True
+    assert restored.hooks[2].on == "always"
 
 
 def test_task_spec_response_hooks_round_trip_json() -> None:
@@ -59,12 +60,12 @@ def test_task_spec_response_hooks_round_trip_json() -> None:
         secret_env={},
         hooks=[
             CopyWorkdirHook(),
-            CommandHook(command="teardown.sh", when="teardown"),
+            TeardownCommandHook(command="teardown.sh"),
         ],
         details=AgentTaskDetails(inputs=None),
     )
     restored = TaskSpecResponse.model_validate_json(spec.model_dump_json())
     assert restored == spec
     assert isinstance(restored.hooks[0], CopyWorkdirHook)
-    assert isinstance(restored.hooks[1], CommandHook)
-    assert restored.hooks[1].run_on_failure is False
+    assert isinstance(restored.hooks[1], TeardownCommandHook)
+    assert restored.hooks[1].on == "success"

--- a/tests/api_models/test_hook.py
+++ b/tests/api_models/test_hook.py
@@ -1,0 +1,70 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for task hook API models."""
+
+import uuid
+
+from kitaru.api_models.v1.agent_version import RunSpec
+from kitaru.api_models.v1.hook import CopyWorkdirHook, GitCloneHook, GitPushHook
+from kitaru.api_models.v1.task import (
+    AgentTaskDetails,
+    TaskKind,
+    TaskRunSpec,
+    TaskSpecResponse,
+)
+
+
+def test_run_spec_hooks_round_trip_json() -> None:
+    """Round-trip a run spec's hooks through JSON, preserving each variant."""
+    spec = RunSpec(
+        command="run.sh",
+        hooks=[
+            CopyWorkdirHook(),
+            GitCloneHook(url="https://example.com/repo.git", ref="main"),
+            GitPushHook(branch="results"),
+        ],
+    )
+    restored = RunSpec.model_validate_json(spec.model_dump_json())
+    assert restored == spec
+    assert isinstance(restored.hooks[0], CopyWorkdirHook)
+    assert isinstance(restored.hooks[1], GitCloneHook)
+    assert restored.hooks[1].url == "https://example.com/repo.git"
+    assert restored.hooks[1].ref == "main"
+    assert isinstance(restored.hooks[2], GitPushHook)
+    assert restored.hooks[2].branch == "results"
+
+
+def test_task_spec_response_hooks_round_trip_json() -> None:
+    """Round-trip a task spec response's hooks through JSON."""
+    spec = TaskSpecResponse(
+        task_id=uuid.uuid4(),
+        kind=TaskKind.AGENT,
+        timeout_seconds=60,
+        run=TaskRunSpec(command="run.sh", env={}),
+        env={},
+        secret_env={},
+        hooks=[
+            CopyWorkdirHook(),
+            GitCloneHook(url="https://example.com/repo.git"),
+            GitPushHook(),
+        ],
+        details=AgentTaskDetails(inputs=None),
+    )
+    restored = TaskSpecResponse.model_validate_json(spec.model_dump_json())
+    assert restored == spec
+    assert isinstance(restored.hooks[0], CopyWorkdirHook)
+    assert isinstance(restored.hooks[1], GitCloneHook)
+    assert restored.hooks[1].ref is None
+    assert isinstance(restored.hooks[2], GitPushHook)
+    assert restored.hooks[2].branch is None

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -804,6 +804,44 @@
           "title": "CohortVersionResponse",
           "type": "object"
         },
+        "CommandHook": {
+          "additionalProperties": false,
+          "description": "Command hook.",
+          "properties": {
+            "command": {
+              "description": "Shell command to run.",
+              "title": "Command",
+              "type": "string"
+            },
+            "run_on_failure": {
+              "default": false,
+              "description": "Whether a teardown command runs when the task process failed.",
+              "title": "Run On Failure",
+              "type": "boolean"
+            },
+            "type": {
+              "const": "command",
+              "default": "command",
+              "title": "Type",
+              "type": "string"
+            },
+            "when": {
+              "description": "Phase the command runs in.",
+              "enum": [
+                "setup",
+                "teardown"
+              ],
+              "title": "When",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command",
+            "when"
+          ],
+          "title": "CommandHook",
+          "type": "object"
+        },
         "CopyWorkdirHook": {
           "additionalProperties": false,
           "description": "Copy workdir hook.",
@@ -1119,68 +1157,6 @@
             "evaluators"
           ],
           "title": "ExperimentResponse",
-          "type": "object"
-        },
-        "GitCloneHook": {
-          "additionalProperties": false,
-          "description": "Git clone hook.",
-          "properties": {
-            "ref": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Ref checked out after the clone.",
-              "title": "Ref"
-            },
-            "type": {
-              "const": "git_clone",
-              "default": "git_clone",
-              "title": "Type",
-              "type": "string"
-            },
-            "url": {
-              "description": "Repository to clone.",
-              "title": "Url",
-              "type": "string"
-            }
-          },
-          "required": [
-            "url"
-          ],
-          "title": "GitCloneHook",
-          "type": "object"
-        },
-        "GitPushHook": {
-          "additionalProperties": false,
-          "description": "Git push hook.",
-          "properties": {
-            "branch": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Branch pushed to.",
-              "title": "Branch"
-            },
-            "type": {
-              "const": "git_push",
-              "default": "git_push",
-              "title": "Type",
-              "type": "string"
-            }
-          },
-          "title": "GitPushHook",
           "type": "object"
         },
         "HistoryConfig": {
@@ -1682,9 +1658,8 @@
               "items": {
                 "discriminator": {
                   "mapping": {
-                    "copy_workdir": "#/$defs/CopyWorkdirHook",
-                    "git_clone": "#/$defs/GitCloneHook",
-                    "git_push": "#/$defs/GitPushHook"
+                    "command": "#/$defs/CommandHook",
+                    "copy_workdir": "#/$defs/CopyWorkdirHook"
                   },
                   "propertyName": "type"
                 },
@@ -1693,10 +1668,7 @@
                     "$ref": "#/$defs/CopyWorkdirHook"
                   },
                   {
-                    "$ref": "#/$defs/GitCloneHook"
-                  },
-                  {
-                    "$ref": "#/$defs/GitPushHook"
+                    "$ref": "#/$defs/CommandHook"
                   }
                 ]
               },

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -804,6 +804,20 @@
           "title": "CohortVersionResponse",
           "type": "object"
         },
+        "CopyWorkdirHook": {
+          "additionalProperties": false,
+          "description": "Copy workdir hook.",
+          "properties": {
+            "type": {
+              "const": "copy_workdir",
+              "default": "copy_workdir",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "title": "CopyWorkdirHook",
+          "type": "object"
+        },
         "EvaluatorConfig": {
           "additionalProperties": false,
           "description": "Evaluator config.",
@@ -1105,6 +1119,68 @@
             "evaluators"
           ],
           "title": "ExperimentResponse",
+          "type": "object"
+        },
+        "GitCloneHook": {
+          "additionalProperties": false,
+          "description": "Git clone hook.",
+          "properties": {
+            "ref": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Ref checked out after the clone.",
+              "title": "Ref"
+            },
+            "type": {
+              "const": "git_clone",
+              "default": "git_clone",
+              "title": "Type",
+              "type": "string"
+            },
+            "url": {
+              "description": "Repository to clone.",
+              "title": "Url",
+              "type": "string"
+            }
+          },
+          "required": [
+            "url"
+          ],
+          "title": "GitCloneHook",
+          "type": "object"
+        },
+        "GitPushHook": {
+          "additionalProperties": false,
+          "description": "Git push hook.",
+          "properties": {
+            "branch": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Branch pushed to.",
+              "title": "Branch"
+            },
+            "type": {
+              "const": "git_push",
+              "default": "git_push",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "title": "GitPushHook",
           "type": "object"
         },
         "HistoryConfig": {
@@ -1600,6 +1676,32 @@
               "description": "Process environment.",
               "title": "Env",
               "type": "object"
+            },
+            "hooks": {
+              "description": "Hooks run around the task process.",
+              "items": {
+                "discriminator": {
+                  "mapping": {
+                    "copy_workdir": "#/$defs/CopyWorkdirHook",
+                    "git_clone": "#/$defs/GitCloneHook",
+                    "git_push": "#/$defs/GitPushHook"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/CopyWorkdirHook"
+                  },
+                  {
+                    "$ref": "#/$defs/GitCloneHook"
+                  },
+                  {
+                    "$ref": "#/$defs/GitPushHook"
+                  }
+                ]
+              },
+              "title": "Hooks",
+              "type": "array"
             },
             "secret_ids": {
               "description": "Secrets merged into the process environment.",

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -804,44 +804,6 @@
           "title": "CohortVersionResponse",
           "type": "object"
         },
-        "CommandHook": {
-          "additionalProperties": false,
-          "description": "Command hook.",
-          "properties": {
-            "command": {
-              "description": "Shell command to run.",
-              "title": "Command",
-              "type": "string"
-            },
-            "run_on_failure": {
-              "default": false,
-              "description": "Whether a teardown command runs when the task process failed.",
-              "title": "Run On Failure",
-              "type": "boolean"
-            },
-            "type": {
-              "const": "command",
-              "default": "command",
-              "title": "Type",
-              "type": "string"
-            },
-            "when": {
-              "description": "Phase the command runs in.",
-              "enum": [
-                "setup",
-                "teardown"
-              ],
-              "title": "When",
-              "type": "string"
-            }
-          },
-          "required": [
-            "command",
-            "when"
-          ],
-          "title": "CommandHook",
-          "type": "object"
-        },
         "CopyWorkdirHook": {
           "additionalProperties": false,
           "description": "Copy workdir hook.",
@@ -1658,8 +1620,9 @@
               "items": {
                 "discriminator": {
                   "mapping": {
-                    "command": "#/$defs/CommandHook",
-                    "copy_workdir": "#/$defs/CopyWorkdirHook"
+                    "copy_workdir": "#/$defs/CopyWorkdirHook",
+                    "setup_command": "#/$defs/SetupCommandHook",
+                    "teardown_command": "#/$defs/TeardownCommandHook"
                   },
                   "propertyName": "type"
                 },
@@ -1668,7 +1631,10 @@
                     "$ref": "#/$defs/CopyWorkdirHook"
                   },
                   {
-                    "$ref": "#/$defs/CommandHook"
+                    "$ref": "#/$defs/SetupCommandHook"
+                  },
+                  {
+                    "$ref": "#/$defs/TeardownCommandHook"
                   }
                 ]
               },
@@ -1738,6 +1704,28 @@
             "entrypoint"
           ],
           "title": "ScriptPluginSource",
+          "type": "object"
+        },
+        "SetupCommandHook": {
+          "additionalProperties": false,
+          "description": "Setup command hook.",
+          "properties": {
+            "command": {
+              "description": "Shell command to run.",
+              "title": "Command",
+              "type": "string"
+            },
+            "type": {
+              "const": "setup_command",
+              "default": "setup_command",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "title": "SetupCommandHook",
           "type": "object"
         },
         "StaticCase": {
@@ -1862,6 +1850,39 @@
           ],
           "title": "TaskKind",
           "type": "string"
+        },
+        "TeardownCommandHook": {
+          "additionalProperties": false,
+          "description": "Teardown command hook.",
+          "properties": {
+            "command": {
+              "description": "Shell command to run.",
+              "title": "Command",
+              "type": "string"
+            },
+            "on": {
+              "default": "success",
+              "description": "Task process outcome the command runs on.",
+              "enum": [
+                "success",
+                "failure",
+                "always"
+              ],
+              "title": "On",
+              "type": "string"
+            },
+            "type": {
+              "const": "teardown_command",
+              "default": "teardown_command",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "title": "TeardownCommandHook",
+          "type": "object"
         },
         "ToolError": {
           "additionalProperties": false,

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,7 +6,7 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 156806,
+      "discovery_response_bytes": 156556,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
@@ -45,11 +45,11 @@
           "output_bytes": 7317
         },
         "kitaru_registry_read": {
-          "$defs_count": 48,
-          "combined_bytes": 32854,
+          "$defs_count": 47,
+          "combined_bytes": 32604,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 27148
+          "output_bytes": 26898
         },
         "kitaru_review_manage": {
           "$defs_count": 30,
@@ -89,7 +89,7 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 79543,
+      "discovery_response_bytes": 79293,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
@@ -100,11 +100,11 @@
           "output_bytes": 28314
         },
         "kitaru_registry_read": {
-          "$defs_count": 48,
-          "combined_bytes": 32854,
+          "$defs_count": 47,
+          "combined_bytes": 32604,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 27148
+          "output_bytes": 26898
         },
         "kitaru_review_read": {
           "$defs_count": 20,
@@ -116,7 +116,7 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 145414,
+      "discovery_response_bytes": 145164,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
@@ -148,11 +148,11 @@
           "output_bytes": 7317
         },
         "kitaru_registry_read": {
-          "$defs_count": 48,
-          "combined_bytes": 32854,
+          "$defs_count": 47,
+          "combined_bytes": 32604,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 27148
+          "output_bytes": 26898
         },
         "kitaru_review_manage": {
           "$defs_count": 30,

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -1,20 +1,20 @@
 {
   "budgets": {
     "maximum_destructive_discovery_bytes": 196608,
-    "maximum_tool_schema_bytes": 37888,
+    "maximum_tool_schema_bytes": 33792,
     "maximum_tools": 12
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 159052,
+      "discovery_response_bytes": 156806,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
-          "$defs_count": 44,
-          "combined_bytes": 37136,
+          "$defs_count": 43,
+          "combined_bytes": 33522,
           "input_bytes": 5208,
           "maximum_nesting_depth": 8,
-          "output_bytes": 31928
+          "output_bytes": 28314
         },
         "kitaru_cohorts_manage": {
           "$defs_count": 7,
@@ -45,11 +45,11 @@
           "output_bytes": 7317
         },
         "kitaru_registry_read": {
-          "$defs_count": 45,
-          "combined_bytes": 31486,
+          "$defs_count": 48,
+          "combined_bytes": 32854,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25780
+          "output_bytes": 27148
         },
         "kitaru_review_manage": {
           "$defs_count": 30,
@@ -89,22 +89,22 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 81789,
+      "discovery_response_bytes": 79543,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
-          "$defs_count": 44,
-          "combined_bytes": 37136,
+          "$defs_count": 43,
+          "combined_bytes": 33522,
           "input_bytes": 5208,
           "maximum_nesting_depth": 8,
-          "output_bytes": 31928
+          "output_bytes": 28314
         },
         "kitaru_registry_read": {
-          "$defs_count": 45,
-          "combined_bytes": 31486,
+          "$defs_count": 48,
+          "combined_bytes": 32854,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25780
+          "output_bytes": 27148
         },
         "kitaru_review_read": {
           "$defs_count": 20,
@@ -116,15 +116,15 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 147660,
+      "discovery_response_bytes": 145414,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
-          "$defs_count": 44,
-          "combined_bytes": 37136,
+          "$defs_count": 43,
+          "combined_bytes": 33522,
           "input_bytes": 5208,
           "maximum_nesting_depth": 8,
-          "output_bytes": 31928
+          "output_bytes": 28314
         },
         "kitaru_cohorts_manage": {
           "$defs_count": 7,
@@ -148,11 +148,11 @@
           "output_bytes": 7317
         },
         "kitaru_registry_read": {
-          "$defs_count": 45,
-          "combined_bytes": 31486,
+          "$defs_count": 48,
+          "combined_bytes": 32854,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25780
+          "output_bytes": 27148
         },
         "kitaru_review_manage": {
           "$defs_count": 30,

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,7 +6,7 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 160170,
+      "discovery_response_bytes": 160537,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
@@ -45,11 +45,11 @@
           "output_bytes": 7317
         },
         "kitaru_registry_read": {
-          "$defs_count": 47,
-          "combined_bytes": 32604,
+          "$defs_count": 48,
+          "combined_bytes": 32971,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 26898
+          "output_bytes": 27265
         },
         "kitaru_review_manage": {
           "$defs_count": 30,
@@ -89,7 +89,7 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 82907,
+      "discovery_response_bytes": 83274,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
@@ -100,11 +100,11 @@
           "output_bytes": 31928
         },
         "kitaru_registry_read": {
-          "$defs_count": 47,
-          "combined_bytes": 32604,
+          "$defs_count": 48,
+          "combined_bytes": 32971,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 26898
+          "output_bytes": 27265
         },
         "kitaru_review_read": {
           "$defs_count": 20,
@@ -116,7 +116,7 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 148778,
+      "discovery_response_bytes": 149145,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
@@ -148,11 +148,11 @@
           "output_bytes": 7317
         },
         "kitaru_registry_read": {
-          "$defs_count": 47,
-          "combined_bytes": 32604,
+          "$defs_count": 48,
+          "combined_bytes": 32971,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 26898
+          "output_bytes": 27265
         },
         "kitaru_review_manage": {
           "$defs_count": 30,

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -1,20 +1,20 @@
 {
   "budgets": {
     "maximum_destructive_discovery_bytes": 196608,
-    "maximum_tool_schema_bytes": 33792,
+    "maximum_tool_schema_bytes": 37888,
     "maximum_tools": 12
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 156556,
+      "discovery_response_bytes": 160170,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
-          "$defs_count": 43,
-          "combined_bytes": 33522,
+          "$defs_count": 44,
+          "combined_bytes": 37136,
           "input_bytes": 5208,
           "maximum_nesting_depth": 8,
-          "output_bytes": 28314
+          "output_bytes": 31928
         },
         "kitaru_cohorts_manage": {
           "$defs_count": 7,
@@ -89,15 +89,15 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 79293,
+      "discovery_response_bytes": 82907,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
-          "$defs_count": 43,
-          "combined_bytes": 33522,
+          "$defs_count": 44,
+          "combined_bytes": 37136,
           "input_bytes": 5208,
           "maximum_nesting_depth": 8,
-          "output_bytes": 28314
+          "output_bytes": 31928
         },
         "kitaru_registry_read": {
           "$defs_count": 47,
@@ -116,15 +116,15 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 145164,
+      "discovery_response_bytes": 148778,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
-          "$defs_count": 43,
-          "combined_bytes": 33522,
+          "$defs_count": 44,
+          "combined_bytes": 37136,
           "input_bytes": 5208,
           "maximum_nesting_depth": 8,
-          "output_bytes": 28314
+          "output_bytes": 31928
         },
         "kitaru_cohorts_manage": {
           "$defs_count": 7,

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -804,6 +804,44 @@
           "title": "CohortVersionResponse",
           "type": "object"
         },
+        "CommandHook": {
+          "additionalProperties": false,
+          "description": "Command hook.",
+          "properties": {
+            "command": {
+              "description": "Shell command to run.",
+              "title": "Command",
+              "type": "string"
+            },
+            "run_on_failure": {
+              "default": false,
+              "description": "Whether a teardown command runs when the task process failed.",
+              "title": "Run On Failure",
+              "type": "boolean"
+            },
+            "type": {
+              "const": "command",
+              "default": "command",
+              "title": "Type",
+              "type": "string"
+            },
+            "when": {
+              "description": "Phase the command runs in.",
+              "enum": [
+                "setup",
+                "teardown"
+              ],
+              "title": "When",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command",
+            "when"
+          ],
+          "title": "CommandHook",
+          "type": "object"
+        },
         "CopyWorkdirHook": {
           "additionalProperties": false,
           "description": "Copy workdir hook.",
@@ -1119,68 +1157,6 @@
             "evaluators"
           ],
           "title": "ExperimentResponse",
-          "type": "object"
-        },
-        "GitCloneHook": {
-          "additionalProperties": false,
-          "description": "Git clone hook.",
-          "properties": {
-            "ref": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Ref checked out after the clone.",
-              "title": "Ref"
-            },
-            "type": {
-              "const": "git_clone",
-              "default": "git_clone",
-              "title": "Type",
-              "type": "string"
-            },
-            "url": {
-              "description": "Repository to clone.",
-              "title": "Url",
-              "type": "string"
-            }
-          },
-          "required": [
-            "url"
-          ],
-          "title": "GitCloneHook",
-          "type": "object"
-        },
-        "GitPushHook": {
-          "additionalProperties": false,
-          "description": "Git push hook.",
-          "properties": {
-            "branch": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Branch pushed to.",
-              "title": "Branch"
-            },
-            "type": {
-              "const": "git_push",
-              "default": "git_push",
-              "title": "Type",
-              "type": "string"
-            }
-          },
-          "title": "GitPushHook",
           "type": "object"
         },
         "HistoryConfig": {
@@ -1682,9 +1658,8 @@
               "items": {
                 "discriminator": {
                   "mapping": {
-                    "copy_workdir": "#/$defs/CopyWorkdirHook",
-                    "git_clone": "#/$defs/GitCloneHook",
-                    "git_push": "#/$defs/GitPushHook"
+                    "command": "#/$defs/CommandHook",
+                    "copy_workdir": "#/$defs/CopyWorkdirHook"
                   },
                   "propertyName": "type"
                 },
@@ -1693,10 +1668,7 @@
                     "$ref": "#/$defs/CopyWorkdirHook"
                   },
                   {
-                    "$ref": "#/$defs/GitCloneHook"
-                  },
-                  {
-                    "$ref": "#/$defs/GitPushHook"
+                    "$ref": "#/$defs/CommandHook"
                   }
                 ]
               },

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -804,6 +804,20 @@
           "title": "CohortVersionResponse",
           "type": "object"
         },
+        "CopyWorkdirHook": {
+          "additionalProperties": false,
+          "description": "Copy workdir hook.",
+          "properties": {
+            "type": {
+              "const": "copy_workdir",
+              "default": "copy_workdir",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "title": "CopyWorkdirHook",
+          "type": "object"
+        },
         "EvaluatorConfig": {
           "additionalProperties": false,
           "description": "Evaluator config.",
@@ -1105,6 +1119,68 @@
             "evaluators"
           ],
           "title": "ExperimentResponse",
+          "type": "object"
+        },
+        "GitCloneHook": {
+          "additionalProperties": false,
+          "description": "Git clone hook.",
+          "properties": {
+            "ref": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Ref checked out after the clone.",
+              "title": "Ref"
+            },
+            "type": {
+              "const": "git_clone",
+              "default": "git_clone",
+              "title": "Type",
+              "type": "string"
+            },
+            "url": {
+              "description": "Repository to clone.",
+              "title": "Url",
+              "type": "string"
+            }
+          },
+          "required": [
+            "url"
+          ],
+          "title": "GitCloneHook",
+          "type": "object"
+        },
+        "GitPushHook": {
+          "additionalProperties": false,
+          "description": "Git push hook.",
+          "properties": {
+            "branch": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Branch pushed to.",
+              "title": "Branch"
+            },
+            "type": {
+              "const": "git_push",
+              "default": "git_push",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "title": "GitPushHook",
           "type": "object"
         },
         "HistoryConfig": {
@@ -1600,6 +1676,32 @@
               "description": "Process environment.",
               "title": "Env",
               "type": "object"
+            },
+            "hooks": {
+              "description": "Hooks run around the task process.",
+              "items": {
+                "discriminator": {
+                  "mapping": {
+                    "copy_workdir": "#/$defs/CopyWorkdirHook",
+                    "git_clone": "#/$defs/GitCloneHook",
+                    "git_push": "#/$defs/GitPushHook"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/CopyWorkdirHook"
+                  },
+                  {
+                    "$ref": "#/$defs/GitCloneHook"
+                  },
+                  {
+                    "$ref": "#/$defs/GitPushHook"
+                  }
+                ]
+              },
+              "title": "Hooks",
+              "type": "array"
             },
             "secret_ids": {
               "description": "Secrets merged into the process environment.",

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -804,44 +804,6 @@
           "title": "CohortVersionResponse",
           "type": "object"
         },
-        "CommandHook": {
-          "additionalProperties": false,
-          "description": "Command hook.",
-          "properties": {
-            "command": {
-              "description": "Shell command to run.",
-              "title": "Command",
-              "type": "string"
-            },
-            "run_on_failure": {
-              "default": false,
-              "description": "Whether a teardown command runs when the task process failed.",
-              "title": "Run On Failure",
-              "type": "boolean"
-            },
-            "type": {
-              "const": "command",
-              "default": "command",
-              "title": "Type",
-              "type": "string"
-            },
-            "when": {
-              "description": "Phase the command runs in.",
-              "enum": [
-                "setup",
-                "teardown"
-              ],
-              "title": "When",
-              "type": "string"
-            }
-          },
-          "required": [
-            "command",
-            "when"
-          ],
-          "title": "CommandHook",
-          "type": "object"
-        },
         "CopyWorkdirHook": {
           "additionalProperties": false,
           "description": "Copy workdir hook.",
@@ -1658,8 +1620,9 @@
               "items": {
                 "discriminator": {
                   "mapping": {
-                    "command": "#/$defs/CommandHook",
-                    "copy_workdir": "#/$defs/CopyWorkdirHook"
+                    "copy_workdir": "#/$defs/CopyWorkdirHook",
+                    "setup_command": "#/$defs/SetupCommandHook",
+                    "teardown_command": "#/$defs/TeardownCommandHook"
                   },
                   "propertyName": "type"
                 },
@@ -1668,7 +1631,10 @@
                     "$ref": "#/$defs/CopyWorkdirHook"
                   },
                   {
-                    "$ref": "#/$defs/CommandHook"
+                    "$ref": "#/$defs/SetupCommandHook"
+                  },
+                  {
+                    "$ref": "#/$defs/TeardownCommandHook"
                   }
                 ]
               },
@@ -1738,6 +1704,28 @@
             "entrypoint"
           ],
           "title": "ScriptPluginSource",
+          "type": "object"
+        },
+        "SetupCommandHook": {
+          "additionalProperties": false,
+          "description": "Setup command hook.",
+          "properties": {
+            "command": {
+              "description": "Shell command to run.",
+              "title": "Command",
+              "type": "string"
+            },
+            "type": {
+              "const": "setup_command",
+              "default": "setup_command",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "title": "SetupCommandHook",
           "type": "object"
         },
         "StaticCase": {
@@ -1862,6 +1850,39 @@
           ],
           "title": "TaskKind",
           "type": "string"
+        },
+        "TeardownCommandHook": {
+          "additionalProperties": false,
+          "description": "Teardown command hook.",
+          "properties": {
+            "command": {
+              "description": "Shell command to run.",
+              "title": "Command",
+              "type": "string"
+            },
+            "on": {
+              "default": "success",
+              "description": "Task process outcome the command runs on.",
+              "enum": [
+                "success",
+                "failure",
+                "always"
+              ],
+              "title": "On",
+              "type": "string"
+            },
+            "type": {
+              "const": "teardown_command",
+              "default": "teardown_command",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "title": "TeardownCommandHook",
+          "type": "object"
         },
         "ToolError": {
           "additionalProperties": false,

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -804,6 +804,44 @@
           "title": "CohortVersionResponse",
           "type": "object"
         },
+        "CommandHook": {
+          "additionalProperties": false,
+          "description": "Command hook.",
+          "properties": {
+            "command": {
+              "description": "Shell command to run.",
+              "title": "Command",
+              "type": "string"
+            },
+            "run_on_failure": {
+              "default": false,
+              "description": "Whether a teardown command runs when the task process failed.",
+              "title": "Run On Failure",
+              "type": "boolean"
+            },
+            "type": {
+              "const": "command",
+              "default": "command",
+              "title": "Type",
+              "type": "string"
+            },
+            "when": {
+              "description": "Phase the command runs in.",
+              "enum": [
+                "setup",
+                "teardown"
+              ],
+              "title": "When",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command",
+            "when"
+          ],
+          "title": "CommandHook",
+          "type": "object"
+        },
         "CopyWorkdirHook": {
           "additionalProperties": false,
           "description": "Copy workdir hook.",
@@ -1119,68 +1157,6 @@
             "evaluators"
           ],
           "title": "ExperimentResponse",
-          "type": "object"
-        },
-        "GitCloneHook": {
-          "additionalProperties": false,
-          "description": "Git clone hook.",
-          "properties": {
-            "ref": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Ref checked out after the clone.",
-              "title": "Ref"
-            },
-            "type": {
-              "const": "git_clone",
-              "default": "git_clone",
-              "title": "Type",
-              "type": "string"
-            },
-            "url": {
-              "description": "Repository to clone.",
-              "title": "Url",
-              "type": "string"
-            }
-          },
-          "required": [
-            "url"
-          ],
-          "title": "GitCloneHook",
-          "type": "object"
-        },
-        "GitPushHook": {
-          "additionalProperties": false,
-          "description": "Git push hook.",
-          "properties": {
-            "branch": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Branch pushed to.",
-              "title": "Branch"
-            },
-            "type": {
-              "const": "git_push",
-              "default": "git_push",
-              "title": "Type",
-              "type": "string"
-            }
-          },
-          "title": "GitPushHook",
           "type": "object"
         },
         "HistoryConfig": {
@@ -1682,9 +1658,8 @@
               "items": {
                 "discriminator": {
                   "mapping": {
-                    "copy_workdir": "#/$defs/CopyWorkdirHook",
-                    "git_clone": "#/$defs/GitCloneHook",
-                    "git_push": "#/$defs/GitPushHook"
+                    "command": "#/$defs/CommandHook",
+                    "copy_workdir": "#/$defs/CopyWorkdirHook"
                   },
                   "propertyName": "type"
                 },
@@ -1693,10 +1668,7 @@
                     "$ref": "#/$defs/CopyWorkdirHook"
                   },
                   {
-                    "$ref": "#/$defs/GitCloneHook"
-                  },
-                  {
-                    "$ref": "#/$defs/GitPushHook"
+                    "$ref": "#/$defs/CommandHook"
                   }
                 ]
               },

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -804,6 +804,20 @@
           "title": "CohortVersionResponse",
           "type": "object"
         },
+        "CopyWorkdirHook": {
+          "additionalProperties": false,
+          "description": "Copy workdir hook.",
+          "properties": {
+            "type": {
+              "const": "copy_workdir",
+              "default": "copy_workdir",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "title": "CopyWorkdirHook",
+          "type": "object"
+        },
         "EvaluatorConfig": {
           "additionalProperties": false,
           "description": "Evaluator config.",
@@ -1105,6 +1119,68 @@
             "evaluators"
           ],
           "title": "ExperimentResponse",
+          "type": "object"
+        },
+        "GitCloneHook": {
+          "additionalProperties": false,
+          "description": "Git clone hook.",
+          "properties": {
+            "ref": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Ref checked out after the clone.",
+              "title": "Ref"
+            },
+            "type": {
+              "const": "git_clone",
+              "default": "git_clone",
+              "title": "Type",
+              "type": "string"
+            },
+            "url": {
+              "description": "Repository to clone.",
+              "title": "Url",
+              "type": "string"
+            }
+          },
+          "required": [
+            "url"
+          ],
+          "title": "GitCloneHook",
+          "type": "object"
+        },
+        "GitPushHook": {
+          "additionalProperties": false,
+          "description": "Git push hook.",
+          "properties": {
+            "branch": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Branch pushed to.",
+              "title": "Branch"
+            },
+            "type": {
+              "const": "git_push",
+              "default": "git_push",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "title": "GitPushHook",
           "type": "object"
         },
         "HistoryConfig": {
@@ -1600,6 +1676,32 @@
               "description": "Process environment.",
               "title": "Env",
               "type": "object"
+            },
+            "hooks": {
+              "description": "Hooks run around the task process.",
+              "items": {
+                "discriminator": {
+                  "mapping": {
+                    "copy_workdir": "#/$defs/CopyWorkdirHook",
+                    "git_clone": "#/$defs/GitCloneHook",
+                    "git_push": "#/$defs/GitPushHook"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/$defs/CopyWorkdirHook"
+                  },
+                  {
+                    "$ref": "#/$defs/GitCloneHook"
+                  },
+                  {
+                    "$ref": "#/$defs/GitPushHook"
+                  }
+                ]
+              },
+              "title": "Hooks",
+              "type": "array"
             },
             "secret_ids": {
               "description": "Secrets merged into the process environment.",

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -804,44 +804,6 @@
           "title": "CohortVersionResponse",
           "type": "object"
         },
-        "CommandHook": {
-          "additionalProperties": false,
-          "description": "Command hook.",
-          "properties": {
-            "command": {
-              "description": "Shell command to run.",
-              "title": "Command",
-              "type": "string"
-            },
-            "run_on_failure": {
-              "default": false,
-              "description": "Whether a teardown command runs when the task process failed.",
-              "title": "Run On Failure",
-              "type": "boolean"
-            },
-            "type": {
-              "const": "command",
-              "default": "command",
-              "title": "Type",
-              "type": "string"
-            },
-            "when": {
-              "description": "Phase the command runs in.",
-              "enum": [
-                "setup",
-                "teardown"
-              ],
-              "title": "When",
-              "type": "string"
-            }
-          },
-          "required": [
-            "command",
-            "when"
-          ],
-          "title": "CommandHook",
-          "type": "object"
-        },
         "CopyWorkdirHook": {
           "additionalProperties": false,
           "description": "Copy workdir hook.",
@@ -1658,8 +1620,9 @@
               "items": {
                 "discriminator": {
                   "mapping": {
-                    "command": "#/$defs/CommandHook",
-                    "copy_workdir": "#/$defs/CopyWorkdirHook"
+                    "copy_workdir": "#/$defs/CopyWorkdirHook",
+                    "setup_command": "#/$defs/SetupCommandHook",
+                    "teardown_command": "#/$defs/TeardownCommandHook"
                   },
                   "propertyName": "type"
                 },
@@ -1668,7 +1631,10 @@
                     "$ref": "#/$defs/CopyWorkdirHook"
                   },
                   {
-                    "$ref": "#/$defs/CommandHook"
+                    "$ref": "#/$defs/SetupCommandHook"
+                  },
+                  {
+                    "$ref": "#/$defs/TeardownCommandHook"
                   }
                 ]
               },
@@ -1738,6 +1704,28 @@
             "entrypoint"
           ],
           "title": "ScriptPluginSource",
+          "type": "object"
+        },
+        "SetupCommandHook": {
+          "additionalProperties": false,
+          "description": "Setup command hook.",
+          "properties": {
+            "command": {
+              "description": "Shell command to run.",
+              "title": "Command",
+              "type": "string"
+            },
+            "type": {
+              "const": "setup_command",
+              "default": "setup_command",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "title": "SetupCommandHook",
           "type": "object"
         },
         "StaticCase": {
@@ -1862,6 +1850,39 @@
           ],
           "title": "TaskKind",
           "type": "string"
+        },
+        "TeardownCommandHook": {
+          "additionalProperties": false,
+          "description": "Teardown command hook.",
+          "properties": {
+            "command": {
+              "description": "Shell command to run.",
+              "title": "Command",
+              "type": "string"
+            },
+            "on": {
+              "default": "success",
+              "description": "Task process outcome the command runs on.",
+              "enum": [
+                "success",
+                "failure",
+                "always"
+              ],
+              "title": "On",
+              "type": "string"
+            },
+            "type": {
+              "const": "teardown_command",
+              "default": "teardown_command",
+              "title": "Type",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "title": "TeardownCommandHook",
+          "type": "object"
         },
         "ToolError": {
           "additionalProperties": false,

--- a/tests/server/test_agent_version_repository.py
+++ b/tests/server/test_agent_version_repository.py
@@ -80,7 +80,11 @@ from kitaru.server.domain.cohort import Cohort
 from kitaru.server.domain.cohort_version import CohortVersion
 from kitaru.server.domain.experiment import Experiment
 from kitaru.server.domain.experiment_run import ExperimentRun
-from kitaru.server.domain.hook import CommandHook, CopyWorkdirHook
+from kitaru.server.domain.hook import (
+    CopyWorkdirHook,
+    SetupCommandHook,
+    TeardownCommandHook,
+)
 from kitaru.server.domain.replay_config import (
     PassthroughConfig,
     ReplayConfig,
@@ -307,8 +311,8 @@ async def test_create_with_run_spec_hooks(setup: Setup) -> None:
     repository, owner_id, agent_id, _, _, _, _, _ = setup
     hooks = [
         CopyWorkdirHook(),
-        CommandHook(command="setup.sh", when="setup"),
-        CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
+        SetupCommandHook(command="setup.sh"),
+        TeardownCommandHook(command="teardown.sh", on="always"),
     ]
     version = await repository.create(
         AgentVersion(
@@ -535,8 +539,8 @@ async def test_update_replaces_run_spec_hooks(setup: Setup) -> None:
         )
     )
     new_hooks = [
-        CommandHook(command="setup.sh", when="setup"),
-        CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
+        SetupCommandHook(command="setup.sh"),
+        TeardownCommandHook(command="teardown.sh", on="always"),
     ]
     created.update_run_spec(RunSpec(command="run.sh", hooks=new_hooks))
     updated = await repository.update(created)

--- a/tests/server/test_agent_version_repository.py
+++ b/tests/server/test_agent_version_repository.py
@@ -33,6 +33,7 @@ from kitaru.api_models.v1.filter import FilterOp
 from kitaru.api_models.v1.session import SessionOrigin
 from kitaru.api_models.v1.tag import TagResourceType
 from kitaru.server.adapters.db.encryption import AesGcmCipher
+from kitaru.server.adapters.db.orm.agent_version import AgentVersionORM
 from kitaru.server.adapters.db.repositories.account_repository import (
     SQLAccountRepository,
 )
@@ -79,6 +80,7 @@ from kitaru.server.domain.cohort import Cohort
 from kitaru.server.domain.cohort_version import CohortVersion
 from kitaru.server.domain.experiment import Experiment
 from kitaru.server.domain.experiment_run import ExperimentRun
+from kitaru.server.domain.hook import CopyWorkdirHook, GitCloneHook, GitPushHook
 from kitaru.server.domain.replay_config import (
     PassthroughConfig,
     ReplayConfig,
@@ -300,6 +302,43 @@ async def test_create_with_run_spec_and_secret_order(setup: Setup) -> None:
     assert loaded.run_spec.secret_ids == secret_ids
 
 
+async def test_create_with_run_spec_hooks(setup: Setup) -> None:
+    """Round-trip a run spec's hooks, preserving each variant and its fields."""
+    repository, owner_id, agent_id, _, _, _, _, _ = setup
+    hooks = [
+        CopyWorkdirHook(),
+        GitCloneHook(url="https://example.com/repo.git", ref="main"),
+        GitPushHook(branch="results"),
+    ]
+    version = await repository.create(
+        AgentVersion(
+            owner_id=owner_id,
+            agent_id=agent_id,
+            run_spec=RunSpec(command="run.sh", hooks=hooks),
+        )
+    )
+    assert version.run_spec is not None
+    assert version.run_spec.hooks == hooks
+    loaded = await repository.get(version.id)
+    assert loaded.run_spec is not None
+    assert loaded.run_spec.hooks == hooks
+
+
+async def test_create_with_run_spec_without_hooks(setup: Setup) -> None:
+    """Read back an empty hooks list for a run spec created without hooks."""
+    repository, owner_id, agent_id, _, _, _, _, _ = setup
+    version = await repository.create(
+        AgentVersion(
+            owner_id=owner_id,
+            agent_id=agent_id,
+            run_spec=RunSpec(command="run.sh"),
+        )
+    )
+    loaded = await repository.get(version.id)
+    assert loaded.run_spec is not None
+    assert loaded.run_spec.hooks == []
+
+
 async def test_create_with_unknown_secret_id_rejected() -> None:
     """Reject a run spec that references a secret that does not exist."""
     if not await postgres_available():
@@ -318,6 +357,32 @@ async def test_create_with_unknown_secret_id_rejected() -> None:
                     run_spec=RunSpec(command="run.sh", secret_ids=[uuid.uuid4()]),
                 )
             )
+
+
+async def test_null_run_hooks_column_reads_back_empty() -> None:
+    """Read back an empty hooks list from a row stored before the hooks column."""
+    if not await postgres_available():
+        pytest.skip("PostgreSQL is not reachable")
+    async with pg_session() as session:
+        owner = await SQLAccountRepository(session).create(Account(name="owner"))
+        agent = await SQLAgentRepository(session).create(
+            Agent(owner_id=owner.id, name=f"agent-{uuid.uuid4().hex[:8]}")
+        )
+        repository = SQLAgentVersionRepository(session)
+        created = await repository.create(
+            AgentVersion(
+                owner_id=owner.id,
+                agent_id=agent.id,
+                run_spec=RunSpec(command="run.sh"),
+            )
+        )
+        row = await session.get(AgentVersionORM, created.id)
+        assert row is not None
+        row.run_hooks = None
+        await session.flush()
+        loaded = await repository.get(created.id)
+        assert loaded.run_spec is not None
+        assert loaded.run_spec.hooks == []
 
 
 async def test_get(setup: Setup) -> None:
@@ -457,6 +522,30 @@ async def test_update_replaces_run_spec_and_secret_links(setup: Setup) -> None:
     loaded = await repository.get(created.id)
     assert loaded.run_spec is not None
     assert loaded.run_spec.secret_ids == new_secret_ids
+
+
+async def test_update_replaces_run_spec_hooks(setup: Setup) -> None:
+    """Replace the run spec's hooks on update."""
+    repository, owner_id, agent_id, _, _, _, _, _ = setup
+    created = await repository.create(
+        AgentVersion(
+            owner_id=owner_id,
+            agent_id=agent_id,
+            run_spec=RunSpec(command="run.sh", hooks=[CopyWorkdirHook()]),
+        )
+    )
+    new_hooks = [
+        GitCloneHook(url="https://example.com/repo.git", ref="main"),
+        GitPushHook(branch="results"),
+    ]
+    created.update_run_spec(RunSpec(command="run.sh", hooks=new_hooks))
+    updated = await repository.update(created)
+    assert updated.run_spec is not None
+    assert updated.run_spec.hooks == new_hooks
+
+    loaded = await repository.get(created.id)
+    assert loaded.run_spec is not None
+    assert loaded.run_spec.hooks == new_hooks
 
 
 async def test_update_clears_run_spec_and_secret_links(setup: Setup) -> None:

--- a/tests/server/test_agent_version_repository.py
+++ b/tests/server/test_agent_version_repository.py
@@ -80,7 +80,7 @@ from kitaru.server.domain.cohort import Cohort
 from kitaru.server.domain.cohort_version import CohortVersion
 from kitaru.server.domain.experiment import Experiment
 from kitaru.server.domain.experiment_run import ExperimentRun
-from kitaru.server.domain.hook import CopyWorkdirHook, GitCloneHook, GitPushHook
+from kitaru.server.domain.hook import CommandHook, CopyWorkdirHook
 from kitaru.server.domain.replay_config import (
     PassthroughConfig,
     ReplayConfig,
@@ -307,8 +307,8 @@ async def test_create_with_run_spec_hooks(setup: Setup) -> None:
     repository, owner_id, agent_id, _, _, _, _, _ = setup
     hooks = [
         CopyWorkdirHook(),
-        GitCloneHook(url="https://example.com/repo.git", ref="main"),
-        GitPushHook(branch="results"),
+        CommandHook(command="setup.sh", when="setup"),
+        CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
     ]
     version = await repository.create(
         AgentVersion(
@@ -535,8 +535,8 @@ async def test_update_replaces_run_spec_hooks(setup: Setup) -> None:
         )
     )
     new_hooks = [
-        GitCloneHook(url="https://example.com/repo.git", ref="main"),
-        GitPushHook(branch="results"),
+        CommandHook(command="setup.sh", when="setup"),
+        CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
     ]
     created.update_run_spec(RunSpec(command="run.sh", hooks=new_hooks))
     updated = await repository.update(created)

--- a/tests/server/test_rest_mapping.py
+++ b/tests/server/test_rest_mapping.py
@@ -21,7 +21,11 @@ from kitaru.api_models.v1.agent_version import (
     AgentVersionUpdateRequest,
     RunSpec,
 )
-from kitaru.api_models.v1.hook import CommandHook, CopyWorkdirHook
+from kitaru.api_models.v1.hook import (
+    CopyWorkdirHook,
+    SetupCommandHook,
+    TeardownCommandHook,
+)
 from kitaru.api_models.v1.plugin import PackagePluginSource, ScriptPluginSource
 from kitaru.api_models.v1.task import TaskKind
 from kitaru.server.adapters.rest.mapping.agent_versions import (
@@ -38,10 +42,13 @@ from kitaru.server.domain.agent_version import (
 from kitaru.server.domain.agent_version import AgentVersion
 from kitaru.server.domain.agent_version import RunSpec as DomainRunSpec
 from kitaru.server.domain.hook import (
-    CommandHook as DomainCommandHook,
+    CopyWorkdirHook as DomainCopyWorkdirHook,
 )
 from kitaru.server.domain.hook import (
-    CopyWorkdirHook as DomainCopyWorkdirHook,
+    SetupCommandHook as DomainSetupCommandHook,
+)
+from kitaru.server.domain.hook import (
+    TeardownCommandHook as DomainTeardownCommandHook,
 )
 from kitaru.server.domain.plugin import (
     PackagePluginSource as DomainPackagePluginSource,
@@ -83,18 +90,16 @@ def test_run_spec_hooks_convert_to_domain_variants() -> None:
             command="run.sh",
             hooks=[
                 CopyWorkdirHook(),
-                CommandHook(command="setup.sh", when="setup"),
-                CommandHook(
-                    command="teardown.sh", when="teardown", run_on_failure=True
-                ),
+                SetupCommandHook(command="setup.sh"),
+                TeardownCommandHook(command="teardown.sh", on="always"),
             ],
         )
     )
 
     assert run_spec.hooks == [
         DomainCopyWorkdirHook(),
-        DomainCommandHook(command="setup.sh", when="setup"),
-        DomainCommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
+        DomainSetupCommandHook(command="setup.sh"),
+        DomainTeardownCommandHook(command="teardown.sh", on="always"),
     ]
 
 
@@ -108,10 +113,8 @@ def test_agent_version_response_carries_run_spec_hooks() -> None:
             command="run.sh",
             hooks=[
                 DomainCopyWorkdirHook(),
-                DomainCommandHook(command="setup.sh", when="setup"),
-                DomainCommandHook(
-                    command="teardown.sh", when="teardown", run_on_failure=True
-                ),
+                DomainSetupCommandHook(command="setup.sh"),
+                DomainTeardownCommandHook(command="teardown.sh", on="always"),
             ],
         ),
         created=now,
@@ -123,8 +126,8 @@ def test_agent_version_response_carries_run_spec_hooks() -> None:
     assert response.run_spec is not None
     assert response.run_spec.hooks == [
         CopyWorkdirHook(),
-        CommandHook(command="setup.sh", when="setup"),
-        CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
+        SetupCommandHook(command="setup.sh"),
+        TeardownCommandHook(command="teardown.sh", on="always"),
     ]
 
 
@@ -136,10 +139,8 @@ def test_task_spec_response_carries_hooks() -> None:
         timeout_seconds=60,
         hooks=[
             DomainCopyWorkdirHook(),
-            DomainCommandHook(command="setup.sh", when="setup"),
-            DomainCommandHook(
-                command="teardown.sh", when="teardown", run_on_failure=True
-            ),
+            DomainSetupCommandHook(command="setup.sh"),
+            DomainTeardownCommandHook(command="teardown.sh", on="always"),
         ],
         details=DomainAgentTaskDetails(),
     )
@@ -148,8 +149,8 @@ def test_task_spec_response_carries_hooks() -> None:
 
     assert response.hooks == [
         CopyWorkdirHook(),
-        CommandHook(command="setup.sh", when="setup"),
-        CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
+        SetupCommandHook(command="setup.sh"),
+        TeardownCommandHook(command="teardown.sh", on="always"),
     ]
 
 

--- a/tests/server/test_rest_mapping.py
+++ b/tests/server/test_rest_mapping.py
@@ -14,27 +14,46 @@
 """Isolated unit tests for the REST mapping layer."""
 
 import uuid
+from datetime import UTC, datetime
 
 from kitaru.api_models.v1.agent_version import (
     AgentCapabilities,
     AgentVersionUpdateRequest,
     RunSpec,
 )
+from kitaru.api_models.v1.hook import CopyWorkdirHook, GitCloneHook, GitPushHook
 from kitaru.api_models.v1.plugin import PackagePluginSource, ScriptPluginSource
+from kitaru.api_models.v1.task import TaskKind
 from kitaru.server.adapters.rest.mapping.agent_versions import (
+    agent_version_to_response,
     agent_version_update_to_command,
     capabilities_to_domain,
     run_spec_to_domain,
 )
 from kitaru.server.adapters.rest.mapping.plugins import plugin_source_to_domain
+from kitaru.server.adapters.rest.mapping.tasks import spec_to_response
 from kitaru.server.domain.agent_version import (
     AgentCapabilities as DomainAgentCapabilities,
 )
+from kitaru.server.domain.agent_version import AgentVersion
 from kitaru.server.domain.agent_version import RunSpec as DomainRunSpec
+from kitaru.server.domain.hook import (
+    CopyWorkdirHook as DomainCopyWorkdirHook,
+)
+from kitaru.server.domain.hook import (
+    GitCloneHook as DomainGitCloneHook,
+)
+from kitaru.server.domain.hook import (
+    GitPushHook as DomainGitPushHook,
+)
 from kitaru.server.domain.plugin import (
     PackagePluginSource as DomainPackagePluginSource,
 )
 from kitaru.server.domain.plugin import ScriptPluginSource as DomainScriptPluginSource
+from kitaru.server.domain.task import (
+    AgentTaskDetails as DomainAgentTaskDetails,
+)
+from kitaru.server.domain.task import TaskSpec as DomainTaskSpec
 
 
 def test_agent_version_create_converts_nested_wire_models() -> None:
@@ -58,6 +77,77 @@ def test_agent_version_update_preserves_omitted_and_explicit_null() -> None:
     assert "run_spec" not in omitted.model_fields_set
     assert "run_spec" in explicit_null.model_fields_set
     assert explicit_null.run_spec is None
+
+
+def test_run_spec_hooks_convert_to_domain_variants() -> None:
+    """Convert every discriminated hook variant to its domain value object."""
+    run_spec = run_spec_to_domain(
+        RunSpec(
+            command="run.sh",
+            hooks=[
+                CopyWorkdirHook(),
+                GitCloneHook(url="https://example.com/repo.git", ref="main"),
+                GitPushHook(branch="results"),
+            ],
+        )
+    )
+
+    assert run_spec.hooks == [
+        DomainCopyWorkdirHook(),
+        DomainGitCloneHook(url="https://example.com/repo.git", ref="main"),
+        DomainGitPushHook(branch="results"),
+    ]
+
+
+def test_agent_version_response_carries_run_spec_hooks() -> None:
+    """Convert a stored run spec's hooks back to their wire variants."""
+    now = datetime.now(UTC)
+    version = AgentVersion(
+        owner_id=uuid.uuid4(),
+        agent_id=uuid.uuid4(),
+        run_spec=DomainRunSpec(
+            command="run.sh",
+            hooks=[
+                DomainCopyWorkdirHook(),
+                DomainGitCloneHook(url="https://example.com/repo.git", ref="main"),
+                DomainGitPushHook(branch="results"),
+            ],
+        ),
+        created=now,
+        updated=now,
+    )
+
+    response = agent_version_to_response(version)
+
+    assert response.run_spec is not None
+    assert response.run_spec.hooks == [
+        CopyWorkdirHook(),
+        GitCloneHook(url="https://example.com/repo.git", ref="main"),
+        GitPushHook(branch="results"),
+    ]
+
+
+def test_task_spec_response_carries_hooks() -> None:
+    """Convert a task spec's hooks to their wire variants."""
+    spec = DomainTaskSpec(
+        task_id=uuid.uuid4(),
+        kind=TaskKind.AGENT,
+        timeout_seconds=60,
+        hooks=[
+            DomainCopyWorkdirHook(),
+            DomainGitCloneHook(url="https://example.com/repo.git", ref="main"),
+            DomainGitPushHook(branch="results"),
+        ],
+        details=DomainAgentTaskDetails(),
+    )
+
+    response = spec_to_response(spec)
+
+    assert response.hooks == [
+        CopyWorkdirHook(),
+        GitCloneHook(url="https://example.com/repo.git", ref="main"),
+        GitPushHook(branch="results"),
+    ]
 
 
 def test_plugin_sources_convert_to_domain_variants() -> None:

--- a/tests/server/test_rest_mapping.py
+++ b/tests/server/test_rest_mapping.py
@@ -21,7 +21,7 @@ from kitaru.api_models.v1.agent_version import (
     AgentVersionUpdateRequest,
     RunSpec,
 )
-from kitaru.api_models.v1.hook import CopyWorkdirHook, GitCloneHook, GitPushHook
+from kitaru.api_models.v1.hook import CommandHook, CopyWorkdirHook
 from kitaru.api_models.v1.plugin import PackagePluginSource, ScriptPluginSource
 from kitaru.api_models.v1.task import TaskKind
 from kitaru.server.adapters.rest.mapping.agent_versions import (
@@ -38,13 +38,10 @@ from kitaru.server.domain.agent_version import (
 from kitaru.server.domain.agent_version import AgentVersion
 from kitaru.server.domain.agent_version import RunSpec as DomainRunSpec
 from kitaru.server.domain.hook import (
+    CommandHook as DomainCommandHook,
+)
+from kitaru.server.domain.hook import (
     CopyWorkdirHook as DomainCopyWorkdirHook,
-)
-from kitaru.server.domain.hook import (
-    GitCloneHook as DomainGitCloneHook,
-)
-from kitaru.server.domain.hook import (
-    GitPushHook as DomainGitPushHook,
 )
 from kitaru.server.domain.plugin import (
     PackagePluginSource as DomainPackagePluginSource,
@@ -86,16 +83,18 @@ def test_run_spec_hooks_convert_to_domain_variants() -> None:
             command="run.sh",
             hooks=[
                 CopyWorkdirHook(),
-                GitCloneHook(url="https://example.com/repo.git", ref="main"),
-                GitPushHook(branch="results"),
+                CommandHook(command="setup.sh", when="setup"),
+                CommandHook(
+                    command="teardown.sh", when="teardown", run_on_failure=True
+                ),
             ],
         )
     )
 
     assert run_spec.hooks == [
         DomainCopyWorkdirHook(),
-        DomainGitCloneHook(url="https://example.com/repo.git", ref="main"),
-        DomainGitPushHook(branch="results"),
+        DomainCommandHook(command="setup.sh", when="setup"),
+        DomainCommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
     ]
 
 
@@ -109,8 +108,10 @@ def test_agent_version_response_carries_run_spec_hooks() -> None:
             command="run.sh",
             hooks=[
                 DomainCopyWorkdirHook(),
-                DomainGitCloneHook(url="https://example.com/repo.git", ref="main"),
-                DomainGitPushHook(branch="results"),
+                DomainCommandHook(command="setup.sh", when="setup"),
+                DomainCommandHook(
+                    command="teardown.sh", when="teardown", run_on_failure=True
+                ),
             ],
         ),
         created=now,
@@ -122,8 +123,8 @@ def test_agent_version_response_carries_run_spec_hooks() -> None:
     assert response.run_spec is not None
     assert response.run_spec.hooks == [
         CopyWorkdirHook(),
-        GitCloneHook(url="https://example.com/repo.git", ref="main"),
-        GitPushHook(branch="results"),
+        CommandHook(command="setup.sh", when="setup"),
+        CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
     ]
 
 
@@ -135,8 +136,10 @@ def test_task_spec_response_carries_hooks() -> None:
         timeout_seconds=60,
         hooks=[
             DomainCopyWorkdirHook(),
-            DomainGitCloneHook(url="https://example.com/repo.git", ref="main"),
-            DomainGitPushHook(branch="results"),
+            DomainCommandHook(command="setup.sh", when="setup"),
+            DomainCommandHook(
+                command="teardown.sh", when="teardown", run_on_failure=True
+            ),
         ],
         details=DomainAgentTaskDetails(),
     )
@@ -145,8 +148,8 @@ def test_task_spec_response_carries_hooks() -> None:
 
     assert response.hooks == [
         CopyWorkdirHook(),
-        GitCloneHook(url="https://example.com/repo.git", ref="main"),
-        GitPushHook(branch="results"),
+        CommandHook(command="setup.sh", when="setup"),
+        CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
     ]
 
 

--- a/tests/server/test_task_service.py
+++ b/tests/server/test_task_service.py
@@ -64,7 +64,11 @@ from kitaru.server.application.services.server_analytics import ServerAnalytics
 from kitaru.server.application.services.task_transitions import TaskTransitions
 from kitaru.server.domain.account import Account
 from kitaru.server.domain.agent_version import RunSpec
-from kitaru.server.domain.hook import CommandHook, CopyWorkdirHook
+from kitaru.server.domain.hook import (
+    CopyWorkdirHook,
+    SetupCommandHook,
+    TeardownCommandHook,
+)
 from kitaru.server.domain.plugin import Plugin, PluginKind, ScriptPluginSource
 from kitaru.server.domain.task import (
     AgentTask,
@@ -823,8 +827,8 @@ async def test_agent_spec_carries_run_spec_hooks(
     agent = await create_agent(services.agents, ACTOR.account.id)
     hooks = [
         CopyWorkdirHook(),
-        CommandHook(command="setup.sh", when="setup"),
-        CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
+        SetupCommandHook(command="setup.sh"),
+        TeardownCommandHook(command="teardown.sh", on="always"),
     ]
     version = await create_agent_version(
         services.agent_versions,

--- a/tests/server/test_task_service.py
+++ b/tests/server/test_task_service.py
@@ -64,6 +64,7 @@ from kitaru.server.application.services.server_analytics import ServerAnalytics
 from kitaru.server.application.services.task_transitions import TaskTransitions
 from kitaru.server.domain.account import Account
 from kitaru.server.domain.agent_version import RunSpec
+from kitaru.server.domain.hook import CopyWorkdirHook, GitCloneHook, GitPushHook
 from kitaru.server.domain.plugin import Plugin, PluginKind, ScriptPluginSource
 from kitaru.server.domain.task import (
     AgentTask,
@@ -815,6 +816,29 @@ async def test_agent_spec_merges_secrets_in_order_with_later_wins(
     assert spec.run_spec.env == {"STATIC": "x"}
 
 
+async def test_agent_spec_carries_run_spec_hooks(
+    services: JobAndTaskServices,
+) -> None:
+    """An agent spec carries the hooks of its version's run spec."""
+    agent = await create_agent(services.agents, ACTOR.account.id)
+    hooks = [
+        CopyWorkdirHook(),
+        GitCloneHook(url="https://example.com/repo.git", ref="main"),
+        GitPushHook(branch="results"),
+    ]
+    version = await create_agent_version(
+        services.agent_versions,
+        agent_id=agent.id,
+        owner_id=ACTOR.account.id,
+        run_spec=RunSpec(command="run.sh", hooks=hooks, timeout_seconds=60),
+    )
+
+    job_id = await _pending_job(services)
+    task = await create_agent_task(services.tasks, job_id, agent_version_id=version.id)
+    spec = await services.task_service.get_spec(task.id, actor=ACTOR)
+    assert spec.hooks == hooks
+
+
 async def test_evaluation_spec_uses_the_evaluator_timeout_and_no_run(
     services: JobAndTaskServices,
 ) -> None:
@@ -842,6 +866,7 @@ async def test_evaluation_spec_uses_the_evaluator_timeout_and_no_run(
         spec.timeout_seconds == services.task_service._policy.evaluator_timeout_seconds
     )
     assert spec.run_spec is None
+    assert spec.hooks == []
     assert spec.details.kind.value == "evaluator"
 
 
@@ -878,6 +903,7 @@ async def test_import_spec_carries_the_payload_sha256_and_provider(
     assert (
         spec.timeout_seconds == services.task_service._policy.importer_timeout_seconds
     )
+    assert spec.hooks == []
     assert isinstance(spec.details, ImportTaskDetails)
     assert spec.details.provider == "acme"
     assert spec.details.payload.blob_id == payload.id

--- a/tests/server/test_task_service.py
+++ b/tests/server/test_task_service.py
@@ -64,7 +64,7 @@ from kitaru.server.application.services.server_analytics import ServerAnalytics
 from kitaru.server.application.services.task_transitions import TaskTransitions
 from kitaru.server.domain.account import Account
 from kitaru.server.domain.agent_version import RunSpec
-from kitaru.server.domain.hook import CopyWorkdirHook, GitCloneHook, GitPushHook
+from kitaru.server.domain.hook import CommandHook, CopyWorkdirHook
 from kitaru.server.domain.plugin import Plugin, PluginKind, ScriptPluginSource
 from kitaru.server.domain.task import (
     AgentTask,
@@ -823,8 +823,8 @@ async def test_agent_spec_carries_run_spec_hooks(
     agent = await create_agent(services.agents, ACTOR.account.id)
     hooks = [
         CopyWorkdirHook(),
-        GitCloneHook(url="https://example.com/repo.git", ref="main"),
-        GitPushHook(branch="results"),
+        CommandHook(command="setup.sh", when="setup"),
+        CommandHook(command="teardown.sh", when="teardown", run_on_failure=True),
     ]
     version = await create_agent_version(
         services.agent_versions,

--- a/tests/worker/fakes.py
+++ b/tests/worker/fakes.py
@@ -19,6 +19,7 @@ from datetime import UTC, datetime
 from typing import Any, cast
 
 from kitaru.api_models.v1.base import Page
+from kitaru.api_models.v1.hook import TaskHook
 from kitaru.api_models.v1.job import JobKind, JobResponse, JobStatus
 from kitaru.api_models.v1.session import SessionOrigin, SessionResponse, SessionStatus
 from kitaru.api_models.v1.task import (
@@ -99,6 +100,7 @@ def make_agent_spec(
     secret_env: dict[str, str] | None = None,
     working_dir: str | None = None,
     replay_id: uuid.UUID | None = None,
+    hooks: list[TaskHook] | None = None,
 ) -> TaskSpecResponse:
     """Build an agent task spec.
 
@@ -112,6 +114,7 @@ def make_agent_spec(
         secret_env: Secrets merged into the process environment.
         working_dir: Working directory.
         replay_id: Replay the task runs for.
+        hooks: Hooks run around the task process.
 
     Returns:
         Agent task spec.
@@ -123,6 +126,7 @@ def make_agent_spec(
         run=TaskRunSpec(command=command, working_dir=working_dir, env=run_env or {}),
         env=extra_env or {},
         secret_env=secret_env or {},
+        hooks=hooks or [],
         details=AgentTaskDetails(inputs=inputs, replay_id=replay_id),
     )
 

--- a/tests/worker/test_hooks.py
+++ b/tests/worker/test_hooks.py
@@ -21,17 +21,21 @@ from pathlib import Path
 import pytest
 
 from kitaru.api_models.v1.hook import (
-    CommandHook as CommandHookSpec,
-)
-from kitaru.api_models.v1.hook import (
     CopyWorkdirHook as CopyWorkdirHookSpec,
 )
+from kitaru.api_models.v1.hook import (
+    SetupCommandHook as SetupCommandHookSpec,
+)
 from kitaru.api_models.v1.hook import TaskHook
+from kitaru.api_models.v1.hook import (
+    TeardownCommandHook as TeardownCommandHookSpec,
+)
 from kitaru.worker.hooks import (
-    CommandHook,
     CopyWorkdirHook,
     HookContext,
     HookError,
+    SetupCommandHook,
+    TeardownCommandHook,
     build_hooks,
 )
 from kitaru.worker.process import TaskProcess
@@ -53,20 +57,27 @@ def _make_ctx(scratch_dir: Path, working_dir: str | None = None) -> HookContext:
     )
 
 
+def _make_workdir_ctx(tmp_path: Path) -> tuple[HookContext, Path]:
+    """Build a hook context whose process has a working directory."""
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+    return _make_ctx(tmp_path, working_dir=str(working_dir)), working_dir
+
+
 def test_build_hooks_maps_each_spec_type_in_order() -> None:
     """Each spec type builds its implementation in declared order."""
     specs: list[TaskHook] = [
-        CommandHookSpec(command="setup.sh", when="setup"),
+        SetupCommandHookSpec(command="setup.sh"),
         CopyWorkdirHookSpec(),
-        CommandHookSpec(command="teardown.sh", when="teardown"),
+        TeardownCommandHookSpec(command="teardown.sh"),
     ]
 
     hooks = build_hooks(specs)
 
     assert [type(hook) for hook in hooks] == [
-        CommandHook,
+        SetupCommandHook,
         CopyWorkdirHook,
-        CommandHook,
+        TeardownCommandHook,
     ]
 
 
@@ -102,12 +113,10 @@ async def test_copy_workdir_without_a_working_dir_raises(tmp_path: Path) -> None
 
 async def test_setup_command_runs_in_the_working_dir(tmp_path: Path) -> None:
     """A setup command runs in the task process's working directory."""
-    working_dir = tmp_path / "work"
-    working_dir.mkdir()
-    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
-    spec = CommandHookSpec(command="touch marker.txt", when="setup")
+    ctx, working_dir = _make_workdir_ctx(tmp_path)
+    spec = SetupCommandHookSpec(command="touch marker.txt")
 
-    await CommandHook(spec).setup(ctx)
+    await SetupCommandHook(spec).setup(ctx)
 
     assert (working_dir / "marker.txt").exists()
 
@@ -122,10 +131,7 @@ async def test_setup_command_after_copy_workdir_runs_in_the_copy(
     scratch.mkdir()
     ctx = _make_ctx(scratch, working_dir=str(original))
     hooks = build_hooks(
-        [
-            CopyWorkdirHookSpec(),
-            CommandHookSpec(command="touch marker.txt", when="setup"),
-        ]
+        [CopyWorkdirHookSpec(), SetupCommandHookSpec(command="touch marker.txt")]
     )
 
     for hook in hooks:
@@ -140,44 +146,38 @@ async def test_failing_setup_command_raises_with_the_exit_code(
 ) -> None:
     """A setup command with a nonzero exit raises with the exit code."""
     ctx = _make_ctx(tmp_path, working_dir=str(tmp_path))
-    spec = CommandHookSpec(command="exit 3", when="setup")
+    spec = SetupCommandHookSpec(command="exit 3")
 
     with pytest.raises(HookError, match="exited with code 3"):
-        await CommandHook(spec).setup(ctx)
+        await SetupCommandHook(spec).setup(ctx)
 
 
 async def test_teardown_command_does_not_run_at_setup(tmp_path: Path) -> None:
-    """A teardown command runs nothing during setup."""
-    working_dir = tmp_path / "work"
-    working_dir.mkdir()
-    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
-    spec = CommandHookSpec(command="touch marker.txt", when="teardown")
+    """A teardown command hook runs nothing during setup."""
+    ctx, working_dir = _make_workdir_ctx(tmp_path)
+    spec = TeardownCommandHookSpec(command="touch marker.txt")
 
-    await CommandHook(spec).setup(ctx)
+    await TeardownCommandHook(spec).setup(ctx)
 
     assert not (working_dir / "marker.txt").exists()
 
 
 async def test_setup_command_does_not_run_at_teardown(tmp_path: Path) -> None:
-    """A setup command runs nothing during teardown."""
-    working_dir = tmp_path / "work"
-    working_dir.mkdir()
-    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
-    spec = CommandHookSpec(command="touch marker.txt", when="setup")
+    """A setup command hook runs nothing during teardown."""
+    ctx, working_dir = _make_workdir_ctx(tmp_path)
+    spec = SetupCommandHookSpec(command="touch marker.txt")
 
-    await CommandHook(spec).teardown(ctx, True)
+    await SetupCommandHook(spec).teardown(ctx, True)
 
     assert not (working_dir / "marker.txt").exists()
 
 
 async def test_teardown_command_runs_on_success(tmp_path: Path) -> None:
     """A teardown command runs after a successful task process."""
-    working_dir = tmp_path / "work"
-    working_dir.mkdir()
-    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
-    spec = CommandHookSpec(command="touch marker.txt", when="teardown")
+    ctx, working_dir = _make_workdir_ctx(tmp_path)
+    spec = TeardownCommandHookSpec(command="touch marker.txt")
 
-    await CommandHook(spec).teardown(ctx, True)
+    await TeardownCommandHook(spec).teardown(ctx, True)
 
     assert (working_dir / "marker.txt").exists()
 
@@ -186,27 +186,38 @@ async def test_teardown_command_skipped_on_failure_by_default(
     tmp_path: Path,
 ) -> None:
     """A failed task process runs no teardown command by default."""
-    working_dir = tmp_path / "work"
-    working_dir.mkdir()
-    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
-    spec = CommandHookSpec(command="touch marker.txt", when="teardown")
+    ctx, working_dir = _make_workdir_ctx(tmp_path)
+    spec = TeardownCommandHookSpec(command="touch marker.txt")
 
-    await CommandHook(spec).teardown(ctx, False)
+    await TeardownCommandHook(spec).teardown(ctx, False)
 
     assert not (working_dir / "marker.txt").exists()
 
 
-async def test_teardown_command_runs_on_failure_when_requested(
+async def test_teardown_command_on_failure_runs_only_on_failure(
     tmp_path: Path,
 ) -> None:
-    """A run_on_failure teardown command runs after a failed task process."""
-    working_dir = tmp_path / "work"
-    working_dir.mkdir()
-    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
-    spec = CommandHookSpec(
-        command="touch marker.txt", when="teardown", run_on_failure=True
-    )
+    """An on=failure teardown command runs after a failure and not a success."""
+    ctx, working_dir = _make_workdir_ctx(tmp_path)
+    spec = TeardownCommandHookSpec(command="touch marker.txt", on="failure")
 
-    await CommandHook(spec).teardown(ctx, False)
+    await TeardownCommandHook(spec).teardown(ctx, True)
+    assert not (working_dir / "marker.txt").exists()
 
+    await TeardownCommandHook(spec).teardown(ctx, False)
     assert (working_dir / "marker.txt").exists()
+
+
+async def test_teardown_command_on_always_runs_on_both_outcomes(
+    tmp_path: Path,
+) -> None:
+    """An on=always teardown command runs after either outcome."""
+    ctx, working_dir = _make_workdir_ctx(tmp_path)
+    spec = TeardownCommandHookSpec(command="touch success.txt", on="always")
+
+    await TeardownCommandHook(spec).teardown(ctx, True)
+    assert (working_dir / "success.txt").exists()
+
+    failure_spec = TeardownCommandHookSpec(command="touch failure.txt", on="always")
+    await TeardownCommandHook(failure_spec).teardown(ctx, False)
+    assert (working_dir / "failure.txt").exists()

--- a/tests/worker/test_hooks.py
+++ b/tests/worker/test_hooks.py
@@ -15,26 +15,21 @@
 
 import asyncio
 import os
-import subprocess
 import uuid
 from pathlib import Path
 
 import pytest
 
 from kitaru.api_models.v1.hook import (
+    CommandHook as CommandHookSpec,
+)
+from kitaru.api_models.v1.hook import (
     CopyWorkdirHook as CopyWorkdirHookSpec,
-)
-from kitaru.api_models.v1.hook import (
-    GitCloneHook as GitCloneHookSpec,
-)
-from kitaru.api_models.v1.hook import (
-    GitPushHook as GitPushHookSpec,
 )
 from kitaru.api_models.v1.hook import TaskHook
 from kitaru.worker.hooks import (
+    CommandHook,
     CopyWorkdirHook,
-    GitCloneHook,
-    GitPushHook,
     HookContext,
     HookError,
     build_hooks,
@@ -58,66 +53,20 @@ def _make_ctx(scratch_dir: Path, working_dir: str | None = None) -> HookContext:
     )
 
 
-def _run_git(cwd: Path, *args: str) -> str:
-    """Run a git command in a directory and return its stripped stdout."""
-    result = subprocess.run(
-        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
-    )
-    return result.stdout.strip()
-
-
-def _configure_git_identity(repo: Path) -> None:
-    """Set a per-repo committer identity so commits need no global config."""
-    _run_git(repo, "config", "user.email", "worker@example.com")
-    _run_git(repo, "config", "user.name", "Kitaru Worker")
-
-
-def _init_repo(path: Path) -> Path:
-    """Initialize a git repository with a committer identity."""
-    path.mkdir()
-    _run_git(path, "init", "--quiet")
-    _configure_git_identity(path)
-    return path
-
-
-def _commit_file(repo: Path, name: str, content: str) -> str:
-    """Write a file, commit it, and return the commit SHA."""
-    (repo / name).write_text(content)
-    _run_git(repo, "add", "-A")
-    _run_git(repo, "commit", "--quiet", "-m", f"Add {name}")
-    return _run_git(repo, "rev-parse", "HEAD")
-
-
-def _make_origin(tmp_path: Path) -> Path:
-    """Build a bare repository with one commit to push to and clone from."""
-    seed = _init_repo(tmp_path / "seed")
-    _commit_file(seed, "README.md", "seed\n")
-    bare = tmp_path / "origin.git"
-    _run_git(tmp_path, "clone", "--quiet", "--bare", str(seed), str(bare))
-    return bare
-
-
-def _clone(origin: Path, dest: Path) -> Path:
-    """Clone a repository and set a per-repo committer identity."""
-    _run_git(dest.parent, "clone", "--quiet", str(origin), str(dest))
-    _configure_git_identity(dest)
-    return dest
-
-
 def test_build_hooks_maps_each_spec_type_in_order() -> None:
     """Each spec type builds its implementation in declared order."""
     specs: list[TaskHook] = [
-        GitCloneHookSpec(url="https://example.com/repo.git"),
+        CommandHookSpec(command="setup.sh", when="setup"),
         CopyWorkdirHookSpec(),
-        GitPushHookSpec(),
+        CommandHookSpec(command="teardown.sh", when="teardown"),
     ]
 
     hooks = build_hooks(specs)
 
     assert [type(hook) for hook in hooks] == [
-        GitCloneHook,
+        CommandHook,
         CopyWorkdirHook,
-        GitPushHook,
+        CommandHook,
     ]
 
 
@@ -151,133 +100,113 @@ async def test_copy_workdir_without_a_working_dir_raises(tmp_path: Path) -> None
         await CopyWorkdirHook(0).setup(ctx)
 
 
-async def test_copy_workdir_after_git_clone_copies_the_clone(tmp_path: Path) -> None:
-    """A copy_workdir setup after a git_clone setup copies the clone."""
-    repo = _init_repo(tmp_path / "repo")
-    _commit_file(repo, "app.py", "print('hi')\n")
+async def test_setup_command_runs_in_the_working_dir(tmp_path: Path) -> None:
+    """A setup command runs in the task process's working directory."""
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
+    spec = CommandHookSpec(command="touch marker.txt", when="setup")
+
+    await CommandHook(spec).setup(ctx)
+
+    assert (working_dir / "marker.txt").exists()
+
+
+async def test_setup_command_after_copy_workdir_runs_in_the_copy(
+    tmp_path: Path,
+) -> None:
+    """A setup command after a copy_workdir setup runs in the copy."""
+    original = tmp_path / "original"
+    original.mkdir()
     scratch = tmp_path / "scratch"
     scratch.mkdir()
-    ctx = _make_ctx(scratch)
-    hooks = build_hooks([GitCloneHookSpec(url=str(repo)), CopyWorkdirHookSpec()])
+    ctx = _make_ctx(scratch, working_dir=str(original))
+    hooks = build_hooks(
+        [
+            CopyWorkdirHookSpec(),
+            CommandHookSpec(command="touch marker.txt", when="setup"),
+        ]
+    )
 
     for hook in hooks:
         await hook.setup(ctx)
 
-    assert ctx.process.working_dir == str(scratch / "hook-1-workdir")
-    assert (scratch / "hook-1-workdir" / "app.py").read_text() == "print('hi')\n"
+    assert (scratch / "hook-0-workdir" / "marker.txt").exists()
+    assert not (original / "marker.txt").exists()
 
 
-async def test_git_clone_clones_and_rewires_the_working_dir(tmp_path: Path) -> None:
-    """The setup clones the repository and points the process at the clone."""
-    repo = _init_repo(tmp_path / "repo")
-    _commit_file(repo, "app.py", "print('hi')\n")
-    scratch = tmp_path / "scratch"
-    scratch.mkdir()
-    ctx = _make_ctx(scratch)
-
-    await GitCloneHook(GitCloneHookSpec(url=str(repo)), 0).setup(ctx)
-
-    clone = scratch / "hook-0-clone"
-    assert ctx.process.working_dir == str(clone)
-    assert (clone / "app.py").read_text() == "print('hi')\n"
-
-
-async def test_git_clone_checks_out_the_ref(tmp_path: Path) -> None:
-    """A spec ref is checked out after the clone."""
-    repo = _init_repo(tmp_path / "repo")
-    first = _commit_file(repo, "app.py", "one\n")
-    _commit_file(repo, "app.py", "two\n")
-    scratch = tmp_path / "scratch"
-    scratch.mkdir()
-    ctx = _make_ctx(scratch)
-
-    await GitCloneHook(GitCloneHookSpec(url=str(repo), ref=first), 0).setup(ctx)
-
-    assert (scratch / "hook-0-clone" / "app.py").read_text() == "one\n"
-
-
-async def test_git_clone_of_a_missing_path_raises_with_the_exit_code(
+async def test_failing_setup_command_raises_with_the_exit_code(
     tmp_path: Path,
 ) -> None:
-    """A clone of a nonexistent path raises with the git exit code."""
-    scratch = tmp_path / "scratch"
-    scratch.mkdir()
-    ctx = _make_ctx(scratch)
-    spec = GitCloneHookSpec(url=str(tmp_path / "missing"))
+    """A setup command with a nonzero exit raises with the exit code."""
+    ctx = _make_ctx(tmp_path, working_dir=str(tmp_path))
+    spec = CommandHookSpec(command="exit 3", when="setup")
 
-    with pytest.raises(HookError, match="exited with code 128"):
-        await GitCloneHook(spec, 0).setup(ctx)
+    with pytest.raises(HookError, match="exited with code 3"):
+        await CommandHook(spec).setup(ctx)
 
 
-async def test_git_push_teardown_does_nothing_without_success(tmp_path: Path) -> None:
-    """A failed task process pushes nothing."""
-    origin = _make_origin(tmp_path)
-    work = _clone(origin, tmp_path / "work")
-    (work / "README.md").write_text("changed\n")
-    ctx = _make_ctx(tmp_path, working_dir=str(work))
+async def test_teardown_command_does_not_run_at_setup(tmp_path: Path) -> None:
+    """A teardown command runs nothing during setup."""
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
+    spec = CommandHookSpec(command="touch marker.txt", when="teardown")
 
-    await GitPushHook(GitPushHookSpec()).teardown(ctx, False)
+    await CommandHook(spec).setup(ctx)
 
-    assert _run_git(origin, "branch", "--list", f"kitaru/task-{ctx.task_id}") == ""
+    assert not (working_dir / "marker.txt").exists()
 
 
-async def test_git_push_pushes_a_task_commit_to_the_task_branch(
+async def test_setup_command_does_not_run_at_teardown(tmp_path: Path) -> None:
+    """A setup command runs nothing during teardown."""
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
+    spec = CommandHookSpec(command="touch marker.txt", when="setup")
+
+    await CommandHook(spec).teardown(ctx, True)
+
+    assert not (working_dir / "marker.txt").exists()
+
+
+async def test_teardown_command_runs_on_success(tmp_path: Path) -> None:
+    """A teardown command runs after a successful task process."""
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
+    spec = CommandHookSpec(command="touch marker.txt", when="teardown")
+
+    await CommandHook(spec).teardown(ctx, True)
+
+    assert (working_dir / "marker.txt").exists()
+
+
+async def test_teardown_command_skipped_on_failure_by_default(
     tmp_path: Path,
 ) -> None:
-    """A successful task's changes are committed and pushed to the task branch."""
-    origin = _make_origin(tmp_path)
-    work = _clone(origin, tmp_path / "work")
-    (work / "README.md").write_text("changed\n")
-    ctx = _make_ctx(tmp_path, working_dir=str(work))
+    """A failed task process runs no teardown command by default."""
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
+    spec = CommandHookSpec(command="touch marker.txt", when="teardown")
 
-    await GitPushHook(GitPushHookSpec()).teardown(ctx, True)
+    await CommandHook(spec).teardown(ctx, False)
 
-    branch = f"kitaru/task-{ctx.task_id}"
-    assert _run_git(origin, "log", "-1", "--format=%s", branch) == (
-        f"Kitaru task {ctx.task_id}"
+    assert not (working_dir / "marker.txt").exists()
+
+
+async def test_teardown_command_runs_on_failure_when_requested(
+    tmp_path: Path,
+) -> None:
+    """A run_on_failure teardown command runs after a failed task process."""
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+    ctx = _make_ctx(tmp_path, working_dir=str(working_dir))
+    spec = CommandHookSpec(
+        command="touch marker.txt", when="teardown", run_on_failure=True
     )
 
+    await CommandHook(spec).teardown(ctx, False)
 
-async def test_git_push_pushes_to_the_explicit_branch(tmp_path: Path) -> None:
-    """A spec branch overrides the default task branch."""
-    origin = _make_origin(tmp_path)
-    work = _clone(origin, tmp_path / "work")
-    (work / "README.md").write_text("changed\n")
-    ctx = _make_ctx(tmp_path, working_dir=str(work))
-
-    await GitPushHook(GitPushHookSpec(branch="results")).teardown(ctx, True)
-
-    assert _run_git(origin, "log", "-1", "--format=%s", "results") == (
-        f"Kitaru task {ctx.task_id}"
-    )
-
-
-async def test_git_push_without_changes_pushes_nothing(tmp_path: Path) -> None:
-    """A clean working directory pushes no branch."""
-    origin = _make_origin(tmp_path)
-    work = _clone(origin, tmp_path / "work")
-    ctx = _make_ctx(tmp_path, working_dir=str(work))
-
-    await GitPushHook(GitPushHookSpec()).teardown(ctx, True)
-
-    assert _run_git(origin, "branch", "--list", f"kitaru/task-{ctx.task_id}") == ""
-
-
-async def test_git_push_after_a_detached_head_checkout(tmp_path: Path) -> None:
-    """A push succeeds from the detached HEAD a ref checkout leaves behind."""
-    origin = _make_origin(tmp_path)
-    sha = _run_git(origin, "rev-parse", "HEAD")
-    scratch = tmp_path / "scratch"
-    scratch.mkdir()
-    ctx = _make_ctx(scratch)
-    await GitCloneHook(GitCloneHookSpec(url=str(origin), ref=sha), 0).setup(ctx)
-    clone = scratch / "hook-0-clone"
-    _configure_git_identity(clone)
-    (clone / "README.md").write_text("changed\n")
-
-    await GitPushHook(GitPushHookSpec()).teardown(ctx, True)
-
-    branch = f"kitaru/task-{ctx.task_id}"
-    assert _run_git(origin, "log", "-1", "--format=%s", branch) == (
-        f"Kitaru task {ctx.task_id}"
-    )
+    assert (working_dir / "marker.txt").exists()

--- a/tests/worker/test_hooks.py
+++ b/tests/worker/test_hooks.py
@@ -1,0 +1,283 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests for task hook execution around the task process."""
+
+import asyncio
+import os
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+from kitaru.api_models.v1.hook import (
+    CopyWorkdirHook as CopyWorkdirHookSpec,
+)
+from kitaru.api_models.v1.hook import (
+    GitCloneHook as GitCloneHookSpec,
+)
+from kitaru.api_models.v1.hook import (
+    GitPushHook as GitPushHookSpec,
+)
+from kitaru.api_models.v1.hook import TaskHook
+from kitaru.worker.hooks import (
+    CopyWorkdirHook,
+    GitCloneHook,
+    GitPushHook,
+    HookContext,
+    HookError,
+    build_hooks,
+)
+from kitaru.worker.process import TaskProcess
+
+
+def _make_ctx(scratch_dir: Path, working_dir: str | None = None) -> HookContext:
+    """Build a hook context around a placeholder task process."""
+    process = TaskProcess(
+        command="true",
+        working_dir=working_dir,
+        env=dict(os.environ),
+        timeout_seconds=30,
+    )
+    return HookContext(
+        task_id=uuid.uuid4(),
+        scratch_dir=scratch_dir,
+        canceled=asyncio.Event(),
+        process=process,
+    )
+
+
+def _run_git(cwd: Path, *args: str) -> str:
+    """Run a git command in a directory and return its stripped stdout."""
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def _configure_git_identity(repo: Path) -> None:
+    """Set a per-repo committer identity so commits need no global config."""
+    _run_git(repo, "config", "user.email", "worker@example.com")
+    _run_git(repo, "config", "user.name", "Kitaru Worker")
+
+
+def _init_repo(path: Path) -> Path:
+    """Initialize a git repository with a committer identity."""
+    path.mkdir()
+    _run_git(path, "init", "--quiet")
+    _configure_git_identity(path)
+    return path
+
+
+def _commit_file(repo: Path, name: str, content: str) -> str:
+    """Write a file, commit it, and return the commit SHA."""
+    (repo / name).write_text(content)
+    _run_git(repo, "add", "-A")
+    _run_git(repo, "commit", "--quiet", "-m", f"Add {name}")
+    return _run_git(repo, "rev-parse", "HEAD")
+
+
+def _make_origin(tmp_path: Path) -> Path:
+    """Build a bare repository with one commit to push to and clone from."""
+    seed = _init_repo(tmp_path / "seed")
+    _commit_file(seed, "README.md", "seed\n")
+    bare = tmp_path / "origin.git"
+    _run_git(tmp_path, "clone", "--quiet", "--bare", str(seed), str(bare))
+    return bare
+
+
+def _clone(origin: Path, dest: Path) -> Path:
+    """Clone a repository and set a per-repo committer identity."""
+    _run_git(dest.parent, "clone", "--quiet", str(origin), str(dest))
+    _configure_git_identity(dest)
+    return dest
+
+
+def test_build_hooks_maps_each_spec_type_in_order() -> None:
+    """Each spec type builds its implementation in declared order."""
+    specs: list[TaskHook] = [
+        GitCloneHookSpec(url="https://example.com/repo.git"),
+        CopyWorkdirHookSpec(),
+        GitPushHookSpec(),
+    ]
+
+    hooks = build_hooks(specs)
+
+    assert [type(hook) for hook in hooks] == [
+        GitCloneHook,
+        CopyWorkdirHook,
+        GitPushHook,
+    ]
+
+
+async def test_copy_workdir_copies_the_working_dir_and_rewires_the_process(
+    tmp_path: Path,
+) -> None:
+    """The setup copies the working directory and points the process at it."""
+    original = tmp_path / "original"
+    (original / "nested").mkdir(parents=True)
+    (original / "nested" / "inner.txt").write_text("inner")
+    (original / "link.txt").symlink_to("nested/inner.txt")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    ctx = _make_ctx(scratch, working_dir=str(original))
+
+    await CopyWorkdirHook(0).setup(ctx)
+
+    copy = scratch / "hook-0-workdir"
+    assert ctx.process.working_dir == str(copy)
+    assert (copy / "nested" / "inner.txt").read_text() == "inner"
+    assert (copy / "link.txt").is_symlink()
+    (copy / "added.txt").write_text("added")
+    assert not (original / "added.txt").exists()
+
+
+async def test_copy_workdir_without_a_working_dir_raises(tmp_path: Path) -> None:
+    """A process without a working directory fails the copy setup."""
+    ctx = _make_ctx(tmp_path)
+
+    with pytest.raises(HookError, match="no working directory"):
+        await CopyWorkdirHook(0).setup(ctx)
+
+
+async def test_copy_workdir_after_git_clone_copies_the_clone(tmp_path: Path) -> None:
+    """A copy_workdir setup after a git_clone setup copies the clone."""
+    repo = _init_repo(tmp_path / "repo")
+    _commit_file(repo, "app.py", "print('hi')\n")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    ctx = _make_ctx(scratch)
+    hooks = build_hooks([GitCloneHookSpec(url=str(repo)), CopyWorkdirHookSpec()])
+
+    for hook in hooks:
+        await hook.setup(ctx)
+
+    assert ctx.process.working_dir == str(scratch / "hook-1-workdir")
+    assert (scratch / "hook-1-workdir" / "app.py").read_text() == "print('hi')\n"
+
+
+async def test_git_clone_clones_and_rewires_the_working_dir(tmp_path: Path) -> None:
+    """The setup clones the repository and points the process at the clone."""
+    repo = _init_repo(tmp_path / "repo")
+    _commit_file(repo, "app.py", "print('hi')\n")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    ctx = _make_ctx(scratch)
+
+    await GitCloneHook(GitCloneHookSpec(url=str(repo)), 0).setup(ctx)
+
+    clone = scratch / "hook-0-clone"
+    assert ctx.process.working_dir == str(clone)
+    assert (clone / "app.py").read_text() == "print('hi')\n"
+
+
+async def test_git_clone_checks_out_the_ref(tmp_path: Path) -> None:
+    """A spec ref is checked out after the clone."""
+    repo = _init_repo(tmp_path / "repo")
+    first = _commit_file(repo, "app.py", "one\n")
+    _commit_file(repo, "app.py", "two\n")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    ctx = _make_ctx(scratch)
+
+    await GitCloneHook(GitCloneHookSpec(url=str(repo), ref=first), 0).setup(ctx)
+
+    assert (scratch / "hook-0-clone" / "app.py").read_text() == "one\n"
+
+
+async def test_git_clone_of_a_missing_path_raises_with_the_exit_code(
+    tmp_path: Path,
+) -> None:
+    """A clone of a nonexistent path raises with the git exit code."""
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    ctx = _make_ctx(scratch)
+    spec = GitCloneHookSpec(url=str(tmp_path / "missing"))
+
+    with pytest.raises(HookError, match="exited with code 128"):
+        await GitCloneHook(spec, 0).setup(ctx)
+
+
+async def test_git_push_teardown_does_nothing_without_success(tmp_path: Path) -> None:
+    """A failed task process pushes nothing."""
+    origin = _make_origin(tmp_path)
+    work = _clone(origin, tmp_path / "work")
+    (work / "README.md").write_text("changed\n")
+    ctx = _make_ctx(tmp_path, working_dir=str(work))
+
+    await GitPushHook(GitPushHookSpec()).teardown(ctx, False)
+
+    assert _run_git(origin, "branch", "--list", f"kitaru/task-{ctx.task_id}") == ""
+
+
+async def test_git_push_pushes_a_task_commit_to_the_task_branch(
+    tmp_path: Path,
+) -> None:
+    """A successful task's changes are committed and pushed to the task branch."""
+    origin = _make_origin(tmp_path)
+    work = _clone(origin, tmp_path / "work")
+    (work / "README.md").write_text("changed\n")
+    ctx = _make_ctx(tmp_path, working_dir=str(work))
+
+    await GitPushHook(GitPushHookSpec()).teardown(ctx, True)
+
+    branch = f"kitaru/task-{ctx.task_id}"
+    assert _run_git(origin, "log", "-1", "--format=%s", branch) == (
+        f"Kitaru task {ctx.task_id}"
+    )
+
+
+async def test_git_push_pushes_to_the_explicit_branch(tmp_path: Path) -> None:
+    """A spec branch overrides the default task branch."""
+    origin = _make_origin(tmp_path)
+    work = _clone(origin, tmp_path / "work")
+    (work / "README.md").write_text("changed\n")
+    ctx = _make_ctx(tmp_path, working_dir=str(work))
+
+    await GitPushHook(GitPushHookSpec(branch="results")).teardown(ctx, True)
+
+    assert _run_git(origin, "log", "-1", "--format=%s", "results") == (
+        f"Kitaru task {ctx.task_id}"
+    )
+
+
+async def test_git_push_without_changes_pushes_nothing(tmp_path: Path) -> None:
+    """A clean working directory pushes no branch."""
+    origin = _make_origin(tmp_path)
+    work = _clone(origin, tmp_path / "work")
+    ctx = _make_ctx(tmp_path, working_dir=str(work))
+
+    await GitPushHook(GitPushHookSpec()).teardown(ctx, True)
+
+    assert _run_git(origin, "branch", "--list", f"kitaru/task-{ctx.task_id}") == ""
+
+
+async def test_git_push_after_a_detached_head_checkout(tmp_path: Path) -> None:
+    """A push succeeds from the detached HEAD a ref checkout leaves behind."""
+    origin = _make_origin(tmp_path)
+    sha = _run_git(origin, "rev-parse", "HEAD")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    ctx = _make_ctx(scratch)
+    await GitCloneHook(GitCloneHookSpec(url=str(origin), ref=sha), 0).setup(ctx)
+    clone = scratch / "hook-0-clone"
+    _configure_git_identity(clone)
+    (clone / "README.md").write_text("changed\n")
+
+    await GitPushHook(GitPushHookSpec()).teardown(ctx, True)
+
+    branch = f"kitaru/task-{ctx.task_id}"
+    assert _run_git(origin, "log", "-1", "--format=%s", branch) == (
+        f"Kitaru task {ctx.task_id}"
+    )

--- a/tests/worker/test_task_runner.py
+++ b/tests/worker/test_task_runner.py
@@ -31,7 +31,7 @@ from fakes import (
 )
 
 from kitaru.api_models.v1.base import Page
-from kitaru.api_models.v1.hook import CommandHook, CopyWorkdirHook
+from kitaru.api_models.v1.hook import CopyWorkdirHook, TeardownCommandHook
 from kitaru.api_models.v1.session import SessionStatus
 from kitaru.api_models.v1.task import PackagePluginSpec, TaskKind, TaskStatus
 from kitaru.client.exceptions import (
@@ -411,7 +411,7 @@ async def test_failing_teardown_command_fails_a_successful_task(
     spec = make_agent_spec(
         task.id,
         working_dir=str(working_dir),
-        hooks=[CommandHook(command="exit 3", when="teardown")],
+        hooks=[TeardownCommandHook(command="exit 3")],
     )
     running_task = task.model_copy(update={"status": TaskStatus.RUNNING})
     failed_task = running_task.model_copy(update={"status": TaskStatus.FAILED})
@@ -424,7 +424,7 @@ async def test_failing_teardown_command_fails_a_successful_task(
 
     _, request = client.tasks.update_calls[-1]
     assert request.status == TaskStatus.FAILED
-    assert "Hook command failed:" in request.error
+    assert "Hook teardown_command failed:" in request.error
 
 
 async def test_copy_workdir_hook_runs_the_process_in_the_copied_directory(

--- a/tests/worker/test_task_runner.py
+++ b/tests/worker/test_task_runner.py
@@ -31,7 +31,7 @@ from fakes import (
 )
 
 from kitaru.api_models.v1.base import Page
-from kitaru.api_models.v1.hook import CopyWorkdirHook, GitPushHook
+from kitaru.api_models.v1.hook import CommandHook, CopyWorkdirHook
 from kitaru.api_models.v1.session import SessionStatus
 from kitaru.api_models.v1.task import PackagePluginSpec, TaskKind, TaskStatus
 from kitaru.client.exceptions import (
@@ -399,16 +399,20 @@ async def test_failing_setup_hook_fails_the_task(tmp_path: Path) -> None:
     assert request.error.startswith("Hook copy_workdir failed:")
 
 
-async def test_failing_git_push_teardown_fails_a_successful_task(
+async def test_failing_teardown_command_fails_a_successful_task(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A git_push teardown failure fails a task whose process succeeded."""
+    """A teardown command failure fails a task whose process succeeded."""
     _patch_run_task_process(monkeypatch, _fake_run_task_process(0))
     client = FakeKitaruAPIClient()
     task = make_task(kind=TaskKind.AGENT, attempt=1)
-    working_dir = tmp_path / "not-a-repo"
+    working_dir = tmp_path / "work"
     working_dir.mkdir()
-    spec = make_agent_spec(task.id, working_dir=str(working_dir), hooks=[GitPushHook()])
+    spec = make_agent_spec(
+        task.id,
+        working_dir=str(working_dir),
+        hooks=[CommandHook(command="exit 3", when="teardown")],
+    )
     running_task = task.model_copy(update={"status": TaskStatus.RUNNING})
     failed_task = running_task.model_copy(update={"status": TaskStatus.FAILED})
     client.tasks.update_responses.append(running_task)
@@ -420,7 +424,7 @@ async def test_failing_git_push_teardown_fails_a_successful_task(
 
     _, request = client.tasks.update_calls[-1]
     assert request.status == TaskStatus.FAILED
-    assert "Hook git_push failed:" in request.error
+    assert "Hook command failed:" in request.error
 
 
 async def test_copy_workdir_hook_runs_the_process_in_the_copied_directory(

--- a/tests/worker/test_task_runner.py
+++ b/tests/worker/test_task_runner.py
@@ -31,6 +31,7 @@ from fakes import (
 )
 
 from kitaru.api_models.v1.base import Page
+from kitaru.api_models.v1.hook import CopyWorkdirHook, GitPushHook
 from kitaru.api_models.v1.session import SessionStatus
 from kitaru.api_models.v1.task import PackagePluginSpec, TaskKind, TaskStatus
 from kitaru.client.exceptions import (
@@ -376,6 +377,80 @@ async def test_prepare_failure_fails_the_task_with_the_label_and_exception(
     _, request = client.tasks.update_calls[-1]
     assert request.status == TaskStatus.FAILED
     assert request.error.startswith("Failed to prepare the Agent process:")
+
+
+async def test_failing_setup_hook_fails_the_task(tmp_path: Path) -> None:
+    """A setup hook failure fails the task with the hook type in the error."""
+    client = FakeKitaruAPIClient()
+    task = make_task(kind=TaskKind.AGENT, attempt=1)
+    # The run spec has no working directory, so the copy_workdir setup raises.
+    spec = make_agent_spec(task.id, hooks=[CopyWorkdirHook()])
+    running_task = task.model_copy(update={"status": TaskStatus.RUNNING})
+    failed_task = running_task.model_copy(update={"status": TaskStatus.FAILED})
+    client.tasks.update_responses.append(running_task)
+    client.tasks.update_responses.append(failed_task)
+
+    await TaskRunner(_ctx(tmp_path, client)).execute(
+        make_claimed(task, spec), asyncio.Event()
+    )
+
+    _, request = client.tasks.update_calls[-1]
+    assert request.status == TaskStatus.FAILED
+    assert request.error.startswith("Hook copy_workdir failed:")
+
+
+async def test_failing_git_push_teardown_fails_a_successful_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A git_push teardown failure fails a task whose process succeeded."""
+    _patch_run_task_process(monkeypatch, _fake_run_task_process(0))
+    client = FakeKitaruAPIClient()
+    task = make_task(kind=TaskKind.AGENT, attempt=1)
+    working_dir = tmp_path / "not-a-repo"
+    working_dir.mkdir()
+    spec = make_agent_spec(task.id, working_dir=str(working_dir), hooks=[GitPushHook()])
+    running_task = task.model_copy(update={"status": TaskStatus.RUNNING})
+    failed_task = running_task.model_copy(update={"status": TaskStatus.FAILED})
+    client.tasks.update_responses.append(running_task)
+    client.tasks.update_responses.append(failed_task)
+
+    await TaskRunner(_ctx(tmp_path, client)).execute(
+        make_claimed(task, spec), asyncio.Event()
+    )
+
+    _, request = client.tasks.update_calls[-1]
+    assert request.status == TaskStatus.FAILED
+    assert "Hook git_push failed:" in request.error
+
+
+async def test_copy_workdir_hook_runs_the_process_in_the_copied_directory(
+    tmp_path: Path,
+) -> None:
+    """A copy_workdir hook runs the task process in the copy, not the original."""
+    client = FakeKitaruAPIClient()
+    original = tmp_path / "original"
+    original.mkdir()
+    task = make_task(kind=TaskKind.AGENT, attempt=1)
+    command = 'touch marker.txt && printf \'"%s"\' "$PWD" > "$KITARU_TASK_RESULT_PATH"'
+    spec = make_agent_spec(
+        task.id,
+        command=command,
+        working_dir=str(original),
+        hooks=[CopyWorkdirHook()],
+    )
+    running_task = task.model_copy(update={"status": TaskStatus.RUNNING})
+    completed_task = running_task.model_copy(update={"status": TaskStatus.COMPLETED})
+    client.tasks.update_responses.append(running_task)
+    client.tasks.update_responses.append(completed_task)
+
+    await TaskRunner(_ctx(tmp_path, client)).execute(
+        make_claimed(task, spec), asyncio.Event()
+    )
+
+    _, request = client.tasks.update_calls[-1]
+    assert request.status == TaskStatus.COMPLETED
+    assert request.result.endswith("hook-0-workdir")
+    assert not (original / "marker.txt").exists()
 
 
 async def test_running_transition_conflict_abandons_without_running_the_process(


### PR DESCRIPTION
This PR adds hooks to the agent version run spec that a worker runs around the agent process.

- `copy_workdir` runs the agent in a fresh copy of the working directory, so parallel tasks on one worker don't share state.
- `setup_command` runs a shell command in the agent's working directory before the agent process.
- `teardown_command` runs a shell command after it, with `on: "success" | "failure" | "always"` choosing the task outcome it runs on.

Hooks run in declared order before the agent process, their teardowns run in reverse order after it. A hook failure fails the task.
