### PR TITLE
Move the result session link from the task to the replay table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Every worker start now registers a new worker, worker names are labels and no longer need to be unique. Worker listings leave stale workers out unless `include_stale` is set. `kitaru worker get` takes a worker id, the name lookup it also accepted is gone.
 - Server analytics events now carry the reporting client in `client_version`, as the client name and the version it reported. Each client versions on its own series, so a bare version says nothing without the client that sent it.
 - Registering a worker from the Kitaru 0.22.2 Python SDK or older is rejected with HTTP 426. Those versions renew a worker token by registering again, which a server that gives every registration its own id cannot serve: the worker goes on heartbeating an id its token no longer names, and the tasks it is running get swept away from it. Upgrade workers along with the server. Every other caller is unaffected.
+- Replays store their result session id directly instead of deriving it from their task, and a session referenced by a replay's result can no longer be deleted.
+
+### Removed
+
+- Task responses no longer include `result_session_id`. An agent task's result session is the session whose `task_id` matches the task.
 
 ## [0.22.2]
 

--- a/examples/typescript/mastra_support_triage/src/demo.ts
+++ b/examples/typescript/mastra_support_triage/src/demo.ts
@@ -209,11 +209,14 @@ async function getResultSessionId(
   if (tasks.next_cursor !== null) {
     throw new Error(`Job ${job.id} has too many tasks to inspect safely`);
   }
-  const ids = tasks.items.flatMap((task) =>
-    task.kind === "agent" && task.result_session_id !== null
-      ? [task.result_session_id]
-      : [],
-  );
+  const sessions = await client.sessions.list({
+    filter: {
+      field: "task_id",
+      op: "in",
+      value: tasks.items.map((task) => task.id),
+    },
+  });
+  const ids = sessions.items.map((session) => session.id);
   if (ids.length !== 1 || ids[0] === undefined) {
     throw new Error(
       `Kitaru job ${job.id} produced ${ids.length} result sessions`,

--- a/examples/typescript/vercel_ai_support_triage/demo.py
+++ b/examples/typescript/vercel_ai_support_triage/demo.py
@@ -40,7 +40,11 @@ from kitaru.api_models.v1.replay_config import (
     ToolPolicy,
     ToolPolicyOnMiss,
 )
-from kitaru.api_models.v1.session import SessionOrigin, SessionStatus
+from kitaru.api_models.v1.session import (
+    SessionListParams,
+    SessionOrigin,
+    SessionStatus,
+)
 from kitaru.api_models.v1.session_node import (
     NodeType,
     SessionNodeListParams,
@@ -178,9 +182,16 @@ async def _run_job(
 
 async def _result_session_id(client: KitaruAPIClient, job: JobResponse) -> str:
     tasks = await client.jobs.list_tasks(job.id)
-    result_ids = [
-        str(task.result_session_id) for task in tasks.items if task.result_session_id
-    ]
+    sessions = await client.sessions.list(
+        SessionListParams(
+            filter=FilterCondition(
+                field="task_id",
+                op=FilterOp.IN,
+                value=[str(task.id) for task in tasks.items],
+            )
+        )
+    )
+    result_ids = [str(session.id) for session in sessions.items]
     if len(result_ids) != 1:
         raise RuntimeError(
             f"Kitaru job {job.id} produced {len(result_ids)} result sessions"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -7478,19 +7478,6 @@
             "description": "Task result, diagnostic output on a non-completed task.",
             "title": "Result"
           },
-          "result_session_id": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Session an agent task produced.",
-            "title": "Result Session Id"
-          },
           "started_at": {
             "anyOf": [
               {

--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -7668,11 +7668,6 @@ export interface components {
              */
             result: unknown;
             /**
-             * Result Session Id
-             * @description Session an agent task produced.
-             */
-            result_session_id?: string | null;
-            /**
              * Started At
              * @description Time execution started.
              */

--- a/src/kitaru/api_models/v1/task.py
+++ b/src/kitaru/api_models/v1/task.py
@@ -91,9 +91,6 @@ class TaskResponse(TimestampedResponseModel):
     worker_id: uuid.UUID | None = Field(
         default=None, description="Worker that claimed the task."
     )
-    result_session_id: uuid.UUID | None = Field(
-        default=None, description="Session an agent task produced."
-    )
     claimed_at: datetime | None = Field(
         default=None, description="Time the task was claimed."
     )

--- a/src/kitaru/server/adapters/db/orm/replay.py
+++ b/src/kitaru/server/adapters/db/orm/replay.py
@@ -47,6 +47,7 @@ REPLAY_REPLAY_CONFIG_ID_FOREIGN_KEY = foreign_key_name("replay", ["replay_config
 REPLAY_BASELINE_SESSION_ID_FOREIGN_KEY = foreign_key_name(
     "replay", ["baseline_session_id"]
 )
+REPLAY_RESULT_SESSION_ID_FOREIGN_KEY = foreign_key_name("replay", ["result_session_id"])
 REPLAY_JOB_ID_UNIQUE_CONSTRAINT = unique_constraint_name("replay", ["job_id"])
 REPLAY_RUN_BASELINE_UNIQUE_CONSTRAINT = unique_constraint_name(
     "replay", ["experiment_run_id", "baseline_session_id"]
@@ -55,6 +56,7 @@ REPLAY_EXPERIMENT_RUN_ID_STATUS_INDEX = index_name(
     "replay", ["experiment_run_id", "status"]
 )
 REPLAY_BASELINE_SESSION_ID_INDEX = index_name("replay", ["baseline_session_id"])
+REPLAY_RESULT_SESSION_ID_INDEX = index_name("replay", ["result_session_id"])
 
 
 class ReplayORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -84,6 +86,11 @@ class ReplayORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             ["session.id"],
             name=REPLAY_BASELINE_SESSION_ID_FOREIGN_KEY,
         ),
+        ForeignKeyConstraint(
+            ["result_session_id"],
+            ["session.id"],
+            name=REPLAY_RESULT_SESSION_ID_FOREIGN_KEY,
+        ),
         UniqueConstraint("job_id", name=REPLAY_JOB_ID_UNIQUE_CONSTRAINT),
         UniqueConstraint(
             "experiment_run_id",
@@ -92,6 +99,7 @@ class ReplayORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         ),
         Index(REPLAY_EXPERIMENT_RUN_ID_STATUS_INDEX, "experiment_run_id", "status"),
         Index(REPLAY_BASELINE_SESSION_ID_INDEX, "baseline_session_id"),
+        Index(REPLAY_RESULT_SESSION_ID_INDEX, "result_session_id"),
     )
 
     owner_id: Mapped[uuid.UUID]
@@ -99,6 +107,7 @@ class ReplayORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     experiment_run_id: Mapped[uuid.UUID | None]
     replay_config_id: Mapped[uuid.UUID]
     baseline_session_id: Mapped[uuid.UUID]
+    result_session_id: Mapped[uuid.UUID | None]
     evaluate_baselines: Mapped[bool] = mapped_column(Boolean)
     status: Mapped[str] = mapped_column(String(STATUS_LENGTH))
     error: Mapped[str | None] = mapped_column(Text)
@@ -120,6 +129,7 @@ class ReplayORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             experiment_run_id=replay.experiment_run_id,
             replay_config_id=replay.replay_config_id,
             baseline_session_id=replay.baseline_session_id,
+            result_session_id=replay.result_session_id,
             evaluate_baselines=replay.evaluate_baselines,
             status=replay.status.value,
             error=replay.error,
@@ -131,6 +141,7 @@ class ReplayORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         Args:
             replay: Replay with modified fields.
         """
+        self.result_session_id = replay.result_session_id
         self.status = replay.status.value
         self.error = replay.error
 
@@ -147,6 +158,7 @@ class ReplayORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             experiment_run_id=self.experiment_run_id,
             replay_config_id=self.replay_config_id,
             baseline_session_id=self.baseline_session_id,
+            result_session_id=self.result_session_id,
             evaluate_baselines=self.evaluate_baselines,
             status=ReplayStatus(self.status),
             error=self.error,

--- a/src/kitaru/server/adapters/db/orm/task.py
+++ b/src/kitaru/server/adapters/db/orm/task.py
@@ -58,14 +58,12 @@ TASK_AGENT_ID_FOREIGN_KEY = foreign_key_name("task", ["agent_id"])
 TASK_PLUGIN_VERSION_ID_FOREIGN_KEY = foreign_key_name("task", ["plugin_version_id"])
 TASK_PAYLOAD_BLOB_ID_FOREIGN_KEY = foreign_key_name("task", ["payload_blob_id"])
 TASK_INPUT_SESSION_ID_FOREIGN_KEY = foreign_key_name("task", ["input_session_id"])
-TASK_RESULT_SESSION_ID_FOREIGN_KEY = foreign_key_name("task", ["result_session_id"])
 TASK_WORKER_ID_FOREIGN_KEY = foreign_key_name("task", ["worker_id"])
 TASK_EVALUATOR_PAIR_UNIQUE_CONSTRAINT = unique_constraint_name(
     "task", ["job_id", "input_session_id", "plugin_version_id"]
 )
 TASK_JOB_ID_STATUS_INDEX = index_name("task", ["job_id", "status"])
 TASK_INPUT_SESSION_ID_INDEX = index_name("task", ["input_session_id"])
-TASK_RESULT_SESSION_ID_INDEX = index_name("task", ["result_session_id"])
 # Partial indexes covering the queue scans: a scope claiming everything reads
 # pending rows in id order, a kind claim reads them per kind, and a
 # version-pinned claim reads them per agent version. The staleness sweep
@@ -113,11 +111,6 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             name=TASK_INPUT_SESSION_ID_FOREIGN_KEY,
         ),
         ForeignKeyConstraint(
-            ["result_session_id"],
-            ["session.id"],
-            name=TASK_RESULT_SESSION_ID_FOREIGN_KEY,
-        ),
-        ForeignKeyConstraint(
             ["worker_id"],
             ["worker.id"],
             name=TASK_WORKER_ID_FOREIGN_KEY,
@@ -131,7 +124,6 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         ),
         Index(TASK_JOB_ID_STATUS_INDEX, "job_id", "status"),
         Index(TASK_INPUT_SESSION_ID_INDEX, "input_session_id"),
-        Index(TASK_RESULT_SESSION_ID_INDEX, "result_session_id"),
         Index(TASK_PENDING_ID_INDEX, "id", postgresql_where=text(PENDING_PREDICATE)),
         Index(
             TASK_PENDING_KIND_INDEX,
@@ -159,7 +151,6 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     plugin_version_id: Mapped[uuid.UUID | None]
     payload_blob_id: Mapped[uuid.UUID | None]
     input_session_id: Mapped[uuid.UUID | None]
-    result_session_id: Mapped[uuid.UUID | None]
     status: Mapped[str] = mapped_column(String(STATUS_LENGTH))
     attempt: Mapped[int]
     on_failure: Mapped[str] = mapped_column(String(ON_FAILURE_LENGTH))
@@ -197,7 +188,6 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             labels=task.labels,
             env=task.env,
             worker_id=task.worker_id,
-            result_session_id=task.result_session_id,
             claimed_at=task.claimed_at,
             heartbeat_at=task.heartbeat_at,
             cancel_requested_at=task.cancel_requested_at,
@@ -230,7 +220,6 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         self.status = task.status.value
         self.attempt = task.attempt
         self.worker_id = task.worker_id
-        self.result_session_id = task.result_session_id
         self.claimed_at = task.claimed_at
         self.heartbeat_at = task.heartbeat_at
         self.cancel_requested_at = task.cancel_requested_at
@@ -257,7 +246,6 @@ class TaskORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             "labels": self.labels,
             "env": self.env,
             "worker_id": self.worker_id,
-            "result_session_id": self.result_session_id,
             "claimed_at": self.claimed_at,
             "heartbeat_at": self.heartbeat_at,
             "cancel_requested_at": self.cancel_requested_at,

--- a/src/kitaru/server/adapters/db/repositories/replay_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/replay_repository.py
@@ -142,6 +142,19 @@ class SQLReplayRepository(BaseSQLRepository[ReplayORM]):
         row = (await self._session.scalars(statement)).one_or_none()
         return row.to_domain() if row is not None else None
 
+    async def get_by_result_session_id(self, session_id: uuid.UUID) -> Replay | None:
+        """Load the replay that produced a session, if any.
+
+        Args:
+            session_id: Id of the produced session.
+
+        Returns:
+            Stored replay, or ``None`` when no replay produced the session.
+        """
+        statement = select(ReplayORM).where(ReplayORM.result_session_id == session_id)
+        row = (await self._session.scalars(statement)).one_or_none()
+        return row.to_domain() if row is not None else None
+
     async def get_many_by_job_ids(
         self, job_ids: Sequence[uuid.UUID]
     ) -> dict[uuid.UUID, Replay]:

--- a/src/kitaru/server/adapters/db/repositories/replay_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/replay_repository.py
@@ -16,14 +16,11 @@
 import uuid
 from collections.abc import Mapping, Sequence
 
-from sqlalchemy import ColumnElement, func, select
+from sqlalchemy import func, select
 
-from kitaru.api_models.v1.filter import FilterOp
 from kitaru.api_models.v1.replay import ReplayStatus
-from kitaru.api_models.v1.task import TaskKind
 from kitaru.server.adapters.db.filtering import (
     FilterBinding,
-    compile_column_condition,
     compile_filter_expression,
 )
 from kitaru.server.adapters.db.orm.replay import (
@@ -31,7 +28,6 @@ from kitaru.server.adapters.db.orm.replay import (
     REPLAY_RUN_BASELINE_UNIQUE_CONSTRAINT,
     ReplayORM,
 )
-from kitaru.server.adapters.db.orm.task import TaskORM
 from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.replay import ReplayFilter, ReplayStatusCounts
@@ -42,50 +38,12 @@ from kitaru.server.domain.replay import (
     ReplayAlreadyExistsForJob,
     ReplayNotFound,
 )
-from kitaru.server.filtering import FilterCondition
-
-
-def _compile_result_session_condition(
-    condition: FilterCondition,
-) -> ColumnElement[bool]:
-    """Compile a result session condition into an agent task predicate.
-
-    Args:
-        condition: Validated result session condition.
-
-    Returns:
-        SQL predicate.
-    """
-    # The result session belongs to the replay's agent task, not to the replay
-    # row, so this resolves through the job the two share.
-    if condition.op is FilterOp.IS_NULL:
-        # A replay whose agent task has not produced a session yet, which
-        # includes one that never will because the task failed. Written as a
-        # correlated NOT EXISTS so Postgres can plan it as an anti-join: NOT IN
-        # is not anti-join convertible, so it degrades to a subplan over every
-        # agent task holding a result session.
-        linked = (
-            select(TaskORM.id)
-            .where(
-                TaskORM.job_id == ReplayORM.job_id,
-                TaskORM.kind == TaskKind.AGENT.value,
-                TaskORM.result_session_id.is_not(None),
-            )
-            .correlate(ReplayORM)
-        )
-        return ~linked.exists()
-    agent_tasks = select(TaskORM.job_id).where(
-        TaskORM.kind == TaskKind.AGENT.value,
-        compile_column_condition(TaskORM.result_session_id, condition),
-    )
-    return ReplayORM.job_id.in_(agent_tasks)
-
 
 REPLAY_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
     "id": ReplayORM.id,
     "experiment_run_id": ReplayORM.experiment_run_id,
     "baseline_session_id": ReplayORM.baseline_session_id,
-    "result_session_id": _compile_result_session_condition,
+    "result_session_id": ReplayORM.result_session_id,
     "status": ReplayORM.status,
 }
 

--- a/src/kitaru/server/adapters/db/repositories/session_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/session_repository.py
@@ -34,7 +34,11 @@ from kitaru.server.adapters.db.orm.cohort_version_session import (
     CohortVersionSessionORM,
 )
 from kitaru.server.adapters.db.orm.evaluation import EvaluationORM
-from kitaru.server.adapters.db.orm.replay import ReplayORM
+from kitaru.server.adapters.db.orm.replay import (
+    REPLAY_BASELINE_SESSION_ID_FOREIGN_KEY,
+    REPLAY_RESULT_SESSION_ID_FOREIGN_KEY,
+    ReplayORM,
+)
 from kitaru.server.adapters.db.orm.session import (
     SESSION_IMPORTED_FROM_EXTERNAL_ID_UNIQUE_CONSTRAINT,
     SessionORM,
@@ -42,7 +46,6 @@ from kitaru.server.adapters.db.orm.session import (
 from kitaru.server.adapters.db.orm.task import (
     TASK_INPUT_SESSION_ID_FOREIGN_KEY,
     TASK_RESULT_SESSION_ID_FOREIGN_KEY,
-    TaskORM,
 )
 from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
@@ -53,42 +56,20 @@ from kitaru.server.domain.session import (
     DuplicateSessionExternalId,
     Session,
     SessionInUse,
+    SessionInUseByReplay,
     SessionInUseByTask,
     SessionNotFound,
     SessionRollups,
 )
 from kitaru.server.filtering import FilterCondition
 
-# A replay's tasks share its job, and the run owns the replay.
+# Matched through the replay's result session, so a run's baseline sessions
+# stay out of the result set.
 _scopes_to_experiment_run = build_scope_condition_binding(
-    local_column=TaskORM.job_id,
-    related_key=ReplayORM.job_id,
+    local_column=SessionORM.id,
+    related_key=ReplayORM.result_session_id,
     scope_column=ReplayORM.experiment_run_id,
 )
-
-
-def _compile_experiment_run_condition(
-    condition: FilterCondition,
-) -> ColumnElement[bool]:
-    """Compile an experiment run scope condition into a task predicate.
-
-    Args:
-        condition: Validated experiment run condition.
-
-    Returns:
-        SQL predicate.
-    """
-    # Matched through the task's result session, so a run's baseline sessions
-    # stay out of the result set.
-    run_tasks = (
-        select(TaskORM.id)
-        .where(
-            TaskORM.result_session_id == SessionORM.id,
-            _scopes_to_experiment_run(condition),
-        )
-        .correlate(SessionORM)
-    )
-    return run_tasks.exists()
 
 
 def _compile_cohort_version_condition(
@@ -147,7 +128,7 @@ SESSION_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
     "name": SessionORM.name,
     "tag": build_tag_condition_binding(TagResourceType.SESSION, SessionORM.id),
     "cohort_version_id": _compile_cohort_version_condition,
-    "experiment_run_id": _compile_experiment_run_condition,
+    "experiment_run_id": _scopes_to_experiment_run,
     "has_evaluation": _compile_has_evaluation_condition,
     "started_at": SessionORM.started_at,
     "ended_at": SessionORM.ended_at,
@@ -368,6 +349,8 @@ class SQLSessionRepository(BaseSQLRepository[SessionORM]):
                 cannot be deleted.
             SessionInUseByTask: The session is a task's input or result
                 session and cannot be deleted.
+            SessionInUseByReplay: The session is a replay's baseline or
+                result session and cannot be deleted.
         """
         await self._delete_row(
             session_id,
@@ -379,6 +362,12 @@ class SQLSessionRepository(BaseSQLRepository[SessionORM]):
                     session_id
                 ),
                 TASK_RESULT_SESSION_ID_FOREIGN_KEY: lambda: SessionInUseByTask(
+                    session_id
+                ),
+                REPLAY_BASELINE_SESSION_ID_FOREIGN_KEY: lambda: SessionInUseByReplay(
+                    session_id
+                ),
+                REPLAY_RESULT_SESSION_ID_FOREIGN_KEY: lambda: SessionInUseByReplay(
                     session_id
                 ),
             },

--- a/src/kitaru/server/adapters/db/repositories/session_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/session_repository.py
@@ -43,10 +43,7 @@ from kitaru.server.adapters.db.orm.session import (
     SESSION_IMPORTED_FROM_EXTERNAL_ID_UNIQUE_CONSTRAINT,
     SessionORM,
 )
-from kitaru.server.adapters.db.orm.task import (
-    TASK_INPUT_SESSION_ID_FOREIGN_KEY,
-    TASK_RESULT_SESSION_ID_FOREIGN_KEY,
-)
+from kitaru.server.adapters.db.orm.task import TASK_INPUT_SESSION_ID_FOREIGN_KEY
 from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.session import SessionFilter
@@ -246,6 +243,24 @@ class SQLSessionRepository(BaseSQLRepository[SessionORM]):
         row = await self._get_row(session_id, exclusive=exclusive)
         return row.to_domain()
 
+    async def get_by_task_id(
+        self, task_id: uuid.UUID, exclusive: bool = False
+    ) -> Session | None:
+        """Load the session a task produced, if any.
+
+        Args:
+            task_id: Id of the producing task.
+            exclusive: Lock the row for update.
+
+        Returns:
+            Stored session, or ``None`` when no session links the task.
+        """
+        statement = select(SessionORM).where(SessionORM.task_id == task_id)
+        if exclusive:
+            statement = statement.with_for_update()
+        row = (await self._session.scalars(statement)).one_or_none()
+        return row.to_domain() if row is not None else None
+
     async def query(
         self, session_filter: SessionFilter
     ) -> tuple[list[Session], str | None]:
@@ -347,8 +362,8 @@ class SQLSessionRepository(BaseSQLRepository[SessionORM]):
             SessionNotFound: No session has this id.
             SessionInUse: The session belongs to a cohort version and
                 cannot be deleted.
-            SessionInUseByTask: The session is a task's input or result
-                session and cannot be deleted.
+            SessionInUseByTask: The session is a task's input session and
+                cannot be deleted.
             SessionInUseByReplay: The session is a replay's baseline or
                 result session and cannot be deleted.
         """
@@ -359,9 +374,6 @@ class SQLSessionRepository(BaseSQLRepository[SessionORM]):
                     session_id
                 ),
                 TASK_INPUT_SESSION_ID_FOREIGN_KEY: lambda: SessionInUseByTask(
-                    session_id
-                ),
-                TASK_RESULT_SESSION_ID_FOREIGN_KEY: lambda: SessionInUseByTask(
                     session_id
                 ),
                 REPLAY_BASELINE_SESSION_ID_FOREIGN_KEY: lambda: SessionInUseByReplay(

--- a/src/kitaru/server/adapters/db/repositories/task_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/task_repository.py
@@ -28,7 +28,7 @@ from sqlalchemy import (
     update,
 )
 
-from kitaru.api_models.v1.task import TaskKind, TaskStatus
+from kitaru.api_models.v1.task import TaskStatus
 from kitaru.api_models.v1.worker import WorkerScope
 from kitaru.server.adapters.db.filtering import FilterBinding, compile_filter_expression
 from kitaru.server.adapters.db.orm.job import JobORM
@@ -602,22 +602,3 @@ class SQLTaskRepository(BaseSQLRepository[TaskORM]):
         for session_id, plugin_version_id in rows:
             scored.setdefault(session_id, set()).add(plugin_version_id)
         return scored
-
-    async def get_agent_tasks_by_job_ids(
-        self, job_ids: Sequence[uuid.UUID]
-    ) -> dict[uuid.UUID, Task]:
-        """Bulk-load the agent task of each job, keyed by job id.
-
-        Args:
-            job_ids: Ids of the jobs.
-
-        Returns:
-            Agent tasks keyed by job id, jobs without an agent task omitted.
-        """
-        if not job_ids:
-            return {}
-        statement = select(TaskORM).where(
-            TaskORM.job_id.in_(job_ids), TaskORM.kind == TaskKind.AGENT.value
-        )
-        rows = (await self._session.scalars(statement)).all()
-        return {row.job_id: row.to_domain() for row in rows}

--- a/src/kitaru/server/adapters/rest/dependencies.py
+++ b/src/kitaru/server/adapters/rest/dependencies.py
@@ -545,6 +545,7 @@ def get_task_service(
         Task service bound to the SQL repositories.
     """
     policy = get_task_policy(settings)
+    replay_repository = SQLReplayRepository(session)
     spec_builder = TaskSpecBuilder(
         agent_version_repository=SQLAgentVersionRepository(session),
         plugin_repository=SQLPluginRepository(session),
@@ -552,7 +553,7 @@ def get_task_service(
         secret_repository=SQLSecretRepository(
             session, AesGcmCipher(settings.SECRET_ENCRYPTION_KEY)
         ),
-        replay_repository=SQLReplayRepository(session),
+        replay_repository=replay_repository,
         policy=policy,
     )
     return TaskService(
@@ -560,6 +561,7 @@ def get_task_service(
         worker_repository=SQLWorkerRepository(session),
         session_repository=SQLSessionRepository(session, engine),
         job_repository=SQLJobRepository(session),
+        replay_repository=replay_repository,
         spec_builder=spec_builder,
         transitions=_build_task_transitions(session, analytics),
         policy=policy,

--- a/src/kitaru/server/adapters/rest/mapping/replays.py
+++ b/src/kitaru/server/adapters/rest/mapping/replays.py
@@ -13,8 +13,6 @@
 #  permissions and limitations under the License.
 """Replay DTO conversions."""
 
-import uuid
-
 from kitaru.api_models.v1.replay import (
     ReplayCreateRequest,
     ReplayListParams,
@@ -66,19 +64,15 @@ def replay_create_to_command(body: ReplayCreateRequest) -> ReplayCreate:
     )
 
 
-def replay_to_response(
-    replay: Replay, config: ReplayConfig, result_session_id: uuid.UUID | None
-) -> ReplayResponse:
+def replay_to_response(replay: Replay, config: ReplayConfig) -> ReplayResponse:
     """Convert a replay and its config to the response DTO.
 
     Args:
         replay: Stored replay.
         config: The replay's config.
-        result_session_id: Session produced by the replay's agent task, if
-            any.
 
     Returns:
-        Replay response, inlining the config and the result session id.
+        Replay response, inlining the config.
     """
     assert replay.created is not None
     assert replay.updated is not None
@@ -87,7 +81,7 @@ def replay_to_response(
         job_id=replay.job_id,
         experiment_run_id=replay.experiment_run_id,
         baseline_session_id=replay.baseline_session_id,
-        result_session_id=result_session_id,
+        result_session_id=replay.result_session_id,
         override=(
             replay_override_to_wire(config.override)
             if config.override is not None

--- a/src/kitaru/server/adapters/rest/mapping/tasks.py
+++ b/src/kitaru/server/adapters/rest/mapping/tasks.py
@@ -97,7 +97,6 @@ def task_to_response(task: Task) -> TaskResponse:
         ),
         agent_id=task.agent_id if isinstance(task, ImportTask) else None,
         worker_id=task.worker_id,
-        result_session_id=task.result_session_id,
         claimed_at=task.claimed_at,
         heartbeat_at=task.heartbeat_at,
         cancel_requested_at=task.cancel_requested_at,

--- a/src/kitaru/server/adapters/rest/routers/replays.py
+++ b/src/kitaru/server/adapters/rest/routers/replays.py
@@ -69,7 +69,7 @@ async def create_replay(
     """
     command = replay_create_to_command(body)
     bundle = await service.create_replay(command, actor=actor)
-    return replay_to_response(bundle.replay, bundle.config, bundle.result_session_id)
+    return replay_to_response(bundle.replay, bundle.config)
 
 
 @router.get("")
@@ -94,10 +94,7 @@ async def list_replays(
     replay_filter = replay_list_params_to_filter(params)
     bundles, next_cursor = await service.list_replays(replay_filter, actor=actor)
     return Page[ReplayResponse](
-        items=[
-            replay_to_response(bundle.replay, bundle.config, bundle.result_session_id)
-            for bundle in bundles
-        ],
+        items=[replay_to_response(bundle.replay, bundle.config) for bundle in bundles],
         next_cursor=next_cursor,
     )
 
@@ -122,7 +119,7 @@ async def get_replay(
         Stored replay.
     """
     bundle = await service.get_replay(replay_id, actor=actor)
-    return replay_to_response(bundle.replay, bundle.config, bundle.result_session_id)
+    return replay_to_response(bundle.replay, bundle.config)
 
 
 @router.post("/{replay_id}/tool-lookup")

--- a/src/kitaru/server/adapters/rest/routers/ui.py
+++ b/src/kitaru/server/adapters/rest/routers/ui.py
@@ -265,9 +265,9 @@ async def list_experiment_run_evaluation_aggregates(
         dict.fromkeys(details.replay.baseline_session_id for details in replays)
     )
     result_session_ids = [
-        details.result_session_id
+        details.replay.result_session_id
         for details in replays
-        if details.result_session_id is not None
+        if details.replay.result_session_id is not None
     ]
     evaluations = await _load_session_evaluations(
         evaluation_service, baseline_session_ids + result_session_ids, actor
@@ -312,10 +312,10 @@ async def list_experiment_run_evaluation_aggregates(
                             ).get(key)
                         ),
                         result=_evaluation_value(
-                            session_evaluations.get(details.result_session_id, {}).get(
-                                key
-                            )
-                            if details.result_session_id is not None
+                            session_evaluations.get(
+                                details.replay.result_session_id, {}
+                            ).get(key)
+                            if details.replay.result_session_id is not None
                             else None
                         ),
                     )

--- a/src/kitaru/server/application/interfaces/replay_repository.py
+++ b/src/kitaru/server/application/interfaces/replay_repository.py
@@ -76,6 +76,17 @@ class ReplayRepository(Protocol):
         """
         ...
 
+    async def get_by_result_session_id(self, session_id: uuid.UUID) -> Replay | None:
+        """Load the replay that produced a session, if any.
+
+        Args:
+            session_id: Id of the produced session.
+
+        Returns:
+            Stored replay, or ``None`` when no replay produced the session.
+        """
+        ...
+
     async def get_many_by_job_ids(
         self, job_ids: Sequence[uuid.UUID]
     ) -> dict[uuid.UUID, Replay]:

--- a/src/kitaru/server/application/interfaces/session_repository.py
+++ b/src/kitaru/server/application/interfaces/session_repository.py
@@ -72,6 +72,20 @@ class SessionRepository(Protocol):
         """
         ...
 
+    async def get_by_task_id(
+        self, task_id: uuid.UUID, exclusive: bool = False
+    ) -> Session | None:
+        """Load the session a task produced, if any.
+
+        Args:
+            task_id: Id of the producing task.
+            exclusive: Lock the row for update.
+
+        Returns:
+            Stored session, or ``None`` when no session links the task.
+        """
+        ...
+
     async def query(
         self, session_filter: SessionFilter
     ) -> tuple[list[Session], str | None]:

--- a/src/kitaru/server/application/interfaces/task_repository.py
+++ b/src/kitaru/server/application/interfaces/task_repository.py
@@ -267,16 +267,3 @@ class TaskRepository(Protocol):
             session, keyed by session id, sessions without one omitted.
         """
         ...
-
-    async def get_agent_tasks_by_job_ids(
-        self, job_ids: Sequence[uuid.UUID]
-    ) -> dict[uuid.UUID, Task]:
-        """Bulk-load the agent task of each job, keyed by job id.
-
-        Args:
-            job_ids: Ids of the jobs.
-
-        Returns:
-            Agent tasks keyed by job id, jobs without an agent task omitted.
-        """
-        ...

--- a/src/kitaru/server/application/models/replay.py
+++ b/src/kitaru/server/application/models/replay.py
@@ -66,11 +66,10 @@ class ToolLookupResult(NamedTuple):
 
 
 class ReplayWithDetails(NamedTuple):
-    """Replay paired with its config and result session id."""
+    """Replay paired with its config."""
 
     replay: Replay
     config: ReplayConfig
-    result_session_id: uuid.UUID | None
 
 
 class ReplayStatusCounts(FrozenModel):

--- a/src/kitaru/server/application/services/replay_pipeline.py
+++ b/src/kitaru/server/application/services/replay_pipeline.py
@@ -152,12 +152,12 @@ async def append_result_evaluations(
     if replay is None:
         return
     config = await experiment_repository.get_replay_config(replay.replay_config_id)
-    assert task.result_session_id is not None
+    assert replay.result_session_id is not None
     evaluator_tasks: list[Task] = [
         EvaluationTask(
             job_id=task.job_id,
             plugin_version_id=evaluator.evaluator_version_id,
-            input_session_id=task.result_session_id,
+            input_session_id=replay.result_session_id,
             params=evaluator.params,
             on_failure=TaskOnFailure.ABORT,
         )

--- a/src/kitaru/server/application/services/replay_service.py
+++ b/src/kitaru/server/application/services/replay_service.py
@@ -102,33 +102,21 @@ class ReplayService:
         self._analytics = analytics
 
     async def _bundle(self, replays: list[Replay]) -> list[ReplayWithDetails]:
-        """Enrich replays with their config and result session id, in bulk.
+        """Enrich replays with their config, in bulk.
 
         Args:
             replays: Replays to enrich.
 
         Returns:
-            Replays paired with their config and result session id, in the
-            input order.
+            Replays paired with their config, in the input order.
         """
         if not replays:
             return []
         configs = await self._experiments.get_many_replay_configs(
             list({replay.replay_config_id for replay in replays})
         )
-        agent_tasks = await self._tasks.get_agent_tasks_by_job_ids(
-            [replay.job_id for replay in replays]
-        )
         return [
-            ReplayWithDetails(
-                replay=replay,
-                config=configs[replay.replay_config_id],
-                result_session_id=(
-                    agent_tasks[replay.job_id].result_session_id
-                    if replay.job_id in agent_tasks
-                    else None
-                ),
-            )
+            ReplayWithDetails(replay=replay, config=configs[replay.replay_config_id])
             for replay in replays
         ]
 
@@ -155,7 +143,7 @@ class ReplayService:
                 version.
 
         Returns:
-            Created replay, paired with its config and result session id.
+            Created replay, paired with its config.
         """
         baseline = await self._sessions.get(command.baseline_session_id)
         agent_version_id = command.agent_version_id
@@ -212,7 +200,7 @@ class ReplayService:
             ReplayNotFound: No replay has this id.
 
         Returns:
-            Stored replay, paired with its config and result session id.
+            Stored replay, paired with its config.
         """
         replay = await self._repository.get(replay_id)
         await self._check_task_access(replay, actor)
@@ -228,8 +216,8 @@ class ReplayService:
             actor: Caller context.
 
         Returns:
-            Page of matching replays, each paired with its config and result
-            session id, and the next cursor.
+            Page of matching replays, each paired with its config, and the
+            next cursor.
         """
         _ = actor
         replays, next_cursor = await self._repository.query(replay_filter)

--- a/src/kitaru/server/application/services/session_service.py
+++ b/src/kitaru/server/application/services/session_service.py
@@ -254,9 +254,8 @@ class SessionService:
     ) -> Session:
         """Get the baseline session a replayed session was produced from.
 
-        The link runs from the session's producing task to the replay owning
-        that task's job. A session with no producing task, or one whose task
-        belongs to a job that is not a replay, has no baseline.
+        The link runs from the replay holding the session as its result. A
+        session no replay holds as its result has no baseline.
 
         Args:
             session_id: Id of the replayed session.
@@ -274,10 +273,7 @@ class SessionService:
         """
         session = await self._repository.get(session_id)
         check_task_session_read(session_id, session.task_id, actor)
-        if session.task_id is None:
-            raise SessionBaselineNotFound(session_id)
-        task = await self._tasks.get(session.task_id)
-        replay = await self._replays.get_by_job_id(task.job_id)
+        replay = await self._replays.get_by_result_session_id(session_id)
         if replay is None:
             raise SessionBaselineNotFound(session_id)
         return await self._repository.get(replay.baseline_session_id)

--- a/src/kitaru/server/application/services/session_service.py
+++ b/src/kitaru/server/application/services/session_service.py
@@ -90,10 +90,11 @@ class SessionService:
         A task principal's session is linked to the principal's task, which
         must be running. An agent task links exactly one session and gets its
         result session written in the same transaction, an import task links
-        every session it creates. The task is the source of truth for the
-        agent and the agent version. The session takes the next number of
-        its agent, allocated outside the request transaction, so a failed
-        create leaves a gap.
+        every session it creates. A replay owning the agent task's job also
+        stores the session as its result session. The task is the source of
+        truth for the agent and the agent version. The session takes the next
+        number of its agent, allocated outside the request transaction, so a
+        failed create leaves a gap.
 
         Args:
             command: Fields for the new session.
@@ -161,6 +162,10 @@ class SessionService:
         if isinstance(task, AgentTask):
             task.link_result_session(stored.id)
             await self._tasks.update(task)
+            replay = await self._replays.get_by_job_id(task.job_id)
+            if replay is not None:
+                replay.link_result_session(stored.id)
+                await self._replays.update(replay)
         if self._analytics is not None and stored.status != SessionStatus.IN_PROGRESS:
             self._analytics.track(
                 stored.owner_id,

--- a/src/kitaru/server/application/services/session_service.py
+++ b/src/kitaru/server/application/services/session_service.py
@@ -88,11 +88,11 @@ class SessionService:
         """Create a session owned by the caller.
 
         A task principal's session is linked to the principal's task, which
-        must be running. An agent task links exactly one session and gets its
-        result session written in the same transaction, an import task links
-        every session it creates. A replay owning the agent task's job also
-        stores the session as its result session. The task is the source of
-        truth for the agent and the agent version. The session takes the next
+        must be running. An agent task links exactly one session, and its
+        result session is found through that link. An import task links
+        every session it creates. A replay owning the agent task's job stores
+        the session as its result session. The task is the source of truth
+        for the agent and the agent version. The session takes the next
         number of its agent, allocated outside the request transaction, so a
         failed create leaves a gap.
 
@@ -132,7 +132,10 @@ class SessionService:
             # Check the attempt on the locked task so a requeue cannot race
             # the result link.
             task.check_attempt(actor.principal.attempt)
-            if isinstance(task, AgentTask) and task.result_session_id is not None:
+            if (
+                isinstance(task, AgentTask)
+                and await self._repository.get_by_task_id(task.id) is not None
+            ):
                 raise TaskResultSessionAlreadyLinked(task.id)
         agent_id, agent_version_id = await self._resolve_agent(command, task)
         number = await self._repository.allocate_session_number(agent_id)
@@ -160,8 +163,6 @@ class SessionService:
         )
         stored = await self._repository.create(session)
         if isinstance(task, AgentTask):
-            task.link_result_session(stored.id)
-            await self._tasks.update(task)
             replay = await self._replays.get_by_job_id(task.job_id)
             if replay is not None:
                 replay.link_result_session(stored.id)

--- a/src/kitaru/server/application/services/task_service.py
+++ b/src/kitaru/server/application/services/task_service.py
@@ -23,6 +23,7 @@ from typing import Any
 from kitaru.api_models.v1.session import SessionStatus
 from kitaru.api_models.v1.task import TaskStatus
 from kitaru.server.application.interfaces.job_repository import JobRepository
+from kitaru.server.application.interfaces.replay_repository import ReplayRepository
 from kitaru.server.application.interfaces.session_repository import SessionRepository
 from kitaru.server.application.interfaces.task_repository import TaskRepository
 from kitaru.server.application.interfaces.worker_repository import WorkerRepository
@@ -65,6 +66,7 @@ class TaskService:
         worker_repository: WorkerRepository,
         session_repository: SessionRepository,
         job_repository: JobRepository,
+        replay_repository: ReplayRepository,
         spec_builder: TaskSpecBuilder,
         transitions: TaskTransitions,
         policy: TaskPolicy,
@@ -76,6 +78,7 @@ class TaskService:
             worker_repository: Worker repository.
             session_repository: Session repository.
             job_repository: Job repository.
+            replay_repository: Replay repository.
             spec_builder: Task execution spec builder.
             transitions: Task transition dispatch.
             policy: Task execution policy.
@@ -84,6 +87,7 @@ class TaskService:
         self._workers = worker_repository
         self._sessions = session_repository
         self._jobs = job_repository
+        self._replays = replay_repository
         self._spec_builder = spec_builder
         self._transitions = transitions
         self._policy = policy
@@ -425,20 +429,31 @@ class TaskService:
         """
         if not isinstance(task, AgentTask):
             return
-        if task.result_session_id is None:
+        session = await self._sessions.get_by_task_id(task.id)
+        if session is None:
             raise TaskResultSessionMissing(task.id)
-        session = await self._sessions.get(task.result_session_id)
         if session.status is not SessionStatus.COMPLETED:
             raise TaskResultSessionNotCompleted(task.id, session.id)
 
     async def _unlink_result_session(self, task: Task) -> None:
         """Free the result session slot a requeued attempt left behind.
 
+        Clears the replay's result session link too, when the task's job
+        holds a replay.
+
         Args:
             task: Task about to be requeued.
         """
-        if task.result_session_id is None:
+        if not isinstance(task, AgentTask):
             return
-        session = await self._sessions.get(task.result_session_id, exclusive=True)
+        # The replay's link is written together with the session, so no
+        # session means nothing to clear on the replay either.
+        session = await self._sessions.get_by_task_id(task.id, exclusive=True)
+        if session is None:
+            return
         session.unlink_task()
         await self._sessions.update(session)
+        replay = await self._replays.get_by_job_id(task.job_id)
+        if replay is not None:
+            replay.unlink_result_session()
+            await self._replays.update(replay)

--- a/src/kitaru/server/database/migrations/versions/003_replay_result_session_id.py
+++ b/src/kitaru/server/database/migrations/versions/003_replay_result_session_id.py
@@ -1,0 +1,56 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Replay result session id Alembic revision.
+
+Revision ID: 003_replay_result_session_id
+Revises: 002_idempotency_key
+Create Date: 2026-08-21
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "003_replay_result_session_id"
+down_revision = "002_idempotency_key"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    with op.batch_alter_table("replay", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("result_session_id", sa.Uuid(), nullable=True))
+    # Backfill from the agent task sharing the replay's job, before the index
+    # and foreign key exist, so the update skips per-row index and FK upkeep.
+    op.execute(
+        "UPDATE replay SET result_session_id = task.result_session_id "
+        "FROM task WHERE task.job_id = replay.job_id AND task.kind = 'agent'"
+    )
+    with op.batch_alter_table("replay", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_replay_result_session_id", ["result_session_id"], unique=False
+        )
+        batch_op.create_foreign_key(
+            "fk_replay_result_session_id", "session", ["result_session_id"], ["id"]
+        )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    with op.batch_alter_table("replay", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_replay_result_session_id", type_="foreignkey")
+        batch_op.drop_index("ix_replay_result_session_id")
+        batch_op.drop_column("result_session_id")

--- a/src/kitaru/server/database/migrations/versions/004_replay_result_session_id.py
+++ b/src/kitaru/server/database/migrations/versions/004_replay_result_session_id.py
@@ -13,8 +13,8 @@
 #  permissions and limitations under the License.
 """Replay result session id Alembic revision.
 
-Revision ID: 003_replay_result_session_id
-Revises: 002_idempotency_key
+Revision ID: 004_replay_result_session_id
+Revises: 003_worker_liveness_index
 Create Date: 2026-08-21
 
 """
@@ -23,8 +23,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "003_replay_result_session_id"
-down_revision = "002_idempotency_key"
+revision = "004_replay_result_session_id"
+down_revision = "003_worker_liveness_index"
 branch_labels = None
 depends_on = None
 
@@ -46,10 +46,28 @@ def upgrade() -> None:
         batch_op.create_foreign_key(
             "fk_replay_result_session_id", "session", ["result_session_id"], ["id"]
         )
+    with op.batch_alter_table("task", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_task_result_session_id", type_="foreignkey")
+        batch_op.drop_index("ix_task_result_session_id")
+        batch_op.drop_column("result_session_id")
 
 
 def downgrade() -> None:
     """Downgrade database schema and/or data back to the previous revision."""
+    with op.batch_alter_table("task", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("result_session_id", sa.Uuid(), nullable=True))
+    # Restore the task-side link from the session's task pointer.
+    op.execute(
+        "UPDATE task SET result_session_id = session.id "
+        "FROM session WHERE session.task_id = task.id AND task.kind = 'agent'"
+    )
+    with op.batch_alter_table("task", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_task_result_session_id", ["result_session_id"], unique=False
+        )
+        batch_op.create_foreign_key(
+            "fk_task_result_session_id", "session", ["result_session_id"], ["id"]
+        )
     with op.batch_alter_table("replay", schema=None) as batch_op:
         batch_op.drop_constraint("fk_replay_result_session_id", type_="foreignkey")
         batch_op.drop_index("ix_replay_result_session_id")

--- a/src/kitaru/server/domain/replay.py
+++ b/src/kitaru/server/domain/replay.py
@@ -113,6 +113,7 @@ class Replay(DomainModel):
     experiment_run_id: uuid.UUID | None = None
     replay_config_id: uuid.UUID
     baseline_session_id: uuid.UUID
+    result_session_id: uuid.UUID | None = None
     evaluate_baselines: bool = False
     status: ReplayStatus = ReplayStatus.PENDING
     error: str | None = None
@@ -179,3 +180,11 @@ class Replay(DomainModel):
                 self.id, self.status, ReplayStatus.CANCELED
             )
         self.status = ReplayStatus.CANCELED
+
+    def link_result_session(self, session_id: uuid.UUID) -> None:
+        """Link the session this replay produced.
+
+        Args:
+            session_id: Id of the produced session.
+        """
+        self.result_session_id = session_id

--- a/src/kitaru/server/domain/replay.py
+++ b/src/kitaru/server/domain/replay.py
@@ -188,3 +188,7 @@ class Replay(DomainModel):
             session_id: Id of the produced session.
         """
         self.result_session_id = session_id
+
+    def unlink_result_session(self) -> None:
+        """Clear the session this replay produced."""
+        self.result_session_id = None

--- a/src/kitaru/server/domain/session.py
+++ b/src/kitaru/server/domain/session.py
@@ -111,6 +111,18 @@ class SessionInUseByTask(ConflictError):
         super().__init__(f"Session {session_id} is in use by a task")
 
 
+class SessionInUseByReplay(ConflictError):
+    """Raised when a session is referenced by a replay and cannot be deleted."""
+
+    def __init__(self, session_id: uuid.UUID) -> None:
+        """Initialize the error.
+
+        Args:
+            session_id: Id of the session that cannot be deleted.
+        """
+        super().__init__(f"Session {session_id} is in use by a replay")
+
+
 class SessionAgentVersionMismatch(ValidationError):
     """Raised when a session names a different agent version than its task runs."""
 

--- a/src/kitaru/server/domain/task.py
+++ b/src/kitaru/server/domain/task.py
@@ -264,7 +264,6 @@ class Task(DomainModel):
     labels: dict[str, str] = Field(default_factory=dict)
     env: dict[str, str] = Field(default_factory=dict)
     worker_id: uuid.UUID | None = None
-    result_session_id: uuid.UUID | None = None
     claimed_at: datetime | None = None
     heartbeat_at: datetime | None = None
     cancel_requested_at: datetime | None = None
@@ -394,7 +393,6 @@ class Task(DomainModel):
         self.claimed_at = None
         self.heartbeat_at = None
         self.started_at = None
-        self.result_session_id = None
 
     def check_result(self, result: Any) -> None:
         """Validate a completion result against the task kind's contract.
@@ -507,19 +505,6 @@ class Task(DomainModel):
         self.error = error
         self.ended_at = now
 
-    def link_result_session(self, session_id: uuid.UUID) -> None:
-        """Link the session this task produced.
-
-        Args:
-            session_id: Id of the produced session.
-
-        Raises:
-            TaskResultSessionAlreadyLinked: A session is already linked.
-        """
-        if self.result_session_id is not None:
-            raise TaskResultSessionAlreadyLinked(self.id)
-        self.result_session_id = session_id
-
     def check_running(self) -> None:
         """Require the task to be running.
 
@@ -589,18 +574,6 @@ class AgentTask(Task):
             Agent kind.
         """
         return TaskKind.AGENT
-
-    def check_result(self, result: Any) -> None:
-        """Require a linked result session, the agent task's actual outcome.
-
-        Args:
-            result: Result the completion carries, diagnostic only.
-
-        Raises:
-            TaskResultSessionMissing: No session is linked.
-        """
-        if self.result_session_id is None:
-            raise TaskResultSessionMissing(self.id)
 
 
 class EvaluationTask(Task):

--- a/src/kitaru/worker/task_runner.py
+++ b/src/kitaru/worker/task_runner.py
@@ -23,7 +23,8 @@ from typing import Any
 
 import httpx
 
-from kitaru.api_models.v1.session import SessionStatus
+from kitaru.api_models.v1.filter import FilterCondition, FilterOp
+from kitaru.api_models.v1.session import SessionListParams, SessionStatus
 from kitaru.api_models.v1.task import (
     TaskKind,
     TaskResponse,
@@ -381,20 +382,21 @@ class TaskRunner:
             Error message naming the missing result session, its status when
             not completed, or a missing result.
         """
-        if task.result_session_id is None:
-            if kind is TaskKind.AGENT:
-                return (
-                    "Agent process exited successfully without recording "
-                    "a result session."
-                )
+        if kind is not TaskKind.AGENT:
             return f"{label} process exited successfully without writing a result."
+        params = SessionListParams(
+            filter=FilterCondition(field="task_id", op=FilterOp.EQ, value=str(task.id))
+        )
         try:
-            session = await client.sessions.get(task.result_session_id)
+            page = await client.sessions.list(params)
         except (APIError, httpx.TransportError) as exc:
-            logger.warning(
-                "Failed to fetch session %s: %s", task.result_session_id, exc
-            )
+            logger.warning("Failed to list sessions for task %s: %s", task.id, exc)
             return f"{label} process exited successfully without writing a result."
+        session = page.items[0] if page.items else None
+        if session is None:
+            return (
+                "Agent process exited successfully without recording a result session."
+            )
         if session.status is not SessionStatus.COMPLETED:
             return f"Result session {session.id} is {session.status}, not completed."
         return f"{label} process exited successfully without writing a result."

--- a/tests/client/test_workers.py
+++ b/tests/client/test_workers.py
@@ -153,6 +153,7 @@ async def api_client(
         worker_repository=worker_repository,
         session_repository=FakeSessionRepository(),
         job_repository=job_repository,
+        replay_repository=FakeReplayRepository(),
         spec_builder=spec_builder,
         transitions=transitions,
         policy=task_policy,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4254,6 +4254,20 @@ class FakeReplayRepository:
                 return replay.model_copy()
         return None
 
+    async def get_by_result_session_id(self, session_id: uuid.UUID) -> Replay | None:
+        """Load the replay that produced a session, if any.
+
+        Args:
+            session_id: Id of the produced session.
+
+        Returns:
+            Stored replay, or ``None`` when no replay produced the session.
+        """
+        for replay in self._replays.values():
+            if replay.result_session_id == session_id:
+                return replay.model_copy()
+        return None
+
     async def get_many_by_job_ids(
         self, job_ids: Sequence[uuid.UUID]
     ) -> dict[uuid.UUID, Replay]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2326,6 +2326,25 @@ class FakeSessionRepository:
             raise SessionNotFound(session_id)
         return session.model_copy()
 
+    async def get_by_task_id(
+        self, task_id: uuid.UUID, exclusive: bool = False
+    ) -> Session | None:
+        """Load the session a task produced, if any.
+
+        Args:
+            task_id: Id of the producing task.
+            exclusive: Ignored, the fake has no concurrent callers to lock
+                against.
+
+        Returns:
+            Stored session, or ``None`` when no session links the task.
+        """
+        _ = exclusive
+        for session in self._sessions.values():
+            if session.task_id == task_id:
+                return session.model_copy()
+        return None
+
     def _session_ids_tagged(self, tag_name: str) -> set[uuid.UUID]:
         """Resolve the ids of sessions linked to a tag by name.
 
@@ -5754,12 +5773,13 @@ def build_job_and_task_services(
         dispatcher=EventDispatcher(),
     )
     task_policy = policy if policy is not None else TaskPolicy()
+    replays = FakeReplayRepository()
     spec_builder = TaskSpecBuilder(
         agent_version_repository=substrate.agent_versions,
         plugin_repository=substrate.plugins,
         blob_repository=substrate.blobs,
         secret_repository=substrate.secrets,
-        replay_repository=FakeReplayRepository(),
+        replay_repository=replays,
         policy=task_policy,
     )
     task_service = TaskService(
@@ -5767,6 +5787,7 @@ def build_job_and_task_services(
         worker_repository=substrate.workers,
         session_repository=substrate.sessions,
         job_repository=substrate.jobs,
+        replay_repository=replays,
         spec_builder=spec_builder,
         transitions=transitions,
         policy=task_policy,
@@ -5894,6 +5915,7 @@ def build_replay_services(policy: TaskPolicy | None = None) -> ReplayServices:
         worker_repository=workers,
         session_repository=sessions,
         job_repository=jobs,
+        replay_repository=replays,
         spec_builder=spec_builder,
         transitions=transitions,
         policy=task_policy,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4151,16 +4151,9 @@ async def create_experiment(
 class FakeReplayRepository:
     """In-memory replay repository."""
 
-    def __init__(self, tasks: "FakeTaskRepository | None" = None) -> None:
-        """Initialize the repository.
-
-        Args:
-            tasks: Fake task repository, needed to resolve the result session
-                filter, which reads through the agent task rather than the
-                replay row.
-        """
+    def __init__(self) -> None:
+        """Initialize the repository."""
         self._replays: dict[uuid.UUID, Replay] = {}
-        self._tasks = tasks
 
     def _check_duplicate_baseline(self, replay: Replay) -> None:
         for other in self._replays.values():
@@ -4273,38 +4266,13 @@ class FakeReplayRepository:
         """
         replays = list(self._replays.values())
         if replay_filter.expression is not None:
-            resolvers = {"result_session_id": self._evaluate_result_session_condition}
             replays = [
                 r
                 for r in replays
-                if _evaluate_filter_expression(r, replay_filter.expression, resolvers)
+                if _evaluate_filter_expression(r, replay_filter.expression)
             ]
         page, next_cursor = _paginate_fake(replays, replay_filter)
         return [r.model_copy() for r in page], next_cursor
-
-    def _evaluate_result_session_condition(
-        self, replay: Replay, condition: FilterCondition
-    ) -> bool:
-        """Evaluate a result session condition against a replay.
-
-        Args:
-            replay: Replay to evaluate.
-            condition: Validated result session condition.
-
-        Returns:
-            Whether the replay's agent task produced a matching session.
-        """
-        assert self._tasks is not None
-        agent_task = next(
-            (
-                task
-                for task in self._tasks._tasks.values()
-                if task.job_id == replay.job_id and isinstance(task, AgentTask)
-            ),
-            None,
-        )
-        result_session_id = agent_task.result_session_id if agent_task else None
-        return _matches_condition(result_session_id, condition)
 
     async def list_by_experiment_run(
         self, experiment_run_id: uuid.UUID
@@ -5549,24 +5517,6 @@ class FakeTaskRepository:
                 )
         return scored
 
-    async def get_agent_tasks_by_job_ids(
-        self, job_ids: Sequence[uuid.UUID]
-    ) -> dict[uuid.UUID, Task]:
-        """Bulk-load the agent task of each job, keyed by job id.
-
-        Args:
-            job_ids: Ids of the jobs.
-
-        Returns:
-            Agent tasks keyed by job id, jobs without an agent task omitted.
-        """
-        job_id_set = set(job_ids)
-        return {
-            task.job_id: task.model_copy()
-            for task in self._tasks.values()
-            if isinstance(task, AgentTask) and task.job_id in job_id_set
-        }
-
 
 def _is_stale_before(task: Task, bound: datetime) -> bool:
     """Report whether a task last showed a sign of life before a bound.
@@ -5902,7 +5852,7 @@ def build_replay_services(policy: TaskPolicy | None = None) -> ReplayServices:
     jobs = substrate.jobs
     tags = FakeTagRepository()
     cohorts = FakeCohortRepository(tags=tags)
-    replays = FakeReplayRepository(tasks=tasks)
+    replays = FakeReplayRepository()
     experiment_runs = FakeExperimentRunRepository(tag_repository=tags)
     cohort_versions = FakeCohortVersionRepository(
         cohorts=cohorts, sessions=sessions, experiment_runs=experiment_runs, tags=tags

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -4362,20 +4362,6 @@
               "description": "Task result, diagnostic output on a non-completed task.",
               "title": "Result"
             },
-            "result_session_id": {
-              "anyOf": [
-                {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Session an agent task produced.",
-              "title": "Result Session Id"
-            },
             "started_at": {
               "anyOf": [
                 {

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,15 +6,15 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 151759,
+      "discovery_response_bytes": 151586,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
           "$defs_count": 43,
-          "combined_bytes": 33661,
+          "combined_bytes": 33488,
           "input_bytes": 5208,
           "maximum_nesting_depth": 8,
-          "output_bytes": 28453
+          "output_bytes": 28280
         },
         "kitaru_cohorts_manage": {
           "$defs_count": 7,
@@ -89,15 +89,15 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 78121,
+      "discovery_response_bytes": 77948,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
           "$defs_count": 43,
-          "combined_bytes": 33661,
+          "combined_bytes": 33488,
           "input_bytes": 5208,
           "maximum_nesting_depth": 8,
-          "output_bytes": 28453
+          "output_bytes": 28280
         },
         "kitaru_registry_read": {
           "$defs_count": 45,
@@ -116,15 +116,15 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 140367,
+      "discovery_response_bytes": 140194,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
           "$defs_count": 43,
-          "combined_bytes": 33661,
+          "combined_bytes": 33488,
           "input_bytes": 5208,
           "maximum_nesting_depth": 8,
-          "output_bytes": 28453
+          "output_bytes": 28280
         },
         "kitaru_cohorts_manage": {
           "$defs_count": 7,

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -4362,20 +4362,6 @@
               "description": "Task result, diagnostic output on a non-completed task.",
               "title": "Result"
             },
-            "result_session_id": {
-              "anyOf": [
-                {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Session an agent task produced.",
-              "title": "Result Session Id"
-            },
             "started_at": {
               "anyOf": [
                 {

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -4362,20 +4362,6 @@
               "description": "Task result, diagnostic output on a non-completed task.",
               "title": "Result"
             },
-            "result_session_id": {
-              "anyOf": [
-                {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "default": null,
-              "description": "Session an agent task produced.",
-              "title": "Result Session Id"
-            },
             "started_at": {
               "anyOf": [
                 {

--- a/tests/server/test_job_service.py
+++ b/tests/server/test_job_service.py
@@ -526,10 +526,6 @@ async def test_ignore_failure_neither_cancels_nor_counts(
     )
     session.status = SessionStatus.COMPLETED
     await services.sessions.update(session)
-    stored_sibling = await services.tasks.get(sibling.id)
-    assert isinstance(stored_sibling, AgentTask)
-    stored_sibling.result_session_id = session.id
-    await services.tasks.update(stored_sibling)
     await services.task_service.update_task(
         sibling.id,
         TaskUpdate(status=TaskStatus.COMPLETED),
@@ -563,10 +559,6 @@ async def test_appended_task_blocks_settlement(services: JobAndTaskServices) -> 
         services.sessions, ACTOR.account.id, agent_id=uuid.uuid4(), task_id=task.id
     )
     session.status = SessionStatus.COMPLETED
-    stored_task = await services.tasks.get(task.id)
-    assert isinstance(stored_task, AgentTask)
-    stored_task.result_session_id = session.id
-    await services.tasks.update(stored_task)
     await services.task_service.update_task(
         task.id,
         TaskUpdate(status=TaskStatus.RUNNING),

--- a/tests/server/test_job_settlement_pg.py
+++ b/tests/server/test_job_settlement_pg.py
@@ -88,21 +88,21 @@ async def test_advance_job_serializes_concurrent_task_completions() -> None:
 
         task_ids = []
         for number in range(1, 3):
-            result_session = await SQLSessionRepository(seed_session, engine).create(
-                Session(
-                    owner_id=owner.id,
-                    agent_id=agent.id,
-                    number=number,
-                    origin=SessionOrigin.REPLAY,
-                )
-            )
             task = await SQLTaskRepository(seed_session).create(
                 AgentTask(
                     job_id=job.id,
                     agent_version_id=agent_version.id,
                     status=TaskStatus.RUNNING,
                     attempt=1,
-                    result_session_id=result_session.id,
+                )
+            )
+            await SQLSessionRepository(seed_session, engine).create(
+                Session(
+                    owner_id=owner.id,
+                    agent_id=agent.id,
+                    number=number,
+                    origin=SessionOrigin.REPLAY,
+                    task_id=task.id,
                 )
             )
             task_ids.append(task.id)

--- a/tests/server/test_jobs_api_pg.py
+++ b/tests/server/test_jobs_api_pg.py
@@ -123,8 +123,8 @@ async def test_session_run_lifecycle_completes_the_job(
     assert body["status"] == "completed"
     assert body["ended_at"] is not None
 
-    response = await client.get(f"/api/v1/tasks/{task['id']}")
-    assert response.json()["result_session_id"] == session["id"]
+    response = await client.get(f"/api/v1/sessions/{session['id']}")
+    assert response.json()["task_id"] == task["id"]
 
 
 async def test_cancel_job_persists_across_requests(client: httpx.AsyncClient) -> None:

--- a/tests/server/test_replay_pipeline.py
+++ b/tests/server/test_replay_pipeline.py
@@ -136,7 +136,7 @@ async def test_standalone_replay_pipeline_end_to_end(services: ReplayServices) -
         actor=ACTOR,
     )
     assert bundle.replay.status is ReplayStatus.PENDING
-    assert bundle.result_session_id is None
+    assert bundle.replay.result_session_id is None
 
     tasks, _ = await services.task_service.list_tasks(
         TaskFilter(job_id=bundle.replay.job_id), actor=ACTOR
@@ -178,6 +178,10 @@ async def test_standalone_replay_pipeline_end_to_end(services: ReplayServices) -
     assert isinstance(stored_agent_task, AgentTask)
     stored_agent_task.result_session_id = result_session.id
     await services.tasks.update(stored_agent_task)
+    replay_with_task = await services.replays.get_by_job_id(bundle.replay.job_id)
+    assert replay_with_task is not None
+    replay_with_task.link_result_session(result_session.id)
+    await services.replays.update(replay_with_task)
 
     await services.task_service.update_task(
         agent_task.id,
@@ -238,7 +242,7 @@ async def test_standalone_replay_pipeline_end_to_end(services: ReplayServices) -
     final_bundle = await services.replay_service.get_replay(
         bundle.replay.id, actor=ACTOR
     )
-    assert final_bundle.result_session_id == result_session.id
+    assert final_bundle.replay.result_session_id == result_session.id
 
 
 async def test_standalone_replay_stamps_the_job_kind_replay(

--- a/tests/server/test_replay_pipeline.py
+++ b/tests/server/test_replay_pipeline.py
@@ -174,10 +174,6 @@ async def test_standalone_replay_pipeline_end_to_end(services: ReplayServices) -
     )
     result_session.status = SessionStatus.COMPLETED
     await services.sessions.update(result_session)
-    stored_agent_task = await services.tasks.get(agent_task.id)
-    assert isinstance(stored_agent_task, AgentTask)
-    stored_agent_task.result_session_id = result_session.id
-    await services.tasks.update(stored_agent_task)
     replay_with_task = await services.replays.get_by_job_id(bundle.replay.job_id)
     assert replay_with_task is not None
     replay_with_task.link_result_session(result_session.id)

--- a/tests/server/test_replay_service.py
+++ b/tests/server/test_replay_service.py
@@ -560,10 +560,10 @@ async def test_tool_lookup_occurrence_rejected_for_non_baseline_scope(
         )
 
 
-async def test_get_replay_result_session_id_appears_after_agent_task_links_it(
+async def test_get_replay_result_session_id_appears_once_linked_on_the_replay(
     services: ReplayServices,
 ) -> None:
-    """result_session_id starts null and appears once the agent task links a session."""
+    """result_session_id starts null and appears once linked on the replay row."""
     agent_version = await _agent_version(services)
     await _evaluator(services)
     baseline = await _session(services, agent_version)
@@ -575,26 +575,16 @@ async def test_get_replay_result_session_id_appears_after_agent_task_links_it(
         ),
         actor=ACTOR,
     )
-    assert bundle.result_session_id is None
+    assert bundle.replay.result_session_id is None
 
-    tasks, _ = await services.task_service.list_tasks(
-        TaskFilter(job_id=bundle.replay.job_id), actor=ACTOR
-    )
-    agent_task = tasks[0]
-    worker = await create_worker(services.workers, ACTOR.account.id)
-    await services.task_service.claim_tasks(
-        10,
-        actor=WorkerAuthContext(
-            account=ACTOR.account, principal=WorkerPrincipal(worker_id=worker.id)
-        ),
-    )
-    stored_task = await services.tasks.get(agent_task.id)
-    assert isinstance(stored_task, AgentTask)
-    stored_task.result_session_id = uuid.uuid4()
-    await services.tasks.update(stored_task)
+    replay = await services.replays.get_by_job_id(bundle.replay.job_id)
+    assert replay is not None
+    result_session_id = uuid.uuid4()
+    replay.link_result_session(result_session_id)
+    await services.replays.update(replay)
 
     refreshed = await services.replay_service.get_replay(bundle.replay.id, actor=ACTOR)
-    assert refreshed.result_session_id == stored_task.result_session_id
+    assert refreshed.replay.result_session_id == result_session_id
 
 
 async def test_replay_agent_tasks_claim_only_their_scoped_version(
@@ -807,10 +797,9 @@ async def test_tool_lookup_denies_a_task_principal_from_another_job(
 async def test_list_replays_filters_by_result_session(
     services: ReplayServices,
 ) -> None:
-    """List replays filters on the result session linked by the agent task."""
+    """List replays filters on the result session linked on the replay row."""
     agent_version = await _agent_version(services)
     await _evaluator(services)
-    worker = await create_worker(services.workers, ACTOR.account.id)
 
     async def replay_with_result_session() -> tuple[uuid.UUID, uuid.UUID]:
         baseline = await _session(services, agent_version)
@@ -821,20 +810,12 @@ async def test_list_replays_filters_by_result_session(
             ),
             actor=ACTOR,
         )
-        tasks, _ = await services.task_service.list_tasks(
-            TaskFilter(job_id=bundle.replay.job_id), actor=ACTOR
-        )
-        await services.task_service.claim_tasks(
-            10,
-            actor=WorkerAuthContext(
-                account=ACTOR.account, principal=WorkerPrincipal(worker_id=worker.id)
-            ),
-        )
-        stored_task = await services.tasks.get(tasks[0].id)
-        assert isinstance(stored_task, AgentTask)
-        stored_task.result_session_id = uuid.uuid4()
-        await services.tasks.update(stored_task)
-        return bundle.replay.id, stored_task.result_session_id
+        replay = await services.replays.get_by_job_id(bundle.replay.job_id)
+        assert replay is not None
+        result_session_id = uuid.uuid4()
+        replay.link_result_session(result_session_id)
+        await services.replays.update(replay)
+        return bundle.replay.id, result_session_id
 
     wanted_replay_id, wanted_session_id = await replay_with_result_session()
     await replay_with_result_session()
@@ -848,7 +829,7 @@ async def test_list_replays_filters_by_result_session(
         actor=ACTOR,
     )
     assert [bundle.replay.id for bundle in matches] == [wanted_replay_id]
-    assert matches[0].result_session_id == wanted_session_id
+    assert matches[0].replay.result_session_id == wanted_session_id
 
     empty, _ = await services.replay_service.list_replays(
         ReplayFilter(
@@ -867,7 +848,6 @@ async def test_list_replays_filters_on_a_missing_result_session(
     """An is_null result session filter keeps the replays with no result yet."""
     agent_version = await _agent_version(services)
     await _evaluator(services)
-    worker = await create_worker(services.workers, ACTOR.account.id)
 
     baseline = await _session(services, agent_version)
     linked = await services.replay_service.create_replay(
@@ -877,19 +857,10 @@ async def test_list_replays_filters_on_a_missing_result_session(
         ),
         actor=ACTOR,
     )
-    tasks, _ = await services.task_service.list_tasks(
-        TaskFilter(job_id=linked.replay.job_id), actor=ACTOR
-    )
-    await services.task_service.claim_tasks(
-        10,
-        actor=WorkerAuthContext(
-            account=ACTOR.account, principal=WorkerPrincipal(worker_id=worker.id)
-        ),
-    )
-    stored_task = await services.tasks.get(tasks[0].id)
-    assert isinstance(stored_task, AgentTask)
-    stored_task.result_session_id = uuid.uuid4()
-    await services.tasks.update(stored_task)
+    replay = await services.replays.get_by_job_id(linked.replay.job_id)
+    assert replay is not None
+    replay.link_result_session(uuid.uuid4())
+    await services.replays.update(replay)
 
     other_baseline = await _session(services, agent_version)
     unlinked = await services.replay_service.create_replay(

--- a/tests/server/test_session_repository.py
+++ b/tests/server/test_session_repository.py
@@ -71,7 +71,6 @@ from kitaru.server.adapters.db.repositories.session_repository import (
     SQLSessionRepository,
 )
 from kitaru.server.adapters.db.repositories.tag_repository import SQLTagRepository
-from kitaru.server.adapters.db.repositories.task_repository import SQLTaskRepository
 from kitaru.server.application.interfaces.cohort_repository import CohortRepository
 from kitaru.server.application.interfaces.cohort_version_repository import (
     CohortVersionRepository,
@@ -79,6 +78,7 @@ from kitaru.server.application.interfaces.cohort_version_repository import (
 from kitaru.server.application.interfaces.evaluation_repository import (
     EvaluationRepository,
 )
+from kitaru.server.application.interfaces.replay_repository import ReplayRepository
 from kitaru.server.application.interfaces.session_repository import (
     SessionRepository,
 )
@@ -104,11 +104,11 @@ from kitaru.server.domain.session import (
     DuplicateSessionExternalId,
     Session,
     SessionInUse,
+    SessionInUseByReplay,
     SessionNotFound,
     SessionRollups,
 )
 from kitaru.server.domain.tag import Tag, TagLink
-from kitaru.server.domain.task import AgentTask
 from kitaru.server.filtering import (
     AndExpression,
     FilterCondition,
@@ -121,6 +121,9 @@ Setup = tuple[
 ]
 CohortSetup = tuple[
     SessionRepository, CohortRepository, CohortVersionRepository, uuid.UUID, uuid.UUID
+]
+ReplaySetup = tuple[
+    SessionRepository, ReplayRepository, uuid.UUID, uuid.UUID, uuid.UUID, uuid.UUID
 ]
 
 
@@ -690,6 +693,101 @@ async def test_delete_in_use_by_cohort_version(cohort_setup: CohortSetup) -> Non
         await sessions.delete(member.id)
 
 
+@pytest.fixture
+async def replay_setup() -> AsyncGenerator[ReplaySetup, None]:
+    """Provide a Postgres session repository and a replay's collaborators.
+
+    Yields a session repository, a replay repository sharing its backend,
+    an owner id, an agent id, a replay config id, and a job id.
+    """
+    if not await postgres_available():
+        pytest.skip("PostgreSQL is not reachable")
+    async with pg_session_with_engine() as (session, engine):
+        owner = await SQLAccountRepository(session).create(Account(name="owner"))
+        agent = await SQLAgentRepository(session).create(
+            Agent(owner_id=owner.id, name="assistant")
+        )
+        config = await SQLExperimentRepository(session).create_replay_config(
+            ReplayConfig(
+                owner_id=owner.id,
+                tool_policy=ToolPolicy(default=PassthroughConfig()),
+                evaluators=[],
+            )
+        )
+        job = await SQLJobRepository(session).create(
+            Job(owner_id=owner.id, kind=JobKind.REPLAY, status=JobStatus.PENDING)
+        )
+        yield (
+            SQLSessionRepository(session, engine),
+            SQLReplayRepository(session),
+            owner.id,
+            agent.id,
+            config.id,
+            job.id,
+        )
+
+
+async def test_delete_in_use_by_replay_as_baseline_session(
+    replay_setup: ReplaySetup,
+) -> None:
+    """Reject deleting a session that is a replay's baseline session."""
+    sessions, replays, owner_id, agent_id, config_id, job_id = replay_setup
+    baseline = await sessions.create(
+        Session(
+            owner_id=owner_id,
+            agent_id=agent_id,
+            number=1,
+            origin=SessionOrigin.RECORDED,
+        )
+    )
+    await replays.create(
+        Replay(
+            owner_id=owner_id,
+            job_id=job_id,
+            replay_config_id=config_id,
+            baseline_session_id=baseline.id,
+        )
+    )
+
+    with pytest.raises(SessionInUseByReplay):
+        await sessions.delete(baseline.id)
+
+
+async def test_delete_in_use_by_replay_as_result_session(
+    replay_setup: ReplaySetup,
+) -> None:
+    """Reject deleting a session that is a replay's result session."""
+    sessions, replays, owner_id, agent_id, config_id, job_id = replay_setup
+    baseline = await sessions.create(
+        Session(
+            owner_id=owner_id,
+            agent_id=agent_id,
+            number=1,
+            origin=SessionOrigin.RECORDED,
+        )
+    )
+    result = await sessions.create(
+        Session(
+            owner_id=owner_id,
+            agent_id=agent_id,
+            number=2,
+            origin=SessionOrigin.RECORDED,
+        )
+    )
+    await replays.create(
+        Replay(
+            owner_id=owner_id,
+            job_id=job_id,
+            replay_config_id=config_id,
+            baseline_session_id=baseline.id,
+            result_session_id=result.id,
+        )
+    )
+
+    with pytest.raises(SessionInUseByReplay):
+        await sessions.delete(result.id)
+
+
 async def test_apply_rollups_accumulates_deltas(setup: Setup) -> None:
     """Add deltas atomically, coalescing null cost and tokens to zero."""
     repository, owner_id, agent_id, _, _ = setup
@@ -929,10 +1027,10 @@ async def test_query_filters_by_cohort_version(cohort_setup: CohortSetup) -> Non
 async def test_query_filters_by_experiment_run() -> None:
     """Filter sessions produced as the results of a run's replays.
 
-    Postgres-only: the run is three hops from the session, reached through
-    the producing task's job and the replay that owns it.
+    Postgres-only: the run is reached through the replay row that links its
+    result session directly.
 
-    Matching through the task's result session is what keeps a run's
+    Matching through the replay's result session is what keeps a run's
     baseline sessions out of the result set, so that is asserted here.
     """
     if not await postgres_available():
@@ -981,7 +1079,6 @@ async def test_query_filters_by_experiment_run() -> None:
         repository = SQLSessionRepository(session, engine)
         jobs = SQLJobRepository(session)
         replays = SQLReplayRepository(session)
-        tasks = SQLTaskRepository(session)
 
         # Sessions are unique per agent and number, and every session here
         # belongs to the same agent.
@@ -1022,13 +1119,9 @@ async def test_query_filters_by_experiment_run() -> None:
                     experiment_run_id=experiment_run_id,
                     replay_config_id=config.id,
                     baseline_session_id=baseline.id,
+                    result_session_id=result.id,
                 )
             )
-            task = await tasks.create(
-                AgentTask(job_id=job.id, agent_version_id=agent_version.id)
-            )
-            task.link_result_session(result.id)
-            await tasks.update(task)
             return baseline, result
 
         baseline, result = await replay_in_run(run.id)

--- a/tests/server/test_session_service.py
+++ b/tests/server/test_session_service.py
@@ -738,6 +738,7 @@ async def test_create_session_requires_the_principals_task_to_be_running(
 
 async def test_create_session_rejects_a_stale_task_attempt(
     service: SessionService,
+    repository: FakeSessionRepository,
     task_repository: FakeTaskRepository,
     agent_repository: FakeAgentRepository,
     agent_version_repository: FakeAgentVersionRepository,
@@ -753,18 +754,17 @@ async def test_create_session_rejects_a_stale_task_attempt(
             SessionCreate(origin=SessionOrigin.RECORDED),
             actor=stale_actor,
         )
-    stored_task = await task_repository.get(task.id)
-    assert stored_task.result_session_id is None
+    assert await repository.get_by_task_id(task.id) is None
     session = await service.create_session(
         SessionCreate(origin=SessionOrigin.RECORDED),
         actor=_task_principal(task.id, attempt=task.attempt),
     )
-    stored_task = await task_repository.get(task.id)
-    assert stored_task.result_session_id == session.id
+    assert session.task_id == task.id
 
 
-async def test_create_session_links_an_agent_tasks_result_session(
+async def test_create_session_links_the_session_to_its_agent_task(
     service: SessionService,
+    repository: FakeSessionRepository,
     task_repository: FakeTaskRepository,
     agent_repository: FakeAgentRepository,
     agent_version_repository: FakeAgentVersionRepository,
@@ -776,8 +776,10 @@ async def test_create_session_links_an_agent_tasks_result_session(
         SessionCreate(origin=SessionOrigin.RECORDED),
         actor=_task_principal(task.id),
     )
-    stored_task = await task_repository.get(task.id)
-    assert stored_task.result_session_id == session.id
+    assert session.task_id == task.id
+    linked = await repository.get_by_task_id(task.id)
+    assert linked is not None
+    assert linked.id == session.id
 
 
 async def test_create_session_links_the_replays_result_session(
@@ -844,8 +846,6 @@ async def test_create_session_links_many_sessions_to_an_import_task(
     )
     assert first.task_id == task.id
     assert second.task_id == task.id
-    stored_task = await task_repository.get(task.id)
-    assert stored_task.result_session_id is None
 
 
 async def test_create_session_infers_agent_and_version_from_an_agent_task(

--- a/tests/server/test_session_service.py
+++ b/tests/server/test_session_service.py
@@ -29,6 +29,7 @@ from conftest import (
     create_agent_task,
     create_agent_version,
     create_import_task,
+    create_replay,
     create_session,
 )
 from kitaru.analytics.events import AnalyticsEvent
@@ -777,6 +778,31 @@ async def test_create_session_links_an_agent_tasks_result_session(
     )
     stored_task = await task_repository.get(task.id)
     assert stored_task.result_session_id == session.id
+
+
+async def test_create_session_links_the_replays_result_session(
+    service: SessionService,
+    task_repository: FakeTaskRepository,
+    agent_repository: FakeAgentRepository,
+    agent_version_repository: FakeAgentVersionRepository,
+    replay_repository: FakeReplayRepository,
+) -> None:
+    """Creating a session for a replay's agent task links it on the replay row."""
+    version = await _stored_agent_version(agent_repository, agent_version_repository)
+    task = await _running_agent_task(task_repository, version.id)
+    replay = await create_replay(
+        replay_repository,
+        ACTOR.account.id,
+        job_id=task.job_id,
+        replay_config_id=uuid.uuid4(),
+        baseline_session_id=uuid.uuid4(),
+    )
+    session = await service.create_session(
+        SessionCreate(origin=SessionOrigin.RECORDED),
+        actor=_task_principal(task.id),
+    )
+    stored_replay = await replay_repository.get(replay.id)
+    assert stored_replay.result_session_id == session.id
 
 
 async def test_create_session_rejects_a_second_link_to_an_agent_task(

--- a/tests/server/test_session_service.py
+++ b/tests/server/test_session_service.py
@@ -258,16 +258,17 @@ async def _replayed_session(
     baseline = await create_session(repository, ACTOR.account.id, uuid.uuid4())
     job_id = uuid.uuid4()
     task = await create_agent_task(task_repository, job_id)
+    result = await create_session(
+        repository, ACTOR.account.id, uuid.uuid4(), task_id=task.id
+    )
     await replay_repository.create(
         Replay(
             owner_id=ACTOR.account.id,
             job_id=job_id,
             replay_config_id=uuid.uuid4(),
             baseline_session_id=baseline.id,
+            result_session_id=result.id,
         )
-    )
-    result = await create_session(
-        repository, ACTOR.account.id, uuid.uuid4(), task_id=task.id
     )
     return baseline, result
 
@@ -282,6 +283,22 @@ async def test_get_baseline_session(
     baseline, result = await _replayed_session(
         repository, task_repository, replay_repository
     )
+    loaded = await service.get_baseline_session(result.id, actor=ACTOR)
+    assert loaded.id == baseline.id
+
+
+async def test_get_baseline_session_after_the_task_link_is_cleared(
+    service: SessionService,
+    repository: FakeSessionRepository,
+    task_repository: FakeTaskRepository,
+    replay_repository: FakeReplayRepository,
+) -> None:
+    """Resolve the baseline through the replay after a requeue unlinked the task."""
+    baseline, result = await _replayed_session(
+        repository, task_repository, replay_repository
+    )
+    result.unlink_task()
+    await repository.update(result)
     loaded = await service.get_baseline_session(result.id, actor=ACTOR)
     assert loaded.id == baseline.id
 

--- a/tests/server/test_sessions_api.py
+++ b/tests/server/test_sessions_api.py
@@ -727,8 +727,7 @@ async def test_create_session_links_the_agent_task_result_session(
     assert response.status_code == 201
     body = response.json()
 
-    stored_task = await task_repository.get(task.id)
-    assert str(stored_task.result_session_id) == body["id"]
+    assert body["task_id"] == str(task.id)
     assert body["agent_id"] == str(agent.id)
     assert body["agent_version_id"] == str(version.id)
 

--- a/tests/server/test_task_cancellation_pg.py
+++ b/tests/server/test_task_cancellation_pg.py
@@ -103,6 +103,7 @@ def _build_task_service(
         worker_repository=SQLWorkerRepository(session),
         session_repository=SQLSessionRepository(session, engine),
         job_repository=SQLJobRepository(session),
+        replay_repository=SQLReplayRepository(session),
         spec_builder=spec_builder,
         transitions=transitions,
         policy=policy,

--- a/tests/server/test_task_domain.py
+++ b/tests/server/test_task_domain.py
@@ -33,8 +33,6 @@ from kitaru.server.domain.task import (
     Task,
     TaskAttemptMismatch,
     TaskNotRunning,
-    TaskResultSessionAlreadyLinked,
-    TaskResultSessionMissing,
 )
 
 NOW = datetime(2026, 7, 29, 12, 0, tzinfo=UTC)
@@ -161,14 +159,12 @@ def test_requeue_drops_the_attempt_state() -> None:
     task.claimed_at = NOW
     task.heartbeat_at = NOW
     task.started_at = NOW
-    task.result_session_id = uuid.uuid4()
     task.requeue()
     assert task.attempt == 1
     assert task.worker_id is None
     assert task.claimed_at is None
     assert task.heartbeat_at is None
     assert task.started_at is None
-    assert task.result_session_id is None
 
 
 def test_request_cancel_leaves_an_in_flight_status_alone() -> None:
@@ -214,38 +210,6 @@ def test_creator_env_extras_pass() -> None:
     """Env extras outside the contract namespace are kept."""
     task = _task(env={"KITARU_SESSION_NAME": "run-1"})
     assert task.env == {"KITARU_SESSION_NAME": "run-1"}
-
-
-def test_agent_completion_requires_a_result_session() -> None:
-    """An agent task without a linked session cannot complete."""
-    task = AgentTask(
-        job_id=uuid.uuid4(),
-        agent_version_id=uuid.uuid4(),
-        status=TaskStatus.RUNNING,
-    )
-    with pytest.raises(TaskResultSessionMissing):
-        task.complete(None, NOW)
-    assert task.status is TaskStatus.RUNNING
-
-
-def test_agent_completion_needs_no_result_payload() -> None:
-    """A linked result session is the agent task's outcome, not its result."""
-    task = AgentTask(
-        job_id=uuid.uuid4(),
-        agent_version_id=uuid.uuid4(),
-        status=TaskStatus.RUNNING,
-    )
-    task.link_result_session(uuid.uuid4())
-    task.complete(None, NOW)
-    assert task.status is TaskStatus.COMPLETED
-
-
-def test_result_session_links_once() -> None:
-    """A second session cannot link to the same task."""
-    task = AgentTask(job_id=uuid.uuid4(), agent_version_id=uuid.uuid4())
-    task.link_result_session(uuid.uuid4())
-    with pytest.raises(TaskResultSessionAlreadyLinked):
-        task.link_result_session(uuid.uuid4())
 
 
 @pytest.mark.parametrize(

--- a/tests/server/test_task_repository.py
+++ b/tests/server/test_task_repository.py
@@ -734,7 +734,6 @@ async def test_stamp_cancel_requested_skips_terminal_tasks(setup: Setup) -> None
     completed = _agent_task(setup)
     completed.claim(setup.worker_id, datetime.now(UTC))
     completed.start(datetime.now(UTC))
-    completed.link_result_session(setup.session_id)
     completed.complete(None, datetime.now(UTC))
     stored_completed = await setup.tasks.create(completed)
 
@@ -756,7 +755,6 @@ async def test_stamp_heartbeats_writes_only_the_heartbeat_column(
     held = _agent_task(setup)
     held.claim(setup.worker_id, start)
     held.start(start)
-    held.link_result_session(setup.session_id)
     stored_held = await setup.tasks.create(held)
 
     canceling = _agent_task(setup)
@@ -795,7 +793,6 @@ async def test_stamp_heartbeats_writes_only_the_heartbeat_column(
     assert isinstance(reloaded_held, AgentTask)
     assert reloaded_held.heartbeat_at == now
     assert reloaded_held.status is TaskStatus.RUNNING
-    assert reloaded_held.result_session_id == setup.session_id
 
     reloaded_completed = await setup.tasks.get(stored_completed.id)
     assert reloaded_completed.heartbeat_at != now

--- a/tests/server/test_task_service.py
+++ b/tests/server/test_task_service.py
@@ -26,7 +26,9 @@ from conftest import (
     FakePluginRepository,
     FakeTaskRepository,
     JobAndTaskServices,
+    ReplayServices,
     build_job_and_task_services,
+    build_replay_services,
     build_task_actor,
     build_worker_actor,
     create_agent,
@@ -37,12 +39,13 @@ from conftest import (
     create_import_task,
     create_job,
     create_plugin,
+    create_replay,
     create_secret,
     create_session,
     create_worker,
 )
 from kitaru.analytics.events import AnalyticsEvent
-from kitaru.api_models.v1.job import JobStatus
+from kitaru.api_models.v1.job import JobKind, JobStatus
 from kitaru.api_models.v1.session import SessionStatus
 from kitaru.api_models.v1.task import (
     TaskKind,
@@ -84,7 +87,7 @@ def services() -> JobAndTaskServices:
     return build_job_and_task_services()
 
 
-async def _sweep_stale(services: JobAndTaskServices) -> None:
+async def _sweep_stale(services: JobAndTaskServices | ReplayServices) -> None:
     """Run the sweeper's stale rescue over every candidate task."""
     now = datetime.now(UTC)
     for task_id in await services.task_service.list_stale_task_ids(now):
@@ -483,17 +486,56 @@ async def test_sweep_requeue_unlinks_the_result_session(
     )
     stored = await services.tasks.get(task.id)
     assert isinstance(stored, AgentTask)
-    stored.result_session_id = session.id
     stored.claimed_at = datetime.now(UTC) - timedelta(hours=1)
     await services.tasks.update(stored)
 
     await _sweep_stale(services)
 
-    reloaded_task = await services.tasks.get(task.id)
-    assert isinstance(reloaded_task, AgentTask)
-    assert reloaded_task.result_session_id is None
     reloaded_session = await services.sessions.get(session.id)
     assert reloaded_session.task_id is None
+
+
+async def test_sweep_requeue_clears_the_replays_result_session() -> None:
+    """Requeuing a stale replay agent task also frees the replay's result session."""
+    services = build_replay_services()
+    job = await create_job(services.jobs, ACTOR.account.id, kind=JobKind.REPLAY)
+    agent = await create_agent(services.agents, ACTOR.account.id)
+    version = await create_agent_version(
+        services.agent_versions,
+        agent_id=agent.id,
+        owner_id=ACTOR.account.id,
+        run_spec=RunSpec(command="run.sh", timeout_seconds=60),
+    )
+    task = await create_agent_task(services.tasks, job.id, agent_version_id=version.id)
+    replay = await create_replay(
+        services.replays,
+        ACTOR.account.id,
+        job_id=job.id,
+        replay_config_id=uuid.uuid4(),
+        baseline_session_id=uuid.uuid4(),
+    )
+    worker = await create_worker(services.workers, ACTOR.account.id)
+    await services.task_service.claim_tasks(
+        10, actor=build_worker_actor(ACTOR.account, worker.id)
+    )
+
+    session = await create_session(
+        services.sessions, ACTOR.account.id, agent_id=agent.id, task_id=task.id
+    )
+    replay.link_result_session(session.id)
+    await services.replays.update(replay)
+
+    stored = await services.tasks.get(task.id)
+    assert isinstance(stored, AgentTask)
+    stored.claimed_at = datetime.now(UTC) - timedelta(hours=1)
+    await services.tasks.update(stored)
+
+    await _sweep_stale(services)
+
+    reloaded_session = await services.sessions.get(session.id)
+    assert reloaded_session.task_id is None
+    reloaded_replay = await services.replays.get(replay.id)
+    assert reloaded_replay.result_session_id is None
 
 
 async def test_sweep_stale_task_abandons_and_settles() -> None:
@@ -588,10 +630,6 @@ async def test_heartbeat_reports_terminal_tasks(services: JobAndTaskServices) ->
     session = await create_session(
         services.sessions, ACTOR.account.id, agent_id=uuid.uuid4(), task_id=task.id
     )
-    stored = await services.tasks.get(task.id)
-    assert isinstance(stored, AgentTask)
-    stored.result_session_id = session.id
-    await services.tasks.update(stored)
     session.status = SessionStatus.COMPLETED
     await services.sessions.update(session)
     await services.task_service.update_task(
@@ -662,10 +700,6 @@ async def test_agent_completion_requires_a_completed_result_session(
     session = await create_session(
         services.sessions, ACTOR.account.id, agent_id=uuid.uuid4(), task_id=task.id
     )
-    stored = await services.tasks.get(task.id)
-    assert isinstance(stored, AgentTask)
-    stored.result_session_id = session.id
-    await services.tasks.update(stored)
 
     with pytest.raises(TaskResultSessionNotCompleted):
         await services.task_service.update_task(
@@ -1014,7 +1048,6 @@ async def test_apply_status_agent_terminal_tracks_nothing() -> None:
         task, partial(Task.claim, worker_id=uuid.uuid4(), now=now)
     )
     started = await transitions.apply_status(claimed, partial(Task.start, now=now))
-    started.link_result_session(uuid.uuid4())
 
     completed = await transitions.apply_status(
         started, partial(Task.complete, result=None, now=now)

--- a/tests/server/test_ui_experiment_runs_api.py
+++ b/tests/server/test_ui_experiment_runs_api.py
@@ -40,7 +40,6 @@ from kitaru.server.application.services.evaluation_service import EvaluationServ
 from kitaru.server.domain.account import Account
 from kitaru.server.domain.evaluation import Evaluation
 from kitaru.server.domain.replay_config import ReplayConfig, default_tool_policy
-from kitaru.server.domain.task import AgentTask
 
 ACCOUNT = Account(id=uuid.uuid4(), name="ann")
 
@@ -108,13 +107,8 @@ async def _add_replay_with_result_session(
         baseline_session_id=baseline_session_id,
         experiment_run_id=run_id,
     )
-    await services.tasks.create(
-        AgentTask(
-            job_id=replay.job_id,
-            agent_version_id=uuid.uuid4(),
-            result_session_id=result_session_id,
-        )
-    )
+    replay.link_result_session(result_session_id)
+    await services.replays.update(replay)
     return replay.id
 
 

--- a/tests/server/test_workers_api.py
+++ b/tests/server/test_workers_api.py
@@ -118,6 +118,7 @@ async def client(
         worker_repository=repository,
         session_repository=FakeSessionRepository(),
         job_repository=job_repository,
+        replay_repository=FakeReplayRepository(),
         spec_builder=spec_builder,
         transitions=transitions,
         policy=task_policy,

--- a/tests/worker/fakes.py
+++ b/tests/worker/fakes.py
@@ -18,6 +18,7 @@ from collections import deque
 from datetime import UTC, datetime
 from typing import Any, cast
 
+from kitaru.api_models.v1.base import Page
 from kitaru.api_models.v1.job import JobKind, JobResponse, JobStatus
 from kitaru.api_models.v1.session import SessionOrigin, SessionResponse, SessionStatus
 from kitaru.api_models.v1.task import (
@@ -58,7 +59,6 @@ def make_task(
     status: TaskStatus = TaskStatus.CLAIMED,
     attempt: int = 1,
     job_id: uuid.UUID | None = None,
-    result_session_id: uuid.UUID | None = None,
     **overrides: Any,
 ) -> TaskResponse:
     """Build a task response with sane defaults for the fields tests vary.
@@ -68,7 +68,6 @@ def make_task(
         status: Task status.
         attempt: Current attempt number.
         job_id: Owning job, a fresh id when omitted.
-        result_session_id: Session an agent task produced.
         overrides: Additional fields to override on the response.
 
     Returns:
@@ -82,7 +81,6 @@ def make_task(
         "on_failure": TaskOnFailure.ABORT,
         "attempt": attempt,
         "labels": {},
-        "result_session_id": result_session_id,
         "result": None,
         "created": _now(),
         "updated": _now(),
@@ -418,14 +416,16 @@ class FakeSessionsResource:
     """Scriptable fake of the sessions SDK resource."""
 
     def __init__(self) -> None:
-        """Initialize the resource with an empty response map."""
-        self.get_calls: list[uuid.UUID] = []
-        self.responses: dict[uuid.UUID, Any] = {}
+        """Initialize the resource with empty scripted responses and call logs."""
+        self.list_calls: list[Any] = []
+        self.list_responses: deque[Any] = deque()
 
-    async def get(self, session_id: uuid.UUID) -> SessionResponse:
-        """Record the call and return the mapped session."""
-        self.get_calls.append(session_id)
-        result = self.responses[session_id]
+    async def list(self, params: Any = None) -> Page[SessionResponse]:
+        """Record the call and return the next scripted list result."""
+        self.list_calls.append(params)
+        if not self.list_responses:
+            raise AssertionError("No scripted list response for sessions")
+        result = self.list_responses.popleft()
         if isinstance(result, BaseException):
             raise result
         return result

--- a/tests/worker/test_task_runner.py
+++ b/tests/worker/test_task_runner.py
@@ -15,7 +15,6 @@
 
 import asyncio
 import json
-import uuid
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 
@@ -31,6 +30,7 @@ from fakes import (
     make_task,
 )
 
+from kitaru.api_models.v1.base import Page
 from kitaru.api_models.v1.session import SessionStatus
 from kitaru.api_models.v1.task import PackagePluginSpec, TaskKind, TaskStatus
 from kitaru.client.exceptions import (
@@ -490,12 +490,13 @@ async def test_completion_conflict_agent_without_result_session(
     """An agent completion conflict with no linked session names that fact."""
     _patch_run_task_process(monkeypatch, _fake_run_task_process(0))
     client = FakeKitaruAPIClient()
-    task = make_task(kind=TaskKind.AGENT, attempt=1, result_session_id=None)
+    task = make_task(kind=TaskKind.AGENT, attempt=1)
     spec = make_agent_spec(task.id)
     running_task = task.model_copy(update={"status": TaskStatus.RUNNING})
     client.tasks.update_responses.append(running_task)
     client.tasks.update_responses.append(APIError(409, "conflict"))
     client.tasks.get_responses.append(running_task)
+    client.sessions.list_responses.append(Page(items=[], next_cursor=None))
     client.tasks.update_responses.append(
         running_task.model_copy(update={"status": TaskStatus.FAILED})
     )
@@ -517,16 +518,14 @@ async def test_completion_conflict_agent_with_incomplete_session(
     """An agent completion conflict with a non-completed session names its status."""
     _patch_run_task_process(monkeypatch, _fake_run_task_process(0))
     client = FakeKitaruAPIClient()
-    session_id = uuid.uuid4()
-    task = make_task(kind=TaskKind.AGENT, attempt=1, result_session_id=session_id)
+    task = make_task(kind=TaskKind.AGENT, attempt=1)
     spec = make_agent_spec(task.id)
     running_task = task.model_copy(update={"status": TaskStatus.RUNNING})
     client.tasks.update_responses.append(running_task)
     client.tasks.update_responses.append(APIError(409, "conflict"))
     client.tasks.get_responses.append(running_task)
-    client.sessions.responses[session_id] = make_session_response(
-        id=session_id, status=SessionStatus.FAILED
-    )
+    session = make_session_response(status=SessionStatus.FAILED)
+    client.sessions.list_responses.append(Page(items=[session], next_cursor=None))
     client.tasks.update_responses.append(
         running_task.model_copy(update={"status": TaskStatus.FAILED})
     )
@@ -536,7 +535,7 @@ async def test_completion_conflict_agent_with_incomplete_session(
     )
 
     _, request = client.tasks.update_calls[-1]
-    assert request.error == f"Result session {session_id} is failed, not completed."
+    assert request.error == f"Result session {session.id} is failed, not completed."
 
 
 async def test_completion_conflict_non_agent_missing_result(


### PR DESCRIPTION
Store a replay's result session id on the replay table, derive an agent task's result session through the session's task link instead of a task column, and block deleting sessions a replay references.