### PR TITLE
User-defined idempotency keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - Added `POST /api/v1/workers/{worker_id}/token` to renew a worker token, and `kitaru worker list --include-stale` to list workers past the liveness window.
+- SDK methods that call an endpoint supporting idempotency now take an `idempotency_key` argument, so callers can supply their own key instead of the per-request key the transport generates. Those endpoints declare an `Idempotency-Key` header parameter in the OpenAPI schema.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Added `POST /api/v1/workers/{worker_id}/token` to renew a worker token, and `kitaru worker list --include-stale` to list workers past the liveness window.
 - SDK methods that call an endpoint supporting idempotency now take an `idempotency_key` argument, so callers can supply their own key instead of the per-request key the transport generates. Those endpoints declare an `Idempotency-Key` header parameter in the OpenAPI schema.
+- MCP tools that create a resource take an optional `idempotency_key` field, so a retried tool call whose response was lost returns the original result instead of acting twice.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Added `POST /api/v1/workers/{worker_id}/token` to renew a worker token, and `kitaru worker list --include-stale` to list workers past the liveness window.
 - SDK methods that call an endpoint supporting idempotency now take an `idempotency_key` argument, so callers can supply their own key instead of the per-request key the transport generates. Those endpoints declare an `Idempotency-Key` header parameter in the OpenAPI schema.
 - MCP tools that create a resource take an optional `idempotency_key` field, so a retried tool call whose response was lost returns the original result instead of acting twice.
+- CLI commands that create a single resource take `--idempotency-key`, so a retried invocation with the same key returns the original result instead of acting twice.
 
 ### Changed
 

--- a/docs/book/concepts/under-the-hood.md
+++ b/docs/book/concepts/under-the-hood.md
@@ -19,6 +19,14 @@ Between them sits the **job/task** layer. Commands like "replay this session," "
 
 Writes are safe to retry: the client stamps every POST request with an `Idempotency-Key` header, held stable across the transport's own retries, and the server stores the first committed response for that key, scoped to your account. A replay or evaluation request that times out on the wire and gets retried never becomes two replays: the retry gets the original response back, marked with an `Idempotent-Replayed: true` header instead of running again. Reusing a key with a different request body is rejected with 422. A failed request stores nothing, so a retry after an error re-executes normally. Stored keys expire after `KITARU_SERVER_IDEMPOTENCY_KEY_RETENTION_SECONDS` (15 minutes by default) and are cleared by the same sweep loop that requeues tasks.
 
+You can also supply the key yourself. Every SDK method that calls an endpoint supporting idempotency takes an `idempotency_key` argument, which replaces the generated one:
+
+```python
+await client.api.replays.create(request, idempotency_key=f"nightly-{date}")
+```
+
+The endpoints that honor a key are the ones whose OpenAPI operation declares an `Idempotency-Key` header parameter, and the SDK exposes the argument on exactly those methods. A key is at most 255 printable characters and is scoped to your account rather than to a user, so two members of one account choosing the same key collide. Calling again with the same key while the first call is still running returns 409. Retention applies to your own keys too, so they protect against retries and double submits inside the retention window rather than acting as a permanent uniqueness constraint.
+
 ## How replay works
 
 1. `POST /api/v1/replays` stores the replay (baseline session, agent version, override, tool policy, evaluators) and creates its job with one agent task.

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -9034,6 +9034,24 @@
       "post": {
         "description": "Create an agent.\n\nClients observe HTTP 201 on success, 409 when the name is already\nregistered, and 422 on invalid input.\n\nArgs:\n    body: Agent create request.\n    service: Agent service.\n    actor: Caller context.\n\nReturns:\n    Created agent.",
         "operationId": "create_agent_api_v1_agents_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -9331,6 +9349,22 @@
               "title": "Agent Id",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
           }
         ],
         "requestBody": {
@@ -9479,6 +9513,24 @@
       "post": {
         "description": "Create a manual annotation, or answer an investigation session.\n\nA body carrying session_id creates a manual annotation. A body carrying\ninvestigation_session_id answers an investigation session, moving a\npending investigation to in_progress on its first answer.\n\nClients observe HTTP 201 on success, 404 when the session or the\ninvestigation session does not exist, and 422 when the selector names a\nnode outside the session.\n\nArgs:\n    body: Manual annotation or investigation answer create request.\n    service: Annotation service.\n    actor: Caller context.\n\nReturns:\n    Created annotation.",
         "operationId": "create_annotation_api_v1_annotations_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -9764,6 +9816,24 @@
       "post": {
         "description": "Create an API key.\n\nClients observe HTTP 201 on success, 409 when the name is already\nregistered, and 422 on invalid input. The response carries the plaintext\nkey exactly once.\n\nArgs:\n    body: API key create request.\n    service: API key service.\n    actor: Caller context.\n\nReturns:\n    Created API key including the plaintext key.",
         "operationId": "create_api_key_api_v1_api_keys_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -9946,6 +10016,22 @@
               "format": "uuid",
               "title": "Api Key Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
             }
           }
         ],
@@ -10389,6 +10475,24 @@
       "post": {
         "description": "Create a cohort namespace.\n\nClients observe HTTP 201 on success, 404 when the agent does not exist,\n409 when the cohort name is already registered, and 422 on invalid\ninput.\n\nArgs:\n    body: Cohort create request.\n    service: Cohort service.\n    actor: Caller context.\n\nReturns:\n    Created cohort.",
         "operationId": "create_cohort_api_v1_cohorts_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -10685,6 +10789,22 @@
               "format": "uuid",
               "title": "Cohort Id",
               "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
             }
           }
         ],
@@ -11182,6 +11302,24 @@
       "post": {
         "description": "Score every input session with every evaluator, as one job.\n\nClients observe HTTP 201 on success, 404 when an evaluator or version\ndoes not exist, and 422 when the pair count exceeds the cap or an input\nsession does not exist.\n\nArgs:\n    body: Evaluation batch create request.\n    service: Job service.\n    actor: Caller context.\n\nReturns:\n    Created job.",
         "operationId": "create_evaluations_api_v1_evaluations_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -11372,6 +11510,24 @@
       "post": {
         "description": "Create an evaluator.\n\nClients observe HTTP 201 on success, 409 when the name is already\nregistered, and 422 on invalid input.\n\nArgs:\n    body: Evaluator create request.\n    service: Evaluator service.\n    actor: Caller context.\n\nReturns:\n    Created evaluator.",
         "operationId": "create_evaluator_api_v1_evaluators_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -12249,6 +12405,24 @@
       "post": {
         "description": "Create an experiment.\n\nClients observe HTTP 201 on success, 404 when the agent does not exist\nor an evaluator config names an unknown evaluator or version, 409 when\nthe name is already registered, and 422 on invalid input, including a\nduplicate resolved evaluator version.\n\nArgs:\n    body: Experiment create request.\n    service: Experiment service.\n    actor: Caller context.\n\nReturns:\n    Created experiment.",
         "operationId": "create_experiment_api_v1_experiments_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -12432,6 +12606,22 @@
               "title": "Experiment Id",
               "type": "string"
             }
+          },
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
           }
         ],
         "requestBody": {
@@ -12580,6 +12770,24 @@
       "post": {
         "description": "Create an importer.\n\nClients observe HTTP 201 on success, 409 when the name is already\nregistered, and 422 on invalid input.\n\nArgs:\n    body: Importer create request.\n    service: Importer service.\n    actor: Caller context.\n\nReturns:\n    Created importer.",
         "operationId": "create_importer_api_v1_importers_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13008,6 +13216,24 @@
       "post": {
         "description": "Import sessions from a payload blob, as a job holding one importer task.\n\nClients observe HTTP 201 on success and 404 when the importer, the\nversion, the payload blob, or the agent does not exist.\n\nArgs:\n    body: Import create request.\n    service: Job service.\n    actor: Caller context.\n\nReturns:\n    Created job.",
         "operationId": "create_import_api_v1_imports_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -13176,6 +13402,24 @@
       "post": {
         "description": "Create an investigation with its linked sessions in one shot.\n\nClients observe HTTP 201 on success, 404 when the agent does not exist,\nand 422 when a linked session id repeats, is missing, or belongs to a\ndifferent agent.\n\nArgs:\n    body: Investigation create request.\n    service: Investigation service.\n    actor: Caller context.\n\nReturns:\n    Created investigation.",
         "operationId": "create_investigation_api_v1_investigations_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -14004,6 +14248,24 @@
       "post": {
         "description": "Create a standalone replay of a recorded or imported session.\n\nClients observe HTTP 201 on success, 404 when the baseline session or\nthe resolved agent version or an evaluator config does not exist, and\n422 when the baseline session carries no agent version and none was\ngiven, the resolved agent version has no run spec, the tool policy uses\ncohort-version-scoped history, or an evaluator version repeats.\n\nArgs:\n    body: Replay create request.\n    service: Replay service.\n    actor: Caller context.\n\nReturns:\n    Created replay.",
         "operationId": "create_replay_api_v1_replays_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -14248,6 +14510,24 @@
       "post": {
         "description": "Create a secret.\n\nClients observe HTTP 201 on success, 409 when the name is already\nregistered, and 422 on invalid input. The response omits the secret\nvalues.\n\nArgs:\n    body: Secret create request.\n    service: Secret service.\n    actor: Caller context.\n\nReturns:\n    Created secret without values.",
         "operationId": "create_secret_api_v1_secrets_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -14439,6 +14719,24 @@
       "post": {
         "description": "Create a service account, active without credentials.\n\nClients observe HTTP 201 on success, 403 outside the ``local`` auth\nscheme and when the caller may not create accounts, 409 when the name is\nalready registered, and 422 on invalid input.\n\nArgs:\n    body: Service account create request.\n    service: Account service.\n    actor: Caller context.\n\nReturns:\n    Created account.",
         "operationId": "create_service_account_api_v1_service_accounts_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -14535,6 +14833,24 @@
       "post": {
         "description": "Run an agent version once, as a job holding one agent task.\n\nClients observe HTTP 201 on success, 404 when no agent version has this\nid, and 422 when the agent version carries no run spec.\n\nArgs:\n    body: Session run create request.\n    service: Job service.\n    actor: Caller context.\n\nReturns:\n    Created job.",
         "operationId": "create_session_run_api_v1_session_runs_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -14681,6 +14997,24 @@
       "post": {
         "description": "Create a session.\n\nA task principal's session is always linked to its own task, regardless\nof the request's task_id. Clients observe HTTP 201 on success, 409 when\nthe imported_from and external id pair is already registered, and 422 on\ninvalid input.\n\nArgs:\n    body: Session create request.\n    service: Session service.\n    actor: Caller context.\n\nReturns:\n    Created session.",
         "operationId": "create_session_api_v1_sessions_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -15204,6 +15538,24 @@
       "post": {
         "description": "Create a tag.\n\nClients observe HTTP 201 on success, 409 when the name is already\nregistered, and 422 on invalid input.\n\nArgs:\n    body: Tag create request.\n    service: Tag service.\n    actor: Caller context.\n\nReturns:\n    Created tag.",
         "operationId": "create_tag_api_v1_tags_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -15930,6 +16282,24 @@
       "post": {
         "description": "Create a user.\n\nA user created without a password starts inactive and its response\ncarries the activation token once.\n\nClients observe HTTP 201 on success, 403 outside the ``local`` auth\nscheme, 409 when the name is already registered, and 422 on invalid input.\n\nArgs:\n    body: User create request.\n    service: Account service.\n    actor: Caller context.\n\nReturns:\n    Created account.",
         "operationId": "create_user_api_v1_users_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Idempotency-Key"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -8518,7 +8518,9 @@ export interface operations {
     create_agent_api_v1_agents_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -8686,7 +8688,9 @@ export interface operations {
     create_agent_version_api_v1_agents__agent_id__versions_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path: {
                 agent_id: string;
             };
@@ -8759,7 +8763,9 @@ export interface operations {
     create_annotation_api_v1_annotations_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -8925,7 +8931,9 @@ export interface operations {
     create_api_key_api_v1_api_keys_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -9053,7 +9061,9 @@ export interface operations {
     rotate_api_key_api_v1_api_keys__api_key_id__rotate_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path: {
                 api_key_id: string;
             };
@@ -9345,7 +9355,9 @@ export interface operations {
     create_cohort_api_v1_cohorts_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -9513,7 +9525,9 @@ export interface operations {
     create_cohort_version_api_v1_cohorts__cohort_id__versions_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path: {
                 cohort_id: string;
             };
@@ -9789,7 +9803,9 @@ export interface operations {
     create_evaluations_api_v1_evaluations_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -9891,7 +9907,9 @@ export interface operations {
     create_evaluator_api_v1_evaluators_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -10367,7 +10385,9 @@ export interface operations {
     create_experiment_api_v1_experiments_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -10495,7 +10515,9 @@ export interface operations {
     start_run_api_v1_experiments__experiment_id__runs_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path: {
                 experiment_id: string;
             };
@@ -10568,7 +10590,9 @@ export interface operations {
     create_importer_api_v1_importers_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -10837,7 +10861,9 @@ export interface operations {
     create_import_api_v1_imports_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -10928,7 +10954,9 @@ export interface operations {
     create_investigation_api_v1_investigations_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -11395,7 +11423,9 @@ export interface operations {
     create_replay_api_v1_replays_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -11532,7 +11562,9 @@ export interface operations {
     create_secret_api_v1_secrets_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -11662,7 +11694,9 @@ export interface operations {
     create_service_account_api_v1_service_accounts_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -11730,7 +11764,9 @@ export interface operations {
     create_session_run_api_v1_session_runs_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -11801,7 +11837,9 @@ export interface operations {
     create_session_api_v1_sessions_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -12106,7 +12144,9 @@ export interface operations {
     create_tag_api_v1_tags_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };
@@ -12537,7 +12577,9 @@ export interface operations {
     create_user_api_v1_users_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };

--- a/src/kitaru/cli/annotations.py
+++ b/src/kitaru/cli/annotations.py
@@ -45,6 +45,7 @@ async def create_annotation(
     investigation_session_id: uuid.UUID | None,
     question_key: str | None,
     selector: str | None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create either a manual annotation or an investigation answer."""
     if (session_id is None) == (investigation_session_id is None):
@@ -90,7 +91,9 @@ async def create_annotation(
         if parsed_selector is not None:
             answer_fields["selector"] = parsed_selector
         request = InvestigationAnswerCreateRequest(**answer_fields)
-    annotation = await client.annotations.create(request)
+    annotation = await client.annotations.create(
+        request, idempotency_key=idempotency_key
+    )
     return CommandResult(item=annotation.model_dump(mode="json"))
 
 

--- a/src/kitaru/cli/app.py
+++ b/src/kitaru/cli/app.py
@@ -1098,6 +1098,14 @@ _WAIT_PARAMETERS = (
         "Local wait timeout; requires --wait.",
     ),
 )
+_IDEMPOTENCY_KEY_PARAMETER = ParameterSpec(
+    "--idempotency-key",
+    "string",
+    "option",
+    False,
+    "Retrying this exact invocation with the same key returns the original "
+    "result instead of acting twice.",
+)
 _AGENT_SOURCE_PARAMETERS = (
     ParameterSpec("--spec", "path", "option", False, "YAML or JSON spec document."),
     ParameterSpec(
@@ -1303,6 +1311,7 @@ async def agent_get(agent: str, /) -> CommandResult:
                 "--description", "string", "option", False, "Version description."
             ),
             *_AGENT_SOURCE_PARAMETERS,
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("reads_local_file", "creates_remote_state"),
@@ -1325,6 +1334,7 @@ async def agent_version_register(
     tool: list[str] | None = None,
     mcp_server: list[str] | None = None,
     skill: list[str] | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create the next server-assigned version of an exact agent."""
     if spec is not None:
@@ -1359,7 +1369,9 @@ async def agent_version_register(
             skills=skill,
         )
     async with _open_asset_client() as client:
-        return await registration.register_agent_version(client, agent, request)
+        return await registration.register_agent_version(
+            client, agent, request, idempotency_key=idempotency_key
+        )
 
 
 @_register(
@@ -1465,6 +1477,7 @@ async def agent_version_get(agent_version: str, /) -> CommandResult:
                 False,
                 "Display version for the membership snapshot.",
             ),
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("creates_remote_state",),
@@ -1488,6 +1501,7 @@ async def cohort_create(
         bool, Parameter(name="--all", help="Select all sessions.")
     ] = False,
     display_version: str | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create a cohort and optionally snapshot selected sessions."""
     async with _open_asset_client() as client:
@@ -1504,6 +1518,7 @@ async def cohort_create(
             filter=filter,
             all_sessions=all_sessions,
             display_version=display_version,
+            idempotency_key=idempotency_key,
         )
 
 
@@ -1670,6 +1685,7 @@ async def cohort_delete(cohort: str, /, *, force: bool = False) -> CommandResult
                 False,
                 "Human-readable version.",
             ),
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("creates_remote_state",),
@@ -1685,6 +1701,7 @@ async def cohort_version_create(
     remove_session: list[uuid.UUID] | None = None,
     baseline: uuid.UUID | None = None,
     display_version: str | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create an immutable version from an ordered membership delta."""
     async with _open_asset_client() as client:
@@ -1695,6 +1712,7 @@ async def cohort_version_create(
             remove_session_ids=remove_session,
             baseline_id=baseline,
             display_version=display_version,
+            idempotency_key=idempotency_key,
         )
 
 
@@ -1872,6 +1890,7 @@ async def cohort_version_delete(
                 False,
                 "Curated highlights for a question added with --session-question.",
             ),
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("creates_remote_state",),
@@ -1888,6 +1907,7 @@ async def investigation_create(
     session: list[uuid.UUID] | None = None,
     session_question: list[str] | None = None,
     session_highlights: list[str] | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create an investigation with its linked sessions."""
     async with _open_asset_client() as client:
@@ -1899,6 +1919,7 @@ async def investigation_create(
             session_ids=session or [],
             session_questions=session_question or [],
             session_highlights=session_highlights or [],
+            idempotency_key=idempotency_key,
         )
 
 
@@ -2123,6 +2144,7 @@ async def investigation_session_verdict(
                 "Optional node, JSON Pointer, or span selector.",
             ),
             ParameterSpec("--value", "JSON value", "option", True, "Annotation value."),
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("creates_remote_state",),
@@ -2137,6 +2159,7 @@ async def annotation_create(
     investigation_session: uuid.UUID | None = None,
     question_key: str | None = None,
     selector: str | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create one manual annotation or investigation answer."""
     async with _open_asset_client() as client:
@@ -2147,6 +2170,7 @@ async def annotation_create(
             investigation_session_id=investigation_session,
             question_key=question_key,
             selector=selector,
+            idempotency_key=idempotency_key,
         )
 
 
@@ -2283,6 +2307,7 @@ async def annotation_delete(
                 False,
                 "Parameters for a selected evaluator token.",
             ),
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("creates_remote_state",),
@@ -2300,6 +2325,7 @@ async def experiment_create(
     override: str | None = None,
     tool_policy: str | None = None,
     evaluator_params: list[str] | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create an experiment with exact evaluator versions."""
     async with _open_asset_client() as client:
@@ -2312,6 +2338,7 @@ async def experiment_create(
             tool_policy=tool_policy,
             evaluators=evaluator,
             evaluator_params=evaluator_params,
+            idempotency_key=idempotency_key,
         )
 
 
@@ -2537,6 +2564,7 @@ async def experiment_delete(
                 False,
                 "Also score the baseline session.",
             ),
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("creates_remote_state",),
@@ -2554,6 +2582,7 @@ async def replay_create(
     override: str | None = None,
     tool_policy: str | None = None,
     evaluate_baselines: bool = False,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create one standalone replay without waiting for its job."""
     async with _open_asset_client() as client:
@@ -2566,6 +2595,7 @@ async def replay_create(
             override=override,
             tool_policy=tool_policy,
             evaluate_baselines=evaluate_baselines,
+            idempotency_key=idempotency_key,
         )
 
 
@@ -2642,6 +2672,7 @@ async def replay_get(replay: uuid.UUID, /) -> CommandResult:
                 "Also score each baseline session.",
             ),
             *_WAIT_PARAMETERS,
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("creates_remote_state",),
@@ -2660,6 +2691,7 @@ async def experiment_run_start(
     wait: bool = False,
     interval: float | None = None,
     timeout: float | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Start one exact experiment run and optionally wait for it."""
     async with _open_asset_client() as client:
@@ -2672,6 +2704,7 @@ async def experiment_run_start(
             wait=wait,
             interval=interval,
             timeout=timeout,
+            idempotency_key=idempotency_key,
         )
 
 
@@ -2882,6 +2915,7 @@ async def _register_plugin_version_command(
     package: str | None,
     entrypoint: str | None,
     display_version: str | None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Run one kind-specific version registration."""
     source = registration.prepare_plugin_source(
@@ -2894,6 +2928,7 @@ async def _register_plugin_version_command(
             reference=reference,
             source=source,
             display_version=display_version,
+            idempotency_key=idempotency_key,
         )
 
 
@@ -3106,6 +3141,7 @@ async def importer_get(importer: str, /) -> CommandResult:
                 "IMPORTER", "reference", "argument", True, "Importer UUID or name."
             ),
             *_PLUGIN_SOURCE_PARAMETERS,
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("reads_local_file", "uploads_data", "creates_remote_state"),
@@ -3121,6 +3157,7 @@ async def importer_version_register(
     package: str | None = None,
     entrypoint: str | None = None,
     display_version: str | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create the next importer version."""
     return await _register_plugin_version_command(
@@ -3130,6 +3167,7 @@ async def importer_version_register(
         package=package,
         entrypoint=entrypoint,
         display_version=display_version,
+        idempotency_key=idempotency_key,
     )
 
 
@@ -3322,6 +3360,7 @@ async def evaluator_get(evaluator: str, /) -> CommandResult:
                 "EVALUATOR", "reference", "argument", True, "Evaluator UUID or name."
             ),
             *_PLUGIN_SOURCE_PARAMETERS,
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("reads_local_file", "uploads_data", "creates_remote_state"),
@@ -3337,6 +3376,7 @@ async def evaluator_version_register(
     package: str | None = None,
     entrypoint: str | None = None,
     display_version: str | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create the next evaluator version."""
     return await _register_plugin_version_command(
@@ -3346,6 +3386,7 @@ async def evaluator_version_register(
         package=package,
         entrypoint=entrypoint,
         display_version=display_version,
+        idempotency_key=idempotency_key,
     )
 
 
@@ -3445,6 +3486,7 @@ async def evaluator_version_get(evaluator_version: str, /) -> CommandResult:
                 "Payload media type.",
             ),
             *_WAIT_PARAMETERS,
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("uploads_data", "creates_remote_state"),
@@ -3469,6 +3511,7 @@ async def session_import(
     wait: bool = False,
     interval: float | None = None,
     timeout: float | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Upload a local payload and create one import job."""
     async with _open_asset_client() as client:
@@ -3484,6 +3527,7 @@ async def session_import(
             wait=wait,
             interval=interval,
             timeout=timeout,
+            idempotency_key=idempotency_key,
         )
 
 
@@ -3695,6 +3739,7 @@ async def session_nodes(
                 "Parameters for a selected evaluator token.",
             ),
             *_WAIT_PARAMETERS,
+            _IDEMPOTENCY_KEY_PARAMETER,
         ),
         read_only=False,
         side_effects=("reads_local_file", "creates_remote_state"),
@@ -3723,6 +3768,7 @@ async def session_evaluate(
     wait: bool = False,
     interval: float | None = None,
     timeout: float | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Evaluate sessions selected by ID, tag, or all sessions."""
     async with _open_asset_client() as client:
@@ -3740,6 +3786,7 @@ async def session_evaluate(
             wait=wait,
             interval=interval,
             timeout=timeout,
+            idempotency_key=idempotency_key,
         )
 
 

--- a/src/kitaru/cli/cohorts.py
+++ b/src/kitaru/cli/cohorts.py
@@ -56,6 +56,7 @@ async def create_cohort(
     filter: str | None = None,
     all_sessions: bool = False,
     display_version: str | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create a cohort and optionally its first selected membership version."""
     parsed_metadata = parse_json_object(metadata, option="--metadata")
@@ -92,7 +93,8 @@ async def create_cohort(
             description=description,
             agent_id=resolved_agent.id,
             metadata=parsed_metadata,
-        )
+        ),
+        idempotency_key=idempotency_key,
     )
     if selected_session_ids is None:
         return CommandResult(item=created_cohort.model_dump(mode="json"))
@@ -217,6 +219,7 @@ async def create_cohort_version(
     remove_session_ids: list[uuid.UUID] | None,
     display_version: str | None,
     baseline_id: uuid.UUID | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create an immutable version from an ordered membership delta."""
     additions = list(add_session_ids or [])
@@ -242,6 +245,7 @@ async def create_cohort_version(
             remove_session_ids=removals,
             display_version=display_version,
         ),
+        idempotency_key=idempotency_key,
     )
     warnings = []
     if not additions and not removals:

--- a/src/kitaru/cli/evaluations.py
+++ b/src/kitaru/cli/evaluations.py
@@ -226,6 +226,7 @@ async def evaluate_sessions(
     wait: bool,
     interval: float | None,
     timeout: float | None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create one evaluation job over selected session/version pairs."""
     wait_settings = receipts.get_wait_settings(
@@ -262,7 +263,7 @@ async def evaluate_sessions(
         input_session_ids=session_ids,
         evaluators=configs,
     )
-    job = await client.evaluations.create(request)
+    job = await client.evaluations.create(request, idempotency_key=idempotency_key)
     created = receipts.created_job_result(
         "session_evaluation",
         job,

--- a/src/kitaru/cli/experiment_runs.py
+++ b/src/kitaru/cli/experiment_runs.py
@@ -173,6 +173,7 @@ async def start_run(
     timeout: float | None,
     clock: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Start one run and optionally wait locally for terminal settlement."""
     wait_settings = get_wait_settings(wait=wait, interval=interval, timeout=timeout)
@@ -188,6 +189,7 @@ async def start_run(
             agent_version_id=agent_version.id,
             evaluate_baselines=evaluate_baselines,
         ),
+        idempotency_key=idempotency_key,
     )
     experiment_identity = _experiment_identity(experiment)
     cohort_version_identity = _cohort_version_identity(cohort_version)

--- a/src/kitaru/cli/experiments.py
+++ b/src/kitaru/cli/experiments.py
@@ -41,6 +41,7 @@ async def create_experiment(
     tool_policy: str | None,
     evaluators: Sequence[str],
     evaluator_params: Sequence[str] | None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create an experiment with exact evaluator versions."""
     resolved_agent = await resolve_asset(client.agents, agent, "Agent")
@@ -56,7 +57,9 @@ async def create_experiment(
     )
     fields["evaluators"] = configs
 
-    experiment = await client.experiments.create(ExperimentCreateRequest(**fields))
+    experiment = await client.experiments.create(
+        ExperimentCreateRequest(**fields), idempotency_key=idempotency_key
+    )
     return CommandResult(item=experiment.model_dump(mode="json"))
 
 

--- a/src/kitaru/cli/investigations.py
+++ b/src/kitaru/cli/investigations.py
@@ -138,6 +138,7 @@ async def create_investigation(
     session_ids: list[uuid.UUID],
     session_questions: list[str],
     session_highlights: list[str],
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create an investigation with linked sessions."""
     if len(set(session_ids)) != len(session_ids):
@@ -172,7 +173,8 @@ async def create_investigation(
             name=name,
             description=description,
             sessions=sessions,
-        )
+        ),
+        idempotency_key=idempotency_key,
     )
     review_url: str | None = None
     warnings: list[str] = []

--- a/src/kitaru/cli/registration.py
+++ b/src/kitaru/cli/registration.py
@@ -557,11 +557,16 @@ async def register_agent(
 
 
 async def register_agent_version(
-    client: Any, reference: str, request: AgentVersionCreateRequest
+    client: Any,
+    reference: str,
+    request: AgentVersionCreateRequest,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Resolve an agent and create its next server-assigned version."""
     parent = await resolve_asset(client.agents, reference, "Agent")
-    version = await client.agents.create_version(parent.id, request)
+    version = await client.agents.create_version(
+        parent.id, request, idempotency_key=idempotency_key
+    )
     return _registration_result("agent", parent, version)
 
 
@@ -609,6 +614,7 @@ async def register_plugin_version(
     reference: str,
     source: PluginSourceInput,
     display_version: str | None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Resolve a plugin parent, upload if needed, and create a version."""
     resource = _plugin_resource(client, kind)
@@ -623,6 +629,7 @@ async def register_plugin_version(
         version = await resource.create_version(
             parent.id,
             request_type(source=plugin_source, display_version=display_version),
+            idempotency_key=idempotency_key,
         )
     except Exception as error:
         if blob is None:

--- a/src/kitaru/cli/replays.py
+++ b/src/kitaru/cli/replays.py
@@ -31,6 +31,7 @@ async def create_replay(
     override: str | None,
     tool_policy: str | None,
     evaluate_baselines: bool,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Create one standalone replay with exact evaluator versions."""
     fields: dict[str, Any] = {"baseline_session_id": baseline_session_id}
@@ -47,7 +48,9 @@ async def create_replay(
     fields["evaluators"] = configs
     fields["evaluate_baselines"] = evaluate_baselines
 
-    replay = await client.replays.create(ReplayCreateRequest(**fields))
+    replay = await client.replays.create(
+        ReplayCreateRequest(**fields), idempotency_key=idempotency_key
+    )
     return CommandResult(
         item=replay.model_dump(mode="json"),
         event="created",

--- a/src/kitaru/cli/sessions.py
+++ b/src/kitaru/cli/sessions.py
@@ -249,6 +249,7 @@ async def import_sessions(
     interval: float | None,
     timeout: float | None,
     join_on: str | None = None,
+    idempotency_key: str | None = None,
 ) -> CommandResult:
     """Upload a local payload and create one import job."""
     tags = _normalize_import_tags(tags, wait=wait)
@@ -314,7 +315,7 @@ async def import_sessions(
         params=parsed_params,
     )
     try:
-        job = await client.imports.create(request)
+        job = await client.imports.create(request, idempotency_key=idempotency_key)
     except APIError as error:
         raise CLIError(
             "partial_failure",

--- a/src/kitaru/client/api_client.py
+++ b/src/kitaru/client/api_client.py
@@ -64,7 +64,7 @@ from kitaru.client.resources.tasks import TasksResource
 from kitaru.client.resources.users import UsersResource
 from kitaru.client.resources.workers import WorkersResource
 from kitaru.headers import CLIENT_HEADER, SKILL_HEADER, format_client_header
-from kitaru.transport import build_async_client
+from kitaru.transport import IDEMPOTENCY_KEY_HEADER, build_async_client
 
 
 class KitaruAPIClient:
@@ -255,6 +255,7 @@ class KitaruAPIClient:
         files: dict[str, tuple[str | None, bytes, str]] | None = None,
         content: bytes | AsyncIterable[bytes] | None = None,
         headers: dict[str, str] | None = None,
+        idempotency_key: str | None = None,
         authenticate: bool = True,
     ) -> httpx.Response:
         """Send a request and raise a typed error on failure.
@@ -269,6 +270,8 @@ class KitaruAPIClient:
                 field.
             content: Raw or streaming request body.
             headers: Additional request headers.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
             authenticate: Whether to send the request through this client's
                 auth flow. The login endpoints send their own credential.
 
@@ -283,6 +286,8 @@ class KitaruAPIClient:
             # httpx renders None query values as empty strings, which the
             # server rejects for typed filters.
             params = {key: value for key, value in params.items() if value is not None}
+        if idempotency_key is not None:
+            headers = {**(headers or {}), IDEMPOTENCY_KEY_HEADER: idempotency_key}
         if self._request_headers:
             headers = {**self._request_headers, **(headers or {})}
         response = await self._http.request(

--- a/src/kitaru/client/resources/agents.py
+++ b/src/kitaru/client/resources/agents.py
@@ -46,11 +46,15 @@ class AgentsResource:
         """
         self._client = client
 
-    async def create(self, request: AgentCreateRequest) -> AgentResponse:
+    async def create(
+        self, request: AgentCreateRequest, idempotency_key: str | None = None
+    ) -> AgentResponse:
         """Create an agent.
 
         Args:
             request: Agent create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 409 for a duplicate name.
@@ -62,6 +66,7 @@ class AgentsResource:
             "POST",
             "/api/v1/agents",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return AgentResponse.model_validate(response.json())
 
@@ -156,13 +161,18 @@ class AgentsResource:
         await self._client.request("DELETE", f"/api/v1/agents/{agent_id}")
 
     async def create_version(
-        self, agent_id: uuid.UUID, request: AgentVersionCreateRequest
+        self,
+        agent_id: uuid.UUID,
+        request: AgentVersionCreateRequest,
+        idempotency_key: str | None = None,
     ) -> AgentVersionResponse:
         """Create a new version of an agent.
 
         Args:
             agent_id: Id of the agent.
             request: Agent version create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 404 for a missing agent.
@@ -174,6 +184,7 @@ class AgentsResource:
             "POST",
             f"/api/v1/agents/{agent_id}/versions",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return AgentVersionResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/annotations.py
+++ b/src/kitaru/client/resources/annotations.py
@@ -41,11 +41,15 @@ class AnnotationsResource:
         """
         self._client = client
 
-    async def create(self, request: AnnotationCreateRequest) -> AnnotationResponse:
+    async def create(
+        self, request: AnnotationCreateRequest, idempotency_key: str | None = None
+    ) -> AnnotationResponse:
         """Create an annotation, either manual or answering an investigation question.
 
         Args:
             request: Annotation create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 404 when the session or
@@ -58,6 +62,7 @@ class AnnotationsResource:
             "POST",
             "/api/v1/annotations",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return AnnotationResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/api_keys.py
+++ b/src/kitaru/client/resources/api_keys.py
@@ -43,13 +43,17 @@ class ApiKeysResource:
         """
         self._client = client
 
-    async def create(self, request: ApiKeyCreateRequest) -> ApiKeyIssuedResponse:
+    async def create(
+        self, request: ApiKeyCreateRequest, idempotency_key: str | None = None
+    ) -> ApiKeyIssuedResponse:
         """Create an API key.
 
         The response carries the plaintext key exactly once.
 
         Args:
             request: API key create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 409 for a duplicate name.
@@ -61,6 +65,7 @@ class ApiKeysResource:
             "POST",
             "/api/v1/api-keys",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return ApiKeyIssuedResponse.model_validate(response.json())
 
@@ -143,7 +148,10 @@ class ApiKeysResource:
         return ApiKeyResponse.model_validate(response.json())
 
     async def rotate(
-        self, api_key_id: uuid.UUID, request: ApiKeyRotateRequest | None = None
+        self,
+        api_key_id: uuid.UUID,
+        request: ApiKeyRotateRequest | None = None,
+        idempotency_key: str | None = None,
     ) -> ApiKeyIssuedResponse:
         """Rotate an API key.
 
@@ -152,6 +160,8 @@ class ApiKeysResource:
         Args:
             api_key_id: Id of the API key.
             request: API key rotate request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 404 for a missing API key.
@@ -164,6 +174,7 @@ class ApiKeysResource:
             "POST",
             f"/api/v1/api-keys/{api_key_id}/rotate",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return ApiKeyIssuedResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/cohorts.py
+++ b/src/kitaru/client/resources/cohorts.py
@@ -46,11 +46,15 @@ class CohortsResource:
         """
         self._client = client
 
-    async def create(self, request: CohortCreateRequest) -> CohortResponse:
+    async def create(
+        self, request: CohortCreateRequest, idempotency_key: str | None = None
+    ) -> CohortResponse:
         """Create a cohort.
 
         Args:
             request: Cohort create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 404 when the agent does
@@ -64,6 +68,7 @@ class CohortsResource:
             "POST",
             "/api/v1/cohorts",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return CohortResponse.model_validate(response.json())
 
@@ -160,13 +165,18 @@ class CohortsResource:
         await self._client.request("DELETE", f"/api/v1/cohorts/{cohort_id}")
 
     async def create_version(
-        self, cohort_id: uuid.UUID, request: CohortVersionCreateRequest
+        self,
+        cohort_id: uuid.UUID,
+        request: CohortVersionCreateRequest,
+        idempotency_key: str | None = None,
     ) -> CohortVersionResponse:
         """Create a new version of a cohort.
 
         Args:
             cohort_id: Id of the cohort.
             request: Cohort version create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 404 for a missing
@@ -180,6 +190,7 @@ class CohortsResource:
             "POST",
             f"/api/v1/cohorts/{cohort_id}/versions",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return CohortVersionResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/evaluations.py
+++ b/src/kitaru/client/resources/evaluations.py
@@ -41,11 +41,15 @@ class EvaluationsResource:
         """
         self._client = client
 
-    async def create(self, request: EvaluationBatchCreateRequest) -> JobResponse:
+    async def create(
+        self, request: EvaluationBatchCreateRequest, idempotency_key: str | None = None
+    ) -> JobResponse:
         """Score every input session with every evaluator.
 
         Args:
             request: Evaluation batch create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 422 when the pair count
@@ -58,6 +62,7 @@ class EvaluationsResource:
             "POST",
             "/api/v1/evaluations",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return JobResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/evaluators.py
+++ b/src/kitaru/client/resources/evaluators.py
@@ -44,11 +44,15 @@ class EvaluatorsResource:
         """
         self._client = client
 
-    async def create(self, request: EvaluatorCreateRequest) -> EvaluatorResponse:
+    async def create(
+        self, request: EvaluatorCreateRequest, idempotency_key: str | None = None
+    ) -> EvaluatorResponse:
         """Create an evaluator.
 
         Args:
             request: Evaluator create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 409 for a duplicate name.
@@ -60,6 +64,7 @@ class EvaluatorsResource:
             "POST",
             "/api/v1/evaluators",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return EvaluatorResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/experiments.py
+++ b/src/kitaru/client/resources/experiments.py
@@ -45,11 +45,15 @@ class ExperimentsResource:
         """
         self._client = client
 
-    async def create(self, request: ExperimentCreateRequest) -> ExperimentResponse:
+    async def create(
+        self, request: ExperimentCreateRequest, idempotency_key: str | None = None
+    ) -> ExperimentResponse:
         """Create an experiment.
 
         Args:
             request: Experiment create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 404 when the agent does
@@ -63,6 +67,7 @@ class ExperimentsResource:
             "POST",
             "/api/v1/experiments",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return ExperimentResponse.model_validate(response.json())
 
@@ -159,13 +164,18 @@ class ExperimentsResource:
         await self._client.request("DELETE", f"/api/v1/experiments/{experiment_id}")
 
     async def start_run(
-        self, experiment_id: uuid.UUID, request: ExperimentRunCreateRequest
+        self,
+        experiment_id: uuid.UUID,
+        request: ExperimentRunCreateRequest,
+        idempotency_key: str | None = None,
     ) -> ExperimentRunResponse:
         """Start an experiment run, fanning out one replay per cohort version session.
 
         Args:
             experiment_id: Id of the experiment.
             request: Experiment run create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 404 for a missing
@@ -180,5 +190,6 @@ class ExperimentsResource:
             "POST",
             f"/api/v1/experiments/{experiment_id}/runs",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return ExperimentRunResponse.model_validate(response.json())

--- a/src/kitaru/client/resources/importers.py
+++ b/src/kitaru/client/resources/importers.py
@@ -44,11 +44,15 @@ class ImportersResource:
         """
         self._client = client
 
-    async def create(self, request: ImporterCreateRequest) -> ImporterResponse:
+    async def create(
+        self, request: ImporterCreateRequest, idempotency_key: str | None = None
+    ) -> ImporterResponse:
         """Create an importer.
 
         Args:
             request: Importer create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 409 for a duplicate name.
@@ -60,6 +64,7 @@ class ImportersResource:
             "POST",
             "/api/v1/importers",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return ImporterResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/imports.py
+++ b/src/kitaru/client/resources/imports.py
@@ -33,11 +33,15 @@ class ImportsResource:
         """
         self._client = client
 
-    async def create(self, request: ImportCreateRequest) -> JobResponse:
+    async def create(
+        self, request: ImportCreateRequest, idempotency_key: str | None = None
+    ) -> JobResponse:
         """Import sessions from a payload blob.
 
         Args:
             request: Import create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 404 when the importer,
@@ -50,5 +54,6 @@ class ImportsResource:
             "POST",
             "/api/v1/imports",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return JobResponse.model_validate(response.json())

--- a/src/kitaru/client/resources/investigations.py
+++ b/src/kitaru/client/resources/investigations.py
@@ -45,12 +45,16 @@ class InvestigationsResource:
         self._client = client
 
     async def create(
-        self, request: InvestigationCreateRequest
+        self,
+        request: InvestigationCreateRequest,
+        idempotency_key: str | None = None,
     ) -> InvestigationResponse:
         """Create an investigation with its sessions in one shot.
 
         Args:
             request: Investigation create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 404 when the agent or a
@@ -63,6 +67,7 @@ class InvestigationsResource:
             "POST",
             "/api/v1/investigations",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return InvestigationResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/replays.py
+++ b/src/kitaru/client/resources/replays.py
@@ -42,11 +42,15 @@ class ReplaysResource:
         """
         self._client = client
 
-    async def create(self, request: ReplayCreateRequest) -> ReplayResponse:
+    async def create(
+        self, request: ReplayCreateRequest, idempotency_key: str | None = None
+    ) -> ReplayResponse:
         """Create a standalone replay of a recorded or imported session.
 
         Args:
             request: Replay create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 404 for a missing
@@ -61,6 +65,7 @@ class ReplaysResource:
             "POST",
             "/api/v1/replays",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return ReplayResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/secrets.py
+++ b/src/kitaru/client/resources/secrets.py
@@ -42,11 +42,15 @@ class SecretsResource:
         """
         self._client = client
 
-    async def create(self, request: SecretCreateRequest) -> SecretResponse:
+    async def create(
+        self, request: SecretCreateRequest, idempotency_key: str | None = None
+    ) -> SecretResponse:
         """Create a secret.
 
         Args:
             request: Secret create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 409 for a duplicate name.
@@ -58,6 +62,7 @@ class SecretsResource:
             "POST",
             "/api/v1/secrets",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return SecretResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/service_accounts.py
+++ b/src/kitaru/client/resources/service_accounts.py
@@ -37,11 +37,15 @@ class ServiceAccountsResource:
         """
         self._client = client
 
-    async def create(self, request: ServiceAccountCreateRequest) -> AccountResponse:
+    async def create(
+        self, request: ServiceAccountCreateRequest, idempotency_key: str | None = None
+    ) -> AccountResponse:
         """Create a service account.
 
         Args:
             request: Service account create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 409 for a duplicate name.
@@ -53,6 +57,7 @@ class ServiceAccountsResource:
             "POST",
             "/api/v1/service-accounts",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return AccountResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/session_runs.py
+++ b/src/kitaru/client/resources/session_runs.py
@@ -33,11 +33,15 @@ class SessionRunsResource:
         """
         self._client = client
 
-    async def create(self, request: SessionRunCreateRequest) -> JobResponse:
+    async def create(
+        self, request: SessionRunCreateRequest, idempotency_key: str | None = None
+    ) -> JobResponse:
         """Run an agent version once.
 
         Args:
             request: Session run create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 422 when the agent
@@ -50,5 +54,6 @@ class SessionRunsResource:
             "POST",
             "/api/v1/session-runs",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return JobResponse.model_validate(response.json())

--- a/src/kitaru/client/resources/sessions.py
+++ b/src/kitaru/client/resources/sessions.py
@@ -49,11 +49,15 @@ class SessionsResource:
         """
         self._client = client
 
-    async def create(self, request: SessionCreateRequest) -> SessionResponse:
+    async def create(
+        self, request: SessionCreateRequest, idempotency_key: str | None = None
+    ) -> SessionResponse:
         """Create a session.
 
         Args:
             request: Session create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 409 for a duplicate
@@ -66,6 +70,7 @@ class SessionsResource:
             "POST",
             "/api/v1/sessions",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return SessionResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/tags.py
+++ b/src/kitaru/client/resources/tags.py
@@ -44,11 +44,15 @@ class TagsResource:
         """
         self._client = client
 
-    async def create(self, request: TagCreateRequest) -> TagResponse:
+    async def create(
+        self, request: TagCreateRequest, idempotency_key: str | None = None
+    ) -> TagResponse:
         """Create a tag.
 
         Args:
             request: Tag create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 409 for a duplicate name.
@@ -60,6 +64,7 @@ class TagsResource:
             "POST",
             "/api/v1/tags",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         return TagResponse.model_validate(response.json())
 

--- a/src/kitaru/client/resources/users.py
+++ b/src/kitaru/client/resources/users.py
@@ -40,12 +40,14 @@ class UsersResource:
         self._client = client
 
     async def create(
-        self, request: UserCreateRequest
+        self, request: UserCreateRequest, idempotency_key: str | None = None
     ) -> AccountResponse | UserActivationTokenResponse:
         """Create a user.
 
         Args:
             request: User create request.
+            idempotency_key: Idempotency key overriding the transport's
+                random default.
 
         Raises:
             APIError: The request failed, including 409 for a duplicate name.
@@ -58,6 +60,7 @@ class UsersResource:
             "POST",
             "/api/v1/users",
             json=request.model_dump(mode="json", exclude_unset=True),
+            idempotency_key=idempotency_key,
         )
         payload = response.json()
         if "activation_token" in payload:

--- a/src/kitaru/mcp/models/common.py
+++ b/src/kitaru/mcp/models/common.py
@@ -38,6 +38,13 @@ class MCPModel(BaseModel):
     model_config = ConfigDict(extra="forbid", protected_namespaces=())
 
 
+IDEMPOTENCY_KEY_DESCRIPTION = (
+    "Pass a fresh unique string per logical request. Reuse it only when "
+    "retrying this exact call after a lost or failed response, so the retry "
+    "returns the original result instead of acting twice."
+)
+
+
 class PageOptions(MCPModel):
     """Bounded one-page request options."""
 

--- a/src/kitaru/mcp/models/evaluators.py
+++ b/src/kitaru/mcp/models/evaluators.py
@@ -14,7 +14,7 @@ from kitaru.api_models.v1.plugin import (
     PluginSource,
     ScriptPluginSource,
 )
-from kitaru.mcp.models.common import MCPModel
+from kitaru.mcp.models.common import IDEMPOTENCY_KEY_DESCRIPTION, MCPModel
 
 
 class EvaluatorCreate(MCPModel):
@@ -24,6 +24,10 @@ class EvaluatorCreate(MCPModel):
     name: str = Field(min_length=1)
     description: str | None = None
     metadata: dict[str, JsonValue] = Field(default_factory=dict)
+    idempotency_key: str | None = Field(
+        default=None,
+        description=IDEMPOTENCY_KEY_DESCRIPTION,
+    )
 
 
 class EvaluatorUpdate(MCPModel):

--- a/src/kitaru/mcp/models/management.py
+++ b/src/kitaru/mcp/models/management.py
@@ -10,7 +10,7 @@ from pydantic import Field, model_validator
 
 from kitaru.api_models.v1.base import JsonValue
 from kitaru.api_models.v1.replay_config import ReplayOverride, ToolPolicy
-from kitaru.mcp.models.common import MCPModel
+from kitaru.mcp.models.common import IDEMPOTENCY_KEY_DESCRIPTION, MCPModel
 
 
 class EvaluatorSelection(MCPModel):
@@ -29,6 +29,10 @@ class CohortCreate(MCPModel):
     name: str = Field(min_length=1)
     description: str | None = None
     metadata: dict[str, JsonValue] = Field(default_factory=dict)
+    idempotency_key: str | None = Field(
+        default=None,
+        description=IDEMPOTENCY_KEY_DESCRIPTION,
+    )
 
 
 class CohortUpdate(MCPModel):
@@ -71,6 +75,10 @@ class CohortVersionCreate(MCPModel):
     add_session_ids: list[uuid.UUID] = Field(default_factory=list)
     remove_session_ids: list[uuid.UUID] = Field(default_factory=list)
     display_version: str | None = None
+    idempotency_key: str | None = Field(
+        default=None,
+        description=IDEMPOTENCY_KEY_DESCRIPTION,
+    )
 
     @model_validator(mode="after")
     def _validate_membership(self) -> "CohortVersionCreate":
@@ -116,6 +124,10 @@ class ExperimentCreate(MCPModel):
     override: ReplayOverride | None = None
     tool_policy: ToolPolicy | None = None
     evaluators: list[EvaluatorSelection] = Field(min_length=1, max_length=10)
+    idempotency_key: str | None = Field(
+        default=None,
+        description=IDEMPOTENCY_KEY_DESCRIPTION,
+    )
 
 
 class ExperimentUpdate(MCPModel):

--- a/src/kitaru/mcp/models/review.py
+++ b/src/kitaru/mcp/models/review.py
@@ -17,7 +17,11 @@ from kitaru.api_models.v1.investigation import (
     InvestigationStatus,
 )
 from kitaru.api_models.v1.tag import TagResourceType
-from kitaru.mcp.models.common import MCPModel, PageOptions
+from kitaru.mcp.models.common import (
+    IDEMPOTENCY_KEY_DESCRIPTION,
+    MCPModel,
+    PageOptions,
+)
 
 ReviewKind = Literal["investigation", "annotation"]
 
@@ -61,6 +65,10 @@ class InvestigationCreate(MCPModel):
     name: str = Field(min_length=1)
     description: str | None = None
     sessions: list[InvestigationSessionInput] = Field(max_length=100)
+    idempotency_key: str | None = Field(
+        default=None,
+        description=IDEMPOTENCY_KEY_DESCRIPTION,
+    )
 
     @model_validator(mode="after")
     def _validate_contents(self) -> "InvestigationCreate":
@@ -117,6 +125,10 @@ class ManualAnnotationCreate(MCPModel):
     session_id: uuid.UUID
     selector: AnnotationSelector | None = None
     value: JsonValue = Field()
+    idempotency_key: str | None = Field(
+        default=None,
+        description=IDEMPOTENCY_KEY_DESCRIPTION,
+    )
 
 
 class InvestigationAnswerCreate(MCPModel):
@@ -127,6 +139,10 @@ class InvestigationAnswerCreate(MCPModel):
     question_key: str
     selector: AnnotationSelector | None = None
     value: JsonValue = Field()
+    idempotency_key: str | None = Field(
+        default=None,
+        description=IDEMPOTENCY_KEY_DESCRIPTION,
+    )
 
 
 class AnnotationUpdate(MCPModel):
@@ -142,6 +158,10 @@ class TagCreate(MCPModel):
 
     operation: Literal["create_tag"]
     name: str = Field(min_length=1)
+    idempotency_key: str | None = Field(
+        default=None,
+        description=IDEMPOTENCY_KEY_DESCRIPTION,
+    )
 
 
 class TagUpdate(MCPModel):

--- a/src/kitaru/mcp/models/workflows.py
+++ b/src/kitaru/mcp/models/workflows.py
@@ -10,7 +10,7 @@ from pydantic import Field, model_validator
 
 from kitaru.api_models.v1.base import JsonValue
 from kitaru.api_models.v1.tag import TagResourceType
-from kitaru.mcp.models.common import DeleteKind, MCPModel
+from kitaru.mcp.models.common import IDEMPOTENCY_KEY_DESCRIPTION, DeleteKind, MCPModel
 from kitaru.mcp.models.management import EvaluatorSelection
 
 
@@ -22,6 +22,10 @@ class SessionImportRequest(MCPModel):
     importer_version: int = Field(ge=1)
     agent_version_id: uuid.UUID
     params: dict[str, JsonValue] = Field(default_factory=dict)
+    idempotency_key: str | None = Field(
+        default=None,
+        description=IDEMPOTENCY_KEY_DESCRIPTION,
+    )
 
 
 class EvaluationStart(MCPModel):
@@ -30,6 +34,10 @@ class EvaluationStart(MCPModel):
     operation: Literal["evaluation"]
     session_ids: list[uuid.UUID] = Field(min_length=1, max_length=100)
     evaluators: list[EvaluatorSelection] = Field(min_length=1, max_length=100)
+    idempotency_key: str | None = Field(
+        default=None,
+        description=IDEMPOTENCY_KEY_DESCRIPTION,
+    )
 
     @model_validator(mode="after")
     def _validate_batch(self) -> "EvaluationStart":
@@ -50,6 +58,10 @@ class ExperimentRunStart(MCPModel):
     cohort_version_id: uuid.UUID
     agent_version_id: uuid.UUID
     evaluate_baselines: bool = False
+    idempotency_key: str | None = Field(
+        default=None,
+        description=IDEMPOTENCY_KEY_DESCRIPTION,
+    )
 
 
 WorkflowStartRequest = Annotated[

--- a/src/kitaru/mcp/tools/cohorts.py
+++ b/src/kitaru/mcp/tools/cohorts.py
@@ -28,7 +28,9 @@ async def handle_cohorts_manage(
             agent_id=request.agent_id,
             metadata=request.metadata,
         )
-        return await state.client.cohorts.create(dto)
+        return await state.client.cohorts.create(
+            dto, idempotency_key=request.idempotency_key
+        )
     if isinstance(request, CohortUpdate):
         values = request.model_dump(
             include={"name", "description", "metadata"}, exclude_unset=True
@@ -45,7 +47,9 @@ async def handle_cohorts_manage(
             remove_session_ids=request.remove_session_ids,
             display_version=request.display_version,
         )
-        return await state.client.cohorts.create_version(request.cohort_id, dto)
+        return await state.client.cohorts.create_version(
+            request.cohort_id, dto, idempotency_key=request.idempotency_key
+        )
     values = {
         "display_version": None
         if request.clear_display_version

--- a/src/kitaru/mcp/tools/evaluators.py
+++ b/src/kitaru/mcp/tools/evaluators.py
@@ -30,7 +30,8 @@ async def handle_evaluators_manage(
                 name=request.name,
                 description=request.description,
                 metadata=request.metadata,
-            )
+            ),
+            idempotency_key=request.idempotency_key,
         )
     if isinstance(request, EvaluatorUpdate):
         values = request.model_dump(

--- a/src/kitaru/mcp/tools/experiments.py
+++ b/src/kitaru/mcp/tools/experiments.py
@@ -34,7 +34,9 @@ async def handle_experiments_manage(
             tool_policy=request.tool_policy,
             evaluators=evaluators or [],
         )
-        return await state.client.experiments.create(dto)
+        return await state.client.experiments.create(
+            dto, idempotency_key=request.idempotency_key
+        )
     values = request.model_dump(
         include={"name", "description", "override", "tool_policy"},
         exclude_unset=True,

--- a/src/kitaru/mcp/tools/review.py
+++ b/src/kitaru/mcp/tools/review.py
@@ -109,7 +109,9 @@ async def handle_review_manage(
             description=request.description,
             sessions=request.sessions,
         )
-        investigation = await state.client.investigations.create(dto)
+        investigation = await state.client.investigations.create(
+            dto, idempotency_key=request.idempotency_key
+        )
         review_url: str | None = None
         if info is not None:
             review_url = get_investigation_review_url(
@@ -145,7 +147,8 @@ async def handle_review_manage(
                 session_id=request.session_id,
                 selector=request.selector,
                 value=request.value,
-            )
+            ),
+            idempotency_key=request.idempotency_key,
         )
     if isinstance(request, InvestigationAnswerCreate):
         return await state.client.annotations.create(
@@ -154,14 +157,18 @@ async def handle_review_manage(
                 question_key=request.question_key,
                 selector=request.selector,
                 value=request.value,
-            )
+            ),
+            idempotency_key=request.idempotency_key,
         )
     if isinstance(request, AnnotationUpdate):
         return await state.client.annotations.update(
             request.annotation_id, AnnotationUpdateRequest(value=request.value)
         )
     if isinstance(request, TagCreate):
-        return await state.client.tags.create(TagCreateRequest(name=request.name))
+        return await state.client.tags.create(
+            TagCreateRequest(name=request.name),
+            idempotency_key=request.idempotency_key,
+        )
     if isinstance(request, TagUpdate):
         return await state.client.tags.update(
             request.tag_id, TagUpdateRequest(name=request.name)

--- a/src/kitaru/mcp/tools/workflow_start.py
+++ b/src/kitaru/mcp/tools/workflow_start.py
@@ -24,7 +24,8 @@ async def handle_workflow_start(
             EvaluationBatchCreateRequest(
                 input_session_ids=request.session_ids,
                 evaluators=resolved.configs,
-            )
+            ),
+            idempotency_key=request.idempotency_key,
         )
         return {
             "operation": "evaluation",
@@ -46,7 +47,9 @@ async def handle_workflow_start(
         agent_version_id=request.agent_version_id,
         evaluate_baselines=request.evaluate_baselines,
     )
-    run = await state.client.experiments.start_run(request.experiment_id, dto)
+    run = await state.client.experiments.start_run(
+        request.experiment_id, dto, idempotency_key=request.idempotency_key
+    )
     if (
         run.experiment_id != request.experiment_id
         or run.cohort_version_id != request.cohort_version_id

--- a/src/kitaru/mcp/tools/workflows.py
+++ b/src/kitaru/mcp/tools/workflows.py
@@ -26,7 +26,9 @@ async def handle_session_import(
         payload_blob_id=blob.id,
         params=request.params,
     )
-    job = await state.client.imports.create(dto)
+    job = await state.client.imports.create(
+        dto, idempotency_key=request.idempotency_key
+    )
     return {
         "operation": "session_import",
         "idempotency": "domain-deduplicated-only",

--- a/src/kitaru/server/adapters/rest/idempotency.py
+++ b/src/kitaru/server/adapters/rest/idempotency.py
@@ -18,7 +18,7 @@ import inspect
 from collections.abc import Callable, Coroutine
 from typing import Annotated, Any, get_args, get_origin
 
-from fastapi import Depends, HTTPException, Request, params, status
+from fastapi import Depends, Header, HTTPException, Request, params, status
 
 from kitaru.server.adapters.rest.dependencies import get_idempotency_key_repository
 from kitaru.server.adapters.rest.request_state import (
@@ -121,8 +121,13 @@ def build_idempotency_enforcer(
         repository: Annotated[
             IdempotencyKeyRepository, Depends(get_idempotency_key_repository)
         ],
+        idempotency_key: Annotated[
+            str | None, Header(alias=_IDEMPOTENCY_KEY_HEADER)
+        ] = None,
     ) -> None:
-        await _enforce_idempotency(request, context, repository, encrypt_response)
+        await _enforce_idempotency(
+            request, context, repository, encrypt_response, idempotency_key
+        )
 
     return enforce_idempotency
 
@@ -132,6 +137,7 @@ async def _enforce_idempotency(
     context: AuthContext,
     repository: IdempotencyKeyRepository,
     encrypt_response: bool,
+    idempotency_key: str | None,
 ) -> None:
     """Replay or register a request's idempotency key before it runs.
 
@@ -146,6 +152,7 @@ async def _enforce_idempotency(
         context: Resolved auth context.
         repository: Idempotency key repository for the current request.
         encrypt_response: Whether the route's stored responses are encrypted.
+        idempotency_key: Raw header value, when present.
 
     Raises:
         HTTPException: The header is present but empty, too long, or not
@@ -156,10 +163,9 @@ async def _enforce_idempotency(
         IdempotencyKeyReused: A reused key already has a stored response, to
             replay in place of running the route.
     """
-    header = request.headers.get(_IDEMPOTENCY_KEY_HEADER)
-    if header is None:
+    if idempotency_key is None:
         return
-    key = header.strip()
+    key = idempotency_key.strip()
     if not key or len(key) > MAX_IDEMPOTENCY_KEY_LENGTH or not key.isprintable():
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/tests/cli/test_annotations.py
+++ b/tests/cli/test_annotations.py
@@ -62,6 +62,7 @@ class StubAnnotationClient:
         self.create_calls: list[
             ManualAnnotationCreateRequest | InvestigationAnswerCreateRequest
         ] = []
+        self.create_idempotency_keys: list[str | None] = []
         self.list_calls: list[AnnotationListParams] = []
         self.get_calls: list[uuid.UUID] = []
         self.update_calls: list[tuple[uuid.UUID, AnnotationUpdateRequest]] = []
@@ -75,8 +76,10 @@ class StubAnnotationClient:
         async def create(
             self,
             request: ManualAnnotationCreateRequest | InvestigationAnswerCreateRequest,
+            idempotency_key: str | None = None,
         ) -> StubModel:
             self.owner.create_calls.append(request)
+            self.owner.create_idempotency_keys.append(idempotency_key)
             return self.owner.annotation
 
         async def list(self, params: AnnotationListParams) -> Any:

--- a/tests/cli/test_cohorts.py
+++ b/tests/cli/test_cohorts.py
@@ -93,10 +93,12 @@ class StubCohortClient:
         self.agent_lookups = 0
         self.cohort_lookups = 0
         self.created_cohorts: list[CohortCreateRequest] = []
+        self.create_idempotency_keys: list[str | None] = []
         self.list_calls: list[CohortListParams] = []
         self.update_calls: list[tuple[uuid.UUID, CohortUpdateRequest]] = []
         self.deleted_cohorts: list[uuid.UUID] = []
         self.created_versions: list[tuple[uuid.UUID, CohortVersionCreateRequest]] = []
+        self.version_idempotency_keys: list[str | None] = []
         self.version_error: Exception | None = None
         self.version_list_calls: list[tuple[uuid.UUID, ListParams]] = []
         self.version_get_calls: list[uuid.UUID] = []
@@ -142,8 +144,11 @@ class StubCohortClient:
         def __init__(self, owner: "StubCohortClient") -> None:
             self.owner = owner
 
-        async def create(self, request: CohortCreateRequest) -> StubModel:
+        async def create(
+            self, request: CohortCreateRequest, idempotency_key: str | None = None
+        ) -> StubModel:
             self.owner.created_cohorts.append(request)
+            self.owner.create_idempotency_keys.append(idempotency_key)
             return self.owner.cohort
 
         async def get(self, cohort_id: uuid.UUID) -> StubModel:
@@ -169,9 +174,13 @@ class StubCohortClient:
             self.owner.deleted_cohorts.append(cohort_id)
 
         async def create_version(
-            self, cohort_id: uuid.UUID, request: CohortVersionCreateRequest
+            self,
+            cohort_id: uuid.UUID,
+            request: CohortVersionCreateRequest,
+            idempotency_key: str | None = None,
         ) -> StubModel:
             self.owner.created_versions.append((cohort_id, request))
+            self.owner.version_idempotency_keys.append(idempotency_key)
             if self.owner.version_error is not None:
                 raise self.owner.version_error
             return self.owner.version_two
@@ -299,6 +308,25 @@ async def test_cohort_create_snapshots_a_tag_selection() -> None:
     assert request.display_version == "discovery-v1"
     assert result.item["reference"] == "regression@2"
     assert result.item["session_count"] == 2
+
+
+async def test_cohort_create_forwards_idempotency_key_to_parent_create_only() -> None:
+    """A retried invocation dedupes the cohort but not its first version."""
+    client = StubCohortClient()
+
+    await cohorts.create_cohort(
+        client,
+        "nightly",
+        agent="assistant",
+        description="Nightly cases",
+        metadata=None,
+        tag="baseline",
+        display_version="discovery-v1",
+        idempotency_key="retry-nightly",
+    )
+
+    assert client.create_idempotency_keys == ["retry-nightly"]
+    assert client.version_idempotency_keys == [None]
 
 
 async def test_cohort_create_reports_surviving_parent_on_version_failure() -> None:

--- a/tests/cli/test_evaluations.py
+++ b/tests/cli/test_evaluations.py
@@ -241,6 +241,7 @@ class StubEvaluationClient:
         )
         self.job = _job()
         self.requests: list[EvaluationBatchCreateRequest] = []
+        self.create_idempotency_keys: list[str | None] = []
         self.create_error = create_error
         self.evaluators = self._Evaluators(self)
         self.evaluations = self._Evaluations(self)
@@ -295,8 +296,13 @@ class StubEvaluationClient:
         def __init__(self, owner: "StubEvaluationClient") -> None:
             self.owner = owner
 
-        async def create(self, request: EvaluationBatchCreateRequest) -> JobResponse:
+        async def create(
+            self,
+            request: EvaluationBatchCreateRequest,
+            idempotency_key: str | None = None,
+        ) -> JobResponse:
             self.owner.requests.append(request)
+            self.owner.create_idempotency_keys.append(idempotency_key)
             if self.owner.create_error is not None:
                 raise self.owner.create_error
             return self.owner.job

--- a/tests/cli/test_experiment_runs.py
+++ b/tests/cli/test_experiment_runs.py
@@ -110,6 +110,7 @@ class StubRunsClient:
         )
         self.get_responses = [self.created_run]
         self.start_calls: list[tuple[uuid.UUID, ExperimentRunCreateRequest]] = []
+        self.start_idempotency_keys: list[str | None] = []
         self.list_calls: list[ExperimentRunListParams] = []
         self.jobs_calls: list[tuple[uuid.UUID, ExperimentRunJobsListParams]] = []
         self.get_calls = 0
@@ -141,9 +142,13 @@ class StubRunsClient:
             return self.owner.experiment
 
         async def start_run(
-            self, experiment_id: uuid.UUID, request: ExperimentRunCreateRequest
+            self,
+            experiment_id: uuid.UUID,
+            request: ExperimentRunCreateRequest,
+            idempotency_key: str | None = None,
         ) -> ExperimentRunResponse:
             self.owner.start_calls.append((experiment_id, request))
+            self.owner.start_idempotency_keys.append(idempotency_key)
             return self.owner.created_run
 
     class _Runs:

--- a/tests/cli/test_experiments.py
+++ b/tests/cli/test_experiments.py
@@ -80,6 +80,7 @@ class StubExperimentClient:
         self.evaluator_lookups = 0
         self.experiment_lookups = 0
         self.create_calls: list[ExperimentCreateRequest] = []
+        self.create_idempotency_keys: list[str | None] = []
         self.list_calls: list[ExperimentListParams] = []
         self.update_calls: list[tuple[uuid.UUID, ExperimentUpdateRequest]] = []
         self.deleted: list[uuid.UUID] = []
@@ -137,8 +138,11 @@ class StubExperimentClient:
         def __init__(self, owner: "StubExperimentClient") -> None:
             self.owner = owner
 
-        async def create(self, request: ExperimentCreateRequest) -> StubModel:
+        async def create(
+            self, request: ExperimentCreateRequest, idempotency_key: str | None = None
+        ) -> StubModel:
             self.owner.create_calls.append(request)
+            self.owner.create_idempotency_keys.append(idempotency_key)
             return self.owner.experiment
 
         async def get(self, experiment_id: uuid.UUID) -> StubModel:

--- a/tests/cli/test_investigations.py
+++ b/tests/cli/test_investigations.py
@@ -92,6 +92,7 @@ class StubInvestigationClient:
         )
         self.agent_lookups = 0
         self.create_calls: list[InvestigationCreateRequest] = []
+        self.create_idempotency_keys: list[str | None] = []
         self.list_calls: list[InvestigationListParams] = []
         self.get_calls: list[uuid.UUID] = []
         self.update_calls: list[tuple[uuid.UUID, InvestigationUpdateRequest]] = []
@@ -144,8 +145,13 @@ class StubInvestigationClient:
         def __init__(self, owner: "StubInvestigationClient") -> None:
             self.owner = owner
 
-        async def create(self, request: InvestigationCreateRequest) -> StubModel:
+        async def create(
+            self,
+            request: InvestigationCreateRequest,
+            idempotency_key: str | None = None,
+        ) -> StubModel:
             self.owner.create_calls.append(request)
+            self.owner.create_idempotency_keys.append(idempotency_key)
             return self.owner.investigation
 
         async def list(self, params: InvestigationListParams) -> Any:
@@ -243,6 +249,24 @@ async def test_create_maps_sessions_questions_and_highlights_to_sdk() -> None:
         ],
     }
     assert result.item["id"] == str(client.investigation.id)
+
+
+async def test_create_forwards_idempotency_key_to_the_sdk_call() -> None:
+    """A retried invocation reaches the SDK create call with the same key."""
+    client = StubInvestigationClient()
+
+    await investigations.create_investigation(
+        client,
+        "triage",
+        agent="assistant",
+        description=None,
+        session_ids=[],
+        session_questions=[],
+        session_highlights=[],
+        idempotency_key="retry-triage",
+    )
+
+    assert client.create_idempotency_keys == ["retry-triage"]
 
 
 async def _create_minimal(client: StubInvestigationClient) -> Any:

--- a/tests/cli/test_registration.py
+++ b/tests/cli/test_registration.py
@@ -67,6 +67,8 @@ class StubResource:
         self.versions: list[StubModel] = []
         self.created_requests: list[Any] = []
         self.version_requests: list[tuple[uuid.UUID, Any]] = []
+        self.create_idempotency_keys: list[str | None] = []
+        self.version_idempotency_keys: list[str | None] = []
         self.create_error: Exception | None = None
         self.version_error: Exception | None = None
         self.parent = StubModel("created")
@@ -104,16 +106,25 @@ class StubResource:
                 return item
         raise AssertionError("unexpected version")
 
-    async def create(self, request: Any) -> StubModel:
+    async def create(
+        self, request: Any, idempotency_key: str | None = None
+    ) -> StubModel:
         """Record parent creation."""
         self.created_requests.append(request)
+        self.create_idempotency_keys.append(idempotency_key)
         if self.create_error:
             raise self.create_error
         return self.parent
 
-    async def create_version(self, parent_id: uuid.UUID, request: Any) -> StubModel:
+    async def create_version(
+        self,
+        parent_id: uuid.UUID,
+        request: Any,
+        idempotency_key: str | None = None,
+    ) -> StubModel:
         """Record version creation."""
         self.version_requests.append((parent_id, request))
+        self.version_idempotency_keys.append(idempotency_key)
         if self.version_error:
             raise self.version_error
         return self.version

--- a/tests/cli/test_replays.py
+++ b/tests/cli/test_replays.py
@@ -61,6 +61,7 @@ class StubReplayClient:
             updated=now,
         )
         self.create_calls: list[ReplayCreateRequest] = []
+        self.create_idempotency_keys: list[str | None] = []
         self.list_calls: list[ReplayListParams] = []
         self.get_calls: list[uuid.UUID] = []
         self.agents = self._Agents(self)
@@ -102,8 +103,11 @@ class StubReplayClient:
         def __init__(self, owner: "StubReplayClient") -> None:
             self.owner = owner
 
-        async def create(self, request: ReplayCreateRequest) -> ReplayResponse:
+        async def create(
+            self, request: ReplayCreateRequest, idempotency_key: str | None = None
+        ) -> ReplayResponse:
             self.owner.create_calls.append(request)
+            self.owner.create_idempotency_keys.append(idempotency_key)
             return self.owner.replay
 
         async def list(self, params: ReplayListParams) -> Any:

--- a/tests/cli/test_schema.py
+++ b/tests/cli/test_schema.py
@@ -437,3 +437,38 @@ def test_help_exposes_only_the_schema_command_surface(capsys) -> None:
 
     [job_get] = describe_schema(("job", "get"))
     assert job_get["side_effects"]["reads_local_file"] is True
+
+
+def test_idempotency_key_option_covers_only_single_create_commands() -> None:
+    """--idempotency-key is offered on every command backed by one create call."""
+    covered_paths = (
+        ("cohort", "create"),
+        ("cohort", "version", "create"),
+        ("investigation", "create"),
+        ("annotation", "create"),
+        ("experiment", "create"),
+        ("replay", "create"),
+        ("experiment", "run", "start"),
+        ("session", "import"),
+        ("session", "evaluate"),
+        ("agent", "version", "register"),
+        ("importer", "version", "register"),
+        ("evaluator", "version", "register"),
+    )
+    for path in covered_paths:
+        [command] = describe_schema(path)
+        names = {parameter["name"] for parameter in command["parameters"]}
+        assert "--idempotency-key" in names, path
+
+    # These register both a parent and its initial version in one invocation, so
+    # a single user-supplied key cannot be forwarded to both without one of the
+    # two creates failing with a fingerprint conflict on retry.
+    uncovered_paths = (
+        ("agent", "register"),
+        ("importer", "register"),
+        ("evaluator", "register"),
+    )
+    for path in uncovered_paths:
+        [command] = describe_schema(path)
+        names = {parameter["name"] for parameter in command["parameters"]}
+        assert "--idempotency-key" not in names, path

--- a/tests/cli/test_sessions.py
+++ b/tests/cli/test_sessions.py
@@ -118,6 +118,7 @@ class StubImportClient:
         self.job = _job()
         self.uploads: list[tuple[bytes, str, str | None]] = []
         self.requests: list[Any] = []
+        self.create_idempotency_keys: list[str | None] = []
         self.lookup_calls: list[str] = []
         self.create_error = create_error
         self.importers = self._Importers(self)
@@ -174,8 +175,11 @@ class StubImportClient:
         def __init__(self, owner: "StubImportClient") -> None:
             self.owner = owner
 
-        async def create(self, request: Any) -> JobResponse:
+        async def create(
+            self, request: Any, idempotency_key: str | None = None
+        ) -> JobResponse:
             self.owner.requests.append(request)
+            self.owner.create_idempotency_keys.append(idempotency_key)
             if self.owner.create_error is not None:
                 raise self.owner.create_error
             return self.owner.job

--- a/tests/client/test_idempotency_keys.py
+++ b/tests/client/test_idempotency_keys.py
@@ -1,0 +1,159 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Tests that the SDK exposes idempotency_key on exactly the marked routes."""
+
+import inspect
+import uuid
+from collections.abc import AsyncGenerator
+from types import FunctionType, MethodType
+from typing import cast
+
+import pytest
+
+from conftest import (
+    FakeTagRepository,
+    RequestRecordingTransport,
+    local_settings,
+    marked_idempotent_routes,
+    override_idempotency,
+    recording_asgi_api_client,
+)
+from kitaru.api_models.v1.tag import TagCreateRequest
+from kitaru.client.api_client import KitaruAPIClient
+from kitaru.server.adapters.rest.dependencies import authorize, get_tag_service
+from kitaru.server.api.app import create_app
+from kitaru.server.application.models.auth import AuthContext
+from kitaru.server.application.services.tag_service import TagService
+from kitaru.server.domain.account import Account
+from kitaru.transport import IDEMPOTENCY_KEY_HEADER
+
+ACCOUNT = Account(id=uuid.uuid4(), name="ann")
+
+# Maps each idempotent route to the SDK resource attribute and method name
+# that issues it, so drift in either direction fails a test below.
+MAPPING = {
+    ("POST", "/api/v1/sessions"): ("sessions", "create"),
+    ("POST", "/api/v1/replays"): ("replays", "create"),
+    ("POST", "/api/v1/evaluations"): ("evaluations", "create"),
+    ("POST", "/api/v1/session-runs"): ("session_runs", "create"),
+    ("POST", "/api/v1/imports"): ("imports", "create"),
+    ("POST", "/api/v1/agents"): ("agents", "create"),
+    ("POST", "/api/v1/agents/{agent_id}/versions"): ("agents", "create_version"),
+    ("POST", "/api/v1/cohorts"): ("cohorts", "create"),
+    ("POST", "/api/v1/cohorts/{cohort_id}/versions"): ("cohorts", "create_version"),
+    ("POST", "/api/v1/experiments"): ("experiments", "create"),
+    ("POST", "/api/v1/experiments/{experiment_id}/runs"): ("experiments", "start_run"),
+    ("POST", "/api/v1/annotations"): ("annotations", "create"),
+    ("POST", "/api/v1/investigations"): ("investigations", "create"),
+    ("POST", "/api/v1/api-keys"): ("api_keys", "create"),
+    ("POST", "/api/v1/api-keys/{api_key_id}/rotate"): ("api_keys", "rotate"),
+    ("POST", "/api/v1/evaluators"): ("evaluators", "create"),
+    ("POST", "/api/v1/importers"): ("importers", "create"),
+    ("POST", "/api/v1/tags"): ("tags", "create"),
+    ("POST", "/api/v1/secrets"): ("secrets", "create"),
+    ("POST", "/api/v1/service-accounts"): ("service_accounts", "create"),
+    ("POST", "/api/v1/users"): ("users", "create"),
+}
+
+
+def _resource_methods(client: KitaruAPIClient) -> dict[tuple[str, str], MethodType]:
+    """Return every public method on every resource bound to a client.
+
+    Args:
+        client: Client whose bound resources are walked.
+
+    Returns:
+        Mapping from (resource attribute, method name) to the bound method.
+    """
+    methods: dict[tuple[str, str], MethodType] = {}
+    for attribute, resource in vars(client).items():
+        if attribute.startswith("_"):
+            continue
+        for name, member in inspect.getmembers(resource, predicate=inspect.ismethod):
+            if name.startswith("_"):
+                continue
+            methods[(attribute, name)] = member
+    return methods
+
+
+def _parameter_names(method: MethodType) -> set[str]:
+    """Return the parameter names of a bound method.
+
+    Args:
+        method: Bound method to inspect.
+
+    Returns:
+        Parameter names.
+    """
+    # Read the parameters off the code object because inspect.signature
+    # evaluates annotations, which fails on Python 3.14 where a resource
+    # method named list shadows the builtin that a return annotation
+    # subscripts.
+    code = cast(FunctionType, method.__func__).__code__
+    return set(code.co_varnames[: code.co_argcount + code.co_kwonlyargcount])
+
+
+def test_mapping_matches_the_marked_routes() -> None:
+    """Assert the mapping covers exactly the routes the app marks idempotent."""
+    assert set(MAPPING.keys()) == marked_idempotent_routes(create_app(local_settings()))
+
+
+def test_mapped_methods_accept_idempotency_key() -> None:
+    """Assert every mapped SDK method accepts an idempotency_key parameter."""
+    client = KitaruAPIClient("http://test")
+    resources = _resource_methods(client)
+    for attribute, method_name in MAPPING.values():
+        method = resources[(attribute, method_name)]
+        assert "idempotency_key" in _parameter_names(method), (
+            f"{attribute}.{method_name} does not accept idempotency_key"
+        )
+
+
+def test_no_other_method_accepts_idempotency_key() -> None:
+    """Assert idempotency_key is absent from every method the mapping omits."""
+    client = KitaruAPIClient("http://test")
+    mapped = set(MAPPING.values())
+    for (attribute, method_name), method in _resource_methods(client).items():
+        if (attribute, method_name) in mapped:
+            continue
+        assert "idempotency_key" not in _parameter_names(method), (
+            f"{attribute}.{method_name} accepts idempotency_key but is not "
+            "in the idempotent route mapping"
+        )
+
+
+@pytest.fixture
+async def api_client() -> AsyncGenerator[
+    tuple[KitaruAPIClient, RequestRecordingTransport], None
+]:
+    """Provide an API client routed to the app with a fake-backed tag service."""
+    app = create_app(local_settings())
+    service = TagService(repository=FakeTagRepository())
+    app.dependency_overrides[get_tag_service] = lambda: service
+    app.dependency_overrides[authorize] = lambda: AuthContext(account=ACCOUNT)
+    override_idempotency(app, ACCOUNT)
+    client, recorder = recording_asgi_api_client(app)
+    async with client:
+        yield client, recorder
+
+
+async def test_caller_supplied_key_wins_over_the_transport_default(
+    api_client: tuple[KitaruAPIClient, RequestRecordingTransport],
+) -> None:
+    """Send the caller's key on the wire instead of the transport's random one."""
+    client, recorder = api_client
+    await client.tags.create(
+        TagCreateRequest(name="prod"), idempotency_key="caller-key"
+    )
+    assert recorder.requests[0].headers[IDEMPOTENCY_KEY_HEADER] == "caller-key"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 from fastapi import FastAPI
+from fastapi.routing import iter_route_contexts
 from pydantic import SecretStr
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
@@ -69,6 +70,7 @@ from kitaru.server.adapters.rest.dependencies import (
     _resolve_auth_context,
     get_idempotency_key_repository,
 )
+from kitaru.server.adapters.rest.route import is_idempotent
 from kitaru.server.api.app import create_app
 from kitaru.server.api.composition import register_subscribers
 from kitaru.server.api.config import APISettings
@@ -1532,6 +1534,25 @@ def override_idempotency(
     )
     app.dependency_overrides[get_idempotency_key_repository] = lambda: repository
     return repository
+
+
+def marked_idempotent_routes(app: FastAPI) -> set[tuple[str, str]]:
+    """Return the method and path pairs an app marks idempotent.
+
+    Args:
+        app: App whose routes are walked.
+
+    Returns:
+        Marked routes.
+    """
+    return {
+        (method, context.path)
+        for context in iter_route_contexts(app.routes)
+        if context.path is not None
+        and context.endpoint is not None
+        and is_idempotent(context.endpoint)
+        for method in context.methods or ()
+    }
 
 
 class FakeSecretRepository:

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -5743,6 +5743,19 @@
               "default": null,
               "title": "Description"
             },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "metadata": {
               "additionalProperties": true,
               "title": "Metadata",
@@ -5872,6 +5885,19 @@
               ],
               "default": null,
               "title": "Display Version"
+            },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
             },
             "operation": {
               "const": "create_version",
@@ -6287,6 +6313,19 @@
               "minItems": 1,
               "title": "Evaluators",
               "type": "array"
+            },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
             },
             "name": {
               "minLength": 1,
@@ -7304,6 +7343,19 @@
               "title": "Agent Version Id",
               "type": "string"
             },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "importer_id": {
               "format": "uuid",
               "title": "Importer Id",
@@ -7741,6 +7793,19 @@
           "additionalProperties": false,
           "description": "Answer one investigation question for one linked session.",
           "properties": {
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "investigation_session_id": {
               "format": "uuid",
               "title": "Investigation Session Id",
@@ -7799,6 +7864,19 @@
               ],
               "default": null,
               "title": "Description"
+            },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
             },
             "name": {
               "minLength": 1,
@@ -7992,6 +8070,19 @@
           "additionalProperties": false,
           "description": "Create a manual annotation for one session.",
           "properties": {
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "operation": {
               "const": "create_annotation",
               "title": "Operation",
@@ -8068,6 +8159,19 @@
           "additionalProperties": false,
           "description": "Create a tag.",
           "properties": {
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "name": {
               "minLength": 1,
               "title": "Name",
@@ -8884,6 +8988,19 @@
               "title": "Evaluators",
               "type": "array"
             },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "operation": {
               "const": "evaluation",
               "title": "Operation",
@@ -8958,6 +9075,19 @@
               "format": "uuid",
               "title": "Experiment Id",
               "type": "string"
+            },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
             },
             "operation": {
               "const": "experiment_run",
@@ -9543,6 +9673,19 @@
               ],
               "default": null,
               "title": "Description"
+            },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
             },
             "metadata": {
               "additionalProperties": true,

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,7 +6,7 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 151586,
+      "discovery_response_bytes": 155018,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
@@ -18,8 +18,8 @@
         },
         "kitaru_cohorts_manage": {
           "$defs_count": 7,
-          "combined_bytes": 6446,
-          "input_bytes": 3083,
+          "combined_bytes": 7070,
+          "input_bytes": 3707,
           "maximum_nesting_depth": 7,
           "output_bytes": 3363
         },
@@ -32,15 +32,15 @@
         },
         "kitaru_evaluators_manage": {
           "$defs_count": 11,
-          "combined_bytes": 8431,
-          "input_bytes": 3958,
+          "combined_bytes": 8743,
+          "input_bytes": 4270,
           "maximum_nesting_depth": 7,
           "output_bytes": 4473
         },
         "kitaru_experiments_manage": {
           "$defs_count": 26,
-          "combined_bytes": 14374,
-          "input_bytes": 7057,
+          "combined_bytes": 14686,
+          "input_bytes": 7369,
           "maximum_nesting_depth": 8,
           "output_bytes": 7317
         },
@@ -53,8 +53,8 @@
         },
         "kitaru_review_manage": {
           "$defs_count": 30,
-          "combined_bytes": 17906,
-          "input_bytes": 8491,
+          "combined_bytes": 19154,
+          "input_bytes": 9739,
           "maximum_nesting_depth": 7,
           "output_bytes": 9415
         },
@@ -67,8 +67,8 @@
         },
         "kitaru_session_import": {
           "$defs_count": 6,
-          "combined_bytes": 4336,
-          "input_bytes": 793,
+          "combined_bytes": 4648,
+          "input_bytes": 1105,
           "maximum_nesting_depth": 7,
           "output_bytes": 3543
         },
@@ -81,8 +81,8 @@
         },
         "kitaru_workflow_start": {
           "$defs_count": 13,
-          "combined_bytes": 9236,
-          "input_bytes": 1950,
+          "combined_bytes": 9860,
+          "input_bytes": 2574,
           "maximum_nesting_depth": 7,
           "output_bytes": 7286
         }
@@ -116,7 +116,7 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 140194,
+      "discovery_response_bytes": 143626,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
@@ -128,22 +128,22 @@
         },
         "kitaru_cohorts_manage": {
           "$defs_count": 7,
-          "combined_bytes": 6446,
-          "input_bytes": 3083,
+          "combined_bytes": 7070,
+          "input_bytes": 3707,
           "maximum_nesting_depth": 7,
           "output_bytes": 3363
         },
         "kitaru_evaluators_manage": {
           "$defs_count": 11,
-          "combined_bytes": 8431,
-          "input_bytes": 3958,
+          "combined_bytes": 8743,
+          "input_bytes": 4270,
           "maximum_nesting_depth": 7,
           "output_bytes": 4473
         },
         "kitaru_experiments_manage": {
           "$defs_count": 26,
-          "combined_bytes": 14374,
-          "input_bytes": 7057,
+          "combined_bytes": 14686,
+          "input_bytes": 7369,
           "maximum_nesting_depth": 8,
           "output_bytes": 7317
         },
@@ -156,8 +156,8 @@
         },
         "kitaru_review_manage": {
           "$defs_count": 30,
-          "combined_bytes": 17906,
-          "input_bytes": 8491,
+          "combined_bytes": 19154,
+          "input_bytes": 9739,
           "maximum_nesting_depth": 7,
           "output_bytes": 9415
         },
@@ -170,15 +170,15 @@
         },
         "kitaru_session_import": {
           "$defs_count": 6,
-          "combined_bytes": 4336,
-          "input_bytes": 793,
+          "combined_bytes": 4648,
+          "input_bytes": 1105,
           "maximum_nesting_depth": 7,
           "output_bytes": 3543
         },
         "kitaru_workflow_start": {
           "$defs_count": 13,
-          "combined_bytes": 9236,
-          "input_bytes": 1950,
+          "combined_bytes": 9860,
+          "input_bytes": 2574,
           "maximum_nesting_depth": 7,
           "output_bytes": 7286
         }

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -5743,6 +5743,19 @@
               "default": null,
               "title": "Description"
             },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "metadata": {
               "additionalProperties": true,
               "title": "Metadata",
@@ -5872,6 +5885,19 @@
               ],
               "default": null,
               "title": "Display Version"
+            },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
             },
             "operation": {
               "const": "create_version",
@@ -6287,6 +6313,19 @@
               "minItems": 1,
               "title": "Evaluators",
               "type": "array"
+            },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
             },
             "name": {
               "minLength": 1,
@@ -7304,6 +7343,19 @@
               "title": "Agent Version Id",
               "type": "string"
             },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "importer_id": {
               "format": "uuid",
               "title": "Importer Id",
@@ -7741,6 +7793,19 @@
           "additionalProperties": false,
           "description": "Answer one investigation question for one linked session.",
           "properties": {
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "investigation_session_id": {
               "format": "uuid",
               "title": "Investigation Session Id",
@@ -7799,6 +7864,19 @@
               ],
               "default": null,
               "title": "Description"
+            },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
             },
             "name": {
               "minLength": 1,
@@ -7992,6 +8070,19 @@
           "additionalProperties": false,
           "description": "Create a manual annotation for one session.",
           "properties": {
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "operation": {
               "const": "create_annotation",
               "title": "Operation",
@@ -8068,6 +8159,19 @@
           "additionalProperties": false,
           "description": "Create a tag.",
           "properties": {
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "name": {
               "minLength": 1,
               "title": "Name",
@@ -8884,6 +8988,19 @@
               "title": "Evaluators",
               "type": "array"
             },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
+            },
             "operation": {
               "const": "evaluation",
               "title": "Operation",
@@ -8958,6 +9075,19 @@
               "format": "uuid",
               "title": "Experiment Id",
               "type": "string"
+            },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
             },
             "operation": {
               "const": "experiment_run",
@@ -9543,6 +9673,19 @@
               ],
               "default": null,
               "title": "Description"
+            },
+            "idempotency_key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Pass a fresh unique string per logical request. Reuse it only when retrying this exact call after a lost or failed response, so the retry returns the original result instead of acting twice.",
+              "title": "Idempotency Key"
             },
             "metadata": {
               "additionalProperties": true,

--- a/tests/mcp/test_handlers_protocol.py
+++ b/tests/mcp/test_handlers_protocol.py
@@ -30,8 +30,11 @@ from kitaru.mcp.lifecycle import MCPServerState
 from kitaru.mcp.models.activity import ActivityListRequest
 from kitaru.mcp.models.common import PageData
 from kitaru.mcp.models.management import (
+    CohortCreate,
     CohortUpdate,
     CohortVersionCreate,
+    EvaluatorSelection,
+    ExperimentCreate,
     ExperimentUpdate,
 )
 from kitaru.mcp.models.registry import (
@@ -54,6 +57,7 @@ class UpdateClient:
         self.cohort_updates: list[object] = []
         self.experiment_updates: list[object] = []
         self.cohort_version_creates: list[object] = []
+        self.cohort_version_idempotency_keys: list[str | None] = []
         self.cohorts = SimpleNamespace(
             update=self._update_cohort, create_version=self._create_cohort_version
         )
@@ -68,9 +72,10 @@ class UpdateClient:
         return SimpleNamespace()
 
     async def _create_cohort_version(
-        self, _item_id: uuid.UUID, request: object
+        self, _item_id: uuid.UUID, request: object, idempotency_key: str | None = None
     ) -> object:
         self.cohort_version_creates.append(request)
+        self.cohort_version_idempotency_keys.append(idempotency_key)
         return SimpleNamespace()
 
 
@@ -636,3 +641,76 @@ async def test_cohort_version_create_forwards_optional_baseline() -> None:
 
     assert cast(Any, client.cohort_version_creates[0]).baseline_id == baseline_id
     assert cast(Any, client.cohort_version_creates[1]).baseline_id is None
+
+
+async def test_cohort_version_create_forwards_idempotency_key() -> None:
+    client = UpdateClient()
+    state = MCPServerState(MCPSettings(), cast(Any, client))
+
+    await handle_cohorts_manage(
+        state,
+        CohortVersionCreate(
+            operation="create_version",
+            cohort_id=uuid.uuid4(),
+            idempotency_key="retry-cohort-version-1",
+        ),
+    )
+
+    assert client.cohort_version_idempotency_keys == ["retry-cohort-version-1"]
+
+
+async def test_cohort_create_forwards_idempotency_key() -> None:
+    idempotency_keys: list[str | None] = []
+
+    async def create(_request: object, idempotency_key: str | None = None) -> object:
+        idempotency_keys.append(idempotency_key)
+        return SimpleNamespace()
+
+    client = SimpleNamespace(cohorts=SimpleNamespace(create=create))
+    state = MCPServerState(MCPSettings(), cast(Any, client))
+
+    await handle_cohorts_manage(
+        state,
+        CohortCreate(
+            operation="create",
+            agent_id=uuid.uuid4(),
+            name="regression-cases",
+            idempotency_key="retry-cohort-1",
+        ),
+    )
+
+    assert idempotency_keys == ["retry-cohort-1"]
+
+
+async def test_experiment_create_forwards_idempotency_key() -> None:
+    evaluator_id = uuid.uuid4()
+    idempotency_keys: list[str | None] = []
+
+    async def get_evaluator(item_id: uuid.UUID) -> object:
+        return SimpleNamespace(id=item_id, name="accuracy")
+
+    async def get_version(item_id: uuid.UUID, version: int) -> object:
+        return SimpleNamespace(id=uuid.uuid4(), evaluator_id=item_id, version=version)
+
+    async def create(_request: object, idempotency_key: str | None = None) -> object:
+        idempotency_keys.append(idempotency_key)
+        return SimpleNamespace()
+
+    client = SimpleNamespace(
+        evaluators=SimpleNamespace(get=get_evaluator, get_version=get_version),
+        experiments=SimpleNamespace(create=create),
+    )
+    state = MCPServerState(MCPSettings(), cast(Any, client))
+
+    await handle_experiments_manage(
+        state,
+        ExperimentCreate(
+            operation="create",
+            agent_id=uuid.uuid4(),
+            name="baseline-comparison",
+            evaluators=[EvaluatorSelection(evaluator_id=evaluator_id, version=1)],
+            idempotency_key="retry-experiment-1",
+        ),
+    )
+
+    assert idempotency_keys == ["retry-experiment-1"]

--- a/tests/mcp/test_review_workflows.py
+++ b/tests/mcp/test_review_workflows.py
@@ -350,20 +350,28 @@ async def test_investigation_pending_preserves_downstream_transition_error() -> 
 async def test_review_creates_and_updates_forward_typed_sdk_dtos() -> None:
     calls: list[str] = []
     investigation_requests: list[object] = []
+    investigation_idempotency_keys: list[str | None] = []
     annotation_creates: list[object] = []
+    annotation_idempotency_keys: list[str | None] = []
     annotation_updates: list[object] = []
 
-    async def create_investigation(request: object) -> object:
+    async def create_investigation(
+        request: object, idempotency_key: str | None = None
+    ) -> object:
         calls.append("create")
         investigation_requests.append(request)
+        investigation_idempotency_keys.append(idempotency_key)
         return _investigation()
 
     async def get_info() -> ServerInfoResponse:
         calls.append("info")
         return ServerInfoResponse(version="0.0.0", auth_scheme=AuthScheme.LOCAL)
 
-    async def create_annotation(request: object) -> object:
+    async def create_annotation(
+        request: object, idempotency_key: str | None = None
+    ) -> object:
         annotation_creates.append(request)
+        annotation_idempotency_keys.append(idempotency_key)
         return SimpleNamespace()
 
     async def update_annotation(_id: uuid.UUID, request: object) -> object:
@@ -391,6 +399,7 @@ async def test_review_creates_and_updates_forward_typed_sdk_dtos() -> None:
                     "questions": [{"key": "root-cause", "question": "Was it correct?"}],
                 }
             ],
+            idempotency_key="retry-investigation-1",
         ),
     )
     await handle_review_manage(
@@ -399,6 +408,7 @@ async def test_review_creates_and_updates_forward_typed_sdk_dtos() -> None:
             operation="create_annotation",
             session_id=uuid.uuid4(),
             value={"label": "bad"},
+            idempotency_key="retry-annotation-1",
         ),
     )
     await handle_review_manage(
@@ -408,6 +418,7 @@ async def test_review_creates_and_updates_forward_typed_sdk_dtos() -> None:
             investigation_session_id=investigation_session_id,
             question_key="root-cause",
             value=False,
+            idempotency_key="retry-answer-1",
         ),
     )
     await handle_review_manage(
@@ -436,6 +447,8 @@ async def test_review_creates_and_updates_forward_typed_sdk_dtos() -> None:
     )
     assert cast(Any, annotation_updates[0]).model_dump(mode="json") == {"value": True}
     assert calls == ["info", "create"]
+    assert investigation_idempotency_keys == ["retry-investigation-1"]
+    assert annotation_idempotency_keys == ["retry-annotation-1", "retry-answer-1"]
 
 
 def _investigation() -> InvestigationResponse:
@@ -461,7 +474,10 @@ async def _create_investigation(
     *,
     handler_timeout: float = 120.0,
 ) -> CallToolResult:
-    async def create(_request: object) -> InvestigationResponse:
+    async def create(
+        _request: object, idempotency_key: str | None = None
+    ) -> InvestigationResponse:
+        del idempotency_key
         return investigation
 
     client = SimpleNamespace(
@@ -624,8 +640,10 @@ async def test_review_tag_mutations_forward_typed_sdk_dtos() -> None:
         updated=now,
     )
 
-    async def create(request: TagCreateRequest) -> TagResponse:
-        calls.append(("create", request, None))
+    async def create(
+        request: TagCreateRequest, idempotency_key: str | None = None
+    ) -> TagResponse:
+        calls.append(("create", request, idempotency_key))
         return tag
 
     async def update(
@@ -647,7 +665,12 @@ async def test_review_tag_mutations_forward_typed_sdk_dtos() -> None:
     )
     assert (
         await handle_review_manage(
-            state, TagCreate(operation="create_tag", name="regression")
+            state,
+            TagCreate(
+                operation="create_tag",
+                name="regression",
+                idempotency_key="retry-tag-1",
+            ),
         )
         is tag
     )
@@ -673,6 +696,7 @@ async def test_review_tag_mutations_forward_typed_sdk_dtos() -> None:
 
     assert isinstance(calls[0][1], TagCreateRequest)
     assert calls[0][1].model_dump() == {"name": "regression"}
+    assert calls[0][2] == "retry-tag-1"
     assert calls[1][1] == tag_id
     assert isinstance(calls[1][2], TagUpdateRequest)
     assert calls[1][2].model_dump() == {"name": "known-failure"}
@@ -694,7 +718,10 @@ async def test_review_tag_create_has_typed_protocol_result() -> None:
         updated=now,
     )
 
-    async def create(request: TagCreateRequest) -> TagResponse:
+    async def create(
+        request: TagCreateRequest, idempotency_key: str | None = None
+    ) -> TagResponse:
+        del idempotency_key
         assert isinstance(request, TagCreateRequest)
         return tag
 
@@ -726,7 +753,10 @@ async def test_review_tag_create_has_typed_protocol_result() -> None:
 async def test_review_tag_api_errors_use_redacted_protocol_envelope(
     status_code: int, code: str, message: str
 ) -> None:
-    async def create(_request: TagCreateRequest) -> TagResponse:
+    async def create(
+        _request: TagCreateRequest, idempotency_key: str | None = None
+    ) -> TagResponse:
+        del idempotency_key
         raise APIError(status_code, "Bearer sensitive-token")
 
     server, context = _get_context(
@@ -795,6 +825,8 @@ def test_evaluation_start_caps_pairs_and_rejects_duplicates() -> None:
 
 async def test_workflow_starts_return_without_polling() -> None:
     calls: list[str] = []
+    evaluation_idempotency_keys: list[str | None] = []
+    experiment_start_idempotency_keys: list[str | None] = []
     evaluator_id = uuid.uuid4()
 
     async def get_evaluator(item_id: uuid.UUID) -> object:
@@ -805,12 +837,19 @@ async def test_workflow_starts_return_without_polling() -> None:
         calls.append("evaluator_version")
         return SimpleNamespace(id=uuid.uuid4(), evaluator_id=item_id, version=version)
 
-    async def create_evaluation(request: object) -> object:
+    async def create_evaluation(
+        request: object, idempotency_key: str | None = None
+    ) -> object:
+        del request
         calls.append("evaluation_create")
+        evaluation_idempotency_keys.append(idempotency_key)
         return SimpleNamespace(model_dump=lambda **_kwargs: {"id": str(uuid.uuid4())})
 
-    async def start_run(experiment_id: uuid.UUID, request: object) -> object:
+    async def start_run(
+        experiment_id: uuid.UUID, request: object, idempotency_key: str | None = None
+    ) -> object:
         calls.append("experiment_start")
+        experiment_start_idempotency_keys.append(idempotency_key)
         run_id = uuid.uuid4()
         return SimpleNamespace(
             id=run_id,
@@ -836,11 +875,13 @@ async def test_workflow_starts_return_without_polling() -> None:
                 operation="evaluation",
                 session_ids=[uuid.uuid4()],
                 evaluators=[{"evaluator_id": evaluator_id, "version": 2}],
+                idempotency_key="retry-evaluation-1",
             ),
         ),
     )
     assert calls == ["evaluator", "evaluator_version", "evaluation_create"]
     assert evaluation["operation"] == "evaluation"
+    assert evaluation_idempotency_keys == ["retry-evaluation-1"]
 
     experiment = cast(
         dict[str, Any],
@@ -851,11 +892,13 @@ async def test_workflow_starts_return_without_polling() -> None:
                 experiment_id=uuid.uuid4(),
                 cohort_version_id=uuid.uuid4(),
                 agent_version_id=uuid.uuid4(),
+                idempotency_key="retry-experiment-run-1",
             ),
         ),
     )
     assert calls[-1] == "experiment_start"
     assert experiment["operation"] == "experiment_run"
+    assert experiment_start_idempotency_keys == ["retry-experiment-run-1"]
 
 
 async def test_experiment_run_start_rejects_mismatched_receipt() -> None:
@@ -866,7 +909,10 @@ async def test_experiment_run_start_rejects_mismatched_receipt() -> None:
         agent_version_id=uuid.uuid4(),
     )
 
-    async def start_run(_experiment_id: uuid.UUID, _request: object) -> object:
+    async def start_run(
+        _experiment_id: uuid.UUID, _request: object, idempotency_key: str | None = None
+    ) -> object:
+        del idempotency_key
         return SimpleNamespace(
             experiment_id=uuid.uuid4(),
             cohort_version_id=request.cohort_version_id,
@@ -898,7 +944,10 @@ async def test_evaluator_resolution_uses_bounded_concurrency() -> None:
         await wait_for_read()
         return SimpleNamespace(id=uuid.uuid4(), evaluator_id=item_id, version=version)
 
-    async def create_evaluation(_request: object) -> object:
+    async def create_evaluation(
+        _request: object, idempotency_key: str | None = None
+    ) -> object:
+        del idempotency_key
         return SimpleNamespace(model_dump=lambda **_kwargs: {"id": str(uuid.uuid4())})
 
     client = SimpleNamespace(
@@ -996,7 +1045,10 @@ async def test_evaluation_start_protocol_returns_typed_receipt() -> None:
             updated=now,
         )
 
-    async def create_evaluation(_request: object) -> JobResponse:
+    async def create_evaluation(
+        _request: object, idempotency_key: str | None = None
+    ) -> JobResponse:
+        del idempotency_key
         return JobResponse(
             id=job_id,
             owner_id=uuid.uuid4(),
@@ -1088,9 +1140,11 @@ def test_evaluator_updates_require_explicit_non_conflicting_changes() -> None:
 
 async def test_evaluator_management_uses_only_typed_sdk_mutations() -> None:
     calls: list[tuple[str, object]] = []
+    create_idempotency_keys: list[str | None] = []
 
-    async def create(request: object) -> object:
+    async def create(request: object, idempotency_key: str | None = None) -> object:
         calls.append(("create", request))
+        create_idempotency_keys.append(idempotency_key)
         return SimpleNamespace()
 
     async def update(_id: uuid.UUID, request: object) -> object:
@@ -1115,7 +1169,10 @@ async def test_evaluator_management_uses_only_typed_sdk_mutations() -> None:
     )
     state = _get_state(client)
     await handle_evaluators_manage(
-        state, EvaluatorCreate(operation="create", name="accuracy")
+        state,
+        EvaluatorCreate(
+            operation="create", name="accuracy", idempotency_key="retry-evaluator-1"
+        ),
     )
     await handle_evaluators_manage(
         state,
@@ -1167,6 +1224,7 @@ async def test_evaluator_management_uses_only_typed_sdk_mutations() -> None:
     assert cast(Any, calls[3][1]).model_dump(exclude_unset=True) == {
         "display_version": None
     }
+    assert create_idempotency_keys == ["retry-evaluator-1"]
 
 
 async def test_script_evaluator_version_requires_existing_exact_blob() -> None:

--- a/tests/mcp/test_workflow_integration.py
+++ b/tests/mcp/test_workflow_integration.py
@@ -19,6 +19,7 @@ from kitaru.mcp.tools.workflows import handle_session_import
 class _ImportClient:
     def __init__(self) -> None:
         self.calls: list[str] = []
+        self.idempotency_key: str | None = None
         self.blobs = SimpleNamespace(get=self._get_blob)
         self.importers = SimpleNamespace(
             get_version=self._get_importer_version, get=self._get_importer
@@ -42,8 +43,11 @@ class _ImportClient:
         self.calls.append("agent_version")
         return SimpleNamespace(id=item_id, agent_id=uuid.uuid4())
 
-    async def _create_import(self, _request: object) -> object:
+    async def _create_import(
+        self, _request: object, idempotency_key: str | None = None
+    ) -> object:
         self.calls.append("create")
+        self.idempotency_key = idempotency_key
         return SimpleNamespace(model_dump=lambda **_kwargs: {"id": str(uuid.uuid4())})
 
 
@@ -100,6 +104,23 @@ async def test_existing_blob_import_uses_four_bounded_preflight_reads() -> None:
     ]
     assert result["operation"] == "session_import"
     assert result["idempotency"] == "domain-deduplicated-only"
+
+
+async def test_session_import_forwards_idempotency_key() -> None:
+    client = _ImportClient()
+
+    await handle_session_import(
+        _get_state(client),
+        SessionImportRequest(
+            payload_blob_id=uuid.uuid4(),
+            importer_id=uuid.uuid4(),
+            importer_version=2,
+            agent_version_id=uuid.uuid4(),
+            idempotency_key="retry-import-1",
+        ),
+    )
+
+    assert client.idempotency_key == "retry-import-1"
 
 
 async def test_evaluator_selections_use_name_version_dto_and_cache_parent() -> None:

--- a/tests/server/test_idempotency_api.py
+++ b/tests/server/test_idempotency_api.py
@@ -18,7 +18,6 @@ from collections.abc import AsyncGenerator
 
 import httpx
 import pytest
-from fastapi.routing import iter_route_contexts
 
 from conftest import (
     FakeAgentRepository,
@@ -26,6 +25,7 @@ from conftest import (
     FakeApiKeyRepository,
     FakeIdempotencyKeyRepository,
     FakeTagRepository,
+    marked_idempotent_routes,
 )
 from kitaru.server.adapters.rest.dependencies import (
     _resolve_auth_context,
@@ -34,7 +34,6 @@ from kitaru.server.adapters.rest.dependencies import (
     get_idempotency_key_repository,
     get_tag_service,
 )
-from kitaru.server.adapters.rest.route import is_idempotent
 from kitaru.server.api.app import create_app
 from kitaru.server.api.config import APISettings
 from kitaru.server.application.models.auth import (
@@ -267,14 +266,24 @@ async def test_unmarked_route_ignores_the_header(
 async def test_idempotent_routes_match_the_expected_set() -> None:
     """Assert exactly the specified routes carry the idempotent marker."""
     app = create_app(_settings())
-    marked = {
-        (method, context.path)
-        for context in iter_route_contexts(app.routes)
-        if context.endpoint is not None and is_idempotent(context.endpoint)
-        for method in context.methods or ()
-    }
+    marked = marked_idempotent_routes(app)
     assert marked == EXPECTED_IDEMPOTENT_ROUTES
     assert ("POST", "/api/v1/tasks/claim") not in marked
+
+
+async def test_openapi_schema_documents_the_header_on_the_expected_routes() -> None:
+    """Assert the OpenAPI schema declares the header on exactly the expected routes."""
+    app = create_app(_settings())
+    schema = app.openapi()
+    documented = {
+        (method.upper(), path)
+        for path, operations in schema["paths"].items()
+        for method, operation in operations.items()
+        for parameter in operation.get("parameters", [])
+        if parameter.get("name") == "Idempotency-Key"
+        and parameter.get("in") == "header"
+    }
+    assert documented == EXPECTED_IDEMPOTENT_ROUTES
 
 
 async def test_non_printable_header_returns_400(client: httpx.AsyncClient) -> None:


### PR DESCRIPTION
This PR lets callers supply their own `Idempotency-Key` instead of the per-request key the transport generates, so retries of the same logical request within the retention window return the original response instead of acting twice.