### PR TITLE
Send a product query param on device login

### DIFF
--- a/src/kitaru/client/control_plane.py
+++ b/src/kitaru/client/control_plane.py
@@ -37,6 +37,9 @@ LOGIN_PATH = "/auth/login"
 API_KEY_GRANT_TYPE = "zenml_api_key"
 DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
 
+# Product the verification page is told to render for.
+PRODUCT = "kitaru"
+
 
 class ControlPlaneLoginError(Exception):
     """Raised when a control plane login cannot be started."""
@@ -166,13 +169,12 @@ class ControlPlaneSession:
         authorization = ControlPlaneDeviceAuthorization.model_validate(response.json())
         uri = authorization.verification_uri_complete or authorization.verification_uri
         verification_uri = self._url + uri if uri.startswith("/") else uri
+        parsed = urlparse(verification_uri)
+        query_params = dict(parse_qsl(parsed.query))
+        query_params["product"] = PRODUCT
         if workspace_id is not None:
-            parsed = urlparse(verification_uri)
-            query_params = dict(parse_qsl(parsed.query))
             query_params["workspace"] = workspace_id
-            verification_uri = urlunparse(
-                parsed._replace(query=urlencode(query_params))
-            )
+        verification_uri = urlunparse(parsed._replace(query=urlencode(query_params)))
         # Written back so the prompt shows the same URL the browser opens.
         authorization.verification_uri_complete = verification_uri
         if prompt is not None:

--- a/tests/client/test_control_plane.py
+++ b/tests/client/test_control_plane.py
@@ -39,6 +39,7 @@ class FakeControlPlane:
         self,
         pending_polls: int = 0,
         login_error: dict[str, str] | None = None,
+        verification_uri: str = "/devices/verify",
     ) -> None:
         """Initialize the stub.
 
@@ -46,9 +47,11 @@ class FakeControlPlane:
             pending_polls: Device code polls answered with
                 ``authorization_pending`` before the confirmation lands.
             login_error: OAuth 2.0 error body every login is refused with.
+            verification_uri: Verification URI the authorization carries.
         """
         self.pending_polls = pending_polls
         self.login_error = login_error
+        self.verification_uri = verification_uri
         self.requests: list[httpx.Request] = []
         self.logins = 0
 
@@ -69,7 +72,7 @@ class FakeControlPlane:
                 json={
                     "device_code": "cp-device-code",
                     "user_code": "ABCD-EFGH",
-                    "verification_uri": "/devices/verify",
+                    "verification_uri": self.verification_uri,
                     "verification_uri_complete": None,
                     "expires_in": 300,
                     "interval": 0,
@@ -268,7 +271,26 @@ async def test_relative_verification_uri_is_opened_against_the_control_plane(
     await session.device_login(prompt=lambda _: None)
     await session.close()
 
-    assert opened == [f"{CONTROL_PLANE_URL}/devices/verify"]
+    assert opened == [f"{CONTROL_PLANE_URL}/devices/verify?product=kitaru"]
+
+
+async def test_device_login_adds_the_product_to_the_verification_uri(
+    credential_store: CredentialStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Open the verification page with the product query parameter."""
+    opened: list[str] = []
+    monkeypatch.setattr(
+        "kitaru.client.control_plane.webbrowser.open", lambda uri: opened.append(uri)
+    )
+    session = _session(
+        credential_store,
+        FakeControlPlane(verification_uri="https://control.example.com/verify?foo=bar"),
+    )
+
+    await session.device_login(prompt=lambda _: None)
+    await session.close()
+
+    assert opened == ["https://control.example.com/verify?foo=bar&product=kitaru"]
 
 
 async def test_device_login_adds_the_workspace_to_the_verification_uri(
@@ -290,6 +312,8 @@ async def test_device_login_adds_the_workspace_to_the_verification_uri(
     )
     await session.close()
 
-    expected = f"{CONTROL_PLANE_URL}/devices/verify?workspace=workspace-id"
+    expected = (
+        f"{CONTROL_PLANE_URL}/devices/verify?product=kitaru&workspace=workspace-id"
+    )
     assert opened == [expected]
     assert prompted == [expected]


### PR DESCRIPTION
Adds `product=kitaru` to the device login verification URL so the control plane UI can tell which product started the flow.