### PR TITLE
Optionally scope evaluators to an agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Evaluators can now be scoped to a single agent with `agent_id` on `POST /api/v1/evaluators`, null for a workspace-global evaluator. A scoped evaluator can only be used by experiments, replays, and evaluation batches whose sessions belong to that agent. `agent_id` is immutable and importers cannot be scoped.
 - Added `POST /api/v1/workers/{worker_id}/token` to renew a worker token, and `kitaru worker list --include-stale` to list workers past the liveness window.
 - SDK methods that call an endpoint supporting idempotency now take an `idempotency_key` argument, so callers can supply their own key instead of the per-request key the transport generates. Those endpoints declare an `Idempotency-Key` header parameter in the OpenAPI schema.
 - MCP tools that create a resource take an optional `idempotency_key` field, so a retried tool call whose response was lost returns the original result instead of acting twice.
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `POST /api/v1/evaluations` requires every input session to belong to the same agent.
 - Every worker start now registers a new worker, worker names are labels and no longer need to be unique. Worker listings leave stale workers out unless `include_stale` is set. `kitaru worker get` takes a worker id, the name lookup it also accepted is gone.
 - Server analytics events now carry the reporting client in `client_version`, as the client name and the version it reported. Each client versions on its own series, so a bare version says nothing without the client that sent it.
 - Registering a worker from the Kitaru 0.22.2 Python SDK or older is rejected with HTTP 426. Those versions renew a worker token by registering again, which a server that gives every registration its own id cannot serve: the worker goes on heartbeating an id its token no longer names, and the tasks it is running get swept away from it. Upgrade workers along with the server. Every other caller is unaffected.

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1658,7 +1658,7 @@
             "type": "array"
           },
           "input_session_ids": {
-            "description": "Sessions to score.",
+            "description": "Sessions to score, all belonging to one agent.",
             "items": {
               "format": "uuid",
               "type": "string"
@@ -2126,6 +2126,19 @@
         "additionalProperties": false,
         "description": "Evaluator create request.",
         "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Id of the agent this evaluator is scoped to, null for a global evaluator.",
+            "title": "Agent Id"
+          },
           "description": {
             "anyOf": [
               {
@@ -2171,6 +2184,19 @@
       "EvaluatorResponse": {
         "description": "Evaluator response.",
         "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Id of the agent this evaluator is scoped to, null for a global evaluator.",
+            "title": "Agent Id"
+          },
           "created": {
             "description": "Creation time.",
             "format": "date-time",
@@ -2252,7 +2278,8 @@
           "description",
           "logo_url",
           "metadata",
-          "latest_version"
+          "latest_version",
+          "agent_id"
         ],
         "title": "EvaluatorResponse",
         "type": "object"

--- a/packages/core/src/generated/openapi.ts
+++ b/packages/core/src/generated/openapi.ts
@@ -4509,7 +4509,7 @@ export interface components {
             evaluators: components["schemas"]["EvaluatorConfig"][];
             /**
              * Input Session Ids
-             * @description Sessions to score.
+             * @description Sessions to score, all belonging to one agent.
              */
             input_session_ids: string[];
         };
@@ -4755,6 +4755,11 @@ export interface components {
          */
         EvaluatorCreateRequest: {
             /**
+             * Agent Id
+             * @description Id of the agent this evaluator is scoped to, null for a global evaluator.
+             */
+            agent_id?: string | null;
+            /**
              * Description
              * @description Evaluator description.
              */
@@ -4782,6 +4787,11 @@ export interface components {
          * @description Evaluator response.
          */
         EvaluatorResponse: {
+            /**
+             * Agent Id
+             * @description Id of the agent this evaluator is scoped to, null for a global evaluator.
+             */
+            agent_id: string | null;
             /**
              * Created
              * Format: date-time

--- a/packages/core/src/resources/internal.ts
+++ b/packages/core/src/resources/internal.ts
@@ -251,6 +251,9 @@ export function validateEvaluator(
   if (value.owner_id !== null) {
     requireUuid(value, "owner_id", method, path, status);
   }
+  if (value.agent_id !== null) {
+    requireUuid(value, "agent_id", method, path, status);
+  }
   requireString(value, "name", method, path, status);
   requireNumber(value, "latest_version", method, path, status);
   if (!isRecord(value.metadata)) {

--- a/packages/core/test/resources/management.test.ts
+++ b/packages/core/test/resources/management.test.ts
@@ -55,6 +55,7 @@ const annotation = {
 };
 
 const evaluator = {
+  agent_id: null,
   created: "2026-01-01T00:00:00Z",
   description: null,
   id: ID,
@@ -289,6 +290,24 @@ describe("management resources", () => {
       ],
       [`https://api.example/api/v1/evaluators/${ID}`, "DELETE"],
     ]);
+  });
+
+  it("creates an agent-scoped evaluator", async () => {
+    const request = {
+      agent_id: RELATED_ID,
+      name: "correctness",
+    } satisfies EvaluatorCreateRequest;
+    const scopedEvaluator = { ...evaluator, agent_id: RELATED_ID };
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(jsonResponse(scopedEvaluator, 201));
+    const client = new KitaruClient({ apiUrl: "https://api.example", fetch });
+
+    await expect(client.evaluators.create(request)).resolves.toEqual(
+      scopedEvaluator,
+    );
+
+    expect(fetch.mock.calls[0]?.[1]?.body).toBe(JSON.stringify(request));
   });
 
   it("returns an evaluation job and reads evaluation results", async () => {

--- a/src/kitaru/api_models/v1/evaluation.py
+++ b/src/kitaru/api_models/v1/evaluation.py
@@ -126,7 +126,7 @@ class EvaluationBatchCreateRequest(RequestModel):
     """Evaluation batch create request."""
 
     input_session_ids: list[uuid.UUID] = Field(
-        min_length=1, description="Sessions to score."
+        min_length=1, description="Sessions to score, all belonging to one agent."
     )
     evaluators: list[EvaluatorConfig] = Field(
         min_length=1, description="Evaluators run against every session."

--- a/src/kitaru/api_models/v1/evaluator.py
+++ b/src/kitaru/api_models/v1/evaluator.py
@@ -35,6 +35,12 @@ class EvaluatorCreateRequest(RequestModel):
     metadata: dict[str, JsonValue] = Field(
         default_factory=dict, description="Arbitrary metadata."
     )
+    agent_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Id of the agent this evaluator is scoped to, null for a global evaluator."
+        ),
+    )
 
 
 class EvaluatorUpdateRequest(RequestModel):
@@ -66,6 +72,10 @@ class EvaluatorResponse(TimestampedResponseModel):
     metadata: dict[str, JsonValue] = Field(description="Arbitrary metadata.")
     latest_version: int = Field(
         description="Highest version number created for this evaluator."
+    )
+    agent_id: uuid.UUID | None = Field(
+        description="Id of the agent this evaluator is scoped to, null for a "
+        "global evaluator."
     )
 
 

--- a/src/kitaru/cli/app.py
+++ b/src/kitaru/cli/app.py
@@ -2871,6 +2871,10 @@ def _plugin_register_parameters(kind: str) -> tuple[ParameterSpec, ...]:
         parent.append(
             ParameterSpec("--provider", "string", "option", False, "Source provider.")
         )
+    if kind == "evaluator":
+        parent.append(
+            ParameterSpec("--agent-id", "UUID", "option", False, "Scoping agent.")
+        )
     return (*parent, *_PLUGIN_SOURCE_PARAMETERS)
 
 
@@ -2884,6 +2888,7 @@ async def _register_plugin_command(
     description: str | None,
     provider: str | None,
     metadata: str | None,
+    agent_id: uuid.UUID | None,
     display_version: str | None,
 ) -> CommandResult:
     """Run one kind-specific parent-plus-version registration."""
@@ -2896,6 +2901,7 @@ async def _register_plugin_command(
         description=description,
         provider=provider,
         metadata=metadata,
+        agent_id=agent_id,
     )
     async with _open_asset_client() as client:
         return await registration.register_plugin(
@@ -3087,6 +3093,7 @@ async def importer_register(
         description=description,
         provider=provider,
         metadata=metadata,
+        agent_id=None,
         display_version=display_version,
     )
 
@@ -3294,6 +3301,7 @@ async def evaluator_register(
     entrypoint: str | None = None,
     description: str | None = None,
     metadata: str | None = None,
+    agent_id: uuid.UUID | None = None,
     display_version: str | None = None,
 ) -> CommandResult:
     """Create an evaluator parent, source, and initial version."""
@@ -3306,6 +3314,7 @@ async def evaluator_register(
         description=description,
         provider=None,
         metadata=metadata,
+        agent_id=agent_id,
         display_version=display_version,
     )
 

--- a/src/kitaru/cli/registration.py
+++ b/src/kitaru/cli/registration.py
@@ -651,10 +651,15 @@ def plugin_parent_request(
     description: str | None,
     provider: str | None,
     metadata: str | None,
+    agent_id: uuid.UUID | None,
 ) -> ImporterCreateRequest | EvaluatorCreateRequest:
     """Build one kind-specific plugin parent request."""
     parsed_metadata = parse_json_object(metadata, option="--metadata")
     if kind == "importer":
+        if agent_id is not None:
+            raise CLIError(
+                "invalid_arguments", "--agent-id is only valid for evaluators."
+            )
         return ImporterCreateRequest(
             name=name,
             description=description,
@@ -664,7 +669,7 @@ def plugin_parent_request(
     if provider is not None:
         raise CLIError("invalid_arguments", "--provider is only valid for importers.")
     return EvaluatorCreateRequest(
-        name=name, description=description, metadata=parsed_metadata
+        name=name, description=description, metadata=parsed_metadata, agent_id=agent_id
     )
 
 

--- a/src/kitaru/server/adapters/db/orm/plugin.py
+++ b/src/kitaru/server/adapters/db/orm/plugin.py
@@ -53,6 +53,8 @@ PLUGIN_KIND_NAME_UNIQUE_CONSTRAINT = unique_constraint_name("plugin", ["kind", "
 PLUGIN_OWNER_ID_FOREIGN_KEY = foreign_key_name("plugin", ["owner_id"])
 PLUGIN_OWNER_ID_INDEX = index_name("plugin", ["owner_id"])
 PLUGIN_KIND_PROVIDER_INDEX = index_name("plugin", ["kind", "provider"])
+PLUGIN_AGENT_ID_FOREIGN_KEY = foreign_key_name("plugin", ["agent_id"])
+PLUGIN_AGENT_ID_INDEX = index_name("plugin", ["agent_id"])
 
 
 class PluginORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
@@ -64,8 +66,15 @@ class PluginORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         ForeignKeyConstraint(
             ["owner_id"], ["account.id"], name=PLUGIN_OWNER_ID_FOREIGN_KEY
         ),
+        ForeignKeyConstraint(
+            ["agent_id"],
+            ["agent.id"],
+            name=PLUGIN_AGENT_ID_FOREIGN_KEY,
+            ondelete="SET NULL",
+        ),
         Index(PLUGIN_OWNER_ID_INDEX, "owner_id"),
         Index(PLUGIN_KIND_PROVIDER_INDEX, "kind", "provider"),
+        Index(PLUGIN_AGENT_ID_INDEX, "agent_id"),
     )
 
     owner_id: Mapped[uuid.UUID | None]
@@ -76,6 +85,7 @@ class PluginORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     logo_url: Mapped[str | None] = mapped_column(Text)
     metadata_: Mapped[dict[str, Any]] = mapped_column("metadata", JSONB)
     latest_version: Mapped[int]
+    agent_id: Mapped[uuid.UUID | None]
 
     @classmethod
     def from_domain(cls, plugin: Plugin) -> "PluginORM":
@@ -97,6 +107,7 @@ class PluginORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             logo_url=plugin.logo_url,
             metadata_=plugin.metadata,
             latest_version=plugin.latest_version,
+            agent_id=plugin.agent_id,
         )
 
     def to_domain(self) -> Plugin:
@@ -115,6 +126,7 @@ class PluginORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             logo_url=self.logo_url,
             metadata=self.metadata_,
             latest_version=self.latest_version,
+            agent_id=self.agent_id,
             created=self.created,
             updated=self.updated,
         )

--- a/src/kitaru/server/adapters/db/repositories/plugin_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/plugin_repository.py
@@ -23,6 +23,7 @@ from kitaru.server.adapters.db.orm.evaluation import (
     EVALUATION_EVALUATOR_VERSION_ID_FOREIGN_KEY,
 )
 from kitaru.server.adapters.db.orm.plugin import (
+    PLUGIN_AGENT_ID_FOREIGN_KEY,
     PLUGIN_KIND_NAME_UNIQUE_CONSTRAINT,
     PLUGIN_VERSION_BLOB_ID_FOREIGN_KEY,
     PLUGIN_VERSION_PLUGIN_ID_VERSION_UNIQUE_CONSTRAINT,
@@ -32,6 +33,7 @@ from kitaru.server.adapters.db.orm.plugin import (
 from kitaru.server.adapters.db.pagination import paginate
 from kitaru.server.adapters.db.repositories.base import BaseSQLRepository
 from kitaru.server.application.models.plugin import PluginFilter, PluginVersionFilter
+from kitaru.server.domain.agent import AgentNotFound
 from kitaru.server.domain.base import DomainError, NotFoundError
 from kitaru.server.domain.blob import BlobNotFound
 from kitaru.server.domain.plugin import (
@@ -52,6 +54,7 @@ PLUGIN_FILTER_BINDINGS: Mapping[str, FilterBinding] = {
     "id": PluginORM.id,
     "name": PluginORM.name,
     "provider": PluginORM.provider,
+    "agent_id": PluginORM.agent_id,
 }
 
 
@@ -78,20 +81,22 @@ class SQLPluginRepository(BaseSQLRepository[PluginORM]):
             plugin: Plugin to store.
 
         Raises:
+            AgentNotFound: The plugin names an agent id and no agent has it.
             DuplicatePluginName: The (kind, name) pair is already registered.
 
         Returns:
             Stored plugin with timestamps set.
         """
         row = PluginORM.from_domain(plugin)
-        await self._add(
-            row,
-            {
-                PLUGIN_KIND_NAME_UNIQUE_CONSTRAINT: lambda: DuplicatePluginName(
-                    plugin.kind, plugin.name
-                )
-            },
-        )
+        constraints: dict[str, Callable[[], DomainError]] = {
+            PLUGIN_KIND_NAME_UNIQUE_CONSTRAINT: lambda: DuplicatePluginName(
+                plugin.kind, plugin.name
+            ),
+        }
+        if plugin.agent_id is not None:
+            agent_id = plugin.agent_id
+            constraints[PLUGIN_AGENT_ID_FOREIGN_KEY] = lambda: AgentNotFound(agent_id)
+        await self._add(row, constraints)
         return row.to_domain()
 
     async def get(self, plugin_id: uuid.UUID) -> Plugin:

--- a/src/kitaru/server/adapters/rest/mapping/plugins.py
+++ b/src/kitaru/server/adapters/rest/mapping/plugins.py
@@ -129,6 +129,8 @@ def plugin_to_response(
     }
     if plugin.kind is PluginKind.IMPORTER:
         fields["provider"] = plugin.provider
+    if plugin.kind is PluginKind.EVALUATOR:
+        fields["agent_id"] = plugin.agent_id
     return response_class(**fields)
 
 
@@ -198,12 +200,15 @@ def plugin_create_to_command(
     """
     # Read the provider off importer requests only, evaluators reject one.
     provider = body.provider if isinstance(body, ImporterCreateRequest) else None
+    # Read agent_id off evaluator requests only, importers are not scopeable.
+    agent_id = body.agent_id if isinstance(body, EvaluatorCreateRequest) else None
     return PluginCreate(
         name=body.name,
         description=body.description,
         provider=provider,
         logo_url=body.logo_url,
         metadata=body.metadata,
+        agent_id=agent_id,
     )
 
 

--- a/src/kitaru/server/application/interfaces/plugin_repository.py
+++ b/src/kitaru/server/application/interfaces/plugin_repository.py
@@ -30,6 +30,7 @@ class PluginRepository(Protocol):
             plugin: Plugin to store.
 
         Raises:
+            AgentNotFound: The plugin names an agent id and no agent has it.
             DuplicatePluginName: The (kind, name) pair is already registered.
 
         Returns:

--- a/src/kitaru/server/application/models/plugin.py
+++ b/src/kitaru/server/application/models/plugin.py
@@ -42,6 +42,7 @@ class EvaluatorFilter(PluginFilter):
     filterable_fields: ClassVar[Mapping[str, FilterField]] = {
         "id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS),
         "name": FilterField(value_type=str, ops=STRING_OPS),
+        "agent_id": FilterField(value_type=uuid.UUID, ops=EQUALITY_OPS | NULLABLE_OPS),
     }
 
 
@@ -69,6 +70,7 @@ class PluginCreate(FrozenModel):
     provider: str | None = None
     logo_url: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    agent_id: uuid.UUID | None = None
 
 
 class PluginUpdate(FrozenModel):

--- a/src/kitaru/server/application/services/evaluator_resolution.py
+++ b/src/kitaru/server/application/services/evaluator_resolution.py
@@ -58,6 +58,7 @@ def _validate_builtin_evaluator_params(config: EvaluatorConfigInput) -> None:
 async def resolve_evaluator_config(
     config: EvaluatorConfigInput,
     plugin_repository: PluginRepository,
+    agent_id: uuid.UUID | None,
     actor: AuthContext | None = None,
 ) -> EvaluatorConfig:
     """Resolve an evaluator config to a concrete plugin version.
@@ -67,12 +68,15 @@ async def resolve_evaluator_config(
     Args:
         config: Evaluator config awaiting resolution.
         plugin_repository: Plugin repository, queried for the evaluator kind.
+        agent_id: Caller's agent context, must match a scoped evaluator's
+            agent id.
         actor: Caller context, unused, ownership is provenance only.
 
     Raises:
         PluginNotFound: No evaluator plugin has this name.
         PluginVersionNotFound: The resolved version has no matching plugin
             version.
+        ValidationError: The evaluator is scoped to a different agent.
 
     Returns:
         Resolved evaluator config carrying the concrete version and its id.
@@ -81,6 +85,10 @@ async def resolve_evaluator_config(
     plugin = await resolve_plugin(
         config.evaluator, PluginKind.EVALUATOR, plugin_repository
     )
+    if plugin.agent_id is not None and plugin.agent_id != agent_id:
+        raise ValidationError(
+            f"Evaluator '{config.evaluator}' is scoped to a different agent"
+        )
     plugin_version = await resolve_plugin_version(
         plugin, config.version, plugin_repository
     )
@@ -96,6 +104,7 @@ async def resolve_evaluator_config(
 async def validate_evaluators(
     configs: list[EvaluatorConfigInput],
     plugin_repository: PluginRepository,
+    agent_id: uuid.UUID | None,
     actor: AuthContext | None = None,
 ) -> list[EvaluatorConfig]:
     """Resolve every evaluator config, rejecting a repeated resolved version.
@@ -103,18 +112,21 @@ async def validate_evaluators(
     Args:
         configs: Evaluator configs awaiting resolution.
         plugin_repository: Plugin repository, queried for the evaluator kind.
+        agent_id: Caller's agent context, must match a scoped evaluator's
+            agent id.
         actor: Caller context, unused, ownership is provenance only.
 
     Raises:
         PluginNotFound: A config names an unknown evaluator.
         PluginVersionNotFound: A config names an unknown version.
-        ValidationError: Two configs resolve to the same evaluator version.
+        ValidationError: A config's evaluator is scoped to a different
+            agent, or two configs resolve to the same evaluator version.
 
     Returns:
         Resolved evaluator configs.
     """
     resolved = [
-        await resolve_evaluator_config(config, plugin_repository, actor)
+        await resolve_evaluator_config(config, plugin_repository, agent_id, actor)
         for config in configs
     ]
     seen_ids: set[uuid.UUID] = set()

--- a/src/kitaru/server/application/services/experiment_service.py
+++ b/src/kitaru/server/application/services/experiment_service.py
@@ -169,8 +169,9 @@ class ExperimentService:
             PluginNotFound: An evaluator config names an unknown evaluator.
             PluginVersionNotFound: An evaluator config names an unknown
                 version.
-            ValidationError: Two evaluator configs resolve to the same
-                evaluator version.
+            ValidationError: An evaluator config is scoped to another agent,
+                or two evaluator configs resolve to the same evaluator
+                version.
             DuplicateExperimentName: The experiment name is already
                 registered.
 
@@ -179,7 +180,7 @@ class ExperimentService:
         """
         await self._agents.get(command.agent_id)
         evaluators = await validate_evaluators(
-            command.evaluators, self._plugin_repository, actor
+            command.evaluators, self._plugin_repository, command.agent_id, actor
         )
         config = await self._create_replay_config(
             actor.account.id,
@@ -269,8 +270,9 @@ class ExperimentService:
             PluginVersionNotFound: A new evaluator config names an unknown
                 version.
             ValidationError: The command clears the experiment name, the
-                tool policy, or every evaluator, or two evaluator configs
-                resolve to the same evaluator version.
+                tool policy, or every evaluator, a new evaluator config is
+                scoped to another agent, or two evaluator configs resolve to
+                the same evaluator version.
             DuplicateExperimentName: The experiment name is already
                 registered.
             ExperimentFrozen: The experiment has runs and the command
@@ -305,7 +307,7 @@ class ExperimentService:
             if not command.evaluators:
                 raise ValidationError("Experiment evaluators cannot be cleared")
             evaluators = await validate_evaluators(
-                command.evaluators, self._plugin_repository, actor
+                command.evaluators, self._plugin_repository, experiment.agent_id, actor
             )
         tool_policy = current_config.tool_policy
         if "tool_policy" in config_fields:

--- a/src/kitaru/server/application/services/job_service.py
+++ b/src/kitaru/server/application/services/job_service.py
@@ -352,8 +352,9 @@ class JobService:
             actor: Caller context.
 
         Raises:
-            ValidationError: The pair count exceeds the cap, or an input
-                session does not exist.
+            ValidationError: The pair count exceeds the cap, an input
+                session does not exist, the input sessions do not all belong
+                to one agent, or a config is scoped to another agent.
             PluginNotFound: A config names an unknown evaluator.
             PluginVersionNotFound: A config names an unknown version.
 
@@ -366,11 +367,16 @@ class JobService:
                 f"Evaluation request holds {pairs} pairs, the cap is "
                 f"{self._policy.evaluation_pair_limit}"
             )
-        evaluators = await validate_evaluators(command.evaluators, self._plugins, actor)
         stored = await self._sessions.get_many(command.input_session_ids)
         for session_id in command.input_session_ids:
             if session_id not in stored:
                 raise ValidationError(f"Session {session_id} was not found")
+        agent_ids = {session.agent_id for session in stored.values()}
+        if len(agent_ids) > 1:
+            raise ValidationError("Input sessions must belong to a single agent")
+        evaluators = await validate_evaluators(
+            command.evaluators, self._plugins, next(iter(agent_ids)), actor
+        )
         job = await self.create_job(JobKind.EVALUATION, actor)
         # The job was just created in this call and cannot have settled yet, so
         # each pair skips add_task's redundant per-iteration settled check.

--- a/src/kitaru/server/application/services/plugin_service.py
+++ b/src/kitaru/server/application/services/plugin_service.py
@@ -69,7 +69,11 @@ class PluginService:
             actor: Caller context.
 
         Raises:
+            AgentNotFound: The command names an agent id and no agent has
+                it.
             DuplicatePluginName: The (kind, name) pair is already registered.
+            InvalidPluginAgentScope: The kind is importer and agent_id is
+                set.
             InvalidPluginProvider: The kind is evaluator and provider is set.
             ReservedPluginName: The name is under the reserved namespace.
 
@@ -86,6 +90,7 @@ class PluginService:
             provider=command.provider,
             logo_url=command.logo_url,
             metadata=command.metadata,
+            agent_id=command.agent_id,
         )
         return await self._repository.create(plugin)
 

--- a/src/kitaru/server/application/services/replay_service.py
+++ b/src/kitaru/server/application/services/replay_service.py
@@ -136,7 +136,8 @@ class ReplayService:
             SessionNotFound: No session has the baseline session id.
             ValidationError: The baseline session carries no agent version
                 and none was given, the resolved agent version has no run
-                spec, or the config uses cohort-version-scoped history.
+                spec, the config uses cohort-version-scoped history, or an
+                evaluator config is scoped to another agent.
             AgentVersionNotFound: No agent version has the resolved id.
             PluginNotFound: An evaluator config names an unknown evaluator.
             PluginVersionNotFound: An evaluator config names an unknown
@@ -157,7 +158,9 @@ class ReplayService:
         agent_version = await resolve_runnable_agent_version(
             agent_version_id, self._agent_versions
         )
-        evaluators = await validate_evaluators(command.evaluators, self._plugins, actor)
+        evaluators = await validate_evaluators(
+            command.evaluators, self._plugins, baseline.agent_id, actor
+        )
         config = ReplayConfig(
             owner_id=actor.account.id,
             override=command.override,

--- a/src/kitaru/server/database/migrations/versions/005_evaluator_agent_scoping.py
+++ b/src/kitaru/server/database/migrations/versions/005_evaluator_agent_scoping.py
@@ -1,0 +1,47 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Optional agent scoping for evaluator plugins.
+
+Revision ID: 005_evaluator_agent_scoping
+Revises: 004_replay_result_session_id
+Create Date: 2026-08-25
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "005_evaluator_agent_scoping"
+down_revision = "004_replay_result_session_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    with op.batch_alter_table("plugin", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("agent_id", sa.Uuid(), nullable=True))
+        batch_op.create_index("ix_plugin_agent_id", ["agent_id"], unique=False)
+        batch_op.create_foreign_key(
+            "fk_plugin_agent_id", "agent", ["agent_id"], ["id"], ondelete="SET NULL"
+        )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    with op.batch_alter_table("plugin", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_plugin_agent_id", type_="foreignkey")
+        batch_op.drop_index("ix_plugin_agent_id")
+        batch_op.drop_column("agent_id")

--- a/src/kitaru/server/domain/plugin.py
+++ b/src/kitaru/server/domain/plugin.py
@@ -147,6 +147,14 @@ class InvalidPluginProvider(ValidationError):
         super().__init__("Evaluator plugins do not carry a provider")
 
 
+class InvalidPluginAgentScope(ValidationError):
+    """Raised when an importer plugin carries an agent id."""
+
+    def __init__(self) -> None:
+        """Initialize the error."""
+        super().__init__("Importer plugins do not carry an agent id")
+
+
 class InvalidPluginRequirement(ValidationError):
     """Raised when a package plugin requirement fails validation."""
 
@@ -279,6 +287,7 @@ class Plugin(DomainModel):
     logo_url: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
     latest_version: int = 0
+    agent_id: uuid.UUID | None = None
     created: datetime | None = None
     updated: datetime | None = None
 
@@ -294,6 +303,21 @@ class Plugin(DomainModel):
         """
         if self.kind is PluginKind.EVALUATOR and self.provider is not None:
             raise InvalidPluginProvider
+        return self
+
+    @model_validator(mode="after")
+    def _check_agent_id(self) -> "Plugin":
+        """Reject an agent id on an importer plugin.
+
+        Raises:
+            InvalidPluginAgentScope: The kind is importer and agent_id is
+                set.
+
+        Returns:
+            The validated plugin.
+        """
+        if self.kind is PluginKind.IMPORTER and self.agent_id is not None:
+            raise InvalidPluginAgentScope
         return self
 
     def update_description(self, description: str | None) -> None:

--- a/tests/client/test_evaluators.py
+++ b/tests/client/test_evaluators.py
@@ -19,11 +19,13 @@ from collections.abc import AsyncGenerator
 import pytest
 
 from conftest import (
+    FakeAgentRepository,
     FakeBlobRepository,
     FakePluginRepository,
     asgi_api_client,
     override_idempotency,
 )
+from kitaru.api_models.v1.agent import AgentCreateRequest
 from kitaru.api_models.v1.evaluator import (
     EvaluatorCreateRequest,
     EvaluatorUpdateRequest,
@@ -33,10 +35,15 @@ from kitaru.api_models.v1.evaluator import (
 from kitaru.api_models.v1.plugin import PackagePluginSource
 from kitaru.client.api_client import KitaruAPIClient
 from kitaru.client.exceptions import APIError, NotFoundError
-from kitaru.server.adapters.rest.dependencies import authorize, get_evaluator_service
+from kitaru.server.adapters.rest.dependencies import (
+    authorize,
+    get_agent_service,
+    get_evaluator_service,
+)
 from kitaru.server.api.app import create_app
 from kitaru.server.api.config import APISettings
 from kitaru.server.application.models.auth import AuthContext
+from kitaru.server.application.services.agent_service import AgentService
 from kitaru.server.application.services.plugin_service import PluginService
 from kitaru.server.domain.account import Account
 from kitaru.server.domain.plugin import PluginKind
@@ -54,12 +61,16 @@ async def api_client() -> AsyncGenerator[KitaruAPIClient, None]:
             JWT_SIGNING_KEY="test-signing-key-0123456789abcdef",
         )
     )
+    agent_repository = FakeAgentRepository()
     service = PluginService(
         kind=PluginKind.EVALUATOR,
-        repository=FakePluginRepository(),
+        repository=FakePluginRepository(agent_repository=agent_repository),
         blob_repository=FakeBlobRepository(),
     )
     app.dependency_overrides[get_evaluator_service] = lambda: service
+    app.dependency_overrides[get_agent_service] = lambda: AgentService(
+        repository=agent_repository
+    )
     app.dependency_overrides[authorize] = lambda: AuthContext(account=ACCOUNT)
     override_idempotency(app, ACCOUNT)
     async with asgi_api_client(app) as client:
@@ -73,6 +84,18 @@ async def test_create(api_client: KitaruAPIClient) -> None:
     )
     assert evaluator.name == "accuracy"
     assert evaluator.metadata == {"a": 1}
+
+
+async def test_create_scoped_to_agent(api_client: KitaruAPIClient) -> None:
+    """Round-trip an evaluator's agent scoping through the SDK."""
+    agent = await api_client.agents.create(AgentCreateRequest(name="assistant"))
+    evaluator = await api_client.evaluators.create(
+        EvaluatorCreateRequest(name="accuracy", agent_id=agent.id)
+    )
+    assert evaluator.agent_id == agent.id
+
+    loaded = await api_client.evaluators.get(evaluator.id)
+    assert loaded.agent_id == agent.id
 
 
 async def test_create_duplicate_name(api_client: KitaruAPIClient) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1711,6 +1711,17 @@ class FakeAgentRepository:
             if other.id != agent.id and other.name == agent.name:
                 raise DuplicateAgentName(agent.name)
 
+    def exists(self, agent_id: uuid.UUID) -> bool:
+        """Report whether an agent has this id.
+
+        Args:
+            agent_id: Id of the agent.
+
+        Returns:
+            Whether an agent has this id.
+        """
+        return agent_id in self._agents
+
     def increment_latest_version(self, agent_id: uuid.UUID) -> int:
         """Bump and return the agent's version counter.
 
@@ -3665,16 +3676,23 @@ async def create_blob(
 class FakePluginRepository:
     """In-memory plugin and plugin version repository."""
 
-    def __init__(self, blob_repository: FakeBlobRepository | None = None) -> None:
+    def __init__(
+        self,
+        blob_repository: FakeBlobRepository | None = None,
+        agent_repository: FakeAgentRepository | None = None,
+    ) -> None:
         """Initialize the repository.
 
         Args:
             blob_repository: Blob repository, marked when a script version
                 references one of its blobs, mirroring the FK restrict.
+            agent_repository: Agent repository, checked against a plugin's
+                agent id on create, mirroring the FK.
         """
         self._plugins: dict[uuid.UUID, Plugin] = {}
         self._versions: dict[uuid.UUID, PluginVersion] = {}
         self._blob_repository = blob_repository
+        self._agent_repository = agent_repository
         self._referenced_version_ids: set[uuid.UUID] = set()
 
     def mark_version_referenced(self, version_id: uuid.UUID) -> None:
@@ -3704,11 +3722,18 @@ class FakePluginRepository:
             plugin: Plugin to store.
 
         Raises:
+            AgentNotFound: The plugin names an agent id and no agent has it.
             DuplicatePluginName: The (kind, name) pair is already registered.
 
         Returns:
             Stored plugin with timestamps set.
         """
+        if (
+            plugin.agent_id is not None
+            and self._agent_repository is not None
+            and not self._agent_repository.exists(plugin.agent_id)
+        ):
+            raise AgentNotFound(plugin.agent_id)
         self._check_duplicate_name(plugin)
         now = datetime.now(UTC)
         stored = plugin.model_copy(update={"created": now, "updated": now})
@@ -3955,6 +3980,7 @@ async def create_plugin(
     description: str | None = None,
     provider: str | None = None,
     metadata: dict[str, Any] | None = None,
+    agent_id: uuid.UUID | None = None,
 ) -> Plugin:
     """Store a plugin in the fake repository.
 
@@ -3966,6 +3992,8 @@ async def create_plugin(
         description: Plugin description.
         provider: Source system, evaluators must leave this unset.
         metadata: Arbitrary metadata.
+        agent_id: Agent the plugin is scoped to, importers must leave this
+            unset.
 
     Returns:
         Stored plugin.
@@ -3978,6 +4006,7 @@ async def create_plugin(
             description=description,
             provider=provider,
             metadata=metadata or {},
+            agent_id=agent_id,
         )
     )
 

--- a/tests/mcp/snapshots/destructive.json
+++ b/tests/mcp/snapshots/destructive.json
@@ -842,6 +842,19 @@
         "EvaluatorResponse": {
           "description": "Evaluator response.",
           "properties": {
+            "agent_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the agent this evaluator is scoped to, null for a global evaluator.",
+              "title": "Agent Id"
+            },
             "created": {
               "description": "Creation time.",
               "format": "date-time",
@@ -923,7 +936,8 @@
             "description",
             "logo_url",
             "metadata",
-            "latest_version"
+            "latest_version",
+            "agent_id"
           ],
           "title": "EvaluatorResponse",
           "type": "object"
@@ -9958,6 +9972,19 @@
         "EvaluatorResponse": {
           "description": "Evaluator response.",
           "properties": {
+            "agent_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the agent this evaluator is scoped to, null for a global evaluator.",
+              "title": "Agent Id"
+            },
             "created": {
               "description": "Creation time.",
               "format": "date-time",
@@ -10039,7 +10066,8 @@
             "description",
             "logo_url",
             "metadata",
-            "latest_version"
+            "latest_version",
+            "agent_id"
           ],
           "title": "EvaluatorResponse",
           "type": "object"

--- a/tests/mcp/snapshots/metrics.json
+++ b/tests/mcp/snapshots/metrics.json
@@ -6,7 +6,7 @@
   },
   "modes": {
     "destructive": {
-      "discovery_response_bytes": 155018,
+      "discovery_response_bytes": 155404,
       "tool_count": 11,
       "tools": {
         "kitaru_activity_read": {
@@ -32,10 +32,10 @@
         },
         "kitaru_evaluators_manage": {
           "$defs_count": 11,
-          "combined_bytes": 8743,
+          "combined_bytes": 8936,
           "input_bytes": 4270,
           "maximum_nesting_depth": 7,
-          "output_bytes": 4473
+          "output_bytes": 4666
         },
         "kitaru_experiments_manage": {
           "$defs_count": 26,
@@ -46,10 +46,10 @@
         },
         "kitaru_registry_read": {
           "$defs_count": 45,
-          "combined_bytes": 31293,
+          "combined_bytes": 31486,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25587
+          "output_bytes": 25780
         },
         "kitaru_review_manage": {
           "$defs_count": 30,
@@ -89,7 +89,7 @@
       }
     },
     "read-only": {
-      "discovery_response_bytes": 77948,
+      "discovery_response_bytes": 78141,
       "tool_count": 3,
       "tools": {
         "kitaru_activity_read": {
@@ -101,10 +101,10 @@
         },
         "kitaru_registry_read": {
           "$defs_count": 45,
-          "combined_bytes": 31293,
+          "combined_bytes": 31486,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25587
+          "output_bytes": 25780
         },
         "kitaru_review_read": {
           "$defs_count": 20,
@@ -116,7 +116,7 @@
       }
     },
     "standard": {
-      "discovery_response_bytes": 143626,
+      "discovery_response_bytes": 144012,
       "tool_count": 9,
       "tools": {
         "kitaru_activity_read": {
@@ -135,10 +135,10 @@
         },
         "kitaru_evaluators_manage": {
           "$defs_count": 11,
-          "combined_bytes": 8743,
+          "combined_bytes": 8936,
           "input_bytes": 4270,
           "maximum_nesting_depth": 7,
-          "output_bytes": 4473
+          "output_bytes": 4666
         },
         "kitaru_experiments_manage": {
           "$defs_count": 26,
@@ -149,10 +149,10 @@
         },
         "kitaru_registry_read": {
           "$defs_count": 45,
-          "combined_bytes": 31293,
+          "combined_bytes": 31486,
           "input_bytes": 5706,
           "maximum_nesting_depth": 8,
-          "output_bytes": 25587
+          "output_bytes": 25780
         },
         "kitaru_review_manage": {
           "$defs_count": 30,

--- a/tests/mcp/snapshots/read-only.json
+++ b/tests/mcp/snapshots/read-only.json
@@ -842,6 +842,19 @@
         "EvaluatorResponse": {
           "description": "Evaluator response.",
           "properties": {
+            "agent_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the agent this evaluator is scoped to, null for a global evaluator.",
+              "title": "Agent Id"
+            },
             "created": {
               "description": "Creation time.",
               "format": "date-time",
@@ -923,7 +936,8 @@
             "description",
             "logo_url",
             "metadata",
-            "latest_version"
+            "latest_version",
+            "agent_id"
           ],
           "title": "EvaluatorResponse",
           "type": "object"

--- a/tests/mcp/snapshots/standard.json
+++ b/tests/mcp/snapshots/standard.json
@@ -842,6 +842,19 @@
         "EvaluatorResponse": {
           "description": "Evaluator response.",
           "properties": {
+            "agent_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the agent this evaluator is scoped to, null for a global evaluator.",
+              "title": "Agent Id"
+            },
             "created": {
               "description": "Creation time.",
               "format": "date-time",
@@ -923,7 +936,8 @@
             "description",
             "logo_url",
             "metadata",
-            "latest_version"
+            "latest_version",
+            "agent_id"
           ],
           "title": "EvaluatorResponse",
           "type": "object"
@@ -9958,6 +9972,19 @@
         "EvaluatorResponse": {
           "description": "Evaluator response.",
           "properties": {
+            "agent_id": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Id of the agent this evaluator is scoped to, null for a global evaluator.",
+              "title": "Agent Id"
+            },
             "created": {
               "description": "Creation time.",
               "format": "date-time",
@@ -10039,7 +10066,8 @@
             "description",
             "logo_url",
             "metadata",
-            "latest_version"
+            "latest_version",
+            "agent_id"
           ],
           "title": "EvaluatorResponse",
           "type": "object"

--- a/tests/mcp/test_review_workflows.py
+++ b/tests/mcp/test_review_workflows.py
@@ -1028,6 +1028,7 @@ async def test_evaluation_start_protocol_returns_typed_receipt() -> None:
             logo_url=None,
             metadata={},
             latest_version=1,
+            agent_id=None,
             created=now,
             updated=now,
         )

--- a/tests/server/test_evaluator_resolution.py
+++ b/tests/server/test_evaluator_resolution.py
@@ -51,7 +51,7 @@ async def test_resolve_latest_version(repository: FakePluginRepository) -> None:
     second = await repository.create_version(plugin.id, SOURCE, display_version="v2")
 
     config = EvaluatorConfigInput(evaluator="accuracy")
-    resolved = await resolve_evaluator_config(config, repository)
+    resolved = await resolve_evaluator_config(config, repository, agent_id=None)
     assert resolved.evaluator == "accuracy"
     assert resolved.version == 2
     assert resolved.evaluator_version_id == second.id
@@ -66,7 +66,7 @@ async def test_resolve_explicit_version(repository: FakePluginRepository) -> Non
     await repository.create_version(plugin.id, SOURCE, display_version="v2")
 
     config = EvaluatorConfigInput(evaluator="accuracy", version=1)
-    resolved = await resolve_evaluator_config(config, repository)
+    resolved = await resolve_evaluator_config(config, repository, agent_id=None)
     assert resolved.version == 1
     assert resolved.evaluator_version_id == first.id
 
@@ -75,7 +75,7 @@ async def test_resolve_missing_evaluator(repository: FakePluginRepository) -> No
     """Raise when no evaluator plugin has the config's name."""
     config = EvaluatorConfigInput(evaluator="missing")
     with pytest.raises(PluginNotFound, match="Plugin missing was not found"):
-        await resolve_evaluator_config(config, repository)
+        await resolve_evaluator_config(config, repository, agent_id=None)
 
 
 async def test_resolve_missing_version(repository: FakePluginRepository) -> None:
@@ -85,7 +85,7 @@ async def test_resolve_missing_version(repository: FakePluginRepository) -> None
     )
     config = EvaluatorConfigInput(evaluator="accuracy", version=5)
     with pytest.raises(PluginVersionNotFound):
-        await resolve_evaluator_config(config, repository)
+        await resolve_evaluator_config(config, repository, agent_id=None)
 
 
 async def test_resolve_no_versions_yet(repository: FakePluginRepository) -> None:
@@ -93,7 +93,76 @@ async def test_resolve_no_versions_yet(repository: FakePluginRepository) -> None
     await create_plugin(repository, OWNER_ID, kind=PluginKind.EVALUATOR, name="fresh")
     config = EvaluatorConfigInput(evaluator="fresh")
     with pytest.raises(PluginVersionNotFound):
-        await resolve_evaluator_config(config, repository)
+        await resolve_evaluator_config(config, repository, agent_id=None)
+
+
+async def test_resolve_evaluator_config_scoped_matching_agent(
+    repository: FakePluginRepository,
+) -> None:
+    """Resolve a scoped evaluator when the agent context matches."""
+    agent_id = uuid.uuid4()
+    plugin = await create_plugin(
+        repository,
+        OWNER_ID,
+        kind=PluginKind.EVALUATOR,
+        name="accuracy",
+        agent_id=agent_id,
+    )
+    await repository.create_version(plugin.id, SOURCE, display_version="v1")
+
+    config = EvaluatorConfigInput(evaluator="accuracy")
+    resolved = await resolve_evaluator_config(config, repository, agent_id=agent_id)
+    assert resolved.evaluator == "accuracy"
+
+
+async def test_resolve_evaluator_config_scoped_different_agent(
+    repository: FakePluginRepository,
+) -> None:
+    """Reject a scoped evaluator when the agent context is a different agent."""
+    plugin = await create_plugin(
+        repository,
+        OWNER_ID,
+        kind=PluginKind.EVALUATOR,
+        name="accuracy",
+        agent_id=uuid.uuid4(),
+    )
+    await repository.create_version(plugin.id, SOURCE, display_version="v1")
+
+    config = EvaluatorConfigInput(evaluator="accuracy")
+    with pytest.raises(ValidationError, match="scoped to a different agent"):
+        await resolve_evaluator_config(config, repository, agent_id=uuid.uuid4())
+
+
+async def test_resolve_evaluator_config_scoped_none_context(
+    repository: FakePluginRepository,
+) -> None:
+    """Reject a scoped evaluator when the caller carries no agent context."""
+    plugin = await create_plugin(
+        repository,
+        OWNER_ID,
+        kind=PluginKind.EVALUATOR,
+        name="accuracy",
+        agent_id=uuid.uuid4(),
+    )
+    await repository.create_version(plugin.id, SOURCE, display_version="v1")
+
+    config = EvaluatorConfigInput(evaluator="accuracy")
+    with pytest.raises(ValidationError, match="scoped to a different agent"):
+        await resolve_evaluator_config(config, repository, agent_id=None)
+
+
+async def test_resolve_evaluator_config_unscoped_any_agent(
+    repository: FakePluginRepository,
+) -> None:
+    """Resolve a global evaluator regardless of the agent context."""
+    plugin = await create_plugin(
+        repository, OWNER_ID, kind=PluginKind.EVALUATOR, name="accuracy"
+    )
+    await repository.create_version(plugin.id, SOURCE, display_version="v1")
+
+    config = EvaluatorConfigInput(evaluator="accuracy")
+    resolved = await resolve_evaluator_config(config, repository, agent_id=uuid.uuid4())
+    assert resolved.evaluator == "accuracy"
 
 
 async def test_validate_evaluators_resolves_every_config(
@@ -115,6 +184,7 @@ async def test_validate_evaluators_resolves_every_config(
             EvaluatorConfigInput(evaluator="relevance"),
         ],
         repository,
+        agent_id=None,
     )
     assert {config.evaluator for config in resolved} == {"accuracy", "relevance"}
 
@@ -135,6 +205,7 @@ async def test_validate_evaluators_rejects_duplicate_version(
                 EvaluatorConfigInput(evaluator="accuracy"),
             ],
             repository,
+            agent_id=None,
         )
 
 
@@ -165,4 +236,5 @@ async def test_validate_evaluators_rejects_output_contract_without_rules(
         await validate_evaluators(
             [EvaluatorConfigInput(evaluator="kitaru/output-contract", params=params)],
             repository,
+            agent_id=None,
         )

--- a/tests/server/test_evaluators_api.py
+++ b/tests/server/test_evaluators_api.py
@@ -21,8 +21,10 @@ import httpx
 import pytest
 
 from conftest import (
+    FakeAgentRepository,
     FakeBlobRepository,
     FakePluginRepository,
+    create_agent,
     create_blob,
     override_idempotency,
 )
@@ -47,14 +49,25 @@ def blob_repository() -> FakeBlobRepository:
 
 
 @pytest.fixture
-def repository(blob_repository: FakeBlobRepository) -> FakePluginRepository:
+def agent_repository() -> FakeAgentRepository:
+    """Provide the fake agent repository backing the app."""
+    return FakeAgentRepository()
+
+
+@pytest.fixture
+def repository(
+    blob_repository: FakeBlobRepository, agent_repository: FakeAgentRepository
+) -> FakePluginRepository:
     """Provide the fake plugin repository backing the app."""
-    return FakePluginRepository(blob_repository=blob_repository)
+    return FakePluginRepository(
+        blob_repository=blob_repository, agent_repository=agent_repository
+    )
 
 
 @pytest.fixture
 async def client(
-    repository: FakePluginRepository, blob_repository: FakeBlobRepository
+    repository: FakePluginRepository,
+    blob_repository: FakeBlobRepository,
 ) -> AsyncGenerator[httpx.AsyncClient, None]:
     """Provide an HTTP client for the app with a fake-backed evaluator service."""
     app = create_app(
@@ -501,3 +514,62 @@ async def test_update_evaluator_logo_url(client: httpx.AsyncClient) -> None:
     )
     assert updated.status_code == 200
     assert updated.json()["logo_url"] == "https://example.com/new.svg"
+
+
+async def test_create_evaluator_scoped_to_agent(
+    client: httpx.AsyncClient, agent_repository: FakeAgentRepository
+) -> None:
+    """Create an evaluator scoped to an agent and observe agent_id in the response."""
+    agent = await create_agent(agent_repository, ACCOUNT.id)
+    response = await client.post(
+        "/api/v1/evaluators", json={"name": "accuracy", "agent_id": str(agent.id)}
+    )
+    assert response.status_code == 201
+    assert response.json()["agent_id"] == str(agent.id)
+
+
+async def test_create_evaluator_without_agent_id(client: httpx.AsyncClient) -> None:
+    """Return a null agent id for a global evaluator."""
+    response = await client.post("/api/v1/evaluators", json={"name": "accuracy"})
+    assert response.status_code == 201
+    assert response.json()["agent_id"] is None
+
+
+async def test_create_evaluator_unknown_agent_id(client: httpx.AsyncClient) -> None:
+    """Observe HTTP 404 for an evaluator scoped to an unknown agent."""
+    missing_agent_id = uuid.uuid4()
+    response = await client.post(
+        "/api/v1/evaluators",
+        json={"name": "accuracy", "agent_id": str(missing_agent_id)},
+    )
+    assert response.status_code == 404
+    assert response.json() == {"detail": f"Agent {missing_agent_id} was not found"}
+
+
+async def test_list_evaluators_filtered_by_agent(
+    client: httpx.AsyncClient, agent_repository: FakeAgentRepository
+) -> None:
+    """List global evaluators together with one agent's scoped evaluators."""
+    agent = await create_agent(agent_repository, ACCOUNT.id)
+    other_agent = await create_agent(agent_repository, ACCOUNT.id, name="other")
+    await client.post("/api/v1/evaluators", json={"name": "global"})
+    await client.post(
+        "/api/v1/evaluators", json={"name": "scoped", "agent_id": str(agent.id)}
+    )
+    await client.post(
+        "/api/v1/evaluators",
+        json={"name": "other-scoped", "agent_id": str(other_agent.id)},
+    )
+
+    filter_expression = {
+        "or": [
+            {"field": "agent_id", "op": "is_null"},
+            {"field": "agent_id", "op": "eq", "value": str(agent.id)},
+        ]
+    }
+    response = await client.get(
+        "/api/v1/evaluators", params={"filter": json.dumps(filter_expression)}
+    )
+    assert response.status_code == 200
+    names = {item["name"] for item in response.json()["items"]}
+    assert names == {"global", "scoped"}

--- a/tests/server/test_evaluators_api_pg.py
+++ b/tests/server/test_evaluators_api_pg.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """End-to-end evaluator tests against PostgreSQL."""
 
+import uuid
 from collections.abc import AsyncGenerator
 
 import httpx
@@ -91,3 +92,31 @@ async def test_delete_cascades_versions(client: httpx.AsyncClient) -> None:
     )
     response = await client.delete(f"/api/v1/evaluators/{created['id']}")
     assert response.status_code == 204
+
+
+async def test_agent_deletion_nulls_scoped_evaluator_agent_id(
+    client: httpx.AsyncClient,
+) -> None:
+    """Clear a scoped evaluator's agent id when its agent is deleted."""
+    agent = (await client.post("/api/v1/agents", json={"name": "assistant"})).json()
+    created = (
+        await client.post(
+            "/api/v1/evaluators", json={"name": "accuracy", "agent_id": agent["id"]}
+        )
+    ).json()
+
+    response = await client.delete(f"/api/v1/agents/{agent['id']}")
+    assert response.status_code == 204
+
+    response = await client.get(f"/api/v1/evaluators/{created['id']}")
+    assert response.status_code == 200
+    assert response.json()["agent_id"] is None
+
+
+async def test_create_unknown_agent_not_found(client: httpx.AsyncClient) -> None:
+    """Translate the database constraint into HTTP 404."""
+    response = await client.post(
+        "/api/v1/evaluators",
+        json={"name": "accuracy", "agent_id": str(uuid.uuid4())},
+    )
+    assert response.status_code == 404

--- a/tests/server/test_experiment_service.py
+++ b/tests/server/test_experiment_service.py
@@ -121,10 +121,16 @@ async def agent_id(services: ReplayServices) -> uuid.UUID:
 
 
 async def _register_evaluator(
-    plugin_repository: FakePluginRepository, name: str = "accuracy"
+    plugin_repository: FakePluginRepository,
+    name: str = "accuracy",
+    agent_id: uuid.UUID | None = None,
 ) -> uuid.UUID:
     plugin = await create_plugin(
-        plugin_repository, ACTOR.account.id, kind=PluginKind.EVALUATOR, name=name
+        plugin_repository,
+        ACTOR.account.id,
+        kind=PluginKind.EVALUATOR,
+        name=name,
+        agent_id=agent_id,
     )
     version = await plugin_repository.create_version(
         plugin.id, SOURCE, display_version="v1"
@@ -239,6 +245,38 @@ async def test_create_experiment_duplicate_evaluator_version(
     )
     with pytest.raises(ValidationError, match="appears more than once"):
         await service.create_experiment(command, actor=ACTOR)
+
+
+async def test_create_experiment_evaluator_scoped_to_other_agent(
+    service: ExperimentService,
+    plugin_repository: FakePluginRepository,
+    agent_id: uuid.UUID,
+) -> None:
+    """Reject an evaluator scoped to an agent other than the experiment's."""
+    await _register_evaluator(plugin_repository, agent_id=uuid.uuid4())
+    command = ExperimentCreate(
+        name="exp1",
+        agent_id=agent_id,
+        evaluators=[EvaluatorConfigInput(evaluator="accuracy")],
+    )
+    with pytest.raises(ValidationError, match="scoped to a different agent"):
+        await service.create_experiment(command, actor=ACTOR)
+
+
+async def test_create_experiment_evaluator_scoped_to_same_agent(
+    service: ExperimentService,
+    plugin_repository: FakePluginRepository,
+    agent_id: uuid.UUID,
+) -> None:
+    """Resolve an evaluator scoped to the experiment's own agent."""
+    await _register_evaluator(plugin_repository, agent_id=agent_id)
+    command = ExperimentCreate(
+        name="exp1",
+        agent_id=agent_id,
+        evaluators=[EvaluatorConfigInput(evaluator="accuracy")],
+    )
+    experiment, _ = await service.create_experiment(command, actor=ACTOR)
+    assert experiment.name == "exp1"
 
 
 async def test_get_experiment(

--- a/tests/server/test_importers_api.py
+++ b/tests/server/test_importers_api.py
@@ -53,7 +53,8 @@ def repository(blob_repository: FakeBlobRepository) -> FakePluginRepository:
 
 @pytest.fixture
 async def client(
-    repository: FakePluginRepository, blob_repository: FakeBlobRepository
+    repository: FakePluginRepository,
+    blob_repository: FakeBlobRepository,
 ) -> AsyncGenerator[httpx.AsyncClient, None]:
     """Provide an HTTP client for the app with a fake-backed importer service."""
     app = create_app(
@@ -64,7 +65,9 @@ async def client(
         )
     )
     service = PluginService(
-        kind=PluginKind.IMPORTER, repository=repository, blob_repository=blob_repository
+        kind=PluginKind.IMPORTER,
+        repository=repository,
+        blob_repository=blob_repository,
     )
     app.dependency_overrides[get_importer_service] = lambda: service
     app.dependency_overrides[authorize] = lambda: AuthContext(account=ACCOUNT)
@@ -84,6 +87,7 @@ async def test_create_importer(client: httpx.AsyncClient) -> None:
     assert body["name"] == "langfuse-import"
     assert body["provider"] == "langfuse"
     assert body["latest_version"] == 0
+    assert "agent_id" not in body
 
 
 async def test_create_importer_duplicate_name(client: httpx.AsyncClient) -> None:

--- a/tests/server/test_job_service.py
+++ b/tests/server/test_job_service.py
@@ -85,9 +85,15 @@ async def _runnable_agent_version(services: JobAndTaskServices) -> uuid.UUID:
     return version.id
 
 
-async def _evaluator_version(services: JobAndTaskServices, name: str) -> uuid.UUID:
+async def _evaluator_version(
+    services: JobAndTaskServices, name: str, agent_id: uuid.UUID | None = None
+) -> uuid.UUID:
     plugin = await create_plugin(
-        services.plugins, ACTOR.account.id, PluginKind.EVALUATOR, name=name
+        services.plugins,
+        ACTOR.account.id,
+        PluginKind.EVALUATOR,
+        name=name,
+        agent_id=agent_id,
     )
     version = await services.plugins.create_version(
         plugin.id,
@@ -319,18 +325,72 @@ async def test_create_evaluations_rejects_an_unknown_session(
         )
 
 
-async def test_create_evaluations_makes_one_continue_task_per_pair(
+async def test_create_evaluations_scoped_evaluator_all_sessions_match(
     services: JobAndTaskServices,
 ) -> None:
-    """One continue evaluator task is created per (session, evaluator) pair."""
-    await _evaluator_version(services, "accuracy")
-    await _evaluator_version(services, "tone")
+    """Accept a scoped evaluator when every input session belongs to its agent."""
+    agent_id = uuid.uuid4()
+    await _evaluator_version(services, "scorer", agent_id=agent_id)
+    session_a = await create_session(services.sessions, ACTOR.account.id, agent_id)
+    session_b = await create_session(services.sessions, ACTOR.account.id, agent_id)
+    job = await services.job_service.create_evaluations(
+        EvaluationBatchCreate(
+            input_session_ids=[session_a.id, session_b.id],
+            evaluators=[EvaluatorConfigInput(evaluator="scorer")],
+        ),
+        actor=ACTOR,
+    )
+    assert job.kind is JobKind.EVALUATION
+
+
+async def test_create_evaluations_scoped_evaluator_session_from_other_agent(
+    services: JobAndTaskServices,
+) -> None:
+    """Reject a scoped evaluator whose only session belongs to another agent."""
+    await _evaluator_version(services, "scorer", agent_id=uuid.uuid4())
+    session = await create_session(
+        services.sessions, ACTOR.account.id, agent_id=uuid.uuid4()
+    )
+    with pytest.raises(ValidationError, match="scoped to a different agent"):
+        await services.job_service.create_evaluations(
+            EvaluationBatchCreate(
+                input_session_ids=[session.id],
+                evaluators=[EvaluatorConfigInput(evaluator="scorer")],
+            ),
+            actor=ACTOR,
+        )
+
+
+async def test_create_evaluations_rejects_sessions_spanning_agents(
+    services: JobAndTaskServices,
+) -> None:
+    """Reject input sessions that do not all belong to one agent."""
+    await _evaluator_version(services, "scorer")
     session_a = await create_session(
         services.sessions, ACTOR.account.id, agent_id=uuid.uuid4()
     )
     session_b = await create_session(
         services.sessions, ACTOR.account.id, agent_id=uuid.uuid4()
     )
+    with pytest.raises(ValidationError, match="single agent"):
+        await services.job_service.create_evaluations(
+            EvaluationBatchCreate(
+                input_session_ids=[session_a.id, session_b.id],
+                evaluators=[EvaluatorConfigInput(evaluator="scorer")],
+            ),
+            actor=ACTOR,
+        )
+
+
+async def test_create_evaluations_makes_one_continue_task_per_pair(
+    services: JobAndTaskServices,
+) -> None:
+    """One continue evaluator task is created per (session, evaluator) pair."""
+    await _evaluator_version(services, "accuracy")
+    await _evaluator_version(services, "tone")
+    agent_id = uuid.uuid4()
+    session_a = await create_session(services.sessions, ACTOR.account.id, agent_id)
+    session_b = await create_session(services.sessions, ACTOR.account.id, agent_id)
 
     job = await services.job_service.create_evaluations(
         EvaluationBatchCreate(

--- a/tests/server/test_plugin_service.py
+++ b/tests/server/test_plugin_service.py
@@ -18,7 +18,13 @@ from typing import Any
 
 import pytest
 
-from conftest import FakeBlobRepository, FakePluginRepository, create_blob
+from conftest import (
+    FakeAgentRepository,
+    FakeBlobRepository,
+    FakePluginRepository,
+    create_agent,
+    create_blob,
+)
 from kitaru.analytics.events import AnalyticsEvent
 from kitaru.server.application.models.auth import AuthContext
 from kitaru.server.application.models.plugin import (
@@ -30,9 +36,11 @@ from kitaru.server.application.models.plugin import (
 from kitaru.server.application.services.plugin_service import PluginService
 from kitaru.server.application.services.server_analytics import ServerAnalytics
 from kitaru.server.domain.account import Account
+from kitaru.server.domain.agent import AgentNotFound
 from kitaru.server.domain.blob import BlobNotFound
 from kitaru.server.domain.plugin import (
     DuplicatePluginName,
+    InvalidPluginAgentScope,
     InvalidPluginProvider,
     PackagePluginSource,
     PluginKind,
@@ -75,14 +83,25 @@ def blob_repository() -> FakeBlobRepository:
 
 
 @pytest.fixture
-def repository(blob_repository: FakeBlobRepository) -> FakePluginRepository:
+def agent_repository() -> FakeAgentRepository:
+    """Provide a fake agent repository."""
+    return FakeAgentRepository()
+
+
+@pytest.fixture
+def repository(
+    blob_repository: FakeBlobRepository, agent_repository: FakeAgentRepository
+) -> FakePluginRepository:
     """Provide a fake plugin repository wired to the fake blob repository."""
-    return FakePluginRepository(blob_repository=blob_repository)
+    return FakePluginRepository(
+        blob_repository=blob_repository, agent_repository=agent_repository
+    )
 
 
 @pytest.fixture
 def evaluator_service(
-    repository: FakePluginRepository, blob_repository: FakeBlobRepository
+    repository: FakePluginRepository,
+    blob_repository: FakeBlobRepository,
 ) -> PluginService:
     """Provide a plugin service bound to the evaluator kind."""
     return PluginService(
@@ -94,11 +113,14 @@ def evaluator_service(
 
 @pytest.fixture
 def importer_service(
-    repository: FakePluginRepository, blob_repository: FakeBlobRepository
+    repository: FakePluginRepository,
+    blob_repository: FakeBlobRepository,
 ) -> PluginService:
     """Provide a plugin service bound to the importer kind, sharing the repository."""
     return PluginService(
-        kind=PluginKind.IMPORTER, repository=repository, blob_repository=blob_repository
+        kind=PluginKind.IMPORTER,
+        repository=repository,
+        blob_repository=blob_repository,
     )
 
 
@@ -476,7 +498,8 @@ async def test_update_version_not_found(evaluator_service: PluginService) -> Non
 
 
 async def test_create_version_tracks_plugin_version_registered(
-    repository: FakePluginRepository, blob_repository: FakeBlobRepository
+    repository: FakePluginRepository,
+    blob_repository: FakeBlobRepository,
 ) -> None:
     """Fire PLUGIN_VERSION_REGISTERED with the plugin kind and source type."""
     analytics = _RecordingAnalytics()
@@ -572,3 +595,42 @@ async def test_update_plugin_explicit_null_clears_logo_url(
         created.id, PluginUpdate(logo_url=None), actor=ACTOR
     )
     assert updated.logo_url is None
+
+
+async def test_create_plugin_scoped_to_agent(
+    evaluator_service: PluginService, agent_repository: FakeAgentRepository
+) -> None:
+    """Store the agent id given at creation."""
+    agent = await create_agent(agent_repository, ACTOR.account.id)
+    plugin = await evaluator_service.create_plugin(
+        PluginCreate(name="accuracy", agent_id=agent.id), actor=ACTOR
+    )
+    assert plugin.agent_id == agent.id
+
+
+async def test_create_plugin_without_agent_id(evaluator_service: PluginService) -> None:
+    """Leave the agent id unset when the command omits it."""
+    plugin = await evaluator_service.create_plugin(
+        PluginCreate(name="accuracy"), actor=ACTOR
+    )
+    assert plugin.agent_id is None
+
+
+async def test_create_plugin_unknown_agent_id(evaluator_service: PluginService) -> None:
+    """Reject an agent id naming no agent."""
+    missing_agent_id = uuid.uuid4()
+    with pytest.raises(AgentNotFound, match=f"Agent {missing_agent_id} was not found"):
+        await evaluator_service.create_plugin(
+            PluginCreate(name="accuracy", agent_id=missing_agent_id), actor=ACTOR
+        )
+
+
+async def test_create_plugin_importer_rejects_agent_id(
+    importer_service: PluginService, agent_repository: FakeAgentRepository
+) -> None:
+    """Reject an agent id on an importer plugin."""
+    agent = await create_agent(agent_repository, ACTOR.account.id)
+    with pytest.raises(InvalidPluginAgentScope):
+        await importer_service.create_plugin(
+            PluginCreate(name="langfuse-import", agent_id=agent.id), actor=ACTOR
+        )

--- a/tests/server/test_replay_service.py
+++ b/tests/server/test_replay_service.py
@@ -116,9 +116,15 @@ async def _agent_version(
     )
 
 
-async def _evaluator(services: ReplayServices, name: str = "accuracy") -> uuid.UUID:
+async def _evaluator(
+    services: ReplayServices, name: str = "accuracy", agent_id: uuid.UUID | None = None
+) -> uuid.UUID:
     plugin = await create_plugin(
-        services.plugins, ACTOR.account.id, kind=PluginKind.EVALUATOR, name=name
+        services.plugins,
+        ACTOR.account.id,
+        kind=PluginKind.EVALUATOR,
+        name=name,
+        agent_id=agent_id,
     )
     blob = await create_blob(services.blobs, ACTOR.account.id, content=name.encode())
     version = await services.plugins.create_version(
@@ -270,6 +276,42 @@ async def test_create_replay_rejects_cohort_version_scoped_history(
             ),
             actor=ACTOR,
         )
+
+
+async def test_create_replay_evaluator_scoped_to_other_agent(
+    services: ReplayServices,
+) -> None:
+    """Reject an evaluator scoped to an agent other than the baseline's."""
+    agent_version = await _agent_version(services)
+    await _evaluator(services, agent_id=uuid.uuid4())
+    baseline = await _session(services, agent_version)
+    with pytest.raises(ValidationError, match="scoped to a different agent"):
+        await services.replay_service.create_replay(
+            ReplayCreate(
+                baseline_session_id=baseline.id,
+                agent_version_id=agent_version.id,
+                evaluators=[EvaluatorConfigInput(evaluator="accuracy")],
+            ),
+            actor=ACTOR,
+        )
+
+
+async def test_create_replay_evaluator_scoped_to_baseline_agent(
+    services: ReplayServices,
+) -> None:
+    """Resolve an evaluator scoped to the baseline session's own agent."""
+    agent_version = await _agent_version(services)
+    baseline = await _session(services, agent_version)
+    await _evaluator(services, agent_id=baseline.agent_id)
+    bundle = await services.replay_service.create_replay(
+        ReplayCreate(
+            baseline_session_id=baseline.id,
+            agent_version_id=agent_version.id,
+            evaluators=[EvaluatorConfigInput(evaluator="accuracy")],
+        ),
+        actor=ACTOR,
+    )
+    assert bundle.replay.baseline_session_id == baseline.id
 
 
 def _cache_node(


### PR DESCRIPTION
Adds an optional `agent_id` to evaluator creation, null for a workspace-global evaluator. A scoped evaluator can only be used by experiments, replays, and evaluation batches for that agent, and evaluator listing supports filtering on `agent_id`. Evaluation batches now require every input session to belong to the same agent.