### PR TITLE
0.23.0+dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [0.23.0]
 
 ### Added

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8711,7 +8711,7 @@
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.23.0"
+    "version": "0.23.0+dev"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -924,7 +924,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.23.0"
+version = "0.23.0+dev"
 source = { editable = "../" }
 dependencies = [
     { name = "httpx" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.23.0"
+version = "0.23.0+dev"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -907,7 +907,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.23.0"
+version = "0.23.0+dev"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- set the core development version to `0.23.0+dev`
- restore the top `Unreleased` changelog section
- update the core version in both lockfiles and the generated OpenAPI document

## Merge order

Merge this PR only after `main` contains release commit `72636523af3399b34e7833aa0c593d87be00244b`, so `main` remains at the clean `0.23.0` release state. At PR creation time, remote `main` still points to the `0.22.2` release and can fast-forward cleanly to this commit.

## Validation

- `uv lock --check`
- `uv lock --project plugins --check`
- `uv run --no-project --with packaging==26.2 python scripts/release_units.py validate`
- `just check`
- `git diff --check`

## Reviewer Notes

Confirm the diff contains only `pyproject.toml`, `uv.lock`, `plugins/uv.lock`, `openapi/openapi.json`, and `CHANGELOG.md`. Verify `main` contains `72636523af3399b34e7833aa0c593d87be00244b` before marking this draft ready or merging it.
