### PR TITLE
Explain the returns agent before investigation

### DIFF
--- a/docs/book/tutorials/returns-agent/README.md
+++ b/docs/book/tutorials/returns-agent/README.md
@@ -11,6 +11,23 @@ You begin with ten recorded PydanticAI sessions exported from Langfuse. The walk
 
 The tutorial is intentionally more detailed than the [Quickstart](../../getting-started/quickstart.md). It explains what each resource preserves and why each command is part of the evidence chain. Your exact sessions, questions, evaluator, candidate, and result will depend on what you observe.
 
+## Meet the example agent
+
+Each session starts with one synthetic customer ticket. The agent looks up the order, gathers the relevant policy or shipping evidence, chooses one terminal outcome, and returns a structured resolution with a customer reply.
+
+<figure><img src="https://assets.kitaru.ai/docs/diagrams/returns-agent-overview.png" alt="The returns agent reads a ticket, looks up the order, checks shipping or return policy, chooses a resolution, then acts before replying."><figcaption>The lookup tools gather evidence. The action tools record whether a refund, replacement, or escalation actually succeeded.</figcaption></figure>
+
+For return and refund requests, `get_return_policy` supplies the rules for the order's product category. **Final sale** means the item is not eligible for an ordinary return. A reported defect can still qualify when the category has a final-sale defect exception.
+
+| Category | Return window | Final-sale defect exception | Human approval threshold |
+| --- | --- | --- | --- |
+| Footwear | 30 days | Yes | $150 |
+| Apparel | 30 days | Yes | $150 |
+| Accessories | 14 days | No | $100 |
+| Luggage | 45 days | Yes | $200 |
+
+These values are evidence available to the agent, not guarantees enforced by Kitaru. The tutorial asks you to inspect whether the agent used that evidence correctly and whether the recorded action agrees with its final response.
+
 ## What you will build
 
 | Phase | You will create | Why it exists |

--- a/docs/book/tutorials/returns-agent/observe.md
+++ b/docs/book/tutorials/returns-agent/observe.md
@@ -15,6 +15,8 @@ The [PydanticAI returns agent setup](https://github.com/zenml-io/kitaru/tree/mai
 
 The setup also imported `traces/langfuse-traces.jsonl` under that exact version. One complete recorded run became a [session](../../concepts/agents-and-sessions.md); model calls, tool calls, tool results, and other events inside it became session nodes. Importing preserved the evidence and its source identity without calling the historical agent.
 
+<figure><img src="https://assets.kitaru.ai/docs/diagrams/returns-trace-evidence.png" alt="A returns-agent trace runs from the customer ticket through lookup evidence and a terminal action to the final structured resolution."><figcaption>Read the complete sequence. The final reply records what the agent said; the tool result records whether its action succeeded.</figcaption></figure>
+
 Do not repeat registration or import here. If either `returns-resolver@1` or the ten `returns-baseline` sessions is missing, return to the example README and resolve that setup failure before continuing.
 
 ## Survey before judging

--- a/docs/components/diagrams.tsx
+++ b/docs/components/diagrams.tsx
@@ -2174,3 +2174,151 @@ export function SkillProcedureFlowDiagram() {
     </DiagramFrame>
   );
 }
+
+// ============================================================
+// Returns agent tutorial diagrams
+// ============================================================
+
+function NumberedStep({
+  number,
+  title,
+  children,
+}: {
+  number: number;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "42px 1fr",
+        gap: 12,
+        alignItems: "center",
+      }}
+    >
+      <span
+        style={{
+          display: "grid",
+          placeItems: "center",
+          width: 38,
+          height: 38,
+          border: `1px solid ${toneBorder("accent")}`,
+          borderRadius: "50%",
+          background: "var(--color-fd-card)",
+          color: "var(--color-fd-primary)",
+          fontSize: 14,
+          fontWeight: 700,
+        }}
+      >
+        {number}
+      </span>
+      <Node title={title} subtitle={children} tone="muted" fullWidth />
+    </div>
+  );
+}
+
+export function ReturnsAgentOverviewDiagram() {
+  return (
+    <DiagramFrame>
+      <div style={{ ...col, gap: 12, minWidth: 640 }}>
+        <NumberedStep number={1} title="Read the ticket">
+          Identify a return, refund, delivery problem, or missing order.
+        </NumberedStep>
+        <NumberedStep number={2} title="Look up the order">
+          <code>lookup_order</code> returns the product, category, price,
+          delivery state, and earlier actions.
+        </NumberedStep>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 10,
+            marginLeft: 54,
+          }}
+        >
+          <Node
+            title="Delivery problem"
+            subtitle={
+              <>
+                <code>check_shipping</code> returns the carrier status.
+              </>
+            }
+            tone="info"
+            fullWidth
+          />
+          <Node
+            title="Return or refund"
+            subtitle={
+              <>
+                <code>get_return_policy</code> returns the category rules.
+              </>
+            }
+            tone="warn"
+            fullWidth
+          />
+        </div>
+        <NumberedStep number={3} title="Choose a resolution">
+          Select a refund, replacement, escalation, or rejection from the
+          evidence returned by the tools.
+        </NumberedStep>
+        <NumberedStep number={4} title="Act, then reply">
+          Run <code>issue_refund</code>, <code>create_replacement</code>, or{" "}
+          <code>escalate_to_human</code> when required, then return a structured
+          resolution and customer reply.
+        </NumberedStep>
+      </div>
+      <Caption>
+        The agent decides what to do, while its tool calls and results record
+        what it looked up and which action actually succeeded.
+      </Caption>
+    </DiagramFrame>
+  );
+}
+
+export function ReturnsTraceEvidenceDiagram() {
+  return (
+    <DiagramFrame compact>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minWidth: 760,
+        }}
+      >
+        <Node
+          title="Customer ticket"
+          subtitle="The request the agent received"
+          tone="muted"
+          minWidth={140}
+        />
+        <HArrow />
+        <Node
+          title="Lookup evidence"
+          subtitle="Order, policy, or shipping results"
+          tone="info"
+          minWidth={165}
+        />
+        <HArrow />
+        <Node
+          title="Terminal action"
+          subtitle="Accepted, rejected, or not attempted"
+          tone="warn"
+          minWidth={165}
+        />
+        <HArrow />
+        <Node
+          title="Final resolution"
+          subtitle="Structured outcome and customer reply"
+          tone="success"
+          minWidth={170}
+        />
+      </div>
+      <Caption>
+        Read the complete sequence. A customer reply can claim an action
+        happened, but only the recorded tool result shows whether it succeeded.
+      </Caption>
+    </DiagramFrame>
+  );
+}


### PR DESCRIPTION
## What changed?

The returns-agent tutorial now explains the example agent and its category policy before asking readers to investigate recorded sessions. The Observe phase also shows how a trace connects the customer ticket, lookup evidence, terminal action, and final response.

## Why?

Readers previously reached the evidence-review workflow without a clear model of what the agent knew or could do. The new context makes policy failures and the distinction between a claimed action and an accepted tool result easier to understand.

## Release context

The two rendered PNGs are published under `assets.kitaru.ai/docs/diagrams/`. No other release coordination is required.

## Reviewer Notes

Start with the tutorial landing page and compare the numbered flow and policy table with the shipped PydanticAI example. The policy values come from its fixtures, while the flow reflects its lookup tools, terminal tools, and structured `Resolution` outcomes. Then check the Observe page: its smaller diagram reinforces that the final reply is not proof that a tool action succeeded.

## Reproduction

1. Open [`docs/book/tutorials/returns-agent/README.md`](https://github.com/zenml-io/kitaru/blob/feat/document-returns-agent/docs/book/tutorials/returns-agent/README.md) and confirm the agent overview and four-category policy table appear before **What you will build**.
2. Open [`docs/book/tutorials/returns-agent/observe.md`](https://github.com/zenml-io/kitaru/blob/feat/document-returns-agent/docs/book/tutorials/returns-agent/observe.md) and confirm the trace-evidence diagram appears after the imported-session explanation.
3. Confirm both diagrams remain readable at their rendered size and that their captions explain the evidence boundary without supplying a session verdict.

## Local checks run

- `cd docs && pnpm lint`
- `cd docs && pnpm build`
- Confirmed both public diagram URLs return HTTP 200 with `image/png`.

## Evidence

![Returns agent overview](https://assets.kitaru.ai/docs/diagrams/returns-agent-overview.png)

![Returns trace evidence](https://assets.kitaru.ai/docs/diagrams/returns-trace-evidence.png)
