### PR TITLE
Mark Kitaru as beta on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "ZenML GmbH", email = "info@zenml.io" },
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Framework :: Pydantic",
     "Framework :: Pydantic :: 2",


### PR DESCRIPTION
## What changed?

Kitaru's next PyPI release will advertise beta maturity instead of alpha maturity.

## Why?

The beta classifier reflects the project's agreed current development status and keeps the package index metadata aligned with product messaging.

## Release context

This PR does not publish a release. The classifier will take effect the next time the Kitaru distribution is built and published.

No frontend, plugin, skills, ZenML docs, website, or example follow-up is required for this packaging metadata change.

## Reviewer Notes

Review the `classifiers` entry in `pyproject.toml`. This changes only the standard PyPI development-status classifier; package behavior and the release version are unchanged.

## Reproduction

Build the distribution, then inspect the wheel metadata:

```bash
uv build
unzip -p dist/kitaru-0.23.0+dev-py3-none-any.whl '*/METADATA' | rg 'Development Status'
```

The output should be:

```text
Classifier: Development Status :: 4 - Beta
```

## Local checks run

- `git diff --check`
- `just check`
- `uv run --no-project --with packaging==26.2 python scripts/release_units.py validate`
- `uv build` and wheel metadata inspection
