### PR TITLE
Add ARM64 support to public Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,31 +176,40 @@ jobs:
         env:
           KITARU_VERSION: ${{ needs.build.outputs.version }}
         run: curl -fsS "https://pypi.org/pypi/kitaru/$KITARU_VERSION/json" >/dev/null
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+        with:
+          platforms: arm64
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
       - name: Build and test client image
         env:
           KITARU_VERSION: ${{ needs.build.outputs.version }}
         run: |
-          docker build --load -f docker/release-client.Dockerfile \
-            --target client --build-arg KITARU_VERSION="$KITARU_VERSION" \
-            -t kitaru-bundle-client:test .
-          docker run --rm kitaru-bundle-client:test python -c "import kitaru"
+          for platform in linux/amd64 linux/arm64; do
+            docker buildx build --load --platform "$platform" -f docker/release-client.Dockerfile \
+              --target client --build-arg KITARU_VERSION="$KITARU_VERSION" \
+              -t kitaru-bundle-client:test .
+            docker run --rm --platform "$platform" kitaru-bundle-client:test python -c "import kitaru"
+          done
       - name: Build and test server image
         env:
           KITARU_VERSION: ${{ needs.build.outputs.version }}
         run: |
-          docker build --load -f docker/release-server.Dockerfile \
-            --target server --build-arg KITARU_VERSION="$KITARU_VERSION" \
-            -t kitaru-bundle-server:test .
-          docker run --rm kitaru-bundle-server:test python -c "import kitaru"
+          for platform in linux/amd64 linux/arm64; do
+            docker buildx build --load --platform "$platform" -f docker/release-server.Dockerfile \
+              --target server --build-arg KITARU_VERSION="$KITARU_VERSION" \
+              -t kitaru-bundle-server:test .
+            docker run --rm --platform "$platform" kitaru-bundle-server:test python -c "import kitaru"
+          done
       - name: Build and test worker image
         env:
           KITARU_VERSION: ${{ needs.build.outputs.version }}
         run: |
-          docker build --load -f docker/release-worker.Dockerfile \
-            --target worker --build-arg KITARU_VERSION="$KITARU_VERSION" \
-            -t kitaru-bundle-worker:test .
-          docker run --rm kitaru-bundle-worker:test python -c "import kitaru"
+          for platform in linux/amd64 linux/arm64; do
+            docker buildx build --load --platform "$platform" -f docker/release-worker.Dockerfile \
+              --target worker --build-arg KITARU_VERSION="$KITARU_VERSION" \
+              -t kitaru-bundle-worker:test .
+            docker run --rm --platform "$platform" kitaru-bundle-worker:test python -c "import kitaru"
+          done
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
         with:
           version: v3.9.2
@@ -221,6 +230,7 @@ jobs:
           context: .
           file: docker/release-client.Dockerfile
           target: client
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: KITARU_VERSION=${{ needs.build.outputs.version }}
           tags: zenmldocker/kitaru:${{ needs.build.outputs.bundle-version }}
@@ -230,6 +240,7 @@ jobs:
           context: .
           file: docker/release-worker.Dockerfile
           target: worker
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: KITARU_VERSION=${{ needs.build.outputs.version }}
           tags: zenmldocker/kitaru-worker:${{ needs.build.outputs.bundle-version }}
@@ -239,6 +250,7 @@ jobs:
           context: .
           file: docker/release-server.Dockerfile
           target: server
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: KITARU_VERSION=${{ needs.build.outputs.version }}
           tags: zenmldocker/kitaru-server:${{ needs.build.outputs.bundle-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Added native ARM64 support alongside AMD64 for the public client, server, and worker Docker images.
 - Added `DELETE /api/v1/replays/{replay_id}` to delete a standalone replay. A replay that belongs to an experiment run returns HTTP 409, since deleting the run removes its replays.
 - Added `POST /api/v1/workers/{worker_id}/token` to renew a worker token, and `kitaru worker list --include-stale` to list workers past the liveness window.
 - Added task hooks to the agent version run spec: `copy_workdir` runs the agent in a fresh copy of the working directory, `setup_command` runs a shell command in the working directory before the agent process, and `teardown_command` runs one after it based on the task outcome. Hooks run in the declared order before the agent process, and their teardowns run in reverse order after it.


### PR DESCRIPTION
## What changed?

Public client, server, and worker images will include both `linux/amd64` and `linux/arm64` under their existing version tags. Docker selects the matching architecture automatically.

## Why?

Apple Silicon and other ARM64 users currently need AMD64 emulation to run our published images.

## Release context

Takes effect with the next core release. No frontend or plugin release is needed. Private managed and onboarding images are unchanged.

## Reviewer Notes

@schustmi: this keeps the existing release job and uses QEMU for ARM64 builds instead of adding runner matrices or manifest assembly jobs. The existing build/import checks run once per architecture before any public image is pushed. Smoke builds use the same Buildx builder as publication so their layers can be reused. Emulation will add release build time; no application or Dockerfile changes are included.

## Reproduction

After the next release, run `docker buildx imagetools inspect zenmldocker/kitaru-server:<version>` and repeat for `zenmldocker/kitaru:<version>` and `zenmldocker/kitaru-worker:<version>`. Each should include `linux/amd64` and `linux/arm64`. Run `docker run --rm --platform linux/arm64 zenmldocker/kitaru-server:<version> python -c 'import kitaru'` on an ARM64 host or with emulation enabled; it should exit successfully.

## Local checks run

- `actionlint .github/workflows/release.yml`
- `yamlfix --check .github/workflows/release.yml`
- `git diff --check`
- Four simplify review angles completed with no changes needed.

Actual image builds and release publication were not run locally. Validation was kept to the changed workflow; no new test framework or release verification jobs were added.
