### PR TITLE
Fix redaction and capture invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Unified CLI and MCP credential masking, including plural credential fields, while preserving numeric token usage. Output now preserves colliding mapping keys and safely bounds deep or cyclic data.
+- LangGraph capture now marks mapping-key coercion and collisions as non-replayable. Tool-result encoding preserves nested tuples, and replay rejects missing message status and malformed stored outcomes without running the live tool.
 - Fixed `kitaru evaluator version register` and `kitaru importer version register`, which always failed with a `TypeError` after uploading the source. `POST /api/v1/evaluators/{evaluator_id}/versions` and `POST /api/v1/importers/{importer_id}/versions` now support idempotency keys, and the SDK `create_version` methods take an `idempotency_key` argument, matching agent and cohort version creation. The MCP evaluator management tool's `create_version` operation takes an optional `idempotency_key` field.
 
 ## [0.23.0]

--- a/docs/book/adapters/langgraph.md
+++ b/docs/book/adapters/langgraph.md
@@ -112,6 +112,10 @@ Misses follow the replay policy without silent fallback:
 
 Malformed, unsupported, or lossy recorded results fail closed with `ToolPolicyError`; they do not become misses or permit passthrough. A matched recorded failure also raises `ToolPolicyError` with the stored error text and aborts the graph unless application middleware catches it. Kitaru does not recreate the original exception class or LangGraph recovery behavior. The adapter rejects the `llm` tool policy. It does not substitute stored model responses.
 
+Newly recorded supported tool results preserve nested tuples and lists as distinct types, including tuple pairs in `Command.update` and the default empty tuple in `Command.goto`. Stored `ToolMessage` values must have an explicit `success` or `error` status; a missing or invalid status is rejected rather than treated as success.
+
+The tool-result envelope remains `kitaru.langgraph.tool_result.v1`. Valid older envelopes remain readable, and their stored lists remain lists. Older adapter versions reject the new nested tuple tag, so use an updated adapter to replay newly recorded tuple-bearing results. These changes cannot recover keys or tuple types already lost in historical records.
+
 ## Interrupts and unsupported invocation modes
 
 For a direct call outside a Kitaru worker, a public LangGraph interrupt result is returned unchanged and the session is recorded as completed with interruption metadata. Resume the same LangGraph thread with your existing checkpointer and `Command(resume=...)`; the resume call becomes a second Kitaru session. Kitaru never reads or replaces private checkpointer state.
@@ -137,6 +141,8 @@ The default per-invocation bounds are:
 | Items per collection |   1,000 |
 
 Limit hits or serialization failures mark the recording as lossy, truncate or drop only the stored copy, and preserve the graph outcome. Lossy tool arguments or results are not eligible for history substitution.
+
+Converting a non-string mapping key to a JSON string also marks the recording as lossy. This includes collisions such as the distinct keys `1` and `"1"`; the stored copy is best effort, and Kitaru will not use it for history substitution.
 
 ## Recording failures
 

--- a/plugins/packages/langgraph/src/kitaru_langgraph/capture.py
+++ b/plugins/packages/langgraph/src/kitaru_langgraph/capture.py
@@ -239,6 +239,10 @@ def _convert(
                     reasons.append("max_field_bytes")
                     break
                 output_key = str(key)
+                if not isinstance(key, str):
+                    reasons.append("non_string_key")
+                if output_key in result:
+                    reasons.append("key_collision")
                 if _key_is_sensitive(key):
                     work_remaining[0] -= 1
                     reasons.append("sensitive_key_redacted")

--- a/plugins/packages/langgraph/src/kitaru_langgraph/codec.py
+++ b/plugins/packages/langgraph/src/kitaru_langgraph/codec.py
@@ -94,7 +94,12 @@ def _encode_nested(
                 if work_remaining[0] <= 0:
                     reasons.append("max_field_bytes")
                     break
-                encoded[str(key)] = _encode_nested(
+                output_key = str(key)
+                if not isinstance(key, str):
+                    reasons.append("non_string_key")
+                if output_key in encoded:
+                    reasons.append("key_collision")
+                encoded[output_key] = _encode_nested(
                     item,
                     policy=policy,
                     depth=depth + 1,
@@ -138,6 +143,8 @@ def _encode_nested(
                         work_remaining=work_remaining,
                     )
                 )
+            if isinstance(value, tuple):
+                return {_NESTED_TYPE: "tuple", _NESTED_VALUE: encoded_items}
             return encoded_items
         finally:
             active_ids.remove(identity)
@@ -169,12 +176,23 @@ def _decode_nested(value: Any, *, tool_call_id: str, tool_name: str) -> Any:
                 tool_call_id=tool_call_id,
                 tool_name=tool_name,
             )
+        if nested_type == "tuple":
+            nested_value = value.get(_NESTED_VALUE)
+            if not isinstance(nested_value, list):
+                raise ToolPolicyError("Stored nested tuple payload is malformed")
+            return tuple(
+                _decode_nested(item, tool_call_id=tool_call_id, tool_name=tool_name)
+                for item in nested_value
+            )
         if nested_type == "tool_message":
             fields = _decode_mapping(
                 {key: item for key, item in value.items() if key != _NESTED_TYPE},
                 tool_call_id=tool_call_id,
                 tool_name=tool_name,
             )
+            status = fields.get("status")
+            if status not in ("success", "error"):
+                raise ToolPolicyError("Stored ToolMessage status is malformed")
             return ToolMessage(
                 content=fields.get("content"),
                 additional_kwargs=dict(fields.get("additional_kwargs") or {}),
@@ -183,7 +201,7 @@ def _decode_nested(value: Any, *, tool_call_id: str, tool_name: str) -> Any:
                 id=fields.get("id"),
                 tool_call_id=tool_call_id,
                 artifact=fields.get("artifact"),
-                status=fields.get("status", "success"),
+                status=status,
             )
         if nested_type is not None:
             raise ToolPolicyError("Stored nested value type is unsupported")
@@ -269,15 +287,15 @@ def decode_tool_outcome(
     tool_name: str,
 ) -> ToolMessage | Command[Any]:
     """Decode one exact tagged outcome and remap current call identity."""
-    if not isinstance(value, Mapping) or value.get("schema") != TOOL_OUTCOME_SCHEMA:
-        raise ToolPolicyError("Stored tool result has an unknown envelope")
-    if value.get("replayable") is not True:
-        raise ToolPolicyError("Stored tool result is not replayable")
-    payload = value.get("payload")
-    if not isinstance(payload, Mapping):
-        raise ToolPolicyError("Stored tool result payload is malformed")
-    kind = value.get("kind")
     try:
+        if not isinstance(value, Mapping) or value.get("schema") != TOOL_OUTCOME_SCHEMA:
+            raise ToolPolicyError("Stored tool result has an unknown envelope")
+        if value.get("replayable") is not True:
+            raise ToolPolicyError("Stored tool result is not replayable")
+        payload = value.get("payload")
+        if not isinstance(payload, Mapping):
+            raise ToolPolicyError("Stored tool result payload is malformed")
+        kind = value.get("kind")
         if kind == "tool_message":
             decoded = _decode_nested(
                 payload, tool_call_id=tool_call_id, tool_name=tool_name
@@ -286,27 +304,33 @@ def decode_tool_outcome(
                 raise ToolPolicyError("Stored ToolMessage payload is malformed")
             return decoded
         if kind == "command":
+            required_fields = ("graph", "update", "resume", "goto")
+            if not all(field in payload for field in required_fields):
+                raise ToolPolicyError("Stored Command payload is malformed")
             return Command(
-                graph=cast(str | None, payload.get("graph")),
+                graph=cast(str | None, payload["graph"]),
                 update=_decode_nested(
-                    payload.get("update"),
+                    payload["update"],
                     tool_call_id=tool_call_id,
                     tool_name=tool_name,
                 ),
                 resume=_decode_nested(
-                    payload.get("resume"),
+                    payload["resume"],
                     tool_call_id=tool_call_id,
                     tool_name=tool_name,
                 ),
                 goto=_decode_nested(
-                    payload.get("goto", ()),
+                    payload["goto"],
                     tool_call_id=tool_call_id,
                     tool_name=tool_name,
                 ),
             )
-    except (TypeError, ValueError) as exc:
-        raise ToolPolicyError("Stored tool result payload is malformed") from exc
-    raise ToolPolicyError("Stored tool result kind is unsupported")
+        raise ToolPolicyError("Stored tool result kind is unsupported")
+    except ToolPolicyError:
+        raise
+    except Exception:
+        # Validation and custom mappings can include stored secrets in their errors.
+        raise ToolPolicyError("Stored tool result payload is malformed") from None
 
 
 def coerce_static_tool_result(

--- a/plugins/tests/adapters/langgraph/test_capture.py
+++ b/plugins/tests/adapters/langgraph/test_capture.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import overload
+from typing import Any, overload
 
 import pytest
 
@@ -57,6 +57,43 @@ def test_capture_custom_redactor_marks_result_as_lossy() -> None:
     assert captured.value == {"private": "removed"}
     assert not captured.replayable
     assert captured.reasons == ("custom_redactor",)
+
+
+@pytest.mark.parametrize("key", [1, True, (1,)])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_capture_marks_nested_key_collisions_as_lossy(key: Any, reverse: bool) -> None:
+    items = [(key, "first"), (str(key), "second")]
+    if reverse:
+        items.reverse()
+    mapping = dict(items)
+
+    captured = capture_value({"nested": [mapping, mapping]}, CapturePolicy())
+
+    assert captured.value == {"nested": [{str(key): items[-1][1]}] * 2}
+    assert set(captured.reasons) == {"non_string_key", "key_collision"}
+    assert len(captured.reasons) == 2
+    assert captured.lossy and not captured.replayable
+    assert not captured.truncated
+    assert list(mapping.items()) == items
+
+
+@pytest.mark.parametrize("key", [1, True, (1,)])
+def test_capture_marks_noncolliding_key_coercion_as_lossy(key: Any) -> None:
+    captured = capture_value({key: "kept"}, CapturePolicy())
+
+    assert captured.value == {str(key): "kept"}
+    assert captured.reasons == ("non_string_key",)
+    assert not captured.replayable
+
+
+def test_capture_preserves_ordinary_string_mapping() -> None:
+    value = {"nested": [{"count": 1, "enabled": True}]}
+
+    captured = capture_value(value, CapturePolicy())
+
+    assert captured.value == value
+    assert captured.replayable
+    assert not captured.reasons
 
 
 @dataclass

--- a/plugins/tests/adapters/langgraph/test_capture_properties.py
+++ b/plugins/tests/adapters/langgraph/test_capture_properties.py
@@ -15,13 +15,10 @@
 
 from typing import Any
 
-import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
 from kitaru_langgraph.capture import CapturePolicy, capture_value
-
-_KNOWN = "#906"
 
 # The string spellings are drawn alongside the non-string keys so that a draw can hold
 # two distinct keys that `str()` maps onto the same name. Purely random text keys
@@ -56,17 +53,15 @@ def test_string_keyed_mapping_is_captured_exactly_or_flagged(
     assert result.lossy or result.value == value
 
 
-@pytest.mark.xfail(strict=True, reason=_KNOWN)
 @given(value=st.dictionaries(_keys, _values, max_size=6))
 def test_key_collapse_is_reported_as_lossy(value: dict[Any, Any]) -> None:
     result = capture_value(value, CapturePolicy())
-    if len({str(k) for k in value}) < len(value):
+    if any(not isinstance(key, str) for key in value):
         assert result.lossy and result.reasons and not result.replayable
-    else:
+    if len({str(k) for k in value}) == len(value):
         assert len(result.value) == len(value)
 
 
-@pytest.mark.xfail(strict=True, reason=_KNOWN)
 def test_colliding_keys_example() -> None:
     result = capture_value({1: "a", "1": "b"}, CapturePolicy())
     assert len(result.value) == 2 or result.lossy

--- a/plugins/tests/adapters/langgraph/test_codec.py
+++ b/plugins/tests/adapters/langgraph/test_codec.py
@@ -1,19 +1,273 @@
 """Typed tool-outcome codec contracts."""
 
+import asyncio
+import json
+import traceback
 from collections.abc import Sequence
-from typing import overload
+from typing import Any, Literal, NoReturn, overload
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 from langchain_core.messages import ToolMessage
 from langgraph.types import Command
 
 from kitaru_langgraph import ToolPolicyError
 from kitaru_langgraph.capture import CapturePolicy
 from kitaru_langgraph.codec import (
+    TOOL_OUTCOME_SCHEMA,
     coerce_static_tool_result,
     decode_tool_outcome,
     encode_tool_outcome,
 )
+
+
+def _assert_same_nested_types(actual: Any, expected: Any) -> None:
+    assert type(actual) is type(expected)
+    assert actual == expected
+    if isinstance(expected, dict):
+        for key, item in expected.items():
+            _assert_same_nested_types(actual[key], item)
+    elif isinstance(expected, (list, tuple)):
+        for decoded_item, item in zip(actual, expected, strict=True):
+            _assert_same_nested_types(decoded_item, item)
+
+
+_native_values = st.recursive(
+    st.none() | st.booleans() | st.integers() | st.text(max_size=12),
+    lambda children: (
+        st.lists(children, max_size=3)
+        | st.lists(children, max_size=3).map(tuple)
+        | st.dictionaries(
+            st.sampled_from(["state", "value", "__kitaru_langgraph_type__"]),
+            children,
+            max_size=3,
+        )
+    ),
+    max_leaves=10,
+)
+
+
+@given(value=_native_values, command=st.booleans())
+def test_supported_outcomes_round_trip_through_json(value: Any, command: bool) -> None:
+    original = (
+        Command(update=value, resume=value)
+        if command
+        else ToolMessage(content="done", artifact=value, tool_call_id="old")
+    )
+    envelope = encode_tool_outcome(original)
+    serialized = json.loads(json.dumps(envelope))
+    if not envelope["replayable"]:
+        assert envelope["loss_reasons"]
+        with pytest.raises(ToolPolicyError, match="not replayable"):
+            decode_tool_outcome(serialized, tool_call_id="new", tool_name="tool")
+        return
+
+    result = decode_tool_outcome(serialized, tool_call_id="new", tool_name="tool")
+
+    if command:
+        assert isinstance(result, Command)
+        _assert_same_nested_types(result.update, value)
+        _assert_same_nested_types(result.resume, value)
+        _assert_same_nested_types(result.goto, ())
+    else:
+        assert isinstance(result, ToolMessage)
+        _assert_same_nested_types(result.artifact, value)
+        assert result.tool_call_id == "new"
+        assert result.name == "tool"
+
+
+def test_command_tuple_pairs_and_default_goto_round_trip() -> None:
+    original = Command(update=[("count", 1), ("nested", ((), [1, (2,)]))])
+
+    envelope = encode_tool_outcome(original)
+    assert envelope["replayable"] is True
+    decoded = decode_tool_outcome(
+        json.loads(json.dumps(envelope)), tool_call_id="new", tool_name="tool"
+    )
+
+    assert isinstance(decoded, Command)
+    _assert_same_nested_types(decoded.goto, ())
+    _assert_same_nested_types(decoded.update, original.update)
+
+
+@pytest.mark.parametrize("nested", [False, True])
+@pytest.mark.parametrize("status", ["success", "error"])
+def test_explicit_status_round_trips(
+    nested: bool, status: Literal["success", "error"]
+) -> None:
+    message = ToolMessage(content="done", tool_call_id="old", status=status)
+    original = Command(update={"message": message}) if nested else message
+    decoded = decode_tool_outcome(
+        json.loads(json.dumps(encode_tool_outcome(original))),
+        tool_call_id="new",
+        tool_name="tool",
+    )
+    if isinstance(decoded, Command):
+        assert isinstance(decoded.update, dict)
+        result = decoded.update["message"]
+    else:
+        result = decoded
+    assert result.status == status
+    assert result.tool_call_id == "new"
+    assert result.name == "tool"
+
+
+@pytest.mark.parametrize("nested", [False, True])
+@pytest.mark.parametrize("status", ["missing", None, "invalid"])
+def test_missing_or_invalid_status_is_rejected(nested: bool, status: Any) -> None:
+    message = ToolMessage(content="done", tool_call_id="old")
+    envelope = encode_tool_outcome(
+        Command(update={"message": message}) if nested else message
+    )
+    payload = envelope["payload"]
+    if nested:
+        payload = payload["update"]["message"]
+    if status == "missing":
+        payload.pop("status")
+    else:
+        payload["status"] = status
+
+    with pytest.raises(ToolPolicyError):
+        decode_tool_outcome(envelope, tool_call_id="new", tool_name="tool")
+
+
+@pytest.mark.parametrize("operation", ["get", "items"])
+def test_mapping_failures_do_not_leak_payloads(operation: str) -> None:
+    class BrokenMapping(dict[str, Any]):
+        def get(self, key: object, default: Any = None) -> Any:
+            if operation == "get":
+                raise RuntimeError("private-payload-sentinel")
+            return super().get(key, default)
+
+        def items(self) -> NoReturn:
+            raise RuntimeError("private-payload-sentinel")
+
+    envelope = encode_tool_outcome(Command())
+    if operation == "get":
+        value = BrokenMapping(envelope)
+    else:
+        envelope["payload"]["update"] = BrokenMapping()
+        value = envelope
+
+    with pytest.raises(ToolPolicyError) as caught:
+        decode_tool_outcome(value, tool_call_id="new", tool_name="tool")
+    assert "private-payload-sentinel" not in "".join(
+        traceback.format_exception(caught.value)
+    )
+
+
+def test_validation_exception_chain_does_not_leak_payloads() -> None:
+    envelope = encode_tool_outcome(ToolMessage(content="done", tool_call_id="old"))
+    envelope["payload"]["id"] = {"private-payload-sentinel": 1}
+
+    with pytest.raises(ToolPolicyError) as caught:
+        decode_tool_outcome(envelope, tool_call_id="new", tool_name="tool")
+    assert "private-payload-sentinel" not in "".join(
+        traceback.format_exception(caught.value)
+    )
+
+
+@pytest.mark.parametrize("cycle", [False, True])
+def test_deep_or_cyclic_stored_payload_is_rejected(cycle: bool) -> None:
+    value: list[Any] = []
+    if cycle:
+        value.append(value)
+    else:
+        for _ in range(3000):
+            value = [value]
+    envelope = encode_tool_outcome(Command())
+    envelope["payload"]["update"] = value
+
+    with pytest.raises(ToolPolicyError):
+        decode_tool_outcome(envelope, tool_call_id="new", tool_name="tool")
+
+
+@pytest.mark.parametrize("exception", [SystemExit(), asyncio.CancelledError()])
+def test_process_exit_and_cancellation_are_not_swallowed(
+    exception: BaseException,
+) -> None:
+    class InterruptedMapping(dict[str, Any]):
+        def get(self, key: object, default: Any = None) -> NoReturn:
+            raise exception
+
+    with pytest.raises(type(exception)):
+        decode_tool_outcome(InterruptedMapping(), tool_call_id="new", tool_name="tool")
+
+
+@pytest.mark.parametrize("tuple_value", [None, {}, "wrong", 1])
+def test_malformed_tuple_tags_are_rejected(tuple_value: Any) -> None:
+    envelope = encode_tool_outcome(Command())
+    envelope["payload"]["update"] = {
+        "__kitaru_langgraph_type__": "tuple",
+        "value": tuple_value,
+    }
+
+    with pytest.raises(ToolPolicyError):
+        decode_tool_outcome(envelope, tool_call_id="new", tool_name="tool")
+
+
+def test_legacy_command_lists_stay_lists() -> None:
+    envelope = {
+        "schema": TOOL_OUTCOME_SCHEMA,
+        "kind": "command",
+        "replayable": True,
+        "loss_reasons": [],
+        "payload": {
+            "graph": None,
+            "update": [["count", 1]],
+            "resume": None,
+            "goto": [],
+        },
+    }
+
+    decoded = decode_tool_outcome(envelope, tool_call_id="new", tool_name="tool")
+
+    assert isinstance(decoded, Command)
+    _assert_same_nested_types(decoded.update, [["count", 1]])
+    _assert_same_nested_types(decoded.goto, [])
+
+
+def test_legacy_tool_message_with_explicit_status_still_decodes() -> None:
+    envelope = {
+        "schema": TOOL_OUTCOME_SCHEMA,
+        "kind": "tool_message",
+        "replayable": True,
+        "loss_reasons": [],
+        "payload": {
+            "__kitaru_langgraph_type__": "tool_message",
+            "content": "failed",
+            "artifact": [[1, 2]],
+            "status": "error",
+        },
+    }
+
+    decoded = decode_tool_outcome(envelope, tool_call_id="new", tool_name="tool")
+
+    assert isinstance(decoded, ToolMessage)
+    assert decoded.status == "error"
+    assert decoded.tool_call_id == "new"
+    _assert_same_nested_types(decoded.artifact, [[1, 2]])
+
+
+def test_unknown_nested_type_fails_closed() -> None:
+    envelope = encode_tool_outcome(Command())
+    envelope["payload"]["update"] = {"__kitaru_langgraph_type__": "future-type"}
+
+    with pytest.raises(ToolPolicyError, match="type is unsupported"):
+        decode_tool_outcome(envelope, tool_call_id="new", tool_name="tool")
+
+
+def test_existing_tool_policy_error_is_preserved() -> None:
+    error = ToolPolicyError("Already classified")
+
+    class RejectedMapping(dict[str, Any]):
+        def get(self, key: object, default: Any = None) -> NoReturn:
+            raise error
+
+    with pytest.raises(ToolPolicyError) as caught:
+        decode_tool_outcome(RejectedMapping(), tool_call_id="new", tool_name="tool")
+    assert caught.value is error
 
 
 def test_tool_message_round_trip_remaps_current_identity() -> None:
@@ -67,11 +321,12 @@ def test_command_round_trip_preserves_control_fields_and_nested_message() -> Non
     assert message.name == "approval"
 
 
-def test_command_round_trip_preserves_mapping_with_reserved_type_key() -> None:
+@pytest.mark.parametrize("tag", ["tool_message", "tuple", "mapping"])
+def test_command_round_trip_preserves_mapping_with_reserved_type_key(tag: str) -> None:
     original = Command(
         update={
             "state": {
-                "__kitaru_langgraph_type__": "tool_message",
+                "__kitaru_langgraph_type__": tag,
                 "content": "ordinary application state",
             }
         }
@@ -178,6 +433,41 @@ def test_redacted_tool_outcome_is_not_replayable() -> None:
         decode_tool_outcome(envelope, tool_call_id="current", tool_name="tool")
 
 
+@pytest.mark.parametrize("kind", ["tool_message", "command"])
+@pytest.mark.parametrize("key", [1, True, (1,)])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_key_collision_in_native_outcome_is_not_replayable(
+    kind: str, key: Any, reverse: bool
+) -> None:
+    items = [(key, "first"), (str(key), "second")]
+    if reverse:
+        items.reverse()
+    mapping = dict(items)
+    value = {"nested": [mapping, mapping]}
+    original = (
+        ToolMessage(content="done", artifact=value, tool_call_id="old")
+        if kind == "tool_message"
+        else Command(update=value)
+    )
+
+    envelope = encode_tool_outcome(original)
+
+    assert envelope["replayable"] is False
+    assert set(envelope["loss_reasons"]) == {"non_string_key", "key_collision"}
+    assert len(envelope["loss_reasons"]) == 2
+    assert list(mapping.items()) == items
+    with pytest.raises(ToolPolicyError, match="not replayable"):
+        decode_tool_outcome(envelope, tool_call_id="current", tool_name="tool")
+
+
+def test_noncolliding_key_coercion_in_outcome_is_not_replayable() -> None:
+    envelope = encode_tool_outcome(Command(update={1: "kept"}))
+
+    assert envelope["payload"]["update"] == {"1": "kept"}
+    assert envelope["loss_reasons"] == ["non_string_key"]
+    assert envelope["replayable"] is False
+
+
 def test_lossy_envelope_is_not_replayable() -> None:
     envelope = encode_tool_outcome(
         ToolMessage(content="x" * 100, tool_call_id="old"),
@@ -195,11 +485,32 @@ def test_lossy_envelope_is_not_replayable() -> None:
 
 @pytest.mark.parametrize(
     "value",
-    [None, {}, {"schema": "unknown"}, {"schema": "kitaru.langgraph.tool_result.v1"}],
+    [
+        None,
+        {},
+        {"schema": "unknown"},
+        {"schema": TOOL_OUTCOME_SCHEMA},
+        {"schema": TOOL_OUTCOME_SCHEMA, "replayable": True, "payload": []},
+        {
+            "schema": TOOL_OUTCOME_SCHEMA,
+            "replayable": True,
+            "payload": {},
+            "kind": "unknown",
+        },
+    ],
 )
 def test_malformed_or_unknown_envelopes_are_rejected(value: object) -> None:
     with pytest.raises(ToolPolicyError):
         decode_tool_outcome(value, tool_call_id="call", tool_name="tool")
+
+
+@pytest.mark.parametrize("field", ["graph", "update", "resume", "goto"])
+def test_command_requires_every_stored_field(field: str) -> None:
+    envelope = encode_tool_outcome(Command(update={"value": 1}))
+    envelope["payload"].pop(field)
+
+    with pytest.raises(ToolPolicyError, match="Command payload"):
+        decode_tool_outcome(envelope, tool_call_id="call", tool_name="tool")
 
 
 def test_plain_static_json_becomes_tool_message() -> None:

--- a/plugins/tests/adapters/langgraph/test_recording.py
+++ b/plugins/tests/adapters/langgraph/test_recording.py
@@ -3,12 +3,51 @@
 import uuid
 from typing import Any
 
+from langchain_core.messages import ToolMessage
 from langchain_core.outputs import LLMResult
+from langchain_core.runnables import RunnableConfig, RunnableLambda
+from langchain_core.tools import tool
 
 from kitaru.api_models.v1.session_node import NodeType
+from kitaru_langgraph import KitaruGraphRunner
 from kitaru_langgraph.callbacks import AsyncKitaruCallback
 from kitaru_langgraph.capture import CapturePolicy
 from kitaru_langgraph.recording import InvocationRecorder
+
+
+async def test_key_loss_in_recorded_copy_preserves_native_tool_result(
+    fake_client: Any,
+) -> None:
+    artifact = {1: "first", "1": "second"}
+    native_results: list[ToolMessage] = []
+
+    @tool(response_format="content_and_artifact")
+    def lookup() -> tuple[str, dict[Any, str]]:
+        """Return a mapping with distinct native keys."""
+        return "done", artifact
+
+    async def run(_: Any, config: RunnableConfig) -> ToolMessage:
+        result = await lookup.ainvoke(
+            {"name": "lookup", "args": {}, "id": "call-1", "type": "tool_call"},
+            config,
+        )
+        assert isinstance(result, ToolMessage)
+        native_results.append(result)
+        return result
+
+    returned = await KitaruGraphRunner(RunnableLambda(run)).ainvoke("hello")
+
+    assert returned is native_results[0]
+    assert returned.artifact == {1: "first", "1": "second"}
+    assert artifact == {1: "first", "1": "second"}
+    client = fake_client.instances[0]
+    nodes = [node for _, batch in client.sessions.node_batches for node in batch.nodes]
+    recorded = next(node for node in nodes if node.node_type is NodeType.TOOL_CALL)
+    assert recorded.outputs["replayable"] is False
+    assert set(recorded.outputs["loss_reasons"]) == {
+        "non_string_key",
+        "key_collision",
+    }
 
 
 async def test_nested_ancestor_is_persisted_before_child(fake_client: Any) -> None:

--- a/plugins/tests/adapters/langgraph/test_replay.py
+++ b/plugins/tests/adapters/langgraph/test_replay.py
@@ -614,7 +614,10 @@ async def test_history_non_baseline_scope_sends_no_occurrence() -> None:
 
 
 @pytest.mark.parametrize("sync", [False, True], ids=["async", "sync"])
-@pytest.mark.parametrize("invalid_result", ["null", "malformed"])
+@pytest.mark.parametrize(
+    "invalid_result",
+    ["null", "malformed", "missing-status", "malformed-tuple", "missing-command"],
+)
 async def test_invalid_completed_history_match_fails_closed_under_passthrough(
     sync: bool,
     invalid_result: str,
@@ -627,11 +630,22 @@ async def test_invalid_completed_history_match_fails_closed_under_passthrough(
     )
     recorder = _Recorder(override=None, policy=policy)
     result: Any = None
-    if invalid_result == "malformed":
+    if invalid_result == "missing-command":
+        result = encode_tool_outcome(Command(update={"value": 1}))
+        result["payload"].pop("goto")
+    elif invalid_result != "null":
         result = encode_tool_outcome(
             ToolMessage(content="history", tool_call_id="old", name="old")
         )
-        result["payload"]["additional_kwargs"] = 1
+        if invalid_result == "malformed":
+            result["payload"]["additional_kwargs"] = 1
+        elif invalid_result == "missing-status":
+            result["payload"].pop("status")
+        else:
+            result["payload"]["artifact"] = {
+                "__kitaru_langgraph_type__": "tuple",
+                "value": "not a list",
+            }
 
     async def lookup(*_: Any) -> Any:
         return _history_match(result)
@@ -663,10 +677,21 @@ async def test_invalid_completed_history_match_fails_closed_under_passthrough(
             CapturePolicy(max_field_bytes=64),
             id="truncated",
         ),
+        pytest.param(
+            {"nested": {1: "first", "1": "second"}},
+            CapturePolicy(),
+            id="colliding-keys",
+        ),
+        pytest.param(
+            {1: "kept"},
+            CapturePolicy(),
+            id="non-string-key",
+        ),
     ],
 )
+@pytest.mark.parametrize("sync", [False, True], ids=["async", "sync"])
 async def test_lossy_history_result_fails_closed(
-    artifact: dict[str, Any], capture_policy: CapturePolicy
+    artifact: dict[Any, Any], capture_policy: CapturePolicy, sync: bool
 ) -> None:
     policy = ToolPolicy(
         default=HistoryConfig(
@@ -693,7 +718,7 @@ async def test_lossy_history_result_fails_closed(
 
     assert envelope["replayable"] is False
     with pytest.raises(ToolPolicyError, match="not replayable"):
-        await _invoke_history_tool(recorder, live_calls, sync=False)
+        await _invoke_history_tool(recorder, live_calls, sync=sync)
     assert live_calls == []
 
 

--- a/src/kitaru/cli/output.py
+++ b/src/kitaru/cli/output.py
@@ -17,7 +17,7 @@ import json
 import traceback as traceback_module
 import unicodedata
 from contextvars import ContextVar, Token
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from types import TracebackType
 from typing import Any, Literal, TextIO
 
@@ -250,7 +250,7 @@ def emit_event(event: str, item: Any = None) -> None:
             },
         )
         return
-    suffix = "" if item is None else f": {_display_value(item)}"
+    suffix = "" if item is None else f": {_display_value(redact_data(item))}"
     print(f"{event}{suffix}", file=context.stdout, flush=True)
 
 
@@ -328,6 +328,16 @@ def write_interaction(message: str) -> None:
 
 def _emit_text(context: OutputContext, result: CommandResult) -> None:
     """Render one result as rich or plain text."""
+    # Sanitize before field selection loses the containing credential key.
+    result = replace(
+        result,
+        item=redact_data(result.item),
+        items=redact_data(result.items),
+        page=redact_data(result.page),
+        warnings=redact_data(result.warnings),
+        links=redact_data(result.links),
+        next_actions=redact_data(result.next_actions),
+    )
     value = result.items if result.items is not None else result.item
     if context.rich:
         console = _get_console(context, context.stdout)
@@ -596,7 +606,7 @@ def _human_field_value(
     if item is _MISSING:
         return "-"
     if field.formatter is not None:
-        return field.formatter(redact_data(item))
+        return field.formatter(item)
     if detail:
         return _detail_value(item)
     return _display_value(item)
@@ -604,7 +614,6 @@ def _human_field_value(
 
 def _detail_value(value: Any) -> str:
     """Format nested detail data as readable indented JSON."""
-    value = redact_data(value)
     if isinstance(value, (dict, list)):
         return json.dumps(value, indent=2, sort_keys=True)
     return _display_value(value)
@@ -612,7 +621,6 @@ def _detail_value(value: Any) -> str:
 
 def _display_value(value: Any) -> str:
     """Format a value for a human-oriented cell or line."""
-    value = redact_data(value)
     if isinstance(value, (dict, list)):
         return json.dumps(value, sort_keys=True)
     if value is None:

--- a/src/kitaru/cli/redaction.py
+++ b/src/kitaru/cli/redaction.py
@@ -11,55 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 #  or implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-"""Redact recognizable credentials from CLI output."""
+"""Shared credential redaction for CLI output."""
 
-import re
-from datetime import date, datetime
-from enum import Enum
-from pathlib import Path
-from typing import Any
-from uuid import UUID
-
-from pydantic import BaseModel
-
-_SECRET_KEY = re.compile(
-    r"(?:^|[_-])(?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|"
-    r"password|secret)$|^(?:authorization|credential|device[_-]?code|"
-    r"client[_-]?secret|private[_-]?key|secret[_-]?env)$",
-    re.IGNORECASE,
-)
-_SECRET_VALUE = re.compile(r"(?i)(bearer\s+|KITKEY_|ZENPROKEY_)[^\s,;\]\}\"']+")
-
-
-def redact(value: str) -> str:
-    """Mask recognizable credentials in a string."""
-    return _SECRET_VALUE.sub(lambda match: f"{match.group(1)}***", value)
-
-
-def redact_data(value: Any, *, key: str | None = None) -> Any:
-    """Recursively mask secret-like fields."""
-    if key is not None and _SECRET_KEY.search(key):
-        return "***"
-    if isinstance(value, BaseModel):
-        return redact_data(value.model_dump(mode="json"))
-    if isinstance(value, dict):
-        return {
-            str(item_key): redact_data(item, key=str(item_key))
-            for item_key, item in value.items()
-        }
-    if isinstance(value, (list, tuple, set)):
-        return [redact_data(item) for item in value]
-    if isinstance(value, str):
-        return redact(value)
-    return _get_json_value(value)
-
-
-def _get_json_value(value: Any) -> Any:
-    """Convert common model values into JSON-compatible values."""
-    if isinstance(value, Enum):
-        return value.value
-    if isinstance(value, (datetime, date)):
-        return value.isoformat()
-    if isinstance(value, (UUID, Path)):
-        return str(value)
-    return value
+from kitaru.redaction import redact as redact
+from kitaru.redaction import redact_data as redact_data

--- a/src/kitaru/mcp/errors.py
+++ b/src/kitaru/mcp/errors.py
@@ -81,13 +81,27 @@ def error_result(result_type: type[ToolResult], error: BaseException) -> ToolRes
 
 def protocol_result(envelope: ToolResult) -> CallToolResult:
     """Render identical redacted canonical JSON as structured and text content."""
-    dumped = envelope.model_dump(mode="json")
-    structured = cast(dict[str, JsonValue], redact_data(dumped))
+    structured = redact_data(envelope)
+    if not isinstance(structured, dict):
+        # Whole-model normalization can fail before yielding any safe fields.
+        structured = {
+            "schema_version": "1",
+            "ok": False,
+            "data": None,
+            "warnings": [],
+            "error": {
+                "code": "internal_error",
+                "message": "The MCP result could not be serialized.",
+                "retryable": False,
+                "details": None,
+                "recovery": None,
+            },
+        }
     text = json.dumps(structured, sort_keys=True, separators=(",", ":"))
     return CallToolResult(
         content=[TextContent(type="text", text=text)],
         structured_content=structured,
-        is_error=not envelope.ok,
+        is_error=not structured["ok"],
     )
 
 

--- a/src/kitaru/mcp/redaction.py
+++ b/src/kitaru/mcp/redaction.py
@@ -1,54 +1,7 @@
 #  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
-"""MCP-local redaction for protocol results and diagnostics."""
+"""Shared credential redaction for MCP output."""
 
-import re
-from datetime import date, datetime
-from enum import Enum
-from pathlib import Path
-from typing import Any
-from uuid import UUID
-
-from pydantic import BaseModel
-
-_SECRET_KEY = re.compile(
-    r"(?:^|_)(?:api_key|access_token|refresh_token|token|password|secret)$|"
-    r"^(?:authorization|credential|device_code|client_secret|private_key|"
-    r"secret_env)$",
-    re.IGNORECASE,
-)
-_SECRET_VALUE = re.compile(r"(?i)(bearer\s+|KITKEY_|ZENPROKEY_)[^\s,;\]\}\"']+")
-
-
-def redact(value: str) -> str:
-    """Mask recognizable credential values in text."""
-    return _SECRET_VALUE.sub(lambda match: f"{match.group(1)}***", value)
-
-
-def redact_data(value: Any, *, key: str | None = None) -> Any:
-    """Recursively mask secret fields and normalize JSON-compatible values."""
-    if key is not None and _SECRET_KEY.search(key):
-        return "***"
-    if isinstance(value, BaseModel):
-        return redact_data(value.model_dump(mode="json"))
-    if isinstance(value, dict):
-        return {
-            str(item_key): redact_data(item, key=str(item_key))
-            for item_key, item in value.items()
-        }
-    if isinstance(value, (list, tuple, set)):
-        return [redact_data(item) for item in value]
-    if isinstance(value, str):
-        return redact(value)
-    return _get_json_value(value)
-
-
-def _get_json_value(value: Any) -> Any:
-    if isinstance(value, Enum):
-        return value.value
-    if isinstance(value, (datetime, date)):
-        return value.isoformat()
-    if isinstance(value, (UUID, Path)):
-        return str(value)
-    return value
+from kitaru.redaction import redact as redact
+from kitaru.redaction import redact_data as redact_data

--- a/src/kitaru/redaction.py
+++ b/src/kitaru/redaction.py
@@ -1,0 +1,130 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Redact recognizable credentials from structured output and diagnostics."""
+
+import re
+from datetime import date, datetime
+from decimal import Decimal
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel
+
+_SECRET_KEY = re.compile(
+    r"(?:^|[_-])(?:api[_-]?keys?|access[_-]?tokens?|refresh[_-]?tokens?|tokens?|"
+    r"passwords?|secrets?)$|^(?:authorization|credentials?|device[_-]?codes?|"
+    r"client[_-]?secrets?|private[_-]?keys?|secret[_-]?env)$",
+    re.IGNORECASE,
+)
+_SECRET_VALUE = re.compile(r"(?i)(bearer\s+|KITKEY_|ZENPROKEY_)[^\s,;\]\}\"']+")
+
+_TOKEN_USAGE_KEYS = frozenset(
+    {"input_tokens", "output_tokens", "cached_input_tokens", "reasoning_tokens"}
+)
+_MAX_DEPTH = 64
+
+
+def redact(value: str) -> str:
+    """Mask recognizable credentials in a string."""
+    return _SECRET_VALUE.sub(lambda match: f"{match.group(1)}***", value)
+
+
+def redact_data(value: Any, *, key: str | None = None) -> Any:
+    """Return bounded JSON-safe output with recognizable credentials masked."""
+    try:
+        return _redact_data(value, key=key, depth=0, active_ids=set())
+    except Exception:
+        # Normalization errors can include credentials in their messages.
+        return "[unavailable]"
+
+
+def _redact_data(
+    value: Any, *, key: str | None, depth: int, active_ids: set[int]
+) -> Any:
+    """Normalize one value while retaining key context and active ancestors."""
+    if (
+        key is not None
+        and _SECRET_KEY.search(key)
+        and not _is_token_usage(value, key=key)
+    ):
+        return "***"
+    if depth >= _MAX_DEPTH:
+        return "[depth limit]"
+    if isinstance(value, BaseModel):
+        # JSON-mode dumping collapses mixed keys before we can disambiguate them.
+        value = value.model_dump(mode="python")
+    if isinstance(value, (dict, list, tuple, set)):
+        identity = id(value)
+        if identity in active_ids:
+            return "[cycle]"
+        active_ids.add(identity)
+        try:
+            if isinstance(value, dict):
+                reserved = {item_key for item_key in value if isinstance(item_key, str)}
+                result: dict[str, Any] = {}
+                for item_key, item in value.items():
+                    original_key = str(item_key)
+                    output_key = original_key
+                    if not isinstance(item_key, str):
+                        suffix = 2
+                        while output_key in reserved or output_key in result:
+                            output_key = f"{original_key} [{suffix}]"
+                            suffix += 1
+                    result[output_key] = _redact_data(
+                        item, key=original_key, depth=depth + 1, active_ids=active_ids
+                    )
+                return result
+            return [
+                _redact_data(item, key=None, depth=depth + 1, active_ids=active_ids)
+                for item in value
+            ]
+        finally:
+            active_ids.remove(identity)
+    if isinstance(value, Enum):
+        return _redact_data(
+            value.value, key=key, depth=depth + 1, active_ids=active_ids
+        )
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, (UUID, Path)):
+        return redact(str(value))
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, str):
+        return redact(value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return "[unavailable]"
+
+
+def _is_token_usage(value: Any, *, key: str) -> bool:
+    """Recognize only the numeric token usage fields emitted by the API."""
+    if key not in _TOKEN_USAGE_KEYS and key != "tokens":
+        return False
+    if value is None or (isinstance(value, int) and not isinstance(value, bool)):
+        return True
+    return (
+        key == "tokens"
+        and isinstance(value, dict)
+        and all(
+            field in _TOKEN_USAGE_KEYS
+            and (
+                count is None
+                or (isinstance(count, int) and not isinstance(count, bool))
+            )
+            for field, count in value.items()
+        )
+    )

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -26,9 +26,37 @@ import pytest
 
 import kitaru.cli
 from kitaru.cli import app as app_module
-from kitaru.cli.output import CommandResult, OutputMode, emit_event, get_output_context
+from kitaru.cli.output import (
+    CLIError,
+    CommandResult,
+    OutputMode,
+    emit_event,
+    get_output_context,
+)
 from kitaru.cli.skill_discovery import INSTALL_COMMAND, SKILLS_URL
 from kitaru.client.exceptions import APIError, InvalidServerResponseError
+
+
+def test_main_emits_deep_error_as_structured_stderr(monkeypatch, capsys) -> None:
+    """Deep error details do not escape the CLI's error boundary."""
+    details: dict[str, Any] = {}
+    cursor = details
+    for _ in range(3000):
+        cursor["nested"] = {}
+        cursor = cursor["nested"]
+    cursor["password"] = "unmarked-secret"
+
+    def fail_version() -> str:
+        raise CLIError("invalid_arguments", "Invalid input", details=details)
+
+    monkeypatch.setattr(app_module.diagnostics, "package_version", fail_version)
+    assert app_module.main(["version", "--output", "json"]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["error"]["kind"] == "invalid_arguments"
+    assert "Traceback" not in captured.err
+    assert "unmarked-secret" not in captured.err
 
 
 def test_bare_command_group_prints_help_without_bootstrap(monkeypatch, capsys) -> None:

--- a/tests/cli/test_output.py
+++ b/tests/cli/test_output.py
@@ -15,6 +15,7 @@
 
 import io
 import json
+from typing import Any, Literal
 
 import pytest
 from rich.console import Console
@@ -67,6 +68,57 @@ def _render_text(
             stderr.getvalue()
         ).plain
     return stdout.getvalue(), stderr.getvalue()
+
+
+@pytest.mark.parametrize("rich", [False, True])
+def test_text_redacts_fields_and_metadata_before_rendering(rich: bool) -> None:
+    """Selecting a display field must not discard its secret-key context."""
+    result = CommandResult(
+        item={"password": "unmarked-secret", "tokens": {"input_tokens": 4}},
+        warnings=["Bearer warning-secret"],
+        links={"inspect": "https://example.test/KITKEY_link-secret"},
+        next_actions=["Use ZENPROKEY_action-secret"],
+    )
+    stdout, stderr = _render_text("example.get", result, rich=rich)
+    assert "unmarked-secret" not in stdout
+    assert "link-secret" not in stdout
+    assert "action-secret" not in stdout
+    assert "warning-secret" not in stderr
+    assert "input_tokens" in stdout
+    assert result.item["password"] == "unmarked-secret"
+    assert result.warnings == ["Bearer warning-secret"]
+
+
+@pytest.mark.parametrize("mode", ["json", "jsonl", "text"])
+def test_deep_result_and_error_remain_serializable(
+    mode: Literal["json", "jsonl", "text"],
+) -> None:
+    """Deep values must not break success or error emission."""
+    value: Any = {"password": "deep-secret"}
+    for _ in range(3000):
+        value = {"nested": value}
+    stdout, stderr = io.StringIO(), io.StringIO()
+    context = OutputContext(
+        command="example.get",
+        mode=mode,
+        debug=False,
+        traceback=False,
+        stdout=stdout,
+        stderr=stderr,
+        rich=False,
+    )
+    token = set_output_context(context)
+    try:
+        assert emit_result(CommandResult(item=value)) == 0
+        assert (
+            emit_error(CLIError("invalid_arguments", "bad input", details=value)) == 2
+        )
+    finally:
+        reset_output_context(token)
+    assert "deep-secret" not in stdout.getvalue() + stderr.getvalue()
+    if mode != "text":
+        assert json.loads(stdout.getvalue())["ok"] is True
+        assert json.loads(stderr.getvalue())["ok"] is False
 
 
 def test_auto_mode_and_finite_jsonl_contract() -> None:
@@ -152,6 +204,33 @@ def test_jsonl_lifecycle_events_are_append_only() -> None:
     events = [json.loads(line) for line in stdout.getvalue().splitlines()]
     assert [event["event"] for event in events] == ["starting", "stopped"]
     assert all(event["command"] == "worker.start" for event in events)
+
+
+def test_text_lifecycle_event_redacts_structured_data() -> None:
+    """Text events retain safe fields without exposing credential context."""
+    stdout = io.StringIO()
+    token = set_output_context(
+        OutputContext(
+            command="worker.start",
+            mode="text",
+            debug=False,
+            traceback=False,
+            stdout=stdout,
+            stderr=io.StringIO(),
+            rich=False,
+        )
+    )
+    try:
+        emit_event(
+            "starting",
+            {"name": "local", "password": "unmarked-secret", "note": "Bearer marked"},
+        )
+    finally:
+        reset_output_context(token)
+
+    output = stdout.getvalue()
+    assert "starting" in output and "local" in output
+    assert "unmarked-secret" not in output and "marked" not in output
 
 
 def test_interrupted_error_has_stable_structured_shape() -> None:

--- a/tests/cli/test_redaction_properties.py
+++ b/tests/cli/test_redaction_properties.py
@@ -14,17 +14,22 @@
 """Property tests for CLI and MCP credential redaction."""
 
 import json
+from datetime import date, datetime
+from decimal import Decimal
+from enum import Enum
+from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
+from pydantic import BaseModel
 
 from kitaru.cli.redaction import redact_data as cli_redact
 from kitaru.mcp.redaction import redact_data as mcp_redact
 
 _REDACTORS = [pytest.param(cli_redact, id="cli"), pytest.param(mcp_redact, id="mcp")]
-_KNOWN = "#906"
 
 _json = st.recursive(
     st.none() | st.booleans() | st.integers() | st.text(max_size=30),
@@ -33,11 +38,23 @@ _json = st.recursive(
     ),
     max_leaves=12,
 )
-# #906: "apiKey" and "x-api-key" are omitted here because only the CLI regex spells the
-# separator as `[_-]?`; the MCP copy accepts `_` only, so it leaves those two key names
-# untouched. `test_camel_and_hyphen_secret_keys_are_masked` pins that gap.
 _secret_keys = st.sampled_from(
-    ["api_key", "token", "password", "secret", "authorization"]
+    [
+        "api_key",
+        "apiKey",
+        "x-api-key",
+        "API_KEY",
+        "token",
+        "tokens",
+        "access_tokens",
+        "refreshTokens",
+        "password",
+        "passwords",
+        "secret",
+        "secrets",
+        "authorization",
+        "credentials",
+    ]
 )
 
 
@@ -75,39 +92,24 @@ def test_inline_marker_never_survives(
     assert secret not in out
 
 
-@pytest.mark.parametrize(
-    "redact_data",
-    [
-        pytest.param(cli_redact, id="cli"),
-        pytest.param(
-            mcp_redact,
-            id="mcp",
-            marks=pytest.mark.xfail(strict=True, reason=_KNOWN),
-        ),
-    ],
-)
+@pytest.mark.parametrize("redact_data", _REDACTORS)
 def test_camel_and_hyphen_secret_keys_are_masked(redact_data: Any) -> None:
     out = redact_data({"apiKey": "0123456789", "x-api-key": "0123456789"})
     assert out == {"apiKey": "***", "x-api-key": "***"}
 
 
 @pytest.mark.parametrize("redact_data", _REDACTORS)
-@pytest.mark.xfail(strict=True, reason=_KNOWN)
 def test_distinct_keys_are_preserved(redact_data: Any) -> None:
     assert len(redact_data({1: "a", "1": "b"})) == 2
 
 
-# Whether plural forms count as secret keys is an open question in #906; strict xfail
-# forces the decision when the issue is resolved.
 @pytest.mark.parametrize("redact_data", _REDACTORS)
-@pytest.mark.xfail(strict=True, reason=_KNOWN)
 def test_plural_secret_keys_are_masked(redact_data: Any) -> None:
     out = redact_data({"secrets": {"a": "s5"}, "tokens": "s2"})
     assert out["secrets"] == "***" and out["tokens"] == "***"
 
 
 @pytest.mark.parametrize("redact_data", _REDACTORS)
-@pytest.mark.xfail(strict=True, reason=_KNOWN)
 def test_deep_nesting_does_not_recurse_out(redact_data: Any) -> None:
     value: dict[str, Any] = {}
     cursor = value
@@ -115,3 +117,154 @@ def test_deep_nesting_does_not_recurse_out(redact_data: Any) -> None:
         cursor["k"] = {}
         cursor = cursor["k"]
     json.dumps(redact_data(value))
+
+
+@pytest.mark.parametrize("redact_data", _REDACTORS)
+@given(
+    value=st.dictionaries(
+        st.text(max_size=12)
+        | st.integers(-5, 5)
+        | st.booleans()
+        | st.tuples(st.integers(-5, 5)),
+        _json,
+        max_size=8,
+    )
+)
+def test_mixed_keys_survive_json_and_repeated_redaction(
+    redact_data: Any, value: Any
+) -> None:
+    output = redact_data(value)
+    assert len(json.loads(json.dumps(output))) == len(value)
+    assert redact_data(output) == output
+
+
+@pytest.mark.parametrize("redact_data", _REDACTORS)
+@pytest.mark.parametrize("key", [1, True, (1,)])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_key_aliases_reserve_existing_strings(
+    redact_data: Any, key: Any, reverse: bool
+) -> None:
+    entries = [(key, "native"), (str(key), "string"), (f"{key} [2]", "reserved")]
+    value = dict(reversed(entries) if reverse else entries)
+    output = json.loads(json.dumps(redact_data({"nested": [value]})))["nested"][0]
+    assert len(output) == 3
+    assert output[str(key)] == "string"
+    assert output[f"{key} [2]"] == "reserved"
+    assert set(output.values()) == {"native", "string", "reserved"}
+    assert list(value.items()) == list(reversed(entries) if reverse else entries)
+
+
+@pytest.mark.parametrize("redact_data", _REDACTORS)
+def test_cycles_are_bounded_but_shared_values_remain_visible(redact_data: Any) -> None:
+    mapping: dict[str, Any] = {}
+    sequence: list[Any] = [mapping]
+    mapping["cycle"] = sequence
+    shared = {"visible": 1, "password": "hidden"}
+    output = redact_data({"cycle": mapping, "first": shared, "second": shared})
+    assert "hidden" not in json.dumps(output)
+    assert output["first"] == output["second"] == {"visible": 1, "password": "***"}
+    assert "cycle" in output["cycle"]
+    assert sequence[0] is mapping and mapping["cycle"] is sequence
+
+
+@pytest.mark.parametrize("redact_data", _REDACTORS)
+@pytest.mark.parametrize("depth", [63, 64, 65])
+def test_depth_boundary_is_bounded(redact_data: Any, depth: int) -> None:
+    value: Any = "visible"
+    for _ in range(depth):
+        value = [value]
+    serialized = json.dumps(redact_data(value))
+    assert ("visible" in serialized) == (depth < 64)
+    assert len(serialized) < 200
+
+
+@pytest.mark.parametrize("redact_data", _REDACTORS)
+def test_model_normalization_keeps_keys_and_supported_scalars(redact_data: Any) -> None:
+    class Values(BaseModel):
+        values: dict[Any, Any]
+
+    class Label(Enum):
+        VALUE = "value"
+
+    value = Values(
+        values={
+            1: "native",
+            "1": "string",
+            "enum": Label.VALUE,
+            "date": date(2026, 8, 31),
+            "datetime": datetime(2026, 8, 31, 12),
+            "uuid": UUID(int=1),
+            "path": Path("/tmp/example"),
+            "decimal": Decimal("0.1250"),
+            "tuple": (1, 2),
+            "set": {3},
+        }
+    )
+    output = json.loads(json.dumps(redact_data(value)))["values"]
+    assert len(output) == len(value.values)
+    assert output["1"] == "string"
+    assert output["enum"] == "value"
+    assert output["date"] == "2026-08-31"
+    assert output["datetime"] == "2026-08-31T12:00:00"
+    assert output["uuid"] == str(UUID(int=1))
+    assert output["path"] == "/tmp/example"
+    assert output["decimal"] == "0.1250"
+    assert output["tuple"] == [1, 2] and output["set"] == [3]
+
+
+@pytest.mark.parametrize("redact_data", _REDACTORS)
+@pytest.mark.parametrize(
+    "usage",
+    [
+        None,
+        0,
+        17,
+        {},
+        {
+            "input_tokens": 12,
+            "output_tokens": None,
+            "cached_input_tokens": 3,
+            "reasoning_tokens": 4,
+        },
+    ],
+)
+def test_numeric_token_usage_is_preserved(redact_data: Any, usage: Any) -> None:
+    assert redact_data({"tokens": usage}) == {"tokens": usage}
+
+
+@pytest.mark.parametrize("redact_data", _REDACTORS)
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "credential-value",
+        ["credential-value"],
+        True,
+        False,
+        1.5,
+        {"input_tokens": "credential-value"},
+        {"input_tokens": True},
+        {"input_tokens": 1, "access_token": "credential-value"},
+        {"unknown": 1},
+    ],
+)
+def test_secret_bearing_tokens_are_masked(redact_data: Any, secret: Any) -> None:
+    assert redact_data({"tokens": secret}) == {"tokens": "***"}
+
+
+@pytest.mark.parametrize("redact_data", _REDACTORS)
+@pytest.mark.parametrize(
+    "key", ["input_tokens", "output_tokens", "cached_input_tokens", "reasoning_tokens"]
+)
+@given(count=st.none() | st.integers())
+def test_numeric_usage_fields_are_preserved(
+    redact_data: Any, key: str, count: Any
+) -> None:
+    assert redact_data({key: count}) == {key: count}
+    assert redact_data({key: "credential-value"}) == {key: "***"}
+    assert redact_data({key: True}) == {key: "***"}
+
+
+@pytest.mark.parametrize("redact_data", _REDACTORS)
+def test_credential_status_fields_are_preserved(redact_data: Any) -> None:
+    value = {"credential_stored": True, "credential_status": "configured"}
+    assert redact_data(value) == value

--- a/tests/mcp/test_handlers_protocol.py
+++ b/tests/mcp/test_handlers_protocol.py
@@ -4,6 +4,7 @@
 import json
 import uuid
 from datetime import UTC, datetime
+from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any, Literal, cast
 
@@ -18,7 +19,8 @@ from kitaru.api_models.v1.agent import AgentResponse
 from kitaru.api_models.v1.base import Page
 from kitaru.api_models.v1.cohort import CohortResponse
 from kitaru.api_models.v1.investigation import InvestigationSessionResponse
-from kitaru.api_models.v1.session import SessionDetailResponse
+from kitaru.api_models.v1.session import SessionDetailResponse, TokenUsage
+from kitaru.api_models.v1.session_node import SessionNodeResponse
 from kitaru.api_models.v1.tag import TagResponse
 from kitaru.api_models.v1.task import TaskKind
 from kitaru.api_models.v1.worker import (
@@ -707,3 +709,61 @@ async def test_experiment_create_forwards_idempotency_key() -> None:
     )
 
     assert idempotency_keys == ["retry-experiment-1"]
+
+
+@pytest.mark.parametrize("kind", ["session", "session_nodes"])
+@pytest.mark.parametrize(
+    "usage", [None, TokenUsage(input_tokens=12, output_tokens=4, cached_input_tokens=2)]
+)
+async def test_public_activity_preserves_typed_token_usage(
+    kind: str, usage: TokenUsage | None
+) -> None:
+    client = FakeClient()
+    session_id = uuid.uuid4()
+    session = _get_session(session_id).model_copy(
+        update={"tokens": usage, "cost": Decimal("0.1250")}
+    )
+    node = SessionNodeResponse(
+        id=uuid.uuid4(),
+        session_id=session_id,
+        index=0,
+        parent_index=None,
+        secondary_parent_indexes=[],
+        secondary_parent_ids=[],
+        node_type="llm_call",
+        name="model",
+        status="completed",
+        tokens=usage,
+        cost=Decimal("0.2500"),
+        metadata={},
+    )
+
+    async def get_session(_item_id: uuid.UUID) -> SessionDetailResponse:
+        return session
+
+    async def list_nodes(
+        _session_id: uuid.UUID, _params: object
+    ) -> Page[SessionNodeResponse]:
+        return Page(items=[node], next_cursor=None)
+
+    client.sessions.get = get_session
+    client.sessions.list_nodes = list_nodes
+    server, context = _get_context(client)
+    request = (
+        {"operation": "get", "kind": kind, "id": str(session_id)}
+        if kind == "session"
+        else {"operation": "list_children", "kind": kind, "parent_id": str(session_id)}
+    )
+    result = await server.call_tool(
+        "kitaru_activity_read", {"request": request}, context
+    )
+
+    assert isinstance(result, CallToolResult)
+    assert result.is_error is False
+    assert isinstance(result.content[0], TextContent)
+    assert result.structured_content is not None
+    assert json.loads(result.content[0].text) == result.structured_content
+    data = result.structured_content["data"]
+    item = data if kind == "session" else data["items"][0]
+    assert item["tokens"] == (usage.model_dump() if usage is not None else None)
+    assert item["cost"] == ("0.1250" if kind == "session" else "0.2500")

--- a/tests/mcp/test_optional_import.py
+++ b/tests/mcp/test_optional_import.py
@@ -72,3 +72,22 @@ def test_missing_extra_has_actionable_error_without_traceback(
         "Install the Kitaru MCP server with pip install 'kitaru[mcp]'\n"
     )
     assert "Traceback" not in captured.err
+
+
+def test_shared_redaction_does_not_load_cli_or_server_dependencies() -> None:
+    script = """
+import sys
+import kitaru.redaction
+import kitaru.mcp.redaction
+for prefix in ("cyclopts", "rich", "kitaru.cli", "kitaru.server"):
+    assert not any(
+        name == prefix or name.startswith(prefix + ".") for name in sys.modules
+    ), prefix
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/mcp/test_settings_errors.py
+++ b/tests/mcp/test_settings_errors.py
@@ -1,8 +1,12 @@
 #  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
 """Settings precedence, stable error mapping, and redaction tests."""
 
+import json
+from typing import Any
+
 import httpx
 import pytest
+from mcp.types import TextContent
 from pydantic import ValidationError
 
 from kitaru.analytics.source import AnalyticsSource
@@ -10,8 +14,65 @@ from kitaru.client.exceptions import APIError
 from kitaru.mcp import connection as mcp_connection
 from kitaru.mcp import server as mcp_server
 from kitaru.mcp.connection import ConnectionConfigurationError, MCPConnection
-from kitaru.mcp.errors import MCPOutputValidationError, MCPToolError, map_exception
+from kitaru.mcp.errors import (
+    MCPOutputValidationError,
+    MCPToolError,
+    map_exception,
+    protocol_result,
+)
+from kitaru.mcp.models.common import ToolResult
 from kitaru.mcp.settings import CapabilityMode, MCPSettings
+
+
+def test_protocol_preserves_model_mapping_keys() -> None:
+    """Model conversion must not erase distinct keys before redaction."""
+
+    class MappingResult(ToolResult):
+        data: Any = None
+
+    result = protocol_result(MappingResult(ok=True, data={1: "first", "1": "second"}))
+    structured = result.structured_content
+    assert structured is not None
+    assert len(structured["data"]) == 2
+    assert set(structured["data"].values()) == {"first", "second"}
+    content = result.content[0]
+    assert isinstance(content, TextContent)
+    assert json.loads(content.text) == structured
+
+
+def test_protocol_contains_model_serialization_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed model conversion returns a safe MCP error, never a raw cause."""
+
+    def fail_dump(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise ValueError("Bearer raw-secret")
+
+    monkeypatch.setattr(ToolResult, "model_dump", fail_dump)
+    result = protocol_result(ToolResult(ok=True, data={"value": "raw-secret"}))
+    assert result.is_error is True
+    structured = result.structured_content
+    assert structured is not None
+    assert structured["ok"] is False
+    assert structured["error"]["code"] == "internal_error"
+    assert "raw-secret" not in json.dumps(structured)
+    content = result.content[0]
+    assert isinstance(content, TextContent)
+    assert json.loads(content.text) == structured
+
+
+def test_protocol_contains_deep_model_data() -> None:
+    """Model serialization and JSON encoding both stay within safe bounds."""
+    value: Any = {"password": "deep-secret"}
+    for _ in range(3000):
+        value = {"nested": value}
+    envelope = ToolResult.model_construct(ok=True, data=value)
+    result = protocol_result(envelope)
+    assert result.structured_content is not None
+    content = result.content[0]
+    assert isinstance(content, TextContent)
+    assert json.loads(content.text) == result.structured_content
+    assert "deep-secret" not in content.text
 
 
 def test_settings_default_and_explicit_over_environment_precedence() -> None:


### PR DESCRIPTION
## Summary

CLI and MCP output now masks the same credential fields, preserves distinct mapping entries, and stays serializable for deeply nested or cyclic values. LangGraph recording now rejects captured outcomes whose mapping keys changed, preserves tuples, and fails closed on malformed stored results instead of executing the live tool.

The redaction exception for token usage is deliberately narrow: only numeric or null values in the current `TokenUsage` shape remain visible. Mixed or credential-shaped token fields are masked.

## Reviewer Notes

Please focus on the mixed-key suffix policy in `kitaru.redaction`, the token-usage exception, and backward compatibility of the existing `kitaru.langgraph.tool_result.v1` envelope. New tuple tags fail closed on older adapter versions; existing list values remain lists.

### Reproduction

1. Run `uv run pytest -q tests/cli/test_redaction_properties.py tests/cli/test_output.py tests/mcp/test_handlers_protocol.py tests/mcp/test_settings_errors.py`.
2. Run `uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests/adapters/langgraph`.
3. Confirm the #906 tests are ordinary passing tests and no longer carry strict xfail markers.

Local validation: `just check`; full core suite (4,167 passed, 16 skipped, 14 unrelated xfailed); full plugin suite (578 passed, 14 unrelated xfailed); relevant CI/nightly Hypothesis profiles; JavaScript package tests (102 passed); Python TypeScript integration tests (15 passed).

Code review: harness-native fallback. The configured peer review was blocked by the host approval boundary, so Codex correctness, adversarial, testing, and project-standards reviewers covered the diff locally. All four findings were applied and their affected tests rerun.

## Post-Deploy Monitoring & Validation

- Search for `The MCP result could not be serialized` and `Stored tool result payload is malformed` during the first seven days after release.
- Healthy signal: CLI/MCP result emission remains successful and valid LangGraph history hits continue to replay without new policy errors.
- Failure signal: a sustained increase in serialization internal errors or rejected previously valid LangGraph history. If seen, revert this PR from the release branch and inspect the rejected payload shape before re-releasing.
- Owner: Kitaru maintainers.

Closes #906

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
