### PR TITLE
Prepare Kitaru 0.24.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.24.0]
 
 ### Added
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -9177,7 +9177,7 @@
   },
   "info": {
     "title": "Kitaru",
-    "version": "0.23.0+dev"
+    "version": "0.24.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenml-io/kitaru",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "TypeScript SDK and adapter foundation for Kitaru agent tracing and replay",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/mastra/package.json
+++ b/packages/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenml-io/kitaru-mastra",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Mastra adapter for Kitaru agent tracing and replay",
   "license": "Apache-2.0",
   "repository": {
@@ -38,7 +38,7 @@
     "mastra"
   ],
   "dependencies": {
-    "@zenml-io/kitaru": "workspace:0.1.2"
+    "@zenml-io/kitaru": "workspace:0.2.0"
   },
   "peerDependencies": {
     "@mastra/core": ">=1.51.0 <1.52.0"

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenml-io/kitaru-vercel-ai",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Kitaru tracing and replay adapter for the Vercel AI SDK",
   "license": "Apache-2.0",
   "repository": {
@@ -38,7 +38,7 @@
     "vercel-ai-sdk"
   ],
   "dependencies": {
-    "@zenml-io/kitaru": "workspace:0.1.2"
+    "@zenml-io/kitaru": "workspace:0.2.0"
   },
   "peerDependencies": {
     "ai": ">=7.0.60 <8.0.0"

--- a/plugins/packages/langgraph/CHANGELOG.md
+++ b/plugins/packages/langgraph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2
+
+- Mark captured mapping-key coercion and collisions as non-replayable, preserve nested tuples in tool results, and reject malformed stored outcomes without executing the live tool.
+
 ## 0.1.1
 
 - History replay now distinguishes genuine misses from matched tool calls, replays completed native tool outcomes, and raises matched failures with their stored errors without executing the live tool.

--- a/plugins/packages/langgraph/pyproject.toml
+++ b/plugins/packages/langgraph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru-langgraph"
-version = "0.1.1"
+version = "0.1.2"
 description = "LangGraph recording and replay adapter for Kitaru."
 readme = "README.md"
 license = "Apache-2.0"

--- a/plugins/packages/pydantic-ai/CHANGELOG.md
+++ b/plugins/packages/pydantic-ai/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.0
+
+- Support PydanticAI 2.23 through 2.36 in addition to the existing 2.14 through 2.22 minor lines.
+
 ## 0.1.1
 
 - History replay now distinguishes a genuine miss from a matched tool call, replays completed results including `None`, and raises a matched failure with its stored error without executing the live tool.

--- a/plugins/packages/pydantic-ai/pyproject.toml
+++ b/plugins/packages/pydantic-ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru-pydantic-ai"
-version = "0.1.1"
+version = "0.2.0"
 description = "PydanticAI recording and replay adapter for Kitaru."
 readme = "README.md"
 license = "Apache-2.0"

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -560,15 +560,15 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.1.1"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/9b/85e646305a90a2da18f1edf055498668391e71f9849d3e1754d66559a311/genai_prices-0.1.1.tar.gz", hash = "sha256:54a2237691e0aaefb057d10a0c3c20160accc9fc09521c64c03fcdb7a4a69f68", size = 91182, upload-time = "2026-08-01T09:02:49.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/e3/23f4be7d5626878a6297c728f5f8db83bd9b135da481935d4c1bb82efc21/genai_prices-0.1.4.tar.gz", hash = "sha256:f3b8a0bf0c21b01f5af3ca42babcab2f17728bf3c602f87f42b72d1d2bf61d98", size = 94678, upload-time = "2026-08-19T23:53:25.527Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/5e/cfe36dff790ffad6aeff8a069b6f36743987ac17053579035ee0a67635dd/genai_prices-0.1.1-py3-none-any.whl", hash = "sha256:de2e3d8ea3ca1d0d292025995c598da447a74e94f22cd3342df46941aeb5416b", size = 95300, upload-time = "2026-08-01T09:02:48.308Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/54/911961e926a4c4ea30bf1fa0bf9d8ffc5c9ac5ed6a3f77b3d9e0ab5bb9a5/genai_prices-0.1.4-py3-none-any.whl", hash = "sha256:1d1b01cc7ab1adfa17c3a1121f4c13990bd0a4377640ecd37ebfde5836768240", size = 99160, upload-time = "2026-08-19T23:53:24.52Z" },
 ]
 
 [[package]]
@@ -1009,7 +1009,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.23.0+dev"
+version = "0.24.0"
 source = { editable = "../" }
 dependencies = [
     { name = "httpx" },
@@ -1127,7 +1127,7 @@ requires-dist = [{ name = "kitaru", editable = "../" }]
 
 [[package]]
 name = "kitaru-langgraph"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "packages/langgraph" }
 dependencies = [
     { name = "kitaru" },
@@ -1201,7 +1201,7 @@ requires-dist = [{ name = "kitaru", editable = "../" }]
 
 [[package]]
 name = "kitaru-pydantic-ai"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "packages/pydantic-ai" }
 dependencies = [
     { name = "genai-prices" },
@@ -1504,26 +1504,24 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.53.0"
+version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
-    { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/cf/36e3e7235fdf6d125c052acc0970924611b17a20a4fe580596faf4566a65/openai-2.53.0.tar.gz", hash = "sha256:baf5802ad08980e1d9d561e1b996e800c8bcd14af5847c6d0e7a5cc59e4d4116", size = 1099435, upload-time = "2026-08-03T21:42:01.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/d3/50ffb9a7bce5097ffeb476905c0661f4468a3ca7bb489b152542f14fdd8e/openai-3.5.0.tar.gz", hash = "sha256:743738bb458a586d0d02d173bf398d29d7d7a80d182d167aa74f1c08814ecc78", size = 1355486, upload-time = "2026-08-27T01:00:49.113Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/0f/cc6afea3542a5142c5d8fc8211c5e059a8375105d004a41dfa2c7948dbb0/openai-2.53.0-py3-none-any.whl", hash = "sha256:c694ffc747a3c4d1663ef2b07b811315a476164ee5efa3a993967349ebca7618", size = 1659829, upload-time = "2026-08-03T21:41:59.581Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9f/03bba05ade050f306c9b9e8b99e3681791dbb30148cd76a793c277fed494/openai-3.5.0-py3-none-any.whl", hash = "sha256:7c0873d379655f65fa515c5692c8620e73bf6a6dce3e63f37589bc99bda3fdfd", size = 1697968, upload-time = "2026-08-27T01:00:47.131Z" },
 ]
 
 [[package]]
 name = "openai-agents"
-version = "0.19.4"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
@@ -1534,9 +1532,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/ea/a8cae2dadf798f369be5f9cb544a169f5f6aecc096a80f1a209dddc4c00f/openai_agents-0.19.4.tar.gz", hash = "sha256:fe21778ee1e8216c9cdb775fa86d11b08be68c0184e14023993088d3f812c0be", size = 5784063, upload-time = "2026-08-05T02:59:12.939Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/17/2a92451547a66d56bd5f10128aa64aa0fc282420421775c390902e7dfa42/openai_agents-0.22.0.tar.gz", hash = "sha256:6c3d7b9e34d3ca4bf763d4557d01ec844685290f0d80cb72e10a304029c0d7ee", size = 6390140, upload-time = "2026-08-19T13:45:22.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/d8/98925e1e4888e58d7694ba71af2ba93b94540f481c45ee8b7f7be7e30fcd/openai_agents-0.19.4-py3-none-any.whl", hash = "sha256:12e0372fae9698fe6f78e05aaeb4ccdb229602f7ef99b8195a7d68dc82869f51", size = 968498, upload-time = "2026-08-05T02:59:11.191Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/220a5a9283fba72107db7cb549fd127a0e532dbcbc89dda82cd28b9765a1/openai_agents-0.22.0-py3-none-any.whl", hash = "sha256:985a74a8024123980c2d4dc329d19b2332a0f86919fa7b3f6b9c2abaae022680", size = 1117078, upload-time = "2026-08-19T13:45:19.876Z" },
 ]
 
 [[package]]
@@ -1732,21 +1730,21 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.22.0"
+version = "2.35.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "genai-prices" },
     { name = "griffelib" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/aa/af0c3f1a0a34003a1f024ca7c50694e28b03d4cd4faa4b2026ff44979579/pydantic_ai_slim-2.22.0.tar.gz", hash = "sha256:00a09316951ba4587348a5233a5d0b395ed7cf97ee3991666841bd55e41ddc85", size = 939122, upload-time = "2026-08-01T02:38:22.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/e5/f6fdeeb568ad5f0cdfaf8bd669a08fa74c5a86ff8d2a06620f56889a1688/pydantic_ai_slim-2.35.3.tar.gz", hash = "sha256:73c0c81836c04122ed19519e2bbecac2af310864796bb69f512aadcdedf6cd0d", size = 1265371, upload-time = "2026-08-28T00:51:50.913Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/0f/a9e71b83a74bb5773e31c5ccd1ad8d753fb99554be7842c9f1da18168772/pydantic_ai_slim-2.22.0-py3-none-any.whl", hash = "sha256:156e772b1a4a568c65d779ae1e1012dd58bc255e5355067981a490e9acd7cb45", size = 1130161, upload-time = "2026-08-01T02:38:15.741Z" },
+    { url = "https://files.pythonhosted.org/packages/af/f6/369ed803c8f80316967ba1e8bda1c6f88f682314e1afc771628c1621fde8/pydantic_ai_slim-2.35.3-py3-none-any.whl", hash = "sha256:f5d0c7a5e0797e770117df06c13e019da45e17d1adc909cc36181bcea6012be4", size = 1492524, upload-time = "2026-08-28T00:51:42.111Z" },
 ]
 
 [package.optional-dependencies]
@@ -1859,18 +1857,17 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "2.22.0"
+version = "2.35.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
     { name = "logfire-api" },
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/a8/6c0a831e111f017339f2463b03eba6ab3cdf86c789f9d5ff279031df8204/pydantic_graph-2.22.0.tar.gz", hash = "sha256:1350e63b1af5cea421aba7ed996af5d853b5b1da3c92b7cf7439d558bda4c8dd", size = 45180, upload-time = "2026-08-01T02:38:24.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/34/e610b567e0ec6ef0df555c23abbf3e2aadcfcede4e2553c08af742f4450a/pydantic_graph-2.35.3.tar.gz", hash = "sha256:f2bb41c17cd610e764cfe36be085470c88b2f261dab1916ab79357cd98c3baa1", size = 45191, upload-time = "2026-08-28T00:51:53.391Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/38/3e51ef169df4d7c3fb6196b51064f3f39b2a9ee9b99edeb412333273825a/pydantic_graph-2.22.0-py3-none-any.whl", hash = "sha256:26663839b426114834e3b9047ae6620c2a0a88cdefe67e63a3074d378ff9ed8a", size = 52661, upload-time = "2026-08-01T02:38:18.621Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c2/be70478232567f19dc0983875ecb36d1e1b08546d812dd6a510a57ab090a/pydantic_graph-2.35.3-py3-none-any.whl", hash = "sha256:daab4037b55d18209532b69e8b34d4f542bf854a83995cd0d0cb2422463feee3", size = 52703, upload-time = "2026-08-28T00:51:45.864Z" },
 ]
 
 [[package]]
@@ -2485,18 +2482,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
     { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
     { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
-]
-
-[[package]]
-name = "tqdm"
-version = "4.70.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
 ]
 
 [[package]]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
   packages/mastra:
     dependencies:
       '@zenml-io/kitaru':
-        specifier: workspace:0.1.2
+        specifier: workspace:0.2.0
         version: link:../core
     devDependencies:
       '@mastra/core':
@@ -78,7 +78,7 @@ importers:
   packages/vercel-ai:
     dependencies:
       '@zenml-io/kitaru':
-        specifier: workspace:0.1.2
+        specifier: workspace:0.2.0
         version: link:../core
     devDependencies:
       ai:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kitaru"
-version = "0.23.0+dev"
+version = "0.24.0"
 description = "Record, replay, and improve AI agents in production."
 readme = "README.md"
 license = "Apache-2.0"

--- a/releases/python/kitaru/0.24.0.toml
+++ b/releases/python/kitaru/0.24.0.toml
@@ -1,0 +1,3 @@
+schema-version = 1
+kitaru-version = "0.24.0"
+ui-tag = "kitaru-ui-v0.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1004,7 +1004,7 @@ wheels = [
 
 [[package]]
 name = "kitaru"
-version = "0.23.0+dev"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Release shape

- Core: `kitaru==0.24.0`
- Frontend: pending stable `kitaru-ui-v0.3.0`, built from `zenml-io/zenml-frontend-monorepo` `main` commit `5a27ede9a27263265f04d48a9fb7a21ef4f7f923`
- Python follow-ups after core: `kitaru-langgraph==0.1.2`, `kitaru-openai-agents==0.2.0`, and `kitaru-pydantic-ai==0.2.0`
- TypeScript follow-up after core: `@zenml-io/kitaru`, `@zenml-io/kitaru-mastra`, and `@zenml-io/kitaru-vercel-ai` at `0.2.0`

## Included release work

- Core behavior and API: #835, #865, #890, #896, #900, #915, #920, #921, and #925
- Release and packaging infrastructure: #895 and #901
- Hosted onboarding image inputs: #902 and #919
- Property-test coverage: #909
- LangGraph `0.1.2`: #925
- OpenAI Agents `0.2.0`: #911
- PydanticAI `0.2.0`: #912
- TypeScript `0.2.0`: generated API and client changes from #835, #865, #896, #900, and #915, plus Vercel AI compatibility coverage from #913
- In-repository documentation: #898

The repository version proposal selects `0.24.0` because #835 and #896 carry the `Breaking Change` label.

## Frontend status

Frontend `main` is 25 commits ahead of `kitaru-ui-v0.2.3` and contains the matching Kitaru UI work. The main promotion in zenml-io/zenml-frontend-monorepo#469 passed CI and the Kitaru UI Vercel check.

`kitaru-ui-v0.3.0` does not exist yet. Publish it from frontend commit `5a27ede9a27263265f04d48a9fb7a21ef4f7f923`, verify `kitaru-ui.tar.gz` and `kitaru-ui.tar.gz.sha256`, and promote the GitHub Release from prerelease to stable before creating the core tag.

## Plugin and dependency decisions

- The three selected Python packages are adapters and remain outside the default server plugin catalog. No default requirement or display version changes are needed.
- `kitaru-openai-agents==0.2.0` was already prepared on `develop`; this PR includes it in the coordinated release without another version bump.
- `kitaru-pydantic-ai` moves to `0.2.0` because supporting PydanticAI 2.23 through 2.36 is a new pre-1.0 compatibility capability.
- `kitaru-langgraph` moves to `0.1.2` for compatible capture and replay correctness fixes.
- `plugins/uv.lock` now resolves the advertised compatibility lines: `openai-agents==0.22.0`, `openai==3.5.0`, `pydantic-ai-slim==2.35.3`, `pydantic-graph==2.35.3`, and `genai-prices==0.1.4`. #909 had unintentionally re-resolved these to the older supported lines.

## Follow-ups

- zenml-io/zenml-frontend-monorepo#462 and zenml-io/kitaru-skills#43 are merged.
- Build and validate the workspace-versioned onboarding image after core publication, as required by #919.
- Refresh the Python quickstart lock after `kitaru-pydantic-ai==0.2.0` is available from PyPI; until then it intentionally continues to resolve the published adapter line.
- No external ZenML docs or website follow-up was declared for this release range.

## Validation

- `git diff --check`
- `just check`
- `uv lock --check`
- `uv lock --project plugins --check`
- `uv run --no-project --with packaging==26.2 python scripts/release_units.py validate` — 11 units
- `uv run python scripts/release_ui.py --version 0.24.0`
- `uv run pytest -q tests/scripts/test_release_ui.py tests/scripts/test_release_units.py` — 90 passed
- Plugin Ruff format and lint checks
- Plugin `ty` check
- `uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests tests/server/test_default_plugins.py` — 578 passed, 14 expected xfails
- `just plugin-artifact-smoke`
- `pnpm run generate:check`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test:built` — 429 tests passed across the three packages and Mastra example
- `pnpm run pack:check:built`
- `just build` — wheel and source distribution built successfully

The local TypeScript run used Node 25.6.0 and emitted the repository's expected engine warning for its pinned Node 22.22 line; all checks passed, and CI will rerun them on the pinned version.

## Publication and follow-up order

1. Publish and verify stable `kitaru-ui-v0.3.0` from frontend commit `5a27ede9a27263265f04d48a9fb7a21ef4f7f923`.
2. Merge this PR and resolve its exact merge commit.
3. Tag and publish core as `python/kitaru/v0.24.0`.
4. Tag and publish `python/kitaru-langgraph/v0.1.2`, `python/kitaru-openai-agents/v0.2.0`, and `python/kitaru-pydantic-ai/v0.2.0`, verifying each workflow before pushing the next tag.
5. Tag and publish the TypeScript packages as `typescript/kitaru/v0.2.0`.
6. Fast-forward Kitaru `main` to the immutable core release commit using the release-owner procedure.
7. Build and validate the workspace-versioned onboarding image.
8. Refresh the quickstart lock against the published PydanticAI adapter.

No tag, workflow dispatch, or artifact publication is part of this PR.

## Reviewer Notes

Review `pyproject.toml`, the top section of `CHANGELOG.md`, `releases/python/kitaru/0.24.0.toml`, `uv.lock`, and regenerated `openapi/openapi.json` for the core release. Then review the three TypeScript package manifests and `pnpm-lock.yaml` as one version set.

For Python plugins, compare the LangGraph and PydanticAI manifests and changelogs with `plugins/uv.lock`. Confirm OpenAI Agents remains at its already-prepared `0.2.0`, all three candidate versions are unused, and none of these adapter packages appears in the default server catalog.

Before creating `python/kitaru/v0.24.0`, confirm the frontend GitHub Release is stable and contains both required assets. Publish core before every Python or TypeScript follow-up tag.
