### PR TITLE
Remove deterministic evaluator provenance hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Creating a replay or starting an experiment run is now rejected with HTTP 422 when the config carries an override or a non-passthrough tool policy that the agent version's runtime capabilities do not declare.
 - Importer-backed adapters now reject a replay config carrying an override or a non-passthrough tool policy with a RuntimeError before the wrapped function runs.
 - `session_request` in `kitaru.task.importer` now takes the parsed session, the agent id, the provider, and the origin instead of the import task details.
+- The built-in deterministic evaluators (`kitaru/session-diagnostics@1` and the other nine bundles) no longer emit `input_sha256` or `config_sha256` results.
 
 ### Fixed
 

--- a/docs/book/guides/deterministic-evaluations.md
+++ b/docs/book/guides/deterministic-evaluations.md
@@ -71,8 +71,6 @@ Configured rules use conservative evidence semantics:
 
 ## Understand result evidence
 
-Every bundle emits `input_sha256` and `config_sha256`. The input hash covers the materialized session and node fields used across the deterministic catalog. The configuration hash covers normalized parameters for that evaluator. Use both values to tell whether two attempts analyzed the same fetched evidence with the same configuration.
-
 Finding results use compact JSON in `value`:
 
 ```json
@@ -154,7 +152,7 @@ For larger sets, split the session IDs into chunks that satisfy the formula and 
 
 ## Current evidence limits
 
-The worker fetches the session and its nodes when an attempt runs. These reads are separate and the underlying records can change, so a retry can observe a later or internally mixed materialization. The hashes expose that difference, but they do not create an immutable snapshot. Repeatability also depends on a compatible Kitaru and Python worker runtime.
+The worker fetches the session and its nodes when an attempt runs. These reads are separate and the underlying records can change, so a retry is not guaranteed to observe the same materialization. Repeatability also depends on a compatible Kitaru and Python worker runtime.
 
 The current session view cannot distinguish an absent normalized output from an explicit JSON null. An observed null session output is therefore unavailable to `output-contract`, including when the expected value is null. A null tool result has the same ambiguity and is reported as a diagnostic rather than an integrity verdict.
 

--- a/plugins/packages/evaluator/CHANGELOG.md
+++ b/plugins/packages/evaluator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Stop emitting `input_sha256` and `config_sha256` from the built-in deterministic evaluators.
+
 ## 0.1.2
 
 - Include directly priced non-root spans and fall back to aggregate costs when direct coverage is incomplete.

--- a/plugins/packages/evaluator/src/kitaru_evaluator/deterministic.py
+++ b/plugins/packages/evaluator/src/kitaru_evaluator/deterministic.py
@@ -26,7 +26,6 @@ from kitaru.api_models.v1.session import SessionStatus
 from kitaru.api_models.v1.session_node import NodeStatus, NodeType, SessionNodeResponse
 from kitaru.task.evaluator import SessionView
 
-_ENCODING_REVISION = 1
 _EVIDENCE_LIMIT = 20
 _RESULT_VALUE_MAX_BYTES = 64_000
 _UNAVAILABLE = {"$kitaru": "unavailable"}
@@ -122,77 +121,6 @@ def _token_fields(tokens: Any) -> Any:
         "output_tokens": tokens.output_tokens,
         "reasoning_tokens": tokens.reasoning_tokens,
     }
-
-
-def _input_envelope(view: SessionView) -> dict[str, Any]:
-    """Select the union of score-relevant fields in supplied node order."""
-    session = view.session
-    selected_session = {
-        "cost": session.cost,
-        "ended_at": session.ended_at,
-        "error": session.error,
-        "id": session.id,
-        "inputs": session.inputs,
-        "llm_call_count": session.llm_call_count,
-        "outputs": session.outputs,
-        "started_at": session.started_at,
-        "status": session.status,
-        "tokens": _token_fields(session.tokens),
-        "tool_call_count": session.tool_call_count,
-    }
-    selected_nodes = [
-        {
-            "cost": node.cost,
-            "ended_at": node.ended_at,
-            "error": node.error,
-            "id": node.id,
-            "index": node.index,
-            "inputs": node.inputs,
-            "model": node.model,
-            "node_type": node.node_type,
-            "outputs": node.outputs,
-            "parent_id": node.parent_id,
-            "parent_index": node.parent_index,
-            "provider": node.model_provider,
-            "requested_model": node.requested_model,
-            "secondary_parent_ids": node.secondary_parent_ids,
-            "secondary_parent_indexes": node.secondary_parent_indexes,
-            "started_at": node.started_at,
-            "status": node.status,
-            "tokens": _token_fields(node.tokens),
-            "tool_name": node.tool_name,
-        }
-        for node in view.nodes
-    ]
-    normalized, _ = _normalize_observed(
-        {
-            "encoding_revision": _ENCODING_REVISION,
-            "nodes": selected_nodes,
-            "session": selected_session,
-        }
-    )
-    return normalized
-
-
-def _base_results(view: SessionView, config: dict[str, Any]) -> list[EvaluationResult]:
-    """Emit stable retry receipts shared by every bundle."""
-    normalized_config, complete = _normalize_observed(
-        {"encoding_revision": _ENCODING_REVISION, "parameters": config}
-    )
-    if not complete:
-        raise ValueError("configuration must contain only finite JSON values")
-    return [
-        EvaluationResult(
-            name="input_sha256",
-            value=_hash(_input_envelope(view)),
-            explanation="Hash of the revision-1 materialized input envelope.",
-        ),
-        EvaluationResult(
-            name="config_sha256",
-            value=_hash(normalized_config),
-            explanation="Hash of the normalized revision-1 evaluator parameters.",
-        ),
-    ]
 
 
 def _json_result(
@@ -462,7 +390,7 @@ def session_diagnostics(session: SessionView) -> list[EvaluationResult]:
                             "scope": "node",
                         }
                     )
-    results = _base_results(session, {})
+    results: list[EvaluationResult] = []
     results.extend(
         [
             _json_result(
@@ -656,14 +584,7 @@ def output_contract(
         normalized_expected, expected_complete = _normalize_observed(expected)
         if not expected_complete:
             raise ValueError("expected must contain only finite JSON values")
-    config: dict[str, Any] = {}
-    if expected is not _UNSET:
-        config["expected"] = normalized_expected
-    if paths is not None:
-        config["required_paths"] = paths
-    if type_requirements is not None:
-        config["type_requirements"] = dict(sorted(type_requirements.items()))
-    results = _base_results(session, config)
+    results: list[EvaluationResult] = []
     output_available = session.session.outputs is not None and output_complete
     terminal = _is_terminal(session)
     results.append(
@@ -832,7 +753,7 @@ def trajectory_signals(session: SessionView) -> list[EvaluationResult]:
         repeats.append(evidence)
         if first.status is NodeStatus.FAILED:
             retries.append(evidence)
-    results = _base_results(session, {})
+    results: list[EvaluationResult] = []
     results.extend(
         [
             _json_result(
@@ -913,7 +834,7 @@ def tool_health(session: SessionView) -> list[EvaluationResult]:
             repeated_failures.append(
                 {"indexes": [first.index, second.index], "tool_name": first.tool_name}
             )
-    results = _base_results(session, {})
+    results: list[EvaluationResult] = []
     results.extend(
         [
             _finding_result("failed_calls", failed, "Tool calls recorded as failed."),
@@ -987,7 +908,7 @@ def timing_profile(
         active[node_id] = node
         heapq.heappush(active_heap, (ended_at, node_id))
     wall_clock = _duration(session.session.started_at, session.session.ended_at)
-    results = _base_results(session, {"evidence_limit": limit})
+    results: list[EvaluationResult] = []
     results.extend(
         [
             EvaluationResult(
@@ -1129,12 +1050,7 @@ def resource_budget(
             raise ValueError(f"{name} must be an integer")
     if all(value is None for value in ceilings.values()):
         raise ValueError("at least one resource ceiling is required")
-    config = {
-        name: _format_decimal(value)
-        for name, value in ceilings.items()
-        if value is not None
-    }
-    results = _base_results(session, config)
+    results: list[EvaluationResult] = []
     terminal = _is_terminal(session)
     nodes = _analysis_nodes(session)
     tool_count = sum(node.node_type is NodeType.TOOL_CALL for node in nodes)
@@ -1281,16 +1197,7 @@ def tool_policy(
     if required is None and forbidden is None and max_calls_per_tool is None:
         raise ValueError("at least one tool policy rule is required")
     maximums = dict(sorted((max_calls_per_tool or {}).items()))
-    config = {
-        key: value
-        for key, value in {
-            "forbidden_tools": forbidden,
-            "max_calls_per_tool": maximums or None,
-            "required_tools": required,
-        }.items()
-        if value is not None
-    }
-    results = _base_results(session, config)
+    results: list[EvaluationResult] = []
     calls = _tool_calls(session)
     known, name_coverage = _get_tool_name_coverage(calls)
     complete = _is_terminal(session) and len(known) == len(calls)
@@ -1388,7 +1295,7 @@ def llm_call_signals(session: SessionView) -> list[EvaluationResult]:
         and node.model is not None
         and node.requested_model != node.model
     ]
-    results = _base_results(session, {})
+    results: list[EvaluationResult] = []
     results.extend(
         [
             _finding_result("failed_calls", failed, "LLM calls recorded as failed."),
@@ -1443,14 +1350,7 @@ def model_policy(
         raise ValueError("require_requested_model_match must be a boolean")
     if models is None and providers is None and not require_requested_model_match:
         raise ValueError("at least one model policy rule is required")
-    config: dict[str, Any] = {
-        "require_requested_model_match": require_requested_model_match
-    }
-    if models is not None:
-        config["allowed_models"] = models
-    if providers is not None:
-        config["allowed_providers"] = providers
-    results = _base_results(session, config)
+    results: list[EvaluationResult] = []
     calls = _llm_calls(session)
     terminal = _is_terminal(session)
     can_pass = terminal and bool(calls)
@@ -1534,7 +1434,7 @@ def workflow_conformance(
         raise ValueError("expected_tools must be a non-empty list of non-empty strings")
     if mode not in _WORKFLOW_MODES:
         raise ValueError(f"mode must be one of {sorted(_WORKFLOW_MODES)}")
-    results = _base_results(session, {"expected_tools": expected_tools, "mode": mode})
+    results: list[EvaluationResult] = []
     calls = _tool_calls(session)
     observed, name_coverage = _get_tool_name_coverage(calls)
     matched = False

--- a/plugins/tests/evaluators/test_deterministic.py
+++ b/plugins/tests/evaluators/test_deterministic.py
@@ -169,7 +169,7 @@ def test_entrypoint_loads_through_package_plugin_contract() -> None:
     assert [result.model_dump(mode="json") for result in first] == [
         result.model_dump(mode="json") for result in repeated
     ]
-    assert {result.name for result in first} >= {"input_sha256", "terminality"}
+    assert "terminality" in {result.name for result in first}
 
 
 def test_ordered_result_name_contracts() -> None:
@@ -214,8 +214,6 @@ def test_ordered_result_name_contracts() -> None:
     }
     expected = {
         "session_diagnostics": [
-            "input_sha256",
-            "config_sha256",
             "terminality",
             "node_order",
             "parent_linkage",
@@ -228,16 +226,12 @@ def test_ordered_result_name_contracts() -> None:
             "resource_integrity",
         ],
         "output_contract": [
-            "input_sha256",
-            "config_sha256",
             "output_availability",
             "exact_output",
             "required_paths",
             "type_requirements",
         ],
         "trajectory_signals": [
-            "input_sha256",
-            "config_sha256",
             "tool_identity_coverage",
             "adjacent_identical_calls",
             "failed_identical_retries",
@@ -245,8 +239,6 @@ def test_ordered_result_name_contracts() -> None:
             "cycle_detector_bounds",
         ],
         "tool_health": [
-            "input_sha256",
-            "config_sha256",
             "failed_calls",
             "null_results",
             "empty_results",
@@ -254,8 +246,6 @@ def test_ordered_result_name_contracts() -> None:
             "adjacent_repeated_failures",
         ],
         "timing_profile": [
-            "input_sha256",
-            "config_sha256",
             "wall_clock_duration_seconds",
             "node_duration_coverage",
             "slowest_nodes",
@@ -263,8 +253,6 @@ def test_ordered_result_name_contracts() -> None:
             "invalid_intervals",
         ],
         "resource_budget": [
-            "input_sha256",
-            "config_sha256",
             "duration_budget",
             "cost_budget",
             "total_tokens_budget",
@@ -273,16 +261,12 @@ def test_ordered_result_name_contracts() -> None:
             "tool_call_count_budget",
         ],
         "tool_policy": [
-            "input_sha256",
-            "config_sha256",
             "tool_name_coverage",
             "required_tools",
             "forbidden_tools",
             "per_tool_maximums",
         ],
         "llm_call_signals": [
-            "input_sha256",
-            "config_sha256",
             "failed_calls",
             "empty_results",
             "adjacent_identical_inputs",
@@ -290,15 +274,11 @@ def test_ordered_result_name_contracts() -> None:
             "metadata_coverage",
         ],
         "model_policy": [
-            "input_sha256",
-            "config_sha256",
             "allowed_models",
             "allowed_providers",
             "requested_model_match",
         ],
         "workflow_conformance": [
-            "input_sha256",
-            "config_sha256",
             "tool_name_coverage",
             "workflow_match",
         ],
@@ -306,40 +286,6 @@ def test_ordered_result_name_contracts() -> None:
     assert {
         name: [result.name for result in results] for name, results in calls.items()
     } == expected
-
-
-def test_shared_hashes_are_stable_and_preserve_node_array_order() -> None:
-    """Canonicalize object keys while retaining supplied node order."""
-    first = _node(0, tool_name="search", inputs={"b": 2, "a": 1}, outputs={})
-    second = _node(1, tool_name="read", inputs={}, outputs={})
-    same = _node(0, tool_name="search", inputs={"a": 1, "b": 2}, outputs={})
-    hash_a = _by_name(evaluators.session_diagnostics(_view([first, second])))[
-        "input_sha256"
-    ].value
-    hash_b = _by_name(evaluators.session_diagnostics(_view([same, second])))[
-        "input_sha256"
-    ].value
-    hash_reordered = _by_name(evaluators.session_diagnostics(_view([second, first])))[
-        "input_sha256"
-    ].value
-    assert hash_a == hash_b
-    assert hash_a != hash_reordered
-    config_a = _by_name(
-        evaluators.output_contract(
-            _view(), type_requirements={"/answer": "integer", "": "object"}
-        )
-    )["config_sha256"].value
-    config_b = _by_name(
-        evaluators.output_contract(
-            _view(), type_requirements={"": "object", "/answer": "integer"}
-        )
-    )["config_sha256"].value
-    assert config_a == config_b
-    assert [
-        result.model_dump_json() for result in evaluators.session_diagnostics(_view())
-    ] == [
-        result.model_dump_json() for result in evaluators.session_diagnostics(_view())
-    ]
 
 
 def test_decimal_encoding_ignores_ambient_precision() -> None:


### PR DESCRIPTION
## Summary

- Removed `_base_results`, `_input_envelope`, and `_ENCODING_REVISION` from `plugins/packages/evaluator/src/kitaru_evaluator/deterministic.py`, which were the only source of the `input_sha256`/`config_sha256` provenance results.
- Replaced every `results = _base_results(session, config)` call site (all 9: `session_diagnostics`, `output_contract`, `trajectory_signals`, `tool_health`, `timing_profile`, `resource_budget`, `tool_policy`, `llm_call_signals`, `model_policy`, `workflow_conformance`) with `results: list[EvaluationResult] = []`, and deleted the now-dead `config` construction blocks that only fed `_base_results`.
- Kept `_token_fields` (still used by `session_diagnostics`'s resource-integrity checks) and kept `expected_sha256`/`observed_sha256` inside `output-contract`'s `exact_output` result plus the oversized-result truncation digest in `_json_result`, both explicitly out of scope.
- Updated `plugins/tests/evaluators/test_deterministic.py`: removed `"input_sha256"`/`"config_sha256"` from the ordered-name lists in `test_ordered_result_name_contracts`, dropped `"input_sha256"` from the set assertion in `test_entrypoint_loads_through_package_plugin_contract`, and deleted `test_shared_hashes_are_stable_and_preserve_node_array_order` entirely since it only pinned behavior of the removed hashes.
- Updated `docs/book/guides/deterministic-evaluations.md`: removed the paragraph describing `input_sha256`/`config_sha256` in "Understand result evidence", and reworded the "Current evidence limits" sentence that referenced hash-based retry-materialization detection.
- Added `## Unreleased` entries: `plugins/packages/evaluator/CHANGELOG.md` (new heading, since it had none) and the root `CHANGELOG.md`'s `[Unreleased] > ### Changed`, both noting the two results are no longer emitted. Left `plugins/packages/evaluator/pyproject.toml`'s version at `0.1.2`.
- Verified with `uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests/evaluators/test_deterministic.py` (56 passed), plus scoped `ruff format --check`, `ruff check`, `ty check --project plugins`, and `typos` on all touched files.

Plan: `spec/plans/bugfix-software-factory-eval-hashes-2.md`
