### PR TITLE
Fix API fuzz failure reporting

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -81,7 +81,8 @@ jobs:
         with:
           name: hypothesis-examples-${{ matrix.name }}
           path: .hypothesis/examples
-          if-no-files-found: ignore
+          include-hidden-files: true
+          if-no-files-found: error
       - name: Open issue on scheduled failure
         if: failure() && github.event_name == 'schedule'
         env:

--- a/tests/server/test_fuzz_api.py
+++ b/tests/server/test_fuzz_api.py
@@ -33,7 +33,7 @@ while "did the server crash?" stays well-posed. Schemathesis's
 import os
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -45,6 +45,7 @@ import schemathesis
 from fuzz_server import FuzzServer
 from hypothesis import HealthCheck, settings
 from schemathesis.checks import not_a_server_error
+from schemathesis.core.failures import FailureGroup, ServerError
 from schemathesis.generation import GenerationMode
 from schemathesis.specs.openapi.checks import response_schema_conformance
 
@@ -103,11 +104,45 @@ def _run(case: schemathesis.Case, server: FuzzServer, checks: list[Any]) -> None
             checks=checks,
             timeout=30,
         )
-    except AssertionError:
+    except (AssertionError, FailureGroup):
         captured = server.capture.describe(case.method.upper(), case.path)
         if captured:
             pytest.fail(f"{case.method.upper()} {case.path}\n{captured}", pytrace=False)
         raise
+
+
+def test_run_reports_captured_grouped_failure() -> None:
+    """Include the server exception when Schemathesis groups check failures."""
+
+    class FailingCase:
+        method = "POST"
+        path = "/api/v1/users"
+
+        def call_and_validate(self, **kwargs: Any) -> None:
+            _ = kwargs
+            raise FailureGroup(
+                [ServerError(operation="POST /api/v1/users", status_code=500)]
+            )
+
+    class Capture:
+        def describe(self, method: str, path: str) -> str:
+            assert (method, path) == ("POST", "/api/v1/users")
+            return "ValueError: password cannot be longer than 72 bytes"
+
+    class Server:
+        def __init__(self) -> None:
+            self.base_url = "http://test"
+            self.auth_headers: dict[str, str] = {}
+            self.capture = Capture()
+
+    with pytest.raises(
+        pytest.fail.Exception, match="password cannot be longer than 72 bytes"
+    ):
+        _run(
+            cast(schemathesis.Case, FailingCase()),
+            cast(FuzzServer, Server()),
+            [],
+        )
 
 
 @schema_hunt.parametrize()

--- a/tests/server/test_fuzz_api.py
+++ b/tests/server/test_fuzz_api.py
@@ -45,7 +45,7 @@ import schemathesis
 from fuzz_server import FuzzServer
 from hypothesis import HealthCheck, settings
 from schemathesis.checks import not_a_server_error
-from schemathesis.core.failures import FailureGroup, ServerError
+from schemathesis.core.failures import Failure, FailureGroup, ServerError
 from schemathesis.generation import GenerationMode
 from schemathesis.specs.openapi.checks import response_schema_conformance
 
@@ -104,10 +104,18 @@ def _run(case: schemathesis.Case, server: FuzzServer, checks: list[Any]) -> None
             checks=checks,
             timeout=30,
         )
-    except (AssertionError, FailureGroup):
+    except AssertionError:
         captured = server.capture.describe(case.method.upper(), case.path)
         if captured:
             pytest.fail(f"{case.method.upper()} {case.path}\n{captured}", pytrace=False)
+        raise
+    except FailureGroup as exc:
+        if any(isinstance(failure, ServerError) for failure in exc.exceptions):
+            captured = server.capture.describe(case.method.upper(), case.path)
+            if captured:
+                pytest.fail(
+                    f"{case.method.upper()} {case.path}\n{captured}", pytrace=False
+                )
         raise
 
 
@@ -138,6 +146,43 @@ def test_run_reports_captured_grouped_failure() -> None:
     with pytest.raises(
         pytest.fail.Exception, match="password cannot be longer than 72 bytes"
     ):
+        _run(
+            cast(schemathesis.Case, FailingCase()),
+            cast(FuzzServer, Server()),
+            [],
+        )
+
+
+def test_run_preserves_group_without_server_error() -> None:
+    """Do not replace a non-server failure with stale captured details."""
+
+    class FailingCase:
+        method = "POST"
+        path = "/api/v1/workers"
+
+        def call_and_validate(self, **kwargs: Any) -> None:
+            _ = kwargs
+            raise FailureGroup(
+                [
+                    Failure(
+                        operation="POST /api/v1/workers",
+                        title="Schema mismatch",
+                        message="Response violates the schema",
+                    )
+                ]
+            )
+
+    class Capture:
+        def describe(self, method: str, path: str) -> str:
+            raise AssertionError(f"unexpected capture lookup for {method} {path}")
+
+    class Server:
+        def __init__(self) -> None:
+            self.base_url = "http://test"
+            self.auth_headers: dict[str, str] = {}
+            self.capture = Capture()
+
+    with pytest.raises(FailureGroup):
         _run(
             cast(schemathesis.Case, FailingCase()),
             cast(FuzzServer, Server()),


### PR DESCRIPTION
The nightly API fuzz job now reports the captured server exception when Schemathesis groups check failures, so the failure points to the application defect instead of ending at an opaque `FailureGroup`. Failed fuzz runs also publish hidden Hypothesis examples and fail the upload step when no replay artifact exists.

Related: #960

Related: #962

## Reviewer Notes

The load-bearing behavior is in `_run`: Schemathesis 4 raises `FailureGroup`, which inherits from `BaseExceptionGroup` rather than `AssertionError`. The regression test raises that exact type and verifies that the server-side exception replaces the generic grouped failure in pytest output.

### Reproduction

```bash
UV_CACHE_DIR=/tmp/kitaru-960-uv-cache KITARU_FUZZ=1 uv run --extra server --group fuzz pytest tests/server/test_fuzz_api.py::test_run_reports_captured_grouped_failure -p no:randomly -q
```

Before the fix, `FailureGroup` escaped `_run` and the test failed. After the fix, the captured bcrypt exception appears in the pytest failure and the regression test passes.

## Validation

- `just check` passes.
- The targeted opt-in regression passes: 1 test.
- The full Python suite passes. The combined `just test` result was 4,281 passed, 299 skipped, and 13 xfailed. Five TypeScript checks did not run because this checkout has no `node_modules` and therefore no `tsc`; this is unrelated to the Python and workflow changes.
- Independent review found no actionable issues. Review artifact: `/tmp/compound-engineering-501/ce-code-review/20260903-GrD4KS`.

## Post-Deploy Monitoring & Validation

- Window and owner: the PR author checks the next failed nightly API fuzz run.
- Healthy signal: the job log includes the captured server exception, and `hypothesis-examples-api` is present, non-empty, downloadable, and replayable after extraction into `.hypothesis/examples`.
- Failure signal: the log ends at a bare grouped failure, the upload says no files were found without failing, or the artifact is missing or empty.
- Mitigation: inspect the failed workflow's upload step and revert this PR if it hides evidence or causes unrelated matrix failures.
