### PR TITLE
Make bare login connect to managed cloud

### DIFF
--- a/.agents/skills/kitaru-dev/SKILL.md
+++ b/.agents/skills/kitaru-dev/SKILL.md
@@ -73,7 +73,7 @@ Agent-facing commands use the version-1 structured contract. Success documents i
 
 For agent-facing use, prefer `--output json --machine --non-interactive --no-browser`. A deliberate dashboard or device-login handoff is the exception.
 
-Document login consistently: `kitaru login SERVER` targets the full managed or self-hosted instance URL, while `kitaru login --local` provisions or reuses the CLI-owned Docker Compose deployment. It defaults to `http://localhost:8000`; `--port` takes precedence over `KITARU_LOCAL_PORT`, and the selected port persists with the deployment. `kitaru logout` stops that deployment when it is selected, and `kitaru logout --volumes` also deletes its PostgreSQL data.
+Document login consistently: `kitaru login` starts the interactive managed-cloud device flow and connects to the Kitaru workspace selected or created in the browser. `kitaru login SERVER` targets the full managed or self-hosted instance URL, while `kitaru login --local` provisions or reuses the CLI-owned Docker Compose deployment. The local deployment defaults to `http://localhost:8000`; `--port` takes precedence over `KITARU_LOCAL_PORT`, and the selected port persists with the deployment. `kitaru logout` stops that deployment when it is selected, and `kitaru logout --volumes` also deletes its PostgreSQL data.
 
 `kitaru status` shows the selected server, provenance, credential state, compatibility, and live-worker count. `kitaru info` adds local package, Python, platform, and server details. `kitaru doctor` runs independent local, server, authentication, and tooling checks without stopping after the first failure. These commands never print secret values.
 

--- a/.claude/skills/kitaru-dev/SKILL.md
+++ b/.claude/skills/kitaru-dev/SKILL.md
@@ -73,7 +73,7 @@ Agent-facing commands use the version-1 structured contract. Success documents i
 
 For agent-facing use, prefer `--output json --machine --non-interactive --no-browser`. A deliberate dashboard or device-login handoff is the exception.
 
-Document login consistently: `kitaru login SERVER` targets the full managed or self-hosted instance URL, while `kitaru login --local` provisions or reuses the CLI-owned Docker Compose deployment. It defaults to `http://localhost:8000`; `--port` takes precedence over `KITARU_LOCAL_PORT`, and the selected port persists with the deployment. `kitaru logout` stops that deployment when it is selected, and `kitaru logout --volumes` also deletes its PostgreSQL data.
+Document login consistently: `kitaru login` starts the interactive managed-cloud device flow and connects to the Kitaru workspace selected or created in the browser. `kitaru login SERVER` targets the full managed or self-hosted instance URL, while `kitaru login --local` provisions or reuses the CLI-owned Docker Compose deployment. The local deployment defaults to `http://localhost:8000`; `--port` takes precedence over `KITARU_LOCAL_PORT`, and the selected port persists with the deployment. `kitaru logout` stops that deployment when it is selected, and `kitaru logout --volumes` also deletes its PostgreSQL data.
 
 `kitaru status` shows the selected server, provenance, credential state, compatibility, and live-worker count. `kitaru info` adds local package, Python, platform, and server details. `kitaru doctor` runs independent local, server, authentication, and tooling checks without stopping after the first failure. These commands never print secret values.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Running `kitaru login` without a server now opens the managed-cloud device flow, connects to the Kitaru workspace selected or created in the browser, waits for a new workspace to become available, and stores it as the active server. Explicit server URLs and `kitaru login --local` keep their existing behavior.
 - Added `baseline_evaluation_mode` to replay and experiment run creation, with values `none`, `if_missing`, and `force`. `if_missing` scores baselines while skipping evaluators that already scored them, `force` always scores them fresh. A request that sets neither `baseline_evaluation_mode` nor the deprecated `evaluate_baselines` defaults to `if_missing`. `evaluate_baselines` is deprecated in favor of this field and still accepted on the wire, mapping `False` to `none` and `True` to `if_missing`. Setting both fields on one request returns HTTP 422.
 - Added `evaluator_params` to the evaluation response, the params the producing evaluator ran with, `None` on a manual row.
 - Added a `replay_id` filter to evaluation listing, matching evaluations linked to a replay.

--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ Already in Claude Code, Codex, or Cursor? Paste this instead and let it run the 
 Set up Kitaru on this machine by following https://kitaru.ai/install.md. Use the one-line installer, tell me what it did, and stop before logging in if Docker is not running.
 ```
 
-Prefer to do it by hand, or want Kitaru inside your project's environment? The local server is FastAPI + Postgres, and `kitaru login --local` provisions it with Docker:
+Prefer to do it by hand, or want Kitaru inside your project's environment? Choose managed cloud with `kitaru login`, or provision the local FastAPI + Postgres server with Docker:
 
 ```bash
 uv add "kitaru[cli,worker,mcp]" kitaru-pydantic-ai    # or: pip install
-kitaru login --local                                  # or: kitaru login <your-team-url>
+kitaru login                                          # managed cloud; 14-day trial, no credit card required
+kitaru login --local                                  # local server in Docker
+# or: kitaru login <your-team-url>
 ```
 
 **2. Make your coding assistant Kitaru-capable.** This is the intended way to drive Kitaru: skills teach the method, and the MCP server gives your assistant bounded operations.

--- a/docs/book/getting-started/installation.md
+++ b/docs/book/getting-started/installation.md
@@ -25,7 +25,9 @@ Prefer to do it by hand? The installer is three commands, which you can run your
 ```bash
 uv tool install "kitaru[cli,mcp,worker]"     # CLI + MCP server, isolated from your projects
 npx skills add zenml-io/kitaru-skills          # the coding-agent skills
-kitaru login --local                           # local server in Docker, or: kitaru login <team-url>
+kitaru login                                   # managed cloud; 14-day trial, no credit card required
+kitaru login --local                           # local server in Docker
+# or: kitaru login <team-url>                  # an existing managed or self-hosted workspace
 ```
 
 then point your assistant at `kitaru-mcp` as described in [Set up your coding agent](../agent-native/setup.md).
@@ -64,11 +66,13 @@ kitaru logout --volumes      # stop and delete the database (a clean reset)
 
 After upgrading the `kitaru` package, upgrade the local server to match with `kitaru login --local --upgrade`; a plain login deliberately never replaces the server image. Prefer to manage Docker yourself, or need a shared deployment with your own Postgres, real auth, and TLS? See [Docker](../deploy/docker.md) and [Deploy Kitaru](../deploy/README.md).
 
-## Connect to a team server
+## Connect to managed cloud or a team server
 
 `kitaru login --local` already connected you; `kitaru status` confirms it.
 
-Against a shared server, log in with `kitaru login <url>`. For non-interactive use (CI, production services), create an API key and set two environment variables that the SDK, the CLI, and workers all read:
+For managed cloud, run `kitaru login`. The browser flow lets you select or create a Kitaru workspace, then the CLI waits for it to become available and selects it. Managed cloud includes a 14-day trial with no credit card required.
+
+Against an existing managed or self-hosted workspace, log in with `kitaru login <url>`. For non-interactive use (CI, production services), create an API key and set two environment variables that the SDK, the CLI, and workers all read:
 
 ```bash
 export KITARU_API_URL="https://kitaru.your-team.example"

--- a/src/kitaru/cli/app.py
+++ b/src/kitaru/cli/app.py
@@ -618,14 +618,15 @@ def _add_parameter_help(function: F, spec: CommandSpec) -> None:
     app,
     _spec(
         ("login",),
-        "Authenticate with a Kitaru server.",
+        "Authenticate with managed cloud (14-day trial, no credit card required) "
+        "or a Kitaru server.",
         parameters=(
             ParameterSpec(
                 "SERVER",
                 "URL",
                 "argument",
                 False,
-                "Managed or self-hosted instance URL.",
+                "Managed or self-hosted instance URL; omit for managed cloud.",
             ),
             ParameterSpec(
                 "--local",
@@ -703,7 +704,7 @@ async def login(
     api_key_stdin: bool = False,
     refresh: bool = False,
 ) -> CommandResult:
-    """Authenticate with a server and store its credential when required."""
+    """Authenticate with managed cloud or a server and store its credential."""
     invocation = _invocation()
     chosen_server = server or invocation.server
     if chosen_server and not local:

--- a/src/kitaru/cli/app.py
+++ b/src/kitaru/cli/app.py
@@ -688,6 +688,7 @@ def _add_parameter_help(function: F, spec: CommandSpec) -> None:
             "authentication_failed",
             "interaction_required",
             "network_error",
+            "timeout",
             "internal_error",
         ),
     ),

--- a/src/kitaru/cli/auth.py
+++ b/src/kitaru/cli/auth.py
@@ -285,9 +285,7 @@ async def _login_managed_cloud(
     finally:
         await session.close()
 
-    server_url = validate_server_url(
-        cast(str, workspace.server_url), configuration=True
-    )
+    server_url = _validate_managed_server_url(cast(str, workspace.server_url))
     client = KitaruAPIClient(
         base_url=server_url,
         timeout=timeout,
@@ -352,6 +350,17 @@ def _get_selected_workspace_id(device_metadata: dict[str, str]) -> uuid.UUID:
             "invalid_configuration",
             "Managed-cloud login returned an invalid workspace ID.",
         ) from error
+
+
+def _validate_managed_server_url(server_url: str) -> str:
+    """Validate a managed server URL before forwarding a bearer token."""
+    server_url = validate_server_url(server_url, configuration=True)
+    if not server_url.startswith("https://"):
+        raise CLIError(
+            "invalid_configuration",
+            "Managed workspace server URLs must use HTTPS.",
+        )
+    return server_url
 
 
 async def _wait_for_managed_workspace(

--- a/src/kitaru/cli/auth.py
+++ b/src/kitaru/cli/auth.py
@@ -368,15 +368,9 @@ async def _wait_for_managed_workspace(
                 "invalid_configuration",
                 "The workspace selected during login is not a Kitaru workspace.",
             )
-        if workspace.status == "available":
-            if workspace.server_url:
-                return workspace
-            raise CLIError(
-                "invalid_configuration",
-                f"Managed workspace {workspace.name!r} is available but has no "
-                "Kitaru server URL.",
-            )
-        if workspace.status not in {"not_initialized", "pending"}:
+        if workspace.status == "available" and workspace.server_url:
+            return workspace
+        if workspace.status not in {"not_initialized", "pending", "available"}:
             raise CLIError(
                 "invalid_configuration",
                 f"Managed workspace {workspace.name!r} is {workspace.status}.",

--- a/src/kitaru/cli/auth.py
+++ b/src/kitaru/cli/auth.py
@@ -13,7 +13,9 @@
 #  permissions and limitations under the License.
 """Authentication command orchestration over the existing SDK flows."""
 
+import asyncio
 import getpass
+import uuid
 from collections.abc import Callable
 from typing import TextIO, cast
 
@@ -25,12 +27,23 @@ from kitaru.cli.config import validate_server_url
 from kitaru.cli.output import CLIError, CommandResult, write_interaction
 from kitaru.client.api_client import KitaruAPIClient
 from kitaru.client.config import set_server_url
-from kitaru.client.control_plane import ControlPlaneDeviceAuthorization
-from kitaru.client.control_plane_auth import control_plane_login
+from kitaru.client.control_plane import (
+    MANAGED_CLOUD_API_URL,
+    ControlPlaneDeviceAuthorization,
+    ControlPlaneSession,
+    ControlPlaneWorkspace,
+)
+from kitaru.client.control_plane_auth import (
+    control_plane_login,
+    exchange_control_plane_credential,
+)
 from kitaru.client.credential_store import CredentialStore
 from kitaru.client.credentials import ApiToken
 from kitaru.client.device_auth import device_login
 from kitaru.client.exceptions import NotFoundError
+
+_WORKSPACE_POLL_INTERVAL_SECONDS = 5
+_WORKSPACE_POLL_ATTEMPTS = 36
 
 
 async def login(
@@ -76,11 +89,6 @@ async def login(
     """
     if local and server:
         raise CLIError("invalid_arguments", "Pass either SERVER or --local, not both.")
-    if not local and not server:
-        raise CLIError(
-            "invalid_arguments",
-            "Login requires a SERVER argument or --local.",
-        )
     if upgrade and not local:
         raise CLIError("invalid_arguments", "--upgrade requires --local.")
     if port is not None and not local:
@@ -89,6 +97,16 @@ async def login(
         raise CLIError(
             "invalid_arguments",
             "--password-stdin and --api-key-stdin cannot be combined.",
+        )
+    if not local and server is None:
+        return await _login_managed_cloud(
+            credential_store=credential_store,
+            timeout=timeout,
+            non_interactive=non_interactive,
+            no_browser=no_browser,
+            username=username,
+            password_stdin=password_stdin,
+            api_key_stdin=api_key_stdin,
         )
     if local:
         _reject_auth_inputs(
@@ -220,6 +238,164 @@ async def login(
             "credential_kind": credential_kind,
             "credential_stored": credential_stored,
         }
+    )
+
+
+async def _login_managed_cloud(
+    *,
+    credential_store: CredentialStore,
+    timeout: float,
+    non_interactive: bool,
+    no_browser: bool,
+    username: str | None,
+    password_stdin: bool,
+    api_key_stdin: bool,
+) -> CommandResult:
+    """Authorize with managed cloud and connect to the selected workspace."""
+    _reject_control_plane_password(username, password_stdin)
+    if api_key_stdin:
+        raise CLIError(
+            "invalid_arguments",
+            "Bare managed-cloud login does not accept --api-key-stdin.",
+            hint="Pass the workspace URL when logging in with an API key.",
+        )
+    if non_interactive:
+        raise CLIError(
+            "interaction_required",
+            "Managed-cloud device login requires interaction.",
+            hint="Run `kitaru login` in an interactive terminal.",
+        )
+
+    session = ControlPlaneSession(
+        MANAGED_CLOUD_API_URL,
+        credential_store,
+        timeout=timeout,
+    )
+    try:
+        device_login = await session.device_login_with_metadata(
+            open_browser=not no_browser,
+            prompt=_show_device_prompt,
+        )
+        workspace_id = _get_selected_workspace_id(device_login.device_metadata)
+        workspace = await _wait_for_managed_workspace(
+            session,
+            workspace_id,
+            device_login.token.access_token,
+        )
+    finally:
+        await session.close()
+
+    server_url = validate_server_url(
+        cast(str, workspace.server_url), configuration=True
+    )
+    client = KitaruAPIClient(
+        base_url=server_url,
+        timeout=timeout,
+        analytics_source=AnalyticsSource.CLI,
+    )
+    try:
+        info = await client.info.get()
+        if (
+            info.auth_scheme is not AuthScheme.CONTROL_PLANE
+            or info.id != workspace_id
+            or info.control_plane_api_url != MANAGED_CLOUD_API_URL
+        ):
+            raise CLIError(
+                "invalid_configuration",
+                f"Managed workspace {workspace.name!r} returned inconsistent "
+                "Kitaru connection details.",
+            )
+        await exchange_control_plane_credential(
+            client,
+            server_url,
+            credential_store,
+            MANAGED_CLOUD_API_URL,
+            device_login.token.access_token,
+        )
+        set_server_url(server_url)
+    except OSError as error:
+        raise CLIError(
+            "invalid_configuration",
+            "Authentication succeeded but local connection state could not be "
+            f"stored: {error}",
+        ) from error
+    finally:
+        await client.close()
+
+    return CommandResult(
+        item={
+            "server_url": server_url,
+            "workspace_id": str(workspace.id),
+            "workspace_name": workspace.name,
+            "auth_scheme": info.auth_scheme.value,
+            "authentication": "authenticated",
+            "credential_kind": "device",
+            "credential_stored": True,
+        },
+        next_actions=["Run `kitaru status` to inspect the managed workspace."],
+    )
+
+
+def _get_selected_workspace_id(device_metadata: dict[str, str]) -> uuid.UUID:
+    """Read the workspace selected in the browser device flow."""
+    value = device_metadata.get("tenant_id")
+    if value is None:
+        raise CLIError(
+            "invalid_configuration",
+            "Managed-cloud login completed without a selected Kitaru workspace.",
+            hint="Run `kitaru login` again and select or create a workspace.",
+        )
+    try:
+        return uuid.UUID(value)
+    except ValueError as error:
+        raise CLIError(
+            "invalid_configuration",
+            "Managed-cloud login returned an invalid workspace ID.",
+        ) from error
+
+
+async def _wait_for_managed_workspace(
+    session: ControlPlaneSession,
+    workspace_id: uuid.UUID,
+    access_token: str,
+) -> ControlPlaneWorkspace:
+    """Wait for the selected managed workspace to expose its server URL."""
+    waiting = False
+    for attempt in range(_WORKSPACE_POLL_ATTEMPTS):
+        workspace = await session.get_workspace(workspace_id, access_token)
+        if workspace.workspace_type != "kitaru":
+            raise CLIError(
+                "invalid_configuration",
+                "The workspace selected during login is not a Kitaru workspace.",
+            )
+        if workspace.status == "available":
+            if workspace.server_url:
+                return workspace
+            raise CLIError(
+                "invalid_configuration",
+                f"Managed workspace {workspace.name!r} is available but has no "
+                "Kitaru server URL.",
+            )
+        if workspace.status not in {"not_initialized", "pending"}:
+            raise CLIError(
+                "invalid_configuration",
+                f"Managed workspace {workspace.name!r} is {workspace.status}.",
+                hint="Open https://cloud.kitaru.ai to inspect the workspace.",
+            )
+        if attempt == _WORKSPACE_POLL_ATTEMPTS - 1:
+            break
+        if not waiting:
+            write_interaction(
+                f"Waiting for managed workspace {workspace.name!r} to be ready."
+            )
+            waiting = True
+        await asyncio.sleep(_WORKSPACE_POLL_INTERVAL_SECONDS)
+    raise CLIError(
+        "timeout",
+        "The managed workspace is taking longer than expected to become ready.",
+        hint=(
+            "Open https://cloud.kitaru.ai to inspect it, then run `kitaru login` again."
+        ),
     )
 
 

--- a/src/kitaru/cli/auth.py
+++ b/src/kitaru/cli/auth.py
@@ -276,11 +276,11 @@ async def _login_managed_cloud(
             open_browser=not no_browser,
             prompt=_show_device_prompt,
         )
-        workspace_id = _get_selected_workspace_id(device_login.device_metadata)
+        workspace_id = _get_selected_workspace_id(device_login.device_metadata or {})
         workspace = await _wait_for_managed_workspace(
             session,
             workspace_id,
-            device_login.token.access_token,
+            device_login.access_token,
         )
     finally:
         await session.close()
@@ -310,7 +310,7 @@ async def _login_managed_cloud(
             server_url,
             credential_store,
             MANAGED_CLOUD_API_URL,
-            device_login.token.access_token,
+            device_login.access_token,
         )
         set_server_url(server_url)
     except OSError as error:

--- a/src/kitaru/client/control_plane.py
+++ b/src/kitaru/client/control_plane.py
@@ -17,7 +17,6 @@ import logging
 import uuid
 import webbrowser
 from collections.abc import Callable
-from dataclasses import dataclass
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import httpx
@@ -71,14 +70,6 @@ class ControlPlaneToken(BaseModel):
     access_token: str
     expires_in: int
     device_metadata: dict[str, str] | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class ControlPlaneDeviceLogin:
-    """Token and workspace selection returned by a device login."""
-
-    token: ApiToken
-    device_metadata: dict[str, str]
 
 
 class ControlPlaneKitaruServiceStatus(BaseModel):
@@ -197,14 +188,14 @@ class ControlPlaneSession:
             prompt=prompt,
             workspace_id=workspace_id,
         )
-        return result.token
+        return ApiToken.issued(result.access_token, result.expires_in)
 
     async def device_login_with_metadata(
         self,
         open_browser: bool = True,
         prompt: Callable[[ControlPlaneDeviceAuthorization], None] | None = None,
         workspace_id: str | None = None,
-    ) -> ControlPlaneDeviceLogin:
+    ) -> ControlPlaneToken:
         """Authorize this machine against the control plane.
 
         The call blocks until a signed-in account confirms the user code in a
@@ -220,7 +211,7 @@ class ControlPlaneSession:
             DeviceLoginError: The authorization expired or was refused.
 
         Returns:
-            Token and workspace selection issued for the authorized device.
+            Control plane token and workspace selection issued for the device.
         """
         client_id = get_client_id()
         device = describe_this_device()
@@ -265,11 +256,8 @@ class ControlPlaneSession:
             exchange, authorization.expires_in, authorization.interval
         )
         issued = ControlPlaneToken.model_validate(confirmed.json())
-        token = self._store_issued_token(issued)
-        return ControlPlaneDeviceLogin(
-            token=token,
-            device_metadata=issued.device_metadata or {},
-        )
+        self._store_issued_token(issued)
+        return issued
 
     async def get_workspace(
         self, workspace_id: uuid.UUID, access_token: str

--- a/src/kitaru/client/control_plane.py
+++ b/src/kitaru/client/control_plane.py
@@ -14,8 +14,10 @@
 """Control plane login for clients of a control plane backed server."""
 
 import logging
+import uuid
 import webbrowser
 from collections.abc import Callable
+from dataclasses import dataclass
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import httpx
@@ -32,6 +34,9 @@ logger = logging.getLogger(__name__)
 
 DEVICE_AUTHORIZATION_PATH = "/auth/device_authorization"
 LOGIN_PATH = "/auth/login"
+WORKSPACE_PATH = "/workspaces/{workspace_id}"
+
+MANAGED_CLOUD_API_URL = "https://cloudapi.zenml.io"
 
 # Grant the control plane accepts an API key under.
 API_KEY_GRANT_TYPE = "zenml_api_key"
@@ -65,6 +70,50 @@ class ControlPlaneToken(BaseModel):
 
     access_token: str
     expires_in: int
+    device_metadata: dict[str, str] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ControlPlaneDeviceLogin:
+    """Token and workspace selection returned by a device login."""
+
+    token: ApiToken
+    device_metadata: dict[str, str]
+
+
+class ControlPlaneKitaruServiceStatus(BaseModel):
+    """Deployment details needed to connect to a Kitaru workspace."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    server_url: str | None = None
+
+
+class ControlPlaneKitaruService(BaseModel):
+    """Kitaru service attached to a managed workspace."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    status: ControlPlaneKitaruServiceStatus | None = None
+
+
+class ControlPlaneWorkspace(BaseModel):
+    """Managed workspace fields required by the Kitaru login flow."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: uuid.UUID
+    name: str
+    workspace_type: str
+    status: str
+    kitaru_service: ControlPlaneKitaruService | None = None
+
+    @property
+    def server_url(self) -> str | None:
+        """Return the deployed Kitaru server URL, if available."""
+        if self.kitaru_service is None or self.kitaru_service.status is None:
+            return None
+        return self.kitaru_service.status.server_url
 
 
 class ControlPlaneSession:
@@ -142,6 +191,20 @@ class ControlPlaneSession:
         prompt: Callable[[ControlPlaneDeviceAuthorization], None] | None = None,
         workspace_id: str | None = None,
     ) -> ApiToken:
+        """Authorize this machine and return its cached control plane token."""
+        result = await self.device_login_with_metadata(
+            open_browser=open_browser,
+            prompt=prompt,
+            workspace_id=workspace_id,
+        )
+        return result.token
+
+    async def device_login_with_metadata(
+        self,
+        open_browser: bool = True,
+        prompt: Callable[[ControlPlaneDeviceAuthorization], None] | None = None,
+        workspace_id: str | None = None,
+    ) -> ControlPlaneDeviceLogin:
         """Authorize this machine against the control plane.
 
         The call blocks until a signed-in account confirms the user code in a
@@ -157,7 +220,7 @@ class ControlPlaneSession:
             DeviceLoginError: The authorization expired or was refused.
 
         Returns:
-            Token issued for the authorized device.
+            Token and workspace selection issued for the authorized device.
         """
         client_id = get_client_id()
         device = describe_this_device()
@@ -201,7 +264,31 @@ class ControlPlaneSession:
         confirmed = await poll_for_token(
             exchange, authorization.expires_in, authorization.interval
         )
-        return self._store_token(confirmed)
+        issued = ControlPlaneToken.model_validate(confirmed.json())
+        token = self._store_issued_token(issued)
+        return ControlPlaneDeviceLogin(
+            token=token,
+            device_metadata=issued.device_metadata or {},
+        )
+
+    async def get_workspace(
+        self, workspace_id: uuid.UUID, access_token: str
+    ) -> ControlPlaneWorkspace:
+        """Get the managed workspace selected during device authorization.
+
+        Args:
+            workspace_id: Selected workspace ID.
+            access_token: Control plane bearer token.
+
+        Returns:
+            Managed workspace connection details.
+        """
+        response = await self._http.get(
+            WORKSPACE_PATH.format(workspace_id=workspace_id),
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        raise_for_response(response)
+        return ControlPlaneWorkspace.model_validate(response.json())
 
     async def close(self) -> None:
         """Close the underlying HTTP client."""
@@ -217,6 +304,10 @@ class ControlPlaneSession:
             Cached token.
         """
         issued = ControlPlaneToken.model_validate(response.json())
+        return self._store_issued_token(issued)
+
+    def _store_issued_token(self, issued: ControlPlaneToken) -> ApiToken:
+        """Cache a validated control plane token response."""
         token = ApiToken.issued(issued.access_token, issued.expires_in)
         self._store.set_token(self._url, token, type=ApiType.CONTROL_PLANE)
         return token

--- a/src/kitaru/client/control_plane_auth.py
+++ b/src/kitaru/client/control_plane_auth.py
@@ -75,7 +75,7 @@ async def control_plane_login(
     try:
         if api_key is not None:
             credential = (await session.login_with_api_key(api_key)).access_token
-            token = await _exchange_credential(
+            token = await exchange_control_plane_credential(
                 api_client, base_url, store, control_plane_api_url, credential
             )
             return token, "api_key"
@@ -88,7 +88,7 @@ async def control_plane_login(
                 credential = None
             if credential is not None:
                 try:
-                    token = await _exchange_credential(
+                    token = await exchange_control_plane_credential(
                         api_client, base_url, store, control_plane_api_url, credential
                     )
                     return token, "stored"
@@ -101,7 +101,7 @@ async def control_plane_login(
                 workspace_id=str(info.id) if info.id else None,
             )
         ).access_token
-        token = await _exchange_credential(
+        token = await exchange_control_plane_credential(
             api_client, base_url, store, control_plane_api_url, credential
         )
         return token, "device"
@@ -109,7 +109,7 @@ async def control_plane_login(
         await session.close()
 
 
-async def _exchange_credential(
+async def exchange_control_plane_credential(
     api_client: KitaruAPIClient,
     base_url: str,
     store: CredentialStore,

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -601,6 +601,27 @@ def test_transport_error_without_request_uses_selected_server() -> None:
     assert error.details == {"server_url": "https://api.example.com/kitaru"}
 
 
+def test_bare_login_dispatches_without_a_server(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Leave the target empty so auth orchestration starts managed-cloud login."""
+    captured: dict[str, Any] = {}
+
+    async def fake_login(**options: Any) -> CommandResult:
+        captured.update(options)
+        return CommandResult(item={"server_url": "https://managed.example.com"})
+
+    monkeypatch.setattr(app_module.auth_commands, "login", fake_login)
+
+    assert app_module.main(["login", "--output", "json"]) == 0
+
+    assert captured["server"] is None
+    assert captured["local"] is False
+    assert captured["non_interactive"] is True
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["item"]["server_url"] == "https://managed.example.com"
+
+
 def test_login_network_error_preserves_selected_server_path(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -28,8 +28,8 @@ from kitaru.cli.output import CLIError
 from kitaru.client.config import get_server_url, set_server_url
 from kitaru.client.control_plane import (
     MANAGED_CLOUD_API_URL,
-    ControlPlaneDeviceLogin,
     ControlPlaneSession,
+    ControlPlaneToken,
     ControlPlaneWorkspace,
 )
 from kitaru.client.credential_store import CredentialStore
@@ -136,10 +136,11 @@ async def test_bare_login_connects_to_the_browser_selected_managed_workspace(
 
         async def device_login_with_metadata(
             self, *, open_browser: bool, prompt: object
-        ) -> ControlPlaneDeviceLogin:
+        ) -> ControlPlaneToken:
             calls.append(("device", open_browser, prompt))
-            return ControlPlaneDeviceLogin(
-                token=ApiToken.issued("control-plane-token", 3600),
+            return ControlPlaneToken(
+                access_token="control-plane-token",
+                expires_in=3600,
                 device_metadata={"tenant_id": str(WORKSPACE_ID)},
             )
 
@@ -225,11 +226,10 @@ async def test_bare_login_rejects_a_mismatched_workspace_server(
         def __init__(self, *_args, **_kwargs) -> None:
             pass
 
-        async def device_login_with_metadata(
-            self, **_kwargs
-        ) -> ControlPlaneDeviceLogin:
-            return ControlPlaneDeviceLogin(
-                token=ApiToken.issued("control-plane-token", 3600),
+        async def device_login_with_metadata(self, **_kwargs) -> ControlPlaneToken:
+            return ControlPlaneToken(
+                access_token="control-plane-token",
+                expires_in=3600,
                 device_metadata={"tenant_id": str(WORKSPACE_ID)},
             )
 
@@ -280,11 +280,10 @@ async def test_bare_login_requires_the_browser_to_select_a_workspace(
         def __init__(self, *_args, **_kwargs) -> None:
             pass
 
-        async def device_login_with_metadata(
-            self, **_kwargs
-        ) -> ControlPlaneDeviceLogin:
-            return ControlPlaneDeviceLogin(
-                token=ApiToken.issued("control-plane-token", 3600),
+        async def device_login_with_metadata(self, **_kwargs) -> ControlPlaneToken:
+            return ControlPlaneToken(
+                access_token="control-plane-token",
+                expires_in=3600,
                 device_metadata={},
             )
 

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -316,7 +316,11 @@ async def test_bare_login_waits_for_a_pending_workspace(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Poll a newly created workspace until its Kitaru service is available."""
-    responses = [managed_workspace(status="pending"), managed_workspace()]
+    responses = [
+        managed_workspace(status="pending"),
+        managed_workspace(server_url=None),
+        managed_workspace(),
+    ]
     delays: list[float] = []
 
     class FakeManagedCloudSession:
@@ -339,7 +343,7 @@ async def test_bare_login_waits_for_a_pending_workspace(
     )
 
     assert workspace.status == "available"
-    assert delays == [auth._WORKSPACE_POLL_INTERVAL_SECONDS]
+    assert delays == [auth._WORKSPACE_POLL_INTERVAL_SECONDS] * 2
 
 
 async def test_login_explains_when_kitaru_is_not_available(

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -14,8 +14,10 @@
 """Authentication orchestration and credential persistence behavior."""
 
 import io
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -23,7 +25,13 @@ from kitaru.api_models.v1.auth import TokenResponse
 from kitaru.api_models.v1.info import AuthScheme, ServerInfoResponse
 from kitaru.cli import auth
 from kitaru.cli.output import CLIError
-from kitaru.client.config import get_server_url
+from kitaru.client.config import get_server_url, set_server_url
+from kitaru.client.control_plane import (
+    MANAGED_CLOUD_API_URL,
+    ControlPlaneDeviceLogin,
+    ControlPlaneSession,
+    ControlPlaneWorkspace,
+)
 from kitaru.client.credential_store import CredentialStore
 from kitaru.client.credentials import ApiToken
 from kitaru.client.exceptions import AuthenticationError, NotFoundError
@@ -35,6 +43,7 @@ class FakeAuthResource:
 
     error: Exception | None = None
     exchanged: str | None = None
+    control_plane_exchanged: str | None = None
 
     async def exchange_api_key(self, api_key: str) -> TokenResponse:
         """Validate one API key or raise the configured error."""
@@ -43,6 +52,15 @@ class FakeAuthResource:
             raise self.error
         return TokenResponse(
             access_token="session-token", token_type="bearer", expires_in=3600
+        )
+
+    async def exchange_control_plane_credential(self, credential: str) -> TokenResponse:
+        """Exchange one control plane bearer token."""
+        self.control_plane_exchanged = credential
+        if self.error:
+            raise self.error
+        return TokenResponse(
+            access_token="server-session", token_type="bearer", expires_in=3600
         )
 
 
@@ -54,11 +72,18 @@ class FakeClient:
         scheme: AuthScheme,
         error: Exception | None = None,
         info_error: Exception | None = None,
+        server_id: uuid.UUID | None = None,
+        control_plane_api_url: str | None = None,
     ) -> None:
         """Initialize the fake client."""
         self.auth = FakeAuthResource(error)
         self.closed = False
-        info = ServerInfoResponse(version="0.21.0", auth_scheme=scheme)
+        info = ServerInfoResponse(
+            id=server_id,
+            version="0.21.0",
+            auth_scheme=scheme,
+            control_plane_api_url=control_plane_api_url,
+        )
 
         class InfoResource:
             async def get(self) -> ServerInfoResponse:
@@ -71,6 +96,251 @@ class FakeClient:
     async def close(self) -> None:
         """Record client closure."""
         self.closed = True
+
+
+WORKSPACE_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+
+def managed_workspace(
+    *, status: str = "available", server_url: str | None = "https://managed.example.com"
+) -> ControlPlaneWorkspace:
+    """Build the minimal managed workspace response used by login tests."""
+    return ControlPlaneWorkspace.model_validate(
+        {
+            "id": str(WORKSPACE_ID),
+            "name": "my-kitaru",
+            "workspace_type": "kitaru",
+            "status": status,
+            "kitaru_service": {"status": {"server_url": server_url}},
+        }
+    )
+
+
+async def test_bare_login_connects_to_the_browser_selected_managed_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Resolve and select the Kitaru workspace chosen in the device flow."""
+    credential_store = CredentialStore(tmp_path / "credentials.json")
+    client = FakeClient(
+        AuthScheme.CONTROL_PLANE,
+        server_id=WORKSPACE_ID,
+        control_plane_api_url=MANAGED_CLOUD_API_URL,
+    )
+    calls: list[object] = []
+
+    class FakeManagedCloudSession:
+        def __init__(
+            self, api_url: str, store: CredentialStore, timeout: float
+        ) -> None:
+            calls.append((api_url, store, timeout))
+
+        async def device_login_with_metadata(
+            self, *, open_browser: bool, prompt: object
+        ) -> ControlPlaneDeviceLogin:
+            calls.append(("device", open_browser, prompt))
+            return ControlPlaneDeviceLogin(
+                token=ApiToken.issued("control-plane-token", 3600),
+                device_metadata={"tenant_id": str(WORKSPACE_ID)},
+            )
+
+        async def get_workspace(
+            self, workspace_id: uuid.UUID, access_token: str
+        ) -> ControlPlaneWorkspace:
+            calls.append(("workspace", workspace_id, access_token))
+            return managed_workspace()
+
+        async def close(self) -> None:
+            calls.append("closed")
+
+    monkeypatch.setattr(auth, "ControlPlaneSession", FakeManagedCloudSession)
+    monkeypatch.setattr(auth, "KitaruAPIClient", lambda **_: client)
+
+    result = await auth.login(
+        server=None,
+        local=False,
+        username=None,
+        password_stdin=False,
+        api_key_stdin=False,
+        credential_store=credential_store,
+        timeout=30,
+        non_interactive=False,
+        no_browser=True,
+        stdin=io.StringIO(),
+    )
+
+    assert calls[0] == (MANAGED_CLOUD_API_URL, credential_store, 30)
+    assert calls[1] == ("device", False, auth._show_device_prompt)
+    assert calls[2] == ("workspace", WORKSPACE_ID, "control-plane-token")
+    assert calls[3] == "closed"
+    assert client.auth.control_plane_exchanged == "control-plane-token"
+    assert get_server_url() == "https://managed.example.com"
+    assert result.item == {
+        "server_url": "https://managed.example.com",
+        "workspace_id": str(WORKSPACE_ID),
+        "workspace_name": "my-kitaru",
+        "auth_scheme": "control_plane",
+        "authentication": "authenticated",
+        "credential_kind": "device",
+        "credential_stored": True,
+    }
+    stored = credential_store.get("https://managed.example.com")
+    assert stored is not None
+    assert stored.control_plane_api_url == MANAGED_CLOUD_API_URL
+
+
+async def test_bare_login_rejects_non_interactive_use_before_connecting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Do not start browser authorization for a non-interactive invocation."""
+    monkeypatch.setattr(
+        auth,
+        "ControlPlaneSession",
+        lambda *_args, **_kwargs: pytest.fail("control plane should not be contacted"),
+    )
+
+    with pytest.raises(CLIError) as raised:
+        await auth.login(
+            server=None,
+            local=False,
+            username=None,
+            password_stdin=False,
+            api_key_stdin=False,
+            credential_store=CredentialStore(tmp_path / "credentials.json"),
+            timeout=30,
+            non_interactive=True,
+            no_browser=True,
+            stdin=io.StringIO(),
+        )
+
+    assert raised.value.kind == "interaction_required"
+    assert "interactive terminal" in str(raised.value.hint)
+
+
+async def test_bare_login_rejects_a_mismatched_workspace_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Keep the current server when discovery resolves an inconsistent server."""
+
+    class FakeManagedCloudSession:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def device_login_with_metadata(
+            self, **_kwargs
+        ) -> ControlPlaneDeviceLogin:
+            return ControlPlaneDeviceLogin(
+                token=ApiToken.issued("control-plane-token", 3600),
+                device_metadata={"tenant_id": str(WORKSPACE_ID)},
+            )
+
+        async def close(self) -> None:
+            pass
+
+    async def return_workspace(*_args, **_kwargs) -> ControlPlaneWorkspace:
+        return managed_workspace()
+
+    async def reject_exchange(*_args, **_kwargs) -> None:
+        pytest.fail("credentials should not be exchanged")
+
+    monkeypatch.setattr(auth, "ControlPlaneSession", FakeManagedCloudSession)
+    monkeypatch.setattr(auth, "_wait_for_managed_workspace", return_workspace)
+    monkeypatch.setattr(
+        auth,
+        "KitaruAPIClient",
+        lambda **_: FakeClient(AuthScheme.CONTROL_PLANE, server_id=uuid.uuid4()),
+    )
+    monkeypatch.setattr(auth, "exchange_control_plane_credential", reject_exchange)
+    set_server_url("https://existing.example.com")
+
+    with pytest.raises(CLIError) as raised:
+        await auth.login(
+            server=None,
+            local=False,
+            username=None,
+            password_stdin=False,
+            api_key_stdin=False,
+            credential_store=CredentialStore(tmp_path / "credentials.json"),
+            timeout=30,
+            non_interactive=False,
+            no_browser=True,
+            stdin=io.StringIO(),
+        )
+
+    assert raised.value.kind == "invalid_configuration"
+    assert "inconsistent Kitaru connection details" in raised.value.message
+    assert get_server_url() == "https://existing.example.com"
+
+
+async def test_bare_login_requires_the_browser_to_select_a_workspace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explain a successful device grant that carries no workspace selection."""
+
+    class FakeManagedCloudSession:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        async def device_login_with_metadata(
+            self, **_kwargs
+        ) -> ControlPlaneDeviceLogin:
+            return ControlPlaneDeviceLogin(
+                token=ApiToken.issued("control-plane-token", 3600),
+                device_metadata={},
+            )
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(auth, "ControlPlaneSession", FakeManagedCloudSession)
+    set_server_url("https://existing.example.com")
+
+    with pytest.raises(CLIError) as raised:
+        await auth.login(
+            server=None,
+            local=False,
+            username=None,
+            password_stdin=False,
+            api_key_stdin=False,
+            credential_store=CredentialStore(tmp_path / "credentials.json"),
+            timeout=30,
+            non_interactive=False,
+            no_browser=True,
+            stdin=io.StringIO(),
+        )
+
+    assert raised.value.kind == "invalid_configuration"
+    assert "without a selected Kitaru workspace" in raised.value.message
+    assert get_server_url() == "https://existing.example.com"
+
+
+async def test_bare_login_waits_for_a_pending_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Poll a newly created workspace until its Kitaru service is available."""
+    responses = [managed_workspace(status="pending"), managed_workspace()]
+    delays: list[float] = []
+
+    class FakeManagedCloudSession:
+        async def get_workspace(
+            self, workspace_id: uuid.UUID, access_token: str
+        ) -> ControlPlaneWorkspace:
+            assert workspace_id == WORKSPACE_ID
+            assert access_token == "control-plane-token"
+            return responses.pop(0)
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(auth.asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(auth, "write_interaction", lambda _message: None)
+    workspace = await auth._wait_for_managed_workspace(
+        cast(ControlPlaneSession, FakeManagedCloudSession()),
+        WORKSPACE_ID,
+        "control-plane-token",
+    )
+
+    assert workspace.status == "available"
+    assert delays == [auth._WORKSPACE_POLL_INTERVAL_SECONDS]
 
 
 async def test_login_explains_when_kitaru_is_not_available(

--- a/tests/cli/test_auth.py
+++ b/tests/cli/test_auth.py
@@ -346,6 +346,15 @@ async def test_bare_login_waits_for_a_pending_workspace(
     assert delays == [auth._WORKSPACE_POLL_INTERVAL_SECONDS] * 2
 
 
+def test_managed_workspace_server_url_requires_https() -> None:
+    """Do not forward a control-plane bearer token over plaintext HTTP."""
+    with pytest.raises(CLIError) as raised:
+        auth._validate_managed_server_url("http://managed.example.com")
+
+    assert raised.value.kind == "invalid_configuration"
+    assert "must use HTTPS" in raised.value.message
+
+
 async def test_login_explains_when_kitaru_is_not_available(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/test_schema.py
+++ b/tests/cli/test_schema.py
@@ -109,6 +109,9 @@ def test_command_schema_contains_behavior_and_error_contracts() -> None:
     assert {error["kind"]: error["exit_code"] for error in login["errors"]}[
         "authentication_failed"
     ] == 3
+    assert {error["kind"]: error["exit_code"] for error in login["errors"]}[
+        "timeout"
+    ] == 7
     assert any(
         parameter["name"] == "--api-key-stdin" for parameter in login["parameters"]
     )

--- a/tests/client/test_control_plane.py
+++ b/tests/client/test_control_plane.py
@@ -30,6 +30,7 @@ from kitaru.client.device_grant import DeviceLoginError
 from kitaru.transport import RetryTransport
 
 CONTROL_PLANE_URL = "https://control-plane.example.com"
+WORKSPACE_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 
 
 class FakeControlPlane:
@@ -40,6 +41,7 @@ class FakeControlPlane:
         pending_polls: int = 0,
         login_error: dict[str, str] | None = None,
         verification_uri: str = "/devices/verify",
+        workspace_status: str = "available",
     ) -> None:
         """Initialize the stub.
 
@@ -48,10 +50,12 @@ class FakeControlPlane:
                 ``authorization_pending`` before the confirmation lands.
             login_error: OAuth 2.0 error body every login is refused with.
             verification_uri: Verification URI the authorization carries.
+            workspace_status: Status returned by the workspace endpoint.
         """
         self.pending_polls = pending_polls
         self.login_error = login_error
         self.verification_uri = verification_uri
+        self.workspace_status = workspace_status
         self.requests: list[httpx.Request] = []
         self.logins = 0
 
@@ -66,6 +70,19 @@ class FakeControlPlane:
         """
         self.requests.append(request)
         form = dict(httpx.QueryParams(request.content.decode()))
+        if request.url.path == f"/workspaces/{WORKSPACE_ID}":
+            return httpx.Response(
+                200,
+                json={
+                    "id": str(WORKSPACE_ID),
+                    "name": "my-kitaru",
+                    "workspace_type": "kitaru",
+                    "status": self.workspace_status,
+                    "kitaru_service": {
+                        "status": {"server_url": "https://my-kitaru.example.com"}
+                    },
+                },
+            )
         if request.url.path == "/auth/device_authorization":
             return httpx.Response(
                 200,
@@ -96,6 +113,7 @@ class FakeControlPlane:
                 "access_token": f"cp-token-{self.logins}",
                 "expires_in": 3600,
                 "token_type": "bearer",
+                "device_metadata": {"tenant_id": str(WORKSPACE_ID)},
             },
         )
 
@@ -222,6 +240,40 @@ async def test_device_login_polls_until_the_code_is_confirmed(
     assert form["grant_type"] == DEVICE_CODE_GRANT_TYPE
     assert form["device_code"] == "cp-device-code"
     assert uuid.UUID(form["client_id"])
+
+
+async def test_device_login_exposes_the_selected_workspace(
+    credential_store: CredentialStore,
+) -> None:
+    """Return the workspace metadata attached during browser verification."""
+    session = _session(credential_store, FakeControlPlane())
+
+    login = await session.device_login_with_metadata(
+        open_browser=False, prompt=lambda _: None
+    )
+    await session.close()
+
+    assert login.token.access_token == "cp-token-1"
+    assert login.device_metadata == {"tenant_id": str(WORKSPACE_ID)}
+
+
+async def test_get_workspace_uses_the_control_plane_bearer_token(
+    credential_store: CredentialStore,
+) -> None:
+    """Resolve the selected workspace and its Kitaru server URL."""
+    control_plane = FakeControlPlane()
+    session = _session(credential_store, control_plane)
+
+    workspace = await session.get_workspace(WORKSPACE_ID, "cp-token")
+    await session.close()
+
+    assert workspace.id == WORKSPACE_ID
+    assert workspace.workspace_type == "kitaru"
+    assert workspace.status == "available"
+    assert workspace.server_url == "https://my-kitaru.example.com"
+    request = control_plane.requests[-1]
+    assert request.url.path == f"/workspaces/{WORKSPACE_ID}"
+    assert request.headers["Authorization"] == "Bearer cp-token"
 
 
 async def test_device_login_sends_a_stable_client_id(

--- a/tests/client/test_control_plane.py
+++ b/tests/client/test_control_plane.py
@@ -253,7 +253,7 @@ async def test_device_login_exposes_the_selected_workspace(
     )
     await session.close()
 
-    assert login.token.access_token == "cp-token-1"
+    assert login.access_token == "cp-token-1"
     assert login.device_metadata == {"tenant_id": str(WORKSPACE_ID)}
 
 


### PR DESCRIPTION
## What changed?

Running `kitaru login` without a server now starts the managed-cloud device flow, connects to the Kitaru workspace selected or created in the browser, waits for a new workspace to become available, and saves it as the active server. Explicit server URLs, global `--server`, and `kitaru login --local` retain their existing behavior.

## Why?

The first command after installation can now take a new user from authentication to a usable hosted Kitaru workspace without requiring them to find and paste a workspace URL. CLI help and installation docs state that managed cloud includes a 14-day trial with no credit card required.

Fixes #966.

## Release context

This ships with the next core CLI release. It does not require a frontend or Cloud API change because the existing browser verification flow already returns the selected workspace ID.

## Reviewer Notes

Start with the targetless branch in `cli.auth.login`. It authorizes against `https://cloudapi.zenml.io`, reads the browser-selected workspace from legacy device metadata key `tenant_id`, and resolves `GET /workspaces/{id}` until `kitaru_service.status.server_url` is available.

Before exchanging credentials, the CLI confirms that the discovered server reports the expected workspace ID, control-plane auth scheme, and control-plane URL. It changes the active server only after those checks and the credential exchange succeed, so a partial or inconsistent response cannot displace a working connection.

## Reproduction

1. Run `uv run kitaru login --help` and confirm the targetless managed-cloud path and trial terms are shown.
2. Run `uv run kitaru login --no-browser`, open the printed verification URL, enter the code, and select or create a Kitaru workspace.
3. Confirm the CLI waits if the workspace is still provisioning, then reports the selected workspace URL.
4. Run `uv run kitaru status` and confirm it targets that workspace.

## Local checks run

- `just check`
- `uv run --extra server --extra cli pytest tests/client/test_control_plane.py tests/client/test_control_plane_login.py tests/cli/test_auth.py tests/cli/test_app.py -q` (`80 passed`)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH uv run pytest tests/typescript/test_mastra_adapter.py tests/typescript/test_typescript_auth.py tests/typescript/test_vercel_ai_adapter.py -q` (`15 passed`)
- `just test` completed the Python suite with `4296 passed, 300 skipped, 13 xfailed`; its five TypeScript build entries initially lacked `node_modules`, then all passed in the targeted rerun above after `pnpm install --frozen-lockfile`.
