### PR TITLE
CI: post to Discord when the SDK Reference Docs deploy or a release fails

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -129,3 +129,14 @@ jobs:
           packageManager: npm
           wranglerVersion: ${{ env.WRANGLER_VERSION }}
           command: deploy --config wrangler.redirect.toml
+  notify-failure:
+    # PR runs already surface as a red check; only the production deploy path
+    # (push to main, manual dispatch) needs a Discord ping.
+    needs: build-deploy
+    if: failure() && github.event_name != 'pull_request'
+    permissions: {}
+    uses: ./.github/workflows/notify-failure.yml
+    with:
+      title: SDK Reference Docs deploy
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SRE }}

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -1,0 +1,41 @@
+---
+name: Notify failure
+# Reusable job that posts a short message to the SRE Discord channel when a
+# calling workflow fails. Deploy-on-main workflows have no PR to turn red, so
+# without this a broken production path goes unnoticed (the SDK Reference Docs
+# deploy failed on every main push for a week in Aug/Sep 2026 before anyone saw
+# it). Posts with plain curl rather than a marketplace action so there is no
+# unpinnable third-party dependency.
+on:
+  workflow_call:
+    inputs:
+      title:
+        description: Short label for what failed, such as "SDK Reference Docs deploy".
+        required: true
+        type: string
+    secrets:
+      DISCORD_WEBHOOK:
+        required: true
+permissions: {}
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          TITLE: ${{ inputs.title }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+          EVENT: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+            github.run_id }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |-
+          set -euo pipefail
+          content="$(printf '**%s failed** in %s\nRef: %s at %s (%s by %s)\n%s' \
+            "$TITLE" "$REPO" "$REF" "${SHA:0:12}" "$EVENT" "$ACTOR" "$RUN_URL")"
+          payload="$(jq -n --arg content "$content" '{content: $content}')"
+          curl -fsS -X POST -H 'Content-Type: application/json' \
+            --data "$payload" "$DISCORD_WEBHOOK" > /dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,3 +473,22 @@ jobs:
             --draft \
             --title "Start Kitaru $VERSION development" \
             --body "$body"
+  notify-failure:
+    # Any failed job in the release chain, including the non-gating installer
+    # smoke, pings the SRE Discord channel.
+    needs:
+      - build
+      - publish-python
+      - installer-smoke
+      - publish-deployables
+      - promote-latest
+      - create-release
+      - advance-maintenance-branch
+      - create-development-reset-pr
+    if: failure()
+    permissions: {}
+    uses: ./.github/workflows/notify-failure.yml
+    with:
+      title: Release ${{ github.ref_name }}
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_SRE }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -11,10 +11,10 @@ rules:
     ignore: [docs.yml:3]
   # self-repository: zizmor v1.30 wants `uses: $/...` for same-repo actions,
   # but actionlint (through v1.7.12, run by `just check` and CI) rejects that
-  # syntax, so release.yml keeps `./`. The job checks out the workflow's own
-  # ref, so both spellings resolve to the same commit. File-scoped rather than
-  # line-pinned: unrelated edits to release.yml shift line numbers and would
+  # syntax, so release.yml and docs.yml keep `./`. The job checks out the
+  # workflow's own ref, so both spellings resolve to the same commit.
+  # File-scoped rather than line-pinned: unrelated edits shift line numbers and would
   # silently un-suppress the finding. Drop this exception and switch to `$/`
   # once actionlint understands it (rhysd/actionlint#711).
   self-repository:
-    ignore: [release.yml]
+    ignore: [release.yml, docs.yml]


### PR DESCRIPTION
## Summary

Follow-up to #975 (merged). That fix made the `SDK Reference Docs` workflow deploy again, but the underlying gap remains: workflows that run on push to `main` have no PR check to turn red, so when the deploy broke on 26 Aug nobody was notified for a week. This adds a Discord ping on failure, as Alex suggested.

## What changed

- **`.github/workflows/notify-failure.yml`** (new, `workflow_call`): one job that posts a short message (what failed, ref, commit, event, actor, run URL) to the SRE Discord channel. Uses plain `curl` against the existing `DISCORD_WEBHOOK_SRE` repo secret rather than a marketplace action, so there is no `@master`-only dependency to carve a zizmor exception for (the zenml repo's `weekly-agent-pipelines-test.yml` needs one for `Ilshidur/action-discord`).
- **`docs.yml`**: final `notify-failure` job, `if: failure() && github.event_name != 'pull_request'`. PR runs already show as a red check, so only the production path (push to main, manual dispatch) pings.
- **`release.yml`**: final `notify-failure` job needing every job in the chain, `if: failure()`. Covers the non-gating `installer-smoke` too, which otherwise fails quietly by design.
- **`.github/zizmor.yml`**: the existing file-scoped `self-repository` exception for `./` reusable-workflow syntax now covers `docs.yml` as well (same actionlint-vs-zizmor conflict release.yml documents).

## What reviewers should focus on

- Whether `failure()` on a job that needs skipped jobs behaves as expected: skipped jobs do not count as failed, so a rehearsal dispatch that skips `publish-python` will not ping unless something actually fails.
- Message content. It deliberately carries no secrets or logs, just the run link.

## Validation

`uv run yamlfix`, `uvx typos`, actionlint (docker `rhysd/actionlint`), `uvx zizmor --config .github/zizmor.yml` all clean. Not exercised end to end: the job only fires on a real failure of a main push or release, and the secret is not available to PR runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrD7eCgTu11F6qsYMS5JMP