### PR TITLE
Align release guidance and command handoffs

### DIFF
--- a/.agents/skills/kitaru-adapter-development/SKILL.md
+++ b/.agents/skills/kitaru-adapter-development/SKILL.md
@@ -25,6 +25,8 @@ Preserve the framework's ordinary behavior, configured hooks and state, public e
 
 ## Package and documentation work
 
+Python feature PRs follow the version and dependency ownership rules in `plugins/AGENTS.md`. Leave existing package versions unchanged. Use the exact development dependency from `plugins/DEVELOPMENT.md` only when the adapter needs unreleased core; release prep selects the published compatibility floor.
+
 For a new Python adapter, inspect the current package inventory and update only the required integration points:
 
 - `plugins/packages/<slug>/pyproject.toml`, README, changelog, source package, public exports, and focused tests

--- a/.agents/skills/kitaru-importer-development/SKILL.md
+++ b/.agents/skills/kitaru-importer-development/SKILL.md
@@ -33,6 +33,8 @@ An importer package for a provider with a live read API can also ship an importe
 
 ## Package, register, and version
 
+For feature PRs, follow the version and dependency ownership rules in `plugins/AGENTS.md`. Leave existing package versions and default pins unchanged. Record unreleased core requirements with the exact development dependency described in `plugins/DEVELOPMENT.md`; release prep selects and replaces release versions.
+
 An importer distribution lives under `plugins/packages/<slug>-importer/`, with its source, `pyproject.toml`, changelog, and focused tests under `plugins/tests/importers/`. Export `parse` through the package `__all__`. Add the package to `plugins/README.md`, `release/release-units.toml`, the exact inventory in `tests/scripts/test_release_units.py`, and `plugins/uv.lock`. A non-default package also declares `tool.kitaru.artifact.import-module` so artifact smoke can import it without a default-catalog entry.
 
 Use `kitaru importer scaffold` and `kitaru importer test` for bounded local scripts. Register an in-progress self-contained implementation with `kitaru importer register ... --script ... --entrypoint ...`. Use an exact package requirement when validation must cover wheel installation. Registration creates remote state, is not idempotent, and needs an explicit server plus a worker that can resolve the source. Do not run it without authorization. The package's PyPI version and Kitaru's server-assigned importer version are separate: use `kitaru importer version register` for each new immutable registered implementation, and never mutate the behavior behind an existing version.

--- a/.agents/skills/kitaru-release/SKILL.md
+++ b/.agents/skills/kitaru-release/SKILL.md
@@ -9,8 +9,10 @@ Use the current workflows as the source of truth:
 
 - Core: `.github/workflows/release.yml`
 - Plugins: `.github/workflows/release-plugins.yml`
-- Package inventory: `release/release-units.toml`
+- Python package inventory: `release/release-units.toml`
+- TypeScript release set: `release/typescript.md` and `.github/workflows/release-typescript.yml`
 - Frontend: `zenml-io/zenml-frontend-monorepo/.github/workflows/release-kitaru-ui.yml`
+- Follow-up skills release: [skills-release](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md)
 
 Read `AGENTS.md`. Read `plugins/AGENTS.md` and `plugins/DEVELOPMENT.md` for plugin changes. Read `FRONTEND-TESTING.md` for core or UI work.
 
@@ -63,6 +65,18 @@ Before editing, rerun the command with `--candidate <proposed-version>` and requ
 
 Propose explicit versions and changelog entries after discovery. Check PyPI versions and Git tags before proposing a version, and never reuse a published version. Get the user's acceptance before editing release metadata.
 
+## Separate implementation from release preparation
+
+Feature PRs leave existing plugin package versions and server default requirements/display versions unchanged. Put behavior changes in the package's `Unreleased` changelog section. The release-preparation PR selects package versions and updates all matching default-catalog metadata together. New packages require initial metadata, but becoming a server default remains an explicit release decision.
+
+Follow the development dependency policy in `plugins/DEVELOPMENT.md`. Plugins compatible with published core keep their supported minimum. A plugin requiring unreleased core uses an exact dependency on the current root development version, such as `kitaru==0.25.0+dev`, and records the needed core change in `Release context`.
+
+Before changing core to its selected release version, inspect every plugin's core dependency. Replace each resolved development pin with the selected compatible release floor, such as `kitaru>=0.26.0`, preserving extras and compatible upper bounds. Do not guess the future version in the feature PR. An unresolved development pin blocks release preparation; account for every affected plugin and its publication timing. A plugin-only release can replace the pin only when a published core contains the required change.
+
+Regenerate `plugins/uv.lock` after these conversions. Verify the selected wheels' `Requires-Dist` metadata contains no development placeholder or local checkout dependency before handing over publication commands.
+
+Inspect the TypeScript packages separately from the Python inventory. Include their lockstep release when their changes require publication. Inspect the Kitaru skills repository for a pending release and record its own version and compatibility requirements.
+
 ## Apply version rules
 
 - Use canonical PEP 440 for Python: `X.Y.Z` or `X.Y.ZrcN`.
@@ -81,7 +95,7 @@ Perform this section before the core preparation PR when the core needs a new UI
 
 1. Inspect `zenml-io/zenml-frontend-monorepo` and select an exact commit on `main`.
 2. Confirm its Kitaru UI checks pass.
-3. Select the frontend version input, such as `v0.2.0-rc.4`.
+3. Select a stable frontend version input, such as `v0.4.0`, for an official core release.
 4. Ask for explicit confirmation before dispatch because the workflow creates a tag and GitHub Release.
 5. Dispatch the workflow at the selected ref:
 
@@ -89,7 +103,7 @@ Perform this section before the core preparation PR when the core needs a new UI
 gh workflow run release-kitaru-ui.yml \
   --repo zenml-io/zenml-frontend-monorepo \
   --ref main \
-  -f version=v0.2.0-rc.4
+  -f version=v0.4.0
 ```
 
 6. Capture and monitor the exact run:
@@ -103,11 +117,11 @@ gh run view <run-id> --repo zenml-io/zenml-frontend-monorepo
 7. Verify the release tag and both assets:
 
 ```bash
-gh release view kitaru-ui-v0.2.0-rc.4 \
+gh release view kitaru-ui-v0.4.0 \
   --repo zenml-io/zenml-frontend-monorepo
 ```
 
-Require `kitaru-ui.tar.gz` and `kitaru-ui.tar.gz.sha256`. The frontend workflow builds with the selected version, creates both files, and publishes a prerelease.
+Require `kitaru-ui.tar.gz` and `kitaru-ui.tar.gz.sha256`. Verify the workflow ran at the reviewed commit and the release is stable. The frontend workflow derives its release channel from whether the selected commit is on `main`; official core releases require a stable bundle.
 
 If the user asks only for a preparation PR, do not dispatch the frontend workflow. The user can explicitly select an expected frontend tag before it exists. Mark asset verification as pending and do not create the core tag until both assets exist.
 
@@ -126,7 +140,7 @@ kitaru-version = "<python-version>"
 ui-tag = "<kitaru-ui-tag>"
 ```
 
-5. Run `uv lock`. Keep unrelated `exclude-newer` timestamp churn out of the diff.
+5. Resolve plugin development dependencies to the selected core version, then run `uv lock` and `uv lock --project plugins`. Keep unrelated `exclude-newer` timestamp churn out of the diff.
 6. Run `uv run python scripts/generate_openapi.py` and commit `openapi/openapi.json`.
 7. If a default plugin version changes, update every matching server catalog requirement and display version. The release inventory validates these values against the package manifest.
 
@@ -161,9 +175,9 @@ uv version --project plugins --package <distribution> <version> --no-sync
 4. Run `uv lock --project plugins`.
 5. Leave every unselected package unchanged.
 
-If the plugin becomes a new core default, publish the plugin before the core release. Then prepare a new core version with its exact pin.
+For a default-catalog plugin, update matching server requirements and display versions in this release-preparation PR. The current inventory validator requires them to match the selected package version. Feature PRs avoid that coupling by leaving both versions and default pins unchanged.
 
-For a coordinated API change, the release PR can contain future core and plugin versions together. Publish the core first, then publish plugins whose dependency requires that new core version. A default pin may reference the queued plugin version; do not tag core until the repository's pending-default behavior is available and verified.
+For a coordinated release, prepare core and plugin versions together. Tag core first. After the core `publish-python` job succeeds and the exact version is available on PyPI, tag dependent plugins. Core deployables and other jobs can continue while plugins publish. A default pin may reference a queued plugin version when the repository's pending-default behavior is available and verified. An independent plugin release uses an already-published compatible core.
 
 ## Patch an existing plugin release line
 
@@ -258,7 +272,7 @@ RELEASE_SHA="$(gh pr view <release-pr> \
   --jq '.mergeCommit.oid')"
 ```
 
-For a coordinated release, order the hand-off as frontend tag and bundle, core tag and publication, dependent plugin tags and publication, then linked skills, docs, website, examples, and other follow-ups. Do not execute these commands during preparation.
+Emit the complete runnable command handoff in the PR and final response, using [publication-handoff.md](references/publication-handoff.md). Group commands by repository and source branch. Include every selected Python plugin, the TypeScript release set when selected, any new frontend release, manual `main` promotion, and the Kitaru skills release handoff. Use accepted versions and exact reviewed commits; do not leave a selected plugin as “repeat for the other plugins.” Do not execute publication commands during preparation.
 
 Push every release tag in its own `git push origin <tag>` command. GitHub does not create push events when more than three tags are pushed at once, which leaves immutable tags without release workflow runs. Do not batch release tags into one push, even when several point to the same commit. After each push, confirm the matching workflow run exists before pushing the next tag.
 
@@ -269,18 +283,18 @@ Manual dispatch builds and validates without publishing.
 Core:
 
 ```bash
-gh workflow run release.yml --ref <release-sha-or-tag> \
+gh workflow run release.yml --repo zenml-io/kitaru --ref <reviewed-branch-or-tag> \
   -f package-tag=python/kitaru/v<python-version>
 ```
 
 Plugin:
 
 ```bash
-gh workflow run release-plugins.yml --ref <release-sha-or-tag> \
+gh workflow run release-plugins.yml --repo zenml-io/kitaru --ref <reviewed-branch-or-tag> \
   -f package-tag=python/<distribution>/v<python-version>
 ```
 
-Inspect the exact run and its artifacts. Confirm that no publishing job ran.
+Use an existing branch or tag that resolves to the reviewed eligible commit. Confirm the run's `headSha` matches that commit, inspect its artifacts, and confirm no publishing job ran.
 
 ## Publish a plugin
 
@@ -301,7 +315,7 @@ For a stable release, the workflow creates or fast-forwards the unit's maintenan
 
 ## Publish core and deployables
 
-Before tagging, verify the selected frontend release and required plugin versions exist.
+Before tagging, verify the selected stable frontend bundle exists and release metadata is complete. Coordinated plugin versions can remain queued when pending-default behavior has been verified.
 
 ```bash
 git fetch origin develop --tags
@@ -321,18 +335,20 @@ The tag starts `.github/workflows/release.yml`. The workflow:
 5. publishes the Helm chart
 6. moves public Docker `latest` aliases only for a stable release
 7. creates the immutable GitHub Release
-8. creates a draft post-release PR that restores `## [Unreleased]`, sets core to `<version>+dev`, and updates both lockfiles and the generated OpenAPI version
+8. creates or fast-forwards the stable maintenance branch
+9. creates a draft post-release PR that restores `## [Unreleased]`, sets core to `<version>+dev`, and updates both lockfiles and the generated OpenAPI version
+
+Dependent plugin tags can be pushed after step 3 succeeds and the exact core package is available on PyPI. They do not wait for the remaining jobs.
 
 For a stable release, fast-forward `main` to the tagged release commit before merging the generated development-reset PR. The reset PR must leave `main` at the clean release version and change only `pyproject.toml`, `uv.lock`, `plugins/uv.lock`, `openapi/openapi.json`, and `CHANGELOG.md` on `develop`.
-8. creates or fast-forwards the stable maintenance branch
 
 Approve required environments only after checking the candidate evidence. A managed-image failure is reported as a warning and does not block public deployables.
 
-Verify each published surface independently. Do not infer one surface from another.
+Verify each published surface independently. Report core PyPI availability, public artifacts, managed-image status, installer smoke, maintenance-branch state, and development-reset status separately. A reset-job failure can make the workflow red after successful artifact publication. Diagnose and report that follow-up failure without describing the already-published artifacts as unpublished.
 
 After the required core and plugin versions are available on PyPI, complete any pending quickstart dependency refresh through a reviewed follow-up PR and rerun its frozen end-to-end test. Report which branch contains that update: the public README links to `main`, and merging a follow-up into `develop` alone does not update the public example. The development-reset PR does not currently refresh the quickstart lockfile.
 
-The workflow does not update `main`. After the newest stable core release succeeds, tell the release owner to move `main` to the immutable core tag without creating a merge commit:
+The workflow does not update `main`. After the newest stable core's public artifacts and GitHub Release succeed, inspect any remaining workflow failure and tell the release owner to fast-forward `main` to the immutable core tag:
 
 ```bash
 git fetch origin main --tags
@@ -344,6 +360,8 @@ gh api --method PATCH repos/zenml-io/kitaru/git/refs/heads/main \
 ```
 
 The release owner runs this command manually. Do not execute it on their behalf. The fast-forward updates `main` to the tagged commit without a merge commit and triggers the existing docs workflow. Skip this step for prereleases and older maintenance-line core releases.
+
+After core and required plugins are available, hand off pending `zenml-io/kitaru-skills` changes to its [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Read the current skill before emitting that repository's commands. It owns the independent skills version, `develop` release commit, tag, `main` promotion, and GitHub Release. Core publication does not itself authorize publishing skills.
 
 ## Curate GitHub Release Notes
 
@@ -387,13 +405,14 @@ Do not delete or move a release tag. Do not reuse a version for different bytes.
 
 1. Inspect the failed step and completed external writes.
 2. Confirm existing artifacts match the immutable tag.
-3. Fix workflow defects through a reviewed PR.
-4. Ask for explicit confirmation before retrying.
-5. Dispatch the matching workflow at the immutable tag:
+3. Determine whether retrying the original job can succeed. A workflow fix on a newer branch does not change the tagged source.
+4. Ask for explicit confirmation before retrying publication.
+5. Rerun the failed jobs of the original tag-triggered run to preserve its event and immutable artifacts:
 
 ```bash
-gh workflow run release.yml --ref <core-tag> -f package-tag=<core-tag>
-gh workflow run release-plugins.yml --ref <plugin-tag> -f package-tag=<plugin-tag>
+gh run rerun <original-run-id> --repo zenml-io/kitaru --failed
 ```
+
+Manual dispatch is a non-publishing rehearsal and cannot finish a failed publication. If recovery needs different package bytes, prepare a new version through a reviewed PR.
 
 Keep credentials, private endpoints, account IDs, and internal infrastructure names out of committed content and PR descriptions.

--- a/.agents/skills/kitaru-release/SKILL.md
+++ b/.agents/skills/kitaru-release/SKILL.md
@@ -96,15 +96,16 @@ Perform this section before the core preparation PR when the core needs a new UI
 1. Inspect `zenml-io/zenml-frontend-monorepo` and select an exact commit on `main`.
 2. Confirm its Kitaru UI checks pass.
 3. Select a stable frontend version input, such as `v0.4.0`, for an official core release.
-4. Ask for explicit confirmation before dispatch because the workflow creates a tag and GitHub Release.
-5. Dispatch the workflow at the selected ref:
+4. Ask for explicit confirmation before publishing.
+5. Emit minimal tag commands for the frontend repository, using [publication-handoff.md](references/publication-handoff.md). Use `HEAD` only when `main` points to the reviewed commit:
 
 ```bash
-gh workflow run release-kitaru-ui.yml \
-  --repo zenml-io/zenml-frontend-monorepo \
-  --ref main \
-  -f version=v0.4.0
+git checkout main
+git tag kitaru-ui-v0.4.0 HEAD
+git push origin kitaru-ui-v0.4.0
 ```
+
+The tag push starts `release-kitaru-ui.yml`.
 
 6. Capture and monitor the exact run:
 
@@ -123,7 +124,7 @@ gh release view kitaru-ui-v0.4.0 \
 
 Require `kitaru-ui.tar.gz` and `kitaru-ui.tar.gz.sha256`. Verify the workflow ran at the reviewed commit and the release is stable. The frontend workflow derives its release channel from whether the selected commit is on `main`; official core releases require a stable bundle.
 
-If the user asks only for a preparation PR, do not dispatch the frontend workflow. The user can explicitly select an expected frontend tag before it exists. Mark asset verification as pending and do not create the core tag until both assets exist.
+If the user asks only for a preparation PR, do not push the frontend tag or dispatch the frontend workflow. The user can explicitly select an expected frontend tag before it exists. Mark asset verification as pending and do not create the core tag until both assets exist.
 
 ## Prepare a core release PR
 
@@ -204,13 +205,11 @@ On the fix branch:
 
 After the maintenance PR merges, resolve its exact merge commit and prepare the namespaced tag command. Do not push the tag without explicit authorization:
 
+Use `HEAD` only when the maintenance branch points to that reviewed commit; otherwise use its literal SHA:
+
 ```bash
-PATCH_SHA="$(gh pr view <patch-pr> \
-  --repo zenml-io/kitaru \
-  --json mergeCommit \
-  --jq '.mergeCommit.oid')"
-git tag -a python/kitaru-langfuse-importer/v0.4.1 "$PATCH_SHA" \
-  -m python/kitaru-langfuse-importer/v0.4.1
+git checkout release/langfuse/0.4
+git tag python/kitaru-langfuse-importer/v0.4.1 HEAD
 git push origin python/kitaru-langfuse-importer/v0.4.1
 ```
 
@@ -263,22 +262,15 @@ Include:
 
 Stop after the PR unless the user explicitly asks to publish.
 
-After the PR merges, resolve its exact merge commit and write tag commands against that SHA:
+After the PR merges, verify its exact merge commit. Prefer `HEAD` in emitted tag commands when the selected branch points to that commit; otherwise fill in the literal reviewed SHA. Keep discovery commands out of the user-facing publication block.
 
-```bash
-RELEASE_SHA="$(gh pr view <release-pr> \
-  --repo zenml-io/kitaru \
-  --json mergeCommit \
-  --jq '.mergeCommit.oid')"
-```
-
-Emit the complete runnable command handoff in the PR and final response, using [publication-handoff.md](references/publication-handoff.md). Group commands by repository and source branch. Include every selected Python plugin, the TypeScript release set when selected, any new frontend release, manual `main` promotion, and the Kitaru skills release handoff. Use accepted versions and exact reviewed commits; do not leave a selected plugin as “repeat for the other plugins.” Do not execute publication commands during preparation.
+Emit the complete minimal, git-only publication command handoff in the PR and final response, using [publication-handoff.md](references/publication-handoff.md). Group commands by repository and source branch. Include every selected Python plugin, the TypeScript release set when selected, any new frontend release, manual `main` promotion, and the Kitaru skills release handoff. Use accepted versions and exact reviewed commits; do not leave a selected plugin as “repeat for the other plugins.” Do not execute publication commands during preparation.
 
 Push every release tag in its own `git push origin <tag>` command. GitHub does not create push events when more than three tags are pushed at once, which leaves immutable tags without release workflow runs. Do not batch release tags into one push, even when several point to the same commit. After each push, confirm the matching workflow run exists before pushing the next tag.
 
 ## Rehearse before publication
 
-Manual dispatch builds and validates without publishing.
+Manual dispatch builds and validates without publishing. These are agent-side rehearsal commands, not part of the user-facing tag handoff.
 
 Core:
 
@@ -300,13 +292,12 @@ Use an existing branch or tag that resolves to the reviewed eligible commit. Con
 
 After the preparation PR merges, select its exact reachable `develop` commit.
 
+Use the branch and commit checks in [publication-handoff.md](references/publication-handoff.md) before emitting:
+
 ```bash
-git fetch origin develop --tags
-TAG="python/<distribution>/v<python-version>"
-RELEASE_SHA="<reviewed-develop-sha>"
-git merge-base --is-ancestor "$RELEASE_SHA" origin/develop
-git tag -a "$TAG" "$RELEASE_SHA" -m "$TAG"
-git push origin "$TAG"
+git checkout develop
+git tag python/<distribution>/v<python-version> HEAD
+git push origin python/<distribution>/v<python-version>
 ```
 
 Approve the package's PyPI environment when required. Verify the wheel, source distribution, hashes, and immutable GitHub Release.
@@ -317,13 +308,12 @@ For a stable release, the workflow creates or fast-forwards the unit's maintenan
 
 Before tagging, verify the selected stable frontend bundle exists and release metadata is complete. Coordinated plugin versions can remain queued when pending-default behavior has been verified.
 
+Use the branch and commit checks in [publication-handoff.md](references/publication-handoff.md) before emitting:
+
 ```bash
-git fetch origin develop --tags
-TAG="python/kitaru/v<python-version>"
-RELEASE_SHA="<reviewed-develop-sha>"
-git merge-base --is-ancestor "$RELEASE_SHA" origin/develop
-git tag -a "$TAG" "$RELEASE_SHA" -m "$TAG"
-git push origin "$TAG"
+git checkout develop
+git tag python/kitaru/v<python-version> HEAD
+git push origin python/kitaru/v<python-version>
 ```
 
 The tag starts `.github/workflows/release.yml`. The workflow:
@@ -350,16 +340,15 @@ After the required core and plugin versions are available on PyPI, complete any 
 
 The workflow does not update `main`. After the newest stable core's public artifacts and GitHub Release succeed, inspect any remaining workflow failure and tell the release owner to fast-forward `main` to the immutable core tag:
 
+Verify the local and remote `main` branches can fast-forward to the tag before emitting:
+
 ```bash
-git fetch origin main --tags
-TAG="python/kitaru/v<python-version>"
-RELEASE_SHA="$(git rev-list -n 1 "$TAG")"
-git merge-base --is-ancestor origin/main "$RELEASE_SHA"
-gh api --method PATCH repos/zenml-io/kitaru/git/refs/heads/main \
-  -f sha="$RELEASE_SHA" -F force=false
+git checkout main
+git merge --ff-only python/kitaru/v<python-version>
+git push origin main
 ```
 
-The release owner runs this command manually. Do not execute it on their behalf. The fast-forward updates `main` to the tagged commit without a merge commit and triggers the existing docs workflow. Skip this step for prereleases and older maintenance-line core releases.
+The release owner runs these commands manually. Do not execute it on their behalf. The fast-forward updates `main` to the tagged commit without a merge commit and triggers the existing docs workflow. Skip this step for prereleases and older maintenance-line core releases.
 
 After core and required plugins are available, hand off pending `zenml-io/kitaru-skills` changes to its [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Read the current skill before emitting that repository's commands. It owns the independent skills version, `develop` release commit, tag, `main` promotion, and GitHub Release. Core publication does not itself authorize publishing skills.
 

--- a/.agents/skills/kitaru-release/references/publication-handoff.md
+++ b/.agents/skills/kitaru-release/references/publication-handoff.md
@@ -1,35 +1,36 @@
 # Publication command handoff
 
-Include the complete command set in both the release PR and the final user-facing response. Fill in all known repository paths, versions, PR numbers, and tag names. Resolve merge SHAs at execution time when the PR is still open; never tag the preparation branch's pre-merge HEAD.
+Include minimal, copy-pasteable `git` commands in both the release PR and the final user-facing response. Name the repository and prerequisite above each block. Fill in the selected branch and every tag; never leave selected plugins as “repeat for the others.”
 
-For each block, state the repository, source branch, target tag, and prerequisite. Use `git -C <verified-checkout>` or an explicit `cd` so the commands cannot silently target another repository. Use `--repo` on every `gh` command. Preserve active checkouts; tag an explicit SHA without checking out a different branch.
+The publication block should only check out the source branch, tag the reviewed commit, and push that tag. Do discovery and safety checks before emitting it; do not include `gh`, API calls, shell variables, or validation boilerplate. These are commands for the release owner, not permission to change their checkout or publish.
 
 ## Ordered release steps
 
-1. **Frontend, when a new bundle is needed.** In `zenml-io/zenml-frontend-monorepo`, verify the reviewed `main` commit and emit the actual `release-kitaru-ui.yml` dispatch command with the selected version. The workflow creates the UI tag; do not also emit a manual tag push. Include run and asset verification. An existing selected bundle needs verification only.
-2. **Core.** In `zenml-io/kitaru`, resolve the release PR's merge SHA on `develop` (or the exact core maintenance branch). Emit the core tag and push commands.
+1. **Frontend, when a new bundle is needed.** In `zenml-io/zenml-frontend-monorepo`, verify the reviewed `main` commit and emit checkout, `kitaru-ui-v<version>` tag, and push commands. The tag push starts `release-kitaru-ui.yml`. Verify the resulting run and assets before tagging core. An existing selected bundle needs verification only.
+2. **Core.** In `zenml-io/kitaru`, verify the release PR's merge commit on `develop` (or the exact core maintenance branch). Emit the core tag and push commands.
 3. **Core PyPI gate.** Identify the exact core run. Wait for its `publish-python` job to succeed and verify `https://pypi.org/pypi/kitaru/<version>/json`. Dependent plugin publication can then proceed while images, Helm, and other core jobs continue.
-4. **Every selected Python plugin.** Emit each full namespaced tag and its individual push command at the reviewed release SHA. Independent plugin releases use an already-published compatible core and need no new core tag.
-5. **TypeScript, when selected.** Read `release/typescript.md`. Emit the rehearsal and one `typescript/kitaru/v<version>` tag for the entire lockstep set on the exact reviewed `develop` commit. Identify any core API availability prerequisite. Do not create separate tags for the three npm packages.
+4. **Every selected Python plugin.** Emit each full namespaced tag and its individual push command at the reviewed release commit. Independent plugin releases use an already-published compatible core and need no new core tag.
+5. **TypeScript, when selected.** Read `release/typescript.md`. Complete the required rehearsal separately, then emit one `typescript/kitaru/v<version>` tag for the entire lockstep set on the reviewed `develop` commit. Identify any core API availability prerequisite. Do not create separate tags for the three npm packages.
 6. **Stable core completion.** Verify the core's public artifacts and GitHub Release. Emit the manual, non-forced `main` fast-forward to the immutable core tag. Report maintenance/reset failures separately and resolve outstanding release failures before calling the release complete.
 7. **Development reset and quickstart.** Link the generated reset PR and state that `main` must contain the stable tag before it merges. Identify the reviewed quickstart dependency/lockfile follow-up and its frozen E2E check. Report whether it has reached the public example on `main`.
-8. **Kitaru skills.** After the required core/plugin versions are published, link and read the current [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Emit its commands only after the independent skills version and reviewed release commit are selected. Its source is `develop`; its distribution branch is `main`. Do not reuse the core version or SHA. If its version or preparation is unresolved, give the exact handoff and missing choice instead of inventing a tag.
+8. **Kitaru skills.** After the required core/plugin versions are published, link and read the current [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Provide minimal git tag commands only after the independent skills version and reviewed release commit are selected; link the skill for its other release steps. Its source is `develop`; its distribution branch is `main`. Do not reuse the core version or SHA. If its version or preparation is unresolved, give the exact handoff and missing choice instead of inventing a tag.
 9. **Other follow-ups.** Link selected docs, website, examples, and release-note work with their remaining action.
 
-## Python tag block
+## Tag command block
 
-Use this structure with concrete values for every selected tag:
+Run in the named repository. Use this structure with concrete values:
 
 ```bash
-git -C <kitaru-checkout> fetch origin <source-branch> --tags
-RELEASE_SHA="$(gh pr view <release-pr> --repo zenml-io/kitaru --json mergeCommit --jq '.mergeCommit.oid')"
-test -n "$RELEASE_SHA" && test "$RELEASE_SHA" != null
-git -C <kitaru-checkout> merge-base --is-ancestor "$RELEASE_SHA" origin/<source-branch>
-git -C <kitaru-checkout> tag -a <exact-tag> "$RELEASE_SHA" -m <exact-tag>
-git -C <kitaru-checkout> push origin <exact-tag>
+git checkout develop
+git tag <exact-tag> HEAD
+git push origin <exact-tag>
 ```
 
-A maintenance release uses its matching `release/<unit>/<major.minor>` branch and maintenance PR. Check that the tag is unused before offering its creation command. For an existing tag, emit verification or recovery commands instead.
+Use `main` for the frontend and the matching maintenance branch for a maintenance release. Prefer `HEAD` when the checked-out branch points to the reviewed release commit. Verify that condition first. If the local branch is behind, include `git pull --ff-only origin <source-branch>` after checkout only when it brings the branch to that commit. If the branch has advanced, replace `HEAD` with the literal reviewed SHA. If the release PR is still open, state that it must merge and its release commit must be verified before these commands run; never tag the preparation branch's pre-merge HEAD.
+
+For multiple tags in one repository and branch, check out the branch once, then emit one tag/push pair for each selected release. Separate dependent plugin pairs from the core pair with the PyPI gate.
+
+A maintenance release uses its matching `release/<unit>/<major.minor>` branch and maintenance PR. Check that the tag is unused before offering its creation command. For an existing tag, give its status and the recovery handoff; do not recreate or move it.
 
 Push one tag per command. Confirm the matching workflow run exists after each push. For plugins in the same release set, subsequent tag pushes need not wait for the preceding plugin workflow to finish.
 
@@ -40,5 +41,12 @@ Separate the two decision points:
 - **Dependent plugins may publish:** the core PyPI job succeeded and the exact core version is available.
 - **Stable core may be promoted to main:** required public publication jobs and GitHub Release succeeded; inspect remaining workflow failures explicitly.
 
-The managed-image step is warning-only. Installer smoke can fail without preventing artifact publication. Development-reset failure also occurs after publication; it needs repair but does not undo existing artifacts. Emit commands against the immutable core tag for `main` promotion, with an ancestry check and `force=false`, as specified in the release skill.
+The managed-image step is warning-only. Installer smoke can fail without preventing artifact publication. Development-reset failure also occurs after publication; it needs repair but does not undo existing artifacts. After verifying that local and remote `main` can fast-forward to the immutable stable core tag, emit:
 
+```bash
+git checkout main
+git merge --ff-only <exact-core-tag>
+git push origin main
+```
+
+Use the literal core tag. Do not force-push or reset away unrelated work.

--- a/.agents/skills/kitaru-release/references/publication-handoff.md
+++ b/.agents/skills/kitaru-release/references/publication-handoff.md
@@ -1,0 +1,44 @@
+# Publication command handoff
+
+Include the complete command set in both the release PR and the final user-facing response. Fill in all known repository paths, versions, PR numbers, and tag names. Resolve merge SHAs at execution time when the PR is still open; never tag the preparation branch's pre-merge HEAD.
+
+For each block, state the repository, source branch, target tag, and prerequisite. Use `git -C <verified-checkout>` or an explicit `cd` so the commands cannot silently target another repository. Use `--repo` on every `gh` command. Preserve active checkouts; tag an explicit SHA without checking out a different branch.
+
+## Ordered release steps
+
+1. **Frontend, when a new bundle is needed.** In `zenml-io/zenml-frontend-monorepo`, verify the reviewed `main` commit and emit the actual `release-kitaru-ui.yml` dispatch command with the selected version. The workflow creates the UI tag; do not also emit a manual tag push. Include run and asset verification. An existing selected bundle needs verification only.
+2. **Core.** In `zenml-io/kitaru`, resolve the release PR's merge SHA on `develop` (or the exact core maintenance branch). Emit the core tag and push commands.
+3. **Core PyPI gate.** Identify the exact core run. Wait for its `publish-python` job to succeed and verify `https://pypi.org/pypi/kitaru/<version>/json`. Dependent plugin publication can then proceed while images, Helm, and other core jobs continue.
+4. **Every selected Python plugin.** Emit each full namespaced tag and its individual push command at the reviewed release SHA. Independent plugin releases use an already-published compatible core and need no new core tag.
+5. **TypeScript, when selected.** Read `release/typescript.md`. Emit the rehearsal and one `typescript/kitaru/v<version>` tag for the entire lockstep set on the exact reviewed `develop` commit. Identify any core API availability prerequisite. Do not create separate tags for the three npm packages.
+6. **Stable core completion.** Verify the core's public artifacts and GitHub Release. Emit the manual, non-forced `main` fast-forward to the immutable core tag. Report maintenance/reset failures separately and resolve outstanding release failures before calling the release complete.
+7. **Development reset and quickstart.** Link the generated reset PR and state that `main` must contain the stable tag before it merges. Identify the reviewed quickstart dependency/lockfile follow-up and its frozen E2E check. Report whether it has reached the public example on `main`.
+8. **Kitaru skills.** After the required core/plugin versions are published, link and read the current [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Emit its commands only after the independent skills version and reviewed release commit are selected. Its source is `develop`; its distribution branch is `main`. Do not reuse the core version or SHA. If its version or preparation is unresolved, give the exact handoff and missing choice instead of inventing a tag.
+9. **Other follow-ups.** Link selected docs, website, examples, and release-note work with their remaining action.
+
+## Python tag block
+
+Use this structure with concrete values for every selected tag:
+
+```bash
+git -C <kitaru-checkout> fetch origin <source-branch> --tags
+RELEASE_SHA="$(gh pr view <release-pr> --repo zenml-io/kitaru --json mergeCommit --jq '.mergeCommit.oid')"
+test -n "$RELEASE_SHA" && test "$RELEASE_SHA" != null
+git -C <kitaru-checkout> merge-base --is-ancestor "$RELEASE_SHA" origin/<source-branch>
+git -C <kitaru-checkout> tag -a <exact-tag> "$RELEASE_SHA" -m <exact-tag>
+git -C <kitaru-checkout> push origin <exact-tag>
+```
+
+A maintenance release uses its matching `release/<unit>/<major.minor>` branch and maintenance PR. Check that the tag is unused before offering its creation command. For an existing tag, emit verification or recovery commands instead.
+
+Push one tag per command. Confirm the matching workflow run exists after each push. For plugins in the same release set, subsequent tag pushes need not wait for the preceding plugin workflow to finish.
+
+## Core publication status
+
+Separate the two decision points:
+
+- **Dependent plugins may publish:** the core PyPI job succeeded and the exact core version is available.
+- **Stable core may be promoted to main:** required public publication jobs and GitHub Release succeeded; inspect remaining workflow failures explicitly.
+
+The managed-image step is warning-only. Installer smoke can fail without preventing artifact publication. Development-reset failure also occurs after publication; it needs repair but does not undo existing artifacts. Emit commands against the immutable core tag for `main` promotion, with an ancestry check and `force=false`, as specified in the release skill.
+

--- a/.agents/skills/kitaru-tests-release/SKILL.md
+++ b/.agents/skills/kitaru-tests-release/SKILL.md
@@ -49,7 +49,7 @@ Use the PostgreSQL-backed tests for transaction, locking, migration, or cross-re
 - Run `just plugin-artifact-smoke` after changing plugin package metadata, default definitions, requirement pins, or release installation paths.
 - The smoke builds Kitaru and every selected plugin as wheels, installs them into a clean environment, loads each configured package entrypoint, and verifies idempotent default registration.
 - CI runs plugin distributions as a package matrix. Keep the matrix aligned with `plugins/packages/` and the choices in `.github/workflows/release-plugins.yml`.
-- Plugin workflow dispatches are dry-runs. A package tag triggers publishing only when its commit is contained in `main`.
+- Plugin workflow dispatches are dry-runs. Package tags publish from reviewed commits reachable from `develop` or the unit's matching maintenance branch. Dependent plugins wait for core PyPI availability; other core jobs can continue.
 - Kitaru release dry-runs build plugin-owned candidate images from `plugins/candidate-wheels`; production release Dockerfiles continue to install exact versions from PyPI.
 - Commit `plugins/candidate.Dockerfile` and `plugins/docker-compose.candidate.yml`. Do not commit generated files under `plugins/candidate-wheels/`.
 - Keep production release Dockerfiles unchanged when a plugin change only needs local candidate-wheel testing.
@@ -101,9 +101,9 @@ Do not describe the inherited `llm-integration.yml` provider markers or absent `
 
 Use `.agents/skills/kitaru-release/SKILL.md` for the release interview, metadata edits, validation, and preparation PR. Keep this skill focused on selecting and running test surfaces.
 
-`.github/workflows/release-plugins.yml` publishes one Python distribution from an immutable namespaced tag. A core tag such as `python/kitaru/v0.22.0rc1` publishes Kitaru to PyPI and creates its GitHub Release. Plugin tags publish independently and do not gate the core release.
+`.github/workflows/release.yml` handles the core tag `python/kitaru/v<VERSION>`. It publishes Kitaru to PyPI, then publishes client, server, worker, and managed images plus Helm, and creates the GitHub Release. Python RC versions such as `0.22.0rc1` become deployable tags such as `0.22.0-rc.1`. There is no separate bundle tag.
 
-After a successful core Python workflow, `.github/workflows/release.yml` automatically publishes the matching client, server, worker, and managed images plus the Helm chart. It converts Python RC versions such as `0.22.0rc1` to deployable tags such as `0.22.0-rc.1`. No separate bundle tag is used. A manual dispatch with the existing core package tag is the recovery path.
+`.github/workflows/release-plugins.yml` handles one Python plugin distribution per namespaced tag. In a coordinated release, dependent plugin tags follow successful core PyPI publication. They can publish while core deployables and post-release jobs continue. Independent plugins use an already-published compatible core.
 
 `.github/workflows/release-typescript.yml` publishes `@zenml-io/kitaru`, `@zenml-io/kitaru-mastra`, and `@zenml-io/kitaru-vercel-ai` together from an immutable `typescript/kitaru/v<VERSION>` tag. Read `release/typescript.md` before preparing or recovering a TypeScript release. Manual dispatch is a non-publishing rehearsal; pushing the tag publishes the tested tarballs, waits for npm publish-time scanning, verifies a clean registry install, and creates the GitHub Release. The three packages use one lockstep stable or `-rc.N` version.
 
@@ -115,9 +115,9 @@ Before creating a core tag:
 4. Confirm no other release run is active.
 5. After changing the core version, run `uv run python scripts/generate_openapi.py` and commit the updated `openapi/openapi.json`.
 6. Run `just check`, the relevant base/CLI/MCP tests, `just mcp-schema-check`, `just cli-artifact-smoke`, `just plugin-artifact-smoke`, `just migration-check`, and `just build` as applicable. Run `just mcp-wheel-smoke` only after `just build`; it consumes the wheel under `dist/`.
-7. Dispatch `release-plugins.yml` with the proposed package tag when a non-publishing rehearsal is needed.
+7. Dispatch `release.yml` with the proposed core tag when a non-publishing rehearsal is needed. Use `release-plugins.yml` for a plugin rehearsal.
 
-The core Python workflow builds and verifies the wheel, publishes it to PyPI, and creates the GitHub Release. The deployables workflow then verifies the core package, tests the release images, publishes the images and Helm chart, and attaches the chart to the core GitHub Release. Stable releases also move the Docker `latest` aliases.
+Stable core releases move the public Docker `latest` aliases, advance the core maintenance branch, and create a draft development-reset PR. The release owner fast-forwards `main` to the immutable core tag before merging the reset into `develop`. Report PyPI publication, public deployables, managed-image warnings, installer smoke, maintenance state, and reset state separately. A reset failure can leave the workflow red after artifact publication succeeds.
 
 Do not use the removed `scripts/smoke-test.sh`, provider-area flags, remote-stack smoke, v1 adapters, or local ZenML flow runs as v2 release gates.
 
@@ -126,8 +126,8 @@ Do not use the removed `scripts/smoke-test.sh`, provider-area flags, remote-stac
 - Default branch is `develop`.
 - Pull requests normally target `develop`; v2 feature work may target its explicit integration branch until that migration lands.
 - `main` tracks the latest released version only; do not push directly.
-- Python releases are cut with namespaced tags handled by `.github/workflows/release-plugins.yml`.
+- Python core and plugin releases use namespaced tags handled by `release.yml` and `release-plugins.yml`, respectively.
 - TypeScript releases are cut with `typescript/kitaru/v<VERSION>` tags handled by `.github/workflows/release-typescript.yml`; rehearse the exact tag through manual dispatch before pushing it.
-- A successful core Python release automatically starts `.github/workflows/release.yml`; manual dispatch is reserved for recovery.
+- A core tag directly starts `.github/workflows/release.yml`. Manual dispatch rehearses without publishing; recover publication by inspecting and rerunning the original failed jobs with the same immutable artifacts.
 - Release preparation maintains the version in `pyproject.toml`; application code should use `importlib.metadata.version("kitaru")` rather than hardcoding it.
 - Update `CHANGELOG.md` under `[Unreleased]` for user-facing changes.

--- a/.claude/skills/kitaru-adapter-development/SKILL.md
+++ b/.claude/skills/kitaru-adapter-development/SKILL.md
@@ -25,6 +25,8 @@ Preserve the framework's ordinary behavior, configured hooks and state, public e
 
 ## Package and documentation work
 
+Python feature PRs follow the version and dependency ownership rules in `plugins/AGENTS.md`. Leave existing package versions unchanged. Use the exact development dependency from `plugins/DEVELOPMENT.md` only when the adapter needs unreleased core; release prep selects the published compatibility floor.
+
 For a new Python adapter, inspect the current package inventory and update only the required integration points:
 
 - `plugins/packages/<slug>/pyproject.toml`, README, changelog, source package, public exports, and focused tests

--- a/.claude/skills/kitaru-importer-development/SKILL.md
+++ b/.claude/skills/kitaru-importer-development/SKILL.md
@@ -33,6 +33,8 @@ An importer package for a provider with a live read API can also ship an importe
 
 ## Package, register, and version
 
+For feature PRs, follow the version and dependency ownership rules in `plugins/AGENTS.md`. Leave existing package versions and default pins unchanged. Record unreleased core requirements with the exact development dependency described in `plugins/DEVELOPMENT.md`; release prep selects and replaces release versions.
+
 An importer distribution lives under `plugins/packages/<slug>-importer/`, with its source, `pyproject.toml`, changelog, and focused tests under `plugins/tests/importers/`. Export `parse` through the package `__all__`. Add the package to `plugins/README.md`, `release/release-units.toml`, the exact inventory in `tests/scripts/test_release_units.py`, and `plugins/uv.lock`. A non-default package also declares `tool.kitaru.artifact.import-module` so artifact smoke can import it without a default-catalog entry.
 
 Use `kitaru importer scaffold` and `kitaru importer test` for bounded local scripts. Register an in-progress self-contained implementation with `kitaru importer register ... --script ... --entrypoint ...`. Use an exact package requirement when validation must cover wheel installation. Registration creates remote state, is not idempotent, and needs an explicit server plus a worker that can resolve the source. Do not run it without authorization. The package's PyPI version and Kitaru's server-assigned importer version are separate: use `kitaru importer version register` for each new immutable registered implementation, and never mutate the behavior behind an existing version.

--- a/.claude/skills/kitaru-release/SKILL.md
+++ b/.claude/skills/kitaru-release/SKILL.md
@@ -9,8 +9,10 @@ Use the current workflows as the source of truth:
 
 - Core: `.github/workflows/release.yml`
 - Plugins: `.github/workflows/release-plugins.yml`
-- Package inventory: `release/release-units.toml`
+- Python package inventory: `release/release-units.toml`
+- TypeScript release set: `release/typescript.md` and `.github/workflows/release-typescript.yml`
 - Frontend: `zenml-io/zenml-frontend-monorepo/.github/workflows/release-kitaru-ui.yml`
+- Follow-up skills release: [skills-release](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md)
 
 Read `AGENTS.md`. Read `plugins/AGENTS.md` and `plugins/DEVELOPMENT.md` for plugin changes. Read `FRONTEND-TESTING.md` for core or UI work.
 
@@ -63,6 +65,18 @@ Before editing, rerun the command with `--candidate <proposed-version>` and requ
 
 Propose explicit versions and changelog entries after discovery. Check PyPI versions and Git tags before proposing a version, and never reuse a published version. Get the user's acceptance before editing release metadata.
 
+## Separate implementation from release preparation
+
+Feature PRs leave existing plugin package versions and server default requirements/display versions unchanged. Put behavior changes in the package's `Unreleased` changelog section. The release-preparation PR selects package versions and updates all matching default-catalog metadata together. New packages require initial metadata, but becoming a server default remains an explicit release decision.
+
+Follow the development dependency policy in `plugins/DEVELOPMENT.md`. Plugins compatible with published core keep their supported minimum. A plugin requiring unreleased core uses an exact dependency on the current root development version, such as `kitaru==0.25.0+dev`, and records the needed core change in `Release context`.
+
+Before changing core to its selected release version, inspect every plugin's core dependency. Replace each resolved development pin with the selected compatible release floor, such as `kitaru>=0.26.0`, preserving extras and compatible upper bounds. Do not guess the future version in the feature PR. An unresolved development pin blocks release preparation; account for every affected plugin and its publication timing. A plugin-only release can replace the pin only when a published core contains the required change.
+
+Regenerate `plugins/uv.lock` after these conversions. Verify the selected wheels' `Requires-Dist` metadata contains no development placeholder or local checkout dependency before handing over publication commands.
+
+Inspect the TypeScript packages separately from the Python inventory. Include their lockstep release when their changes require publication. Inspect the Kitaru skills repository for a pending release and record its own version and compatibility requirements.
+
 ## Apply version rules
 
 - Use canonical PEP 440 for Python: `X.Y.Z` or `X.Y.ZrcN`.
@@ -81,7 +95,7 @@ Perform this section before the core preparation PR when the core needs a new UI
 
 1. Inspect `zenml-io/zenml-frontend-monorepo` and select an exact commit on `main`.
 2. Confirm its Kitaru UI checks pass.
-3. Select the frontend version input, such as `v0.2.0-rc.4`.
+3. Select a stable frontend version input, such as `v0.4.0`, for an official core release.
 4. Ask for explicit confirmation before dispatch because the workflow creates a tag and GitHub Release.
 5. Dispatch the workflow at the selected ref:
 
@@ -89,7 +103,7 @@ Perform this section before the core preparation PR when the core needs a new UI
 gh workflow run release-kitaru-ui.yml \
   --repo zenml-io/zenml-frontend-monorepo \
   --ref main \
-  -f version=v0.2.0-rc.4
+  -f version=v0.4.0
 ```
 
 6. Capture and monitor the exact run:
@@ -103,11 +117,11 @@ gh run view <run-id> --repo zenml-io/zenml-frontend-monorepo
 7. Verify the release tag and both assets:
 
 ```bash
-gh release view kitaru-ui-v0.2.0-rc.4 \
+gh release view kitaru-ui-v0.4.0 \
   --repo zenml-io/zenml-frontend-monorepo
 ```
 
-Require `kitaru-ui.tar.gz` and `kitaru-ui.tar.gz.sha256`. The frontend workflow builds with the selected version, creates both files, and publishes a prerelease.
+Require `kitaru-ui.tar.gz` and `kitaru-ui.tar.gz.sha256`. Verify the workflow ran at the reviewed commit and the release is stable. The frontend workflow derives its release channel from whether the selected commit is on `main`; official core releases require a stable bundle.
 
 If the user asks only for a preparation PR, do not dispatch the frontend workflow. The user can explicitly select an expected frontend tag before it exists. Mark asset verification as pending and do not create the core tag until both assets exist.
 
@@ -126,7 +140,7 @@ kitaru-version = "<python-version>"
 ui-tag = "<kitaru-ui-tag>"
 ```
 
-5. Run `uv lock`. Keep unrelated `exclude-newer` timestamp churn out of the diff.
+5. Resolve plugin development dependencies to the selected core version, then run `uv lock` and `uv lock --project plugins`. Keep unrelated `exclude-newer` timestamp churn out of the diff.
 6. Run `uv run python scripts/generate_openapi.py` and commit `openapi/openapi.json`.
 7. If a default plugin version changes, update every matching server catalog requirement and display version. The release inventory validates these values against the package manifest.
 
@@ -161,9 +175,9 @@ uv version --project plugins --package <distribution> <version> --no-sync
 4. Run `uv lock --project plugins`.
 5. Leave every unselected package unchanged.
 
-If the plugin becomes a new core default, publish the plugin before the core release. Then prepare a new core version with its exact pin.
+For a default-catalog plugin, update matching server requirements and display versions in this release-preparation PR. The current inventory validator requires them to match the selected package version. Feature PRs avoid that coupling by leaving both versions and default pins unchanged.
 
-For a coordinated API change, the release PR can contain future core and plugin versions together. Publish the core first, then publish plugins whose dependency requires that new core version. A default pin may reference the queued plugin version; do not tag core until the repository's pending-default behavior is available and verified.
+For a coordinated release, prepare core and plugin versions together. Tag core first. After the core `publish-python` job succeeds and the exact version is available on PyPI, tag dependent plugins. Core deployables and other jobs can continue while plugins publish. A default pin may reference a queued plugin version when the repository's pending-default behavior is available and verified. An independent plugin release uses an already-published compatible core.
 
 ## Patch an existing plugin release line
 
@@ -258,7 +272,7 @@ RELEASE_SHA="$(gh pr view <release-pr> \
   --jq '.mergeCommit.oid')"
 ```
 
-For a coordinated release, order the hand-off as frontend tag and bundle, core tag and publication, dependent plugin tags and publication, then linked skills, docs, website, examples, and other follow-ups. Do not execute these commands during preparation.
+Emit the complete runnable command handoff in the PR and final response, using [publication-handoff.md](references/publication-handoff.md). Group commands by repository and source branch. Include every selected Python plugin, the TypeScript release set when selected, any new frontend release, manual `main` promotion, and the Kitaru skills release handoff. Use accepted versions and exact reviewed commits; do not leave a selected plugin as “repeat for the other plugins.” Do not execute publication commands during preparation.
 
 Push every release tag in its own `git push origin <tag>` command. GitHub does not create push events when more than three tags are pushed at once, which leaves immutable tags without release workflow runs. Do not batch release tags into one push, even when several point to the same commit. After each push, confirm the matching workflow run exists before pushing the next tag.
 
@@ -269,18 +283,18 @@ Manual dispatch builds and validates without publishing.
 Core:
 
 ```bash
-gh workflow run release.yml --ref <release-sha-or-tag> \
+gh workflow run release.yml --repo zenml-io/kitaru --ref <reviewed-branch-or-tag> \
   -f package-tag=python/kitaru/v<python-version>
 ```
 
 Plugin:
 
 ```bash
-gh workflow run release-plugins.yml --ref <release-sha-or-tag> \
+gh workflow run release-plugins.yml --repo zenml-io/kitaru --ref <reviewed-branch-or-tag> \
   -f package-tag=python/<distribution>/v<python-version>
 ```
 
-Inspect the exact run and its artifacts. Confirm that no publishing job ran.
+Use an existing branch or tag that resolves to the reviewed eligible commit. Confirm the run's `headSha` matches that commit, inspect its artifacts, and confirm no publishing job ran.
 
 ## Publish a plugin
 
@@ -301,7 +315,7 @@ For a stable release, the workflow creates or fast-forwards the unit's maintenan
 
 ## Publish core and deployables
 
-Before tagging, verify the selected frontend release and required plugin versions exist.
+Before tagging, verify the selected stable frontend bundle exists and release metadata is complete. Coordinated plugin versions can remain queued when pending-default behavior has been verified.
 
 ```bash
 git fetch origin develop --tags
@@ -321,18 +335,20 @@ The tag starts `.github/workflows/release.yml`. The workflow:
 5. publishes the Helm chart
 6. moves public Docker `latest` aliases only for a stable release
 7. creates the immutable GitHub Release
-8. creates a draft post-release PR that restores `## [Unreleased]`, sets core to `<version>+dev`, and updates both lockfiles and the generated OpenAPI version
+8. creates or fast-forwards the stable maintenance branch
+9. creates a draft post-release PR that restores `## [Unreleased]`, sets core to `<version>+dev`, and updates both lockfiles and the generated OpenAPI version
+
+Dependent plugin tags can be pushed after step 3 succeeds and the exact core package is available on PyPI. They do not wait for the remaining jobs.
 
 For a stable release, fast-forward `main` to the tagged release commit before merging the generated development-reset PR. The reset PR must leave `main` at the clean release version and change only `pyproject.toml`, `uv.lock`, `plugins/uv.lock`, `openapi/openapi.json`, and `CHANGELOG.md` on `develop`.
-8. creates or fast-forwards the stable maintenance branch
 
 Approve required environments only after checking the candidate evidence. A managed-image failure is reported as a warning and does not block public deployables.
 
-Verify each published surface independently. Do not infer one surface from another.
+Verify each published surface independently. Report core PyPI availability, public artifacts, managed-image status, installer smoke, maintenance-branch state, and development-reset status separately. A reset-job failure can make the workflow red after successful artifact publication. Diagnose and report that follow-up failure without describing the already-published artifacts as unpublished.
 
 After the required core and plugin versions are available on PyPI, complete any pending quickstart dependency refresh through a reviewed follow-up PR and rerun its frozen end-to-end test. Report which branch contains that update: the public README links to `main`, and merging a follow-up into `develop` alone does not update the public example. The development-reset PR does not currently refresh the quickstart lockfile.
 
-The workflow does not update `main`. After the newest stable core release succeeds, tell the release owner to move `main` to the immutable core tag without creating a merge commit:
+The workflow does not update `main`. After the newest stable core's public artifacts and GitHub Release succeed, inspect any remaining workflow failure and tell the release owner to fast-forward `main` to the immutable core tag:
 
 ```bash
 git fetch origin main --tags
@@ -344,6 +360,8 @@ gh api --method PATCH repos/zenml-io/kitaru/git/refs/heads/main \
 ```
 
 The release owner runs this command manually. Do not execute it on their behalf. The fast-forward updates `main` to the tagged commit without a merge commit and triggers the existing docs workflow. Skip this step for prereleases and older maintenance-line core releases.
+
+After core and required plugins are available, hand off pending `zenml-io/kitaru-skills` changes to its [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Read the current skill before emitting that repository's commands. It owns the independent skills version, `develop` release commit, tag, `main` promotion, and GitHub Release. Core publication does not itself authorize publishing skills.
 
 ## Curate GitHub Release Notes
 
@@ -387,13 +405,14 @@ Do not delete or move a release tag. Do not reuse a version for different bytes.
 
 1. Inspect the failed step and completed external writes.
 2. Confirm existing artifacts match the immutable tag.
-3. Fix workflow defects through a reviewed PR.
-4. Ask for explicit confirmation before retrying.
-5. Dispatch the matching workflow at the immutable tag:
+3. Determine whether retrying the original job can succeed. A workflow fix on a newer branch does not change the tagged source.
+4. Ask for explicit confirmation before retrying publication.
+5. Rerun the failed jobs of the original tag-triggered run to preserve its event and immutable artifacts:
 
 ```bash
-gh workflow run release.yml --ref <core-tag> -f package-tag=<core-tag>
-gh workflow run release-plugins.yml --ref <plugin-tag> -f package-tag=<plugin-tag>
+gh run rerun <original-run-id> --repo zenml-io/kitaru --failed
 ```
+
+Manual dispatch is a non-publishing rehearsal and cannot finish a failed publication. If recovery needs different package bytes, prepare a new version through a reviewed PR.
 
 Keep credentials, private endpoints, account IDs, and internal infrastructure names out of committed content and PR descriptions.

--- a/.claude/skills/kitaru-release/SKILL.md
+++ b/.claude/skills/kitaru-release/SKILL.md
@@ -96,15 +96,16 @@ Perform this section before the core preparation PR when the core needs a new UI
 1. Inspect `zenml-io/zenml-frontend-monorepo` and select an exact commit on `main`.
 2. Confirm its Kitaru UI checks pass.
 3. Select a stable frontend version input, such as `v0.4.0`, for an official core release.
-4. Ask for explicit confirmation before dispatch because the workflow creates a tag and GitHub Release.
-5. Dispatch the workflow at the selected ref:
+4. Ask for explicit confirmation before publishing.
+5. Emit minimal tag commands for the frontend repository, using [publication-handoff.md](references/publication-handoff.md). Use `HEAD` only when `main` points to the reviewed commit:
 
 ```bash
-gh workflow run release-kitaru-ui.yml \
-  --repo zenml-io/zenml-frontend-monorepo \
-  --ref main \
-  -f version=v0.4.0
+git checkout main
+git tag kitaru-ui-v0.4.0 HEAD
+git push origin kitaru-ui-v0.4.0
 ```
+
+The tag push starts `release-kitaru-ui.yml`.
 
 6. Capture and monitor the exact run:
 
@@ -123,7 +124,7 @@ gh release view kitaru-ui-v0.4.0 \
 
 Require `kitaru-ui.tar.gz` and `kitaru-ui.tar.gz.sha256`. Verify the workflow ran at the reviewed commit and the release is stable. The frontend workflow derives its release channel from whether the selected commit is on `main`; official core releases require a stable bundle.
 
-If the user asks only for a preparation PR, do not dispatch the frontend workflow. The user can explicitly select an expected frontend tag before it exists. Mark asset verification as pending and do not create the core tag until both assets exist.
+If the user asks only for a preparation PR, do not push the frontend tag or dispatch the frontend workflow. The user can explicitly select an expected frontend tag before it exists. Mark asset verification as pending and do not create the core tag until both assets exist.
 
 ## Prepare a core release PR
 
@@ -204,13 +205,11 @@ On the fix branch:
 
 After the maintenance PR merges, resolve its exact merge commit and prepare the namespaced tag command. Do not push the tag without explicit authorization:
 
+Use `HEAD` only when the maintenance branch points to that reviewed commit; otherwise use its literal SHA:
+
 ```bash
-PATCH_SHA="$(gh pr view <patch-pr> \
-  --repo zenml-io/kitaru \
-  --json mergeCommit \
-  --jq '.mergeCommit.oid')"
-git tag -a python/kitaru-langfuse-importer/v0.4.1 "$PATCH_SHA" \
-  -m python/kitaru-langfuse-importer/v0.4.1
+git checkout release/langfuse/0.4
+git tag python/kitaru-langfuse-importer/v0.4.1 HEAD
 git push origin python/kitaru-langfuse-importer/v0.4.1
 ```
 
@@ -263,22 +262,15 @@ Include:
 
 Stop after the PR unless the user explicitly asks to publish.
 
-After the PR merges, resolve its exact merge commit and write tag commands against that SHA:
+After the PR merges, verify its exact merge commit. Prefer `HEAD` in emitted tag commands when the selected branch points to that commit; otherwise fill in the literal reviewed SHA. Keep discovery commands out of the user-facing publication block.
 
-```bash
-RELEASE_SHA="$(gh pr view <release-pr> \
-  --repo zenml-io/kitaru \
-  --json mergeCommit \
-  --jq '.mergeCommit.oid')"
-```
-
-Emit the complete runnable command handoff in the PR and final response, using [publication-handoff.md](references/publication-handoff.md). Group commands by repository and source branch. Include every selected Python plugin, the TypeScript release set when selected, any new frontend release, manual `main` promotion, and the Kitaru skills release handoff. Use accepted versions and exact reviewed commits; do not leave a selected plugin as “repeat for the other plugins.” Do not execute publication commands during preparation.
+Emit the complete minimal, git-only publication command handoff in the PR and final response, using [publication-handoff.md](references/publication-handoff.md). Group commands by repository and source branch. Include every selected Python plugin, the TypeScript release set when selected, any new frontend release, manual `main` promotion, and the Kitaru skills release handoff. Use accepted versions and exact reviewed commits; do not leave a selected plugin as “repeat for the other plugins.” Do not execute publication commands during preparation.
 
 Push every release tag in its own `git push origin <tag>` command. GitHub does not create push events when more than three tags are pushed at once, which leaves immutable tags without release workflow runs. Do not batch release tags into one push, even when several point to the same commit. After each push, confirm the matching workflow run exists before pushing the next tag.
 
 ## Rehearse before publication
 
-Manual dispatch builds and validates without publishing.
+Manual dispatch builds and validates without publishing. These are agent-side rehearsal commands, not part of the user-facing tag handoff.
 
 Core:
 
@@ -300,13 +292,12 @@ Use an existing branch or tag that resolves to the reviewed eligible commit. Con
 
 After the preparation PR merges, select its exact reachable `develop` commit.
 
+Use the branch and commit checks in [publication-handoff.md](references/publication-handoff.md) before emitting:
+
 ```bash
-git fetch origin develop --tags
-TAG="python/<distribution>/v<python-version>"
-RELEASE_SHA="<reviewed-develop-sha>"
-git merge-base --is-ancestor "$RELEASE_SHA" origin/develop
-git tag -a "$TAG" "$RELEASE_SHA" -m "$TAG"
-git push origin "$TAG"
+git checkout develop
+git tag python/<distribution>/v<python-version> HEAD
+git push origin python/<distribution>/v<python-version>
 ```
 
 Approve the package's PyPI environment when required. Verify the wheel, source distribution, hashes, and immutable GitHub Release.
@@ -317,13 +308,12 @@ For a stable release, the workflow creates or fast-forwards the unit's maintenan
 
 Before tagging, verify the selected stable frontend bundle exists and release metadata is complete. Coordinated plugin versions can remain queued when pending-default behavior has been verified.
 
+Use the branch and commit checks in [publication-handoff.md](references/publication-handoff.md) before emitting:
+
 ```bash
-git fetch origin develop --tags
-TAG="python/kitaru/v<python-version>"
-RELEASE_SHA="<reviewed-develop-sha>"
-git merge-base --is-ancestor "$RELEASE_SHA" origin/develop
-git tag -a "$TAG" "$RELEASE_SHA" -m "$TAG"
-git push origin "$TAG"
+git checkout develop
+git tag python/kitaru/v<python-version> HEAD
+git push origin python/kitaru/v<python-version>
 ```
 
 The tag starts `.github/workflows/release.yml`. The workflow:
@@ -350,16 +340,15 @@ After the required core and plugin versions are available on PyPI, complete any 
 
 The workflow does not update `main`. After the newest stable core's public artifacts and GitHub Release succeed, inspect any remaining workflow failure and tell the release owner to fast-forward `main` to the immutable core tag:
 
+Verify the local and remote `main` branches can fast-forward to the tag before emitting:
+
 ```bash
-git fetch origin main --tags
-TAG="python/kitaru/v<python-version>"
-RELEASE_SHA="$(git rev-list -n 1 "$TAG")"
-git merge-base --is-ancestor origin/main "$RELEASE_SHA"
-gh api --method PATCH repos/zenml-io/kitaru/git/refs/heads/main \
-  -f sha="$RELEASE_SHA" -F force=false
+git checkout main
+git merge --ff-only python/kitaru/v<python-version>
+git push origin main
 ```
 
-The release owner runs this command manually. Do not execute it on their behalf. The fast-forward updates `main` to the tagged commit without a merge commit and triggers the existing docs workflow. Skip this step for prereleases and older maintenance-line core releases.
+The release owner runs these commands manually. Do not execute it on their behalf. The fast-forward updates `main` to the tagged commit without a merge commit and triggers the existing docs workflow. Skip this step for prereleases and older maintenance-line core releases.
 
 After core and required plugins are available, hand off pending `zenml-io/kitaru-skills` changes to its [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Read the current skill before emitting that repository's commands. It owns the independent skills version, `develop` release commit, tag, `main` promotion, and GitHub Release. Core publication does not itself authorize publishing skills.
 

--- a/.claude/skills/kitaru-release/references/publication-handoff.md
+++ b/.claude/skills/kitaru-release/references/publication-handoff.md
@@ -1,35 +1,36 @@
 # Publication command handoff
 
-Include the complete command set in both the release PR and the final user-facing response. Fill in all known repository paths, versions, PR numbers, and tag names. Resolve merge SHAs at execution time when the PR is still open; never tag the preparation branch's pre-merge HEAD.
+Include minimal, copy-pasteable `git` commands in both the release PR and the final user-facing response. Name the repository and prerequisite above each block. Fill in the selected branch and every tag; never leave selected plugins as “repeat for the others.”
 
-For each block, state the repository, source branch, target tag, and prerequisite. Use `git -C <verified-checkout>` or an explicit `cd` so the commands cannot silently target another repository. Use `--repo` on every `gh` command. Preserve active checkouts; tag an explicit SHA without checking out a different branch.
+The publication block should only check out the source branch, tag the reviewed commit, and push that tag. Do discovery and safety checks before emitting it; do not include `gh`, API calls, shell variables, or validation boilerplate. These are commands for the release owner, not permission to change their checkout or publish.
 
 ## Ordered release steps
 
-1. **Frontend, when a new bundle is needed.** In `zenml-io/zenml-frontend-monorepo`, verify the reviewed `main` commit and emit the actual `release-kitaru-ui.yml` dispatch command with the selected version. The workflow creates the UI tag; do not also emit a manual tag push. Include run and asset verification. An existing selected bundle needs verification only.
-2. **Core.** In `zenml-io/kitaru`, resolve the release PR's merge SHA on `develop` (or the exact core maintenance branch). Emit the core tag and push commands.
+1. **Frontend, when a new bundle is needed.** In `zenml-io/zenml-frontend-monorepo`, verify the reviewed `main` commit and emit checkout, `kitaru-ui-v<version>` tag, and push commands. The tag push starts `release-kitaru-ui.yml`. Verify the resulting run and assets before tagging core. An existing selected bundle needs verification only.
+2. **Core.** In `zenml-io/kitaru`, verify the release PR's merge commit on `develop` (or the exact core maintenance branch). Emit the core tag and push commands.
 3. **Core PyPI gate.** Identify the exact core run. Wait for its `publish-python` job to succeed and verify `https://pypi.org/pypi/kitaru/<version>/json`. Dependent plugin publication can then proceed while images, Helm, and other core jobs continue.
-4. **Every selected Python plugin.** Emit each full namespaced tag and its individual push command at the reviewed release SHA. Independent plugin releases use an already-published compatible core and need no new core tag.
-5. **TypeScript, when selected.** Read `release/typescript.md`. Emit the rehearsal and one `typescript/kitaru/v<version>` tag for the entire lockstep set on the exact reviewed `develop` commit. Identify any core API availability prerequisite. Do not create separate tags for the three npm packages.
+4. **Every selected Python plugin.** Emit each full namespaced tag and its individual push command at the reviewed release commit. Independent plugin releases use an already-published compatible core and need no new core tag.
+5. **TypeScript, when selected.** Read `release/typescript.md`. Complete the required rehearsal separately, then emit one `typescript/kitaru/v<version>` tag for the entire lockstep set on the reviewed `develop` commit. Identify any core API availability prerequisite. Do not create separate tags for the three npm packages.
 6. **Stable core completion.** Verify the core's public artifacts and GitHub Release. Emit the manual, non-forced `main` fast-forward to the immutable core tag. Report maintenance/reset failures separately and resolve outstanding release failures before calling the release complete.
 7. **Development reset and quickstart.** Link the generated reset PR and state that `main` must contain the stable tag before it merges. Identify the reviewed quickstart dependency/lockfile follow-up and its frozen E2E check. Report whether it has reached the public example on `main`.
-8. **Kitaru skills.** After the required core/plugin versions are published, link and read the current [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Emit its commands only after the independent skills version and reviewed release commit are selected. Its source is `develop`; its distribution branch is `main`. Do not reuse the core version or SHA. If its version or preparation is unresolved, give the exact handoff and missing choice instead of inventing a tag.
+8. **Kitaru skills.** After the required core/plugin versions are published, link and read the current [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Provide minimal git tag commands only after the independent skills version and reviewed release commit are selected; link the skill for its other release steps. Its source is `develop`; its distribution branch is `main`. Do not reuse the core version or SHA. If its version or preparation is unresolved, give the exact handoff and missing choice instead of inventing a tag.
 9. **Other follow-ups.** Link selected docs, website, examples, and release-note work with their remaining action.
 
-## Python tag block
+## Tag command block
 
-Use this structure with concrete values for every selected tag:
+Run in the named repository. Use this structure with concrete values:
 
 ```bash
-git -C <kitaru-checkout> fetch origin <source-branch> --tags
-RELEASE_SHA="$(gh pr view <release-pr> --repo zenml-io/kitaru --json mergeCommit --jq '.mergeCommit.oid')"
-test -n "$RELEASE_SHA" && test "$RELEASE_SHA" != null
-git -C <kitaru-checkout> merge-base --is-ancestor "$RELEASE_SHA" origin/<source-branch>
-git -C <kitaru-checkout> tag -a <exact-tag> "$RELEASE_SHA" -m <exact-tag>
-git -C <kitaru-checkout> push origin <exact-tag>
+git checkout develop
+git tag <exact-tag> HEAD
+git push origin <exact-tag>
 ```
 
-A maintenance release uses its matching `release/<unit>/<major.minor>` branch and maintenance PR. Check that the tag is unused before offering its creation command. For an existing tag, emit verification or recovery commands instead.
+Use `main` for the frontend and the matching maintenance branch for a maintenance release. Prefer `HEAD` when the checked-out branch points to the reviewed release commit. Verify that condition first. If the local branch is behind, include `git pull --ff-only origin <source-branch>` after checkout only when it brings the branch to that commit. If the branch has advanced, replace `HEAD` with the literal reviewed SHA. If the release PR is still open, state that it must merge and its release commit must be verified before these commands run; never tag the preparation branch's pre-merge HEAD.
+
+For multiple tags in one repository and branch, check out the branch once, then emit one tag/push pair for each selected release. Separate dependent plugin pairs from the core pair with the PyPI gate.
+
+A maintenance release uses its matching `release/<unit>/<major.minor>` branch and maintenance PR. Check that the tag is unused before offering its creation command. For an existing tag, give its status and the recovery handoff; do not recreate or move it.
 
 Push one tag per command. Confirm the matching workflow run exists after each push. For plugins in the same release set, subsequent tag pushes need not wait for the preceding plugin workflow to finish.
 
@@ -40,5 +41,12 @@ Separate the two decision points:
 - **Dependent plugins may publish:** the core PyPI job succeeded and the exact core version is available.
 - **Stable core may be promoted to main:** required public publication jobs and GitHub Release succeeded; inspect remaining workflow failures explicitly.
 
-The managed-image step is warning-only. Installer smoke can fail without preventing artifact publication. Development-reset failure also occurs after publication; it needs repair but does not undo existing artifacts. Emit commands against the immutable core tag for `main` promotion, with an ancestry check and `force=false`, as specified in the release skill.
+The managed-image step is warning-only. Installer smoke can fail without preventing artifact publication. Development-reset failure also occurs after publication; it needs repair but does not undo existing artifacts. After verifying that local and remote `main` can fast-forward to the immutable stable core tag, emit:
 
+```bash
+git checkout main
+git merge --ff-only <exact-core-tag>
+git push origin main
+```
+
+Use the literal core tag. Do not force-push or reset away unrelated work.

--- a/.claude/skills/kitaru-release/references/publication-handoff.md
+++ b/.claude/skills/kitaru-release/references/publication-handoff.md
@@ -1,0 +1,44 @@
+# Publication command handoff
+
+Include the complete command set in both the release PR and the final user-facing response. Fill in all known repository paths, versions, PR numbers, and tag names. Resolve merge SHAs at execution time when the PR is still open; never tag the preparation branch's pre-merge HEAD.
+
+For each block, state the repository, source branch, target tag, and prerequisite. Use `git -C <verified-checkout>` or an explicit `cd` so the commands cannot silently target another repository. Use `--repo` on every `gh` command. Preserve active checkouts; tag an explicit SHA without checking out a different branch.
+
+## Ordered release steps
+
+1. **Frontend, when a new bundle is needed.** In `zenml-io/zenml-frontend-monorepo`, verify the reviewed `main` commit and emit the actual `release-kitaru-ui.yml` dispatch command with the selected version. The workflow creates the UI tag; do not also emit a manual tag push. Include run and asset verification. An existing selected bundle needs verification only.
+2. **Core.** In `zenml-io/kitaru`, resolve the release PR's merge SHA on `develop` (or the exact core maintenance branch). Emit the core tag and push commands.
+3. **Core PyPI gate.** Identify the exact core run. Wait for its `publish-python` job to succeed and verify `https://pypi.org/pypi/kitaru/<version>/json`. Dependent plugin publication can then proceed while images, Helm, and other core jobs continue.
+4. **Every selected Python plugin.** Emit each full namespaced tag and its individual push command at the reviewed release SHA. Independent plugin releases use an already-published compatible core and need no new core tag.
+5. **TypeScript, when selected.** Read `release/typescript.md`. Emit the rehearsal and one `typescript/kitaru/v<version>` tag for the entire lockstep set on the exact reviewed `develop` commit. Identify any core API availability prerequisite. Do not create separate tags for the three npm packages.
+6. **Stable core completion.** Verify the core's public artifacts and GitHub Release. Emit the manual, non-forced `main` fast-forward to the immutable core tag. Report maintenance/reset failures separately and resolve outstanding release failures before calling the release complete.
+7. **Development reset and quickstart.** Link the generated reset PR and state that `main` must contain the stable tag before it merges. Identify the reviewed quickstart dependency/lockfile follow-up and its frozen E2E check. Report whether it has reached the public example on `main`.
+8. **Kitaru skills.** After the required core/plugin versions are published, link and read the current [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Emit its commands only after the independent skills version and reviewed release commit are selected. Its source is `develop`; its distribution branch is `main`. Do not reuse the core version or SHA. If its version or preparation is unresolved, give the exact handoff and missing choice instead of inventing a tag.
+9. **Other follow-ups.** Link selected docs, website, examples, and release-note work with their remaining action.
+
+## Python tag block
+
+Use this structure with concrete values for every selected tag:
+
+```bash
+git -C <kitaru-checkout> fetch origin <source-branch> --tags
+RELEASE_SHA="$(gh pr view <release-pr> --repo zenml-io/kitaru --json mergeCommit --jq '.mergeCommit.oid')"
+test -n "$RELEASE_SHA" && test "$RELEASE_SHA" != null
+git -C <kitaru-checkout> merge-base --is-ancestor "$RELEASE_SHA" origin/<source-branch>
+git -C <kitaru-checkout> tag -a <exact-tag> "$RELEASE_SHA" -m <exact-tag>
+git -C <kitaru-checkout> push origin <exact-tag>
+```
+
+A maintenance release uses its matching `release/<unit>/<major.minor>` branch and maintenance PR. Check that the tag is unused before offering its creation command. For an existing tag, emit verification or recovery commands instead.
+
+Push one tag per command. Confirm the matching workflow run exists after each push. For plugins in the same release set, subsequent tag pushes need not wait for the preceding plugin workflow to finish.
+
+## Core publication status
+
+Separate the two decision points:
+
+- **Dependent plugins may publish:** the core PyPI job succeeded and the exact core version is available.
+- **Stable core may be promoted to main:** required public publication jobs and GitHub Release succeeded; inspect remaining workflow failures explicitly.
+
+The managed-image step is warning-only. Installer smoke can fail without preventing artifact publication. Development-reset failure also occurs after publication; it needs repair but does not undo existing artifacts. Emit commands against the immutable core tag for `main` promotion, with an ancestry check and `force=false`, as specified in the release skill.
+

--- a/.claude/skills/kitaru-tests-release/SKILL.md
+++ b/.claude/skills/kitaru-tests-release/SKILL.md
@@ -49,7 +49,7 @@ Use the PostgreSQL-backed tests for transaction, locking, migration, or cross-re
 - Run `just plugin-artifact-smoke` after changing plugin package metadata, default definitions, requirement pins, or release installation paths.
 - The smoke builds Kitaru and every selected plugin as wheels, installs them into a clean environment, loads each configured package entrypoint, and verifies idempotent default registration.
 - CI runs plugin distributions as a package matrix. Keep the matrix aligned with `plugins/packages/` and the choices in `.github/workflows/release-plugins.yml`.
-- Plugin workflow dispatches are dry-runs. A package tag triggers publishing only when its commit is contained in `main`.
+- Plugin workflow dispatches are dry-runs. Package tags publish from reviewed commits reachable from `develop` or the unit's matching maintenance branch. Dependent plugins wait for core PyPI availability; other core jobs can continue.
 - Kitaru release dry-runs build plugin-owned candidate images from `plugins/candidate-wheels`; production release Dockerfiles continue to install exact versions from PyPI.
 - Commit `plugins/candidate.Dockerfile` and `plugins/docker-compose.candidate.yml`. Do not commit generated files under `plugins/candidate-wheels/`.
 - Keep production release Dockerfiles unchanged when a plugin change only needs local candidate-wheel testing.
@@ -101,9 +101,9 @@ Do not describe the inherited `llm-integration.yml` provider markers or absent `
 
 Use `.agents/skills/kitaru-release/SKILL.md` for the release interview, metadata edits, validation, and preparation PR. Keep this skill focused on selecting and running test surfaces.
 
-`.github/workflows/release-plugins.yml` publishes one Python distribution from an immutable namespaced tag. A core tag such as `python/kitaru/v0.22.0rc1` publishes Kitaru to PyPI and creates its GitHub Release. Plugin tags publish independently and do not gate the core release.
+`.github/workflows/release.yml` handles the core tag `python/kitaru/v<VERSION>`. It publishes Kitaru to PyPI, then publishes client, server, worker, and managed images plus Helm, and creates the GitHub Release. Python RC versions such as `0.22.0rc1` become deployable tags such as `0.22.0-rc.1`. There is no separate bundle tag.
 
-After a successful core Python workflow, `.github/workflows/release.yml` automatically publishes the matching client, server, worker, and managed images plus the Helm chart. It converts Python RC versions such as `0.22.0rc1` to deployable tags such as `0.22.0-rc.1`. No separate bundle tag is used. A manual dispatch with the existing core package tag is the recovery path.
+`.github/workflows/release-plugins.yml` handles one Python plugin distribution per namespaced tag. In a coordinated release, dependent plugin tags follow successful core PyPI publication. They can publish while core deployables and post-release jobs continue. Independent plugins use an already-published compatible core.
 
 `.github/workflows/release-typescript.yml` publishes `@zenml-io/kitaru`, `@zenml-io/kitaru-mastra`, and `@zenml-io/kitaru-vercel-ai` together from an immutable `typescript/kitaru/v<VERSION>` tag. Read `release/typescript.md` before preparing or recovering a TypeScript release. Manual dispatch is a non-publishing rehearsal; pushing the tag publishes the tested tarballs, waits for npm publish-time scanning, verifies a clean registry install, and creates the GitHub Release. The three packages use one lockstep stable or `-rc.N` version.
 
@@ -115,9 +115,9 @@ Before creating a core tag:
 4. Confirm no other release run is active.
 5. After changing the core version, run `uv run python scripts/generate_openapi.py` and commit the updated `openapi/openapi.json`.
 6. Run `just check`, the relevant base/CLI/MCP tests, `just mcp-schema-check`, `just cli-artifact-smoke`, `just plugin-artifact-smoke`, `just migration-check`, and `just build` as applicable. Run `just mcp-wheel-smoke` only after `just build`; it consumes the wheel under `dist/`.
-7. Dispatch `release-plugins.yml` with the proposed package tag when a non-publishing rehearsal is needed.
+7. Dispatch `release.yml` with the proposed core tag when a non-publishing rehearsal is needed. Use `release-plugins.yml` for a plugin rehearsal.
 
-The core Python workflow builds and verifies the wheel, publishes it to PyPI, and creates the GitHub Release. The deployables workflow then verifies the core package, tests the release images, publishes the images and Helm chart, and attaches the chart to the core GitHub Release. Stable releases also move the Docker `latest` aliases.
+Stable core releases move the public Docker `latest` aliases, advance the core maintenance branch, and create a draft development-reset PR. The release owner fast-forwards `main` to the immutable core tag before merging the reset into `develop`. Report PyPI publication, public deployables, managed-image warnings, installer smoke, maintenance state, and reset state separately. A reset failure can leave the workflow red after artifact publication succeeds.
 
 Do not use the removed `scripts/smoke-test.sh`, provider-area flags, remote-stack smoke, v1 adapters, or local ZenML flow runs as v2 release gates.
 
@@ -126,8 +126,8 @@ Do not use the removed `scripts/smoke-test.sh`, provider-area flags, remote-stac
 - Default branch is `develop`.
 - Pull requests normally target `develop`; v2 feature work may target its explicit integration branch until that migration lands.
 - `main` tracks the latest released version only; do not push directly.
-- Python releases are cut with namespaced tags handled by `.github/workflows/release-plugins.yml`.
+- Python core and plugin releases use namespaced tags handled by `release.yml` and `release-plugins.yml`, respectively.
 - TypeScript releases are cut with `typescript/kitaru/v<VERSION>` tags handled by `.github/workflows/release-typescript.yml`; rehearse the exact tag through manual dispatch before pushing it.
-- A successful core Python release automatically starts `.github/workflows/release.yml`; manual dispatch is reserved for recovery.
+- A core tag directly starts `.github/workflows/release.yml`. Manual dispatch rehearses without publishing; recover publication by inspecting and rerunning the original failed jobs with the same immutable artifacts.
 - Release preparation maintains the version in `pyproject.toml`; application code should use `importlib.metadata.version("kitaru")` rather than hardcoding it.
 - Update `CHANGELOG.md` under `[Unreleased]` for user-facing changes.

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -11,10 +11,13 @@ Read `plugins/DEVELOPMENT.md` before you change package metadata, default defini
 - Do not bump unrelated plugin distributions.
 - Keep the definitions in `src/kitaru/server/api/bootstrap.py` aligned with their owning wheels.
 
-## Required updates
+## Implementation and release preparation
 
-- Update the selected package version with `uv version --project plugins --package DISTRIBUTION VERSION --no-sync`.
-- For a default importer or evaluator, update the requirement and display version in `DEFAULT_PLUGIN_DEFINITIONS`. The release inventory validates both against the package version.
+- Feature PRs change implementation, tests, and `Unreleased` changelog entries. Leave existing package versions and server default requirements/display versions unchanged.
+- The release-preparation PR selects plugin versions and updates matching `DEFAULT_PLUGIN_DEFINITIONS` requirements and display versions together. The release inventory validates their equality.
+- Preserve a published core dependency floor when it remains supported. If new behavior requires unreleased core, follow the exact development-pin policy in `plugins/DEVELOPMENT.md` and record the core change in `Release context`.
+- Release prep replaces development pins with the selected core release floor and regenerates `plugins/uv.lock` before publication.
+- New packages need initial metadata. Adding a server default requires an explicit release decision.
 - Keep adapter distributions out of the server catalog.
 - Run plugin workspace commands with `--project plugins`; the root workspace contains only Kitaru.
 - Commit the resulting `plugins/uv.lock` change.
@@ -39,9 +42,10 @@ Read `plugins/DEVELOPMENT.md` before you change package metadata, default defini
 
 ## Release safety
 
-- Use the `Release plugin` workflow. Do not publish plugin distributions from a developer machine.
-- Run a dry-run from the feature branch before merge.
-- Publish only from a package tag whose commit is contained in `main`.
+- Use the `Release Kitaru plugins` workflow. Do not publish plugin distributions from a developer machine.
+- Use the non-publishing rehearsal in `plugins/DEVELOPMENT.md` on an eligible reviewed commit.
+- Publish only from a namespaced package tag reachable from `develop` or that unit's matching maintenance branch.
+- For coordinated releases, wait for the required core version on PyPI before pushing dependent plugin tags. The remaining core jobs can continue in parallel.
 - Use the tag format documented in `plugins/DEVELOPMENT.md`.
 - Never reuse a PyPI version or package tag.
 - Confirm the package name, package version, Git commit, PyPI project, and tag before approval.

--- a/plugins/DEVELOPMENT.md
+++ b/plugins/DEVELOPMENT.md
@@ -366,18 +366,12 @@ Every manual dispatch is a dry-run. It validates the selected source and package
 
 Publish the reviewed release commit on `develop` or the unit's matching maintenance branch. For a coordinated release, first require the core `publish-python` job to succeed and verify the exact core version on PyPI. The other core jobs can continue while plugins publish. An independent plugin release uses an already-published compatible core.
 
+Verify that the local source branch points to the reviewed release commit and the tag is unused before running these commands. Update a behind branch with `git pull --ff-only origin develop` if that brings it to the release commit. If the branch has advanced past the release commit, replace `HEAD` with the literal reviewed SHA.
+
 ```bash
-git fetch origin develop --tags
-
-PACKAGE=langfuse-importer
-VERSION=0.2.0
-TAG="python/kitaru-$PACKAGE/v$VERSION"
-RELEASE_SHA="$(gh pr view <release-pr> --repo zenml-io/kitaru --json mergeCommit --jq '.mergeCommit.oid')"
-test -n "$RELEASE_SHA" && test "$RELEASE_SHA" != null
-git merge-base --is-ancestor "$RELEASE_SHA" origin/develop
-
-git tag -a "$TAG" "$RELEASE_SHA" -m "$TAG"
-git push origin "$TAG"
+git checkout develop
+git tag python/kitaru-langfuse-importer/v0.2.0 HEAD
+git push origin python/kitaru-langfuse-importer/v0.2.0
 ```
 
 The tag push starts the `Release Kitaru plugins` workflow. The workflow resolves the package and version from the tag and accepts commits reachable from `develop` or the matching maintenance branch. It builds and verifies the distribution, publishes through PyPI Trusted Publishing, and creates a GitHub Release with the wheel, source distribution, and checksums. Stable publication then creates or advances the maintenance branch. For a maintenance release, use that branch and its exact reviewed merge commit in the commands above.

--- a/plugins/DEVELOPMENT.md
+++ b/plugins/DEVELOPMENT.md
@@ -12,6 +12,20 @@ The root `pyproject.toml` and `uv.lock` manage Kitaru. `plugins/pyproject.toml` 
 
 Registration stores package metadata. It does not upload wheel bytes. A worker resolves the exact requirement when it executes a plugin task.
 
+## Feature PRs and core dependencies
+
+Feature PRs change implementation, tests, and package `Unreleased` changelog entries. Leave existing plugin package versions and server default requirements/display versions unchanged. The release-preparation PR selects the package versions and updates all matching default-catalog metadata together. This also preserves the current inventory validator's requirement that package and default versions match.
+
+The plugin workspace already uses the local Kitaru checkout through `[tool.uv.sources]`. Preserve the published minimum dependency when the plugin still supports that core version.
+
+When a plugin needs unreleased core APIs, use an exact dependency on the current development version from the root manifest. For example, use `kitaru==0.25.0+dev` while core is `0.25.0+dev`. Record the required core commit or PR in `Release context`. If the development reset has not landed, resolve that first rather than changing core's version in a plugin feature PR.
+
+The release-preparation PR replaces this placeholder with the selected compatible release floor, for example `kitaru>=0.26.0`, and regenerates `plugins/uv.lock`. Preserve extras and compatible upper bounds. Verify the candidate wheel's `Requires-Dist` metadata before publication. Never publish a plugin with the development placeholder still present. A plugin-only release needs a published core that contains the required APIs.
+
+Do not use `>=0.25.0+dev`: ordered comparisons with a local version are invalid. Do not substitute `>=0.25.0.dev0`: that range also accepts the old stable `0.25.0`. The exact development pin marks pending compatibility work; it does not prove that every checkout with that version contains the needed API. See the [Python version specification](https://packaging.python.org/en/latest/specifications/version-specifiers/).
+
+New packages require initial manifest versions and inventory entries. Adding a server default remains an explicit release decision.
+
 ## Prepare the checkout
 
 1. Change to the repository root.
@@ -253,22 +267,22 @@ Use the package directory and distribution name from this table:
 
 | Package input | Distribution | Tag format |
 |---|---|---|
-| `braintrust-importer` | `kitaru-braintrust-importer` | `braintrust-importer-vX.Y.Z` |
-| `evaluator` | `kitaru-evaluator` | `evaluator-vX.Y.Z` |
-| `jsonl-importer` | `kitaru-jsonl-importer` | `jsonl-importer-vX.Y.Z` |
-| `langfuse-importer` | `kitaru-langfuse-importer` | `langfuse-importer-vX.Y.Z` |
-| `langgraph` | `kitaru-langgraph` | `langgraph-vX.Y.Z` |
-| `logfire-importer` | `kitaru-logfire-importer` | `logfire-importer-vX.Y.Z` |
+| `braintrust-importer` | `kitaru-braintrust-importer` | `python/kitaru-braintrust-importer/vX.Y.Z` |
+| `evaluator` | `kitaru-evaluator` | `python/kitaru-evaluator/vX.Y.Z` |
+| `jsonl-importer` | `kitaru-jsonl-importer` | `python/kitaru-jsonl-importer/vX.Y.Z` |
+| `langfuse-importer` | `kitaru-langfuse-importer` | `python/kitaru-langfuse-importer/vX.Y.Z` |
+| `langgraph` | `kitaru-langgraph` | `python/kitaru-langgraph/vX.Y.Z` |
+| `logfire-importer` | `kitaru-logfire-importer` | `python/kitaru-logfire-importer/vX.Y.Z` |
 | `phoenix-importer` | `kitaru-phoenix-importer` | `python/kitaru-phoenix-importer/vX.Y.Z` |
-| `langsmith-importer` | `kitaru-langsmith-importer` | `langsmith-importer-vX.Y.Z` |
-| `openai-agents` | `kitaru-openai-agents` | `openai-agents-vX.Y.Z` |
-| `pydantic-ai` | `kitaru-pydantic-ai` | `pydantic-ai-vX.Y.Z` |
+| `langsmith-importer` | `kitaru-langsmith-importer` | `python/kitaru-langsmith-importer/vX.Y.Z` |
+| `openai-agents` | `kitaru-openai-agents` | `python/kitaru-openai-agents/vX.Y.Z` |
+| `pydantic-ai` | `kitaru-pydantic-ai` | `python/kitaru-pydantic-ai/vX.Y.Z` |
 
 Release only the distribution that contains the change. A change to any built-in evaluator releases the shared `kitaru-evaluator` distribution.
 
 ## Prepare a release commit
 
-The examples below release `kitaru-langfuse-importer` as version `0.2.0`.
+Use a release-preparation PR after the implementation merges. The examples below release `kitaru-langfuse-importer` as version `0.2.0`. Select an unused version from the current registry and tags.
 
 1. Update the selected workspace package version and lockfile.
 
@@ -277,7 +291,7 @@ uv version --project plugins --package kitaru-langfuse-importer 0.2.0 --no-sync
 ```
 
 2. For an importer or evaluator in the default catalog, change the matching requirement and display version in `DEFAULT_PLUGIN_DEFINITIONS`. The release inventory derives the expected requirement from the package version. Skip this catalog step for an adapter distribution.
-3. Add or update focused tests.
+3. Resolve any core development dependency to the selected release floor and run `uv lock --project plugins`.
 4. Verify that no unrelated plugin package version changed.
 
 ```bash
@@ -301,7 +315,7 @@ just plugin-artifact-smoke
 ```
 
 6. Run the candidate server procedure when the change affects default definitions, package installation, registration, or task execution.
-7. Commit the version, server default definitions, plugin lockfile, implementation, and tests in the same pull request.
+7. Commit the selected version, changelog, core dependency, server default metadata, and plugin lockfile in the release-preparation PR. The implementation and its tests normally arrive through earlier feature PRs.
 
 ## Configure the first PyPI release
 
@@ -321,51 +335,52 @@ Create one GitHub environment named `pypi-<distribution>` for each distribution.
 
 ## Run a release dry-run
 
-The `Release plugin` workflow must exist on the repository default branch before GitHub accepts a manual dispatch. After that bootstrap merge, dispatch a dry-run from the feature branch:
+The `Release Kitaru plugins` workflow must exist on the repository default branch before GitHub accepts a manual dispatch. Rehearse the reviewed release commit after it is reachable from `develop` or the matching maintenance branch:
 
 ```bash
 PACKAGE=langfuse-importer
 VERSION=0.2.0
-BRANCH="$(git branch --show-current)"
+RELEASE_REF="<branch-or-tag-at-reviewed-commit>"
 
 gh workflow run release-plugins.yml \
   --repo zenml-io/kitaru \
-  --ref "$BRANCH" \
-  -f package="$PACKAGE" \
-  -f version="$VERSION"
+  --ref "$RELEASE_REF" \
+  -f package-tag="python/kitaru-$PACKAGE/v$VERSION"
 
 gh run list \
   --repo zenml-io/kitaru \
   --workflow release-plugins.yml \
-  --branch "$BRANCH" \
+  --event workflow_dispatch \
   --limit 5
 ```
 
-Select the new run ID and watch it:
+Verify the new run's `headSha` matches the reviewed commit. Select its run ID and watch it:
 
 ```bash
 gh run watch RUN_ID --repo zenml-io/kitaru --exit-status
 ```
 
-Every manual dispatch is a dry-run. It checks out the selected branch SHA, validates the requested version, tests default-definition integration, installs the selected wheel in a clean environment, and builds the distribution. It does not publish or create a tag.
+Every manual dispatch is a dry-run. It validates the selected source and package version, builds the wheel, and checks installation metadata. It does not publish or create a tag. Run behavioral and default-catalog tests through the preparation checks above.
 
 ## Publish a plugin
 
-Publish only after the release commit is contained in `main`. This requirement couples plugin publishing to the repository's `main` promotion cadence.
+Publish the reviewed release commit on `develop` or the unit's matching maintenance branch. For a coordinated release, first require the core `publish-python` job to succeed and verify the exact core version on PyPI. The other core jobs can continue while plugins publish. An independent plugin release uses an already-published compatible core.
 
 ```bash
-git fetch origin main --tags
+git fetch origin develop --tags
 
 PACKAGE=langfuse-importer
 VERSION=0.2.0
-TAG="$PACKAGE-v$VERSION"
-RELEASE_SHA="$(git rev-parse origin/main)"
+TAG="python/kitaru-$PACKAGE/v$VERSION"
+RELEASE_SHA="$(gh pr view <release-pr> --repo zenml-io/kitaru --json mergeCommit --jq '.mergeCommit.oid')"
+test -n "$RELEASE_SHA" && test "$RELEASE_SHA" != null
+git merge-base --is-ancestor "$RELEASE_SHA" origin/develop
 
 git tag -a "$TAG" "$RELEASE_SHA" -m "$TAG"
 git push origin "$TAG"
 ```
 
-The tag push starts the `Release Kitaru plugins` workflow. The workflow derives the plugin package and version from the tag. It rejects a tag whose commit is not contained in `origin/develop`. It then runs the tests, builds the selected distribution, publishes through PyPI Trusted Publishing, and creates a GitHub Release with the wheel, source distribution, and checksums.
+The tag push starts the `Release Kitaru plugins` workflow. The workflow resolves the package and version from the tag and accepts commits reachable from `develop` or the matching maintenance branch. It builds and verifies the distribution, publishes through PyPI Trusted Publishing, and creates a GitHub Release with the wheel, source distribution, and checksums. Stable publication then creates or advances the maintenance branch. For a maintenance release, use that branch and its exact reviewed merge commit in the commands above.
 
 If publication stops after PyPI accepts one or more files, rerun the failed jobs from the same workflow run. The rerun downloads the original build artifact, skips files that PyPI already accepted, finishes any remaining artifacts, and creates the GitHub Release if it does not exist. Do not move or recreate the release tag.
 
@@ -390,7 +405,7 @@ curl -fsS \
   https://pypi.org/pypi/kitaru-langfuse-importer/0.2.0/json \
   >/dev/null
 
-gh release view langfuse-importer-v0.2.0 \
+gh release view python/kitaru-langfuse-importer/v0.2.0 \
   --repo zenml-io/kitaru
 ```
 


### PR DESCRIPTION
Align release guidance with the current core PyPI gate and develop-based tag flow. Dependent plugins can publish after core reaches PyPI while deployables and post-release jobs continue; main advances to the immutable stable core tag afterward.

The release skill now emits minimal git-only publication commands grouped by repository and source branch: check out the branch, tag the reviewed commit, and push each tag separately. Prefer verified `HEAD`, with a literal SHA only when the branch has advanced. Include every selected Python plugin, the TypeScript release set, frontend tag, main promotion, and the linked Kitaru skills release skill. Discovery and validation stay outside the copy-paste blocks.

Plugin feature PRs leave package versions and server default pins for release preparation. Plugins requiring unreleased core use the exact current development dependency, such as `kitaru==0.25.0+dev`; release prep resolves it to the selected published compatibility floor. Existing supported minimums remain unchanged when compatible.

Also correct stale plugin tag formats, workflow inputs, main-only source claims, and the recovery guidance: manual dispatch is a rehearsal, while publication recovery uses the original tag-triggered run.

## Validation

- Validated all four changed skill entrypoints and compared every `.agents`/`.claude` mirror, including the new handoff reference.
- Checked dependency specifier behavior with `packaging`: exact `+dev` matching, invalid ordered local-version comparison, and the old stable version accepted by a `.dev0` lower bound.
- Reviewed command shapes against the current core, plugin, TypeScript, and frontend workflows; verified the skills-release link.
- `git diff --check` passes. Documentation and instruction changes only; no package versions, runtime code, or release workflows changed.

## Reviewer Notes

Read `plugins/DEVELOPMENT.md` for feature-PR versus release-preparation ownership and development dependency conversion. Then review `.agents/skills/kitaru-release/references/publication-handoff.md` for repository/branch selection, minimal git-only tag commands, the core PyPI gate, and the skills release handoff. Both host copies contain identical guidance.
