### PR TITLE
Adopt whole evaluator invocations under if_missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - `POST /api/v1/imports` now returns the import instead of the job, with the job in its `job_id`. Import task responses carry `import_id` instead of `payload_blob_id` and `agent_id`.
 
+### Fixed
+
+- `if_missing` baseline scoring now adopts every evaluation an evaluator call produced instead of only one of them, so a rerun's baseline aggregates no longer lose metrics from an evaluator that returns multiple results.
+
 ## [0.25.0] - 2026-09-03
 
 ### Added

--- a/src/kitaru/server/adapters/db/orm/evaluation.py
+++ b/src/kitaru/server/adapters/db/orm/evaluation.py
@@ -171,6 +171,10 @@ class EvaluationORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     evaluator_version_id: Mapped[uuid.UUID | None]
     session_id: Mapped[uuid.UUID]
     task_id: Mapped[uuid.UUID | None]
+    # No foreign key, identifies the evaluator call that produced this row
+    # alongside its siblings, and outlives the task the same way
+    # evaluator_version_id does.
+    invocation_id: Mapped[uuid.UUID | None]
     name: Mapped[str] = mapped_column(String(MAX_NAME_LENGTH))
     data_type: Mapped[str] = mapped_column(String(DATA_TYPE_LENGTH))
     numerical_value: Mapped[float | None] = mapped_column(Double)
@@ -204,6 +208,7 @@ class EvaluationORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             "evaluator_version_id": evaluation.evaluator_version_id,
             "session_id": evaluation.session_id,
             "task_id": evaluation.task_id,
+            "invocation_id": evaluation.invocation_id,
             "name": evaluation.name,
             "data_type": evaluation.data_type.value,
             "numerical_value": numerical_value,
@@ -230,6 +235,7 @@ class EvaluationORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
             evaluator_version_id=self.evaluator_version_id,
             session_id=self.session_id,
             task_id=self.task_id,
+            invocation_id=self.invocation_id,
             name=self.name,
             data_type=data_type,
             score=_score_from_row(data_type, self.numerical_value),

--- a/src/kitaru/server/adapters/db/orm/evaluation.py
+++ b/src/kitaru/server/adapters/db/orm/evaluation.py
@@ -171,9 +171,8 @@ class EvaluationORM(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     evaluator_version_id: Mapped[uuid.UUID | None]
     session_id: Mapped[uuid.UUID]
     task_id: Mapped[uuid.UUID | None]
-    # No foreign key, identifies the evaluator call that produced this row
-    # alongside its siblings, and outlives the task the same way
-    # evaluator_version_id does.
+    # No foreign key, identifies the evaluator invocation that produced this row
+    # alongside its siblings.
     invocation_id: Mapped[uuid.UUID | None]
     name: Mapped[str] = mapped_column(String(MAX_NAME_LENGTH))
     data_type: Mapped[str] = mapped_column(String(DATA_TYPE_LENGTH))

--- a/src/kitaru/server/adapters/db/repositories/evaluation_repository.py
+++ b/src/kitaru/server/adapters/db/repositories/evaluation_repository.py
@@ -324,18 +324,21 @@ class SQLEvaluationRepository(BaseSQLRepository[EvaluationORM]):
 
     async def get_latest_evaluation_ids_by_identity(
         self, session_ids: Sequence[uuid.UUID]
-    ) -> dict[EvaluationIdentity, uuid.UUID]:
-        """Read the latest evaluation id per (session, evaluator version, params hash).
+    ) -> dict[EvaluationIdentity, list[uuid.UUID]]:
+        """Read the latest invocation's evaluation ids per identity.
 
-        Only rows carrying both an evaluator version id and a params hash
-        are considered.
+        An identity is (session, evaluator version, params hash). Only rows
+        carrying an evaluator version id, a params hash, and an invocation
+        id are considered, and every row sharing the latest invocation id
+        for an identity is returned, not just one.
 
         Args:
             session_ids: Ids of the candidate sessions.
 
         Returns:
-            Latest evaluation id keyed by (session_id, evaluator_version_id,
-            params_hash), identities without a match omitted.
+            Evaluation ids of the latest invocation keyed by (session_id,
+            evaluator_version_id, params_hash), identities without a match
+            omitted.
         """
         if not session_ids:
             return {}
@@ -344,8 +347,9 @@ class SQLEvaluationRepository(BaseSQLRepository[EvaluationORM]):
                 EvaluationORM.session_id,
                 EvaluationORM.evaluator_version_id,
                 EvaluationORM.params_hash,
+                EvaluationORM.invocation_id,
                 EvaluationORM.id,
-                func.row_number()
+                func.first_value(EvaluationORM.invocation_id)
                 .over(
                     partition_by=(
                         EvaluationORM.session_id,
@@ -354,26 +358,37 @@ class SQLEvaluationRepository(BaseSQLRepository[EvaluationORM]):
                     ),
                     order_by=(EvaluationORM.created.desc(), EvaluationORM.id.desc()),
                 )
-                .label("rank"),
+                .label("latest_invocation_id"),
             )
             .where(
                 EvaluationORM.session_id.in_(session_ids),
                 EvaluationORM.evaluator_version_id.is_not(None),
                 EvaluationORM.params_hash.is_not(None),
+                EvaluationORM.invocation_id.is_not(None),
             )
             .subquery()
         )
-        statement = select(
-            ranked.c.session_id,
-            ranked.c.evaluator_version_id,
-            ranked.c.params_hash,
-            ranked.c.id,
-        ).where(ranked.c.rank == 1)
+        statement = (
+            select(
+                ranked.c.session_id,
+                ranked.c.evaluator_version_id,
+                ranked.c.params_hash,
+                ranked.c.id,
+            )
+            .where(ranked.c.invocation_id == ranked.c.latest_invocation_id)
+            .order_by(
+                ranked.c.session_id,
+                ranked.c.evaluator_version_id,
+                ranked.c.params_hash,
+                ranked.c.id,
+            )
+        )
         rows = (await self._session.execute(statement)).all()
-        return {
-            (session_id, evaluator_version_id, params_hash): evaluation_id
-            for session_id, evaluator_version_id, params_hash, evaluation_id in rows
-        }
+        result: dict[EvaluationIdentity, list[uuid.UUID]] = {}
+        for session_id, evaluator_version_id, params_hash, evaluation_id in rows:
+            identity = (session_id, evaluator_version_id, params_hash)
+            result.setdefault(identity, []).append(evaluation_id)
+        return result
 
     async def add_replay_links(
         self, links: Sequence[tuple[uuid.UUID, uuid.UUID]]

--- a/src/kitaru/server/application/interfaces/evaluation_repository.py
+++ b/src/kitaru/server/application/interfaces/evaluation_repository.py
@@ -106,18 +106,21 @@ class EvaluationRepository(Protocol):
 
     async def get_latest_evaluation_ids_by_identity(
         self, session_ids: Sequence[uuid.UUID]
-    ) -> dict[EvaluationIdentity, uuid.UUID]:
-        """Read the latest evaluation id per (session, evaluator version, params hash).
+    ) -> dict[EvaluationIdentity, list[uuid.UUID]]:
+        """Read the latest invocation's evaluation ids per identity.
 
-        Only rows carrying both an evaluator version id and a params hash
-        are considered.
+        An identity is (session, evaluator version, params hash). Only rows
+        carrying an evaluator version id, a params hash, and an invocation
+        id are considered, and every row sharing the latest invocation id
+        for an identity is returned, not just one.
 
         Args:
             session_ids: Ids of the candidate sessions.
 
         Returns:
-            Latest evaluation id keyed by (session_id, evaluator_version_id,
-            params_hash), identities without a match omitted.
+            Evaluation ids of the latest invocation keyed by (session_id,
+            evaluator_version_id, params_hash), identities without a match
+            omitted.
         """
         ...
 

--- a/src/kitaru/server/application/services/evaluation_recording.py
+++ b/src/kitaru/server/application/services/evaluation_recording.py
@@ -24,6 +24,7 @@ from kitaru.server.application.interfaces.replay_repository import ReplayReposit
 from kitaru.server.application.interfaces.session_repository import SessionRepository
 from kitaru.server.domain.base import NotFoundError
 from kitaru.server.domain.evaluation import Evaluation
+from kitaru.server.domain.ids import uuid7
 from kitaru.server.domain.task import EvaluationTask
 from kitaru.server.utils import hash_params
 
@@ -57,12 +58,16 @@ async def record_task_evaluations(
     job = await job_repository.get(task.job_id)
     results = task.result if isinstance(task.result, list) else []
     params_hash = hash_params(task.params)
+    # One id per call, shared by every result it produced, so the whole set
+    # can be adopted together instead of only the row a ranking query picks.
+    invocation_id = uuid7()
     evaluations = [
         Evaluation(
             owner_id=job.owner_id,
             evaluator_version_id=task.plugin_version_id,
             session_id=task.input_session_id,
             task_id=task.id,
+            invocation_id=invocation_id,
             name=result.name,
             data_type=result.data_type,
             score=result.score,

--- a/src/kitaru/server/application/services/evaluation_recording.py
+++ b/src/kitaru/server/application/services/evaluation_recording.py
@@ -58,8 +58,6 @@ async def record_task_evaluations(
     job = await job_repository.get(task.job_id)
     results = task.result if isinstance(task.result, list) else []
     params_hash = hash_params(task.params)
-    # One id per call, shared by every result it produced, so the whole set
-    # can be adopted together instead of only the row a ranking query picks.
     invocation_id = uuid7()
     evaluations = [
         Evaluation(

--- a/src/kitaru/server/application/services/replay_pipeline.py
+++ b/src/kitaru/server/application/services/replay_pipeline.py
@@ -66,9 +66,9 @@ async def create_replay_pipelines(
     Each agent task carries its baseline session's inputs and the agent
     version as a label. With ``baseline_evaluation_mode`` other than
     ``NONE``, one baseline evaluator task is appended per evaluator, unless
-    ``IF_MISSING`` finds a prior evaluation of the same identity (baseline
+    ``IF_MISSING`` finds prior evaluations of the same identity (baseline
     session, evaluator version, params) to adopt instead, linking the
-    baseline's replay to it.
+    baseline's replay to every one of them.
 
     Args:
         baselines: Sessions being replayed.
@@ -113,7 +113,7 @@ async def create_replay_pipelines(
         )
         for job, baseline in zip(jobs, baselines, strict=True)
     ]
-    adoptable: dict[tuple[uuid.UUID, uuid.UUID, str], uuid.UUID] = {}
+    adoptable: dict[tuple[uuid.UUID, uuid.UUID, str], list[uuid.UUID]] = {}
     if baseline_evaluation_mode is BaselineEvaluationMode.IF_MISSING:
         adoptable = await evaluation_repository.get_latest_evaluation_ids_by_identity(
             [baseline.id for baseline in baselines]
@@ -143,9 +143,11 @@ async def create_replay_pipelines(
                     evaluator.evaluator_version_id,
                     evaluator_hashes[evaluator.evaluator_version_id],
                 )
-                evaluation_id = adoptable.get(identity)
-                if evaluation_id is not None:
-                    adopted_links.append((replay.id, evaluation_id))
+                evaluation_ids = adoptable.get(identity)
+                if evaluation_ids is not None:
+                    adopted_links.extend(
+                        (replay.id, evaluation_id) for evaluation_id in evaluation_ids
+                    )
                     continue
             tasks.append(
                 EvaluationTask(

--- a/src/kitaru/server/database/migrations/versions/014_evaluation_invocation_id.py
+++ b/src/kitaru/server/database/migrations/versions/014_evaluation_invocation_id.py
@@ -1,0 +1,48 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Evaluation invocation id Alembic revision.
+
+Revision ID: 014_evaluation_invocation_id
+Revises: 013_import
+Create Date: 2026-09-04
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "014_evaluation_invocation_id"
+down_revision = "013_import"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade database schema and/or data, creating a new revision."""
+    with op.batch_alter_table("evaluation", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("invocation_id", sa.Uuid(), nullable=True))
+
+    # Backfill from the task id because every evaluator call before this
+    # revision wrote exactly one task. Rows whose task was already pruned stay
+    # null and are not adoptable.
+    op.execute(
+        "UPDATE evaluation SET invocation_id = task_id WHERE task_id IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    """Downgrade database schema and/or data back to the previous revision."""
+    with op.batch_alter_table("evaluation", schema=None) as batch_op:
+        batch_op.drop_column("invocation_id")

--- a/src/kitaru/server/domain/evaluation.py
+++ b/src/kitaru/server/domain/evaluation.py
@@ -82,6 +82,7 @@ class Evaluation(DomainModel):
     evaluator_version_id: uuid.UUID | None = None
     session_id: uuid.UUID
     task_id: uuid.UUID | None = None
+    invocation_id: uuid.UUID | None = None
     name: EvaluationName
     data_type: EvaluationDataType
     score: FiniteFloat | bool | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5629,35 +5629,46 @@ class FakeEvaluationRepository:
 
     async def get_latest_evaluation_ids_by_identity(
         self, session_ids: Sequence[uuid.UUID]
-    ) -> dict[tuple[uuid.UUID, uuid.UUID, str], uuid.UUID]:
-        """Read the latest evaluation id per (session, evaluator version, params hash).
+    ) -> dict[tuple[uuid.UUID, uuid.UUID, str], list[uuid.UUID]]:
+        """Read the latest invocation's evaluation ids per identity.
 
         Args:
             session_ids: Ids of the candidate sessions.
 
         Returns:
-            Latest evaluation id keyed by (session_id, evaluator_version_id,
-            params_hash), identities without a match omitted.
+            Evaluation ids of the latest invocation keyed by (session_id,
+            evaluator_version_id, params_hash), identities without a match
+            omitted.
         """
         session_id_set = set(session_ids)
-        candidates = [
-            evaluation
-            for evaluation in self._evaluations.values()
-            if evaluation.session_id in session_id_set
-            and evaluation.evaluator_version_id is not None
-            and evaluation.params_hash is not None
-        ]
-        candidates.sort(key=lambda evaluation: (evaluation.created, evaluation.id))
-        latest: dict[tuple[uuid.UUID, uuid.UUID, str], uuid.UUID] = {}
-        for evaluation in candidates:
-            assert evaluation.evaluator_version_id is not None
-            assert evaluation.params_hash is not None
+        rows: list[tuple[tuple[uuid.UUID, uuid.UUID, str], uuid.UUID, uuid.UUID]] = []
+        for evaluation in self._evaluations.values():
+            if (
+                evaluation.session_id not in session_id_set
+                or evaluation.evaluator_version_id is None
+                or evaluation.params_hash is None
+                or evaluation.invocation_id is None
+            ):
+                continue
             identity = (
                 evaluation.session_id,
                 evaluation.evaluator_version_id,
                 evaluation.params_hash,
             )
-            latest[identity] = evaluation.id
+            rows.append((identity, evaluation.invocation_id, evaluation.id))
+        rows.sort(
+            key=lambda row: (
+                self._evaluations[row[2]].created,
+                self._evaluations[row[2]].id,
+            )
+        )
+        latest_invocation: dict[tuple[uuid.UUID, uuid.UUID, str], uuid.UUID] = {}
+        for identity, invocation_id, _ in rows:
+            latest_invocation[identity] = invocation_id
+        latest: dict[tuple[uuid.UUID, uuid.UUID, str], list[uuid.UUID]] = {}
+        for identity, invocation_id, evaluation_id in rows:
+            if invocation_id == latest_invocation[identity]:
+                latest.setdefault(identity, []).append(evaluation_id)
         return latest
 
     async def add_replay_links(

--- a/tests/server/test_evaluation_repository.py
+++ b/tests/server/test_evaluation_repository.py
@@ -973,7 +973,7 @@ async def test_fake_refuses_replay_id_filter() -> None:
 async def test_get_latest_evaluation_ids_by_identity_picks_the_latest(
     plugin_setup: PluginSetup,
 ) -> None:
-    """The identity lookup returns the most recently created matching row."""
+    """The identity lookup returns the most recent invocation's evaluation id."""
     plugin_repository, evaluation_repository, owner_id, session_id = plugin_setup
     plugin = await plugin_repository.create(
         Plugin(owner_id=owner_id, kind=PluginKind.EVALUATOR, name="accuracy-scorer")
@@ -983,7 +983,7 @@ async def test_get_latest_evaluation_ids_by_identity_picks_the_latest(
     )
     params_hash = hash_params({"threshold": 0.5})
 
-    def _scored(score: float) -> Evaluation:
+    def _scored(score: float, invocation_id: uuid.UUID | None) -> Evaluation:
         return _evaluation(
             owner_id,
             session_id,
@@ -994,18 +994,75 @@ async def test_get_latest_evaluation_ids_by_identity_picks_the_latest(
             update={
                 "evaluator_params": {"threshold": 0.5},
                 "params_hash": params_hash,
+                "invocation_id": invocation_id,
             }
         )
 
-    await evaluation_repository.create_task_evaluations([_scored(0.8)], replay_id=None)
+    await evaluation_repository.create_task_evaluations(
+        [_scored(0.8, uuid.uuid4())], replay_id=None
+    )
     [second] = await evaluation_repository.create_task_evaluations(
-        [_scored(0.9)], replay_id=None
+        [_scored(0.9, uuid.uuid4())], replay_id=None
     )
 
     identity_map = await evaluation_repository.get_latest_evaluation_ids_by_identity(
         [session_id]
     )
-    assert identity_map[(session_id, version.id, params_hash)] == second.id
+    assert identity_map[(session_id, version.id, params_hash)] == [second.id]
+
+
+async def test_get_latest_evaluation_ids_by_identity_returns_whole_invocation(
+    plugin_setup: PluginSetup,
+) -> None:
+    """A multi-result invocation is returned whole, without an older one mixed in."""
+    plugin_repository, evaluation_repository, owner_id, session_id = plugin_setup
+    plugin = await plugin_repository.create(
+        Plugin(owner_id=owner_id, kind=PluginKind.EVALUATOR, name="accuracy-scorer")
+    )
+    version = await plugin_repository.create_version(
+        plugin.id, SOURCE, display_version="v1"
+    )
+    params_hash = hash_params({"threshold": 0.5})
+
+    def _scored(name: str, score: float, invocation_id: uuid.UUID | None) -> Evaluation:
+        return _evaluation(
+            owner_id,
+            session_id,
+            name,
+            score=score,
+            evaluator_version_id=version.id,
+        ).model_copy(
+            update={
+                "evaluator_params": {"threshold": 0.5},
+                "params_hash": params_hash,
+                "invocation_id": invocation_id,
+            }
+        )
+
+    older_invocation = uuid.uuid4()
+    await evaluation_repository.create_task_evaluations(
+        [_scored("accuracy", 0.5, older_invocation)], replay_id=None
+    )
+    latest_invocation = uuid.uuid4()
+    latest_rows = await evaluation_repository.create_task_evaluations(
+        [
+            _scored("accuracy", 0.9, latest_invocation),
+            _scored("tone", 0.7, latest_invocation),
+        ],
+        replay_id=None,
+    )
+    # A row with no invocation id, such as one written before this column
+    # existed and never backfilled, is never adoptable.
+    await evaluation_repository.create_task_evaluations(
+        [_scored("legacy", 0.4, None)], replay_id=None
+    )
+
+    identity_map = await evaluation_repository.get_latest_evaluation_ids_by_identity(
+        [session_id]
+    )
+    assert set(identity_map[(session_id, version.id, params_hash)]) == {
+        row.id for row in latest_rows
+    }
 
 
 async def test_create_task_evaluations_links_the_replay() -> None:

--- a/tests/server/test_replay_pipeline.py
+++ b/tests/server/test_replay_pipeline.py
@@ -348,6 +348,77 @@ async def test_if_missing_skips_already_scored_pairs(
     assert baseline_tasks[0].on_failure is TaskOnFailure.ABORT
 
 
+async def test_if_missing_adopts_every_result_of_one_invocation(
+    services: ReplayServices,
+) -> None:
+    """IF_MISSING links every result of a multi-result evaluator call, not just one."""
+    agent_version = await _agent_version_with_run_spec(services)
+    evaluator_a = await _evaluator_version(services, "accuracy")
+    evaluator_b = await _evaluator_version(services, "tone")
+    baseline = await _baseline_session(services, agent_version)
+
+    prior_job = await create_job(services.jobs, ACTOR.account.id)
+    prior_task = await create_evaluation_task(
+        services.tasks,
+        prior_job.id,
+        plugin_version_id=evaluator_a.id,
+        input_session_id=baseline.id,
+        on_failure=TaskOnFailure.CONTINUE,
+    )
+    worker = await create_worker(services.workers, ACTOR.account.id)
+    await services.task_service.claim_tasks(
+        10, actor=build_worker_actor(ACTOR.account, worker.id)
+    )
+    await services.task_service.update_task(
+        prior_task.id,
+        TaskUpdate(status=TaskStatus.RUNNING),
+        actor=build_task_actor(ACTOR.account, prior_task.id, 1, worker.id),
+    )
+    await services.task_service.update_task(
+        prior_task.id,
+        TaskUpdate(
+            status=TaskStatus.COMPLETED,
+            result=[
+                {"name": "accuracy", "score": 1.0},
+                {"name": "accuracy_detail", "score": 0.5},
+            ],
+        ),
+        actor=build_task_actor(ACTOR.account, prior_task.id, 1, worker.id),
+    )
+
+    bundle = await services.replay_service.create_replay(
+        ReplayCreate(
+            baseline_session_id=baseline.id,
+            evaluators=[
+                EvaluatorConfigInput(evaluator="accuracy"),
+                EvaluatorConfigInput(evaluator="tone"),
+            ],
+            baseline_evaluation_mode=BaselineEvaluationMode.IF_MISSING,
+        ),
+        actor=ACTOR,
+    )
+    tasks, _ = await services.task_service.list_tasks(
+        TaskFilter(job_id=bundle.replay.job_id), actor=ACTOR
+    )
+    baseline_tasks = [
+        task
+        for task in tasks
+        if isinstance(task, EvaluationTask) and task.input_session_id == baseline.id
+    ]
+    assert len(baseline_tasks) == 1
+    assert baseline_tasks[0].plugin_version_id == evaluator_b.id
+
+    linked = await services.evaluations.list_replay_evaluations([bundle.replay.id])
+    assert {evaluation.evaluation.name for _, evaluation in linked} == {
+        "accuracy",
+        "accuracy_detail",
+    }
+    assert all(
+        evaluation.evaluation.evaluator_version_id == evaluator_a.id
+        for _, evaluation in linked
+    )
+
+
 async def test_if_missing_with_different_params_does_not_adopt(
     services: ReplayServices,
 ) -> None:


### PR DESCRIPTION
Fixes #981. Experiment reruns under `if_missing` now link every evaluation of the latest evaluator invocation to the new replay instead of a single row, so multi-result evaluators keep all their baseline metrics. cc @strickvl