### PR TITLE
Stop routine CI downloads from PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,12 +161,13 @@ jobs:
         run: >-
           uv run --no-sync python scripts/smoke_plugin_artifacts.py
           --candidate-dir plugins/candidate-wheels
-      - name: Sync quickstart example
+      - name: Sync quickstart dependencies
         working-directory: examples/python/pydantic_ai_ticket_resolver
-        run: uv sync --frozen
-      - name: Run frozen quickstart example end to end
-        working-directory: examples/python/pydantic_ai_ticket_resolver
-        run: uv run --frozen python scripts/run_ci_e2e.py
+        run: >-
+          uv sync --frozen
+          --no-install-package kitaru
+          --no-install-package kitaru-pydantic-ai
+          --no-install-package kitaru-langfuse-importer
       - name: Install current Kitaru artifacts into quickstart example
         run: |
           uv pip install \

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,7 +1,8 @@
 ---
 name: Installer smoke
-# Runs install.sh on real GitHub-hosted runners the way a user would
-# (`curl ... | bash`), then checks the CLI, MCP server, skills, and PATH.
+# Runs install.sh on real GitHub-hosted runners, then checks the CLI, MCP
+# server, skills, and PATH. PRs install the local wheel so CI does not inflate
+# PyPI download counts. Releases fetch the published package as a user would.
 # No Docker on the runners, so login is skipped.
 # Triggers: PRs that touch the script (path-filtered, so this does not run on
 # ordinary PRs), manual dispatch, and the release workflow right after the
@@ -52,10 +53,28 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        if: github.event_name == 'pull_request'
+      - name: Build local Kitaru wheel
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          wheel_dir="$RUNNER_TEMP/kitaru-wheel"
+          uv build --wheel --out-dir "$wheel_dir"
+          wheel=$(find "$wheel_dir" -maxdepth 1 -name 'kitaru-*.whl' -print -quit)
+          wheel_uri=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve().as_uri())' "$wheel")
+          printf 'kitaru @ %s\n' "$wheel_uri" > "$RUNNER_TEMP/kitaru-constraint.txt"
+          printf 'KITARU_VERSION=%s\n' "$(uv version --short)" >> "$GITHUB_ENV"
+          printf 'UV_CONSTRAINT=%s\n' "$RUNNER_TEMP/kitaru-constraint.txt" >> "$GITHUB_ENV"
+      - name: Select published Kitaru version
+        if: github.event_name != 'pull_request'
+        shell: bash
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: printf 'KITARU_VERSION=%s\n' "$REQUESTED_VERSION" >> "$GITHUB_ENV"
       - name: Run the installer as a user would
         shell: bash
         env:
-          KITARU_VERSION: ${{ inputs.version }}
           SOURCE: ${{ inputs.source || 'file' }}
         # The default (non-verbose) path is the one users run, so that is the
         # path that has to pass. On failure, rerun once with --verbose purely to
@@ -79,15 +98,13 @@ jobs:
           exit 1
       - name: Verify
         shell: bash
-        env:
-          EXPECTED_VERSION: ${{ inputs.version }}
         run: |
           set -euxo pipefail
           export PATH="$HOME/.local/bin:$PATH"
           uname -a
           kitaru --version
-          if [ -n "$EXPECTED_VERSION" ]; then
-            test "$(kitaru --version)" = "$EXPECTED_VERSION"
+          if [ -n "$KITARU_VERSION" ]; then
+            test "$(kitaru --version)" = "$KITARU_VERSION"
           fi
           kitaru-mcp --help >/dev/null
           ls "$HOME/.agents/skills"

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -64,8 +64,11 @@ jobs:
           wheel=$(find "$wheel_dir" -maxdepth 1 -name 'kitaru-*.whl' -print -quit)
           wheel_uri=$(python -c 'from pathlib import Path; import sys; print(Path(sys.argv[1]).resolve().as_uri())' "$wheel")
           printf 'kitaru @ %s\n' "$wheel_uri" > "$RUNNER_TEMP/kitaru-constraint.txt"
-          printf 'KITARU_VERSION=%s\n' "$(uv version --short)" >> "$GITHUB_ENV"
-          printf 'UV_CONSTRAINT=%s\n' "$RUNNER_TEMP/kitaru-constraint.txt" >> "$GITHUB_ENV"
+          {
+            printf 'KITARU_VERSION=%s\n' "$(uv version --short)"
+            printf 'UV_CONSTRAINT=%s\n' "$RUNNER_TEMP/kitaru-constraint.txt"
+            printf 'UV_TOOL_BIN_DIR=%s\n' "$(env -u UV_TOOL_BIN_DIR uv tool dir --bin)"
+          } >> "$GITHUB_ENV"
       - name: Select published Kitaru version
         if: github.event_name != 'pull_request'
         shell: bash


### PR DESCRIPTION
## What changed?

Routine PR and `develop` CI now exercises locally built Kitaru artifacts without downloading Kitaru from PyPI. Release and manual installer smoke tests continue to fetch the requested published package.

## Why?

Our own CI downloads were mixed into Kitaru's PyPI statistics, which made the download count a poor signal for external adoption.

Closes #985.

## Release context

No release coordination is required. The release workflow still tests the exact package after it is published to PyPI.

## Reviewer Notes

Start with the quickstart job: its frozen sync now installs only third-party dependencies, then the existing candidate-wheel step installs Kitaru and the two plugins under review before the contract and end-to-end tests run.

The installer workflow builds a local wheel only for pull requests and passes it to uv as a direct constraint. The constraint applies to the initial global install, the upgrade check, and the project install. Non-PR runs do not set that constraint, so the release and manual paths retain the real PyPI check.

The main risk is event routing. A mistaken condition could make release smoke tests consume a local artifact or let one of the pull-request installer steps fall back to PyPI.

## Reproduction

Inspect the `Quickstart example end to end` check and confirm the sync step does not install the three Kitaru packages; the following candidate-wheel step should report `file://` sources before the tests pass.

Inspect the five `Installer smoke` matrix jobs and confirm `Build local Kitaru wheel` runs on this pull request, each installer reports the branch's development version, and the impossible `99.99.99` regression check still fails as intended.

## Local checks run

- `just check`
- `just yaml-check`
- `just actions-lint`
- Quickstart dependency sync, candidate-wheel installation, `uv pip check`, and 16 quickstart contract tests
- Installer smoke with the local wheel constraint in global and project modes
