### PR TITLE
Clarify agent scope and verification guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,16 @@ matching Kitaru repo skill under `.agents/skills/`. Keep each logical repo skill
 available under the same name in `.claude/skills/`; share host-neutral guidance
 and diverge only for a documented host-specific reason.
 
+Before editing a subtree, read the `AGENTS.md` files along its path that have not already been loaded. If a directory has no `AGENTS.md` but has a `CLAUDE.md`, read that guidance too.
+
+## Task scope and follow-through
+
+Complete the work authorized by the user's request, including relevant verification and final review. Make reasonable assumptions for routine choices and continue independent authorized work while a material decision is pending. Task skills guide execution; they do not independently authorize commits, publication, or release actions. Do not ask again for an action already authorized in the conversation.
+
+If a skill or instruction blocks completion, name and link to its file, quote the relevant clause, and explain the specific unresolved action. Distinguish an explicit requirement from your interpretation. Preserve the repository's human-review and release controls.
+
+For substantial work with independent questions or modules, use subagents when parallel work would save time or improve quality. Assign concrete tasks and distinct file responsibilities for edits; the coordinator integrates and verifies the result. Keep small or tightly coupled work local.
+
 ## Core Commands
 
 Use `uv` for Python dependency management and `just` for the normal command
@@ -32,19 +42,22 @@ stack.
 - `uv sync`: install and sync dependencies
 - `uv sync --extra server`: include server components
 - `just fix`: auto-fix formatting, lint, and YAML issues
-- `just check`: run format, lint, typecheck, typos, YAML, actions lint, and links
+- `just check`: run format, lint, OpenAPI freshness, typecheck, typos, YAML, actions lint, and links
 - `just test`: run the full pytest suite
 - `just test tests/test_file.py::test_name`: run one targeted test
 - `just build`: build wheel and sdist locally
 
-Typical loop: write code -> `just fix` -> `just check` -> `just test`.
+During iteration, format changed files and run tests for the changed behavior. `just fix` rewrites Python files and workflow YAML across the checkout; prefer file-scoped formatters for narrow changes and review incidental edits after a full fix.
 
-When running the full suite through output that may truncate, preserve the
-failure names:
+Before handing off a code PR, run `just check` and the relevant test suites. Run the full core suite for shared core behavior or changes spanning several core modules; plugin changes follow `plugins/AGENTS.md`. Documentation-only changes need relevant documentation checks, not the product test suite. Repeat successful checks only when subsequent edits affect them, failures occur, or unresolved evidence warrants it.
+
+When test output may truncate, save the full log and preserve the test command's exit status. Run this in Bash as a separate command, then inspect the saved log:
 
 ```bash
-just test 2>&1 | grep -E "FAILED|ERROR|passed|failed" | tail -20
+bash -o pipefail -c 'just test 2>&1 | tee /tmp/kitaru-tests-yourtask.log'
 ```
+
+Replace `yourtask` with a unique task identifier. The pipeline reports failure if either the tests or log capture fails; a filtered summary alone is not evidence that tests passed.
 
 ## Coding Style
 

--- a/devtools/AGENTS.md
+++ b/devtools/AGENTS.md
@@ -36,7 +36,7 @@ uv run python devtools/stack.py up --db-name kitaru_<yourtask> --fresh
 uv run python devtools/stack.py workers --count 2
 ```
 
-Jobs (imports, session runs, experiments) settle only while a worker runs. A job stuck pending means no worker, not a bug.
+Jobs (imports, session runs, experiments) need a running worker. For a pending job, first check worker availability and eligibility; if a suitable worker is active, inspect claim and dispatch failures.
 
 `--auth local` prints an API key export, the default is `none`. `--env KEY=VALUE` passes server settings. `--docker` runs from `docker-compose.yml` instead.
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -62,8 +62,7 @@ changes when redirect rules in `docs/worker/redirect.mjs` change.
 
 ## Key Rules
 
-- **Never add Node.js tooling to the repo root.** No root `package.json`,
-  no root `node_modules`, no workspace config.
+- Keep docs-only dependencies and scripts in the docs app. The existing root `package.json` and pnpm workspace support the TypeScript SDK and adapters; use their generation and validation commands when changing those packages.
 - **Never hand-edit generated files:** `content/docs/changelog.mdx` and `content/docs/reference/` are generated and gitignored. The public changelog is hosted at `docs.zenml.io/changelog`; the local `changelog.mdx` is only for local/reference builds. The reference pipeline is `scripts/generate_sdk_docs.py` (Python, griffe extraction filtered to the `PUBLIC_API` allowlist) followed by `docs/scripts/convert-sdk-docs.mjs` (Node, JSON to MDX); run it via `just generate-docs`.
 - **CLI reference is schema-driven:** command metadata lives under `src/kitaru/cli/` and is exposed through `kitaru schema`; `scripts/generate_cli_docs.py` consumes that schema to generate `content/docs/cli/` (run via `just generate-docs`). The generator hardcodes no command names — CLI changes flow through automatically.
 - **Respect static export constraints:** No server-side features (middleware,
@@ -136,7 +135,7 @@ this FumaDocs reference app, and generated output).
 ### Authoring conventions
 
 - Hand-written docs are **GitBook Markdown under `docs/book/`** (not MDX). Edit those `.md` files directly and add new pages to `docs/book/toc.md`. GitBook conventions live in `docs/book/AGENTS.md`.
-- Links **within the GitBook space** use relative `.md` paths (e.g. `../concepts/checkpoints.md`, `flows.md#runtime-options`). Link to the **SDK reference** with `https://sdkdocs.kitaru.ai` (the separate reference site, not in the GitBook space). Link to **other ZenML docs** with absolute `https://docs.zenml.io/...`. Diagrams are static PNG images hosted on Cloudflare R2 and referenced as `https://assets.kitaru.ai/docs/diagrams/<slug>.png` (regenerate via the diagram pipeline, not committed to the repo).
+- Links **within the GitBook space** use relative `.md` paths (e.g. `../concepts/README.md`). Do not add anchors to cross-file links; same-file anchors are fine. Link to the **SDK reference** with `https://sdkdocs.kitaru.ai` (the separate reference site, not in the GitBook space). Link to **other ZenML docs** with absolute `https://docs.zenml.io/...`. Diagrams are static PNG images hosted on Cloudflare R2 and referenced as `https://assets.kitaru.ai/docs/diagrams/<slug>.png` (regenerate via the diagram pipeline, not committed to the repo).
 - Do not commit temporary agent planning/review files such as `docs/plans/*`, `docs/reviews/*`, or prompt exports unless the user explicitly asks for a durable tracked document. Treat them as coordination scratchpads, not product docs.
 - Generated reference output must come from reviewed generation scripts rather than manual edits. The public surface it documents is the `PUBLIC_API` allowlist in `scripts/generate_sdk_docs.py`; change that allowlist (and its tests) rather than hand-editing output when the SDK surface changes.
 

--- a/docs/book/AGENTS.md
+++ b/docs/book/AGENTS.md
@@ -45,4 +45,4 @@ The visual source of truth is the React components in `docs/components/diagrams.
 
 - Keep **Kitaru v2 product terminology**: agent, agent version, session, session node, replay, evaluator, evaluation, cohort, cohort version, experiment, experiment run, worker, importer. The eval objects are **evaluators/evaluations — never "scorers"/"scores" as nouns**. Traces are **recorded** or **imported** — never "captured". Do not describe the retired v1 runtime vocabulary (flow, checkpoint, stack, deployment, wait/HITL) as current — durable execution belongs to ZenML, not Kitaru.
 - Langfuse, LangSmith, and Braintrust are complements, never competitors, in docs copy ("Langfuse stays your system of record").
-- US English. Only document shipped features; mark anything ahead of the launch build with a roadmap callout or a `<!-- TODO(v2-launch) -->` comment.
+- US English. Only document shipped features. Keep plans for unshipped behavior in unpublished planning material until the behavior ships.

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -20,10 +20,12 @@ Read `plugins/DEVELOPMENT.md` before you change package metadata, default defini
 - New packages need initial metadata. Adding a server default requires an explicit release decision.
 - Keep adapter distributions out of the server catalog.
 - Run plugin workspace commands with `--project plugins`; the root workspace contains only Kitaru.
-- Commit the resulting `plugins/uv.lock` change.
+- Include relevant `plugins/uv.lock` changes in the patch and in any requested commit.
 - Keep `.github/workflows/ci.yml`, `.github/workflows/release-plugins.yml`, and `plugins/packages/` aligned when you add or remove a distribution.
 
 ## Required tests
+
+During iteration, run the focused tests and file-scoped checks for the changed behavior. Before handing off a plugin implementation PR, run the workspace format, lint, typecheck, and full test commands below. Metadata, pin, default-definition, and release-path changes also require the artifact smoke check. Documentation-only changes need relevant documentation checks, not the plugin test suite.
 
 - Run the focused plugin tests for changed behavior.
 - Run `uv run --project plugins ruff format --config plugins/pyproject.toml --check plugins` and `uv run --project plugins ruff check --config plugins/pyproject.toml plugins`.
@@ -31,7 +33,7 @@ Read `plugins/DEVELOPMENT.md` before you change package metadata, default defini
 - Run `uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests tests/server/test_default_plugins.py`.
 - Run `just plugin-artifact-smoke` for default definitions, package metadata, pins, or release-path changes.
 - Use `plugins/docker-compose.candidate.yml` when a change needs a candidate-image rehearsal.
-- Commit the candidate Dockerfile and Compose configuration. Do not commit generated candidate wheels.
+- Include relevant candidate Dockerfile and Compose configuration changes in the patch and in any requested commit. Do not commit generated candidate wheels.
 - Do not change production release Dockerfiles to support local plugin wheels.
 
 ## Development registration

--- a/src/kitaru/AGENTS.md
+++ b/src/kitaru/AGENTS.md
@@ -21,10 +21,9 @@ Module naming: modules that define per-entity types are singular
 URL segment they serve (`/api/v1/orders` → `orders.py`), and mapping modules
 follow their router.
 
-## New resource checklist
+## New persistent public API resource checklist
 
-Adding a resource named `Order` touches these places. Skipping one produces a
-half-wired resource that still imports cleanly, so walk the whole list.
+Adding a new persistent public API resource named `Order` touches these places. Walk the whole list so the resource works through persistence, REST, and the SDK. Changes to existing resources apply only the relevant steps. For UI-only read responses, follow the `kitaru-ui-api-development` skill; do not add storage or SDK, CLI, or MCP parity solely to satisfy this checklist.
 
 1. `server/domain/order.py`: entity plus domain errors.
 2. `server/application/interfaces/order_repository.py`: repository Protocol.

--- a/src/kitaru/server/database/migrations/AGENTS.md
+++ b/src/kitaru/server/database/migrations/AGENTS.md
@@ -18,12 +18,11 @@ Rules for the Alembic migration scripts under `versions/`.
 Never hand-write a migration from scratch. Generate it against the schema
 state of `develop`:
 
-1. Create the database state from `develop`: check out `develop` and migrate
-   a database to its head revision.
-2. Switch back to your branch and run
-   `alembic revision --autogenerate -m "<short name>"`.
-3. Modify the generated script if necessary, for example for data
-   backfills or operations autogenerate cannot detect.
+1. Create a separate baseline worktree from current `origin/develop` under the repository's `.worktrees/` directory. Keep the active feature checkout on its branch.
+2. From the baseline worktree, migrate a uniquely named disposable database to its head revision. Do not reuse another task's database.
+3. From the feature checkout, point Alembic at that same disposable database and run `alembic revision --autogenerate -m "<short name>"`. The database must still contain the baseline schema when autogenerate compares it with the feature branch's ORM metadata.
+4. Review and modify the generated script as needed for backfills or operations autogenerate cannot detect. Validate it with the migration checks.
+5. Remove the baseline worktree and drop only the disposable database created for this task.
 
 Index and constraint names in the generated script are inherited from the
 ORM classes, which build them with the `orm_utils` helpers. Do not rename

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,9 +1,10 @@
 # Test rules
 
-Async tests and fixtures are plain `async def`. pytest-asyncio runs in auto
-mode, so no decorators and no `asyncio.run` wrappers.
+Ordinary async tests and fixtures are plain `async def`. pytest-asyncio runs in auto mode, so they need no decorators or `asyncio.run` wrappers. Synchronous Hypothesis `@given` tests are the exception: call async code with `asyncio.run` inside the test body.
 
 ## Test surfaces per server resource
+
+Cover all four surfaces below for a new persistent public API resource. For changes to an existing resource, select the surfaces that prove the affected behavior. Transaction, locking, migration, and cross-request changes need PostgreSQL coverage; an in-memory fake cannot prove those contracts.
 
 1. Service tests against the in-memory fake repository
    (`tests/server/test_<x>_service.py`).


### PR DESCRIPTION
## What changed?

Agents now have clearer instructions for completing authorized work, choosing verification appropriate to the change, and reading applicable nested guidance. The update resolves contradictory test and documentation rules and makes migration preparation use an isolated baseline checkout.

## Why?

The [GPT-6 Astra guidance](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-6-astra) calls out sensitivity to conflicting instructions and overly broad verification. In this repository, those conflicts could trigger unsolicited commits, unnecessary suites, or incorrect assumptions about pending jobs. The previous test-output pipeline could also hide a failing exit status.

## Release context

Internal contributor guidance only. No package versions, public API contracts, or release dependencies change.

## Reviewer Notes

Check that the distinction between authorized actions and workflow instructions is clear, while the existing human-review and publication controls remain intact. The resource checklist still requires complete coverage for a new persistent public API resource; narrower changes select the relevant steps.

The `docs/CLAUDE.md` fixes matter to Codex users with CLAUDE.md fallback discovery enabled: its old ban on root Node tooling conflicted with the existing TypeScript workspace. Its link example now agrees with GitBook's cross-file anchor restriction.

## Reproduction

1. Read the root verification rules for a documentation-only edit, then the plugin rules for a plugin implementation PR. The former selects documentation checks; the latter still requires the workspace checks and suite before handoff.
2. Compare the opening async-test rule with the Hypothesis section. Both allow `asyncio.run` inside synchronous property-test bodies.
3. Exercise the root log-capture pattern with a stub `just` returning 0, 1, or 5. Bash should return the same status and save the complete output. A failed `tee` write must also produce a nonzero status.
4. Follow the migration steps conceptually: the disposable database receives the baseline schema from a separate worktree, then autogenerate compares it with the feature checkout without switching that checkout's branch.

## Local checks run

- Synthetic log-capture checks passed for exit codes 0, 1, and 5, plus log-write failure.
- `git diff --check`, targeted `typos`, and `just docs-lint` passed.
- Independent instruction review found no actionable issues.
- Measured the largest identified instruction chain including docs fallback: 31,914 bytes before separators, below the default 32 KiB cap.
- Product tests and a live migration were not run for these instruction-only changes; no agent-behavior benchmark was run.
