### PR TITLE
Support PydanticAI 2.37-2.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `kitaru-pydantic-ai` now supports the PydanticAI 2.37 through 2.40 minor lines in addition to 2.14.1+, and the plugin workspace lockfile resolves `pydantic-ai-slim` 2.38.0 with `genai-prices` 0.1.6.
 - `POST /api/v1/imports` now returns the import instead of the job, with the job in its `job_id`. Import task responses carry `import_id` instead of `payload_blob_id` and `agent_id`.
 
 ### Fixed

--- a/plugins/packages/pydantic-ai/CHANGELOG.md
+++ b/plugins/packages/pydantic-ai/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support PydanticAI 2.37 through 2.40 in addition to the existing 2.14 through 2.36 minor lines.
+
 ## 0.2.0
 
 - Support PydanticAI 2.23 through 2.36 in addition to the existing 2.14 through 2.22 minor lines.

--- a/plugins/packages/pydantic-ai/pyproject.toml
+++ b/plugins/packages/pydantic-ai/pyproject.toml
@@ -27,11 +27,11 @@ keywords = ["ai-agents", "kitaru", "pydantic-ai", "recording", "replay"]
 dependencies = [
     "genai-prices>=0.1.1,<0.2",
     "kitaru>=0.23.0",
-    "pydantic-ai-slim>=2.14.1,<2.37",
+    "pydantic-ai-slim>=2.14.1,<2.41",
 ]
 
 [project.optional-dependencies]
-openai = ["pydantic-ai-slim[openai]>=2.14.1,<2.37"]
+openai = ["pydantic-ai-slim[openai]>=2.14.1,<2.41"]
 
 [project.urls]
 Homepage = "https://kitaru.ai"

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -666,15 +666,15 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.1.4"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/e3/23f4be7d5626878a6297c728f5f8db83bd9b135da481935d4c1bb82efc21/genai_prices-0.1.4.tar.gz", hash = "sha256:f3b8a0bf0c21b01f5af3ca42babcab2f17728bf3c602f87f42b72d1d2bf61d98", size = 94678, upload-time = "2026-08-19T23:53:25.527Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/16/e5a507d42c0eb629b48ebe6c278f2d8c3f929bb6b28f18108bdd66d8ae12/genai_prices-0.1.6.tar.gz", hash = "sha256:802c1e4cc3ed5e70a09083b83af441a58d91f62e12768f7f1b6b26c98a33fcac", size = 111810, upload-time = "2026-09-02T14:53:54.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/54/911961e926a4c4ea30bf1fa0bf9d8ffc5c9ac5ed6a3f77b3d9e0ab5bb9a5/genai_prices-0.1.4-py3-none-any.whl", hash = "sha256:1d1b01cc7ab1adfa17c3a1121f4c13990bd0a4377640ecd37ebfde5836768240", size = 99160, upload-time = "2026-08-19T23:53:24.52Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a1/43fa2a4c5557cd977e83eecec265b0b77b726b0c7b9f2f180b46c6fdb458/genai_prices-0.1.6-py3-none-any.whl", hash = "sha256:35ac8043dbcf2958488129413bfecba7304fe12a68ad4a78c5b0d15281e82814", size = 118834, upload-time = "2026-09-02T14:53:53.758Z" },
 ]
 
 [[package]]
@@ -1459,8 +1459,8 @@ openai = [
 requires-dist = [
     { name = "genai-prices", specifier = ">=0.1.1,<0.2" },
     { name = "kitaru", editable = "../" },
-    { name = "pydantic-ai-slim", specifier = ">=2.14.1,<2.37" },
-    { name = "pydantic-ai-slim", extras = ["openai"], marker = "extra == 'openai'", specifier = ">=2.14.1,<2.37" },
+    { name = "pydantic-ai-slim", specifier = ">=2.14.1,<2.41" },
+    { name = "pydantic-ai-slim", extras = ["openai"], marker = "extra == 'openai'", specifier = ">=2.14.1,<2.41" },
 ]
 provides-extras = ["openai"]
 
@@ -2184,7 +2184,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.35.3"
+version = "2.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2196,9 +2196,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/e5/f6fdeeb568ad5f0cdfaf8bd669a08fa74c5a86ff8d2a06620f56889a1688/pydantic_ai_slim-2.35.3.tar.gz", hash = "sha256:73c0c81836c04122ed19519e2bbecac2af310864796bb69f512aadcdedf6cd0d", size = 1265371, upload-time = "2026-08-28T00:51:50.913Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/1e/9baa25614062be6fe05c3691816bbd1bcf538a5828bcd9fc7732ca89a2b3/pydantic_ai_slim-2.38.0.tar.gz", hash = "sha256:2e486a8558e9075ca37d545b0e90e241a9d7e2c8b4b5f8255ac9c527dca96a05", size = 1371724, upload-time = "2026-09-03T07:57:29.165Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/f6/369ed803c8f80316967ba1e8bda1c6f88f682314e1afc771628c1621fde8/pydantic_ai_slim-2.35.3-py3-none-any.whl", hash = "sha256:f5d0c7a5e0797e770117df06c13e019da45e17d1adc909cc36181bcea6012be4", size = 1492524, upload-time = "2026-08-28T00:51:42.111Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/db/794b281a4314666f726de4c713e77190945d087065b1bd361c1a5086cef8/pydantic_ai_slim-2.38.0-py3-none-any.whl", hash = "sha256:58bcb7d574eca0f69831855b550236844172bb393d21f7c477faa1bb7d368822", size = 1615570, upload-time = "2026-09-03T07:57:21.89Z" },
 ]
 
 [package.optional-dependencies]
@@ -2311,7 +2311,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "2.35.3"
+version = "2.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2319,9 +2319,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/34/e610b567e0ec6ef0df555c23abbf3e2aadcfcede4e2553c08af742f4450a/pydantic_graph-2.35.3.tar.gz", hash = "sha256:f2bb41c17cd610e764cfe36be085470c88b2f261dab1916ab79357cd98c3baa1", size = 45191, upload-time = "2026-08-28T00:51:53.391Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/0c/140ffa7f0a92267b71cb4ef6a9340e36d341420e18fe537a98c9968bfa14/pydantic_graph-2.38.0.tar.gz", hash = "sha256:3ecab71ba43b754c016ee0d84eeb472089cfaebbfca9116a77596c4f350f9920", size = 45189, upload-time = "2026-09-03T07:57:31.302Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/c2/be70478232567f19dc0983875ecb36d1e1b08546d812dd6a510a57ab090a/pydantic_graph-2.35.3-py3-none-any.whl", hash = "sha256:daab4037b55d18209532b69e8b34d4f542bf854a83995cd0d0cb2422463feee3", size = 52703, upload-time = "2026-08-28T00:51:45.864Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/33/52cf89abe3180beea7f6a921a8f43260f827e1e48181464d344812bc9188/pydantic_graph-2.38.0-py3-none-any.whl", hash = "sha256:00f5f0e6cb7b3126a394fe4c64f175f1c0d587acea075238c3678d9464bd5f58", size = 52700, upload-time = "2026-09-03T07:57:24.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed?

- `kitaru-pydantic-ai`: `pydantic-ai-slim>=2.14.1,<2.37` → `<2.41` (base dependency and the `openai` extra).
- `plugins/uv.lock`: `pydantic-ai-slim`/`pydantic-graph` 2.35.3 → 2.38.0, `genai-prices` 0.1.4 → 0.1.6 (2.38.0 is the newest release the workspace `exclude-newer = "3 days"` policy admits; 2.39.0 and 2.40.0 shipped inside that window).
- Package `Unreleased` changelog entry plus root `CHANGELOG.md` entry.

## Why?

Weekly upstream compatibility check. PydanticAI released 2.37.0 through 2.40.0 since the last bump (#912), all excluded by the current `<2.37` cap, so the adapter no longer installs into projects on current PydanticAI. No source changes were needed: the adapter surface it wraps (`Agent.run`/`run_stream`/`iter`, `ModelRequest`/`ModelResponse`, usage and `genai-prices` cost lookup) is unchanged across these releases.

## Release context

Plugin release unit `pydantic-ai` is directly changed; no core change, no default-catalog entry (adapter distribution).

## Reviewer Notes

This is a bounds-only change. The thing to sanity-check is that nothing in `plugins/packages/pydantic-ai/src` relies on a private PydanticAI API that moved in 2.37-2.40; the evidence is that the full adapter suite (recording, history/passthrough replay, streaming, tool-call status, cost tracking) passes unmodified against the pinned 2.38.0 lock and against a resolver-forced 2.40.0 environment. If the bound were wrong, `uv pip check` in the quickstart example would report the conflict and the recording tests would fail on message-part shape changes.

## Reproduction

```bash
uv sync --project plugins --frozen --all-packages
uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests/adapters/pydantic_ai
```

To exercise the top of the new range, force 2.40.0 into the plugin venv and rerun the same tests; they pass. The quickstart example (`examples/python/pydantic_ai_ticket_resolver`) `scripts/run_ci_e2e.py` and `tests/test_contract.py` also pass with `pydantic-ai-slim[openai]==2.40.0` installed over the candidate wheels.

## Local checks run

- Plugin workspace suite against latest upstream (pydantic-ai-slim 2.40.0, genai-prices 0.1.6): 1021 passed
- `plugins/tests/adapters/pydantic_ai` against the committed lock (2.38.0): 54 passed
- `ruff check` / `ruff format --check` / `ty check` for `plugins`
- `just plugin-artifact-smoke`
- Quickstart example contract tests + `run_ci_e2e.py` with pydantic-ai-slim 2.40.0

Link to Devin session: https://app.devin.ai/sessions/5dab7cb675f844c7bd09829e8a5bc6ff
Open in Devin Desktop: https://app.devin.ai/desktop/session/5dab7cb675f844c7bd09829e8a5bc6ff?variant=devin
Requested by: @strickvl