### PR TITLE
Support Logfire 5.x in the Logfire importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `kitaru-logfire-importer[adapter]` now supports Logfire 5.x in addition to 4.35+. Logfire 5.0 removed its deprecated query client APIs but keeps `AsyncLogfireQueryClient.query_json_rows`, which is the only query surface the importer uses.
 - `POST /api/v1/imports` now returns the import instead of the job, with the job in its `job_id`. Import task responses carry `import_id` instead of `payload_blob_id` and `agent_id`.
 
 ### Fixed

--- a/plugins/packages/logfire-importer/CHANGELOG.md
+++ b/plugins/packages/logfire-importer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support Logfire 5.x for the `adapter` extra in addition to the existing 4.35+ line.
+
 ## 0.2.0
 
 - Add the Logfire importer-backed adapter, installed through the `adapter` extra.

--- a/plugins/packages/logfire-importer/pyproject.toml
+++ b/plugins/packages/logfire-importer/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 [project.optional-dependencies]
 adapter = [
     "httpx>=0.27,<1",
-    "logfire>=4.35,<5",
+    "logfire>=4.35,<6",
 ]
 
 [project.urls]

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -1395,7 +1395,7 @@ adapter = [
 requires-dist = [
     { name = "httpx", marker = "extra == 'adapter'", specifier = ">=0.27,<1" },
     { name = "kitaru", editable = "../" },
-    { name = "logfire", marker = "extra == 'adapter'", specifier = ">=4.35,<5" },
+    { name = "logfire", marker = "extra == 'adapter'", specifier = ">=4.35,<6" },
 ]
 provides-extras = ["adapter"]
 


### PR DESCRIPTION
## What changed?

- `kitaru-logfire-importer` `adapter` extra: `logfire>=4.35,<5` → `<6`.
- `plugins/uv.lock` metadata reflects the new specifier; the resolved version stays at 4.41.0 because 5.0.0 (published 2026-09-04) is still inside the workspace `exclude-newer = "3 days"` window.
- Package `Unreleased` changelog entry plus root `CHANGELOG.md` entry.

## Why?

Weekly upstream compatibility check. Logfire 5.0.0 is out and the `<5` cap blocks installing the importer-backed adapter next to it. The 5.0 breaking changes (deprecated query client APIs, deprecated `configure` arguments, HTTPX capture arguments, `logfire.experimental` moves, GenAI attribute `version=2` defaults) do not touch what this package uses: `logfire.span`/`force_flush` in the adapter and `AsyncLogfireQueryClient.query_json_rows` plus `logfire._internal.config.get_base_url_from_token` in the API fetch path. Both remain present in 5.0.0, and the full importer and adapter suites pass unchanged against it.

## Release context

Plugin release unit `logfire-importer` is directly changed; no core change. The default-catalog requirement for the importer itself is unaffected because `logfire` is only pulled in by the optional `adapter` extra.

## Reviewer Notes

The only non-trivial point is `get_base_url_from_token`, imported from `logfire._internal.config` in `plugins/packages/logfire-importer/src/kitaru_logfire_importer/api.py`. It is private upstream, so it is the piece most likely to move in a major release; I verified it still exists in 5.0.0. Note the GenAI attribute format change in 5.0 affects what Logfire *records* from instrumented OpenAI/Anthropic calls (`gen_ai.*` attributes, `version=2`), not the query API. If users upgrade their instrumented apps to Logfire 5 the importer's span normalization may see the new attribute layout; the importer tests already cover the fixtures we have, but that is a data-shape question worth keeping an eye on rather than a dependency-bound one.

## Reproduction

```bash
uv sync --project plugins --frozen --all-packages
uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests/adapters/logfire plugins/tests/importers/test_logfire.py
```

Then `uv pip install --python plugins/.venv/bin/python --exclude-newer 2027-01-01 logfire==5.0.0` and rerun; the same 69 tests pass and `python -c "from logfire.query_client import AsyncLogfireQueryClient; from logfire._internal.config import get_base_url_from_token"` imports cleanly.

## Local checks run

- Plugin workspace suite with logfire 5.0.0 forced: 1021 passed
- Focused logfire adapter + importer tests on the committed lock: 69 passed
- `ruff check` / `ruff format --check` / `ty check` for `plugins`
- `just plugin-artifact-smoke`

Link to Devin session: https://app.devin.ai/sessions/5dab7cb675f844c7bd09829e8a5bc6ff
Open in Devin Desktop: https://app.devin.ai/desktop/session/5dab7cb675f844c7bd09829e8a5bc6ff?variant=devin
Requested by: @strickvl