### PR TITLE
Fix StaticCase tool policy example

### DIFF
--- a/docs/book/guides/tool-policies.md
+++ b/docs/book/guides/tool-policies.md
@@ -22,7 +22,11 @@ policy = ToolPolicy(
         "get_current_time": PassthroughConfig(),
         "refund_payment": StaticConfig(
             cases=[
-                StaticCase(match_mode="exact", match={"order_id": "4821"}, result="refund issued: $129.00")
+                StaticCase(
+                    match_mode="exact",
+                    match={"order_id": "4821"},
+                    result="refund issued: $129.00",
+                )
             ],
             on_miss="error_result",
         ),

--- a/docs/book/guides/tool-policies.md
+++ b/docs/book/guides/tool-policies.md
@@ -22,7 +22,7 @@ policy = ToolPolicy(
         "get_current_time": PassthroughConfig(),
         "refund_payment": StaticConfig(
             cases=[
-                StaticCase(match={"order_id": "4821"}, result="refund issued: $129.00")
+                StaticCase(match_mode="exact", match={"order_id": "4821"}, result="refund issued: $129.00")
             ],
             on_miss="error_result",
         ),


### PR DESCRIPTION
## What changed?

The tool policies guide's Python example now constructs successfully with the required `match_mode="exact"` argument.

## Why?

Copying the example previously raised a Pydantic validation error before the policy could be registered. This documentation correction preserves the existing API contract.

Fixes #990

## Release context

GitBook documentation only; no package release or coordinated changes required.

## Reviewer Notes

Run the first Python code block in `docs/book/guides/tool-policies.md`. It should construct `policy` without an error. Removing `match_mode="exact"` reproduces the missing-field validation error.

## Reproduction

From the repository with its Python dependencies installed:

```bash
uv run python - <<'PY'
from pathlib import Path
from kitaru.api_models.v1.replay_config import ToolPolicy

source = Path("docs/book/guides/tool-policies.md").read_text().split("```python\n", 1)[1].split("```", 1)[0]
namespace = {}
exec(source, namespace)
policy = namespace["policy"]
assert policy.tools["refund_payment"].cases[0].match_mode == "exact"
assert ToolPolicy.model_validate_json(policy.model_dump_json()) == policy
print("PASS")
PY
```

## Local checks run

Executed the documented code block against this checkout's source using Python 3.14.4: construction and JSON round trip passed. Removing the argument reproduced the original error. `git diff --check` passed.
