### PR TITLE
Document Claude recording settings isolation

### DIFF
--- a/docs/book/adapters/claude-agent-sdk.md
+++ b/docs/book/adapters/claude-agent-sdk.md
@@ -36,7 +36,10 @@ async def run() -> None:
     runner = KitaruClaudeRunner(agent_id=uuid.UUID(os.environ["KITARU_AGENT_ID"]))
     stream = runner.query(
         prompt="Investigate ticket 4821.",
-        options=ClaudeAgentOptions(model="claude-sonnet-4-5"),
+        options=ClaudeAgentOptions(
+            model="claude-sonnet-4-5",
+            setting_sources=[],
+        ),
     )
     async with contextlib.aclosing(stream) as messages:
         async for message in messages:
@@ -44,6 +47,10 @@ async def run() -> None:
 ```
 
 The adapter calls the Claude Agent SDK's public `query()` function and yields each message unchanged. It copies `ClaudeAgentOptions` before adding recording hooks, so it does not modify the options or hook collections you passed in.
+
+Recording preserves the Claude SDK's settings behavior. With `setting_sources` unset, the SDK can load user, project, and local settings, including output styles from `~/.claude/settings.json`. For recordings intended for replay with tool substitution, set `setting_sources=[]` as above so those settings do not add context that the replay omits. Tool substitution forces this setting on replay; an all-passthrough replay preserves your settings instead.
+
+This option disables those settings sources, but does not make the whole execution environment portable. See [Claude's settings isolation limits](https://code.claude.com/docs/en/agent-sdk/claude-code-features#what-settingsources-does-not-control).
 
 Use `contextlib.aclosing()` if the consumer may stop before the terminal `ResultMessage`. Otherwise, cleanup has to wait for Python to close the asynchronous generator. `aclosing()` closes the Claude iterator and finalizes the partial Kitaru session when the consumer exits.
 
@@ -103,6 +110,7 @@ stream = runner.query(
     prompt="Look up ticket 4821.",
     options=ClaudeAgentOptions(
         tools=[],
+        setting_sources=[],
         mcp_servers={},
         allowed_tools=["mcp__support__lookup"],
     ),

--- a/plugins/packages/claude-agent-sdk/README.md
+++ b/plugins/packages/claude-agent-sdk/README.md
@@ -27,7 +27,10 @@ async def run() -> None:
     runner = KitaruClaudeRunner(agent_id=uuid.UUID(os.environ["KITARU_AGENT_ID"]))
     stream = runner.query(
         prompt="Investigate ticket 4821.",
-        options=ClaudeAgentOptions(model="claude-sonnet-4-5"),
+        options=ClaudeAgentOptions(
+            model="claude-sonnet-4-5",
+            setting_sources=[],
+        ),
     )
     async with contextlib.aclosing(stream) as messages:
         async for message in messages:
@@ -35,6 +38,10 @@ async def run() -> None:
 ```
 
 Use `contextlib.aclosing()` whenever the consumer may stop before the terminal message. It closes the Claude iterator and finalizes the partial Kitaru recording promptly.
+
+Recording preserves the Claude SDK's settings behavior. With `setting_sources` unset, the SDK can load user, project, and local settings, including output styles from `~/.claude/settings.json`. For recordings intended for replay with tool substitution, set `setting_sources=[]` as above so those settings do not add context that the replay omits. Tool substitution forces this setting on replay; an all-passthrough replay preserves your settings instead.
+
+This option disables those settings sources, but does not make the whole execution environment portable. See [Claude's settings isolation limits](https://code.claude.com/docs/en/agent-sdk/claude-code-features#what-settingsources-does-not-control).
 
 Standalone queries require either `agent_id` or `agent_version_id`. A Kitaru worker supplies the task-bound identity automatically.
 
@@ -77,6 +84,7 @@ messages = runner.query(
     prompt="Look up ticket 4821.",
     options=ClaudeAgentOptions(
         tools=[],
+        setting_sources=[],
         mcp_servers={},
         allowed_tools=["mcp__support__lookup"],
     ),


### PR DESCRIPTION
## What changed?

The Claude recording examples now explicitly disable user, project, and local settings, so they do not add context that replay with tool substitution omits. The package README and GitBook guide explain the distinction and link to Claude's isolation limits.

## Why?

An unset `setting_sources` allows local configuration such as output styles to affect recordings. Keeping this choice explicit avoids silently changing existing agents or adding runtime warnings.

Fixes #989.

## Release context

Documentation only. No runtime, dependency, or package version changes; no coordinated release required.

## Reviewer Notes

Recording and all-passthrough replay preserve native SDK behavior. Only replay with tool substitution forces settings isolation. The documentation deliberately does not claim that `setting_sources=[]` makes the entire execution environment portable.

## Reproduction

In the SDK command builder, compare `ClaudeAgentOptions(setting_sources=None)` with `ClaudeAgentOptions(setting_sources=[])`: the former omits the settings flag and the latter emits `--setting-sources=`. The updated recording examples explicitly select the latter. This mismatch was reproduced locally with SDK 0.2.149 and verified in upstream 0.2.152 source; no live model request or cost comparison was performed.

## Local checks run

- All 116 Claude adapter tests passed.
- All six Python snippets across the two documentation pages parsed successfully.
- `git diff --check` passed.
