### PR TITLE
Install the modal extra in the managed server image

### DIFF
--- a/.github/actions/publish-managed-image/action.yml
+++ b/.github/actions/publish-managed-image/action.yml
@@ -46,6 +46,7 @@ runs:
         push: true
         build-args: |
           KITARU_VERSION=${{ inputs.package-version }}
+          ADDITIONAL_EXTRAS=modal
         tags: 715803424590.dkr.ecr.eu-central-1.amazonaws.com/kitaru-pro-server:${{ inputs.image-tag }}
         labels: |
           org.opencontainers.image.title=kitaru

--- a/docker/CLAUDE.md
+++ b/docker/CLAUDE.md
@@ -111,6 +111,11 @@ docker build -f docker/release-worker.Dockerfile --target worker \
 docker build -f docker/release-server.Dockerfile --target server \
   --build-arg KITARU_VERSION=<version> -t kitaru-server .
 
+# Managed server with the modal extra, as published to the private ECR registry
+docker build -f docker/release-server.Dockerfile --target server \
+  --build-arg KITARU_VERSION=<version> --build-arg ADDITIONAL_EXTRAS=modal \
+  -t kitaru-pro-server .
+
 # Onboarding sandbox from the published worker image
 docker build -f docker/onboarding-sandbox.Dockerfile --target worker \
   --build-arg BASE_IMAGE=zenmldocker/kitaru-worker:<version> \

--- a/docker/release-server.Dockerfile
+++ b/docker/release-server.Dockerfile
@@ -9,6 +9,7 @@ ARG USERNAME=kitaru
 ARG USER_UID=1000
 ARG USER_GID=1000
 ARG KITARU_VERSION=""
+ARG ADDITIONAL_EXTRAS=""
 
 FROM docker.io/astral/uv:${UV_VERSION} AS uv
 
@@ -19,6 +20,7 @@ ARG USERNAME
 ARG USER_UID
 ARG USER_GID
 ARG KITARU_VERSION
+ARG ADDITIONAL_EXTRAS
 
 FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 
@@ -29,6 +31,7 @@ ARG USERNAME
 ARG USER_UID
 ARG USER_GID
 ARG KITARU_VERSION
+ARG ADDITIONAL_EXTRAS
 
 RUN groupadd --gid $USER_GID $USERNAME && \
   useradd --uid $USER_UID --gid $USER_GID -m $USERNAME && \
@@ -46,6 +49,7 @@ ARG USERNAME
 ARG USER_UID
 ARG USER_GID
 ARG KITARU_VERSION
+ARG ADDITIONAL_EXTRAS
 
 COPY --from=uv /uv /uvx /bin/
 COPY --chown=$USERNAME:$USER_GID pyproject.toml uv.lock ./
@@ -60,18 +64,24 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 USER $USERNAME
 
-# Install the locked server and OpenTelemetry dependencies, then install the
-# matching published Kitaru wheel without resolving its dependencies again.
-# Keep a snapshot of the resulting environment for external inspection.
+# Install the locked server and OpenTelemetry dependencies plus any additional
+# extras, then install the matching published Kitaru wheel without resolving
+# its dependencies again. Keep a snapshot of the resulting environment for
+# external inspection.
 RUN test -n "$KITARU_VERSION" && \
   test "$(uv version --short)" = "$KITARU_VERSION" && \
+  additional_extra_args="" && \
+  for extra in $ADDITIONAL_EXTRAS; do \
+    additional_extra_args="$additional_extra_args --extra $extra"; \
+  done && \
   uv sync \
     --locked \
     --no-dev \
     --no-install-project \
     --extra server \
     --extra s3 \
-    --extra otel && \
+    --extra otel \
+    $additional_extra_args && \
   sh ./install-release-wheel.sh && \
   uv pip check && \
   python -c \
@@ -87,6 +97,7 @@ ARG USERNAME
 ARG USER_UID
 ARG USER_GID
 ARG KITARU_VERSION
+ARG ADDITIONAL_EXTRAS
 
 # The Python base image includes package-management tools that are unnecessary
 # at runtime. uv is mounted only for this command and is not included in the


### PR DESCRIPTION
Install the `modal` extra in the `kitaru-pro-server` image pushed to ECR and in the dev server image, so managed and dev workspaces can start Modal ephemeral workers. The public `zenmldocker/kitaru-server` image is unchanged.

To build the managed image locally, pass `--build-arg ADDITIONAL_EXTRAS=modal` to `docker/release-server.Dockerfile`.