### PR TITLE
Add a Modal environment setting for ephemeral workers

### DIFF
--- a/docker/CLAUDE.md
+++ b/docker/CLAUDE.md
@@ -51,7 +51,7 @@ runtime modes:
 
 | Stage | Purpose |
 |---|---|
-| `pre-builder` | Installs locked `server` and `otel` dependencies without the project |
+| `pre-builder` | Installs locked `server`, `s3`, `otel`, and `modal` dependencies without the project |
 | `common-runtime` | Installs local source editably for bind-mounted development |
 | `local-runtime` | Runs uvicorn with source reload enabled |
 | `builder` | Installs local source non-editably for the self-contained image |

--- a/docker/dev-server.Dockerfile
+++ b/docker/dev-server.Dockerfile
@@ -86,7 +86,8 @@ RUN uv sync \
   --no-install-project \
   --extra server \
   --extra s3 \
-  --extra otel
+  --extra otel \
+  --extra modal
 
 FROM pre-builder AS common-runtime
 
@@ -109,7 +110,7 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Keep the project editable so a source bind mount is immediately visible to
 # the reload process while retaining installed package metadata.
-RUN uv sync --locked --no-dev --extra server --extra s3 --extra otel && \
+RUN uv sync --locked --no-dev --extra server --extra s3 --extra otel --extra modal && \
   uv pip check && \
   python -c \
     "from kitaru.server.api.main import app; assert callable(app)" && \
@@ -149,7 +150,8 @@ RUN uv sync \
   --no-editable \
   --extra server \
   --extra s3 \
-  --extra otel && \
+  --extra otel \
+  --extra modal && \
   uv pip check && \
   python -c \
     "from kitaru.server.api.main import app; assert callable(app)" && \

--- a/helm/templates/_environment.tpl
+++ b/helm/templates/_environment.tpl
@@ -94,6 +94,9 @@ ephemeral_worker__modal__token_id: {{ .tokenID | quote }}
 {{- if .appName }}
 ephemeral_worker__modal__app_name: {{ .appName | quote }}
 {{- end }}
+{{- if .environment }}
+ephemeral_worker__modal__environment: {{ .environment | quote }}
+{{- end }}
 {{- if .cpu }}
 ephemeral_worker__modal__cpu: {{ .cpu | quote }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -377,6 +377,10 @@ server:
       # The Modal app name the sandbox runs under.
       appName: kitaru-workers
 
+      # The Modal environment the app and sandboxes are created in. If not
+      # set, uses the workspace default environment.
+      environment:
+
       # The number of CPU cores to allocate to the sandbox. If not set, uses
       # the Modal default.
       cpu:

--- a/src/kitaru/server/adapters/ephemeral_workers/modal.py
+++ b/src/kitaru/server/adapters/ephemeral_workers/modal.py
@@ -58,7 +58,10 @@ class ModalEphemeralWorkers:
         """
         client = await self._get_client()
         app = await modal.App.lookup.aio(
-            self._modal_settings.app_name, client=client, create_if_missing=True
+            self._modal_settings.app_name,
+            client=client,
+            environment_name=self._modal_settings.environment,
+            create_if_missing=True,
         )
         await modal.Sandbox.create.aio(
             *self._command,
@@ -76,4 +79,5 @@ class ModalEphemeralWorkers:
             cpu=self._modal_settings.cpu,
             memory=self._modal_settings.memory_mb,
             client=client,
+            environment_name=self._modal_settings.environment,
         )

--- a/src/kitaru/server/ephemeral_worker_settings.py
+++ b/src/kitaru/server/ephemeral_worker_settings.py
@@ -36,6 +36,7 @@ class ModalEphemeralWorkerSettings(BaseModel):
     token_id: str
     token_secret: SecretStr
     app_name: str = "kitaru-workers"
+    environment: str | None = None
     cpu: float | None = None
     memory_mb: int | None = None
 

--- a/tests/server/test_modal_ephemeral_workers.py
+++ b/tests/server/test_modal_ephemeral_workers.py
@@ -111,6 +111,7 @@ def _settings(
     command: str = "python -m kitaru.worker",
     cpu: float | None = None,
     memory_mb: int | None = None,
+    environment: str | None = None,
 ) -> EphemeralWorkerSettings:
     return EphemeralWorkerSettings(
         backend=EphemeralWorkerBackend.MODAL,
@@ -118,7 +119,11 @@ def _settings(
         command=command,
         timeout_seconds=120,
         modal=ModalEphemeralWorkerSettings(
-            token_id="ak-test", token_secret="as-test", cpu=cpu, memory_mb=memory_mb
+            token_id="ak-test",
+            token_secret="as-test",
+            cpu=cpu,
+            memory_mb=memory_mb,
+            environment=environment,
         ),
     )
 
@@ -151,7 +156,11 @@ async def test_start_creates_sandbox_with_resource_limits(
     assert fake_modal.app_lookup.calls == [
         (
             ("kitaru-workers",),
-            {"client": fake_modal.client, "create_if_missing": True},
+            {
+                "client": fake_modal.client,
+                "environment_name": None,
+                "create_if_missing": True,
+            },
         )
     ]
     assert len(fake_modal.sandbox_create.calls) == 1
@@ -171,6 +180,19 @@ async def test_start_creates_sandbox_with_resource_limits(
     assert kwargs["cpu"] == 2.0
     assert kwargs["memory"] == 4096
     assert kwargs["client"] is fake_modal.client
+    assert kwargs["environment_name"] is None
+
+
+async def test_start_in_a_configured_environment(fake_modal: _FakeModal) -> None:
+    """Look up the app and create the sandbox in the configured environment."""
+    ephemeral_workers = ModalEphemeralWorkers(_settings(environment="staging"))
+
+    await ephemeral_workers.start(_spec())
+
+    _, lookup_kwargs = fake_modal.app_lookup.calls[0]
+    assert lookup_kwargs["environment_name"] == "staging"
+    _, create_kwargs = fake_modal.sandbox_create.calls[0]
+    assert create_kwargs["environment_name"] == "staging"
 
 
 async def test_start_without_resource_limits_passes_none_through(


### PR DESCRIPTION
Set `KITARU_SERVER_EPHEMERAL_WORKER__MODAL__ENVIRONMENT`, or `server.ephemeralWorker.modal.environment` in the chart, to create the Modal app and sandboxes in a specific Modal environment instead of the workspace default. The dev server image now installs the `modal` extra.