### PR TITLE
Align `CLAUDE.md` release facts with the `kitaru-release` skill and drop stale instruction text

### DIFF
--- a/.agents/skills/kitaru-dev/SKILL.md
+++ b/.agents/skills/kitaru-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kitaru-dev
-description: Use for Kitaru commands, CLI, analytics, PRs.
+description: Kitaru just recipes, CLI structure and structured-output contract, analytics events, and PR-description conventions. Use when running project commands, adding CLI commands or analytics events, or writing a PR description.
 ---
 
 # Kitaru Development, CLI, and PR Workflow
@@ -40,7 +40,7 @@ Use this when you need the command catalog beyond the daily loop in the root `AG
 
 There is no v2 `kitaru init` command or `local` extra. Do not carry the v1 `.kitaru/` project-marker setup into v2 instructions or tests.
 
-When merging the v2 base into a feature branch and resolving `pyproject.toml` or `uv.lock`, check recent dependency-security changes before regenerating the lockfile broadly. Use targeted upgrades when a package was intentionally bumped and run `just audit` before pushing.
+When resolving `pyproject.toml` or `uv.lock` conflicts, do not regenerate the whole lockfile: that silently reverts intentional dependency-security bumps. Upgrade only the packages involved and run `just audit` before pushing.
 
 ## Docs Workflows
 

--- a/.agents/skills/kitaru-docs/SKILL.md
+++ b/.agents/skills/kitaru-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kitaru-docs
-description: Use for Kitaru docs.
+description: Kitaru documentation surfaces, link rules, and accuracy rules. Use when editing docs under docs/book, generated SDK or CLI reference, docs redirects, example READMEs, or docs CI.
 ---
 
 # Kitaru Documentation Workflow

--- a/.agents/skills/kitaru-release/SKILL.md
+++ b/.agents/skills/kitaru-release/SKILL.md
@@ -262,11 +262,7 @@ Include:
 
 Stop after the PR unless the user explicitly asks to publish.
 
-After the PR merges, verify its exact merge commit. Prefer `HEAD` in emitted tag commands when the selected branch points to that commit; otherwise fill in the literal reviewed SHA. Keep discovery commands out of the user-facing publication block.
-
-Emit the complete minimal, git-only publication command handoff in the PR and final response, using [publication-handoff.md](references/publication-handoff.md). Group commands by repository and source branch. Include every selected Python plugin, the TypeScript release set when selected, any new frontend release, manual `main` promotion, and the Kitaru skills release handoff. Use accepted versions and exact reviewed commits; do not leave a selected plugin as “repeat for the other plugins.” Do not execute publication commands during preparation.
-
-Push every release tag in its own `git push origin <tag>` command. GitHub does not create push events when more than three tags are pushed at once, which leaves immutable tags without release workflow runs. Do not batch release tags into one push, even when several point to the same commit. After each push, confirm the matching workflow run exists before pushing the next tag.
+After the PR merges, verify its exact merge commit, then emit the publication command handoff in the PR and final response exactly as [publication-handoff.md](references/publication-handoff.md) specifies: grouped by repository and source branch, covering every selected Python plugin, the TypeScript release set when selected, any new frontend release, manual `main` promotion, and the Kitaru skills release handoff. Do not execute publication commands during preparation.
 
 ## Rehearse before publication
 
@@ -338,17 +334,7 @@ Verify each published surface independently. Report core PyPI availability, publ
 
 After the required core and plugin versions are available on PyPI, complete any pending quickstart dependency refresh through a reviewed follow-up PR and rerun its frozen end-to-end test. Report which branch contains that update: the public README links to `main`, and merging a follow-up into `develop` alone does not update the public example. The development-reset PR does not currently refresh the quickstart lockfile.
 
-The workflow does not update `main`. After the newest stable core's public artifacts and GitHub Release succeed, inspect any remaining workflow failure and tell the release owner to fast-forward `main` to the immutable core tag:
-
-Verify the local and remote `main` branches can fast-forward to the tag before emitting:
-
-```bash
-git checkout main
-git merge --ff-only python/kitaru/v<python-version>
-git push origin main
-```
-
-The release owner runs these commands manually. Do not execute it on their behalf. The fast-forward updates `main` to the tagged commit without a merge commit and triggers the existing docs workflow. Skip this step for prereleases and older maintenance-line core releases.
+The workflow does not update `main`. After the newest stable core's public artifacts and GitHub Release succeed, inspect any remaining workflow failure and emit the `main` fast-forward block from [publication-handoff.md](references/publication-handoff.md) for the release owner to run. Do not execute it on their behalf. The fast-forward triggers the existing docs workflow. Skip this step for prereleases and older maintenance-line core releases.
 
 After core and required plugins are available, hand off pending `zenml-io/kitaru-skills` changes to its [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Read the current skill before emitting that repository's commands. It owns the independent skills version, `develop` release commit, tag, `main` promotion, and GitHub Release. Core publication does not itself authorize publishing skills.
 

--- a/.agents/skills/kitaru-release/references/publication-handoff.md
+++ b/.agents/skills/kitaru-release/references/publication-handoff.md
@@ -32,7 +32,7 @@ For multiple tags in one repository and branch, check out the branch once, then 
 
 A maintenance release uses its matching `release/<unit>/<major.minor>` branch and maintenance PR. Check that the tag is unused before offering its creation command. For an existing tag, give its status and the recovery handoff; do not recreate or move it.
 
-Push one tag per command. Confirm the matching workflow run exists after each push. For plugins in the same release set, subsequent tag pushes need not wait for the preceding plugin workflow to finish.
+Push one tag per command: GitHub does not create push events when more than three tags are pushed at once, which leaves immutable tags without release workflow runs, so never batch tags into one push even when they point to the same commit. Confirm the matching workflow run exists after each push. For plugins in the same release set, subsequent tag pushes need not wait for the preceding plugin workflow to finish.
 
 ## Core publication status
 

--- a/.agents/skills/kitaru-tests-release/SKILL.md
+++ b/.agents/skills/kitaru-tests-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kitaru-tests-release
-description: Use for Kitaru tests, CI, releases.
+description: Kitaru test layout, CI workflows, and release-workflow behavior. Use when adding or debugging tests on any surface (CLI, server, task, worker, MCP, plugins), changing CI, or explaining what a release tag triggers.
 ---
 
 # Kitaru Tests, CI, and Release Workflow
@@ -91,7 +91,7 @@ When adding a new CLI command, MCP tool, SDK resource, task, or worker capabilit
 
 `.github/workflows/ci.yml` runs on pushes to `develop` and on pull requests. It includes separate base, CLI, and MCP matrices across Python 3.11 through 3.14, plus installed CLI-artifact and MCP-wheel contracts. Push-only jobs cover Docker server smoke and UI wheel packaging because those paths may require trusted UI release credentials.
 
-Do not describe the inherited `llm-integration.yml` provider markers or absent `tests/live/` suite as v2 release evidence. V2 currently has no tracked `live_llm`, `live_openai`, `live_anthropic`, or `live_gemini` test surface.
+This repository has no live-LLM test surface; do not cite one as release evidence.
 
 ## Docs CI
 
@@ -99,7 +99,7 @@ Do not describe the inherited `llm-integration.yml` provider markers or absent `
 
 ## Release Workflows
 
-Use `.agents/skills/kitaru-release/SKILL.md` for the release interview, metadata edits, validation, and preparation PR. Keep this skill focused on selecting and running test surfaces.
+Use the current host's `kitaru-release` skill for the release interview, metadata edits, validation, and preparation PR. Keep this skill focused on selecting and running test surfaces.
 
 `.github/workflows/release.yml` handles the core tag `python/kitaru/v<VERSION>`. It publishes Kitaru to PyPI, then publishes client, server, worker, and managed images plus Helm, and creates the GitHub Release. Python RC versions such as `0.22.0rc1` become deployable tags such as `0.22.0-rc.1`. There is no separate bundle tag.
 
@@ -119,12 +119,10 @@ Before creating a core tag:
 
 Stable core releases move the public Docker `latest` aliases, advance the core maintenance branch, and create a draft development-reset PR. The release owner fast-forwards `main` to the immutable core tag before merging the reset into `develop`. Report PyPI publication, public deployables, managed-image warnings, installer smoke, maintenance state, and reset state separately. A reset failure can leave the workflow red after artifact publication succeeds.
 
-Do not use the removed `scripts/smoke-test.sh`, provider-area flags, remote-stack smoke, v1 adapters, or local ZenML flow runs as v2 release gates.
-
 ## Branching and Releases
 
 - Default branch is `develop`.
-- Pull requests normally target `develop`; v2 feature work may target its explicit integration branch until that migration lands.
+- Pull requests target `develop`.
 - `main` tracks the latest released version only; do not push directly.
 - Python core and plugin releases use namespaced tags handled by `release.yml` and `release-plugins.yml`, respectively.
 - TypeScript releases are cut with `typescript/kitaru/v<VERSION>` tags handled by `.github/workflows/release-typescript.yml`; rehearse the exact tag through manual dispatch before pushing it.

--- a/.claude/skills/kitaru-dev/SKILL.md
+++ b/.claude/skills/kitaru-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kitaru-dev
-description: Use for Kitaru commands, CLI, analytics, PRs.
+description: Kitaru just recipes, CLI structure and structured-output contract, analytics events, and PR-description conventions. Use when running project commands, adding CLI commands or analytics events, or writing a PR description.
 ---
 
 # Kitaru Development, CLI, and PR Workflow
@@ -40,7 +40,7 @@ Use this when you need the command catalog beyond the daily loop in the root `AG
 
 There is no v2 `kitaru init` command or `local` extra. Do not carry the v1 `.kitaru/` project-marker setup into v2 instructions or tests.
 
-When merging the v2 base into a feature branch and resolving `pyproject.toml` or `uv.lock`, check recent dependency-security changes before regenerating the lockfile broadly. Use targeted upgrades when a package was intentionally bumped and run `just audit` before pushing.
+When resolving `pyproject.toml` or `uv.lock` conflicts, do not regenerate the whole lockfile: that silently reverts intentional dependency-security bumps. Upgrade only the packages involved and run `just audit` before pushing.
 
 ## Docs Workflows
 

--- a/.claude/skills/kitaru-docs/SKILL.md
+++ b/.claude/skills/kitaru-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kitaru-docs
-description: Use for Kitaru docs.
+description: Kitaru documentation surfaces, link rules, and accuracy rules. Use when editing docs under docs/book, generated SDK or CLI reference, docs redirects, example READMEs, or docs CI.
 ---
 
 # Kitaru Documentation Workflow

--- a/.claude/skills/kitaru-release/SKILL.md
+++ b/.claude/skills/kitaru-release/SKILL.md
@@ -262,11 +262,7 @@ Include:
 
 Stop after the PR unless the user explicitly asks to publish.
 
-After the PR merges, verify its exact merge commit. Prefer `HEAD` in emitted tag commands when the selected branch points to that commit; otherwise fill in the literal reviewed SHA. Keep discovery commands out of the user-facing publication block.
-
-Emit the complete minimal, git-only publication command handoff in the PR and final response, using [publication-handoff.md](references/publication-handoff.md). Group commands by repository and source branch. Include every selected Python plugin, the TypeScript release set when selected, any new frontend release, manual `main` promotion, and the Kitaru skills release handoff. Use accepted versions and exact reviewed commits; do not leave a selected plugin as “repeat for the other plugins.” Do not execute publication commands during preparation.
-
-Push every release tag in its own `git push origin <tag>` command. GitHub does not create push events when more than three tags are pushed at once, which leaves immutable tags without release workflow runs. Do not batch release tags into one push, even when several point to the same commit. After each push, confirm the matching workflow run exists before pushing the next tag.
+After the PR merges, verify its exact merge commit, then emit the publication command handoff in the PR and final response exactly as [publication-handoff.md](references/publication-handoff.md) specifies: grouped by repository and source branch, covering every selected Python plugin, the TypeScript release set when selected, any new frontend release, manual `main` promotion, and the Kitaru skills release handoff. Do not execute publication commands during preparation.
 
 ## Rehearse before publication
 
@@ -338,17 +334,7 @@ Verify each published surface independently. Report core PyPI availability, publ
 
 After the required core and plugin versions are available on PyPI, complete any pending quickstart dependency refresh through a reviewed follow-up PR and rerun its frozen end-to-end test. Report which branch contains that update: the public README links to `main`, and merging a follow-up into `develop` alone does not update the public example. The development-reset PR does not currently refresh the quickstart lockfile.
 
-The workflow does not update `main`. After the newest stable core's public artifacts and GitHub Release succeed, inspect any remaining workflow failure and tell the release owner to fast-forward `main` to the immutable core tag:
-
-Verify the local and remote `main` branches can fast-forward to the tag before emitting:
-
-```bash
-git checkout main
-git merge --ff-only python/kitaru/v<python-version>
-git push origin main
-```
-
-The release owner runs these commands manually. Do not execute it on their behalf. The fast-forward updates `main` to the tagged commit without a merge commit and triggers the existing docs workflow. Skip this step for prereleases and older maintenance-line core releases.
+The workflow does not update `main`. After the newest stable core's public artifacts and GitHub Release succeed, inspect any remaining workflow failure and emit the `main` fast-forward block from [publication-handoff.md](references/publication-handoff.md) for the release owner to run. Do not execute it on their behalf. The fast-forward triggers the existing docs workflow. Skip this step for prereleases and older maintenance-line core releases.
 
 After core and required plugins are available, hand off pending `zenml-io/kitaru-skills` changes to its [skills-release skill](https://github.com/zenml-io/kitaru-skills/blob/develop/.claude/skills/skills-release/SKILL.md). Read the current skill before emitting that repository's commands. It owns the independent skills version, `develop` release commit, tag, `main` promotion, and GitHub Release. Core publication does not itself authorize publishing skills.
 

--- a/.claude/skills/kitaru-release/references/publication-handoff.md
+++ b/.claude/skills/kitaru-release/references/publication-handoff.md
@@ -32,7 +32,7 @@ For multiple tags in one repository and branch, check out the branch once, then 
 
 A maintenance release uses its matching `release/<unit>/<major.minor>` branch and maintenance PR. Check that the tag is unused before offering its creation command. For an existing tag, give its status and the recovery handoff; do not recreate or move it.
 
-Push one tag per command. Confirm the matching workflow run exists after each push. For plugins in the same release set, subsequent tag pushes need not wait for the preceding plugin workflow to finish.
+Push one tag per command: GitHub does not create push events when more than three tags are pushed at once, which leaves immutable tags without release workflow runs, so never batch tags into one push even when they point to the same commit. Confirm the matching workflow run exists after each push. For plugins in the same release set, subsequent tag pushes need not wait for the preceding plugin workflow to finish.
 
 ## Core publication status
 

--- a/.claude/skills/kitaru-tests-release/SKILL.md
+++ b/.claude/skills/kitaru-tests-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kitaru-tests-release
-description: Use for Kitaru tests, CI, releases.
+description: Kitaru test layout, CI workflows, and release-workflow behavior. Use when adding or debugging tests on any surface (CLI, server, task, worker, MCP, plugins), changing CI, or explaining what a release tag triggers.
 ---
 
 # Kitaru Tests, CI, and Release Workflow
@@ -91,7 +91,7 @@ When adding a new CLI command, MCP tool, SDK resource, task, or worker capabilit
 
 `.github/workflows/ci.yml` runs on pushes to `develop` and on pull requests. It includes separate base, CLI, and MCP matrices across Python 3.11 through 3.14, plus installed CLI-artifact and MCP-wheel contracts. Push-only jobs cover Docker server smoke and UI wheel packaging because those paths may require trusted UI release credentials.
 
-Do not describe the inherited `llm-integration.yml` provider markers or absent `tests/live/` suite as v2 release evidence. V2 currently has no tracked `live_llm`, `live_openai`, `live_anthropic`, or `live_gemini` test surface.
+This repository has no live-LLM test surface; do not cite one as release evidence.
 
 ## Docs CI
 
@@ -99,7 +99,7 @@ Do not describe the inherited `llm-integration.yml` provider markers or absent `
 
 ## Release Workflows
 
-Use `.agents/skills/kitaru-release/SKILL.md` for the release interview, metadata edits, validation, and preparation PR. Keep this skill focused on selecting and running test surfaces.
+Use the current host's `kitaru-release` skill for the release interview, metadata edits, validation, and preparation PR. Keep this skill focused on selecting and running test surfaces.
 
 `.github/workflows/release.yml` handles the core tag `python/kitaru/v<VERSION>`. It publishes Kitaru to PyPI, then publishes client, server, worker, and managed images plus Helm, and creates the GitHub Release. Python RC versions such as `0.22.0rc1` become deployable tags such as `0.22.0-rc.1`. There is no separate bundle tag.
 
@@ -119,12 +119,10 @@ Before creating a core tag:
 
 Stable core releases move the public Docker `latest` aliases, advance the core maintenance branch, and create a draft development-reset PR. The release owner fast-forwards `main` to the immutable core tag before merging the reset into `develop`. Report PyPI publication, public deployables, managed-image warnings, installer smoke, maintenance state, and reset state separately. A reset failure can leave the workflow red after artifact publication succeeds.
 
-Do not use the removed `scripts/smoke-test.sh`, provider-area flags, remote-stack smoke, v1 adapters, or local ZenML flow runs as v2 release gates.
-
 ## Branching and Releases
 
 - Default branch is `develop`.
-- Pull requests normally target `develop`; v2 feature work may target its explicit integration branch until that migration lands.
+- Pull requests target `develop`.
 - `main` tracks the latest released version only; do not push directly.
 - Python core and plugin releases use namespaced tags handled by `release.yml` and `release-plugins.yml`, respectively.
 - TypeScript releases are cut with `typescript/kitaru/v<VERSION>` tags handled by `.github/workflows/release-typescript.yml`; rehearse the exact tag through manual dispatch before pushing it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,15 +58,9 @@ they belong in `docs/book/` (GitBook). The public changelog is owned by the
 changelog repo (published to `docs.zenml.io/changelog`), not by either docs
 surface here.
 
-The public marketing/runtime site for Kitaru lives in the sibling `zenml-io-v2`
-repository. If a task involves Astro pages, public site assets, marketing
-Cloudflare Pages deployment, or runtime web APIs such as
-waitlist/get-started/newsletter endpoints, switch to `zenml-io-v2` and follow
-that repo's instructions instead of adding that code back here.
-
 ## Website and marketing assets
 
-The Kitaru marketing site and its asset pipeline now live in `zenml-io-v2`. Do not add Astro pages, public site assets, R2 blog tooling, or runtime website changes to this repository. If a task is about the public website rather than the Python SDK/docs source, work in `zenml-io-v2` instead.
+The Kitaru marketing site, its asset pipeline, and the runtime web APIs (waitlist, get-started, newsletter) live in the sibling `zenml-io-v2` repository. Do not add Astro pages, public site assets, R2 blog tooling, or runtime website changes here. If a task is about the public website rather than the Python SDK or docs source, work in `zenml-io-v2` and follow that repo's instructions.
 
 ## Docs guidance
 
@@ -74,16 +68,12 @@ Detailed authoring conventions, link rules, and accuracy requirements for all
 three docs surfaces live in **`docs/CLAUDE.md`** (loaded when you work under
 `docs/`). Keep the quickstart example setup and import path runnable without provider credentials.
 
-Do not commit temporary agent planning/review files such as `docs/plans/*`,
-`docs/reviews/*`, or prompt exports unless the user explicitly asks for a
-durable tracked document.
-
 ## Branching strategy
 
-- **`develop`** is the default branch and the normal target for PRs. During the v2 migration, v2 feature work may target its explicitly named integration branch.
-- **`main`** contains only released versions. Updated by force-pushing during releases. Never push directly to `main`.
-- **`release/X.Y.Z`** branches are archival snapshots created during the release process.
-- **Tags** follow `vX.Y.Z` (e.g. `v0.1.0`).
+- **`develop`** is the default branch and the target for PRs.
+- **`main`** contains only released versions. After a stable core release the release owner fast-forwards it to the immutable core tag with `git merge --ff-only`. Never push to it directly and never force-push it.
+- **`release/<unit>/<major.minor>`** branches (for example `release/kitaru/0.25`) are maintenance lines that the release workflow creates or fast-forwards after a stable release; patch releases branch from them. The older `release/X.Y.Z` branches are archival snapshots from the previous release process.
+- **Tags** are namespaced per release unit: `python/kitaru/v<X.Y.Z>` for core, `python/<distribution>/v<X.Y.Z>` for Python plugins, and `typescript/kitaru/v<X.Y.Z>` for the TypeScript packages. The `kitaru-release` skill owns the full procedure.
 
 ## Development commands
 
@@ -127,9 +117,9 @@ For adapter, importer, specialized UI API, docs, CI, and release work, load the 
 
 ## Versioning and changelog
 
-- **Single source of truth:** the `version` field in `pyproject.toml`. The release workflow bumps it automatically — never change it by hand.
+- **Single source of truth:** the `version` field in `pyproject.toml`. On `develop` it carries a `+dev` suffix. Only a release-preparation PR (see the `kitaru-release` skill) sets it to a release version, and the workflow's development-reset PR restores the `+dev` placeholder afterward. Do not change it in feature PRs.
 - **Never hardcode the version** in tests or application code. Use `importlib.metadata.version("kitaru")` to read it at runtime.
-- **Update `CHANGELOG.md`** when making user-facing changes. Add entries under the `[Unreleased]` heading. The release workflow moves `[Unreleased]` to a versioned heading (e.g. `[0.2.0] - 2026-04-01`) at release time.
+- **Update `CHANGELOG.md`** when making user-facing changes. Add entries under the `[Unreleased]` heading. The release-preparation PR converts `[Unreleased]` to a versioned heading (e.g. `[0.2.0] - 2026-04-01`), and the development-reset PR restores an empty `[Unreleased]` afterward.
 - **Track deprecations in `DEPRECATIONS.md`** at the repository root, one entry per deprecated surface.
 
 ## Commits and PRs
@@ -139,13 +129,12 @@ For adapter, importer, specialized UI API, docs, CI, and release work, load the 
 - **Keep pre-existing failures separate.** If `just check` or `just test` surfaces a failure unrelated to the requested change, diagnose and report it. Fix it only when it blocks the scoped change or the user explicitly approves expanding the task; do not absorb another contributor's work into the current commit by default.
 - **Commits:** Imperative mood, concise summary (50 chars or less): "Add feature" not "Added feature". Explain *why* in the body (blank line after summary), reference issues when applicable (`Fixes #1234`).
 - **Bug fixes:** Always add a regression test that would have caught the bug. Understand root cause before implementing the fix.
-- **PRs:** Human-readable titles (no "feat:"/"doc:" prefixes). Write comprehensive descriptions: what the changes do, why they're needed, key implementation decisions, and areas needing reviewer attention.
+- **PRs:** Human-readable titles with no "feat:", "doc:", or "[Codex]" prefixes. Write comprehensive descriptions: what the changes do, why they're needed, key implementation decisions, and areas needing reviewer attention.
 - **PR reviewer guidance:** Every PR description should include a "Reviewer Notes" H2 or H3 section, but it should read like a guided walkthrough rather than a file inventory. Explain the story of the change, where the risky behavior lives, what would break if the implementation is wrong, and why the named files or functions matter.
 - **PR reproduction:** Include a concrete "Reproduction" subsection inside Reviewer Notes or immediately after it. Prefer a runnable example, API flow, or UI path that proves the behavior end to end. Tell the reviewer exactly what to run and what to look for afterward.
 - **PR local checks:** Do not create a standalone "Verification" section that only lists `just check`, `just test`, or `/simplify`. Those are still required local hygiene, but they are not useful reviewer guidance by themselves. If useful, include them as a short "Local checks run" note after the reproduction instructions.
 - **Before opening a PR or making a large commit**, always run `/simplify` to review changed code for reuse opportunities, quality issues, and efficiency improvements. Fix any issues it finds before committing.
 - **Preserve quickstart example compatibility** when changing Kitaru behavior used by `examples/python/pydantic_ai_ticket_resolver`. Inspect its current contract and validate the affected example checks before opening a PR.
-- Never include a "[Codex] " or "feat: " prefix to PR titles.
 
 ## Conventions
 

--- a/docker/CLAUDE.md
+++ b/docker/CLAUDE.md
@@ -27,7 +27,7 @@ alongside the exact worker Kitaru version so dependency resolution cannot silent
 upgrade Kitaru away from the workspace version. Provider credentials are not baked
 into this image; installing the adapter does not enable funded model inference.
 
-The image bakes in the published `kitaru-skills` release. To refresh that baked copy during a manual build, use `--no-cache` so Docker reruns the remote skill installation. Once the frontend runtime-refresh change is deployed, newly created sandboxes also install published skills at startup, so skill-only releases no longer require an image rebuild. Dependency and bundled-example changes still require rebuilding the image. The frontend selects the ECR tag from the workspace version, and existing Modal sandboxes do not update when an image or skill release is published.
+The image bakes in the published `kitaru-skills` release. To refresh that baked copy during a manual build, use `--no-cache` so Docker reruns the remote skill installation. Newly created sandboxes also install the published skills at startup, so a skills-only release does not need an image rebuild; dependency and bundled-example changes do. The frontend selects the ECR tag from the workspace version, and existing Modal sandboxes do not update when an image or skill release is published.
 
 The development and release client, server, and worker builds resolve dependencies
 from the committed `uv.lock`. The release

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -2,7 +2,7 @@
 
 FumaDocs-specific instructions for AI-assisted development in the docs app.
 
-## Where the docs live now (read this first)
+## Where the docs live
 
 Kitaru documentation is split across three surfaces:
 
@@ -11,10 +11,10 @@ Kitaru documentation is split across three surfaces:
   (GitBook Git Sync, plain Markdown). Edit those `.md` files directly.
 - **Generated SDK reference** is served by **this FumaDocs app** at
   **`sdkdocs.kitaru.ai`** (mirrors `sdkdocs.zenml.io`).
-- **`kitaru.ai/docs/*`** is now a **redirect** to those new homes
+- **`kitaru.ai/docs/*`** redirects to those two surfaces
   (`docs/worker/redirect.mjs` + `wrangler.redirect.toml`, worker `kitaru-site`).
 
-So **this app is reference-only** — its content is the generated
+**This app is reference-only** — its content is the generated
 `content/docs/reference/python/` and `content/docs/cli/` plus a landing
 `index.mdx`.
 Do not add hand-written pages here; those belong in `docs/book/` (GitBook).
@@ -115,7 +115,7 @@ pnpm run format     # Biome format
 
 The `SDK Reference Docs` workflow runs `pnpm run lint` on every PR that touches `docs/`, and root `just check` does not cover it, so run `just docs-lint` before pushing. `pnpm exec biome check --write` applies the safe fixes (formatting, import order). Rule exceptions live in `biome.jsonc` with a comment explaining each one.
 
-**Important:** Generated content (the local/reference changelog page and SDK reference) is gitignored. On a fresh clone, run `uv sync --extra cli` (the CLI generator runs `kitaru schema` in-process), `pnpm install` in `docs/`, then `uv pip install ./docs/node_modules/fumadocs-python`, then `just generate-docs` to materialize the reference before `just docs` shows the full sidebar. The deployed public changelog still lives at `docs.zenml.io/changelog`; the generated `changelog.mdx` here is not the public changelog source.
+**Important:** Generated content (the local/reference changelog page and SDK reference) is gitignored. On a fresh clone, run `uv sync --extra cli` (the CLI generator runs `kitaru schema` in-process), `pnpm install` in `docs/`, then `uv pip install ./docs/node_modules/fumadocs-python`, then `just generate-docs` to materialize the reference before `just docs` shows the full sidebar.
 
 ## File Responsibilities
 


### PR DESCRIPTION
## What this changes

An audit of the agent instruction files (`CLAUDE.md`, `docs/CLAUDE.md`, `docker/CLAUDE.md`, and the skills under `.claude/skills/` with their `.agents/skills/` mirrors) for text written for an earlier state of the repository. It found no "shouty" prompt cruft at all: zero caps-emphasis, no prohibition walls, no dated prompting idioms. What it did find is worse than cruft: **the always-loaded root `CLAUDE.md` contradicts the `kitaru-release` skill on how releases work**, and the repository agrees with the skill.

### Root `CLAUDE.md` said one thing, the release skill and the repo say another

| Root `CLAUDE.md` claimed | Reality |
|---|---|
| `main` is "updated by force-pushing during releases" | `release.yml` never touches `main`; the release owner runs `git merge --ff-only` and the handoff reference says "Do not force-push" |
| tags follow `vX.Y.Z` | tags are `python/kitaru/v0.25.0`, `python/<distribution>/v...`, `typescript/kitaru/v...` |
| `release/X.Y.Z` branches are archival snapshots | maintenance lines are `release/kitaru/0.25`, `release/langfuse/0.2`, etc. per `release/release-units.toml` |
| the release workflow bumps `pyproject.toml`, "never change it by hand" | the release-preparation PR sets `[project].version` by hand; the workflow's reset PR only restores `+dev` |
| the release workflow moves `[Unreleased]` to a versioned heading | the preparation PR converts it; the reset PR restores it |

These lines date from 2026-03-06 and were never revisited; the skill has 28 commits since. An agent that loads both has to reconcile two release processes, and the root file told it to refuse the skill's first step. The root file now states the current mechanism and points at the skill for the procedure.

### Everything else in the diff

- **Text about things that no longer exist.** The tests skill prohibited citing `llm-integration.yml` and `tests/live/` (deleted in #719, a week before the rule was written) and `scripts/smoke-test.sh`. Naming an absent file in a prohibition is what anchors a model toward inventing it. Replaced with one plain fact or removed.
- **A migration clause whose condition has passed.** "During the v2 migration, v2 feature work may target its integration branch" appeared in `CLAUDE.md` and the tests skill. No such branch exists; `develop` is v2.
- **Rules stated twice in the same file.** The marketing-site rule, the scratch-planning-files rule, and the PR-title-prefix rule each appeared twice in `CLAUDE.md`, and the two scratch-file copies listed different paths. Each is now stated once with the fuller wording.
- **Migration-relative phrasing.** "now a redirect to those new homes", "no longer require", "still lives", "the v2 base". These describe a diff against a layout the reader never saw. Rewritten in the present tense. Note the `docker/CLAUDE.md` rewrite asserts that new onboarding sandboxes install published skills at startup; the old text hedged this on a frontend deploy. Reviewer, please confirm that deploy is live.
- **Duplicated release handoff text.** #978 extracted the publication-handoff paragraphs into `references/publication-handoff.md` but left the originals in `SKILL.md`, and the two had already drifted: the "more than three tags gets no push events" reason lived only in the skill, the `git pull --ff-only` rule only in the reference. The skill now points at the reference, and the reason sits next to the rule it explains.
- **A hardcoded `.agents/...` path** inside the Claude copy of the tests skill, where every other skill says "the current host's skill".
- **Three skill descriptions** (`kitaru-dev`, `kitaru-docs`, `kitaru-tests-release`) were four-word noun lists, e.g. "Use for Kitaru docs." They now name the intent categories they cover, matching the other four skills.

The `.agents/skills/` copies receive identical edits so the two trees stay byte-identical, as `CLAUDE.md` requires.

## Reviewer Notes

The risky part of this PR is the branching and versioning rewrite in `CLAUDE.md`, because it is the file every agent session loads. If any of the five rows in the table above is wrong, agents will start following a wrong release process with confidence. Check each row against the sources the audit used: `git tag --sort=-creatordate | head`, `git branch -r | grep release/`, the `maintenance-branch-prefix` entries in `release/release-units.toml`, the `create-development-reset-pr` job in `.github/workflows/release.yml`, and the "Prepare a core release PR" and "Publish core and deployables" sections of `.claude/skills/kitaru-release/SKILL.md`.

The second thing to read closely is the `kitaru-release/SKILL.md` diff. It replaces two multi-paragraph blocks with pointers into `references/publication-handoff.md`. Confirm nothing in the removed blocks is absent from the reference: the one fact that was only in the skill (the "more than three tags" push-event limit) moved into the reference in the same commit.

Everything else is wording. The removals in the tests skill are safe to take at face value if you agree that prohibitions naming deleted files do more harm than good.

Deliberately left alone: the human-review rule, the run-checks-locally rule, the release skill's length and exact command blocks, and the v1-terminology prohibitions in the docs rules. Those last ones still have live triggers in tracked code (`docs/components/diagrams.tsx` mentions `kitaru.llm()`, `scripts/summarize_pytest_speed.py` handles `primed_zenml` events), so they were kept.

### Reproduction

Prove the old root file was wrong and the new one is right:

```bash
git fetch origin --tags
git tag --sort=-creatordate | head -3          # python/kitaru/v0.25.0, not v0.25.0
git branch -r | grep 'release/kitaru/'          # release/kitaru/0.25, not release/0.25.0
grep -n 'git push' .github/workflows/release.yml  # only the reset branch; main is never pushed
git show develop:CLAUDE.md | sed -n '/^## Branching/,/^## Development/p'   # the old claims
sed -n '/^## Branching/,/^## Development/p' CLAUDE.md                        # the new text
```

Confirm the skill mirrors stayed in sync:

```bash
for d in .claude/skills/*/; do diff -rq "$d" ".agents/skills/$(basename "$d")"; done
# expected: only "Only in .agents/skills/kitaru-release: agents" (pre-existing)
```

Local checks run: `just check` is green after `uv sync --all-extras --all-groups` (the new `modal` extra requires the resync). `just test` reports 4591 passed and 4 failed; the same four fail identically on a clean `develop` checkout and are unrelated to this change: `tests/server/test_auth_api_pg.py::test_failed_request_still_records_api_key_last_used` (DID NOT RAISE), the two `test_read_replica_api_pg.py::test_probe_route_persists_the_throttled_api_key_last_used` cases (probe route returns 404), and `tests/typescript/test_mastra_adapter.py::test_worker_records_and_history_replays_compiled_mastra` (the Mastra example `pnpm build` fails locally). Left for a separate fix.
