### PR TITLE
Use `getLevelNamesMapping` for the OTel log handler level

### DIFF
--- a/src/kitaru/server/api/otel.py
+++ b/src/kitaru/server/api/otel.py
@@ -160,7 +160,8 @@ def _configure_logs(resource: Any, endpoint: str, settings: APISettings) -> bool
         set_logger_provider(provider)
         _providers.append(provider)
         handler = LoggingHandler(
-            level=logging.getLevelName(settings.LOG_LEVEL), logger_provider=provider
+            level=logging.getLevelNamesMapping()[settings.LOG_LEVEL.value],
+            logger_provider=provider,
         )
         logging.getLogger().addHandler(handler)
         _log_handler = handler


### PR DESCRIPTION
## What

One-line change in `src/kitaru/server/api/otel.py`: look up the numeric log level for the OpenTelemetry logging handler via `logging.getLevelNamesMapping()` instead of `logging.getLevelName(name)`.

## Why

ty 0.0.78 (pending in the Dependabot dev-tooling bump #1009) treats the str -> int overload of `getLevelName` as a deprecated mistake and fails `ty check`. `getLevelNamesMapping` is the replacement the deprecation points at. Landing this ahead of #1009 keeps the bot PR untouched so it can rebase and go green on its own.

## Reviewer Notes

The only behavior in play is which integer the handler gets for a level name. `LogLevel` is a `StrEnum` whose values are the standard names (`DEBUG` ... `CRITICAL`), all present in the mapping, so the lookup cannot raise. If the mapping ever returned a different number than `getLevelName` did, OTel log export would filter records at the wrong threshold.

### Reproduction

```bash
uvx ty@0.0.78 check   # fails on develop, passes on this branch
uv run ty check       # passes on both
uv run pytest tests -k otel
```

Local checks run: `ty` (0.0.75 and 0.0.78), `ruff`, the 14 OTel tests.