### PR TITLE
Fix import receipt for jobs with evaluator tasks

### DIFF
--- a/src/kitaru/cli/sessions.py
+++ b/src/kitaru/cli/sessions.py
@@ -242,12 +242,14 @@ def _get_import_stats(
     job: JobResponse, tasks: list[TaskResponse]
 ) -> tuple[TaskResponse, ImportStats | None]:
     """Validate the single importer task and its optional diagnostic result."""
-    if len(tasks) != 1 or tasks[0].kind is not TaskKind.IMPORTER:
+    # Evaluator and analyzer tasks named on the import share its job.
+    importer_tasks = [task for task in tasks if task.kind is TaskKind.IMPORTER]
+    if len(importer_tasks) != 1:
         raise _internal_receipt_error(
             "An import job must contain exactly one importer task.", job, tasks
         )
 
-    task = tasks[0]
+    task = importer_tasks[0]
     stats = None
     if task.result is not None:
         try:

--- a/tests/cli/test_sessions.py
+++ b/tests/cli/test_sessions.py
@@ -1236,6 +1236,22 @@ def test_terminal_import_rejects_missing_or_malformed_completed_result(
     assert error.value.kind == "internal_error"
 
 
+def test_terminal_import_selects_importer_task_among_evaluator_tasks() -> None:
+    """Evaluator tasks appended to the import job do not hide the importer task."""
+    job = _job(JobStatus.COMPLETED)
+    importer_task = _task(
+        job, result={"created": 2, "skipped": 0, "failed": 0, "failures": []}
+    )
+    evaluator_tasks = [_task(job, kind=TaskKind.EVALUATOR) for _ in range(3)]
+
+    result = sessions._terminal_import_result(
+        job, [*evaluator_tasks, importer_task], identity={}
+    )
+
+    assert result.item["task"]["id"] == str(importer_task.id)
+    assert result.item["stats"]["created"] == 2
+
+
 @pytest.mark.parametrize(
     "filter_value", ["not-json", '{"or": []}', '{"field": "node_type"}']
 )


### PR DESCRIPTION
Fixes `kitaru session import --evaluator ... --wait` and `kitaru import get` failing with "An import job must contain exactly one importer task" once the server appends evaluator or analyzer tasks to the import job.
