### PR TITLE
Remove importer payload size cap

### DIFF
--- a/docs/book/guides/import-braintrust-traces.md
+++ b/docs/book/guides/import-braintrust-traces.md
@@ -20,7 +20,7 @@ The importer is permissive about the container because Braintrust logs reach you
 - **A JSON object with an `events` array**, the shape the Braintrust API returns for a log fetch.
 - **A single JSON object**, treated as a one-event export.
 
-Payloads are capped at 50 MiB per import (the importer's own limit, separate from the server's configurable blob limit). Import in slices as often as you like; [dedup](#re-runs-skip-what-is-already-there) makes overlapping slices safe.
+Uploads are capped by the server's configurable blob limit. Import in slices as often as you like; [dedup](#re-runs-skip-what-is-already-there) makes overlapping slices safe.
 
 What matters is the fields on each record, not how you got the file. A full project-log export carries span identity, and that is what you want:
 

--- a/docs/book/guides/import-langfuse-traces.md
+++ b/docs/book/guides/import-langfuse-traces.md
@@ -44,7 +44,7 @@ Set `agent_version_id` when you know which code produced the traces; it's what l
 
 Kitaru ships provider importers as default plugins, registered at server startup under the `kitaru/` namespace, so `--importer kitaru/langfuse@latest` always resolves. They run on your worker like any other importer; there is nothing to write. See [Import your traces](../getting-started/import-your-traces.md) for the current built-in list.
 
-The Langfuse importer parses **Langfuse JSONL exports**, up to 50 MiB per payload (the importer's own cap, separate from the server's configurable blob limit), and understands three record shapes: `trace`, `observation`, and raw `ingestion_event` lines. Traces map to sessions; observations map to nodes with their parent relationships, timings, model names, token usage, and cost preserved. `params`:
+The Langfuse importer parses **Langfuse JSONL exports**, with uploads capped by the server's configurable blob limit, and understands three record shapes: `trace`, `observation`, and raw `ingestion_event` lines. Traces map to sessions; observations map to nodes with their parent relationships, timings, model names, token usage, and cost preserved. `params`:
 
 | Param | Meaning |
 | --- | --- |

--- a/docs/book/guides/import-langsmith-traces.md
+++ b/docs/book/guides/import-langsmith-traces.md
@@ -18,7 +18,7 @@ The importer reads **LangSmith run records**, one JSON object per run, in any of
 - **A run-query envelope**: a JSON object with the runs under a `runs` or `data` key. This is what the LangSmith runs-query API returns, so you can pipe its response straight to a file.
 - **A single JSON object**, treated as a one-run export.
 
-Payloads must be UTF-8 and 50 MiB or smaller (the importer's own cap, separate from the server's configurable blob limit). Export in slices as often as you like; [dedup](#dedup-one-session-per-project-and-thread) makes overlapping exports safe.
+Payloads must be UTF-8, and uploads are capped by the server's configurable blob limit. Export in slices as often as you like; [dedup](#dedup-one-session-per-project-and-thread) makes overlapping exports safe.
 
 Each run record is read for the fields LangSmith already writes: `id`, `trace_id`, `parent_run_id`, `is_root`, `run_type`, `name`, `status`, `error`, `start_time` / `end_time`, `inputs`, `outputs`, `tags`, `extra.metadata`, `extra.invocation_params`, `serialized.kwargs`, `total_cost`, and token counts. Export whole traces rather than filtered subsets: a run whose parent is missing from the file still imports, but the session is marked partial.
 
@@ -114,7 +114,7 @@ This is what makes "export the last 24 hours every night" safe. It also means th
 - **Only what the export contains.** Anything LangSmith did not record (intermediate state, code, environment) is not recoverable from the file.
 - **Imported threads are frozen.** Once a thread is imported, later traces in the same thread are skipped by dedup rather than appended. Import a thread after it is finished, or scope `join_on` to something that closes.
 - **Partial graphs import with a warning.** A trace with more than one root run, a run whose parent is missing from the export, or model output containing `tool_calls` with no corresponding tool runs all set `source_completeness: partial` and add a line to `normalization_warnings`. The session still imports.
-- **A bad trace is isolated, not fatal.** A run with no trace id or run id, a trace with conflicting project identities or conflicting thread values, or a trace missing your chosen `join_on` value is reported as a failure and the rest of the file still imports. A malformed file (invalid JSON, non-UTF-8, empty, or over 50 MiB) fails the task as a whole.
+- **A bad trace is isolated, not fatal.** A run with no trace id or run id, a trace with conflicting project identities or conflicting thread values, or a trace missing your chosen `join_on` value is reported as a failure and the rest of the file still imports. A malformed file (invalid JSON, non-UTF-8, or empty) fails the task as a whole.
 - **Replay needs your code.** Imported sessions replay like recorded ones, but only if the agent version whose code produced the runs is registered with a run command. No trace export contains the code.
 
 {% hint style="warning" %} Imported payloads contain whatever your runs contain: prompts, customer data, tool results. They are stored on your self-hosted server and parsed on your workers, but access and retention are yours to govern. {% endhint %}

--- a/docs/book/guides/import-logfire-traces.md
+++ b/docs/book/guides/import-logfire-traces.md
@@ -21,7 +21,7 @@ The importer reads rows from Logfire's **records** table, one row per span. Expo
 - **A single JSON object**, treated as a one-row export.
 - **The Query API's streaming NDJSON**, where each line is a typed message. `schema`, `explain`, and `end` messages are skipped, rows arrive inside `{"type": "data", "rows": [...]}` (or a single `{"type": "data", "data": {...}}`), and a `{"type": "error"}` message fails the import with the message it carries.
 
-Payloads are capped at 50 MiB per import (the importer's own limit, separate from the server's configurable blob limit). Export in slices as often as you like; [dedup](#re-runs-skip-what-is-already-there) makes overlapping slices safe.
+Uploads are capped by the server's configurable blob limit. Export in slices as often as you like; [dedup](#re-runs-skip-what-is-already-there) makes overlapping slices safe.
 
 Every row needs `trace_id` and `span_id`; a row without both is reported as a failure and the rest of the file still imports. Beyond those, the importer reads `project_id`, `parent_span_id`, `span_name`, `message`, `kind`, `level`, `start_timestamp`, `end_timestamp`, `otel_status_code` / `status_code`, `otel_status_message`, `is_exception`, `exception_message`, `service_name`, `service_namespace`, `service_version`, `deployment_environment`, `otel_scope_name`, `otel_scope_version`, `tags`, and the `attributes` column:
 
@@ -179,7 +179,7 @@ Because a records query returns exactly the rows you asked for, the importer nev
 - `"Trace '<id>' has <n> root records"` when a trace has no single root span, usually a query that sliced through the middle of a trace.
 - `"Span '<id>' references missing parent '<id>'"` when a `parent_span_id` is not in the file. Those nodes are kept as roots.
 
-Some problems fail one session or one row rather than the file, and are reported as import failures: `"Logfire row lacks trace_id or span_id"`, `"Session '<id>' contains conflicting Logfire project ids"`, `"The import contains duplicate span ids"`, and `"The imported span graph contains a parent cycle"`. A malformed file (invalid JSON, non-UTF-8, empty, no data rows, or over 50 MiB) fails the task as a whole.
+Some problems fail one session or one row rather than the file, and are reported as import failures: `"Logfire row lacks trace_id or span_id"`, `"Session '<id>' contains conflicting Logfire project ids"`, `"The import contains duplicate span ids"`, and `"The imported span graph contains a parent cycle"`. A malformed file (invalid JSON, non-UTF-8, empty, or no data rows) fails the task as a whole.
 
 Two more things worth knowing before you rely on an import:
 

--- a/docs/book/guides/import-phoenix-traces.md
+++ b/docs/book/guides/import-phoenix-traces.md
@@ -28,7 +28,7 @@ The importer also accepts the JSON written by Phoenix CLI trace retrieval. A CLI
 
 The UI and CLI therefore carry the same span objects in different containers. You do not need to reshape either one. See Phoenix's [trace retrieval guide](https://arize.com/docs/phoenix/tracing/how-to-tracing/importing-and-exporting-traces/retrieve-traces-via-cli) for the current CLI commands.
 
-Payloads are capped at 50 MiB per import. Split a larger export into smaller files.
+Uploads are capped by the server's configurable blob limit. Split a larger export into smaller files.
 
 ## 2. Import the file
 

--- a/plugins/packages/braintrust-importer/CHANGELOG.md
+++ b/plugins/packages/braintrust-importer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Use supported Braintrust root filtering and cursor pagination so window imports succeed and complete traces are fetched beyond the first page.
 - Fetch traces directly from the Braintrust API through the `api` extra.
 - Import API-fetched traces oldest first in a single payload, so traces sharing a session are grouped instead of dropped as duplicates.

--- a/plugins/packages/braintrust-importer/src/kitaru_braintrust_importer/importer.py
+++ b/plugins/packages/braintrust-importer/src/kitaru_braintrust_importer/importer.py
@@ -39,7 +39,6 @@ from kitaru.task.importer import (
     ImportedSession,
 )
 
-MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 _MAX_NESTED_DEPTH = 64
 _SESSION_FIELDS = (
     "session_id",
@@ -503,8 +502,6 @@ def _parse_datetime(value: Any) -> datetime | None:
 
 def _parse_records(content: bytes) -> tuple[list[dict[str, Any]], bool]:
     """Parse Braintrust JSON, JSONL, or API fetch output."""
-    if len(content) > MAX_UPLOAD_BYTES:
-        raise InvalidImport("Braintrust import exceeds the 50 MiB upload limit")
     try:
         text = content.decode("utf-8")
     except UnicodeDecodeError as exc:

--- a/plugins/packages/jsonl-importer/CHANGELOG.md
+++ b/plugins/packages/jsonl-importer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
+
 ## 0.1.1
 
 - Isolate numeric validation, deeply nested JSON, and invalid Unicode failures per line while retaining flat indexed node support.

--- a/plugins/packages/jsonl-importer/src/kitaru_jsonl_importer/importer.py
+++ b/plugins/packages/jsonl-importer/src/kitaru_jsonl_importer/importer.py
@@ -26,8 +26,6 @@ from pydantic_core import PydanticSerializationError
 from kitaru.api_models.v1.imports import ImportFailure
 from kitaru.task.importer import ImportedSession, SessionImportError, flatten_nodes
 
-MAX_UPLOAD_BYTES = 64 * 1024 * 1024
-
 
 class InvalidImport(ValueError):
     """Raised when a Kitaru JSONL payload cannot be parsed."""
@@ -43,14 +41,12 @@ def parse(
         params: Import parameters, unused by this importer.
 
     Raises:
-        InvalidImport: The upload is too large, empty, or not UTF-8.
+        InvalidImport: The upload is empty or not UTF-8.
 
     Yields:
         Valid sessions and isolated line failures.
     """
     _ = params
-    if len(content) > MAX_UPLOAD_BYTES:
-        raise InvalidImport("Kitaru JSONL import exceeds the 64 MiB upload limit")
     try:
         text = content.decode("utf-8")
     except UnicodeDecodeError as exc:

--- a/plugins/packages/langfuse-importer/CHANGELOG.md
+++ b/plugins/packages/langfuse-importer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Preserve observations outside the selection window when importing a trace that starts inside the window.
 
 - Fetch traces directly from the Langfuse API by trace id or time window, through the `api` extra.

--- a/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
+++ b/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
@@ -38,7 +38,6 @@ from kitaru.task.importer import (
     ImportedSession,
 )
 
-MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 MAX_TREE_DEPTH = 64
 MAX_TOOL_SCAN_DEPTH = 64
 _TRACE_SHAPE = "trace"
@@ -749,8 +748,6 @@ def _detect_shape(record: dict[str, Any]) -> str:
 
 def _parse_records(content: bytes) -> list[dict[str, Any]]:
     """Parse non-empty JSON or JSONL records."""
-    if len(content) > MAX_UPLOAD_BYTES:
-        raise InvalidImport("Langfuse import exceeds the 50 MiB upload limit")
     try:
         text = content.decode("utf-8")
     except UnicodeDecodeError as exc:

--- a/plugins/packages/langsmith-importer/CHANGELOG.md
+++ b/plugins/packages/langsmith-importer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Fetch traces from the LangSmith API by trace id or time window through the `api` extra.
 - Import traces oldest first and group them by thread instead of dropping later traces of a thread as duplicates.
 - Fetch traces concurrently, bounded by the fetch query's `concurrency` key.

--- a/plugins/packages/langsmith-importer/src/kitaru_langsmith_importer/importer.py
+++ b/plugins/packages/langsmith-importer/src/kitaru_langsmith_importer/importer.py
@@ -36,7 +36,6 @@ from kitaru.task.importer import (
     ImportedSession,
 )
 
-MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 _MAX_NESTED_DEPTH = 64
 _DEFAULT_JOIN_PATHS = (
     "extra.metadata.thread_id",
@@ -461,8 +460,6 @@ def _decimal(value: Any) -> Decimal | None:
 
 def _parse_records(content: bytes) -> list[dict[str, Any]]:
     """Parse JSON, JSONL, and LangSmith run-query envelopes."""
-    if len(content) > MAX_UPLOAD_BYTES:
-        raise InvalidImport("LangSmith import exceeds the 50 MiB upload limit")
     try:
         text = content.decode("utf-8")
     except UnicodeDecodeError as exc:

--- a/plugins/packages/logfire-importer/CHANGELOG.md
+++ b/plugins/packages/logfire-importer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Fail API imports visibly when a successful HTTP response contains a query stream error, including after partial results.
 
 - Support Logfire 5.x for the `adapter` extra in addition to the existing 4.35+ line.

--- a/plugins/packages/logfire-importer/src/kitaru_logfire_importer/importer.py
+++ b/plugins/packages/logfire-importer/src/kitaru_logfire_importer/importer.py
@@ -33,7 +33,6 @@ from kitaru.api_models.v1.session import SessionStatus, TokenUsage
 from kitaru.api_models.v1.session_node import NodeStatus, NodeType
 from kitaru.task.importer import ImportedNode, ImportedSession
 
-MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 MAX_PARENT_DEPTH = 64
 _DEFAULT_JOIN_PATHS = (
     "attributes.session.id",
@@ -163,8 +162,6 @@ def _decimal(value: Any) -> Decimal | None:
 
 def _parse_records(content: bytes) -> list[dict[str, Any]]:
     """Parse Logfire JSON, JSONL, or streaming NDJSON output."""
-    if len(content) > MAX_UPLOAD_BYTES:
-        raise InvalidImport("Logfire import exceeds the 50 MiB upload limit")
     try:
         text = content.decode("utf-8")
     except UnicodeDecodeError as exc:

--- a/plugins/packages/phoenix-importer/CHANGELOG.md
+++ b/plugins/packages/phoenix-importer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Follow SDK cursor pagination to import all matching spans, including windows and traces larger than 1,000 spans.
 
 - Fetch traces from the Phoenix API by trace id or time window, importing them oldest first, installed through the `api` extra.

--- a/plugins/packages/phoenix-importer/src/kitaru_phoenix_importer/importer.py
+++ b/plugins/packages/phoenix-importer/src/kitaru_phoenix_importer/importer.py
@@ -31,7 +31,6 @@ from kitaru.api_models.v1.session import SessionStatus, TokenUsage
 from kitaru.api_models.v1.session_node import NodeStatus, NodeType
 from kitaru.task.importer import ImportedNode, ImportedSession
 
-MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 MAX_PARENT_DEPTH = 64
 
 
@@ -142,8 +141,6 @@ def _parse_values(
     content: bytes,
 ) -> tuple[list[tuple[int, dict[str, Any]]], list[ImportFailure]]:
     """Parse Phoenix UI or CLI JSON and JSONL values."""
-    if len(content) > MAX_UPLOAD_BYTES:
-        raise InvalidImport("Phoenix import exceeds the 50 MiB upload limit")
     try:
         text = content.decode("utf-8-sig")
     except UnicodeDecodeError as exc:

--- a/plugins/tests/importers/test_braintrust.py
+++ b/plugins/tests/importers/test_braintrust.py
@@ -19,7 +19,6 @@ from typing import Any
 
 import pytest
 
-import kitaru_braintrust_importer.importer as braintrust_module
 from kitaru.api_models.v1.session import SessionStatus
 from kitaru.api_models.v1.session_node import NodeType
 from kitaru.task.importer import ImportedNode, ImportedSession, ImportFailure
@@ -58,14 +57,6 @@ def sessions(
 def flatten(nodes: list[ImportedNode]) -> list[ImportedNode]:
     """Flatten imported nodes depth-first for assertions."""
     return [node for root in nodes for node in (root, *flatten(root.children))]
-
-
-def test_rejects_oversized_upload(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Reject content before decoding when it exceeds the importer limit."""
-    monkeypatch.setattr(braintrust_module, "MAX_UPLOAD_BYTES", 3)
-
-    with pytest.raises(InvalidImport, match="50 MiB upload limit"):
-        BraintrustProjectLogImporter().parse(b"1234", params())
 
 
 def event(

--- a/plugins/tests/importers/test_langfuse.py
+++ b/plugins/tests/importers/test_langfuse.py
@@ -75,14 +75,6 @@ def flatten(nodes: list[ImportedNode]) -> list[ImportedNode]:
     return [node for root in nodes for node in (root, *flatten(root.children))]
 
 
-def test_rejects_oversized_upload(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Reject content before decoding when it exceeds the importer limit."""
-    monkeypatch.setattr(langfuse_module, "MAX_UPLOAD_BYTES", 3)
-
-    with pytest.raises(InvalidImport, match="50 MiB upload limit"):
-        LangfuseJSONLImporter().parse(b"1234", {})
-
-
 def test_unified_parse_returns_prefixed_external_id() -> None:
     """Expose normalized sessions through the unified plugin entrypoint."""
     parsed = list(

--- a/plugins/tests/importers/test_langsmith.py
+++ b/plugins/tests/importers/test_langsmith.py
@@ -19,7 +19,6 @@ from typing import Any
 
 import pytest
 
-import kitaru_langsmith_importer.importer as langsmith_module
 from kitaru.api_models.v1.imports import ImportFailure
 from kitaru.api_models.v1.session import SessionStatus
 from kitaru.api_models.v1.session_node import NodeStatus, NodeType
@@ -427,14 +426,6 @@ def test_unified_parse_yields_worker_contract_models() -> None:
 
     assert len(parsed) == 1
     assert isinstance(parsed[0], ImportedSession)
-
-
-def test_rejects_oversized_payload(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Enforce the upload limit before decoding."""
-    monkeypatch.setattr(langsmith_module, "MAX_UPLOAD_BYTES", 3)
-
-    with pytest.raises(InvalidImport, match="50 MiB upload limit"):
-        LangSmithRunImporter().parse(b"1234", {})
 
 
 def assert_bad_run_isolated(row: dict[str, Any]) -> None:


### PR DESCRIPTION
This PR removes the per-importer payload size check from all six importers, so uploads are bounded only by the server's configurable blob limit and API imports have no size cap.
