### PR TITLE
Drop version references from `connection create` docs

### DIFF
--- a/docs/book/guides/provider-connections.md
+++ b/docs/book/guides/provider-connections.md
@@ -14,8 +14,10 @@ A **connection** is the alternative: a server-side resource that holds a provide
 Importers and analyzers can declare a `connection_schema`, the set of environment variables their provider SDK reads. Naming either plugin drives the create form:
 
 ```bash
-kitaru connection create langfuse-prod --importer kitaru/langfuse@latest
+kitaru connection create langfuse-prod --importer kitaru/langfuse
 ```
+
+Name the plugin, not a version. A connection holds credentials for the plugin's provider, and every version of that plugin uses the same connection, so `--importer` and `--analyzer` take a plugin name or UUID here rather than a `NAME@VERSION` reference.
 
 For an analyzer, use `--analyzer` instead:
 
@@ -27,7 +29,7 @@ This prompts for each property in the schema, in order, hiding input for anythin
 
 ```bash
 kitaru connection create langfuse-prod \
-  --importer kitaru/langfuse@latest \
+  --importer kitaru/langfuse \
   --set-secret LANGFUSE_PUBLIC_KEY=pk-... \
   --set-secret LANGFUSE_SECRET_KEY=sk-... \
   --set LANGFUSE_BASE_URL=https://cloud.langfuse.com


### PR DESCRIPTION
## What changed?

The provider connections guide no longer shows `--importer kitaru/langfuse@latest` on `kitaru connection create`. Both `connection create` examples now pass the bare plugin name, and a short paragraph explains that the flag takes a plugin name or UUID rather than a `NAME@VERSION` reference.

This PR is docs-only. An earlier version taught the CLI to accept version references on `connection create`; that change was dropped after review, since a connection belongs to the plugin's provider and no version takes part in creating it.

## Why?

The guide's `@latest` example fails with "importer not found", because `connection create` resolves the whole value as a plugin name. Accepting and ignoring a version would make the syntax suggest a version matters when it does not. Fixing the docs makes the syntax match what the command actually uses.

## Release context

Docs only. No core, plugin, or frontend release is needed; GitBook publishes the guide from `docs/book/`.

## Reviewer Notes

Only `docs/book/guides/provider-connections.md` changes. The two `connection create` examples near the top lose `@latest`, and the new paragraph after the first example states the plugin-scoping rule. The `session import` examples further down keep `@latest` on purpose: import commands do resolve a plugin version.

### Reproduction

Against a running server with the built-in Langfuse importer registered:

```bash
kitaru connection create langfuse-prod --importer kitaru/langfuse
```

This prompts from the Langfuse connection schema. The old form, `--importer kitaru/langfuse@latest`, reports the importer as not found.

### Local checks run

`just check` passed, including the offline link check.
