### PR TITLE
Merge changelog entries automatically with the union driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,10 @@
 #   pnpm-lock.yaml    -> `pnpm install` (in the relevant subdir)
 uv.lock              merge=binary
 docs/pnpm-lock.yaml  merge=binary
+
+# Every PR inserts its changelog line directly under the same [Unreleased]
+# heading, so two PRs conflict on that spot even though both lines belong.
+# The union driver keeps both sides. It only applies to local merges and
+# rebases; GitHub's conflict check ignores merge drivers, so a PR can still
+# show as conflicting until `git merge origin/develop` is run and pushed.
+CHANGELOG.md         merge=union

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ For adapter, importer, specialized UI API, docs, CI, and release work, load the 
 
 - **Single source of truth:** the `version` field in `pyproject.toml`. On `develop` it carries a `+dev` suffix. Only a release-preparation PR (see the `kitaru-release` skill) sets it to a release version, and the workflow's development-reset PR restores the `+dev` placeholder afterward. Do not change it in feature PRs.
 - **Never hardcode the version** in tests or application code. Use `importlib.metadata.version("kitaru")` to read it at runtime.
-- **Update `CHANGELOG.md`** when making user-facing changes. Add entries under the `[Unreleased]` heading. The release-preparation PR converts `[Unreleased]` to a versioned heading (e.g. `[0.2.0] - 2026-04-01`), and the development-reset PR restores an empty `[Unreleased]` afterward.
+- **Update `CHANGELOG.md`** when making user-facing changes. Add entries under the `[Unreleased]` heading. The release-preparation PR converts `[Unreleased]` to a versioned heading (e.g. `[0.2.0] - 2026-04-01`), and the development-reset PR restores an empty `[Unreleased]` afterward. `CHANGELOG.md` uses the `merge=union` driver (see `.gitattributes`), so a local `git merge origin/develop` keeps both sides when two PRs added lines under the same heading. GitHub's conflict check ignores merge drivers, so a PR that shows as conflicting only on the changelog is fixed by merging `develop` locally and pushing; after such a merge, check the `[Unreleased]` section for a duplicated line, which the union driver does not remove.
 - **Track deprecations in `DEPRECATIONS.md`** at the repository root, one entry per deprecated surface.
 
 ## Commits and PRs


### PR DESCRIPTION
Two PRs opened the same week both hit a `CHANGELOG.md` conflict against `develop` (#977 and #1004), and both resolutions were the same: keep both sides. This PR makes git do that on its own.

## What changes

- `.gitattributes` gains `CHANGELOG.md merge=union`. On a local merge or rebase, git keeps both sides of a conflicting hunk in the changelog instead of stopping.
- The changelog rule in `CLAUDE.md` explains the driver, its GitHub limitation, and the one thing to check after such a merge.

## Why the changelog conflicts so often

Every PR inserts its entry at the same spot: the first line under a heading in `[Unreleased]`. Git merges by matching surrounding context, so two PRs that both added a line directly below `### Fixed` are two different edits at one location, and git cannot pick an order. Code rarely hits this because PRs touch different functions. The changelog is the one file where every PR edits the same three-line neighborhood.

## Reviewer Notes

The driver only runs in a local git. GitHub's mergeability check does not honor custom merge drivers, so a PR whose only conflict is the changelog will still show as conflicting on GitHub. The fix is unchanged from today, `git merge origin/develop` then push, but the merge now completes without a manual edit. The CLAUDE.md note says exactly that so nobody expects the red badge to disappear.

The trade-off worth knowing: `union` never reports a conflict for this file. If two PRs both edit the same existing line, union keeps both versions silently instead of flagging it. For an append-only file that is the right trade, but it is why the guidance asks for a glance at `[Unreleased]` after a merge. The one duplicate we saw during #977 came from both branches already carrying the same entry once; union would have kept that duplicate too, which is the case the note covers.

I checked that the root `AGENTS.md` carries no changelog rule of its own, so there is nothing to mirror there.

### Reproduction

Simulate two PRs inserting under the same heading, with this branch's `.gitattributes` in place:

```bash
git init -q -b base sim && cd sim
cp /path/to/kitaru/.gitattributes .
printf '## [Unreleased]\n\n### Fixed\n\n- old entry\n' > CHANGELOG.md
git add -A && git commit -qm base
git checkout -qb a && sed -i '4a - entry from PR A' CHANGELOG.md && git commit -qam a
git checkout -q base && git checkout -qb b && sed -i '4a - entry from PR B' CHANGELOG.md && git commit -qam b
git merge a -m merge && cat CHANGELOG.md
```

Without the `.gitattributes` line the merge stops with a conflict. With it, the merge exits 0 and the file lists both new entries above the old one.

Local checks run: typos on the two changed files. No code or tests are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAUAys8r9ZkczYYGnnJ5ae
