### PR TITLE
Add contextual insight copy labels

### DIFF
--- a/plugins/packages/post-import-insights/CHANGELOG.md
+++ b/plugins/packages/post-import-insights/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Persist short, finding-specific copy button labels alongside investigation prompts in both analyzer modes.
+
 - Rewrite the copied investigation prompt as a finding-specific briefing: it opens with ordered setup steps (install the `kitaru` CLI, `kitaru login` against the recorded server, `kitaru setup` when the `kitaru-investigation` skill is missing) and hands the procedure to that skill; names the server, agent, and import; states what is odd with the finding's own counts, where to look first, a concrete cohort boundary, one hypothesis, and what a confirmed hypothesis looks like per family (trajectory, tool health, language, outcome, activity, timing, model mix); and moves the untrusted JSON evidence to the end. The analyzer now records the server URL and looks up the agent name when the task did not supply one, and the default per-card contributing-session cap drops from 250 to 200 so a full briefing still fits the 16,000-character prompt bound. The analysis version is bumped because the briefing text is part of each candidate's content hash.
 - Validate editor copy per card and keep the model's wording for every card that passes; page framing is deterministic and no longer requested from the model.
 - Allow card copy to restate numbers present in the card's facts or chart with their unit, measurable comparatives, and word quantities; keep rejecting invented numbers, causal claims, subjective quality judgments, and negated or unsupported outcome claims.

--- a/plugins/packages/post-import-insights/README.md
+++ b/plugins/packages/post-import-insights/README.md
@@ -24,3 +24,9 @@ The exact `kitaru==0.25.0+dev` dependency requires the unreleased analyzer contr
 - [Issue tracker](https://github.com/zenml-io/kitaru/issues)
 
 Licensed under Apache-2.0.
+
+## Investigation button labels
+
+New cards persist `cta_label` beside `investigation_prompt` in `metadata["kitaru.insights/v1"]`. Both analyzers use a reviewed finding-type catalog, such as "Copy tool retry prompt" and "Copy session duration prompt", with "Copy investigation prompt" for unknown finding types. Labels describe copying, not running an investigation or fixing a problem; they use `Copy [topic] prompt` and stay within 40 characters. No additional model requests are made.
+
+The field is optional for historical records and accepts nonblank strings up to 40 characters. Consumers should render it as text, fall back to "Copy investigation prompt" when the label is missing or unusable, and copy the existing prompt unchanged. A missing prompt should disable the action. Frontend wiring is separate from this backend contract. Older strict metadata readers reject the new field, so update any independently deployed readers before enabling new writers; retain reader compatibility on rollback.

--- a/plugins/packages/post-import-insights/src/kitaru_post_import_insights/models.py
+++ b/plugins/packages/post-import-insights/src/kitaru_post_import_insights/models.py
@@ -27,6 +27,8 @@ from kitaru.api_models.v1.insight import (
 )
 
 INSIGHT_METADATA_KEY = "kitaru.insights/v1"
+MAX_CTA_LABEL_LENGTH = 40
+DEFAULT_CTA_LABEL = "Copy investigation prompt"
 MAX_INSIGHTS = 6
 MAX_EVIDENCE_LOCATORS = 20
 MAX_CONTRIBUTING_SESSIONS = 1000
@@ -178,8 +180,20 @@ class InsightCardMetadata(_InsightGenerationModel):
     investigation_prompt: str = Field(
         min_length=1, max_length=MAX_INVESTIGATION_PROMPT_LENGTH
     )
+    cta_label: str | None = Field(
+        default=None, strict=True, min_length=1, max_length=MAX_CTA_LABEL_LENGTH
+    )
     context: InsightGenerationContext
     generation: GenerationVersions
+
+    @field_validator("cta_label")
+    @classmethod
+    def _validate_cta_label(cls, value: str | None) -> str | None:
+        if value is not None:
+            _require_utf8(value)
+            if not value.strip():
+                raise ValueError("CTA label must not be blank")
+        return value
 
     @model_validator(mode="after")
     def _validate_contributions(self) -> Self:

--- a/plugins/packages/post-import-insights/src/kitaru_post_import_insights/pipeline.py
+++ b/plugins/packages/post-import-insights/src/kitaru_post_import_insights/pipeline.py
@@ -31,6 +31,7 @@ from kitaru_post_import_insights.generation import (
     generate_model_plan,
 )
 from kitaru_post_import_insights.models import (
+    DEFAULT_CTA_LABEL,
     INSIGHT_METADATA_KEY,
     MAX_INVESTIGATION_PROMPT_LENGTH,
     Coverage,
@@ -52,6 +53,25 @@ from kitaru_post_import_insights.profiling import (
     ProfilingResult,
     SessionProfiler,
 )
+
+_CTA_LABELS = {
+    "failed-identical-retries": "Copy tool retry prompt",
+    "short-tool-cycles": "Copy tool cycle prompt",
+    "adjacent-same-tool-failures": "Copy repeated tool failure prompt",
+    "adjacent-identical-calls": "Copy repeated tool call prompt",
+    "tool-error-mix": "Copy tool error prompt",
+    "correction-language": "Copy correction language prompt",
+    "empty-tool-results": "Copy empty tool result prompt",
+    "repeated-punctuation": "Copy repeated punctuation prompt",
+    "mostly-uppercase-messages": "Copy uppercase message prompt",
+    "possible-profanity": "Copy profanity marker prompt",
+    "session-outcomes": "Copy session status prompt",
+    "tool-call-distribution": "Copy tool call count prompt",
+    "model-call-distribution": "Copy model call count prompt",
+    "total-activity-distribution": "Copy recorded activity prompt",
+    "recorded-duration-distribution": "Copy session duration prompt",
+    "model-mix": "Copy model mix prompt",
+}
 
 PROMPT_VERSION = "2026-09-08.2"
 _MAX_COVERAGE_CAVEATS = 10
@@ -380,6 +400,7 @@ def _assemble_result(
             evidence=evidence,
             coverage=coverage,
             investigation_prompt=investigation_prompt,
+            cta_label=_CTA_LABELS.get(candidate_id, DEFAULT_CTA_LABEL),
             context=context,
             generation=GenerationVersions(
                 analysis=profiling.analysis_version,

--- a/plugins/tests/analyzers/post_import_insights/test_models.py
+++ b/plugins/tests/analyzers/post_import_insights/test_models.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Tests for the insight generation result contract."""
 
+import json
 import uuid
 
 import pytest
@@ -419,3 +420,32 @@ def test_text_insights_are_rejected() -> None:
 
     with pytest.raises(ValidationError, match="categorical or binned"):
         InsightGenerationResult.model_validate(data)
+
+
+@pytest.mark.parametrize("label", [None, "Copy tool retry prompt", "x" * 40])
+def test_cta_label_round_trip(label: str | None) -> None:
+    payload = _result().model_dump(mode="json")
+    for insight in payload["insights"]:
+        insight["metadata"][INSIGHT_METADATA_KEY]["cta_label"] = label
+    restored = InsightGenerationResult.model_validate_json(json.dumps(payload))
+    assert all(
+        restored.card_metadata(item).cta_label == label for item in restored.insights
+    )
+
+
+def test_historical_results_without_cta_label_are_readable() -> None:
+    payload = _result().model_dump(mode="json")
+    for insight in payload["insights"]:
+        insight["metadata"][INSIGHT_METADATA_KEY].pop("cta_label", None)
+    restored = InsightGenerationResult.model_validate(payload)
+    assert all(
+        restored.card_metadata(item).cta_label is None for item in restored.insights
+    )
+
+
+@pytest.mark.parametrize("label", ["", "   ", "x" * 41, 123, "broken-\ud800"])
+def test_invalid_cta_label_is_rejected(label: object) -> None:
+    payload = _metadata(position=0, recommended=True).model_dump()
+    payload["cta_label"] = label
+    with pytest.raises(ValidationError):
+        InsightCardMetadata.model_validate(payload)

--- a/plugins/tests/analyzers/post_import_insights/test_pipeline.py
+++ b/plugins/tests/analyzers/post_import_insights/test_pipeline.py
@@ -592,6 +592,14 @@ async def test_result_byte_bound_neutralizes_removed_recommendation(
         "Start here and use the copied prompt to define a focused cohort."
     )
     assert bounded.card_metadata(bounded.insights[0]).recommended is True
+    assert (
+        bounded.card_metadata(bounded.insights[0]).cta_label
+        == full.card_metadata(
+            next(
+                item for item in full.insights if item.name == bounded.insights[0].name
+            )
+        ).cta_label
+    )
 
 
 async def test_oversized_prompt_omits_only_the_affected_card(monkeypatch) -> None:
@@ -1001,3 +1009,45 @@ async def test_full_contribution_prompts_fit_the_length_bound() -> None:
             item.dimension != "investigation_prompt_chars"
             for item in result.coverage.truncations
         )
+
+
+@pytest.mark.parametrize(
+    "generator", [None, SuccessfulGenerator(), FailingEditor(), FailingAnalyst()]
+)
+async def test_generated_labels_survive_json_in_all_modes(generator) -> None:
+    result = await generate_insights(
+        [
+            _session(1, status=SessionStatus.FAILED),
+            _session(2, status=SessionStatus.COMPLETED),
+        ],
+        context=_context(),
+        config=InsightGenerationConfig(model=ModelGenerationConfig(model="test-model"))
+        if generator
+        else None,
+        generator=generator,
+    )
+    assert result.insights
+    for insight in json.loads(result.model_dump_json())["insights"]:
+        label = insight["metadata"][INSIGHT_METADATA_KEY]["cta_label"]
+        assert label.startswith("Copy ") and label.endswith(" prompt")
+        assert len(label) <= 40
+        assert label != "Copy investigation prompt"
+
+
+@pytest.mark.parametrize(
+    "candidate_id, label",
+    [
+        ("failed-identical-retries", "Copy tool retry prompt"),
+        ("adjacent-identical-calls", "Copy repeated tool call prompt"),
+        ("recorded-duration-distribution", "Copy session duration prompt"),
+        ("future-finding", "Copy investigation prompt"),
+    ],
+)
+async def test_cta_labels_follow_candidate_identity(
+    candidate_id: str, label: str
+) -> None:
+    profile = profile_sessions([_session(1, status=SessionStatus.FAILED)])
+    candidate = profile.candidates[0].model_copy(update={"id": candidate_id})
+    profile = profile.model_copy(update={"candidates": [candidate]})
+    result = await generate_insights_from_profile(profile, context=_context())
+    assert result.card_metadata(result.insights[0]).cta_label == label


### PR DESCRIPTION
## What changed?

Generated insights now include a contextual copy button label alongside their investigation prompt, such as "Copy tool retry prompt". Both analyzer modes use the same reviewed catalog, with "Copy investigation prompt" for unknown finding types.

## Why?

Consumers currently have only generic button copy. Persisting the label makes contextual wording available without additional model calls or changes to the investigation prompt.

Related: #1038

## Release context

Release with the post-import-insights plugin. Frontend consumption remains separate. No package version bump, database migration, or historical backfill is included.

## Reviewer Notes

The optional metadata field accepts nonblank strings up to 40 characters. Historical records remain readable, but independently deployed strict readers need the updated field before consuming new records. Labels are assigned once during final assembly, so model fallback does not need its own label logic.

## Reproduction

Run `uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests/analyzers/post_import_insights/test_pipeline.py -k cta_labels_follow_candidate_identity`. This exercises card generation for failed retries, repeated calls, duration findings, and an unknown finding; the resulting metadata must contain the corresponding copy label or the generic fallback.

## Local checks run

- Focused insight suite: 437 passed.
- Plugin workspace formatting, lint, and type checks passed.
- Full plugin suite plus default-plugin tests: 1,538 passed.
- `just check` passed.
- Independent final diff review found no actionable issues.
