### PR TITLE
Standardize source identity across trace importers

### DIFF
--- a/docs/book/getting-started/import-your-traces.md
+++ b/docs/book/getting-started/import-your-traces.md
@@ -33,6 +33,7 @@ Export your traces from Langfuse as JSONL (trace, observation, and ingestion-eve
 kitaru session import langfuse-export.jsonl \
   --importer kitaru/langfuse@latest \
   --agent support-agent@latest \
+  --params '{"source_instance":"my-langfuse-project"}' \
   --tag imported-baseline \
   --media-type application/x-ndjson \
   --wait
@@ -64,9 +65,36 @@ kitaru session import \
 
 Use the file upload from step 2 when you already have an export, when you'd rather not hand a worker live API credentials, or for the Kitaru JSONL importer, which only accepts uploaded files. Use the API fetch to skip the export step for the five provider importers.
 
-## Re-runs are safe
+## Source identity
 
-Every imported session keeps its source identity (`imported_from` + `external_id`). Importing the same export twice, or a bigger export that overlaps an earlier one, skips what's already there instead of duplicating it. Import incrementally, as often as you like.
+The five provider importers choose project identity in the same order: `params.source_instance`, the provider-specific parameter below, then project identity embedded in the export. If none is available, the affected trace or session fails with an error showing the `--params` remedy. Filenames and generic provider names are not identity fallbacks.
+
+| Importer | Alternative parameter |
+| --- | --- |
+| Langfuse | `project_id` |
+| LangSmith | `project_name` |
+| Braintrust | `project_id` |
+| Logfire | `project_id` |
+| Arize Phoenix | `project` |
+
+Identity values must be strings. Surrounding whitespace is removed; `null` and empty or whitespace-only strings count as absent. Other types are rejected, including when an explicit override is available. Conflicting embedded project identities fail the affected trace or session even with an override. Each importer keeps its existing rules for grouping traces into sessions.
+
+Use the same identity value for every import from the same source project, including file and API imports. These parameters do not look up project names or convert them to IDs: `support` and `project-123` are different identities even if they describe the same provider project. `--query` selects what to fetch; `--params` supplies parser options. If fetched records do not carry identity, supply it in `--params`. Phoenix includes its selected API project in the fetched payload.
+
+The native Kitaru JSONL importer is different: each record already supplies its final `external_id`, which the importer preserves.
+
+### Existing imports
+
+- For an earlier Langfuse or Braintrust import that used a filename stem, supply that stem explicitly as `source_instance` to keep the same identity.
+- Braintrust now honors explicit parameters ahead of embedded project IDs. If an earlier import ignored your explicit parameter, omit it or set it to the previously selected embedded ID to retain the same identity.
+- For a Logfire import that used the old `logfire` fallback, supply `"source_instance":"logfire"` explicitly to retain that prefix.
+- Phoenix now prefixes the trace ID with project identity. Previously imported bare trace IDs do not match the new IDs, so importing overlapping traces into the same agent creates additional sessions. Existing sessions are not rewritten automatically.
+
+Trimming whitespace also changes any earlier identity that included surrounding whitespace. New identity validation does not reconcile previously imported sessions.
+
+## Re-runs skip existing sessions
+
+Every imported session keeps its source identity (`imported_from` + `external_id`). This pair is unique per destination agent. Importing the same export twice with the same identity skips what's already there instead of duplicating it. Skipped sessions are not refreshed with new nodes. Changing project identity or the grouping key can create additional sessions.
 
 {% hint style="warning" %} An import stores the parsed trace content (prompts, tool arguments, tool results) on your Kitaru server. The server is self-hosted, but check your own access and retention rules before importing exports that contain customer data. {% endhint %}
 

--- a/docs/book/guides/import-braintrust-traces.md
+++ b/docs/book/guides/import-braintrust-traces.md
@@ -78,7 +78,8 @@ kitaru session list --agent support-agent --origin imported --imported-from brai
 | Param | Meaning |
 | --- | --- |
 | `source_instance` | Project identity fallback. The importer prefers each record's `project_id`; `source_instance` is used when the export carries none. |
-| `filename` | Optional label. When neither `project_id` nor `source_instance` is available, the filename stem becomes the project identity. A record with none of the three fails with "Braintrust export has no project id; provide source\_instance". |
+| `project_id` | Provider-native alias for `source_instance`, used when `source_instance` is absent or empty. Embedded project IDs take precedence over both parameters. |
+| `filename` | Optional label. When neither an embedded project ID nor either identity parameter is available, the filename stem becomes the project identity. If identity is still missing, the error includes the `--params` remedy. |
 | `join_on` | Dotted path or RFC 6901 JSON Pointer selecting the value that groups traces into one session. Defaults to the session id found in metadata. See [Grouping traces into sessions](#grouping-traces-into-sessions). |
 
 Pass them with `--params '{"source_instance": "my-braintrust-project"}'`, or use the dedicated `--join-on` flag, which accepts a JSON Pointer only (it must start with `/`) and cannot be combined with `join_on` inside `--params`.

--- a/docs/book/guides/import-braintrust-traces.md
+++ b/docs/book/guides/import-braintrust-traces.md
@@ -77,12 +77,13 @@ kitaru session list --agent support-agent --origin imported --imported-from brai
 
 | Param | Meaning |
 | --- | --- |
-| `source_instance` | Project identity fallback. The importer prefers each record's `project_id`; `source_instance` is used when the export carries none. |
-| `project_id` | Provider-native alias for `source_instance`, used when `source_instance` is absent or empty. Embedded project IDs take precedence over both parameters. |
-| `filename` | Optional label. When neither an embedded project ID nor either identity parameter is available, the filename stem becomes the project identity. If identity is still missing, the error includes the `--params` remedy. |
+| `source_instance` | Explicit project identity, preferred over the `project_id` parameter and embedded project IDs. Keep it stable across imports from the same project. |
+| `project_id` | Provider-native alias for `source_instance`, used when `source_instance` is absent or blank. Either parameter takes precedence over embedded project IDs. |
 | `join_on` | Dotted path or RFC 6901 JSON Pointer selecting the value that groups traces into one session. Defaults to the session id found in metadata. See [Grouping traces into sessions](#grouping-traces-into-sessions). |
 
 Pass them with `--params '{"source_instance": "my-braintrust-project"}'`, or use the dedicated `--join-on` flag, which accepts a JSON Pointer only (it must start with `/`) and cannot be combined with `join_on` inside `--params`.
+
+If the export contains no project ID, supply one of the identity parameters; filenames do not determine identity. Values are trimmed strings, and conflicting embedded project IDs fail the affected trace or session even with an override. See [Import your traces](../getting-started/import-your-traces.md) for the shared identity rules and guidance for existing imports.
 
 ## 3. Or fetch from the Braintrust API
 
@@ -146,7 +147,7 @@ Session metadata records the provenance you'll want when reading the import back
 
 ## Re-runs skip what is already there
 
-Every imported session records its source identity: `imported_from` (`braintrust`) and an `external_id` of `<project>:<session>`. That pair is unique on the server, so re-importing an overlapping export **skips** what is already stored and reports it as `skipped`, not as an error. Exporting the last 24 hours every night is safe; it will not duplicate earlier sessions.
+Every imported session records its source identity: `imported_from` (`braintrust`) and an `external_id` of `<source_instance>:<session>`. That pair is unique per destination agent, so re-importing an overlapping export with the same identity **skips** what is already stored and reports it as `skipped`, not as an error. Skipped sessions are not refreshed with new nodes.
 
 ## Limitations
 

--- a/docs/book/guides/import-langfuse-traces.md
+++ b/docs/book/guides/import-langfuse-traces.md
@@ -54,6 +54,8 @@ The Langfuse importer parses **Langfuse JSONL exports**, with uploads capped by 
 
 For UI and events exports without project IDs, pass `--params '{"source_instance":"my-langfuse-project"}'` or `--params '{"project_id":"my-langfuse-project"}'`. SDK and REST callers supply the same parameters on import creation. Keep the value stable across exports of the same project; filenames do not determine identity. If earlier imports used a filename stem as their identity, supply that same value explicitly to preserve deduplication.
 
+Identity values are trimmed strings. Conflicting embedded project IDs fail the affected session even with an explicit override. See [Import your traces](../getting-started/import-your-traces.md) for the shared identity rules and guidance for existing imports.
+
 ## Fetch traces from the Langfuse API
 
 Skip the export and upload, and let the import task fetch traces from Langfuse directly:

--- a/docs/book/guides/import-langfuse-traces.md
+++ b/docs/book/guides/import-langfuse-traces.md
@@ -48,11 +48,11 @@ The Langfuse importer parses **Langfuse JSONL exports**, with uploads capped by 
 
 | Param | Meaning |
 | --- | --- |
-| `source_instance` | The Langfuse project the export came from. Optional when the export itself carries project ids; required when it doesn't; it anchors the sessions' external identity. |
-| `filename` | Optional label used as a fallback source name. |
+| `source_instance` | Stable source project identity. Required for file uploads without an embedded project ID, unless `project_id` is supplied instead. Takes precedence over `project_id` and embedded identity. |
+| `project_id` | Provider-native alias for `source_instance`, used when `source_instance` is absent or empty. |
 | `infer_tool_call_links` | Optional boolean, default `true`. The importer matches tool-call ids emitted by a generation with `gen_ai.tool.call.id` on tool observations, nests each unambiguous tool call under the requesting generation, and retains its original Langfuse parent as a secondary parent. Unmatched or ambiguous ids remain unchanged. Set this to `false` to keep only the source observation hierarchy. |
 
-Import in slices as often as you like; dedup makes it safe.
+For UI and events exports without project IDs, pass `--params '{"source_instance":"my-langfuse-project"}'` or `--params '{"project_id":"my-langfuse-project"}'`. SDK and REST callers supply the same parameters on import creation. Keep the value stable across exports of the same project; filenames do not determine identity. If earlier imports used a filename stem as their identity, supply that same value explicitly to preserve deduplication.
 
 ## Fetch traces from the Langfuse API
 
@@ -77,11 +77,9 @@ Omitting FILE and setting `--since` selects an API import: the worker calls the 
 
 The worker installs the package's `api` extra for an API import, which carries the provider client. A [connection](provider-connections.md) you name with `--connection`, or the provider's default connection, supplies `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and `LANGFUSE_BASE_URL` (or the older `LANGFUSE_HOST` for a self-hosted instance). Without either, the worker's own environment does, and only a worker started with `--selector kitaru/requires-credentials=langfuse` claims the task. Each fetched trace is parsed the same way an uploaded export would be, so the `params` table above, and the dedup rules below, apply the same way.
 
-## Dedup: one session per (imported_from, external_id)
+## Dedup: one session per (imported_from, external_id) per agent
 
-Every imported session records its source identity: `imported_from` (`langfuse`) and the trace's `external_id`. That pair is unique on the server, so re-importing an overlapping export **skips** what's already stored; the stats report it as `skipped`, not as an error. This is the property that makes "export the last 24 hours every night" a safe cron job rather than a duplication engine.
-
-Node identity works the same way inside a session: nodes upsert by index, so a re-parse states each node's full content and replaces it whole.
+Every imported session records `imported_from` (`langfuse`) and an `external_id` combining the selected source identity with the source session ID. This pair is unique per destination agent, so re-importing an overlapping export with the same identity **skips** what's already stored; the stats report it as `skipped`, not as an error. Skipped sessions are not updated with new nodes.
 
 ## No importer for your format?
 

--- a/docs/book/guides/import-langsmith-traces.md
+++ b/docs/book/guides/import-langsmith-traces.md
@@ -46,7 +46,8 @@ The import is a job with one importer task. The export is uploaded as a blob; a 
 
 | Param | Meaning |
 | --- | --- |
-| `source_instance` | The LangSmith project the export came from. Optional when the runs carry `session_id`, `project_id`, `session_name`, or `project_name`; required when they don't. It anchors the sessions' external identity, so keep it stable across imports of the same project. |
+| `source_instance` | The LangSmith project the export came from. Optional when the runs carry `session_id`, `project_id`, `session_name`, or `project_name`; otherwise supply this parameter or `project_name`. It anchors the sessions' external identity, so keep it stable across imports of the same project. |
+| `project_name` | Provider-native alias for `source_instance`, used when `source_instance` is absent or empty. Either parameter takes precedence over embedded identity. |
 | `join_on` | The path whose value groups traces into one session. Accepts a dotted path (`extra.metadata.thread_id`) or an RFC 6901 JSON Pointer (`/extra/metadata/thread_id`), resolved against each trace's root run. Omit it to use the defaults below. |
 
 Pass them with `--params '{"source_instance": "my-project"}'`. `join_on` also has its own flag, `--join-on`, which accepts JSON Pointer syntax only (it must start with `/`) and cannot be combined with a `join_on` inside `--params`:

--- a/docs/book/guides/import-langsmith-traces.md
+++ b/docs/book/guides/import-langsmith-traces.md
@@ -60,6 +60,8 @@ kitaru session import langsmith-runs.jsonl \
   --media-type application/x-ndjson --wait
 ```
 
+Identity values are trimmed strings. Conflicting embedded project identities fail the affected trace or session even with an explicit override. A project name and its ID are not automatically reconciled: use the same value across file and API imports. See [Import your traces](../getting-started/import-your-traces.md) for the shared identity rules and guidance for existing imports.
+
 ## Fetch traces from the LangSmith API
 
 Skip the export and upload, and let the import task fetch runs from LangSmith directly:
@@ -106,7 +108,7 @@ At session level you get the thread's trace ids, the join paths used, the union 
 
 ## Dedup: one session per project and thread
 
-Every imported session records `imported_from: langsmith` plus an `external_id` of `<source_instance>:<thread>`. That pair is unique on the server, so re-importing an overlapping export **skips** what is already stored and reports it as `skipped`, not as an error. Nodes upsert by index within a session, so a re-parse restates each node's full content.
+Every imported session records `imported_from: langsmith` plus an `external_id` of `<source_instance>:<thread>`. That pair is unique per destination agent, so re-importing an overlapping export with the same identity **skips** what is already stored and reports it as `skipped`, not as an error. Skipped sessions are not refreshed with new nodes.
 
 This is what makes "export the last 24 hours every night" safe. It also means the grouping key matters: if you change `source_instance` or `join_on` between imports of the same runs, the same thread lands as a second session rather than deduping against the first.
 

--- a/docs/book/guides/import-logfire-traces.md
+++ b/docs/book/guides/import-logfire-traces.md
@@ -102,7 +102,7 @@ kitaru session import logfire-records.jsonl \
   --media-type application/x-ndjson --wait
 ```
 
-If no project identity is available from any of those three sources, the importer falls back to `source_instance` `logfire` and says so in the session's warnings.
+If none of those sources supplies project identity, the affected trace fails with a `--params` remedy. Values are trimmed strings; conflicting embedded project IDs fail even when an override is supplied. There is no automatic `logfire` fallback. See [Import your traces](../getting-started/import-your-traces.md) for the shared identity rules and guidance for existing imports.
 
 ## 3. Or fetch from the Logfire API
 
@@ -166,7 +166,7 @@ Session metadata records the provenance you'll want when reading the import back
 
 ## Re-runs skip what is already there
 
-Every imported session records its source identity: `imported_from` (`logfire`) and an `external_id` of `<source_instance>:<session>`. That pair is unique on the server, so re-importing an overlapping export **skips** what is already stored and reports it as `skipped`, not as an error. Exporting the last 24 hours every night is safe; it will not duplicate earlier sessions.
+Every imported session records its source identity: `imported_from` (`logfire`) and an `external_id` of `<source_instance>:<session>`. That pair is unique per destination agent, so re-importing an overlapping export with the same identity **skips** what is already stored and reports it as `skipped`, not as an error. Skipped sessions are not refreshed with new nodes.
 
 It also means the grouping key matters: if you change `source_instance` or `join_on` between imports of the same records, the same conversation lands as a second session rather than deduping against the first.
 
@@ -174,7 +174,6 @@ It also means the grouping key matters: if you change `source_instance` or `join
 
 Because a records query returns exactly the rows you asked for, the importer never claims a session is complete: `source_completeness` is always `query-dependent`. What it did notice goes into `normalization_warnings` on the session:
 
-- `"No Logfire project identity supplied; using source_instance 'logfire'"` when neither the params nor the rows carry a project id.
 - `"No session attribute found; grouped by trace id"` when a trace has no conversation identity to group on.
 - `"Trace '<id>' has <n> root records"` when a trace has no single root span, usually a query that sliced through the middle of a trace.
 - `"Span '<id>' references missing parent '<id>'"` when a `parent_span_id` is not in the file. Those nodes are kept as roots.

--- a/docs/book/guides/import-phoenix-traces.md
+++ b/docs/book/guides/import-phoenix-traces.md
@@ -45,6 +45,7 @@ Then import a Phoenix UI download:
 kitaru session import phoenix-traces.jsonl \
   --importer kitaru/phoenix@latest \
   --agent support-agent@latest \
+  --params '{"source_instance":"my-phoenix-project"}' \
   --media-type application/x-ndjson \
   --tag imported-baseline \
   --wait
@@ -60,6 +61,12 @@ kitaru session list \
   --origin imported \
   --imported-from phoenix
 ```
+
+### Source identity
+
+The importer chooses `params.source_instance`, then the `params.project` alias, then an embedded top-level `project` on the span or trace envelope. UI and CLI downloads without project identity require one of those parameters. Values are trimmed strings, and conflicting embedded projects fail the affected trace even with an override.
+
+Use the same project identifier for file and API imports. The API fetcher includes the selected query or configured project in its payload; a project name and its ID are not automatically reconciled. See [Import your traces](../getting-started/import-your-traces.md) for the shared identity rules and guidance for existing imports.
 
 ## 3. Or fetch from the Phoenix API
 
@@ -87,7 +94,7 @@ Pass `project` through `--query '{"project": "my-project"}'`. The worker install
 
 ## What becomes a session
 
-The safe default is one Phoenix trace per Kitaru session. The Phoenix `trace_id` becomes the session's `external_id`, so importing the same trace again skips it rather than creating a duplicate. Phoenix session or conversation attributes remain on the span, but this first importer version does not join several traces into one multi-turn session.
+Each Phoenix trace becomes one Kitaru session. Its `external_id` is `<source_instance>:<trace_id>`, so importing the same trace with the same project identity into the same agent skips it. Earlier bare trace IDs do not match these prefixed IDs; overlapping re-imports can therefore create additional sessions. Phoenix session or conversation attributes remain on the span; the importer does not join several traces into one multi-turn session.
 
 Every exported span becomes a node. The importer sorts spans by time and reconstructs their parent relationships instead of trusting export order.
 

--- a/plugins/packages/braintrust-importer/CHANGELOG.md
+++ b/plugins/packages/braintrust-importer/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Accept `project_id` as an alias for `source_instance` when embedded project identity is absent, and include an actionable import parameter example when identity is missing.
+- Standardize source identity precedence as `source_instance`, then `project_id`, then embedded project identity; trim strings, reject other types, and reject embedded conflicts even with overrides. Remove filename-derived identity.
 - Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Use supported Braintrust root filtering and cursor pagination so window imports succeed and complete traces are fetched beyond the first page.
 - Fetch traces directly from the Braintrust API through the `api` extra.

--- a/plugins/packages/braintrust-importer/CHANGELOG.md
+++ b/plugins/packages/braintrust-importer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Accept `project_id` as an alias for `source_instance` when embedded project identity is absent, and include an actionable import parameter example when identity is missing.
 - Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Use supported Braintrust root filtering and cursor pagination so window imports succeed and complete traces are fetched beyond the first page.
 - Fetch traces directly from the Braintrust API through the `api` extra.

--- a/plugins/packages/braintrust-importer/README.md
+++ b/plugins/packages/braintrust-importer/README.md
@@ -13,6 +13,8 @@ kitaru session import braintrust-logs.jsonl \
 
 The importer accepts Braintrust JSON and JSONL export shapes, preserves source hierarchy and evidence when present, and records fidelity warnings for incomplete exports. Re-importing the same source identity skips sessions that Kitaru already stores.
 
+For exports without project identity, pass `--params '{"source_instance":"my-project"}'` or use the `project_id` alias. Embedded project identity takes precedence over import params; otherwise, `source_instance` wins over `project_id`, followed by the filename fallback. Reuse the same value for repeated exports from the same project.
+
 See the [Braintrust import guide](https://docs.zenml.io/kitaru/guides/import-braintrust-traces) for accepted formats, grouping parameters, deduplication behavior, and fidelity limits.
 
 ## Validation limits

--- a/plugins/packages/braintrust-importer/README.md
+++ b/plugins/packages/braintrust-importer/README.md
@@ -13,7 +13,7 @@ kitaru session import braintrust-logs.jsonl \
 
 The importer accepts Braintrust JSON and JSONL export shapes, preserves source hierarchy and evidence when present, and records fidelity warnings for incomplete exports. Re-importing the same source identity skips sessions that Kitaru already stores.
 
-For exports without project identity, pass `--params '{"source_instance":"my-project"}'` or use the `project_id` alias. Embedded project identity takes precedence over import params; otherwise, `source_instance` wins over `project_id`, followed by the filename fallback. Reuse the same value for repeated exports from the same project.
+For exports without project identity, pass `--params '{"source_instance":"my-project"}'` or use the `project_id` alias. `source_instance` takes precedence over `project_id`, and both override embedded project identity. Filenames do not determine source identity. Reuse the same value for repeated exports from the same project.
 
 See the [Braintrust import guide](https://docs.zenml.io/kitaru/guides/import-braintrust-traces) for accepted formats, grouping parameters, deduplication behavior, and fidelity limits.
 
@@ -21,7 +21,7 @@ See the [Braintrust import guide](https://docs.zenml.io/kitaru/guides/import-bra
 
 Nested node trees support at most 64 nodes along a parent path, counting the root as level 1. Tool-activity scans have a separate limit of 64 container or embedded-JSON decoding steps. Costs must be finite and nonnegative, token counts must be nonnegative, and returned sessions must serialize as JSON.
 
-Conflicting project IDs reject the complete Braintrust trace before grouping. A single explicit project ID anywhere in a trace takes precedence over the source-instance or filename fallback. A failure discovered before grouping leaves other traces available, even when they share a session key. Invalid fields or serialization failures found after grouping reject that grouped session; unrelated sessions still import.
+Conflicting project IDs reject the complete Braintrust trace before grouping. An embedded project ID anywhere in a trace supplies identity when import params do not. Conflicting embedded project IDs also reject a grouped session, even when explicit params would give its traces the same source identity. A failure discovered before grouping leaves other traces available, even when they share a session key. Invalid fields or serialization failures found after grouping reject that grouped session; unrelated sessions still import.
 
 ## Adapter
 
@@ -49,3 +49,5 @@ The adapter runs the function inside a Braintrust span, waits for Braintrust to 
 - [Issue tracker](https://github.com/zenml-io/kitaru/issues)
 
 Licensed under Apache-2.0.
+
+Project identity values must be strings. Leading and trailing whitespace is removed; null, empty, and whitespace-only values are absent. Invalid identity types and conflicting embedded projects are rejected even when an explicit parameter would override them. API query fields select what to fetch; import params select the identity used by the parser. File and API imports use the same identity rules.

--- a/plugins/packages/braintrust-importer/src/kitaru_braintrust_importer/importer.py
+++ b/plugins/packages/braintrust-importer/src/kitaru_braintrust_importer/importer.py
@@ -26,7 +26,6 @@ from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from pathlib import Path
 from typing import Any
 
 from pydantic_core import PydanticSerializationError
@@ -591,26 +590,36 @@ def _join_value(record: dict[str, Any], params: dict[str, Any], trace_id: str) -
     return str(value)
 
 
-def _source_instance(record: dict[str, Any], params: dict[str, Any]) -> str:
-    """Resolve project identity with a stable filename fallback."""
-    project_id = record.get("project_id")
-    if project_id not in (None, ""):
-        return str(project_id)
-    selected_source = params.get("source_instance")
-    if selected_source in (None, ""):
-        selected_source = params.get("project_id")
-    if selected_source not in (None, ""):
-        return str(selected_source)
-    filename = params.get("filename")
-    if isinstance(filename, str):
-        stem = Path(filename).stem.strip()
-        if stem:
-            return stem
-    raise InvalidImport(
-        "Braintrust export has no project id or usable filename; provide "
-        "source_instance or project_id in import params, for example "
-        '--params \'{"source_instance":"my-project"}\'.'
-    )
+def _normalize_identity(value: Any, field: str) -> str | None:
+    """Validate and trim a project identity without coercing other types."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise InvalidImport(f"{field} must be a string")
+    return value.strip() or None
+
+
+def _get_project_identities(records: list[dict[str, Any]]) -> set[str]:
+    """Read embedded identity before applying import parameter overrides."""
+    identities: set[str] = set()
+    for record in records:
+        if identity := _normalize_identity(record.get("project_id"), "project_id"):
+            identities.add(identity)
+    return identities
+
+
+def _get_source_instance(projects: set[str], params: dict[str, Any]) -> str:
+    """Resolve explicit identity, its provider alias, then embedded identity."""
+    selected = _normalize_identity(params.get("source_instance"), "source_instance")
+    alias = _normalize_identity(params.get("project_id"), "project_id")
+    source = selected or alias or next(iter(projects), None)
+    if source is None:
+        raise InvalidImport(
+            "Braintrust export has no project identity; provide source_instance "
+            "or project_id in import params, for example "
+            '--params \'{"source_instance":"my-project"}\'.'
+        )
+    return source
 
 
 def _metrics(record: dict[str, Any]) -> dict[str, Any]:
@@ -815,18 +824,12 @@ class BraintrustProjectLogImporter:
         for trace_id, rows in trace_records.items():
             try:
                 root = _root_record(rows, trace_id)
-                projects = {
-                    str(row["project_id"])
-                    for row in rows
-                    if row.get("project_id") not in (None, "")
-                }
+                projects = _get_project_identities(rows)
                 if len(projects) > 1:
                     raise InvalidImport(
                         f"Trace '{trace_id}' contains conflicting project identities"
                     )
-                source_instance = (
-                    next(iter(projects)) if projects else _source_instance(root, params)
-                )
+                source_instance = _get_source_instance(projects, params)
                 session_id = _join_value(root, params, trace_id)
             except InvalidImport as exc:
                 failures.append(
@@ -841,6 +844,10 @@ class BraintrustProjectLogImporter:
 
         for (source_instance, source_id), session_records in grouped.items():
             try:
+                if len(_get_project_identities(session_records)) > 1:
+                    raise InvalidImport(
+                        f"Session '{source_id}' contains conflicting project identities"
+                    )
                 session = self._parse_session(
                     source_instance,
                     source_id,

--- a/plugins/packages/braintrust-importer/src/kitaru_braintrust_importer/importer.py
+++ b/plugins/packages/braintrust-importer/src/kitaru_braintrust_importer/importer.py
@@ -597,6 +597,8 @@ def _source_instance(record: dict[str, Any], params: dict[str, Any]) -> str:
     if project_id not in (None, ""):
         return str(project_id)
     selected_source = params.get("source_instance")
+    if selected_source in (None, ""):
+        selected_source = params.get("project_id")
     if selected_source not in (None, ""):
         return str(selected_source)
     filename = params.get("filename")
@@ -604,7 +606,11 @@ def _source_instance(record: dict[str, Any], params: dict[str, Any]) -> str:
         stem = Path(filename).stem.strip()
         if stem:
             return stem
-    raise InvalidImport("Braintrust export has no project id; provide source_instance")
+    raise InvalidImport(
+        "Braintrust export has no project id or usable filename; provide "
+        "source_instance or project_id in import params, for example "
+        '--params \'{"source_instance":"my-project"}\'.'
+    )
 
 
 def _metrics(record: dict[str, Any]) -> dict[str, Any]:

--- a/plugins/packages/langfuse-importer/CHANGELOG.md
+++ b/plugins/packages/langfuse-importer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Require an explicit source identity when an export has no project ID instead of deriving one from the filename; accept `project_id` as an alias for `source_instance` and include a CLI remedy in the error.
 - Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Preserve observations outside the selection window when importing a trace that starts inside the window.
 

--- a/plugins/packages/langfuse-importer/CHANGELOG.md
+++ b/plugins/packages/langfuse-importer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Standardize source identity precedence as `source_instance`, then `project_id`, then embedded project identity; trim strings, reject other types, and reject embedded conflicts even with overrides.
 - Require an explicit source identity when an export has no project ID instead of deriving one from the filename; accept `project_id` as an alias for `source_instance` and include a CLI remedy in the error.
 - Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Preserve observations outside the selection window when importing a trace that starts inside the window.

--- a/plugins/packages/langfuse-importer/README.md
+++ b/plugins/packages/langfuse-importer/README.md
@@ -13,6 +13,8 @@ kitaru session import langfuse-export.jsonl \
 
 The importer understands Langfuse trace, observation, and ingestion-event records. It preserves hierarchy, timing, models, token usage, cost, and source payloads when the export provides them. Re-importing the same source identity skips sessions that Kitaru already stores.
 
+If the export has no embedded project ID, pass `--params '{"source_instance":"my-langfuse-project"}'` (or use the `project_id` alias). Reuse the same value for subsequent exports from that project. Filenames do not determine source identity. An explicit `source_instance` takes precedence over `project_id`, followed by the embedded project ID.
+
 See the [Langfuse import guide](https://docs.zenml.io/kitaru/guides/import-langfuse-traces) for accepted formats, parameters, deduplication behavior, and fidelity limits.
 
 ## Malformed exports

--- a/plugins/packages/langfuse-importer/README.md
+++ b/plugins/packages/langfuse-importer/README.md
@@ -49,3 +49,5 @@ The adapter runs the function inside a Langfuse trace, waits for Langfuse to fin
 - [Issue tracker](https://github.com/zenml-io/kitaru/issues)
 
 Licensed under Apache-2.0.
+
+Project identity values must be strings. Leading and trailing whitespace is removed; null, empty, and whitespace-only values are absent. Invalid identity types and conflicting embedded projects are rejected even when an explicit parameter would override them. API query fields select what to fetch; import params select the identity used by the parser. File and API imports use the same identity rules.

--- a/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
+++ b/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
@@ -25,7 +25,6 @@ from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from pathlib import Path
 from typing import Any
 
 from pydantic_core import PydanticSerializationError
@@ -1286,15 +1285,17 @@ class LangfuseJSONLImporter:
                 f"Session '{source_id}' contains conflicting Langfuse project ids"
             )
         selected_source = params.get("source_instance")
-        filename = params.get("filename")
+        if selected_source in (None, ""):
+            selected_source = params.get("project_id")
         source_instance = (
             str(selected_source) if selected_source not in (None, "") else None
         ) or next(iter(project_ids), None)
-        if not source_instance and isinstance(filename, str):
-            source_instance = Path(filename).stem.strip() or None
         if not source_instance:
             raise InvalidImport(
-                f"Session '{source_id}' has no project id; provide source_instance"
+                f"Session '{source_id}' has no project id; "
+                "provide source_instance in import params, for example "
+                '--params \'{"source_instance":"my-langfuse-project"}\'. '
+                "Reuse the same value for subsequent exports from this project."
             )
 
         warnings: list[str] = []

--- a/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
+++ b/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/importer.py
@@ -788,11 +788,14 @@ def _parse_records(content: bytes) -> list[dict[str, Any]]:
     return records
 
 
-def _events_to_traces(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _events_to_traces(
+    records: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[ImportFailure]]:
     """Apply legacy ingestion events into trace rows."""
     traces: dict[str, dict[str, Any]] = {}
     observations: dict[tuple[str, str], dict[str, Any]] = {}
     observation_trace_ids: dict[str, set[str]] = defaultdict(set)
+    project_records: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for event in records:
         body = dict(event["body"])
         observation_id = _first(body, "id", "observationId")
@@ -807,6 +810,7 @@ def _events_to_traces(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
             trace_id = str(_first(body, "id", "traceId", "trace_id") or "")
             if not trace_id:
                 raise InvalidImport("A Langfuse trace event has no trace id")
+            project_records[trace_id].append(body)
             traces.setdefault(trace_id, {"id": trace_id, "observations": []}).update(
                 body
             )
@@ -827,12 +831,32 @@ def _events_to_traces(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
             body.setdefault("type", "EVENT")
         else:
             body.setdefault("type", "SPAN")
+        project_records[trace_id].append(body)
         key = (trace_id, observation_id)
         observations.setdefault(key, {}).update(body)
     for (trace_id, _), observation in observations.items():
         trace = traces.setdefault(trace_id, {"id": trace_id, "observations": []})
         trace["observations"].append(observation)
-    return list(traces.values())
+    failures: list[ImportFailure] = []
+    for trace_id, rows in project_records.items():
+        try:
+            project_ids = _get_project_identities(rows)
+            if len(project_ids) > 1:
+                raise InvalidImport(
+                    f"Trace '{trace_id}' contains conflicting Langfuse project ids"
+                )
+            if project_ids:
+                traces[trace_id]["projectId"] = next(iter(project_ids))
+        except InvalidImport as exc:
+            traces.pop(trace_id, None)
+            failures.append(
+                ImportFailure(
+                    line=len(failures) + 1,
+                    external_id=_safe_failure_text(trace_id),
+                    error=_safe_failure_text(str(exc)),
+                )
+            )
+    return list(traces.values()), failures
 
 
 def _trace_rows_to_observations(
@@ -844,6 +868,14 @@ def _trace_rows_to_observations(
         trace_id = str(_first(trace, "id", "traceId", "trace_id") or "")
         if not trace_id:
             raise InvalidImport("A Langfuse trace row has no trace id")
+        project_records = [
+            trace,
+            *(row for row in trace.get("observations", []) if isinstance(row, dict)),
+        ]
+        if len(_get_project_identities(project_records)) > 1:
+            raise InvalidImport(
+                f"Trace '{trace_id}' contains conflicting Langfuse project ids"
+            )
         for raw in trace.get("observations", []):
             if not isinstance(raw, dict):
                 raise InvalidImport(f"Trace '{trace_id}' has a non-object observation")
@@ -864,7 +896,12 @@ def _trace_rows_to_observations(
                 ("tags", "traceTags"),
                 ("version", "traceVersion"),
             ):
-                if source in trace and target not in observation:
+                if target == "projectId":
+                    if _normalize_identity(observation.get(target), target) is None:
+                        observation[target] = _normalize_identity(
+                            trace.get(source), source
+                        )
+                elif source in trace and target not in observation:
                     observation[target] = trace[source]
             observations.append(observation)
     return observations
@@ -1175,6 +1212,42 @@ def _build_node_tree(
     return roots
 
 
+def _normalize_identity(value: Any, field: str) -> str | None:
+    """Validate and trim a project identity without coercing other types."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise InvalidImport(f"{field} must be a string")
+    return value.strip() or None
+
+
+def _get_project_identities(records: list[dict[str, Any]]) -> set[str]:
+    """Read embedded identity before applying import parameter overrides."""
+    identities: set[str] = set()
+    for record in records:
+        values = [
+            _normalize_identity(record.get(field), field)
+            for field in ("projectId", "project_id")
+        ]
+        identities.update(value for value in values if value is not None)
+    return identities
+
+
+def _get_source_instance(projects: set[str], params: dict[str, Any]) -> str:
+    """Resolve explicit identity, its provider alias, then embedded identity."""
+    selected = _normalize_identity(params.get("source_instance"), "source_instance")
+    alias = _normalize_identity(params.get("project_id"), "project_id")
+    source = selected or alias or next(iter(projects), None)
+    if source is None:
+        raise InvalidImport(
+            "Langfuse export has no project identity; provide source_instance "
+            "or project_id in import params, for example "
+            '--params \'{"source_instance":"my-langfuse-project"}\'. '
+            "Reuse the same value for subsequent exports from this project."
+        )
+    return source
+
+
 class LangfuseJSONLImporter:
     """Parse Langfuse trace, observation, and ingestion-event records."""
 
@@ -1195,11 +1268,23 @@ class LangfuseJSONLImporter:
             raise InvalidImport("infer_tool_call_links must be a boolean")
         records = _parse_records(content)
         shape = _detect_shape(records[0])
+        failures: list[ImportFailure] = []
         if shape == _EVENT_SHAPE:
-            records = _events_to_traces(records)
+            records, failures = _events_to_traces(records)
             shape = _TRACE_SHAPE
         if shape == _TRACE_SHAPE:
-            records = _trace_rows_to_observations(records)
+            observations = []
+            for trace in records:
+                try:
+                    observations.extend(_trace_rows_to_observations([trace]))
+                except InvalidImport as exc:
+                    failures.append(
+                        ImportFailure(
+                            line=len(failures) + 1,
+                            error=_safe_failure_text(str(exc)),
+                        )
+                    )
+            records = observations
         file_framework = _detect_framework(
             [record.get("metadata") for record in records]
         )
@@ -1216,7 +1301,6 @@ class LangfuseJSONLImporter:
         )
         join_paths: dict[str, set[str]] = defaultdict(set)
         fallback_sessions: set[str] = set()
-        failures: list[ImportFailure] = []
         for trace_id, observations in trace_records.items():
             try:
                 session_id, join_path, fallback = _join_value(
@@ -1274,29 +1358,14 @@ class LangfuseJSONLImporter:
         infer_tool_call_links: bool,
     ) -> ImportedSession:
         """Parse one grouped Langfuse session."""
-        project_ids = {
-            str(value)
-            for _, observations in traces
-            for record in observations
-            if (value := _first(record, "projectId", "project_id"))
-        }
+        project_ids = _get_project_identities(
+            [record for _, observations in traces for record in observations]
+        )
         if len(project_ids) > 1:
             raise InvalidImport(
                 f"Session '{source_id}' contains conflicting Langfuse project ids"
             )
-        selected_source = params.get("source_instance")
-        if selected_source in (None, ""):
-            selected_source = params.get("project_id")
-        source_instance = (
-            str(selected_source) if selected_source not in (None, "") else None
-        ) or next(iter(project_ids), None)
-        if not source_instance:
-            raise InvalidImport(
-                f"Session '{source_id}' has no project id; "
-                "provide source_instance in import params, for example "
-                '--params \'{"source_instance":"my-langfuse-project"}\'. '
-                "Reuse the same value for subsequent exports from this project."
-            )
+        source_instance = _get_source_instance(project_ids, params)
 
         warnings: list[str] = []
         if trace_fallback:

--- a/plugins/packages/langsmith-importer/CHANGELOG.md
+++ b/plugins/packages/langsmith-importer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Accept `project_name` as an alias for `source_instance` and include an actionable import parameter example when project identity is missing.
 - Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Fetch traces from the LangSmith API by trace id or time window through the `api` extra.
 - Import traces oldest first and group them by thread instead of dropping later traces of a thread as duplicates.

--- a/plugins/packages/langsmith-importer/CHANGELOG.md
+++ b/plugins/packages/langsmith-importer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Standardize source identity precedence as `source_instance`, then `project_name`, then embedded project identity; trim strings, reject other types, and reject embedded conflicts even with overrides.
 - Accept `project_name` as an alias for `source_instance` and include an actionable import parameter example when project identity is missing.
 - Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Fetch traces from the LangSmith API by trace id or time window through the `api` extra.

--- a/plugins/packages/langsmith-importer/README.md
+++ b/plugins/packages/langsmith-importer/README.md
@@ -49,3 +49,7 @@ The adapter runs the function inside a LangSmith trace, waits for LangSmith to f
 - [Issue tracker](https://github.com/zenml-io/kitaru/issues)
 
 Licensed under Apache-2.0.
+
+Embedded `session_id` and `project_id` values take precedence over `session_name` and `project_name` across related runs. Conflicting IDs reject the trace or grouped session; names are compared only when no embedded ID is present.
+
+Project identity values must be strings. Leading and trailing whitespace is removed; null, empty, and whitespace-only values are absent. Invalid identity types and conflicting embedded projects are rejected even when an explicit parameter would override them. API query fields select what to fetch; import params select the identity used by the parser. File and API imports use the same identity rules.

--- a/plugins/packages/langsmith-importer/README.md
+++ b/plugins/packages/langsmith-importer/README.md
@@ -13,6 +13,8 @@ kitaru session import langsmith-runs.jsonl \
 
 The importer accepts LangSmith JSON and JSONL export shapes, reconstructs run hierarchy, and groups traces using thread-like metadata or an explicit grouping path. Re-importing the same source identity skips sessions that Kitaru already stores.
 
+For exports without project identity, pass `--params '{"source_instance":"my-project"}'` or use the `project_name` alias. `source_instance` takes precedence over `project_name`, and both override embedded project identity. Reuse the same value for repeated exports from the same project.
+
 See the [LangSmith import guide](https://docs.zenml.io/kitaru/guides/import-langsmith-traces) for accepted formats, grouping parameters, deduplication behavior, and fidelity limits.
 
 ## Validation limits

--- a/plugins/packages/langsmith-importer/src/kitaru_langsmith_importer/importer.py
+++ b/plugins/packages/langsmith-importer/src/kitaru_langsmith_importer/importer.py
@@ -548,26 +548,41 @@ def _run_id(record: dict[str, Any]) -> str:
     return str(value)
 
 
-def _source_instance(record: dict[str, Any], params: dict[str, Any]) -> str:
-    """Resolve the LangSmith project identity used for deduplication."""
-    selected = params.get("source_instance")
-    if selected in (None, ""):
-        selected = params.get("project_name")
-    if selected not in (None, ""):
-        return str(selected)
-    value = (
-        record.get("session_id")
-        or record.get("project_id")
-        or record.get("session_name")
-        or record.get("project_name")
-    )
-    if value in (None, ""):
+def _normalize_identity(value: Any, field: str) -> str | None:
+    """Validate and trim a project identity without coercing other types."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise InvalidImport(f"{field} must be a string")
+    return value.strip() or None
+
+
+def _get_project_identities(records: list[dict[str, Any]]) -> set[str]:
+    """Prefer embedded project IDs over names, validating both kinds."""
+    project_ids: set[str] = set()
+    project_names: set[str] = set()
+    for record in records:
+        for field in ("session_id", "project_id"):
+            if identity := _normalize_identity(record.get(field), field):
+                project_ids.add(identity)
+        for field in ("session_name", "project_name"):
+            if identity := _normalize_identity(record.get(field), field):
+                project_names.add(identity)
+    return project_ids or project_names
+
+
+def _get_source_instance(projects: set[str], params: dict[str, Any]) -> str:
+    """Resolve explicit identity, its provider alias, then embedded identity."""
+    selected = _normalize_identity(params.get("source_instance"), "source_instance")
+    alias = _normalize_identity(params.get("project_name"), "project_name")
+    source = selected or alias or next(iter(projects), None)
+    if source is None:
         raise InvalidImport(
             "LangSmith export has no project identity; provide source_instance "
             "or project_name in import params, for example "
             '--params \'{"source_instance":"my-project"}\'.'
         )
-    return str(value)
+    return source
 
 
 def _join_value(
@@ -838,12 +853,12 @@ class LangSmithRunImporter:
                         f"Trace '{trace_id}' contains duplicate run ids"
                     )
                 roots = self._get_roots(rows, trace_id)
-                source_instances = {_source_instance(row, params) for row in rows}
-                if len(source_instances) != 1:
+                source_instances = _get_project_identities(rows)
+                if len(source_instances) > 1:
                     raise InvalidImport(
                         f"Trace '{trace_id}' contains conflicting project identities"
                     )
-                source_instance = next(iter(source_instances))
+                source_instance = _get_source_instance(source_instances, params)
                 join_values = {_join_value(row, params, trace_id) for row in roots}
                 values = {value for value, _, _ in join_values}
                 if len(values) != 1:
@@ -870,6 +885,13 @@ class LangSmithRunImporter:
         # grouping traces, so ingestion follows payload order.
         for key, traces in grouped.items():
             try:
+                projects = _get_project_identities(
+                    [row for _, rows in traces for row in rows]
+                )
+                if len(projects) > 1:
+                    raise InvalidImport(
+                        f"Session '{key[1]}' contains conflicting project identities"
+                    )
                 session = self._parse_session(
                     key[0],
                     key[1],

--- a/plugins/packages/langsmith-importer/src/kitaru_langsmith_importer/importer.py
+++ b/plugins/packages/langsmith-importer/src/kitaru_langsmith_importer/importer.py
@@ -551,6 +551,8 @@ def _run_id(record: dict[str, Any]) -> str:
 def _source_instance(record: dict[str, Any], params: dict[str, Any]) -> str:
     """Resolve the LangSmith project identity used for deduplication."""
     selected = params.get("source_instance")
+    if selected in (None, ""):
+        selected = params.get("project_name")
     if selected not in (None, ""):
         return str(selected)
     value = (
@@ -561,7 +563,9 @@ def _source_instance(record: dict[str, Any], params: dict[str, Any]) -> str:
     )
     if value in (None, ""):
         raise InvalidImport(
-            "LangSmith export has no project identity; provide source_instance"
+            "LangSmith export has no project identity; provide source_instance "
+            "or project_name in import params, for example "
+            '--params \'{"source_instance":"my-project"}\'.'
         )
     return str(value)
 

--- a/plugins/packages/logfire-importer/CHANGELOG.md
+++ b/plugins/packages/logfire-importer/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Require a stable project identity instead of falling back to `logfire`; normalize string identities and reject invalid identity types.
+
 - Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Fail API imports visibly when a successful HTTP response contains a query stream error, including after partial results.
 

--- a/plugins/packages/logfire-importer/README.md
+++ b/plugins/packages/logfire-importer/README.md
@@ -11,7 +11,7 @@ kitaru session import logfire-records.jsonl \
   --wait
 ```
 
-The importer rebuilds span hierarchy and conservatively identifies model and tool calls from OpenTelemetry attributes. Supply a stable source identity when an export does not contain one, especially when importing from more than one Logfire project.
+The importer rebuilds span hierarchy and conservatively identifies model and tool calls from OpenTelemetry attributes. Source identity uses `source_instance`, then the `project_id` parameter alias, then the embedded record `project_id`. Values must be strings; surrounding whitespace is removed, and empty values are absent. If none is available, the affected trace fails: retry with `--params '{"source_instance":"my-logfire-project"}'`. Conflicting embedded project IDs remain errors even with an override. File and API imports use the same identity rules; API credentials do not supply a project identity. Keep the identity stable across imports to preserve deduplication.
 
 See the [Logfire import guide](https://docs.zenml.io/kitaru/guides/import-logfire-traces) for accepted formats, parameters, deduplication behavior, and fidelity limits.
 

--- a/plugins/packages/logfire-importer/src/kitaru_logfire_importer/importer.py
+++ b/plugins/packages/logfire-importer/src/kitaru_logfire_importer/importer.py
@@ -463,6 +463,15 @@ def _build_node_tree(
     return roots
 
 
+def _get_project_identity(value: Any, field: str) -> str | None:
+    """Validate and normalize a source project identity."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise InvalidImport(f"Logfire {field} must be a string")
+    return value.strip() or None
+
+
 class LogfireRecordsImporter:
     """Normalize exported rows from Logfire's records table."""
 
@@ -498,24 +507,33 @@ class LogfireRecordsImporter:
             try:
                 session_id, join_path, fallback = _join_value(rows, params, trace_id)
                 project_ids = {
-                    str(row["project_id"])
+                    identity
                     for row in rows
-                    if row.get("project_id") not in (None, "")
+                    if (
+                        identity := _get_project_identity(
+                            row.get("project_id"), "project_id"
+                        )
+                    )
+                    is not None
                 }
                 if len(project_ids) > 1:
                     raise InvalidImport(
                         f"Trace '{trace_id}' contains conflicting Logfire project ids"
                     )
-                source_instance_value = (
-                    params.get("source_instance")
-                    or params.get("project_id")
-                    or next(iter(project_ids), None)
+                source_override = _get_project_identity(
+                    params.get("source_instance"), "source_instance"
+                )
+                project_override = _get_project_identity(
+                    params.get("project_id"), "project_id parameter"
                 )
                 source_instance = (
-                    str(source_instance_value).strip()
-                    if source_instance_value
-                    else "logfire"
+                    source_override or project_override or next(iter(project_ids), None)
                 )
+                if source_instance is None:
+                    raise InvalidImport(
+                        "No Logfire project identity supplied; retry with "
+                        '--params \'{"source_instance":"my-logfire-project"}\''
+                    )
             except InvalidImport as exc:
                 failures.append(
                     ImportFailure(
@@ -566,20 +584,17 @@ class LogfireRecordsImporter:
     ) -> ImportedSession:
         """Normalize one grouped Logfire session."""
         project_ids = {
-            str(row["project_id"])
+            identity
             for _, rows in traces
             for row in rows
-            if row.get("project_id") not in (None, "")
+            if (identity := _get_project_identity(row.get("project_id"), "project_id"))
+            is not None
         }
         if len(project_ids) > 1:
             raise InvalidImport(
                 f"Session '{session_id}' contains conflicting Logfire project ids"
             )
         warnings: list[str] = []
-        if not project_ids and source_instance == "logfire":
-            warnings.append(
-                "No Logfire project identity supplied; using source_instance 'logfire'"
-            )
         if trace_fallback:
             warnings.append("No session attribute found; grouped by trace id")
 

--- a/plugins/packages/phoenix-importer/CHANGELOG.md
+++ b/plugins/packages/phoenix-importer/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Prefix session external IDs with a validated project namespace. Accept `source_instance` and `project` import parameters, require project identity for file exports, and retain the selected API or adapter project in serialized traces. Reimports of sessions created with earlier bare trace IDs can create a second session.
+
 - Remove the importer payload size cap. Uploads are bounded by the server blob limit only.
 - Follow SDK cursor pagination to import all matching spans, including windows and traces larger than 1,000 spans.
 

--- a/plugins/packages/phoenix-importer/README.md
+++ b/plugins/packages/phoenix-importer/README.md
@@ -8,10 +8,13 @@ Most users do not install or call this package directly. Start a Kitaru worker, 
 kitaru session import phoenix-traces.jsonl \
   --importer kitaru/phoenix@latest \
   --agent support-agent@latest \
+  --params '{"project":"my-project"}' \
   --wait
 ```
 
-The importer accepts Phoenix UI and CLI export shapes, preserves trace hierarchy and source evidence, and maps model and tool spans to Kitaru node types. Each Phoenix trace becomes one Kitaru session.
+The importer accepts Phoenix UI and CLI export shapes, preserves trace hierarchy and source evidence, and maps model and tool spans to Kitaru node types. Each Phoenix trace becomes one Kitaru session. Session external IDs are `<source_instance>:<trace_id>`. Identity comes from `params.source_instance`, then `params.project`, then an embedded top-level `project` field on a trace envelope or span. Strings are trimmed; null, empty, and whitespace-only values are absent. Other types and conflicting embedded projects within a trace fail that trace, including when an explicit parameter is supplied. Exports without project identity require an explicit parameter; filenames are never used.
+
+API imports retain the queried project, or the Phoenix environment project, in the parser payload. The adapter retains its configured environment project in the same way. Reuse that exact project identifier for file imports: project names and project IDs are not resolved to one another. This changes external IDs from earlier importer versions, which used bare trace IDs; reimporting an older trace can create a second session.
 
 See [Import your traces](https://docs.zenml.io/kitaru/getting-started/import-your-traces) for the live import workflow. The [provider-specific guide in the Kitaru repository](https://github.com/zenml-io/kitaru/blob/develop/docs/book/guides/import-phoenix-traces.md) documents accepted Phoenix formats, deduplication behavior, and fidelity limits.
 

--- a/plugins/packages/phoenix-importer/src/kitaru_phoenix_importer/adapter.py
+++ b/plugins/packages/phoenix-importer/src/kitaru_phoenix_importer/adapter.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.trace import format_trace_id, get_tracer, get_tracer_provider
+from phoenix.client.utils.config import get_env_project_name
 
 from kitaru.importer_adapter import ImporterBackedAdapter
 
@@ -43,6 +44,9 @@ class PhoenixAdapter(ImporterBackedAdapter):
         """
         super().__init__("phoenix", parse, completeness_timeout=completeness_timeout)
         self._spans: dict[str, list[Any]] = {}
+        self._project = get_env_project_name().strip()
+        if not self._project:
+            raise ValueError("Phoenix project must be a non-empty string")
 
     @contextmanager
     def open_trace(self) -> Iterator[str]:
@@ -72,10 +76,12 @@ class PhoenixAdapter(ImporterBackedAdapter):
         # delivery. Only the SDK provider exposes a flush.
         if isinstance(provider, TracerProvider):
             await asyncio.to_thread(provider.force_flush)
-        self._spans[external_id] = await wait_for_spans(external_id)
+        self._spans[external_id] = await wait_for_spans(
+            external_id, project=self._project
+        )
 
     async def fetch(self, external_id: str) -> bytes:
-        """Fetch the finished trace as a Phoenix span JSON array.
+        """Fetch the finished trace with its selected Phoenix project.
 
         Args:
             external_id: Phoenix trace id.
@@ -85,5 +91,5 @@ class PhoenixAdapter(ImporterBackedAdapter):
         """
         spans = self._spans.pop(external_id, None)
         if spans is None:
-            spans = await fetch_spans(external_id)
-        return serialize_spans(spans)
+            spans = await fetch_spans(external_id, project=self._project)
+        return serialize_spans(spans, project=self._project)

--- a/plugins/packages/phoenix-importer/src/kitaru_phoenix_importer/api.py
+++ b/plugins/packages/phoenix-importer/src/kitaru_phoenix_importer/api.py
@@ -86,16 +86,17 @@ def _has_root(spans: list[Any]) -> bool:
     )
 
 
-async def wait_for_spans(trace_id: str) -> list[Any]:
+async def wait_for_spans(trace_id: str, *, project: str | None = None) -> list[Any]:
     """Poll the Phoenix span API until the trace is complete.
 
     Args:
         trace_id: Phoenix trace id.
+        project: Phoenix project identifier, the environment project when None.
 
     Returns:
         Fetched spans.
     """
-    project = get_env_project_name()
+    project = (project or get_env_project_name()).strip()
     client = AsyncClient()
     # The trace is complete when it has spans, a root span is present,
     # and the span count is stable across two consecutive polls.
@@ -147,16 +148,27 @@ async def fetch_spans(
     )
 
 
-def serialize_spans(spans: list[Any]) -> bytes:
+def serialize_spans(spans: list[Any], *, project: str | None = None) -> bytes:
     """Serialize fetched spans into the payload the parser accepts.
 
     Args:
         spans: Fetched spans.
+        project: Selected project identifier to retain in trace envelopes.
 
     Returns:
         Trace payload bytes.
     """
-    return json.dumps(spans).encode("utf-8")
+    if project is None:
+        return json.dumps(spans).encode("utf-8")
+    traces: dict[str, list[Any]] = {}
+    for span in spans:
+        traces.setdefault(span["context"]["trace_id"], []).append(span)
+    return json.dumps(
+        [
+            {"traceId": trace_id, "project": project, "spans": rows}
+            for trace_id, rows in traces.items()
+        ]
+    ).encode("utf-8")
 
 
 class PhoenixImportQuery(ImportQuery):
@@ -239,18 +251,20 @@ async def fetch(query: dict[str, Any]) -> AsyncIterator[bytes]:
     """
     parsed = PhoenixImportQuery.model_validate(query)
     client = AsyncClient()
+    project = (parsed.project or "").strip() or get_env_project_name().strip()
+    if not project:
+        raise ValueError("Phoenix project must be a non-empty string")
 
     if parsed.trace_ids is not None:
         trace_ids = parsed.trace_ids
     else:
         since, until = parsed.get_window()
-        project = parsed.project or get_env_project_name()
         trace_ids = await _list_root_trace_ids(client, project, since, until)
 
     span_batches = await gather_bounded(
-        (fetch_spans(trace_id, parsed.project, client) for trace_id in trace_ids),
+        (fetch_spans(trace_id, project, client) for trace_id in trace_ids),
         parsed.concurrency,
     )
     spans = [span for batch in span_batches for span in batch]
     if spans:
-        yield serialize_spans(spans)
+        yield serialize_spans(spans, project=project)

--- a/plugins/packages/phoenix-importer/src/kitaru_phoenix_importer/importer.py
+++ b/plugins/packages/phoenix-importer/src/kitaru_phoenix_importer/importer.py
@@ -218,6 +218,43 @@ def _parent_id(span: dict[str, Any]) -> str | None:
     return str(value) if value not in (None, "") else None
 
 
+def _normalize_project(value: Any, field: str) -> str | None:
+    """Normalize a project identity without coercing other data types."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise InvalidImport(f"Phoenix {field} must be a string or null")
+    return value.strip() or None
+
+
+def _get_source_instance(
+    spans: list[dict[str, Any]],
+    trace_metadata: dict[str, Any],
+    params: dict[str, Any],
+) -> str:
+    """Resolve and validate one trace's project namespace."""
+    source = _normalize_project(params.get("source_instance"), "source_instance")
+    alias = _normalize_project(params.get("project"), "project parameter")
+    projects = {
+        project
+        for value in [
+            *trace_metadata.get("_projects", []),
+            *(span.get("project") for span in spans),
+        ]
+        if (project := _normalize_project(value, "embedded project")) is not None
+    }
+    if len(projects) > 1:
+        raise InvalidImport("Phoenix trace contains conflicting project identities")
+    selected = source or alias or next(iter(projects), None)
+    if selected is None:
+        raise InvalidImport(
+            "Phoenix export has no project identity; provide source_instance or "
+            "project in import params, for example "
+            '--params \'{"source_instance":"my-project"}\'.'
+        )
+    return selected
+
+
 def _expand_values(
     values: list[tuple[int, dict[str, Any]]],
 ) -> tuple[
@@ -267,6 +304,7 @@ def _expand_values(
             traces[trace_id].extend(spans)
             trace_lines.setdefault(trace_id, line_number)
             metadata = trace_metadata.setdefault(trace_id, {})
+            metadata.setdefault("_projects", []).append(value.get("project"))
             for key in ("annotations", "notes"):
                 new_value = value.get(key)
                 if new_value in (None, [], ""):
@@ -576,7 +614,6 @@ class PhoenixTraceImporter:
         self, content: bytes, params: dict[str, Any]
     ) -> Iterator[ImportedSession | ImportFailure]:
         """Parse Phoenix traces into one Kitaru session per trace."""
-        del params
         values, failures = _parse_values(content)
         traces, trace_metadata, trace_lines, expansion_failures = _expand_values(values)
         failures.extend(expansion_failures)
@@ -585,7 +622,7 @@ class PhoenixTraceImporter:
         for trace_id, spans in traces.items():
             try:
                 session = self._parse_trace(
-                    trace_id, spans, trace_metadata.get(trace_id, {})
+                    trace_id, spans, trace_metadata.get(trace_id, {}), params
                 )
                 session.model_dump_json()
                 yield session
@@ -602,6 +639,7 @@ class PhoenixTraceImporter:
         trace_id: str,
         spans: list[dict[str, Any]],
         trace_metadata: dict[str, Any],
+        params: dict[str, Any],
     ) -> ImportedSession:
         """Normalize one Phoenix trace."""
         if not spans:
@@ -616,6 +654,7 @@ class PhoenixTraceImporter:
             if not _span_id(span):
                 raise InvalidImport("Phoenix span lacks trace_id or span_id")
 
+        source_instance = _get_source_instance(spans, trace_metadata, params)
         ordered = sorted(
             spans,
             key=lambda span: (
@@ -649,14 +688,16 @@ class PhoenixTraceImporter:
         )
         metadata: dict[str, Any] = {
             "phoenix.trace_id": trace_id,
+            "phoenix.source_instance": source_instance,
             "source_trace_count": 1,
             "source_completeness": "full" if not warnings else "partial",
             "normalization_warnings": warnings,
         }
         for key, value in trace_metadata.items():
-            metadata[f"phoenix.{key}"] = value
+            if key != "_projects":
+                metadata[f"phoenix.{key}"] = value
         return ImportedSession(
-            external_id=trace_id,
+            external_id=f"{source_instance}:{trace_id}",
             name=str(root.get("name") or trace_id),
             status=session_status,
             inputs=(

--- a/plugins/tests/adapters/braintrust/test_api.py
+++ b/plugins/tests/adapters/braintrust/test_api.py
@@ -343,3 +343,28 @@ async def test_fetch_rejects_invalid_queries(query: dict[str, Any], match: str) 
     """Reject an invalid query before yielding any payload."""
     with pytest.raises(ValueError, match=match):
         await collect_payloads(fetch(query))
+
+
+@pytest.mark.parametrize("source", [None, " explicit "])
+async def test_file_and_api_source_identity_match(
+    fake_braintrust: FakeBraintrust,
+    source: str | None,
+) -> None:
+    """Query selection stays separate from parser identity for API and file inputs."""
+    trace_id = "root-a"
+    fake_braintrust.rows_builders = [build_complete_rows]
+    fake_braintrust.project_id = "query-project"
+    [payload] = await collect_payloads(
+        fetch({"project_id": "query-project", "trace_ids": [trace_id]})
+    )
+    params = {"source_instance": source}
+    [api_session] = list(parse(payload, params))
+    [file_session] = list(
+        parse(json.dumps(build_complete_rows(trace_id)).encode(), params)
+    )
+    assert isinstance(api_session, ImportedSession)
+    assert isinstance(file_session, ImportedSession)
+    expected = source.strip() if source else "project-1"
+    assert (
+        api_session.external_id == file_session.external_id == f"{expected}:{trace_id}"
+    )

--- a/plugins/tests/adapters/langfuse/test_api.py
+++ b/plugins/tests/adapters/langfuse/test_api.py
@@ -366,3 +366,29 @@ async def test_window_keeps_children_outside_trace_selection_bounds(
         "early-child",
         "late-child",
     }
+
+
+@pytest.mark.parametrize("source", [None, " explicit "])
+async def test_file_and_api_source_identity_match(
+    fake_langfuse: FakeLangfuseClient,
+    source: str | None,
+) -> None:
+    """Query selection stays separate from parser identity for API and file inputs."""
+    trace_id = "trace-1"
+    fake_langfuse.trace_builders = [build_complete_trace]
+    seed_default_observations(fake_langfuse, [trace_id])
+    [payload] = await collect_payloads(fetch({"trace_ids": [trace_id]}))
+    params = {"source_instance": source}
+    [api_session] = list(parse(payload, params))
+    [file_session] = list(
+        parse(
+            build_complete_trace(trace_id).model_dump_json(by_alias=True).encode(),
+            params,
+        )
+    )
+    assert isinstance(api_session, ImportedSession)
+    assert isinstance(file_session, ImportedSession)
+    expected = source.strip() if source else "project-1"
+    assert (
+        api_session.external_id == file_session.external_id == f"{expected}:{trace_id}"
+    )

--- a/plugins/tests/adapters/langsmith/test_api.py
+++ b/plugins/tests/adapters/langsmith/test_api.py
@@ -335,3 +335,25 @@ async def test_fetch_propagates_a_non_rate_limit_error(
 
     with pytest.raises(RuntimeError, match="server error"):
         await collect_payloads(fetch({"trace_ids": [str(uuid.uuid4())]}))
+
+
+@pytest.mark.parametrize("source", [None, " explicit "])
+async def test_file_and_api_source_identity_match(
+    fake_langsmith_api: FakeLangSmith,
+    source: str | None,
+) -> None:
+    """Query selection stays separate from parser identity for API and file inputs."""
+    trace_id = "22222222-2222-4222-8222-222222222222"
+    fake_langsmith_api.runs_builders = [build_complete_runs]
+    [payload] = await collect_payloads(
+        fetch({"project_name": "query-project", "trace_ids": [trace_id]})
+    )
+    params = {"source_instance": source, "join_on": "trace_id"}
+    [api_session] = list(parse(payload, params))
+    [file_session] = list(parse(serialize_runs(build_complete_runs(trace_id)), params))
+    assert isinstance(api_session, ImportedSession)
+    assert isinstance(file_session, ImportedSession)
+    expected = source.strip() if source else "11111111-1111-4111-8111-111111111111"
+    assert (
+        api_session.external_id == file_session.external_id == f"{expected}:{trace_id}"
+    )

--- a/plugins/tests/adapters/logfire/test_api.py
+++ b/plugins/tests/adapters/logfire/test_api.py
@@ -13,6 +13,7 @@
 #  permissions and limitations under the License.
 """Focused contract tests for the Logfire fetch entrypoint."""
 
+import json
 from datetime import UTC, datetime
 
 import httpx
@@ -315,3 +316,24 @@ async def test_trace_stream_error_fails_before_returning_payload(
             await api_module.fetch_trace(
                 TRACE_ID_1, datetime(2026, 7, 24, tzinfo=UTC), client
             )
+
+
+@pytest.mark.parametrize("params", [{}, {"source_instance": " explicit-project "}])
+async def test_api_and_file_imports_share_project_identity(
+    fake_logfire: FakeLogfire, params: dict[str, str]
+) -> None:
+    """Fetching records preserves the identity of an equivalent file export."""
+    fake_logfire.fetch_builders = [build_complete_rows]
+    [payload] = await collect_payloads(fetch({"trace_ids": [TRACE_ID_1]}))
+    file_payload = json.dumps(build_complete_rows(TRACE_ID_1)).encode()
+
+    [api_session] = list(parse(payload, params))
+    [file_session] = list(parse(file_payload, params))
+
+    assert fake_logfire.requested == [TRACE_ID_1]
+    assert isinstance(api_session, ImportedSession)
+    assert isinstance(file_session, ImportedSession)
+    assert api_session.external_id == file_session.external_id
+    expected_project = params.get("source_instance", "project-1").strip()
+    assert api_session.external_id.startswith(f"{expected_project}:")
+    assert api_session.metadata["logfire.project_id"] == "project-1"

--- a/plugins/tests/adapters/phoenix/test_adapter.py
+++ b/plugins/tests/adapters/phoenix/test_adapter.py
@@ -111,7 +111,7 @@ def test_run_imports_the_phoenix_trace_around_the_function(
     assert request.agent_id is None
     assert request.origin == SessionOrigin.RECORDED
     assert request.status == SessionStatus.COMPLETED
-    assert request.external_id == trace_id
+    assert request.external_id == f"{PROJECT}:{trace_id}"
     assert request.imported_from == "phoenix"
     assert request.metadata["normalization_warnings"] == []
     assert len(client.sessions.batches) == 1
@@ -259,7 +259,7 @@ async def test_fetch_round_trips_through_the_real_parser(
     assert len(items) == 1
     session = items[0]
     assert isinstance(session, ImportedSession)
-    assert session.external_id == trace_id
+    assert session.external_id == f"{PROJECT}:{trace_id}"
     assert session.status == SessionStatus.COMPLETED
     assert session.metadata["normalization_warnings"] == []
     assert [node.name for node in session.nodes] == ["kitaru-run"]
@@ -279,5 +279,5 @@ async def test_fetch_refetches_when_the_cache_is_absent(
 
     assert fake_phoenix.requested == [trace_id]
     assert fake_phoenix.project_identifiers == [PROJECT]
-    spans = json.loads(payload)
+    spans = [span for trace in json.loads(payload) for span in trace["spans"]]
     assert [span["name"] for span in spans] == ["kitaru-run", "llm-call"]

--- a/plugins/tests/adapters/phoenix/test_api.py
+++ b/plugins/tests/adapters/phoenix/test_api.py
@@ -46,7 +46,10 @@ async def test_trace_ids_fetches_exactly_those_traces_in_order(
         for session in parse(payload, {})
         if isinstance(session, ImportedSession)
     ]
-    assert [session.external_id for session in sessions] == ["trace-b", "trace-a"]
+    assert [session.external_id for session in sessions] == [
+        f"{PROJECT}:trace-b",
+        f"{PROJECT}:trace-a",
+    ]
     assert sessions[0].status == SessionStatus.COMPLETED
     assert [node.name for node in sessions[0].nodes] == ["kitaru-run"]
 
@@ -83,7 +86,9 @@ async def test_fetch_bounds_concurrency_and_preserves_order(
         for session in parse(payloads[0], {})
         if isinstance(session, ImportedSession)
     ]
-    assert [session.external_id for session in sessions] == trace_ids
+    assert [session.external_id for session in sessions] == [
+        f"{PROJECT}:{trace_id}" for trace_id in trace_ids
+    ]
 
     # The default query still works at the default concurrency.
     fake_phoenix.span_builders = [build_complete_spans, build_complete_spans]
@@ -205,9 +210,9 @@ async def test_time_window_fetch_yields_one_oldest_first_payload(
         if isinstance(session, ImportedSession)
     ]
     assert [session.external_id for session in sessions] == [
-        "trace-c",
-        "trace-a",
-        "trace-b",
+        f"{PROJECT}:trace-c",
+        f"{PROJECT}:trace-a",
+        f"{PROJECT}:trace-b",
     ]
 
 
@@ -264,13 +269,13 @@ async def test_fetch_payload_round_trips_through_the_real_parser(
 
     [payload] = await collect_payloads(fetch({"trace_ids": ["trace-1"]}))
 
-    spans = json.loads(payload)
+    spans = [span for trace in json.loads(payload) for span in trace["spans"]]
     assert [span["name"] for span in spans] == ["kitaru-run", "llm-call"]
     sessions = list(parse(payload, {}))
     assert len(sessions) == 1
     [session] = sessions
     assert isinstance(session, ImportedSession)
-    assert session.external_id == "trace-1"
+    assert session.external_id == f"{PROJECT}:trace-1"
 
 
 async def test_fetch_waits_out_a_rate_limit_and_succeeds(
@@ -299,7 +304,9 @@ async def test_fetch_waits_out_a_rate_limit_and_succeeds(
     payloads = await collect_payloads(fetch({"trace_ids": ["trace-1"]}))
 
     assert sleeps == [5.0]
-    assert payloads == [serialize_spans(build_complete_spans("trace-1"))]
+    assert payloads == [
+        serialize_spans(build_complete_spans("trace-1"), project=PROJECT)
+    ]
 
 
 async def test_fetch_propagates_a_non_rate_limit_error(
@@ -318,3 +325,24 @@ async def test_fetch_propagates_a_non_rate_limit_error(
 
     with pytest.raises(httpx.HTTPStatusError):
         await collect_payloads(fetch({"trace_ids": ["trace-1"]}))
+
+
+@pytest.mark.parametrize("project", [None, " customer-project ", " \t"])
+async def test_api_and_file_imports_use_the_same_project_namespace(
+    fake_phoenix: FakePhoenix, project: str | None
+) -> None:
+    """Carry the actual fetch project through serialization into the parser."""
+    fake_phoenix.span_builders = [build_complete_spans]
+    [payload] = await collect_payloads(
+        fetch({"trace_ids": ["trace-1"], "project": project})
+    )
+    selected = (project or "").strip() or PROJECT
+    api_sessions = list(parse(payload, {}))
+    file_sessions = list(
+        parse(serialize_spans(build_complete_spans("trace-1")), {"project": selected})
+    )
+    assert fake_phoenix.project_identifiers == [selected]
+    assert len(api_sessions) == 1
+    assert isinstance(api_sessions[0], ImportedSession)
+    assert api_sessions[0].external_id == f"{selected}:trace-1"
+    assert api_sessions == file_sessions

--- a/plugins/tests/importers/test_braintrust.py
+++ b/plugins/tests/importers/test_braintrust.py
@@ -297,7 +297,7 @@ def test_groups_traces_by_json_pointer() -> None:
 
 
 def test_accepts_flat_ui_export_as_partial() -> None:
-    """Accept Braintrust UI JSON with filename-based project identity."""
+    """Accept Braintrust UI JSON with explicit project identity."""
     rows = [
         {
             "created": "2026-07-24T10:00:00Z",
@@ -332,7 +332,7 @@ def test_accepts_flat_ui_export_as_partial() -> None:
         },
     ]
 
-    session = sessions(json.dumps(rows).encode())[0]
+    session = sessions(json.dumps(rows).encode(), params(source_instance="litellm"))[0]
 
     assert session.external_id == "litellm:conversation-1"
     warnings = session.metadata["normalization_warnings"]
@@ -642,19 +642,19 @@ def test_conflicting_project_rejects_trace(reverse: bool) -> None:
     )
     assert [
         item.external_id for item in result if isinstance(item, ImportedSession)
-    ] == ["project:good"]
+    ] == ["fallback:good"]
     assert len([item for item in result if isinstance(item, ImportFailure)]) == 1
 
 
 @pytest.mark.parametrize("reverse", [False, True])
-def test_explicit_project_on_any_row_wins(reverse: bool) -> None:
+def test_source_instance_overrides_project_on_any_row(reverse: bool) -> None:
     rows = [boundary_event(span_id="a", project_id=None), boundary_event(span_id="b")]
     if reverse:
         rows.reverse()
     result = list(parse(json.dumps(rows).encode(), {"source_instance": "fallback"}))
     assert len(result) == 1
     assert isinstance(result[0], ImportedSession)
-    assert result[0].external_id == "project:bad"
+    assert result[0].external_id == "fallback:bad"
 
 
 @pytest.mark.parametrize(
@@ -670,15 +670,14 @@ def test_explicit_project_on_any_row_wins(reverse: bool) -> None:
         (
             "embedded",
             {"source_instance": "explicit", "project_id": "selected"},
-            "embedded",
+            "explicit",
         ),
-        (None, {"filename": "export.jsonl"}, "export"),
     ],
 )
 def test_project_id_alias_preserves_identity_precedence(
     project_id: str | None, params: dict[str, Any], expected: str
 ) -> None:
-    """Embedded identity wins, followed by explicit params and filename fallback."""
+    """Explicit source identity wins over alias and embedded project identity."""
     [session] = list(
         parse(json.dumps([boundary_event(project_id=project_id)]).encode(), params)
     )
@@ -749,3 +748,33 @@ def test_rootless_trace_chooses_stable_join_identity(reverse: bool) -> None:
     if reverse:
         rows.reverse()
     assert sessions(json.dumps(rows).encode())[0].external_id == expected
+
+
+@pytest.mark.parametrize(
+    "override", [{"source_instance": "explicit"}, {"project_id": "alias"}]
+)
+def test_override_does_not_hide_grouped_project_conflicts(
+    override: dict[str, Any],
+) -> None:
+    """Two traces cannot merge across projects through an identity override."""
+    rows = [
+        boundary_event("first", project_id="first", metadata={"session_id": "shared"}),
+        boundary_event(
+            "second", project_id="second", metadata={"session_id": "shared"}
+        ),
+    ]
+    [failure] = list(parse(json.dumps(rows).encode(), override))
+    assert isinstance(failure, ImportFailure)
+    assert "Session 'shared' contains conflicting project identities" in failure.error
+
+
+def test_filename_does_not_supply_project_identity() -> None:
+    """Renaming an export cannot change the project's deduplication identity."""
+    [failure] = list(
+        parse(
+            json.dumps([boundary_event(project_id=None)]).encode(),
+            {"filename": "export.jsonl"},
+        )
+    )
+    assert isinstance(failure, ImportFailure)
+    assert "source_instance" in failure.error

--- a/plugins/tests/importers/test_braintrust.py
+++ b/plugins/tests/importers/test_braintrust.py
@@ -657,6 +657,45 @@ def test_explicit_project_on_any_row_wins(reverse: bool) -> None:
     assert result[0].external_id == "project:bad"
 
 
+@pytest.mark.parametrize(
+    ("project_id", "params", "expected"),
+    [
+        (None, {"project_id": "selected"}, "selected"),
+        (None, {"source_instance": "", "project_id": "selected"}, "selected"),
+        (
+            None,
+            {"source_instance": "explicit", "project_id": "selected"},
+            "explicit",
+        ),
+        (
+            "embedded",
+            {"source_instance": "explicit", "project_id": "selected"},
+            "embedded",
+        ),
+        (None, {"filename": "export.jsonl"}, "export"),
+    ],
+)
+def test_project_id_alias_preserves_identity_precedence(
+    project_id: str | None, params: dict[str, Any], expected: str
+) -> None:
+    """Embedded identity wins, followed by explicit params and filename fallback."""
+    [session] = list(
+        parse(json.dumps([boundary_event(project_id=project_id)]).encode(), params)
+    )
+
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == f"{expected}:bad"
+
+
+def test_missing_project_identity_explains_import_params() -> None:
+    """Include a copyable remedy when no project identity can be selected."""
+    [failure] = list(parse(json.dumps([boundary_event(project_id=None)]).encode(), {}))
+
+    assert isinstance(failure, ImportFailure)
+    assert '--params \'{"source_instance":"my-project"}\'' in failure.error
+    assert "project_id" in failure.error
+
+
 def test_deep_tool_payload_is_isolated() -> None:
     output: Any = "answer"
     for _ in range(66):

--- a/plugins/tests/importers/test_langfuse.py
+++ b/plugins/tests/importers/test_langfuse.py
@@ -1387,3 +1387,87 @@ def test_parent_validation_does_not_repeat_shared_ancestor_walks() -> None:
     # A fresh 63-ancestor walk for each leaf needs far more than this generous
     # per-node budget. Cached walks visit each parent relationship once.
     assert lookups < 20 * len(ids)
+
+
+@pytest.mark.parametrize("project", ["other-project", 42, False, [], {}])
+def test_trace_project_cannot_be_hidden_by_observation_or_override(
+    project: Any,
+) -> None:
+    """Validate trace identity before observation flattening discards context."""
+    payload = {
+        "id": "trace-1",
+        "projectId": project,
+        "observations": [observation("root", "trace-1")],
+    }
+    [failure] = list(
+        parse(json.dumps(payload).encode(), {"source_instance": "explicit"})
+    )
+    assert isinstance(failure, ImportFailure)
+    assert "project" in failure.error
+
+
+@pytest.mark.parametrize("initial_project", ["other-project", 42])
+def test_event_updates_cannot_hide_project_identity(initial_project: Any) -> None:
+    """Check every ingestion event before later updates overwrite its identity."""
+    events = [
+        {
+            "type": "trace-create",
+            "body": {"id": "trace-1", "projectId": initial_project},
+        },
+        {"type": "trace-update", "body": {"id": "trace-1", "projectId": "project-1"}},
+        {"type": "span-create", "body": observation("root", "trace-1")},
+        {
+            "type": "span-create",
+            "body": observation("healthy", "healthy-trace", session_id="healthy"),
+        },
+    ]
+    results = list(parse(json.dumps(events).encode(), {"source_instance": "explicit"}))
+    assert [
+        item.external_id for item in results if isinstance(item, ImportedSession)
+    ] == ["explicit:healthy"]
+    assert len([item for item in results if isinstance(item, ImportFailure)]) == 1
+
+
+@pytest.mark.parametrize("empty_project", [None, "", "  "])
+def test_empty_observation_project_inherits_trace_project(empty_project: Any) -> None:
+    """Empty observation fields do not hide the trace's project identity."""
+    row = observation("root", "trace-1")
+    row["projectId"] = empty_project
+    payload = {"id": "trace-1", "projectId": " parent ", "observations": [row]}
+    [session] = list(parse(json.dumps(payload).encode(), {}))
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == "parent:conversation-1"
+
+
+def test_empty_camelcase_trace_project_does_not_hide_snakecase_identity() -> None:
+    """Use the populated trace alias when the higher-priority field is null."""
+    payload = {
+        "id": "trace-1",
+        "projectId": None,
+        "project_id": " parent ",
+        "observations": [observation("root", "trace-1", project_id=None)],
+    }
+    [session] = list(parse(json.dumps(payload).encode(), {}))
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == "parent:conversation-1"
+
+
+@pytest.mark.parametrize("cleared_project", [None, "", "  "])
+def test_event_update_cannot_clear_recorded_project_identity(
+    cleared_project: Any,
+) -> None:
+    """An empty update preserves the project identity recorded by an earlier event."""
+    events = [
+        {"type": "trace-create", "body": {"id": "trace-1", "projectId": " original "}},
+        {
+            "type": "trace-update",
+            "body": {"id": "trace-1", "projectId": cleared_project},
+        },
+        {
+            "type": "span-create",
+            "body": observation("root", "trace-1", project_id=None),
+        },
+    ]
+    [session] = list(parse(json.dumps(events).encode(), {}))
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == "original:conversation-1"

--- a/plugins/tests/importers/test_langfuse.py
+++ b/plugins/tests/importers/test_langfuse.py
@@ -798,7 +798,11 @@ def test_reports_one_invalid_group_without_losing_valid_sessions() -> None:
     ]
     assert len(parsed_failures) == 1
     assert parsed_failures[0].external_id == "invalid-session"
-    assert "provide source_instance" in parsed_failures[0].error
+    assert (
+        '--params \'{"source_instance":"my-langfuse-project"}\''
+        in parsed_failures[0].error
+    )
+    assert "Reuse the same value" in parsed_failures[0].error
 
 
 def test_source_instance_selection_handles_exports_without_project_ids() -> None:
@@ -809,6 +813,69 @@ def test_source_instance_selection_handles_exports_without_project_ids() -> None
     )
 
     assert parsed[0].external_id == "selected-project:conversation-1"
+
+
+@pytest.mark.parametrize(
+    ("project_id", "importer_params", "expected_source"),
+    [
+        (None, {"project_id": "selected-project"}, "selected-project"),
+        (
+            None,
+            {"source_instance": "", "project_id": "selected-project"},
+            "selected-project",
+        ),
+        ("embedded-project", {"filename": "export.jsonl"}, "embedded-project"),
+        ("embedded-project", {"project_id": "selected-project"}, "selected-project"),
+        (
+            "embedded-project",
+            {"project_id": "alias-project", "source_instance": "selected-project"},
+            "selected-project",
+        ),
+    ],
+)
+def test_source_identity_precedence(
+    project_id: str | None,
+    importer_params: dict[str, Any],
+    expected_source: str,
+) -> None:
+    """Prefer source_instance, then project_id params, then embedded identity."""
+    parsed = sessions(
+        jsonl(observation("root", "trace-1", project_id=project_id)),
+        importer_params,
+    )
+
+    assert parsed[0].external_id == f"{expected_source}:conversation-1"
+
+
+def test_filename_does_not_supply_source_identity() -> None:
+    """Reject a filename-only identity so renaming exports cannot change IDs."""
+    parsed = list(
+        parse(
+            jsonl(observation("root", "trace-1", project_id=None)),
+            {"filename": "customer-support.jsonl"},
+        )
+    )
+
+    assert len(parsed) == 1
+    assert isinstance(parsed[0], ImportFailure)
+    assert '--params \'{"source_instance":"my-langfuse-project"}\'' in parsed[0].error
+
+
+def test_explicit_identity_does_not_hide_conflicting_projects() -> None:
+    """Reject sessions mixing embedded projects despite explicit parameters."""
+    parsed = list(
+        parse(
+            jsonl(
+                observation("root-1", "trace-1", project_id="project-1"),
+                observation("root-2", "trace-2", project_id="project-2"),
+            ),
+            {"source_instance": "selected-project", "project_id": "alias-project"},
+        )
+    )
+
+    assert len(parsed) == 1
+    assert isinstance(parsed[0], ImportFailure)
+    assert "conflicting Langfuse project ids" in parsed[0].error
 
 
 def test_status_message_does_not_imply_failure() -> None:

--- a/plugins/tests/importers/test_langsmith.py
+++ b/plugins/tests/importers/test_langsmith.py
@@ -420,6 +420,41 @@ def test_source_instance_override_supports_exports_without_project_id() -> None:
     assert session.external_id == "selected-project:thread-1"
 
 
+@pytest.mark.parametrize(
+    ("project_id", "params", "expected"),
+    [
+        (None, {"project_name": "named-project"}, "named-project"),
+        (
+            None,
+            {"source_instance": "", "project_name": "named-project"},
+            "named-project",
+        ),
+        ("embedded", {"project_name": "named-project"}, "named-project"),
+        ("embedded", {}, "embedded"),
+        (
+            "embedded",
+            {"source_instance": "selected", "project_name": "named-project"},
+            "selected",
+        ),
+    ],
+)
+def test_project_name_alias_preserves_identity_precedence(
+    project_id: str | None, params: dict[str, Any], expected: str
+) -> None:
+    """Explicit import identity takes precedence over embedded project identity."""
+    [session] = sessions(jsonl(run("root", "trace", project_id=project_id)), params)
+
+    assert session.external_id == f"{expected}:thread-1"
+
+
+def test_missing_project_identity_explains_import_params() -> None:
+    """Include a copyable remedy when the export omits its project identity."""
+    [failure] = failures(jsonl(run("root", "trace", project_id=None)))
+
+    assert '--params \'{"source_instance":"my-project"}\'' in failure.error
+    assert "project_name" in failure.error
+
+
 def test_unified_parse_yields_worker_contract_models() -> None:
     """Expose imported sessions through the standard plugin entrypoint."""
     parsed = list(parse(jsonl(run("root", "trace", inputs="hello")), {}))

--- a/plugins/tests/importers/test_langsmith.py
+++ b/plugins/tests/importers/test_langsmith.py
@@ -608,3 +608,59 @@ def test_valid_unicode_survives() -> None:
     assert result[0].nodes[0].outputs == "你好 🌍"
     assert result[0].nodes[0].model == "模型 🌍"
     result[0].model_dump_json()
+
+
+@pytest.mark.parametrize("same_trace", [False, True])
+def test_override_does_not_hide_embedded_project_conflicts(same_trace: bool) -> None:
+    """Reject conflicting embedded projects within a trace or grouped session."""
+    content = jsonl(
+        run("root-a", "trace-a", project_id="first"),
+        run("root-b", "trace-a" if same_trace else "trace-b", project_id="second"),
+    )
+    result = list(parse(content, {"source_instance": "explicit"}))
+    assert len(result) == 1
+    assert isinstance(result[0], ImportFailure)
+    assert "conflicting project identities" in result[0].error
+
+
+def test_embedded_project_id_takes_priority_over_name() -> None:
+    """A record can contain both a project ID and its different display name."""
+    [session] = sessions(jsonl(run("root", "trace", session_name="display-name")))
+    assert session.external_id == "project-1:thread-1"
+
+
+def test_project_on_one_run_supplies_identity_for_trace() -> None:
+    """A child without project identity inherits the trace's embedded project."""
+    [session] = sessions(
+        jsonl(
+            run("root", "trace"),
+            run("child", "trace", parent_run_id="root", project_id=None),
+        )
+    )
+    assert session.external_id == "project-1:thread-1"
+
+
+def test_embedded_project_id_aliases_cannot_conflict_in_one_run() -> None:
+    """Different values for project ID aliases are conflicting embedded identity."""
+    record = run("root", "trace")
+    record["project_id"] = "other-project"
+    [failure] = list(parse(jsonl(record), {"source_instance": "explicit"}))
+    assert isinstance(failure, ImportFailure)
+    assert "conflicting project identities" in failure.error
+
+
+def test_project_id_on_one_run_takes_priority_over_child_project_name() -> None:
+    """Do not compare a project's display name with its ID across related runs."""
+    [session] = sessions(
+        jsonl(
+            run("root", "trace"),
+            run(
+                "child",
+                "trace",
+                parent_run_id="root",
+                project_id=None,
+                project_name="display-name",
+            ),
+        )
+    )
+    assert session.external_id == "project-1:thread-1"

--- a/plugins/tests/importers/test_logfire.py
+++ b/plugins/tests/importers/test_logfire.py
@@ -505,3 +505,65 @@ def test_valid_numeric_attributes_are_preserved(value: Any) -> None:
         assert node.tokens is not None
         assert node.tokens.input_tokens == int(value)
     session.model_dump_json()
+
+
+@pytest.mark.parametrize("missing", [None, "", "   "])
+def test_requires_project_identity(missing: Any) -> None:
+    """Missing identity fails with an actionable command."""
+    [failure] = parse(jsonl(row("root", project_id=missing)))
+    assert isinstance(failure, ImportFailure)
+    assert '--params \'{"source_instance":"my-logfire-project"}\'' in failure.error
+
+
+@pytest.mark.parametrize(
+    ("params", "expected"),
+    [
+        ({"source_instance": " override ", "project_id": "alias"}, "override"),
+        ({"source_instance": " ", "project_id": " alias "}, "alias"),
+        ({"source_instance": None, "project_id": ""}, "project-1"),
+    ],
+)
+def test_normalizes_project_identity_precedence(
+    params: dict[str, Any], expected: str
+) -> None:
+    """Explicit identities precede normalized embedded identity."""
+    [session] = parse(jsonl(row("root", project_id=" project-1 ")), params)
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == f"{expected}:conversation-1"
+    assert session.metadata["logfire.project_id"] == "project-1"
+
+
+@pytest.mark.parametrize("invalid", [42, False, [], {}])
+@pytest.mark.parametrize("field", ["source_instance", "project_id", "embedded"])
+def test_rejects_nonstring_project_identity(field: str, invalid: Any) -> None:
+    """Invalid identity types never become strings or disappear as false values."""
+    record = row("root", project_id=invalid) if field == "embedded" else row("root")
+    params = (
+        {"source_instance": "override"} if field == "embedded" else {field: invalid}
+    )
+    [failure] = parse(jsonl(record), params)
+    assert isinstance(failure, ImportFailure)
+    assert "must be a string" in failure.error
+
+
+@pytest.mark.parametrize("same_trace", [True, False])
+def test_override_preserves_embedded_project_conflicts(same_trace: bool) -> None:
+    """An override cannot combine conflicting embedded projects."""
+    records = [
+        row("root-1", trace_id="trace-1", project_id="project-1"),
+        row(
+            "root-2",
+            trace_id="trace-1" if same_trace else "trace-2",
+            project_id="project-2",
+        ),
+    ]
+    [failure] = parse(jsonl(*records), {"source_instance": "override"})
+    assert isinstance(failure, ImportFailure)
+    assert "conflicting Logfire project ids" in failure.error
+
+
+def test_missing_project_identity_isolates_trace() -> None:
+    """A rejected trace leaves valid sibling traces importable."""
+    parsed = parse(jsonl(row("bad", project_id=None), row("good", trace_id="trace-2")))
+    assert sum(isinstance(item, ImportedSession) for item in parsed) == 1
+    assert sum(isinstance(item, ImportFailure) for item in parsed) == 1

--- a/plugins/tests/importers/test_phoenix.py
+++ b/plugins/tests/importers/test_phoenix.py
@@ -67,7 +67,7 @@ def jsonl(*records: dict[str, Any]) -> bytes:
 
 def parse(content: bytes) -> list[ImportedSession | ImportFailure]:
     """Parse one test payload."""
-    return list(PhoenixTraceImporter().parse(content, {}))
+    return list(PhoenixTraceImporter().parse(content, {"project": "test-project"}))
 
 
 def flatten(nodes: list[ImportedNode]) -> list[ImportedNode]:
@@ -79,7 +79,8 @@ def test_importer_instance_parse_matches_module_parse() -> None:
     """Yield the same sessions from the module-level instance as from parse."""
     content = jsonl(span("root", span_kind="AGENT"))
 
-    assert list(importer.parse(content, {})) == list(unified_parse(content, {}))
+    params = {"project": "test-project"}
+    assert list(importer.parse(content, params)) == list(unified_parse(content, params))
 
 
 def test_parses_ui_jsonl_and_reconstructs_out_of_order_graph() -> None:
@@ -129,7 +130,7 @@ def test_parses_ui_jsonl_and_reconstructs_out_of_order_graph() -> None:
     [session] = parse(content)
 
     assert isinstance(session, ImportedSession)
-    assert session.external_id == "trace-1"
+    assert session.external_id == "test-project:trace-1"
     assert session.status is SessionStatus.COMPLETED
     assert session.inputs == "Weather in Paris?"
     assert session.outputs == "It is 21 C."
@@ -221,8 +222,8 @@ def test_parses_cli_trace_envelopes_and_preserves_annotations() -> None:
     assert [
         item.external_id for item in sessions if isinstance(item, ImportedSession)
     ] == [
-        "trace-1",
-        "trace-2",
+        "test-project:trace-1",
+        "test-project:trace-2",
     ]
     first = sessions[0]
     assert isinstance(first, ImportedSession)
@@ -242,7 +243,7 @@ def test_emits_sessions_in_first_appearance_order() -> None:
 
     assert [
         item.external_id for item in sessions if isinstance(item, ImportedSession)
-    ] == ["trace-b", "trace-a"]
+    ] == ["test-project:trace-b", "test-project:trace-a"]
 
 
 def test_merges_metadata_when_a_trace_spans_cli_envelopes() -> None:
@@ -364,7 +365,7 @@ def test_isolates_invalid_trace_graphs() -> None:
     parsed = parse(payload)
 
     assert any(
-        isinstance(item, ImportedSession) and item.external_id == "valid"
+        isinstance(item, ImportedSession) and item.external_id == "test-project:valid"
         for item in parsed
     )
     [failure] = [item for item in parsed if isinstance(item, ImportFailure)]
@@ -384,7 +385,7 @@ def test_isolates_duplicate_span_ids() -> None:
     )
 
     assert any(
-        isinstance(item, ImportedSession) and item.external_id == "valid"
+        isinstance(item, ImportedSession) and item.external_id == "test-project:valid"
         for item in parsed
     )
     [failure] = [item for item in parsed if isinstance(item, ImportFailure)]
@@ -406,7 +407,7 @@ def test_isolates_a_malformed_jsonl_line() -> None:
 
     assert {
         item.external_id for item in parsed if isinstance(item, ImportedSession)
-    } == {"first", "second"}
+    } == {"test-project:first", "test-project:second"}
     [failure] = [item for item in parsed if isinstance(item, ImportFailure)]
     assert failure.line == 2
     assert failure.error == "Line 2 is not valid JSON"
@@ -511,7 +512,7 @@ def test_isolates_malformed_cli_envelopes(
     parsed = parse(payload)
 
     assert any(
-        isinstance(item, ImportedSession) and item.external_id == "valid"
+        isinstance(item, ImportedSession) and item.external_id == "test-project:valid"
         for item in parsed
     )
     [failure] = [item for item in parsed if isinstance(item, ImportFailure)]
@@ -707,3 +708,72 @@ def test_valid_numeric_attributes_are_preserved(value: Any) -> None:
         assert node.tokens is not None
         assert node.tokens.input_tokens == int(value)
     session.model_dump_json()
+
+
+@pytest.mark.parametrize(
+    ("params", "embedded", "expected"),
+    [
+        (
+            {"source_instance": " explicit ", "project": " alias "},
+            "embedded",
+            "explicit",
+        ),
+        ({"source_instance": " \t", "project": " alias "}, "embedded", "alias"),
+        ({"source_instance": None, "project": ""}, " embedded ", "embedded"),
+        ({}, "embedded", "embedded"),
+    ],
+)
+def test_project_identity_precedence(
+    params: dict[str, Any], embedded: str, expected: str
+) -> None:
+    """Resolve a normalized project namespace without changing trace grouping."""
+    [session] = unified_parse(jsonl(span("root", project=embedded)), params)
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == f"{expected}:trace-1"
+    assert session.metadata["phoenix.source_instance"] == expected
+
+
+@pytest.mark.parametrize("value", [None, "", " \t"])
+def test_missing_project_identity(value: Any) -> None:
+    """Reject filename-only exports and explain how to provide their project."""
+    [failure] = unified_parse(
+        jsonl(span("root", project=value)),
+        {"source_instance": value, "project": value, "filename": "my-project.jsonl"},
+    )
+    assert isinstance(failure, ImportFailure)
+    assert '--params \'{"source_instance":"my-project"}\'' in failure.error
+
+
+@pytest.mark.parametrize("field", ["source_instance", "project", "embedded"])
+@pytest.mark.parametrize("value", [42, False, [], {}])
+def test_nonstring_project_identity_is_rejected(field: str, value: Any) -> None:
+    """Reject malformed identities even when a higher-priority value is usable."""
+    params: dict[str, Any] = {"source_instance": "selected", "project": "alias"}
+    record = span("root", project="embedded")
+    if field == "embedded":
+        record["project"] = value
+    else:
+        params[field] = value
+    [failure] = unified_parse(jsonl(record), params)
+    assert isinstance(failure, ImportFailure)
+    assert "must be a string or null" in failure.error
+
+
+@pytest.mark.parametrize("envelopes", [False, True])
+def test_conflicting_embedded_projects_fail_only_affected_trace(
+    envelopes: bool,
+) -> None:
+    """An explicit namespace does not hide conflicting project evidence."""
+    rows = [span("root", project="first"), span("child", project="second")]
+    if envelopes:
+        rows = [
+            {"traceId": "trace-1", "project": row.pop("project"), "spans": [row]}
+            for row in rows
+        ]
+    rows.append(span("root", trace_id="healthy", project="first"))
+    results = list(unified_parse(jsonl(*rows), {"source_instance": "override"}))
+    assert len(results) == 2
+    assert isinstance(results[0], ImportFailure)
+    assert "conflicting project identities" in results[0].error
+    assert isinstance(results[1], ImportedSession)
+    assert results[1].external_id == "override:healthy"

--- a/plugins/tests/importers/test_source_identity.py
+++ b/plugins/tests/importers/test_source_identity.py
@@ -1,0 +1,190 @@
+"""Shared source-identity behavior across the provider importers."""
+
+import json
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from kitaru.api_models.v1.imports import ImportFailure
+from kitaru.task.importer import ImportedSession
+from kitaru_braintrust_importer import importer as braintrust
+from kitaru_jsonl_importer.importer import parse as parse_jsonl
+from kitaru_langfuse_importer import importer as langfuse
+from kitaru_langsmith_importer import importer as langsmith
+from kitaru_logfire_importer import importer as logfire
+from kitaru_phoenix_importer import importer as phoenix
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            (
+                langfuse,
+                "project_id",
+                "projectId",
+                {"id": "root", "traceId": "trace-1", "type": "SPAN"},
+            ),
+            id="langfuse",
+        ),
+        pytest.param(
+            (
+                langsmith,
+                "project_name",
+                "session_id",
+                {"id": "root", "trace_id": "trace-1", "run_type": "chain"},
+            ),
+            id="langsmith",
+        ),
+        pytest.param(
+            (
+                braintrust,
+                "project_id",
+                "project_id",
+                {
+                    "id": "root",
+                    "span_id": "root",
+                    "root_span_id": "trace-1",
+                    "span_parents": [],
+                    "span_attributes": {"name": "root", "type": "task"},
+                },
+            ),
+            id="braintrust",
+        ),
+        pytest.param(
+            (
+                logfire,
+                "project_id",
+                "project_id",
+                {"trace_id": "trace-1", "span_id": "root", "kind": "span"},
+            ),
+            id="logfire",
+        ),
+        pytest.param(
+            (
+                phoenix,
+                "project",
+                "project",
+                {"context": {"trace_id": "trace-1", "span_id": "root"}},
+            ),
+            id="phoenix",
+        ),
+    ]
+)
+def provider(
+    request: pytest.FixtureRequest,
+) -> tuple[ModuleType, str, str, dict[str, Any]]:
+    """Provide a parser, its identity fields, and one minimal trace."""
+    return request.param
+
+
+def test_explicit_source_wins_and_is_trimmed(
+    provider: tuple[ModuleType, str, str, dict[str, Any]],
+) -> None:
+    """Choose the explicit namespace over the alias and embedded project."""
+    parser, alias, embedded_field, record = provider
+    payload = json.dumps({**record, embedded_field: "embedded"}).encode()
+
+    [session] = parser.parse(payload, {"source_instance": " explicit ", alias: "alias"})
+
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == "explicit:trace-1"
+
+
+@pytest.mark.parametrize("empty", [None, "", " \t "])
+def test_alias_wins_when_explicit_source_is_empty(
+    provider: tuple[ModuleType, str, str, dict[str, Any]], empty: str | None
+) -> None:
+    """Use the trimmed provider alias ahead of an embedded project."""
+    parser, alias, embedded_field, record = provider
+    payload = json.dumps({**record, embedded_field: "embedded"}).encode()
+
+    [session] = parser.parse(payload, {"source_instance": empty, alias: " alias "})
+
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == "alias:trace-1"
+
+
+def test_embedded_project_is_trimmed(
+    provider: tuple[ModuleType, str, str, dict[str, Any]],
+) -> None:
+    """Use embedded identity when neither parameter supplies one."""
+    parser, _, embedded_field, record = provider
+    payload = json.dumps({**record, embedded_field: " embedded "}).encode()
+
+    [session] = parser.parse(payload, {})
+
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == "embedded:trace-1"
+
+
+def test_missing_identity_never_uses_filename_or_constant(
+    provider: tuple[ModuleType, str, str, dict[str, Any]],
+) -> None:
+    """Require source identity with an actionable remedy for every provider."""
+    parser, _, _, record = provider
+
+    [failure] = parser.parse(json.dumps(record).encode(), {"filename": "export.jsonl"})
+
+    assert isinstance(failure, ImportFailure)
+    assert "--params" in failure.error
+    assert "source_instance" in failure.error
+
+
+def test_embedded_conflict_cannot_be_hidden_by_explicit_source(
+    provider: tuple[ModuleType, str, str, dict[str, Any]],
+) -> None:
+    """Reject a mixed-project trace before applying any namespace override."""
+    parser, _, embedded_field, record = provider
+    other = {**record, embedded_field: "second-project"}
+    for key in ("id", "span_id"):
+        if key in other:
+            other[key] = "child"
+    if "context" in other:
+        other["context"] = {**other["context"], "span_id": "child"}
+    payload = json.dumps([{**record, embedded_field: "first-project"}, other]).encode()
+
+    [failure] = parser.parse(payload, {"source_instance": "explicit"})
+
+    assert isinstance(failure, ImportFailure)
+    assert "conflicting" in failure.error.lower()
+
+
+@pytest.mark.parametrize("invalid", [42, False, [], {}])
+@pytest.mark.parametrize("location", ["source_instance", "alias", "embedded"])
+def test_nonstring_identity_is_rejected_even_with_an_override(
+    provider: tuple[ModuleType, str, str, dict[str, Any]],
+    location: str,
+    invalid: Any,
+) -> None:
+    """Do not stringify malformed identity values or hide them behind an override."""
+    parser, alias, embedded_field, record = provider
+    record = {**record, embedded_field: "embedded"}
+    params = {"source_instance": "explicit", alias: "alias"}
+    if location == "embedded":
+        record[embedded_field] = invalid
+    else:
+        params[alias if location == "alias" else "source_instance"] = invalid
+
+    [failure] = parser.parse(json.dumps(record).encode(), params)
+
+    assert isinstance(failure, ImportFailure)
+    assert "string" in failure.error
+
+
+def test_native_jsonl_keeps_the_supplied_external_id() -> None:
+    """Native sessions already contain their final identity and need no prefix."""
+    payload = json.dumps(
+        {
+            "external_id": "already-qualified",
+            "status": "completed",
+            "inputs": {},
+            "outputs": {},
+            "nodes": [],
+        }
+    ).encode()
+
+    [session] = parse_jsonl(payload, {"source_instance": "ignored"})
+
+    assert isinstance(session, ImportedSession)
+    assert session.external_id == "already-qualified"


### PR DESCRIPTION
## Summary

Langfuse, LangSmith, Braintrust, Logfire, and Phoenix now use the same project identity policy: explicit `source_instance`, then the provider parameter alias, then embedded project identity, otherwise an actionable error. This removes filename and constant fallbacks and gives Phoenix project-prefixed session IDs, so identity no longer depends on which importer happens to be selected.

Fixes #1025.

## Reviewer Notes

Identity values must be strings and are trimmed; null and blank values count as absent, and other types fail validation. Conflicting embedded identities cannot be hidden by an override. LangSmith compares project IDs when present and falls back to names only when no IDs are available. Session grouping is unchanged, and native Kitaru JSONL preserves its supplied external IDs.

Aliases are `project_id` for Langfuse, Braintrust, and Logfire; `project_name` for LangSmith; and `project` for Phoenix. Phoenix API fetches and its adapter carry the selected project into the parser. Tests exercise real fetchers with fake provider clients and compare their identities with equivalent file imports. Project names are not resolved into IDs: callers must use the same value across import paths.

### Compatibility

- Braintrust explicit parameters now take precedence over embedded IDs. To retain an earlier identity, use the previously selected value.
- Langfuse and Braintrust no longer infer identity from filenames. Existing callers can supply the former filename stem explicitly.
- Logfire no longer defaults to `logfire`; supplying that value explicitly preserves an earlier prefix.
- Phoenix changes from a bare trace ID to `<source_instance>:<trace_id>`. Overlapping imports do not deduplicate against old bare IDs. No existing sessions are rewritten.
- Trimming whitespace and rejecting conflicting or non-string identities can change the outcome of older imports.

No CLI, server, schema, package-version, or catalog-pin changes. All five importer distributions are intended for their next applicable releases.

### Reproduction

With the plugin workspace installed, parse the same project-less Phoenix trace with and without an explicit project:

```bash
uv run --project plugins python - <<'PY'
from kitaru_phoenix_importer import parse
payload = b'{"context":{"trace_id":"trace-1","span_id":"root"}}'
print(list(parse(payload, {})))  # ImportFailure with the --params remedy
print(list(parse(payload, {"project": "support"}))[0].external_id)
# support:trace-1
PY
```

The shared `plugins/tests/importers/test_source_identity.py` exercises precedence, whitespace, malformed values, conflicting projects, and missing identity across all five providers, plus native JSONL pass-through.

### Validation

All 1,710 plugin/default-catalog tests passed, as did plugin format/lint/type checks and `just check`. Independent review covered identity propagation, isolation of failures, and compatibility guidance. Provider responses were faked; no live provider or worker-stack rehearsal was run for this expansion.
