### PR TITLE
Add bounded adaptive Mastra conversations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ helm/Chart.lock
 /node_modules/
 /packages/*/node_modules/
 /examples/typescript/mastra_support_triage/node_modules/
+/examples/typescript/mastra_adaptive_conversation/node_modules/
 /examples/typescript/vercel_ai_support_triage/node_modules/
 /packages/*/dist/
 /typescript-dist/

--- a/biome.json
+++ b/biome.json
@@ -6,6 +6,7 @@
       "packages/mastra/**",
       "packages/vercel-ai/**",
       "examples/typescript/mastra_support_triage/**",
+      "examples/typescript/mastra_adaptive_conversation/**",
       "examples/typescript/vercel_ai_support_triage/**",
       "!packages/core/src/generated/**",
       "!**/dist/**"

--- a/changelog.d/mastra-adaptive-conversation.added.md
+++ b/changelog.d/mastra-adaptive-conversation.added.md
@@ -1,0 +1,1 @@
+- Added a bounded adaptive Mastra conversation example with one transcript session per worker run, isolated conversation history, and Python evaluation.

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,7 @@ uv sync --project plugins --frozen --all-packages
 
 The TypeScript examples use the `@zenml-io/kitaru` SDK and its framework adapters:
 
+- [`typescript/mastra_adaptive_conversation/`](typescript/mastra_adaptive_conversation/) generates a bounded response-dependent dialogue with raw Mastra calls, records one transcript session, and evaluates it with a Python evaluator.
 - [`typescript/mastra_support_triage/`](typescript/mastra_support_triage/) records and replays a Mastra support-triage agent, including tool-result reuse from history and Python evaluations.
 - [`typescript/vercel_ai_support_triage/`](typescript/vercel_ai_support_triage/) records a Vercel AI SDK agent and drives a job-scoped worker replay with overrides.
 - [`typescript/vercel_ai_ticket_resolver/`](typescript/vercel_ai_ticket_resolver/) is the full end-to-end returns walkthrough: baseline recording, evaluator, cohort, and replay comparison.

--- a/examples/example-coverage.yaml
+++ b/examples/example-coverage.yaml
@@ -51,6 +51,33 @@ examples:
     release_policy:
       required_when_changed: true
       waiver_allowed: true
+  - id: mastra-adaptive-conversation
+    path: examples/typescript/mastra_adaptive_conversation
+    public_docs: [examples/README.md]
+    owner_area: Bounded adaptive transcript generation and Python contract evaluation
+    coverage:
+      deterministic_pytest:
+        status: not_applicable
+        notes: Conversation behavior is covered by the example Vitest suite in the TypeScript CI job.
+      local_smoke:
+        status: covered
+        command: pnpm --filter @zenml-io/kitaru-example-mastra-adaptive-conversation test
+        requires_server: false
+        timeout_seconds: 60
+        notes: Covers branching, repeat isolation, overrides, input fallback, and bounded failures.
+      live_provider:
+        status: manual_only
+        provider: openai
+        required_env: [OPENAI_API_KEY]
+        timeout_seconds: 900
+        cost_class: low
+        command: uv run python examples/typescript/mastra_adaptive_conversation/demo.py
+        waiver:
+          reason: Two bounded conversations call a paid OpenAI target through a temporary local server and worker.
+          reviewer_action: Run the documented demo and inspect both transcript and Python evaluator results.
+    release_policy:
+      required_when_changed: true
+      waiver_allowed: true
   - id: mastra-support-triage
     path: examples/typescript/mastra_support_triage
     public_docs: [docs/book/adapters/mastra.md, packages/mastra/README.md]

--- a/examples/typescript/mastra_adaptive_conversation/README.md
+++ b/examples/typescript/mastra_adaptive_conversation/README.md
@@ -1,0 +1,56 @@
+# Adaptive Mastra conversation
+
+This example lets a deterministic simulated user choose its next message from the target agent's preceding response. Raw Mastra calls generate a fresh dialogue, and one Kitaru session records its ordered transcript. An existing Python evaluator then checks the transcript's output contract.
+
+The scenario uses only fictional parcel information. The target has no tools or persistent memory. If it asks for an order reference, the simulator supplies `FIXTURE-42`; otherwise the simulator asks it to clarify. Each run creates a new target agent and explicit message history.
+
+## Run the example
+
+From the repository root, use Node 22.22 or newer within Node 22, pnpm 10.33, uv, and local PostgreSQL reachable by the repository's [devtools harness](../../../devtools/AGENTS.md). Docker can provide PostgreSQL when it is not already running.
+
+```bash
+uv sync --frozen --extra server --extra worker --extra cli
+pnpm install --frozen-lockfile
+pnpm --filter @zenml-io/kitaru build
+pnpm --filter @zenml-io/kitaru-example-mastra-adaptive-conversation build
+```
+
+Set `OPENAI_API_KEY` in your environment, then run:
+
+```bash
+uv run python examples/typescript/mastra_adaptive_conversation/demo.py
+```
+
+The command starts an isolated temporary local server, registers the example as an executable agent, and runs two conversations through job-scoped workers using `openai/gpt-5-nano`. It checks that each job produces exactly one distinct session with a fresh opening message, then evaluates both sessions using `kitaru/output-contract`. It prints the session IDs, branch choices, stop reasons, and evaluation verdicts. The temporary server and database are removed when the command exits, including on failure.
+
+To retain the sessions for inspection on an existing development server, set `KITARU_API_KEY` if required and pass its URL:
+
+```bash
+uv run python examples/typescript/mastra_adaptive_conversation/demo.py --api-url http://localhost:8000
+```
+
+This mode keeps the registered agent, sessions, and evaluations on that server. The target makes paid model calls; the deterministic simulator and Python contract evaluator make none.
+
+## What the session means
+
+Outputs contain a versioned transcript, the simulator branches, effective target settings, independently identified simulator and evaluator configuration, observed token usage, and the stop reason. Checkpoints preserve the completed conversation prefix if a later target call fails. There are no automatic target retries.
+
+The example bounds the conversation to three target turns, one generation step per call, 2,000 output tokens per call, a 45-second call deadline, a 120-second conversation deadline, and 12,000 observed total target tokens. Token accounting is checked after each response, so the last call can exceed the aggregate token budget. This is not a hard dollar cap. Missing provider usage fails the run rather than treating unknown usage as zero.
+
+The Python evaluator checks required output fields and types. A passing contract means the transcript has the expected structure; it does not establish that the target's advice is correct or useful. Evaluator parameters belong to the evaluation job and remain separate from target overrides.
+
+These are transcript-only sessions. They do not contain complete model/tool telemetry, support faithful tool replay, or establish automatic cost comparisons. The example generates a new dialogue each time. It does not introduce a production conversation runner or change the Mastra adapter recorder.
+
+## Target variants and worker inputs
+
+The executable accepts a versioned worker input object:
+
+```json
+{"scenario_version":"parcel-fixture-v1","prompt":"Ask for the order reference first, then suggest contacting support about the fictional delay."}
+```
+
+Here `prompt` is the target's instructions. The simulated user's opening message is fixed by the scenario. The command resolves worker inputs once, including the task-spec API fallback when the worker cannot put the payload in its environment.
+
+Replay `prompt` and `system_prompt` overrides change only target instructions; `system_prompt` takes precedence. Model overrides allow `openai/gpt-5-nano` and `openai/gpt-5-mini`; the demo uses nano. The only supported model parameter override is `maxOutputTokens`, from 1 to 2,000. Simulator behavior and evaluator parameters do not change with target variants. Replay tool policies other than the default passthrough policy are rejected because the example has no tools.
+
+`scenario_complete`, `turn_limit`, `usage_limit`, and overall `time_limit` are completed bounded stops. `call_timeout` and `runtime_failure` fail the session and executable, retaining the last recorded prefix. Usage on a failed or timed-out call may be unavailable. A hard process kill or recording-server failure can prevent the final checkpoint, so worker/task status remains authoritative for interrupted runs.

--- a/examples/typescript/mastra_adaptive_conversation/demo.py
+++ b/examples/typescript/mastra_adaptive_conversation/demo.py
@@ -1,0 +1,255 @@
+"""Run two isolated adaptive conversations and an existing Python evaluator."""
+
+import argparse
+import asyncio
+import os
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+from subprocess import TimeoutExpired
+
+from kitaru.api_models.v1.agent import AgentCreateRequest
+from kitaru.api_models.v1.agent_version import AgentVersionCreateRequest, RunSpec
+from kitaru.api_models.v1.evaluation import (
+    EvaluationBatchCreateRequest,
+    EvaluationListParams,
+)
+from kitaru.api_models.v1.filter import FilterCondition, FilterOp
+from kitaru.api_models.v1.job import JobStatus
+from kitaru.api_models.v1.replay_config import EvaluatorConfig
+from kitaru.api_models.v1.session import SessionListParams, SessionStatus
+from kitaru.api_models.v1.session_run import SessionRunCreateRequest
+from kitaru.api_models.v1.task import TaskKind
+from kitaru.api_models.v1.worker import WorkerClaim, WorkerScope
+from kitaru.client.api_client import KitaruAPIClient
+from kitaru.worker import Worker, WorkerConfig
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EXAMPLE_DIR = Path(__file__).resolve().parent
+PROMPT = "I need help with a fictional delayed parcel. What information do you need?"
+TARGET_PROMPT = (
+    "You assist with fictional parcel support. Ask for the order reference first. "
+    "Once given FIXTURE-42, explain that this fixture is delayed and suggest "
+    "contacting support. Never claim to use tools or perform real actions. "
+    "Keep each answer under 80 words."
+)
+MODEL = "openai/gpt-5-nano"
+EVALUATOR = "kitaru/output-contract"
+
+
+async def _run_job(
+    job_id: uuid.UUID, api_url: str, api_key: str, state_dir: Path
+) -> None:
+    """Run only this job's tasks, including evaluator subprocesses."""
+    original = {
+        key: os.environ.get(key) for key in ("KITARU_API_URL", "KITARU_API_KEY")
+    }
+    os.environ["KITARU_API_URL"] = api_url
+    os.environ["KITARU_API_KEY"] = api_key or "local-development-key"
+    try:
+        worker = Worker(
+            WorkerConfig(
+                name=f"adaptive-demo-{job_id}",
+                scope=WorkerScope(
+                    claims=[WorkerClaim(kind=kind) for kind in TaskKind],
+                    job_id=job_id,
+                ),
+                poll_interval=0.1,
+                timeout=240,
+                blob_cache_root=state_dir / "blobs",
+                payload_cache_root=state_dir / "payloads",
+            )
+        )
+        async with asyncio.timeout(270):
+            await worker.run()
+    finally:
+        for key, value in original.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+    async with KitaruAPIClient(base_url=api_url, api_key=api_key or None) as client:
+        job = await client.jobs.get(job_id)
+        if job.status is not JobStatus.COMPLETED:
+            # Keep subprocess errors in local logs, where provider details belong.
+            raise RuntimeError(f"Job {job.id} finished as {job.status}")
+
+
+async def run_demo(api_url: str, api_key: str, state_dir: Path) -> list[str]:
+    """Validate two fresh worker runs and persisted whole-transcript evaluation."""
+    if not (EXAMPLE_DIR / "dist/main.js").is_file():
+        raise RuntimeError(
+            "Build @zenml-io/kitaru-example-mastra-adaptive-conversation first"
+        )
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise RuntimeError("OPENAI_API_KEY is required")
+    async with KitaruAPIClient(base_url=api_url, api_key=api_key or None) as client:
+        agent = await client.agents.create(
+            AgentCreateRequest(name=f"mastra-adaptive-{uuid.uuid4().hex[:12]}")
+        )
+        version = await client.agents.create_version(
+            agent.id,
+            AgentVersionCreateRequest(
+                display_version="v1",
+                run_spec=RunSpec(
+                    command=(
+                        "node examples/typescript/"
+                        "mastra_adaptive_conversation/dist/main.js"
+                    ),
+                    working_dir=str(REPO_ROOT),
+                    env={"KITARU_AGENT_ID": str(agent.id)},
+                    timeout_seconds=180,
+                ),
+            ),
+        )
+        session_ids: list[uuid.UUID] = []
+        for repeat in range(2):
+            job = await client.session_runs.create(
+                SessionRunCreateRequest(
+                    agent_version_id=version.id,
+                    inputs={
+                        "scenario_version": "parcel-fixture-v1",
+                        "prompt": TARGET_PROMPT,
+                    },
+                    name=f"Synthetic adaptive conversation {repeat + 1}",
+                )
+            )
+            await _run_job(job.id, api_url, api_key, state_dir)
+            tasks = await client.jobs.list_tasks(job.id)
+            sessions = await client.sessions.list(
+                SessionListParams(
+                    filter=FilterCondition(
+                        field="task_id",
+                        op=FilterOp.IN,
+                        value=[str(task.id) for task in tasks.items],
+                    )
+                )
+            )
+            if len(sessions.items) != 1 or sessions.next_cursor is not None:
+                raise RuntimeError(
+                    f"Expected one conversation session, got {len(sessions.items)}"
+                )
+            session = await client.sessions.get(sessions.items[0].id)
+            assert session.status is SessionStatus.COMPLETED
+            output = session.outputs
+            assert isinstance(output, dict)
+            messages = output["messages"]
+            assert isinstance(messages, list) and 2 <= len(messages) <= 6
+            assert messages[0] == {"role": "user", "content": PROMPT}
+            assert all(
+                isinstance(message, dict)
+                and message["role"] == ("user" if index % 2 == 0 else "assistant")
+                and isinstance(message["content"], str)
+                and message["content"].strip()
+                for index, message in enumerate(messages)
+            )
+            assert output["transcript_version"] == "1"
+            assert output["scenario_version"] == "parcel-fixture-v1"
+            assert output["stop_reason"] in {"scenario_complete", "turn_limit"}
+            assert output["tools"] == "disabled"
+            assert output["target"]["model"] == MODEL
+            assert len(output["branches"]) == len(messages) // 2 - 1
+            assert session.id not in session_ids
+            session_ids.append(session.id)
+            print(
+                f"repeat={repeat + 1} session={session.id} messages={len(messages)} "
+                f"branches={output['branches']} stop={output['stop_reason']}"
+            )
+
+        evaluation_job = await client.evaluations.create(
+            EvaluationBatchCreateRequest(
+                input_session_ids=session_ids,
+                evaluators=[
+                    EvaluatorConfig(
+                        evaluator=EVALUATOR,
+                        params={
+                            "required_paths": [
+                                "/messages/0/content",
+                                "/messages/1/content",
+                                "/transcript_version",
+                                "/scenario_version",
+                                "/stop_reason",
+                                "/target/model",
+                                "/simulator/version",
+                                "/judge/configuration",
+                            ],
+                            "type_requirements": {
+                                "/messages": "array",
+                                "/branches": "array",
+                                "/stop_reason": "string",
+                                "/transcript_version": "string",
+                            },
+                        },
+                    )
+                ],
+            )
+        )
+        await _run_job(evaluation_job.id, api_url, api_key, state_dir)
+        for session_id in session_ids:
+            results = (
+                await client.evaluations.list(
+                    EvaluationListParams(
+                        filter=FilterCondition(
+                            field="session_id", op=FilterOp.EQ, value=str(session_id)
+                        )
+                    )
+                )
+            ).items
+            # The availability metric is descriptive; contract verdicts must pass.
+            verdicts = [result for result in results if result.passed is not None]
+            assert {result.name for result in verdicts} == {
+                "required_paths",
+                "type_requirements",
+            }
+            assert all(result.passed for result in verdicts)
+            print(
+                f"session={session_id} evaluator={EVALUATOR} "
+                f"evaluator_version_id={results[0].evaluator_version_id} "
+                "contract=passed"
+            )
+        return [str(session_id) for session_id in session_ids]
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--api-url", help="Use an existing server and retain its demo records"
+    )
+    args = parser.parse_args()
+    with tempfile.TemporaryDirectory(prefix="mastra-adaptive-") as temporary:
+        state_dir = Path(temporary)
+        if args.api_url:
+            await run_demo(
+                args.api_url, os.environ.get("KITARU_API_KEY", ""), state_dir
+            )
+            return
+        # Import the repository's local stack helper only for the self-cleaning demo.
+        sys.path.insert(0, str(REPO_ROOT))
+        from devtools import stack
+
+        database = f"kitaru_adaptive_{uuid.uuid4().hex}"
+        await stack.ensure_postgres()
+        await stack.create_database(database)
+        server = None
+        try:
+            port = stack.get_free_port()
+            log_path = state_dir / "server.log"
+            server = stack.start_server(database, port, log_path)
+            api_url = f"http://127.0.0.1:{port}"
+            await stack.wait_for_health(api_url, server, log_path)
+            await run_demo(api_url, "", state_dir)
+        finally:
+            if server is not None:
+                server.terminate()
+                try:
+                    await asyncio.to_thread(server.wait, timeout=10)
+                except TimeoutExpired:
+                    server.kill()
+                    await asyncio.to_thread(server.wait)
+            await stack.drop_database(database)
+    print(f"target={MODEL}; evaluator={EVALUATOR}; temporary stack/data cleaned")
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/examples/typescript/mastra_adaptive_conversation/package.json
+++ b/examples/typescript/mastra_adaptive_conversation/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zenml-io/kitaru-example-mastra-adaptive-conversation",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@10.33.0",
+  "engines": {
+    "node": ">=22.22.0 <23"
+  },
+  "dependencies": {
+    "@ai-sdk/openai": "4.0.20",
+    "@zenml-io/kitaru": "workspace:*",
+    "@mastra/core": "1.64.0"
+  },
+  "scripts": {
+    "build": "node ../../../scripts/clean-typescript-dist.mjs && tsc -p tsconfig.json",
+    "start": "node dist/main.js",
+    "lint": "biome check .",
+    "test": "vitest run test",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
+  }
+}

--- a/examples/typescript/mastra_adaptive_conversation/src/conversation.ts
+++ b/examples/typescript/mastra_adaptive_conversation/src/conversation.ts
@@ -1,0 +1,200 @@
+export const DEFAULT_PROMPT =
+  "I need help with a fictional delayed parcel. What information do you need?";
+export const DEFAULT_SYSTEM =
+  "You assist with fictional parcel support. Ask for the order reference first. Once given FIXTURE-42, explain that this fixture is delayed and suggest contacting support. Never claim to use tools or perform real actions. Keep each answer under 80 words.";
+export const MODEL = "openai/gpt-5-nano";
+export const LIMITS = Object.freeze({
+  turns: 3,
+  stepsPerCall: 1,
+  elapsedMs: 120_000,
+  callMs: 45_000,
+  maxOutputTokens: 2000,
+  totalTokens: 12000,
+  textChars: 6000,
+});
+export type Message =
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string };
+export type Limits = { [Key in keyof typeof LIMITS]: number };
+export interface TargetConfig {
+  model: string;
+  system: string;
+  maxOutputTokens: number;
+}
+export interface Reply {
+  text: string;
+  totalTokens: number;
+}
+export type Generate = (
+  history: Message[],
+  signal: AbortSignal,
+) => Promise<Reply>;
+export interface Transcript {
+  transcript_version: "1";
+  scenario_version: "parcel-fixture-v1";
+  messages: Message[];
+  branches: string[];
+  stop_reason:
+    | "running"
+    | "scenario_complete"
+    | "turn_limit"
+    | "call_timeout"
+    | "time_limit"
+    | "usage_limit"
+    | "runtime_failure";
+  stop_detail?:
+    | "call_deadline"
+    | "conversation_deadline"
+    | "target_or_recording_failure";
+  target: TargetConfig;
+  simulator: { kind: "deterministic"; version: "parcel-fixture-v1" };
+  judge: { kind: "python"; configuration: "independent-evaluator-job" };
+  recording: "transcript-only";
+  tools: "disabled";
+  total_tokens: number;
+  limits: Limits;
+}
+
+export function nextMessage(
+  reply: string,
+): { branch: string; text: string } | undefined {
+  if (/FIXTURE-42/i.test(reply) && /support|delayed/i.test(reply))
+    return undefined;
+  if (/order|reference|tracking/i.test(reply))
+    return {
+      branch: "provide_reference",
+      text: "The fictional order reference is FIXTURE-42. What should I do about the delay?",
+    };
+  return {
+    branch: "request_clarification",
+    text: "Please ask me for the order reference before suggesting next steps.",
+  };
+}
+
+export async function runConversation(options: {
+  prompt: string;
+  target: TargetConfig;
+  createTarget: (config: TargetConfig) => Generate;
+  checkpoint: (transcript: Transcript) => Promise<void>;
+  limits?: Limits;
+}): Promise<Transcript> {
+  const limits = options.limits ?? LIMITS;
+  const result: Transcript = {
+    transcript_version: "1",
+    scenario_version: "parcel-fixture-v1",
+    messages: [],
+    branches: [],
+    stop_reason: "running",
+    target: { ...options.target },
+    simulator: { kind: "deterministic", version: "parcel-fixture-v1" },
+    judge: { kind: "python", configuration: "independent-evaluator-job" },
+    recording: "transcript-only",
+    tools: "disabled",
+    total_tokens: 0,
+    limits: { ...limits },
+  };
+  const started = Date.now();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const generate = options.createTarget({ ...options.target });
+    let user = options.prompt;
+    for (let turn = 0; turn < limits.turns; turn++) {
+      const remaining = limits.elapsedMs - (Date.now() - started);
+      if (remaining <= 0) {
+        result.stop_reason = "time_limit";
+        result.stop_detail = "conversation_deadline";
+        break;
+      }
+      if (result.total_tokens >= limits.totalTokens) {
+        result.stop_reason = "usage_limit";
+        break;
+      }
+      result.messages.push({ role: "user", content: user });
+      await options.checkpoint(structuredClone(result));
+      const callRemaining = limits.elapsedMs - (Date.now() - started);
+      if (callRemaining <= 0) {
+        result.stop_reason = "time_limit";
+        result.stop_detail = "conversation_deadline";
+        break;
+      }
+      const controller = new AbortController();
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => {
+            // Settle the deadline first: an abort listener may reject immediately.
+            reject(
+              new Error(
+                callRemaining <= limits.callMs
+                  ? "conversation_deadline"
+                  : "call_deadline",
+              ),
+            );
+            controller.abort();
+          },
+          Math.min(callRemaining, limits.callMs),
+        );
+      });
+      let reply: Reply;
+      try {
+        reply = await Promise.race([
+          generate(structuredClone(result.messages), controller.signal),
+          timeout,
+        ]);
+      } finally {
+        clearTimeout(timer);
+      }
+      if (!Number.isFinite(reply.totalTokens) || reply.totalTokens < 0)
+        throw new Error("Missing or invalid provider token usage");
+      result.total_tokens += reply.totalTokens;
+      if (!reply.text.trim() || reply.text.length > limits.textChars)
+        throw new Error("Empty or oversized target response");
+      result.messages.push({ role: "assistant", content: reply.text });
+      await options.checkpoint(structuredClone(result));
+      if (Date.now() - started >= limits.elapsedMs) {
+        result.stop_reason = "time_limit";
+        result.stop_detail = "conversation_deadline";
+        break;
+      }
+      if (result.total_tokens >= limits.totalTokens) {
+        result.stop_reason = "usage_limit";
+        break;
+      }
+      const next = nextMessage(reply.text);
+      if (!next) {
+        result.stop_reason = "scenario_complete";
+        break;
+      }
+      if (turn + 1 === limits.turns) {
+        result.stop_reason = "turn_limit";
+        break;
+      }
+      result.branches.push(next.branch);
+      user = next.text;
+    }
+  } catch (error) {
+    result.stop_reason =
+      error instanceof Error && error.message === "conversation_deadline"
+        ? "time_limit"
+        : error instanceof Error && error.message === "call_deadline"
+          ? "call_timeout"
+          : "runtime_failure";
+    result.stop_detail =
+      result.stop_reason === "runtime_failure"
+        ? "target_or_recording_failure"
+        : result.stop_reason === "call_timeout"
+          ? "call_deadline"
+          : "conversation_deadline";
+    await options.checkpoint(structuredClone(result));
+    if (
+      result.stop_reason === "runtime_failure" ||
+      result.stop_reason === "call_timeout"
+    )
+      throw new Error("Conversation target or checkpoint failed", {
+        cause: error,
+      });
+  } finally {
+    clearTimeout(timer);
+  }
+  await options.checkpoint(structuredClone(result));
+  return result;
+}

--- a/examples/typescript/mastra_adaptive_conversation/src/main.ts
+++ b/examples/typescript/mastra_adaptive_conversation/src/main.ts
@@ -1,0 +1,167 @@
+import { openai } from "@ai-sdk/openai";
+import { Agent } from "@mastra/core/agent";
+import type { JsonValue } from "@zenml-io/kitaru";
+import {
+  type AdapterClient,
+  RunRecorder,
+  resolveReplayContext,
+} from "@zenml-io/kitaru/adapter";
+import { createKitaruClient } from "@zenml-io/kitaru/node";
+import {
+  DEFAULT_PROMPT,
+  DEFAULT_SYSTEM,
+  LIMITS,
+  MODEL,
+  runConversation,
+  type TargetConfig,
+} from "./conversation.js";
+
+export function resolveTarget(
+  override:
+    | {
+        system_prompt?: string | null;
+        model_params?: Record<string, unknown> | null;
+      }
+    | undefined,
+  prompt = DEFAULT_SYSTEM,
+  model = MODEL,
+): TargetConfig {
+  const params = override?.model_params ?? {};
+  if (Object.keys(params).some((key) => key !== "maxOutputTokens"))
+    throw new Error("Only maxOutputTokens target settings are supported");
+  const tokens = params.maxOutputTokens ?? LIMITS.maxOutputTokens;
+  if (
+    typeof tokens !== "number" ||
+    !Number.isInteger(tokens) ||
+    tokens < 1 ||
+    tokens > LIMITS.maxOutputTokens
+  )
+    throw new Error("maxOutputTokens must be an integer from 1 to 2000");
+  const system = override?.system_prompt ?? prompt;
+  if (system.length > LIMITS.textChars)
+    throw new Error("Target system prompt too long");
+  return { model, system, maxOutputTokens: tokens };
+}
+
+export async function resolveConfiguration(
+  client: AdapterClient,
+  environment: Parameters<
+    typeof resolveReplayContext
+  >[0]["environment"] = process.env,
+) {
+  const context = await resolveReplayContext({
+    callerInput: {
+      scenario_version: "parcel-fixture-v1",
+      prompt: DEFAULT_SYSTEM,
+    },
+    client,
+    environment,
+    requestedModelId: MODEL,
+    allowedReplayModels: [MODEL, "openai/gpt-5-mini"],
+  });
+  const policy = context.spec?.tool_policy;
+  if (
+    policy &&
+    (policy.default.type !== "passthrough" ||
+      Object.keys(policy.tools ?? {}).length > 0)
+  )
+    throw new Error(
+      "Raw tool-free calls support only the default passthrough policy",
+    );
+  const input = context.effectiveInput;
+  if (
+    typeof input !== "object" ||
+    input === null ||
+    Array.isArray(input) ||
+    input.scenario_version !== "parcel-fixture-v1"
+  )
+    throw new Error("Expected versioned parcel-fixture-v1 input object");
+  const prompt = input.prompt;
+  if (
+    typeof prompt !== "string" ||
+    !prompt.trim() ||
+    prompt.length > LIMITS.textChars
+  )
+    throw new Error(
+      "Worker input must be a nonempty prompt string up to 6000 characters",
+    );
+  const target = resolveTarget(
+    context.override,
+    prompt,
+    context.replacementModelId ?? MODEL,
+  );
+  return { context, target };
+}
+
+async function main(): Promise<void> {
+  const agentId = process.env.KITARU_AGENT_ID;
+  if (!agentId || !process.env.OPENAI_API_KEY)
+    throw new Error("KITARU_AGENT_ID and OPENAI_API_KEY are required");
+  const client = await createKitaruClient();
+  const { context, target } = await resolveConfiguration(client);
+  const recorder = await RunRecorder.create({
+    adapterVersion: "example-v1",
+    agentId,
+    agentVersionId: process.env.KITARU_AGENT_VERSION_ID,
+    client,
+    effectiveInput: context.effectiveInput,
+    framework: "mastra",
+    name: "Adaptive fixture conversation",
+    replayId: context.replayId,
+    requestedModelId: MODEL,
+    sessionIdFile: process.env.KITARU_SESSION_ID_FILE,
+    spec: context.spec,
+  });
+  try {
+    await recorder.initialize();
+    const result = await runConversation({
+      prompt: DEFAULT_PROMPT,
+      target,
+      checkpoint: async (transcript) => {
+        await client.updateSession(recorder.state.sessionId, {
+          outputs: JSON.parse(JSON.stringify(transcript)) as JsonValue,
+        });
+      },
+      createTarget: (config) => {
+        const agent = new Agent({
+          id: "adaptive-parcel-fixture",
+          name: "Adaptive parcel fixture",
+          instructions: config.system,
+          model: openai(config.model.slice("openai/".length)),
+          tools: {},
+        });
+        return async (history, signal) => {
+          const response = await agent.generate(history, {
+            abortSignal: signal,
+            maxSteps: LIMITS.stepsPerCall,
+            modelSettings: {
+              maxOutputTokens: config.maxOutputTokens,
+              maxRetries: 0,
+            },
+          });
+          return {
+            text: response.text,
+            totalTokens: response.totalUsage.totalTokens ?? Number.NaN,
+          };
+        };
+      },
+    });
+    await recorder.complete(result);
+    console.log(
+      JSON.stringify({
+        session_id: recorder.state.sessionId,
+        stop_reason: result.stop_reason,
+      }),
+    );
+  } catch {
+    // Provider errors can include request bodies or credentials; store a fixed error.
+    await recorder.fail(
+      new Error("Adaptive conversation failed; inspect the partial transcript"),
+    );
+    throw new Error(
+      "Adaptive conversation failed; inspect the partial transcript",
+    );
+  }
+}
+
+if (process.argv[1]?.endsWith("/main.js")) await main();

--- a/examples/typescript/mastra_adaptive_conversation/test/configuration.test.ts
+++ b/examples/typescript/mastra_adaptive_conversation/test/configuration.test.ts
@@ -1,0 +1,81 @@
+import type { AdapterClient } from "@zenml-io/kitaru/adapter";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_SYSTEM, MODEL } from "../src/conversation.js";
+import { resolveConfiguration } from "../src/main.js";
+
+const input = { scenario_version: "parcel-fixture-v1", prompt: DEFAULT_SYSTEM };
+const id = "00000000-0000-4000-8000-000000000001";
+function client() {
+  return {
+    getTaskSpec: vi.fn(async () => ({
+      kind: "agent",
+      details: { kind: "agent", inputs: input },
+    })),
+    getReplay: vi.fn(),
+  } as unknown as AdapterClient;
+}
+
+describe("worker configuration", () => {
+  it("resolves task-spec fallback once", async () => {
+    const api = client();
+    const config = await resolveConfiguration(api, { KITARU_TASK_ID: id });
+    expect(api.getTaskSpec).toHaveBeenCalledExactlyOnceWith(id);
+    expect(config.target.system).toBe(DEFAULT_SYSTEM);
+  });
+  it("prefers task inputs and applies prompt/model overrides to target only", async () => {
+    const api = client();
+    const config = await resolveConfiguration(api, {
+      KITARU_TASK_ID: id,
+      KITARU_TASK_INPUTS: JSON.stringify(input),
+      KITARU_OVERRIDE: JSON.stringify({
+        prompt: "Ask a concise reference question",
+        model: "openai/gpt-5-mini",
+      }),
+    });
+    expect(api.getTaskSpec).not.toHaveBeenCalled();
+    expect(config.target.system).toBe("Ask a concise reference question");
+    expect(config.target.model).toBe("openai/gpt-5-mini");
+    expect(config.context.effectiveInput).toEqual({
+      ...input,
+      prompt: "Ask a concise reference question",
+    });
+  });
+  it("accepts the normal replay default policy but rejects mocked tools", async () => {
+    const api = client();
+    vi.mocked(api.getReplay).mockResolvedValue({
+      override: { prompt: "variant" },
+      tool_policy: { default: { type: "passthrough" }, tools: {} },
+    } as never);
+    const config = await resolveConfiguration(api, {
+      KITARU_REPLAY_ID: id,
+      KITARU_TASK_INPUTS: JSON.stringify(input),
+    });
+    expect(config.target.system).toBe("variant");
+    expect(api.getReplay).toHaveBeenCalledTimes(1);
+    vi.mocked(api.getReplay).mockResolvedValue({
+      tool_policy: { default: { type: "history" }, tools: {} },
+    } as never);
+    await expect(
+      resolveConfiguration(api, {
+        KITARU_REPLAY_ID: id,
+        KITARU_TASK_INPUTS: JSON.stringify(input),
+      }),
+    ).rejects.toThrow("passthrough");
+  });
+  it("rejects unknown scenario and unapproved models before generation", async () => {
+    await expect(
+      resolveConfiguration(client(), {
+        KITARU_TASK_INPUTS: JSON.stringify({
+          ...input,
+          scenario_version: "other",
+        }),
+      }),
+    ).rejects.toThrow("versioned");
+    await expect(
+      resolveConfiguration(client(), {
+        KITARU_OVERRIDE: JSON.stringify({ model: "openai/gpt-5" }),
+      }),
+    ).rejects.toThrow("allowedReplayModels");
+    expect((await resolveConfiguration(client(), {})).target.model).toBe(MODEL);
+  });
+});

--- a/examples/typescript/mastra_adaptive_conversation/test/conversation.test.ts
+++ b/examples/typescript/mastra_adaptive_conversation/test/conversation.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_PROMPT,
+  DEFAULT_SYSTEM,
+  LIMITS,
+  type Message,
+  MODEL,
+  runConversation,
+  type Transcript,
+} from "../src/conversation.js";
+import { resolveTarget } from "../src/main.js";
+
+const target = { model: MODEL, system: DEFAULT_SYSTEM, maxOutputTokens: 2000 };
+const checkpoint = async () => {};
+
+describe("adaptive fixture conversation", () => {
+  it("branches from responses and passes fresh explicit complete history", async () => {
+    const histories: Message[][] = [];
+    const createTarget = vi.fn(() => async (history: Message[]) => {
+      histories.push(history);
+      return {
+        text:
+          history.length === 1
+            ? "What is your order reference?"
+            : "FIXTURE-42 is delayed. Please contact support.",
+        totalTokens: 10,
+      };
+    });
+    for (let repeat = 0; repeat < 2; repeat++) {
+      const result = await runConversation({
+        prompt: DEFAULT_PROMPT,
+        target,
+        createTarget,
+        checkpoint,
+      });
+      expect(result.stop_reason).toBe("scenario_complete");
+      expect(result.branches).toEqual(["provide_reference"]);
+      expect(result.messages).toHaveLength(4);
+      expect(result.total_tokens).toBe(20);
+    }
+    expect(createTarget).toHaveBeenCalledTimes(2);
+    expect(histories.map((history) => history.length)).toEqual([1, 3, 1, 3]);
+    expect(histories[0]).not.toBe(histories[2]);
+  });
+
+  it("uses a different branch for an unhelpful response and stops at turn bound", async () => {
+    const result = await runConversation({
+      prompt: DEFAULT_PROMPT,
+      target,
+      checkpoint,
+      createTarget: () => async () => ({ text: "Hello", totalTokens: 1 }),
+    });
+    expect(result.stop_reason).toBe("turn_limit");
+    expect(result.branches).toEqual([
+      "request_clarification",
+      "request_clarification",
+    ]);
+    expect(result.messages).toHaveLength(6);
+  });
+
+  it("keeps target variants separate from fixed simulator and evaluator provenance", async () => {
+    const variant = resolveTarget({
+      system_prompt: "Different target instructions",
+      model_params: { maxOutputTokens: 100 },
+    });
+    const createTarget = vi.fn(() => async () => ({
+      text: "FIXTURE-42 is delayed",
+      totalTokens: 2,
+    }));
+    const result = await runConversation({
+      prompt: "Different target initial prompt",
+      target: variant,
+      checkpoint,
+      createTarget,
+    });
+    expect(createTarget).toHaveBeenCalledWith(variant);
+    expect(result.messages[0]?.content).toBe("Different target initial prompt");
+    expect(result.simulator).toEqual({
+      kind: "deterministic",
+      version: "parcel-fixture-v1",
+    });
+    expect(result.judge).toEqual({
+      kind: "python",
+      configuration: "independent-evaluator-job",
+    });
+    expect(() =>
+      resolveTarget({ model_params: { maxOutputTokens: 2001 } }),
+    ).toThrow();
+    expect(() => resolveTarget({ model_params: { temperature: 1 } })).toThrow();
+  });
+
+  it("stops on reported usage before making another call", async () => {
+    const generate = vi.fn(async () => ({
+      text: "What is your order?",
+      totalTokens: LIMITS.totalTokens,
+    }));
+    const result = await runConversation({
+      prompt: DEFAULT_PROMPT,
+      target,
+      checkpoint,
+      createTarget: () => generate,
+    });
+    expect(result.stop_reason).toBe("usage_limit");
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails a hung provider call and records the unanswered user turn", async () => {
+    let signal: AbortSignal | undefined;
+    const snapshots: Transcript[] = [];
+    await expect(
+      runConversation({
+        prompt: DEFAULT_PROMPT,
+        target,
+        checkpoint: async (value) => {
+          snapshots.push(value);
+        },
+        limits: { ...LIMITS, callMs: 5 },
+        createTarget: () => async (_, abort) => {
+          signal = abort;
+          return new Promise(() => {});
+        },
+      }),
+    ).rejects.toThrow();
+    expect(signal?.aborted).toBe(true);
+    expect(snapshots.at(-1)?.stop_reason).toBe("call_timeout");
+    expect(snapshots.at(-1)?.messages).toEqual([
+      { role: "user", content: DEFAULT_PROMPT },
+    ]);
+  });
+
+  it("completes at the overall elapsed bound without starting a call after slow checkpoint", async () => {
+    const generate = vi.fn(async () => ({ text: "unused", totalTokens: 1 }));
+    const result = await runConversation({
+      prompt: DEFAULT_PROMPT,
+      target,
+      checkpoint: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      },
+      limits: { ...LIMITS, elapsedMs: 1 },
+      createTarget: () => generate,
+    });
+    expect(result.stop_reason).toBe("time_limit");
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it("keeps the overall deadline classification when the provider rejects on abort", async () => {
+    let aborted = false;
+    const result = await runConversation({
+      prompt: DEFAULT_PROMPT,
+      target,
+      checkpoint,
+      limits: { ...LIMITS, elapsedMs: 10 },
+      createTarget: () => async (_, signal) =>
+        new Promise((_, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              aborted = true;
+              reject(new DOMException("Aborted", "AbortError"));
+            },
+            { once: true },
+          );
+        }),
+    });
+    expect(aborted).toBe(true);
+    expect(result.stop_reason).toBe("time_limit");
+    expect(result.stop_detail).toBe("conversation_deadline");
+  });
+
+  it("checkpoints partial failure without leaking provider errors", async () => {
+    const snapshots: Transcript[] = [];
+    await expect(
+      runConversation({
+        prompt: DEFAULT_PROMPT,
+        target,
+        checkpoint: async (value) => {
+          snapshots.push(value);
+        },
+        createTarget: () => async () => {
+          throw new Error("secret provider detail");
+        },
+      }),
+    ).rejects.toThrow("Conversation target or checkpoint failed");
+    expect(snapshots.at(-1)?.stop_reason).toBe("runtime_failure");
+    expect(snapshots.at(-1)?.messages).toHaveLength(1);
+    expect(JSON.stringify(snapshots)).not.toContain("secret");
+  });
+
+  it.each([
+    { text: "", totalTokens: 2 },
+    { text: "x".repeat(LIMITS.textChars + 1), totalTokens: 2 },
+    { text: "answer", totalTokens: Number.NaN },
+  ])("rejects invalid or unbounded output", async (reply) => {
+    await expect(
+      runConversation({
+        prompt: DEFAULT_PROMPT,
+        target,
+        checkpoint,
+        createTarget: () => async () => reply,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/examples/typescript/mastra_adaptive_conversation/tsconfig.json
+++ b/examples/typescript/mastra_adaptive_conversation/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": false,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/typescript/mastra_adaptive_conversation/tsconfig.typecheck.json
+++ b/examples/typescript/mastra_adaptive_conversation/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -6,18 +6,18 @@
     "node": ">=22.22.0 <23"
   },
   "scripts": {
-    "build": "pnpm run build:packages && pnpm --filter @zenml-io/kitaru-example-mastra-support-triage build && pnpm --filter @zenml-io/kitaru-example-vercel-ai-support-triage build",
+    "build": "pnpm run build:packages && pnpm --filter @zenml-io/kitaru-example-mastra-support-triage build && pnpm --filter @zenml-io/kitaru-example-vercel-ai-support-triage build && pnpm --filter @zenml-io/kitaru-example-mastra-adaptive-conversation build",
     "build:packages": "pnpm --filter @zenml-io/kitaru build && pnpm --filter @zenml-io/kitaru-mastra build && pnpm --filter @zenml-io/kitaru-vercel-ai build",
     "generate": "pnpm --filter @zenml-io/kitaru generate",
     "generate:check": "pnpm --filter @zenml-io/kitaru generate:check",
-    "lint": "pnpm --filter @zenml-io/kitaru lint && pnpm --filter @zenml-io/kitaru-mastra lint && pnpm --filter @zenml-io/kitaru-vercel-ai lint && pnpm --filter @zenml-io/kitaru-example-mastra-support-triage lint && pnpm --filter @zenml-io/kitaru-example-vercel-ai-support-triage lint",
+    "lint": "pnpm --filter @zenml-io/kitaru lint && pnpm --filter @zenml-io/kitaru-mastra lint && pnpm --filter @zenml-io/kitaru-vercel-ai lint && pnpm --filter @zenml-io/kitaru-example-mastra-support-triage lint && pnpm --filter @zenml-io/kitaru-example-vercel-ai-support-triage lint && pnpm --filter @zenml-io/kitaru-example-mastra-adaptive-conversation lint",
     "pack:check": "pnpm run build && node scripts/smoke-typescript-packages.mjs",
     "pack:check:built": "node scripts/smoke-typescript-packages.mjs",
     "pack:release": "pnpm run build:packages && node scripts/smoke-typescript-packages.mjs --output-dir typescript-dist",
     "pack:release:built": "node scripts/smoke-typescript-packages.mjs --output-dir typescript-dist",
-    "test": "pnpm --filter @zenml-io/kitaru test && pnpm --filter @zenml-io/kitaru build && pnpm --filter @zenml-io/kitaru-mastra test && pnpm --filter @zenml-io/kitaru-vercel-ai test && pnpm --filter @zenml-io/kitaru-example-mastra-support-triage test",
-    "test:built": "pnpm --filter @zenml-io/kitaru test && pnpm --filter @zenml-io/kitaru-mastra test && pnpm --filter @zenml-io/kitaru-vercel-ai test && pnpm --filter @zenml-io/kitaru-example-mastra-support-triage test",
-    "typecheck": "pnpm --filter @zenml-io/kitaru typecheck && pnpm --filter @zenml-io/kitaru build && pnpm --filter @zenml-io/kitaru-mastra typecheck && pnpm --filter @zenml-io/kitaru-mastra build && pnpm --filter @zenml-io/kitaru-vercel-ai typecheck && pnpm --filter @zenml-io/kitaru-vercel-ai build && pnpm --filter @zenml-io/kitaru-example-mastra-support-triage typecheck && pnpm --filter @zenml-io/kitaru-example-vercel-ai-support-triage typecheck"
+    "test": "pnpm --filter @zenml-io/kitaru test && pnpm --filter @zenml-io/kitaru build && pnpm --filter @zenml-io/kitaru-mastra test && pnpm --filter @zenml-io/kitaru-vercel-ai test && pnpm --filter @zenml-io/kitaru-example-mastra-support-triage test && pnpm --filter @zenml-io/kitaru-example-mastra-adaptive-conversation test",
+    "test:built": "pnpm --filter @zenml-io/kitaru test && pnpm --filter @zenml-io/kitaru-mastra test && pnpm --filter @zenml-io/kitaru-vercel-ai test && pnpm --filter @zenml-io/kitaru-example-mastra-support-triage test && pnpm --filter @zenml-io/kitaru-example-mastra-adaptive-conversation test",
+    "typecheck": "pnpm --filter @zenml-io/kitaru typecheck && pnpm --filter @zenml-io/kitaru build && pnpm --filter @zenml-io/kitaru-mastra typecheck && pnpm --filter @zenml-io/kitaru-mastra build && pnpm --filter @zenml-io/kitaru-vercel-ai typecheck && pnpm --filter @zenml-io/kitaru-vercel-ai build && pnpm --filter @zenml-io/kitaru-example-mastra-support-triage typecheck && pnpm --filter @zenml-io/kitaru-example-vercel-ai-support-triage typecheck && pnpm --filter @zenml-io/kitaru-example-mastra-adaptive-conversation typecheck"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,18 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@types/node@22.20.1)(vite@8.1.5(@types/node@22.20.1))
 
+  examples/typescript/mastra_adaptive_conversation:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: 4.0.20
+        version: 4.0.20(zod@4.4.3)
+      '@mastra/core':
+        specifier: 1.64.0
+        version: 1.64.0(ai@7.0.85(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+      '@zenml-io/kitaru':
+        specifier: workspace:*
+        version: link:../../../packages/core
+
   examples/typescript/mastra_support_triage:
     dependencies:
       '@ai-sdk/openai':
@@ -680,10 +692,6 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-
-  eventsource-parser@3.1.0:
-    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
-    engines: {node: '>=18.0.0'}
 
   eventsource-parser@3.1.1:
     resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
@@ -1592,12 +1600,19 @@ snapshots:
       eventsource-parser: 3.1.1
       zod: 3.25.76
 
+  '@ai-sdk/provider-utils@4.0.40(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.1
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@5.0.12(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.1.1
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@5.0.12(zod@4.4.3)':
@@ -1605,7 +1620,7 @@ snapshots:
       '@ai-sdk/provider': 4.0.3
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
-      eventsource-parser: 3.1.0
+      eventsource-parser: 3.1.1
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.13(zod@3.25.76)':
@@ -1615,6 +1630,14 @@ snapshots:
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.1
       zod: 3.25.76
+
+  '@ai-sdk/provider-utils@5.0.13(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.1
+      zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.34(zod@3.25.76)':
     dependencies:
@@ -1768,10 +1791,60 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@mastra/core@1.64.0(ai@7.0.85(zod@4.4.3))(express@5.2.1)(zod@4.4.3)':
+    dependencies:
+      '@a2a-js/sdk-v0_3': '@a2a-js/sdk@0.3.14(express@5.2.1)'
+      '@a2a-js/sdk-v1': '@a2a-js/sdk@1.0.1(express@5.2.1)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.40(zod@4.4.3)'
+      '@ai-sdk/provider-utils-v7': '@ai-sdk/provider-utils@5.0.13(zod@4.4.3)'
+      '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
+      '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.14'
+      '@ai-sdk/provider-v7': '@ai-sdk/provider@4.0.4'
+      '@isaacs/ttlcache': 2.1.5
+      '@lukeed/uuid': 2.0.1
+      '@mastra/schema-compat': 1.3.8(zod@4.4.3)
+      '@modelcontextprotocol/server': 2.0.0
+      '@sindresorhus/slugify': 2.2.1
+      '@standard-schema/spec': 1.1.0
+      ajv: 8.20.0
+      chat: 4.34.0(ai@7.0.85(zod@4.4.3))(zod@4.4.3)
+      croner: 10.0.1
+      dotenv: 17.4.2
+      execa: 9.6.1
+      fastq: 1.20.1
+      gray-matter: 4.0.3
+      ignore: 7.0.6
+      jpeg-js: 0.4.4
+      json-schema: 0.4.0
+      lru-cache: 11.5.2
+      p-map: 7.0.6
+      p-retry: 7.1.1
+      picomatch: 4.0.5
+      posthog-node: 5.46.1
+      tokenx: 1.3.0
+      ws: 8.21.1
+      xxhash-wasm: 1.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@bufbuild/protobuf'
+      - '@grpc/grpc-js'
+      - ai
+      - bufferutil
+      - express
+      - rxjs
+      - supports-color
+      - utf-8-validate
+
   '@mastra/schema-compat@1.3.8(zod@3.25.76)':
     dependencies:
       json-schema-to-zod: 2.8.1
       zod: 3.25.76
+      zod-from-json-schema: 0.5.6
+
+  '@mastra/schema-compat@1.3.8(zod@4.4.3)':
+    dependencies:
+      json-schema-to-zod: 2.8.1
+      zod: 4.4.3
       zod-from-json-schema: 0.5.6
 
   '@modelcontextprotocol/core@2.0.0':
@@ -2065,6 +2138,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  chat@4.34.0(ai@7.0.85(zod@4.4.3))(zod@4.4.3):
+    dependencies:
+      '@workflow/serde': 4.1.0-beta.2
+      mdast-util-to-string: 4.0.0
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      remend: 1.3.0
+      unified: 11.0.5
+    optionalDependencies:
+      ai: 7.0.85(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   colorette@1.4.0: {}
 
   content-disposition@1.1.0:
@@ -2154,8 +2242,6 @@ snapshots:
 
   etag@1.8.1:
     optional: true
-
-  eventsource-parser@3.1.0: {}
 
   eventsource-parser@3.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - tests/typescript/fixture
   - examples/typescript/mastra_support_triage
   - examples/typescript/vercel_ai_support_triage
+  - examples/typescript/mastra_adaptive_conversation


### PR DESCRIPTION
## Summary

A simulated user can now react to each Mastra target response in a bounded example, with the complete generated dialogue recorded as one Kitaru session and checked by an existing Python evaluator. Each repeat starts with a new raw agent and explicit history; prompt/model overrides change only the target.

This is the example increment of adaptive conversation evaluation. It adds no server schema, production runner, or adapter recorder changes, and does not depend on the pending recorded-context replay PR. The standalone discovery follow-up remains separate.

Fixes #1059
Related: #1056, #1058, #1064

## Reviewer Notes

Start with the example README and `src/conversation.ts`. Tools and persistent memory are disabled. The simulator supplies a fictional reference only when the preceding response requests it. One recorder checkpoints the transcript, and failed calls retain its completed prefix. A call timeout fails the run; exhausting the total conversation budget is a completed bounded stop.

The evaluator checks transcript structure, not semantic answer quality. Sessions do not claim complete model/tool telemetry or faithful tool replay. The aggregate token threshold is checked after calls and may overshoot; usage on failed calls can be unknown.

### Reproduction

With Node 22, pnpm 10.33, uv, local PostgreSQL/Docker, and `OPENAI_API_KEY` available in the environment, run from the repository root:

```bash
uv sync --frozen --extra server --extra worker --extra cli
pnpm install --frozen-lockfile
pnpm --filter @zenml-io/kitaru build
pnpm --filter @zenml-io/kitaru-example-mastra-adaptive-conversation build
uv run python examples/typescript/mastra_adaptive_conversation/demo.py
```

The command runs two independent jobs through dedicated workers, verifies one distinct conversation session per job, evaluates both with `kitaru/output-contract`, and removes its temporary server/database. `--api-url` explicitly retains records on an existing development server.

### Validation

- `pnpm run typecheck`, `pnpm run lint`, and `pnpm run test:built`: passed, 448 tests including 15 example tests covering branching, isolation, target-only overrides, task-spec fallback, replay-policy validation, deadlines, usage limits, and partial failures.
- `UV_TOOL_DIR=/private/tmp/kitaru-1059-uv-tools just check`: passed on current develop; temporary tool directory accommodates the local sandbox.
- `uv run python scripts/audit-example-coverage.py` and `uv run python scripts/changelog_fragments.py check`: passed.
- Live command above passed on 9 September 2026 using `openai/gpt-5-nano`: two distinct worker-created sessions, each with four messages, the response-dependent `provide_reference` branch, and `scenario_complete`. Both existing Python evaluator contract verdicts passed. The temporary server and database were removed.
- Earlier validation exposed incorrect evaluator name/version syntax in the driver; the corrected API configuration was verified first with a synthetic session, then with the complete live run. No live model variant or semantic judge was tested.
