### PR TITLE
Import ATIF trajectories and Harbor rollout outputs

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -8,6 +8,7 @@ Kitaru keeps the default catalog in `src/kitaru/server/api/bootstrap.py`. At sta
 
 | Directory | Distribution | Contents |
 |---|---|---|
+| `atif-importer` | `kitaru-atif-importer` | ATIF trajectories and Harbor rollout results (development, manually registered) |
 | `braintrust-importer` | `kitaru-braintrust-importer` | Braintrust importer and importer-backed adapter |
 | `claude-agent-sdk` | `kitaru-claude-agent-sdk` | Claude Agent SDK recording and replay adapter |
 | `evaluator` | `kitaru-evaluator` | All built-in evaluators |

--- a/plugins/packages/atif-importer/CHANGELOG.md
+++ b/plugins/packages/atif-importer/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- Import ATIF trajectories and Harbor rollout results through the Kitaru importer contract.
+
+### Release context
+
+- New independently released distribution; not included in the default server catalog. Uses the existing Kitaru 0.24.0 importer contract.

--- a/plugins/packages/atif-importer/README.md
+++ b/plugins/packages/atif-importer/README.md
@@ -1,0 +1,54 @@
+# Kitaru ATIF importer
+
+Development package for importing [Agent Trajectory Interchange Format (ATIF)](https://www.harborframework.com/docs/agents/trajectory-format) JSON and local Harbor rollout outputs. It is not yet published or part of Kitaru's default importer catalog.
+
+## Prepare Harbor outputs locally
+
+From the Kitaru checkout, collect a Harbor job or trial directory into one upload:
+
+```bash
+uv run --project plugins python -m kitaru_atif_importer.harbor /path/to/harbor/job --output /tmp/harbor-import.json
+```
+
+The helper collects `agent/trajectory.json` and `steps/<name>/agent/trajectory.json`, with selected outcome and identity fields from each trial's `result.json`. It excludes Harbor configurations and agent-result metadata, which may contain credentials. Trajectory text is preserved: review it before uploading. Symlinked directories are skipped, symlinked input files are rejected, and referenced media or external trajectories are never read. Output must be a new file. The helper limits input and output to 90 MiB and 10,000 trajectories; select smaller job directories for larger collections.
+
+## Register and test the development importer
+
+After logging into your intended test server, register the self-contained parser script:
+
+```bash
+uv run kitaru importer register dev-atif --server SERVER_URL --provider atif --script plugins/packages/atif-importer/src/kitaru_atif_importer/importer.py --entrypoint parse --display-version dev
+uv run kitaru session import /tmp/harbor-import.json --server SERVER_URL --importer dev-atif@1 --agent AGENT@VERSION --wait
+```
+
+An importer-capable worker must be running for that server. Registration uploads this script only; it does not publish a package. Register a new importer version after changing the script. A standalone ATIF JSON file can replace the bundle in the import command.
+
+## Payload contract
+
+`parse(payload: bytes, params: dict)` yields normalized sessions or isolated record failures. Besides a single ATIF trajectory, it accepts this envelope:
+
+```json
+{
+  "trajectories": [
+    {
+      "source_id": "trial-uuid/agent/trajectory.json",
+      "trajectory": {"schema_version": "ATIF-v1.7", "agent": {"name": "example", "version": "1"}, "steps": [{"step_id": 1, "source": "user", "message": "Solve the task"}]},
+      "harbor_result": {"id": "trial-uuid", "verifier_result": {"rewards": {"reward": 1}}}
+    }
+  ]
+}
+```
+
+Each envelope entry can alternatively be a plain ATIF trajectory. The optional `namespace` parser parameter separates independent collections; use it when source IDs are only unique within a job. The helper prefers Harbor trial IDs and includes the trajectory's relative segment path. It falls back to paths relative to the selected input directory when trial IDs are absent. Reimporting an existing source identity skips it rather than updating it.
+
+## Fidelity and limits
+
+- Each root trajectory becomes a session. Multi-step Harbor trials remain separate sessions with their trial identity and step outcome. Continuation files are not automatically stitched together.
+- Explicit reasoning, tool calls/results, model identity, per-step tokens and recorded costs use Kitaru fields. Structured content, source extras, final metrics and training-specific data remain available as source data.
+- Aggregate or deterministic steps remain spans. Kitaru's native model-call count therefore counts represented individual calls, not every underlying inference in an aggregate step. Copied context retains its evidence without adding historical calls, tokens, or costs again.
+- If no descendant reports a cost and there is no copied context, the recorded final cost is assigned to the trajectory span. Otherwise final metrics remain metadata, so partial or subagent costs are not double-counted. Missing per-step token usage is not reconstructed from totals.
+- Point timestamps do not establish durations. Missing or timezone-naive timestamps do not get invented timezone information.
+- Harbor execution errors are separate from verifier rewards. A zero reward does not mark an otherwise completed execution as failed. Rewards are metadata, not native Kitaru evaluation results.
+- Embedded subagent relationships are retained where supplied. External references and media paths are preserved without fetching their content. Imported transcripts alone do not make a Harbor sandbox replayable.
+
+Local parser tests and clean-wheel checks precede live-server verification. See [plugin development](../../DEVELOPMENT.md) for clean worker and candidate-wheel setup.

--- a/plugins/packages/atif-importer/pyproject.toml
+++ b/plugins/packages/atif-importer/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "kitaru-atif-importer"
+version = "0.1.0"
+description = "ATIF trajectory and Harbor rollout importer for Kitaru."
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.11"
+authors = [{ name = "ZenML GmbH", email = "info@zenml.io" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["ai-agents", "atif", "harbor", "kitaru", "traces"]
+dependencies = ["kitaru>=0.24.0"]
+
+[project.urls]
+Homepage = "https://kitaru.ai"
+Documentation = "https://docs.zenml.io/kitaru/getting-started/import-your-traces"
+Repository = "https://github.com/zenml-io/kitaru"
+Issues = "https://github.com/zenml-io/kitaru/issues"
+Changelog = "https://github.com/zenml-io/kitaru/blob/develop/plugins/packages/atif-importer/CHANGELOG.md"
+
+[build-system]
+requires = ["hatchling==1.32.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/kitaru_atif_importer"]
+
+[tool.kitaru.artifact]
+import-module = "kitaru_atif_importer"

--- a/plugins/packages/atif-importer/src/kitaru_atif_importer/__init__.py
+++ b/plugins/packages/atif-importer/src/kitaru_atif_importer/__init__.py
@@ -1,0 +1,5 @@
+"""Import ATIF trajectory archives into Kitaru."""
+
+from kitaru_atif_importer.importer import parse
+
+__all__ = ["parse"]

--- a/plugins/packages/atif-importer/src/kitaru_atif_importer/harbor.py
+++ b/plugins/packages/atif-importer/src/kitaru_atif_importer/harbor.py
@@ -1,0 +1,158 @@
+"""Collect local Harbor trajectories and selected trial results for import."""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+MAX_BYTES = 90 * 1024 * 1024
+MAX_RECORDS = 10_000
+_RESULT_FIELDS = (
+    "id",
+    "task_name",
+    "trial_name",
+    "task_checksum",
+    "source",
+    "agent_info",
+    "verifier_result",
+    "exception_info",
+    "started_at",
+    "finished_at",
+    "agent_execution",
+)
+
+
+def collect_trajectories(
+    directory: Path, *, max_bytes: int = MAX_BYTES
+) -> dict[str, Any]:
+    """Collect a job or trial directory without following external references.
+
+    Configurations and agent-result metadata are excluded from Harbor results because
+    they can contain credentials. Trajectory content is preserved unchanged.
+    Each multi-step trajectory retains its step outcome and enclosing trial ID.
+
+    Args:
+        directory: Local Harbor job, trial, or collection of jobs.
+        max_bytes: Maximum combined source-file bytes.
+
+    Returns:
+        An envelope accepted by the ATIF parser.
+
+    Raises:
+        ValueError: No trajectories, invalid files, symlinks, or excessive size.
+    """
+    root = directory.resolve()
+    if not root.is_dir():
+        raise ValueError("Harbor input must be a directory")
+    paths: list[Path] = []
+    for parent, directories, files in os.walk(root, followlinks=False):
+        directories[:] = sorted(
+            name for name in directories if not (Path(parent) / name).is_symlink()
+        )
+        if Path(parent).name == "agent" and "trajectory.json" in files:
+            paths.append(Path(parent) / "trajectory.json")
+            if len(paths) > MAX_RECORDS:
+                raise ValueError(f"Harbor record limit exceeded ({MAX_RECORDS})")
+    if not paths:
+        raise ValueError("No agent/trajectory.json files found")
+
+    remaining = max_bytes
+
+    def read_object(path: Path) -> dict[str, Any]:
+        nonlocal remaining
+        if path.is_symlink() or not path.resolve().is_relative_to(root):
+            raise ValueError(f"Refusing symlink or external file: {path.name}")
+        with path.open("rb") as stream:
+            content = stream.read(remaining + 1)
+        remaining -= len(content)
+        if remaining < 0:
+            raise ValueError(f"Harbor source size limit exceeded ({max_bytes} bytes)")
+        try:
+            value = json.loads(content)
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise ValueError(f"Invalid JSON in {path.relative_to(root)}") from exc
+        if not isinstance(value, dict):
+            raise ValueError(f"Expected JSON object in {path.relative_to(root)}")
+        return value
+
+    records: list[dict[str, Any]] = []
+    results: dict[Path, dict[str, Any]] = {}
+    for path in sorted(paths):
+        trajectory = read_object(path)
+        trial = path.parent.parent
+        step_name: str | None = None
+        if trial.parent.name == "steps":
+            step_name = trial.name
+            trial = trial.parent.parent
+        result_path = trial / "result.json"
+        if result_path not in results:
+            results[result_path] = (
+                read_object(result_path) if result_path.exists() else {}
+            )
+        raw_result = results[result_path]
+        result = {key: raw_result[key] for key in _RESULT_FIELDS if key in raw_result}
+        if step_name is not None:
+            matches = [
+                step
+                for step in (raw_result.get("step_results") or [])
+                if isinstance(step, dict) and step.get("step_name") == step_name
+            ]
+            if len(matches) > 1:
+                raise ValueError(f"Duplicate Harbor step result: {step_name}")
+            result["step_name"] = step_name
+            # Trial-level failure/timing must not be attributed to every step.
+            for key in ("exception_info", "verifier_result", "agent_execution"):
+                result.pop(key, None)
+                if matches and key in matches[0]:
+                    result[key] = matches[0][key]
+            result.pop("started_at", None)
+            result.pop("finished_at", None)
+        trial_id = raw_result.get("id")
+        source_id = (
+            f"{trial_id}/{path.relative_to(trial).as_posix()}"
+            if isinstance(trial_id, str) and trial_id
+            else path.relative_to(root).as_posix()
+        )
+        records.append(
+            {
+                "trajectory": trajectory,
+                "harbor_result": result,
+                "source_id": source_id,
+            }
+        )
+    return {"trajectories": records}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Write a Harbor import envelope to a new local file."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        envelope = collect_trajectories(args.directory)
+        content = json.dumps(envelope, ensure_ascii=True, allow_nan=False).encode()
+        if len(content) > MAX_BYTES:
+            raise ValueError(
+                "Serialized bundle exceeds size limit; select fewer trials"
+            )
+        # Exclusive creation protects previous bundles from accidental replacement.
+        descriptor = os.open(args.output, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(content)
+        except OSError:
+            # Remove only a file created by this attempt so a retry can succeed.
+            args.output.unlink(missing_ok=True)
+            raise
+    except (OSError, ValueError) as exc:
+        print(f"Cannot prepare Harbor import: {exc}", file=sys.stderr)
+        return 1
+    print(f"Prepared {len(envelope['trajectories'])} trajectories in {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/packages/atif-importer/src/kitaru_atif_importer/importer.py
+++ b/plugins/packages/atif-importer/src/kitaru_atif_importer/importer.py
@@ -1,0 +1,772 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Import archived ATIF documents without reading referenced files or URLs."""
+
+import hashlib
+import json
+import math
+from collections.abc import Iterator
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+from urllib.parse import quote
+
+from pydantic_core import PydanticSerializationError
+
+from kitaru.api_models.v1.session import SessionCreateRequest, SessionStatus, TokenUsage
+from kitaru.api_models.v1.session_node import NodeStatus, NodeType
+from kitaru.task.importer import (
+    ImportedNode,
+    ImportedSession,
+    ImportFailure,
+    SessionImportError,
+    flatten_nodes,
+)
+
+__all__ = ["parse"]
+
+_MAX_DEPTH = 32
+_TOKEN_FIELDS = {
+    "prompt_tokens": "input_tokens",
+    "completion_tokens": "output_tokens",
+    "cached_tokens": "cached_input_tokens",
+}
+
+
+def _get_object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _get_list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be an array")
+    return value
+
+
+def _get_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a nonempty string")
+    return value
+
+
+def _validate_optional_fields(value: dict[str, Any]) -> None:
+    for key in ("extra",):
+        if value.get(key) is not None:
+            _get_object(value[key], key)
+
+
+def _validate_number(value: Any, label: str, *, integer: bool = False) -> None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{label} must be a number")
+    if integer and not isinstance(value, int):
+        raise ValueError(f"{label} must be an integer")
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(f"{label} must be finite and nonnegative")
+
+
+def _validate_metrics(value: Any, *, final: bool = False) -> None:
+    metrics = _get_object(value, "metrics")
+    _validate_optional_fields(metrics)
+    extra = metrics.get("extra") or {}
+    if extra.get("reasoning_output_tokens") is not None:
+        _validate_number(
+            extra["reasoning_output_tokens"], "reasoning_output_tokens", integer=True
+        )
+    prefix = "total_" if final else ""
+    for key in (*_TOKEN_FIELDS, "steps" if final else "llm_call_count"):
+        name = prefix + key
+        if metrics.get(name) is not None:
+            _validate_number(metrics[name], name, integer=True)
+    if metrics.get(prefix + "cost_usd") is not None:
+        _validate_number(metrics[prefix + "cost_usd"], prefix + "cost_usd")
+    for key in ("prompt_token_ids", "completion_token_ids"):
+        if metrics.get(key) is not None:
+            for token in _get_list(metrics[key], key):
+                _validate_number(token, key, integer=True)
+    if metrics.get("logprobs") is not None:
+        for number in _get_list(metrics["logprobs"], "logprobs"):
+            if (
+                isinstance(number, bool)
+                or not isinstance(number, int | float)
+                or not math.isfinite(number)
+            ):
+                raise ValueError("logprobs must contain finite numbers")
+    prompt, cached = (
+        metrics.get(prefix + "prompt_tokens"),
+        metrics.get(prefix + "cached_tokens"),
+    )
+    if prompt is not None and cached is not None and cached > prompt:
+        raise ValueError("cached_tokens cannot exceed prompt_tokens")
+
+
+def _validate_content(value: Any, label: str, *, nullable: bool = False) -> None:
+    if isinstance(value, str) or (nullable and value is None):
+        return
+    for raw_part in _get_list(value, label):
+        part = _get_object(raw_part, "content part")
+        kind = part.get("type")
+        if kind == "text":
+            if not isinstance(part.get("text"), str) or part.get("source") is not None:
+                raise ValueError("text content requires text and no source")
+        elif kind in {"image", "audio"}:
+            source = _get_object(part.get("source"), "media source")
+            _get_string(source.get("path"), "media source.path")
+            media_type = _get_string(source.get("media_type"), "media_type")
+            if not media_type.lower().strip().startswith(f"{kind}/"):
+                raise ValueError("media_type must match the content type")
+            if part.get("text") is not None:
+                raise ValueError("media content cannot contain text")
+            if source.get("duration_sec") is not None:
+                _validate_number(source["duration_sec"], "duration_sec")
+        else:
+            raise ValueError("content type must be text, image, or audio")
+
+
+def _get_timestamp(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    raw = _get_string(value, "timestamp")
+    try:
+        timestamp = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        raise ValueError("timestamp must be ISO 8601") from None
+    # ATIF permits naive times. Preserve them in metadata, without inventing UTC.
+    return timestamp if timestamp.tzinfo is not None else None
+
+
+def _validate_trajectory(value: Any, depth: int = 0) -> dict[str, Any]:
+    if depth > _MAX_DEPTH:
+        raise ValueError("embedded trajectory nesting exceeds 32 levels")
+    trajectory = _get_object(value, "trajectory")
+    if trajectory.get("schema_version") not in {
+        f"ATIF-v1.{minor}" for minor in range(9)
+    }:
+        raise ValueError("schema_version must be ATIF-v1.0 through ATIF-v1.8")
+    _validate_optional_fields(trajectory)
+    for key in ("session_id", "trajectory_id", "continued_trajectory_ref", "notes"):
+        if trajectory.get(key) is not None and not isinstance(trajectory[key], str):
+            raise ValueError(f"{key} must be a string")
+    agent = _get_object(trajectory.get("agent"), "agent")
+    for key in ("name", "version"):
+        _get_string(agent.get(key), f"agent.{key}")
+    if agent.get("model_name") is not None:
+        _get_string(agent["model_name"], "agent.model_name")
+    _validate_optional_fields(agent)
+    if agent.get("tool_definitions") is not None:
+        for definition in _get_list(agent["tool_definitions"], "tool_definitions"):
+            _get_object(definition, "tool definition")
+    if trajectory.get("final_metrics") is not None:
+        _validate_metrics(trajectory["final_metrics"], final=True)
+    steps = _get_list(trajectory.get("steps"), "steps")
+    if not steps:
+        raise ValueError("steps cannot be empty")
+    for expected_id, raw_step in enumerate(steps, 1):
+        step = _get_object(raw_step, "step")
+        if type(step.get("step_id")) is not int or step["step_id"] != expected_id:
+            raise ValueError("step_id values must be sequential integers starting at 1")
+        source = step.get("source")
+        if source not in {"system", "user", "agent"}:
+            raise ValueError("step source must be system, user, or agent")
+        _validate_content(step.get("message"), "message")
+        _validate_optional_fields(step)
+        _get_timestamp(step.get("timestamp"))
+        for key in ("model_name", "reasoning_content"):
+            if step.get(key) is not None and not isinstance(step[key], str):
+                raise ValueError(f"{key} must be a string")
+        effort = step.get("reasoning_effort")
+        if (
+            effort is not None
+            and not isinstance(effort, str)
+            and (
+                isinstance(effort, bool)
+                or not isinstance(effort, int | float)
+                or not math.isfinite(effort)
+            )
+        ):
+            raise ValueError("reasoning_effort must be a string or finite number")
+        if step.get("is_copied_context") is not None and not isinstance(
+            step["is_copied_context"], bool
+        ):
+            raise ValueError("is_copied_context must be a boolean")
+        count = step.get("llm_call_count")
+        if count is not None:
+            _validate_number(count, "llm_call_count", integer=True)
+        if source != "agent" and any(
+            step.get(key) is not None
+            for key in (
+                "model_name",
+                "reasoning_effort",
+                "reasoning_content",
+                "tool_calls",
+                "metrics",
+            )
+        ):
+            raise ValueError("LLM and tool fields require source agent")
+        if (
+            count == 0
+            and source == "agent"
+            and any(
+                step.get(key) is not None for key in ("metrics", "reasoning_content")
+            )
+        ):
+            raise ValueError(
+                "llm_call_count 0 requires absent metrics and reasoning_content"
+            )
+        if step.get("metrics") is not None:
+            _validate_metrics(step["metrics"])
+        call_ids: set[str] = set()
+        if step.get("tool_calls") is not None:
+            for raw_call in _get_list(step["tool_calls"], "tool_calls"):
+                call = _get_object(raw_call, "tool call")
+                call_id = _get_string(call.get("tool_call_id"), "tool_call_id")
+                if call_id in call_ids:
+                    raise ValueError("tool_call_id values must be unique within a step")
+                call_ids.add(call_id)
+                _get_string(call.get("function_name"), "function_name")
+                _get_object(call.get("arguments"), "tool arguments")
+                _validate_optional_fields(call)
+        if step.get("observation") is not None:
+            observation = _get_object(step["observation"], "observation")
+            _validate_optional_fields(observation)
+            for raw_result in _get_list(
+                observation.get("results"), "observation.results"
+            ):
+                result = _get_object(raw_result, "observation result")
+                source_id = result.get("source_call_id")
+                if source_id is not None and (
+                    not isinstance(source_id, str) or source_id not in call_ids
+                ):
+                    raise ValueError(
+                        "source_call_id must reference a tool call in its step"
+                    )
+                _validate_content(
+                    result.get("content"), "observation content", nullable=True
+                )
+                _validate_optional_fields(result)
+                result_extra = result.get("extra") or {}
+                if result_extra.get(
+                    "tool_result_is_error"
+                ) is not None and not isinstance(
+                    result_extra["tool_result_is_error"], bool
+                ):
+                    raise ValueError("tool_result_is_error must be a boolean")
+                if result.get("subagent_trajectory_ref") is not None:
+                    for raw_ref in _get_list(
+                        result["subagent_trajectory_ref"], "subagent_trajectory_ref"
+                    ):
+                        ref = _get_object(raw_ref, "subagent reference")
+                        _validate_optional_fields(ref)
+                        for key in ("trajectory_id", "trajectory_path", "session_id"):
+                            if ref.get(key) is not None:
+                                _get_string(ref[key], f"subagent reference.{key}")
+                        if not ref.get("trajectory_id") and not ref.get(
+                            "trajectory_path"
+                        ):
+                            raise ValueError(
+                                "subagent reference requires trajectory_id "
+                                "or trajectory_path"
+                            )
+    embedded_ids: set[str] = set()
+    if trajectory.get("subagent_trajectories") is not None:
+        for embedded in _get_list(
+            trajectory["subagent_trajectories"], "subagent_trajectories"
+        ):
+            child = _validate_trajectory(embedded, depth + 1)
+            child_id = _get_string(child.get("trajectory_id"), "embedded trajectory_id")
+            if child_id in embedded_ids:
+                raise ValueError("embedded trajectory_id values must be unique")
+            embedded_ids.add(child_id)
+    return trajectory
+
+
+def _get_text_selector(content: Any, prefix: str) -> str | None:
+    if isinstance(content, str):
+        return prefix
+    if isinstance(content, list):
+        for index, part in enumerate(content):
+            if isinstance(part, dict) and part.get("type") == "text":
+                return f"{prefix}/{index}/text"
+    return None
+
+
+def _get_document_metadata(trajectory: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in trajectory.items()
+        if key not in {"steps", "subagent_trajectories"}
+    }
+
+
+def _get_argument_selector(arguments: dict[str, Any]) -> str | None:
+    """Select a named text input, or the sole scalar text argument."""
+    keys = ["command", "query", "input", "text", "prompt", "code"]
+    if len(arguments) == 1:
+        keys.extend(arguments)
+    for key in keys:
+        if isinstance(arguments.get(key), str):
+            return "/" + key.replace("~", "~0").replace("/", "~1")
+    return None
+
+
+def _get_subagent_id(value: str | None) -> str | None:
+    """Fit native subagent identity storage while retaining raw IDs in metadata."""
+    if value is not None and len(value) > 255:
+        return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return value
+
+
+def _apply_final_cost_fallback(root: ImportedNode, trajectory: dict[str, Any]) -> None:
+    """Use a reported total only when it cannot duplicate known execution costs."""
+    total_cost = (trajectory.get("final_metrics") or {}).get("total_cost_usd")
+    if total_cost is None:
+        return
+    documents = [trajectory]
+    while documents:
+        document = documents.pop()
+        if any(step.get("is_copied_context") is True for step in document["steps"]):
+            return
+        documents.extend(document.get("subagent_trajectories") or [])
+    nodes = [root]
+    while nodes:
+        node = nodes.pop()
+        if node.cost is not None:
+            return
+        nodes.extend(node.children)
+    root.cost = Decimal(str(total_cost))
+    root.metadata["normalization"] = {
+        "cost": "final_metrics fallback, no per-step costs reported"
+    }
+
+
+def _build_trajectory_node(trajectory: dict[str, Any], key: str) -> ImportedNode:
+    agent = trajectory["agent"]
+    root = ImportedNode(
+        node_type=NodeType.SPAN,
+        name=agent["name"],
+        external_id=key,
+        status=NodeStatus.COMPLETED,
+        inputs=None,
+        outputs=None,
+        attributes={},
+        metadata={"atif": _get_document_metadata(trajectory)},
+    )
+    embedded = {
+        child["trajectory_id"]: child
+        for child in trajectory.get("subagent_trajectories") or []
+    }
+    attached: set[str] = set()
+    previous: dict[str, Any] | None = None
+    for step in trajectory["steps"]:
+        step_key = f"{key}/step/{step['step_id']}"
+        count = step.get("llm_call_count")
+        copied = step.get("is_copied_context") is True
+        is_model = step["source"] == "agent" and count in (None, 1) and not copied
+        raw_metrics = step.get("metrics") or {}
+        tokens = {
+            target: raw_metrics[source]
+            for source, target in _TOKEN_FIELDS.items()
+            if raw_metrics.get(source) is not None
+        }
+        reasoning_tokens = (raw_metrics.get("extra") or {}).get(
+            "reasoning_output_tokens"
+        )
+        if reasoning_tokens is not None:
+            tokens["reasoning_tokens"] = reasoning_tokens
+        metadata = {
+            "atif": {
+                field: value
+                for field, value in step.items()
+                if field not in {"message", "tool_calls", "observation"}
+            }
+        }
+        if step["source"] == "agent" and count is None:
+            metadata["normalization"] = {
+                "llm_call_count": "unreported; displayed as one model step"
+            }
+        if copied:
+            metadata["normalization"] = {
+                "execution": "copied context; not counted as new execution"
+            }
+        inputs = (
+            {
+                "previous_step_id": previous["step_id"],
+                "message": previous["message"],
+                **(
+                    {"observation": previous["observation"]}
+                    if previous.get("observation") is not None
+                    else {}
+                ),
+            }
+            if previous is not None and step["source"] == "agent"
+            else None
+        )
+        outputs: dict[str, Any] = {"message": step["message"]}
+        if step.get("tool_calls") is not None:
+            outputs["tool_calls"] = step["tool_calls"]
+        observation = step.get("observation") or {}
+        results = observation.get("results") or []
+        grouped_results: dict[str | None, list[dict[str, Any]]] = {}
+        for result in results:
+            grouped_results.setdefault(result.get("source_call_id"), []).append(result)
+        unbound = grouped_results.get(None, [])
+        if unbound:
+            outputs["observation"] = {"results": unbound}
+        observation_metadata = {
+            field: value for field, value in observation.items() if field != "results"
+        }
+        if observation_metadata:
+            metadata["observation"] = observation_metadata
+        node = ImportedNode(
+            external_id=step_key,
+            node_type=NodeType.LLM_CALL if is_model else NodeType.SPAN,
+            name=f"{step['source']} step {step['step_id']}",
+            status=NodeStatus.COMPLETED,
+            started_at=_get_timestamp(step.get("timestamp")),
+            inputs=inputs,
+            input_text_selector=_get_text_selector(inputs["message"], "/message")
+            if inputs
+            else None,
+            system_prompt_selector=(
+                _get_text_selector(previous["message"], "/message")
+                if inputs and previous and previous["source"] == "system"
+                else None
+            ),
+            outputs=outputs,
+            output_text_selector=_get_text_selector(step["message"], "/message"),
+            reasoning=step.get("reasoning_content"),
+            model=(step.get("model_name") or agent.get("model_name"))
+            if step["source"] == "agent" and count != 0
+            else None,
+            tokens=TokenUsage(**tokens) if tokens and not copied else None,
+            cost=Decimal(str(raw_metrics["cost_usd"]))
+            if raw_metrics.get("cost_usd") is not None and not copied
+            else None,
+            attributes={},
+            metadata=metadata,
+        )
+        tool_nodes: dict[str, ImportedNode] = {}
+        for call in step.get("tool_calls") or []:
+            matching = grouped_results.get(call["tool_call_id"], [])
+            failed = any(
+                (result.get("extra") or {}).get("tool_result_is_error") is True
+                for result in matching
+            )
+            tool = ImportedNode(
+                external_id=f"{step_key}/tool/{quote(call['tool_call_id'], safe='')}",
+                node_type=NodeType.SPAN if copied else NodeType.TOOL_CALL,
+                name=call["function_name"],
+                tool_name=call["function_name"],
+                status=NodeStatus.FAILED
+                if failed
+                else NodeStatus.COMPLETED
+                if matching
+                else NodeStatus.IN_PROGRESS,
+                error="ATIF observation reports tool_result_is_error"
+                if failed
+                else None,
+                inputs=call["arguments"],
+                input_text_selector=_get_argument_selector(call["arguments"]),
+                outputs={"results": matching},
+                output_text_selector=next(
+                    (
+                        selector
+                        for index, result in enumerate(matching)
+                        if (
+                            selector := _get_text_selector(
+                                result.get("content"), f"/results/{index}/content"
+                            )
+                        )
+                        is not None
+                    ),
+                    None,
+                ),
+                attributes={},
+                metadata={
+                    "atif": {
+                        field: value
+                        for field, value in call.items()
+                        if field != "arguments"
+                    },
+                    "status_source": "tool_result_is_error"
+                    if failed
+                    else "observation_present"
+                    if matching
+                    else "missing_observation",
+                    "is_copied_context": copied,
+                },
+            )
+            node.children.append(tool)
+            tool_nodes[call["tool_call_id"]] = tool
+        for result_index, result in enumerate(results):
+            parent = tool_nodes.get(result.get("source_call_id"), node)
+            for ref_index, ref in enumerate(
+                result.get("subagent_trajectory_ref") or []
+            ):
+                target_id = ref.get("trajectory_id")
+                target = (
+                    embedded.get(target_id) if not ref.get("trajectory_path") else None
+                )
+                subagent = ImportedNode(
+                    external_id=f"{step_key}/observation/{result_index}/subagent/{ref_index}",
+                    node_type=NodeType.SPAN if copied else NodeType.SUBAGENT_CALL,
+                    name=target["agent"]["name"] if target else "Referenced subagent",
+                    subagent_id=_get_subagent_id(target_id or ref.get("session_id")),
+                    status=NodeStatus.COMPLETED,
+                    inputs=None,
+                    outputs=None,
+                    attributes={},
+                    metadata={"atif": ref, "resolution": "external_or_unresolved"},
+                )
+                if copied:
+                    subagent.metadata["resolution"] = "copied_context"
+                elif target is not None and target_id not in attached:
+                    attached.add(target_id)
+                    subagent.metadata["resolution"] = "embedded"
+                    subagent.children.append(
+                        _build_trajectory_node(
+                            target, f"{key}/trajectory/{quote(target_id, safe='')}"
+                        )
+                    )
+                elif target is not None and target_id in attached:
+                    subagent.metadata["resolution"] = "already_imported"
+                parent.children.append(subagent)
+        root.children.append(node)
+        previous = step
+    unreferenced = [
+        child for child_id, child in embedded.items() if child_id not in attached
+    ]
+    if unreferenced:
+        root.metadata["unreferenced_subagent_trajectories"] = unreferenced
+    _apply_final_cost_fallback(root, trajectory)
+    return root
+
+
+def _get_external_id(
+    trajectory: dict[str, Any], source_id: str | None, namespace: str | None
+) -> str:
+    if source_id is not None:
+        identity = source_id
+    elif trajectory.get("trajectory_id"):
+        identity = trajectory["trajectory_id"]
+    else:
+        canonical = json.dumps(
+            trajectory,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+        digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        identity = f"{trajectory.get('session_id') or 'atif'}:sha256:{digest}"
+    # Encode both components, so separators in a namespace cannot cause collisions.
+    return (
+        json.dumps([namespace, identity], ensure_ascii=True, separators=(",", ":"))
+        if namespace is not None
+        else identity
+    )
+
+
+def _build_session(record: Any, namespace: str | None) -> ImportedSession:
+    value = _get_object(record, "record")
+    source_id = None
+    harbor = None
+    if "trajectory" in value:
+        unknown = value.keys() - {"trajectory", "source_id", "harbor_result"}
+        if unknown:
+            raise ValueError("trajectory envelope contains unsupported fields")
+        if value.get("source_id") is not None:
+            source_id = _get_string(value["source_id"], "source_id")
+        if value.get("harbor_result") is not None:
+            harbor = _get_object(value["harbor_result"], "harbor_result")
+        value = value["trajectory"]
+    trajectory = _validate_trajectory(value)
+    external_id = _get_external_id(trajectory, source_id, namespace)
+    root = _build_trajectory_node(trajectory, external_id)
+    messages = [
+        {
+            "step_id": step["step_id"],
+            "source": step["source"],
+            "message": step["message"],
+        }
+        for step in trajectory["steps"]
+        if step["source"] in {"user", "system"}
+    ]
+    input_selector = next(
+        (
+            selector
+            for index, message in enumerate(messages)
+            if message["source"] == "user"
+            and (
+                selector := _get_text_selector(
+                    message["message"], f"/messages/{index}/message"
+                )
+            )
+            is not None
+        ),
+        None,
+    )
+    last_agent = next(
+        (step for step in reversed(trajectory["steps"]) if step["source"] == "agent"),
+        None,
+    )
+    outputs = {"message": last_agent["message"]} if last_agent else None
+    metadata: dict[str, Any] = {
+        "atif": _get_document_metadata(trajectory),
+        "normalization": {
+            "status": (
+                "archived trajectory treated as completed unless Harbor "
+                "reports an exception"
+            ),
+            "model_inputs": (
+                "immediately preceding source step only; complete provider "
+                "prompts are not reconstructed"
+            ),
+            "metrics": (
+                "per-step reported usage; final cost used only without descendant "
+                "costs or copied context; all final_metrics retained as metadata"
+            ),
+            "timestamps": (
+                "aware step timestamps are event starts; naive values retained "
+                "in metadata; session times from Harbor agent_execution only"
+            ),
+            "media": "references preserved without opening files or URLs",
+            "copied_context": (
+                "historical steps remain spans with raw usage in metadata; "
+                "no new model, tool, or subagent execution is counted"
+            ),
+        },
+    }
+    if "normalization" in root.metadata:
+        metadata["normalization"].update(root.metadata["normalization"])
+    if source_id is not None:
+        metadata["source_id"] = source_id
+    if namespace is not None:
+        metadata["namespace"] = namespace
+    error = None
+    started_at = ended_at = None
+    if harbor is not None:
+        metadata["harbor_result"] = harbor
+        if harbor.get("agent_execution") is not None:
+            execution = _get_object(harbor["agent_execution"], "agent_execution")
+            started_at = _get_timestamp(execution.get("started_at"))
+            ended_at = _get_timestamp(execution.get("finished_at"))
+            if (
+                started_at is not None
+                and ended_at is not None
+                and ended_at < started_at
+            ):
+                raise ValueError("agent_execution finished_at precedes started_at")
+        exception = harbor.get("exception_info")
+        if exception is not None:
+            exception = _get_object(exception, "harbor_result.exception_info")
+            error = (
+                exception.get("exception_message")
+                or exception.get("exception_type")
+                or "Harbor reported an exception"
+            )
+            if not isinstance(error, str):
+                raise ValueError("Harbor exception message/type must be a string")
+    root.status = NodeStatus.FAILED if error else NodeStatus.COMPLETED
+    root.error = error
+    root.started_at = started_at
+    root.ended_at = ended_at
+    return ImportedSession(
+        external_id=external_id,
+        name=trajectory["agent"]["name"],
+        status=SessionStatus.FAILED if error else SessionStatus.COMPLETED,
+        error=error,
+        started_at=started_at,
+        ended_at=ended_at,
+        framework="harbor" if harbor is not None else None,
+        inputs={"messages": messages},
+        input_text_selector=input_selector,
+        outputs=outputs,
+        output_text_selector=_get_text_selector(last_agent["message"], "/message")
+        if last_agent
+        else None,
+        metadata=metadata,
+        nodes=[root],
+    )
+
+
+def parse(
+    payload: bytes, params: dict[str, Any]
+) -> Iterator[ImportedSession | ImportFailure]:
+    """Parse one ATIF JSON document or a ``trajectories`` batch envelope.
+
+    Args:
+        payload: UTF-8 JSON bytes. Batch entries may be ATIF documents or objects
+            with trajectory, optional harbor_result, and optional stable source_id.
+        params: Optional namespace string used to scope source identities.
+
+    Yields:
+        One session per document, or an isolated failure for each invalid record.
+    """
+    try:
+        _get_object(params, "params")
+        if params.keys() - {"namespace"}:
+            raise ValueError("only the namespace parameter is supported")
+        namespace = params.get("namespace")
+        if "namespace" in params:
+            namespace = _get_string(namespace, "namespace")
+        decoded = json.loads(payload.decode("utf-8"))
+        top = _get_object(decoded, "payload")
+        if "trajectories" in top:
+            if top.keys() - {"trajectories"}:
+                raise ValueError("batch envelope contains unsupported fields")
+            records = _get_list(top["trajectories"], "trajectories")
+            if not records:
+                raise ValueError("trajectories cannot be empty")
+        else:
+            records = [top]
+    except (ValueError, TypeError, UnicodeError, RecursionError) as exc:
+        yield ImportFailure(line=1, error=f"Invalid ATIF payload: {exc}")
+        return
+    for line, record in enumerate(records, 1):
+        external_id = None
+        try:
+            # Reject NaN/Infinity even in opaque extras and Harbor evidence.
+            json.dumps(record, allow_nan=False, ensure_ascii=False).encode("utf-8")
+            session = _build_session(record, namespace)
+            external_id = session.external_id
+            SessionCreateRequest.model_validate(
+                session.model_dump(exclude={"nodes"})
+                | {"origin": "imported", "imported_from": "atif"}
+            ).model_dump_json()
+            for request in flatten_nodes(session.nodes):
+                request.model_dump_json()
+            session.model_dump_json()
+            yield session
+        except (
+            ValueError,
+            TypeError,
+            OverflowError,
+            RecursionError,
+            UnicodeError,
+            SessionImportError,
+            PydanticSerializationError,
+        ) as exc:
+            yield ImportFailure(
+                line=line,
+                external_id=external_id,
+                error=f"Invalid ATIF trajectory: {exc}".encode(
+                    "utf-8", errors="backslashreplace"
+                ).decode("utf-8"),
+            )

--- a/plugins/pyproject.toml
+++ b/plugins/pyproject.toml
@@ -6,6 +6,7 @@ members = ["packages/*"]
 
 [tool.uv.sources]
 kitaru = { path = "..", editable = true }
+kitaru-atif-importer = { workspace = true }
 kitaru-claude-agent-sdk = { workspace = true }
 kitaru-braintrust-importer = { workspace = true }
 kitaru-langfuse-importer = { workspace = true }
@@ -21,6 +22,7 @@ kitaru-pydantic-ai = { workspace = true }
 [dependency-groups]
 dev = [
     "kitaru[server]",
+    "kitaru-atif-importer",
     "kitaru-claude-agent-sdk",
     "kitaru-braintrust-importer[adapter]",
     "kitaru-langfuse-importer[adapter]",
@@ -53,6 +55,7 @@ convention = "google"
 [tool.ruff.lint.isort]
 known-first-party = [
     "kitaru",
+    "kitaru_atif_importer",
     "kitaru_claude_agent_sdk",
     "kitaru_evaluator",
     "kitaru_braintrust_importer",

--- a/plugins/tests/importers/test_atif.py
+++ b/plugins/tests/importers/test_atif.py
@@ -1,0 +1,674 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#  or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Synthetic ATIF contracts informed by Harbor v1.7 trajectory exports."""
+
+import json
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from kitaru.api_models.v1.imports import ImportFailure
+from kitaru.api_models.v1.session import SessionStatus
+from kitaru.api_models.v1.session_node import NodeStatus, NodeType
+from kitaru.task.importer import ImportedSession, flatten_nodes
+from kitaru_atif_importer import parse
+
+
+def _trajectory() -> dict[str, Any]:
+    """Build a small trajectory without private benchmark content."""
+    return {
+        "schema_version": "ATIF-v1.7",
+        "session_id": "session-fixture",
+        "agent": {
+            "name": "fixture-agent",
+            "version": "1.0",
+            "model_name": "fixture-model",
+            "extra": {"condition": "synthetic"},
+        },
+        "steps": [
+            {"step_id": 1, "source": "system", "message": "Answer briefly."},
+            {"step_id": 2, "source": "user", "message": "Read the sample."},
+            {
+                "step_id": 3,
+                "source": "agent",
+                "message": "I will read the sample.",
+                "reasoning_content": "The sample contains the answer.",
+                "model_name": "step-model",
+                "llm_call_count": 1,
+                "tool_calls": [
+                    {
+                        "tool_call_id": "call-read",
+                        "function_name": "read_file",
+                        "arguments": {"path": "sample.txt"},
+                        "extra": {"raw_arguments": '{"path":"sample.txt"}'},
+                    }
+                ],
+                "observation": {
+                    "results": [
+                        {
+                            "source_call_id": "call-read",
+                            "content": "The sample says hello.",
+                            "extra": {"tool_result_is_error": False},
+                        }
+                    ]
+                },
+                "metrics": {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 8,
+                    "cached_tokens": 5,
+                    "cost_usd": 0.002,
+                    "extra": {"reasoning_output_tokens": 3},
+                },
+                "extra": {"api_call_id": "api-synthetic", "custom": [1, 2]},
+            },
+            {
+                "step_id": 4,
+                "source": "agent",
+                "message": "Hello.",
+                "llm_call_count": 1,
+            },
+        ],
+        "final_metrics": {
+            "total_prompt_tokens": 20,
+            "total_completion_tokens": 8,
+            "total_cached_tokens": 5,
+            "total_cost_usd": 0.002,
+            "total_steps": 4,
+        },
+        "extra": {"benchmark": "synthetic"},
+    }
+
+
+def _parse_session(
+    value: dict[str, Any], params: dict[str, Any] | None = None
+) -> ImportedSession:
+    """Require exactly one successfully parsed session."""
+    items = list(parse(json.dumps(value).encode(), params or {}))
+    assert len(items) == 1
+    assert isinstance(items[0], ImportedSession), items[0]
+    return items[0]
+
+
+def test_maps_messages_tools_results_and_reasoning() -> None:
+    """Expose readable conversation and link each tool to its generating step."""
+    source = _trajectory()
+    session = _parse_session(source)
+    nodes = flatten_nodes(session.nodes)
+    model = next(node for node in nodes if node.reasoning is not None)
+    tool = next(node for node in nodes if node.node_type is NodeType.TOOL_CALL)
+
+    assert session.status is SessionStatus.COMPLETED
+    assert session.inputs["messages"] == [
+        {"source": "system", "step_id": 1, "message": "Answer briefly."},
+        {"source": "user", "step_id": 2, "message": "Read the sample."},
+    ]
+    assert session.outputs["message"] == "Hello."
+    assert model.node_type is NodeType.LLM_CALL
+    assert model.model == "step-model"
+    assert model.reasoning == "The sample contains the answer."
+    assert model.outputs["message"] == source["steps"][2]["message"]
+    assert model.outputs["tool_calls"] == source["steps"][2]["tool_calls"]
+    assert tool.parent_index == model.index
+    assert tool.tool_name == "read_file"
+    assert tool.inputs == {"path": "sample.txt"}
+    assert tool.outputs["results"] == source["steps"][2]["observation"]["results"]
+    assert tool.status is NodeStatus.COMPLETED
+
+
+def test_preserves_source_extras_and_token_ids_without_double_counting() -> None:
+    """Keep source-only metrics while counting usage on the measured step once."""
+    source = _trajectory()
+    source["steps"][2]["metrics"]["prompt_token_ids"] = [10, 20]
+    source["steps"][2]["metrics"]["completion_token_ids"] = [30, 40]
+    source["steps"][2]["metrics"]["extra"]["cache_creation_input_tokens"] = 2
+    session = _parse_session(source)
+    nodes = flatten_nodes(session.nodes)
+    measured = [node for node in nodes if node.tokens is not None]
+
+    assert len(measured) == 1
+    model = measured[0]
+    assert model.tokens is not None
+    assert model.tokens.input_tokens == 20
+    assert model.tokens.output_tokens == 8
+    assert model.tokens.cached_input_tokens == 5
+    assert model.tokens.reasoning_tokens == 3
+    assert model.cost == Decimal("0.002")
+    assert model.metadata["atif"]["metrics"] == source["steps"][2]["metrics"]
+    assert model.metadata["atif"]["extra"] == source["steps"][2]["extra"]
+    assert session.metadata["atif"]["extra"] == source["extra"]
+    assert session.metadata["atif"]["final_metrics"] == source["final_metrics"]
+    session.model_dump_json()
+
+
+def test_does_not_invent_timing_when_timestamps_are_missing() -> None:
+    """A valid untimed source does not become a zero-duration trace."""
+    session = _parse_session(_trajectory())
+
+    assert session.started_at is None
+    assert session.ended_at is None
+    assert all(
+        node.started_at is None and node.ended_at is None
+        for node in flatten_nodes(session.nodes)
+    )
+
+
+def test_final_cost_is_used_when_no_step_reports_cost() -> None:
+    """Keep Claude-style total cost when the source has no per-step cost values."""
+    source = _trajectory()
+    source["steps"][2]["metrics"].pop("cost_usd")
+    session = _parse_session(source)
+    nodes = flatten_nodes(session.nodes)
+    costs = [node.cost for node in nodes if node.cost is not None]
+
+    assert costs == [Decimal("0.002")]
+    assert nodes[0].cost == Decimal("0.002")
+    assert "final_metrics" in session.metadata["normalization"]["cost"]
+
+
+@pytest.mark.parametrize("step_cost", [0, 0.001])
+def test_partial_step_cost_prevents_adding_final_total(step_cost: float) -> None:
+    """Even a reported zero cost prevents a second aggregate cost contribution."""
+    source = _trajectory()
+    source["steps"][2]["metrics"]["cost_usd"] = step_cost
+    source["final_metrics"]["total_cost_usd"] = 0.5
+    nodes = flatten_nodes(_parse_session(source).nodes)
+
+    assert nodes[0].cost is None
+    assert sum(node.cost for node in nodes if node.cost is not None) == Decimal(
+        str(step_cost)
+    )
+
+
+def test_child_final_cost_fallback_prevents_parent_total_double_counting() -> None:
+    """A child's recorded cost total contributes once to the imported session."""
+    source = _trajectory()
+    source["schema_version"] = "ATIF-v1.8"
+    source["steps"][2]["metrics"].pop("cost_usd")
+    source["final_metrics"]["total_cost_usd"] = 0.5
+    child = _trajectory()
+    child["trajectory_id"] = "child"
+    child["steps"][2]["metrics"].pop("cost_usd")
+    source["subagent_trajectories"] = [child]
+    result = source["steps"][2]["observation"]["results"][0]
+    result["subagent_trajectory_ref"] = [{"trajectory_id": "child"}]
+    nodes = flatten_nodes(_parse_session(source).nodes)
+
+    assert nodes[0].cost is None
+    assert [node.cost for node in nodes if node.cost is not None] == [Decimal("0.002")]
+
+
+@pytest.mark.parametrize("copied_in_child", [False, True])
+def test_copied_context_suppresses_ambiguous_final_cost(copied_in_child: bool) -> None:
+    """Do not count a source total that may include copied historical execution."""
+    source = _trajectory()
+    source["schema_version"] = "ATIF-v1.8"
+    source["steps"][2]["metrics"].pop("cost_usd")
+    if copied_in_child:
+        child = _trajectory()
+        child["trajectory_id"] = "child"
+        child["steps"][2]["is_copied_context"] = True
+        source["subagent_trajectories"] = [child]
+        result = source["steps"][2]["observation"]["results"][0]
+        result["subagent_trajectory_ref"] = [{"trajectory_id": "child"}]
+    else:
+        source["steps"][2]["is_copied_context"] = True
+    session = _parse_session(source)
+
+    assert all(node.cost is None for node in flatten_nodes(session.nodes))
+    assert session.metadata["atif"]["final_metrics"]["total_cost_usd"] == 0.002
+
+
+def test_step_timestamp_does_not_imply_model_or_tool_duration() -> None:
+    """Keep ATIF's event timestamp without treating it as a timed span."""
+    source = _trajectory()
+    source["steps"][2]["timestamp"] = "2026-09-10T10:00:00Z"
+    session = _parse_session(source)
+    model = next(node for node in flatten_nodes(session.nodes) if node.reasoning)
+
+    assert model.metadata["atif"]["timestamp"] == "2026-09-10T10:00:00Z"
+    assert model.ended_at is None
+
+
+@pytest.mark.parametrize("count", [2, 4])
+def test_aggregate_agent_steps_are_not_counted_as_one_model_call(count: int) -> None:
+    """Preserve an agent step that represents zero or multiple model requests."""
+    source = _trajectory()
+    source["steps"][2]["llm_call_count"] = count
+    session = _parse_session(source)
+    step = next(node for node in flatten_nodes(session.nodes) if node.reasoning)
+
+    assert step.node_type is NodeType.SPAN
+    assert step.metadata["atif"]["llm_call_count"] == count
+
+
+def test_zero_call_agent_step_has_no_invented_model_usage() -> None:
+    """A local agent action does not imply a model call."""
+    source = _trajectory()
+    source["steps"][2]["llm_call_count"] = 0
+    source["steps"][2].pop("metrics")
+    source["steps"][2].pop("reasoning_content")
+    session = _parse_session(source)
+    nodes = flatten_nodes(session.nodes)
+    tool = next(node for node in nodes if node.node_type is NodeType.TOOL_CALL)
+    step = next(node for node in nodes if node.index == tool.parent_index)
+
+    assert step.node_type is NodeType.SPAN
+    assert step.model is None
+    assert step.tokens is None
+    assert step.cost is None
+
+
+def test_absent_call_count_records_model_step_convention() -> None:
+    """Older sources retain the importer convention as visible provenance."""
+    source = _trajectory()
+    source["steps"][2].pop("llm_call_count")
+    session = _parse_session(source)
+    model = next(node for node in flatten_nodes(session.nodes) if node.reasoning)
+
+    assert model.node_type is NodeType.LLM_CALL
+    assert "llm_call_count" in model.metadata["normalization"]
+
+
+def test_explicit_tool_error_does_not_mark_whole_session_failed() -> None:
+    """An agent may recover from a tool failure and still complete normally."""
+    source = _trajectory()
+    result = source["steps"][2]["observation"]["results"][0]
+    result["extra"]["tool_result_is_error"] = True
+    result["content"] = "The sample file was unavailable."
+    session = _parse_session(source)
+    tool = next(
+        node
+        for node in flatten_nodes(session.nodes)
+        if node.node_type is NodeType.TOOL_CALL
+    )
+
+    assert tool.status is NodeStatus.FAILED
+    assert session.status is SessionStatus.COMPLETED
+
+
+@pytest.mark.parametrize("reward", [0, 1])
+def test_verifier_reward_does_not_change_execution_status(reward: int) -> None:
+    """An unsuccessful benchmark answer still represents a completed run."""
+    result = {"verifier_result": {"rewards": {"reward": reward}}}
+    session = _parse_session(
+        {"trajectories": [{"trajectory": _trajectory(), "harbor_result": result}]}
+    )
+
+    assert session.status is SessionStatus.COMPLETED
+    assert session.error is None
+    assert session.metadata["harbor_result"] == result
+
+
+def test_harbor_exception_marks_execution_failed_and_keeps_reward() -> None:
+    """Execution exceptions are independent of the benchmark's reward value."""
+    result = {
+        "verifier_result": {"rewards": {"reward": 1}},
+        "exception_info": {
+            "exception_type": "AgentTimeoutError",
+            "exception_message": "The fixture exceeded its time budget.",
+            "exception_traceback": "synthetic traceback",
+        },
+    }
+    session = _parse_session(
+        {"trajectories": [{"trajectory": _trajectory(), "harbor_result": result}]}
+    )
+
+    assert session.status is SessionStatus.FAILED
+    assert session.error is not None
+    assert "time budget" in session.error
+    assert session.metadata["harbor_result"] == result
+
+
+def test_document_identity_is_deterministic_and_distinguishes_continuations() -> None:
+    """Two documents sharing a conversation ID must not silently deduplicate."""
+    source = _trajectory()
+    reordered = dict(reversed(list(source.items())))
+    continuation = _trajectory()
+    continuation["steps"][-1]["message"] = "A later answer."
+
+    first = _parse_session(source)
+    assert first.external_id == _parse_session(reordered).external_id
+    assert first.external_id != _parse_session(continuation).external_id
+    assert (
+        first.external_id != _parse_session(source, {"namespace": "other"}).external_id
+    )
+
+
+def test_trial_source_id_preserves_identity_when_harbor_result_is_added() -> None:
+    """A stable trial-relative source ID identifies one evolving trial artifact."""
+    entry = {"trajectory": _trajectory(), "source_id": "job/trial"}
+    first = _parse_session({"trajectories": [entry]})
+    entry["harbor_result"] = {"verifier_result": {"rewards": {"reward": 0}}}
+
+    assert first.external_id == _parse_session({"trajectories": [entry]}).external_id
+    entry["source_id"] = "job/other-trial"
+    assert first.external_id != _parse_session({"trajectories": [entry]}).external_id
+
+
+def test_batch_isolates_invalid_records_in_source_order() -> None:
+    """Keep valid plain and wrapped entries around a malformed trajectory."""
+    invalid = _trajectory()
+    invalid["steps"][2]["step_id"] = 2
+    payload = {"trajectories": [_trajectory(), invalid, {"trajectory": _trajectory()}]}
+    items = list(parse(json.dumps(payload).encode(), {}))
+
+    assert [type(item) for item in items] == [
+        ImportedSession,
+        ImportFailure,
+        ImportedSession,
+    ]
+    assert isinstance(items[1], ImportFailure)
+    assert items[1].line == 2
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("prompt_tokens", -1),
+        ("completion_tokens", True),
+        ("cached_tokens", "invalid"),
+        ("cost_usd", -0.1),
+        ("cost_usd", float("nan")),
+        ("cost_usd", float("inf")),
+    ],
+)
+def test_invalid_metrics_fail_only_the_affected_record(field: str, value: Any) -> None:
+    """Prevent malformed numeric data from escaping into ingest requests."""
+    invalid = _trajectory()
+    invalid["steps"][2]["metrics"][field] = value
+    items = list(
+        parse(json.dumps({"trajectories": [invalid, _trajectory()]}).encode(), {})
+    )
+
+    assert [type(item) for item in items] == [ImportFailure, ImportedSession]
+    for item in items:
+        item.model_dump_json()
+
+
+@pytest.mark.parametrize("value", ["broken\ud800", float("nan"), float("inf")])
+def test_unserializable_source_extras_fail_locally(value: Any) -> None:
+    """Source metadata must survive JSON serialization before a session is yielded."""
+    invalid = _trajectory()
+    invalid["extra"]["invalid"] = value
+    items = list(
+        parse(json.dumps({"trajectories": [invalid, _trajectory()]}).encode(), {})
+    )
+
+    assert [type(item) for item in items] == [ImportFailure, ImportedSession]
+    for item in items:
+        item.model_dump_json()
+
+
+def test_unmatched_tool_result_fails_only_its_trajectory() -> None:
+    """Do not attach a result to an unrelated or absent tool call."""
+    invalid = _trajectory()
+    invalid["steps"][2]["observation"]["results"][0]["source_call_id"] = "missing"
+    items = list(
+        parse(json.dumps({"trajectories": [invalid, _trajectory()]}).encode(), {})
+    )
+
+    assert [type(item) for item in items] == [ImportFailure, ImportedSession]
+
+
+def test_embedded_subagent_is_attached_to_its_explicit_reference() -> None:
+    """Nested documents become nodes only at a recorded delegation reference."""
+    source = _trajectory()
+    source["schema_version"] = "ATIF-v1.8"
+    child = _trajectory()
+    child["trajectory_id"] = "child"
+    child["agent"]["name"] = "child-agent"
+    source["subagent_trajectories"] = [child]
+    result = source["steps"][2]["observation"]["results"][0]
+    result["subagent_trajectory_ref"] = [{"trajectory_id": "child"}]
+    session = _parse_session(source)
+    nodes = flatten_nodes(session.nodes)
+    call = next(node for node in nodes if node.node_type is NodeType.SUBAGENT_CALL)
+    parent = next(node for node in nodes if node.index == call.parent_index)
+    child_root = next(node for node in nodes if node.parent_index == call.index)
+
+    assert call.subagent_id == "child"
+    assert parent.node_type is NodeType.TOOL_CALL
+    assert child_root.name == "child-agent"
+    assert call.metadata["resolution"] == "embedded"
+    assert len({node.external_id for node in nodes}) == len(nodes)
+    assert sum(node.tokens.input_tokens or 0 for node in nodes if node.tokens) == 40
+
+
+def test_repeated_embedded_reference_does_not_double_count_child_usage() -> None:
+    """A second reference to one embedded document does not import its steps twice."""
+    source = _trajectory()
+    source["schema_version"] = "ATIF-v1.8"
+    child = _trajectory()
+    child["trajectory_id"] = "child"
+    source["subagent_trajectories"] = [child]
+    result = source["steps"][2]["observation"]["results"][0]
+    result["subagent_trajectory_ref"] = [
+        {"trajectory_id": "child"},
+        {"trajectory_id": "child"},
+    ]
+    nodes = flatten_nodes(_parse_session(source).nodes)
+
+    assert sum(node.node_type is NodeType.SUBAGENT_CALL for node in nodes) == 2
+    assert sum(node.tokens.input_tokens or 0 for node in nodes if node.tokens) == 40
+
+
+def test_source_identifiers_cannot_collide_with_generated_node_paths() -> None:
+    """A trajectory ID containing node-path syntax must remain a distinct ID."""
+    source = _trajectory()
+    source["schema_version"] = "ATIF-v1.8"
+    children = []
+    for trajectory_id in ("child", "child/step/1"):
+        child = _trajectory()
+        child["trajectory_id"] = trajectory_id
+        children.append(child)
+    source["subagent_trajectories"] = children
+    result = source["steps"][2]["observation"]["results"][0]
+    result["subagent_trajectory_ref"] = [
+        {"trajectory_id": child["trajectory_id"]} for child in children
+    ]
+    nodes = flatten_nodes(_parse_session(source).nodes)
+
+    assert len({node.external_id for node in nodes}) == len(nodes)
+    assert sum(node.node_type is NodeType.SUBAGENT_CALL for node in nodes) == 2
+
+
+def test_long_subagent_identifier_preserves_source_without_breaking_ingest() -> None:
+    """Long ATIF identities remain available despite native field length limits."""
+    source = _trajectory()
+    source["schema_version"] = "ATIF-v1.8"
+    trajectory_id = "child-" + "x" * 300
+    result = source["steps"][2]["observation"]["results"][0]
+    result["subagent_trajectory_ref"] = [{"trajectory_id": trajectory_id}]
+    nodes = flatten_nodes(_parse_session(source).nodes)
+    subagent = next(node for node in nodes if node.node_type is NodeType.SUBAGENT_CALL)
+
+    assert subagent.subagent_id is not None
+    assert len(subagent.subagent_id) <= 255
+    assert subagent.metadata["atif"]["trajectory_id"] == trajectory_id
+
+
+def test_unreferenced_embedded_document_remains_source_metadata() -> None:
+    """Do not invent a delegation relationship for an unreferenced document."""
+    source = _trajectory()
+    source["schema_version"] = "ATIF-v1.8"
+    child = _trajectory()
+    child["trajectory_id"] = "child"
+    source["subagent_trajectories"] = [child]
+    nodes = flatten_nodes(_parse_session(source).nodes)
+
+    assert not any(node.node_type is NodeType.SUBAGENT_CALL for node in nodes)
+    assert nodes[0].metadata["unreferenced_subagent_trajectories"] == [child]
+
+
+def test_preserves_external_media_and_subagent_refs_without_resolution() -> None:
+    """Import unavailable media and external trajectories as source references."""
+    source = _trajectory()
+    source["schema_version"] = "ATIF-v1.8"
+    message = [
+        {"type": "text", "text": "Inspect the attached sample."},
+        {
+            "type": "image",
+            "source": {"path": "/missing/fixture.png", "media_type": "image/png"},
+        },
+    ]
+    source["steps"][1]["message"] = message
+    ref = {
+        "trajectory_path": "https://invalid.example/child.json",
+        "session_id": "child",
+    }
+    source["steps"][2]["observation"]["results"][0]["subagent_trajectory_ref"] = [ref]
+    session = _parse_session(source)
+    subagent = next(
+        node
+        for node in flatten_nodes(session.nodes)
+        if node.node_type is NodeType.SUBAGENT_CALL
+    )
+
+    assert session.inputs["messages"][1]["message"] == message
+    assert session.input_text_selector == "/messages/1/message/0/text"
+    assert subagent.metadata["atif"] == ref
+    assert subagent.metadata["resolution"] == "external_or_unresolved"
+
+
+def test_external_reference_does_not_attach_same_id_from_another_document() -> None:
+    """An explicit external path takes precedence over a coincident embedded ID."""
+    source = _trajectory()
+    source["schema_version"] = "ATIF-v1.8"
+    child = _trajectory()
+    child["trajectory_id"] = "child"
+    source["subagent_trajectories"] = [child]
+    result = source["steps"][2]["observation"]["results"][0]
+    result["subagent_trajectory_ref"] = [
+        {"trajectory_id": "child", "trajectory_path": "../other/trajectory.json"}
+    ]
+    nodes = flatten_nodes(_parse_session(source).nodes)
+    subagent = next(node for node in nodes if node.node_type is NodeType.SUBAGENT_CALL)
+
+    assert subagent.metadata["resolution"] == "external_or_unresolved"
+    assert not any(node.parent_index == subagent.index for node in nodes)
+    assert sum(node.tokens.input_tokens or 0 for node in nodes if node.tokens) == 20
+
+
+def test_tool_without_recorded_result_is_not_marked_successful() -> None:
+    """Interrupted traces retain a tool call even when its result never arrived."""
+    source = _trajectory()
+    source["steps"][2].pop("observation")
+    nodes = flatten_nodes(_parse_session(source).nodes)
+    tool = next(node for node in nodes if node.node_type is NodeType.TOOL_CALL)
+
+    assert tool.outputs == {"results": []}
+    assert tool.status is NodeStatus.IN_PROGRESS
+
+
+def test_harbor_agent_execution_times_define_session_duration() -> None:
+    """Use the agent execution interval rather than setup or verifier timing."""
+    result = {
+        "started_at": "2026-09-10T09:55:00Z",
+        "finished_at": "2026-09-10T10:05:00Z",
+        "agent_execution": {
+            "started_at": "2026-09-10T10:00:00Z",
+            "finished_at": "2026-09-10T10:02:00Z",
+        },
+    }
+    session = _parse_session(
+        {"trajectories": [{"trajectory": _trajectory(), "harbor_result": result}]}
+    )
+
+    assert session.started_at is not None
+    assert session.ended_at is not None
+    assert (session.ended_at - session.started_at).total_seconds() == 120
+    assert session.framework == "harbor"
+    assert all(
+        node.ended_at is None
+        for node in flatten_nodes(session.nodes)
+        if node.parent_index is not None
+    )
+
+
+def test_copied_context_preserves_evidence_without_counting_execution_again() -> None:
+    """Copied historical steps retain their source data without duplicating usage."""
+    source = _trajectory()
+    source["schema_version"] = "ATIF-v1.8"
+    source["steps"][2]["is_copied_context"] = True
+    child = _trajectory()
+    child["trajectory_id"] = "child"
+    child["agent"]["name"] = "historical-child"
+    source["subagent_trajectories"] = [child]
+    result = source["steps"][2]["observation"]["results"][0]
+    result["subagent_trajectory_ref"] = [{"trajectory_id": "child"}]
+    nodes = flatten_nodes(_parse_session(source).nodes)
+    copied_step = next(node for node in nodes if node.reasoning)
+    copied_children = [node for node in nodes if node.parent_index == copied_step.index]
+
+    assert copied_step.node_type is NodeType.SPAN
+    assert copied_step.tokens is None
+    assert copied_step.cost is None
+    assert copied_step.metadata["atif"]["metrics"] == source["steps"][2]["metrics"]
+    assert copied_step.metadata["atif"]["is_copied_context"] is True
+    assert copied_children
+    assert all(node.node_type is NodeType.SPAN for node in copied_children)
+    assert sum(node.node_type is NodeType.LLM_CALL for node in nodes) == 1
+    assert not any(node.tokens for node in nodes)
+    assert not any(node.node_type is NodeType.SUBAGENT_CALL for node in nodes)
+    reference = next(
+        node for node in nodes if node.metadata.get("resolution") == "copied_context"
+    )
+    assert not any(node.parent_index == reference.index for node in nodes)
+
+
+def test_tool_argument_text_selector_escapes_json_pointer_characters() -> None:
+    """A single text argument remains selectable when its key contains slashes."""
+    source = _trajectory()
+    source["steps"][2]["tool_calls"][0]["arguments"] = {"path/to~file": "sample.txt"}
+    nodes = flatten_nodes(_parse_session(source).nodes)
+    tool = next(node for node in nodes if node.node_type is NodeType.TOOL_CALL)
+
+    assert tool.input_text_selector == "/path~1to~0file"
+
+
+def test_large_trajectory_flattens_beyond_one_ingest_batch() -> None:
+    """Hundreds of source steps must not create an invalid deep node tree."""
+    source = _trajectory()
+    source["steps"] = [
+        {"step_id": index + 1, "source": "agent", "message": f"Step {index + 1}."}
+        for index in range(550)
+    ]
+    session = _parse_session(source)
+    nodes = flatten_nodes(session.nodes)
+
+    assert len(nodes) > 500
+    assert len({node.index for node in nodes}) == len(nodes)
+    assert len({node.external_id for node in nodes}) == len(nodes)
+    session.model_dump_json()
+
+
+@pytest.mark.parametrize("params", [{"unknown": True}, {"namespace": 1}])
+def test_rejects_unsupported_parameters(params: dict[str, Any]) -> None:
+    """Misconfigured imports should fail before yielding any sessions."""
+    items = list(parse(json.dumps(_trajectory()).encode(), params))
+
+    assert len(items) == 1
+    assert isinstance(items[0], ImportFailure)
+
+
+@pytest.mark.parametrize(
+    "payload", [b"", b"\xff", b"not JSON", b"[]", b'{"trajectories":[]}']
+)
+def test_rejects_invalid_uploads(payload: bytes) -> None:
+    """Malformed upload framing cannot masquerade as an empty successful import."""
+    items = list(parse(payload, {}))
+
+    assert len(items) == 1
+    assert isinstance(items[0], ImportFailure)

--- a/plugins/tests/importers/test_atif_harbor.py
+++ b/plugins/tests/importers/test_atif_harbor.py
@@ -1,0 +1,107 @@
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kitaru_atif_importer.harbor import collect_trajectories, main
+
+
+def _write_trial(root: Path, name: str = "trial") -> Path:
+    trial = root / name
+    agent = trial / "agent"
+    agent.mkdir(parents=True)
+    (agent / "trajectory.json").write_text('{"schema_version":"ATIF-v1.7"}')
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "id": name,
+                "task_name": "example",
+                "config": {"env": {"API_KEY": "must-not-be-bundled"}},
+                "verifier_result": {"rewards": {"reward": 0}},
+            }
+        )
+    )
+    return trial
+
+
+def test_collects_sorted_trials_without_configuration(tmp_path: Path) -> None:
+    _write_trial(tmp_path, "b")
+    _write_trial(tmp_path, "a")
+    records = collect_trajectories(tmp_path)["trajectories"]
+    assert [r["source_id"] for r in records] == [
+        "a/agent/trajectory.json",
+        "b/agent/trajectory.json",
+    ]
+    assert records[0]["harbor_result"]["verifier_result"]["rewards"] == {"reward": 0}
+    assert "must-not-be-bundled" not in json.dumps(records)
+
+
+def test_collects_multistep_trial_with_step_outcome(tmp_path: Path) -> None:
+    trial = _write_trial(tmp_path)
+    (trial / "agent" / "trajectory.json").unlink()
+    agent = trial / "steps" / "solve" / "agent"
+    agent.mkdir(parents=True)
+    (agent / "trajectory.json").write_text("{}")
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "id": "trial-id",
+                "step_results": [
+                    {
+                        "step_name": "solve",
+                        "exception_info": {"exception_message": "failed"},
+                    }
+                ],
+            }
+        )
+    )
+    record = collect_trajectories(tmp_path)["trajectories"][0]
+    assert record["source_id"] == "trial-id/steps/solve/agent/trajectory.json"
+    assert record["harbor_result"]["exception_info"]["exception_message"] == "failed"
+
+
+def test_rejects_symlinked_trajectory(tmp_path: Path) -> None:
+    trial = _write_trial(tmp_path)
+    source = trial / "agent" / "trajectory.json"
+    source.unlink()
+    source.symlink_to(trial / "result.json")
+    with pytest.raises(ValueError, match="symlink"):
+        collect_trajectories(tmp_path)
+
+
+def test_rejects_invalid_json_and_oversize_input(tmp_path: Path) -> None:
+    trial = _write_trial(tmp_path)
+    with pytest.raises(ValueError, match="limit"):
+        collect_trajectories(tmp_path, max_bytes=1)
+    (trial / "agent" / "trajectory.json").write_text("invalid")
+    with pytest.raises(ValueError, match="JSON"):
+        collect_trajectories(tmp_path)
+
+
+def test_cli_never_overwrites_output(tmp_path: Path) -> None:
+    _write_trial(tmp_path)
+    output = tmp_path / "bundle.json"
+    assert main([str(tmp_path), "--output", str(output)]) == 0
+    first = output.read_bytes()
+    assert main([str(tmp_path), "--output", str(output)]) == 1
+    assert output.read_bytes() == first
+
+
+def test_cli_removes_partial_output_before_retry(tmp_path: Path) -> None:
+    _write_trial(tmp_path)
+    output = tmp_path / "bundle.json"
+    real_fdopen = os.fdopen
+
+    def fail_write(descriptor: int, mode: str) -> None:
+        stream = real_fdopen(descriptor, mode)
+        stream.write(b'{"partial":')
+        stream.close()
+        raise OSError("disk full")
+
+    with patch("kitaru_atif_importer.harbor.os.fdopen", side_effect=fail_write):
+        assert main([str(tmp_path), "--output", str(output)]) == 1
+    assert not output.exists()
+    assert main([str(tmp_path), "--output", str(output)]) == 0
+    assert len(json.loads(output.read_bytes())["trajectories"]) == 1

--- a/plugins/uv.lock
+++ b/plugins/uv.lock
@@ -17,6 +17,7 @@ exclude-newer-span = "P3D"
 
 [manifest]
 members = [
+    "kitaru-atif-importer",
     "kitaru-braintrust-importer",
     "kitaru-claude-agent-sdk",
     "kitaru-evaluator",
@@ -36,6 +37,7 @@ members = [
 dev = [
     { name = "hypothesis", specifier = ">=6.165" },
     { name = "kitaru", extras = ["server"], editable = "../" },
+    { name = "kitaru-atif-importer", editable = "packages/atif-importer" },
     { name = "kitaru-braintrust-importer", extras = ["adapter"], editable = "packages/braintrust-importer" },
     { name = "kitaru-claude-agent-sdk", editable = "packages/claude-agent-sdk" },
     { name = "kitaru-langfuse-importer", extras = ["adapter"], editable = "packages/langfuse-importer" },
@@ -1268,6 +1270,17 @@ dev = [
     { name = "yamlfix" },
 ]
 fuzz = [{ name = "schemathesis", specifier = ">=4.25,<5" }]
+
+[[package]]
+name = "kitaru-atif-importer"
+version = "0.1.0"
+source = { editable = "packages/atif-importer" }
+dependencies = [
+    { name = "kitaru" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "kitaru", editable = "../" }]
 
 [[package]]
 name = "kitaru-braintrust-importer"

--- a/release/release-units.toml
+++ b/release/release-units.toml
@@ -53,6 +53,21 @@ checks = [
 ]
 
 [[units]]
+slug = "atif-importer"
+path = "plugins/packages/atif-importer"
+distribution = "kitaru-atif-importer"
+registry = "pypi"
+version-source = "plugins/packages/atif-importer/pyproject.toml"
+changelog = "plugins/packages/atif-importer/CHANGELOG.md"
+lock-source = "plugins/uv.lock"
+default-catalog = false
+release-label = "requires:plugin:atif"
+impact-paths = ["plugins/packages/atif-importer/**"]
+tag-prefix = "python/kitaru-atif-importer/v"
+maintenance-branch-prefix = "release/atif/"
+checks = []
+
+[[units]]
 slug = "braintrust-importer"
 path = "plugins/packages/braintrust-importer"
 distribution = "kitaru-braintrust-importer"

--- a/tests/scripts/test_release_units.py
+++ b/tests/scripts/test_release_units.py
@@ -27,6 +27,7 @@ INVENTORY_PATH = REPO_ROOT / "release" / "release-units.toml"
 
 EXPECTED_UNITS = {
     "kitaru": "kitaru",
+    "atif-importer": "kitaru-atif-importer",
     "braintrust-importer": "kitaru-braintrust-importer",
     "claude-agent-sdk": "kitaru-claude-agent-sdk",
     "evaluator": "kitaru-evaluator",
@@ -624,7 +625,7 @@ def test_plugin_matrix_is_generated_from_the_plugin_units_in_three_shards() -> N
 
     shards = matrix["include"]
     assert [shard["shard"] for shard in shards] == ["1/3", "2/3", "3/3"]
-    assert [len(shard["package_paths"].splitlines()) for shard in shards] == [5, 4, 4]
+    assert [len(shard["package_paths"].splitlines()) for shard in shards] == [5, 5, 4]
     assert [
         package_path
         for shard in shards
@@ -869,7 +870,7 @@ def _run_cli(*arguments: str) -> subprocess.CompletedProcess[str]:
     [
         (["list"], "SLUG\tDISTRIBUTION\tVERSION\tDEFAULT\tTAG"),
         (["resolve", "--unit", "kitaru"], "python/kitaru/v"),
-        (["validate"], "Validated 14 release units."),
+        (["validate"], "Validated 15 release units."),
         (
             [
                 "propose-core-version",


### PR DESCRIPTION
## What changed?

Harbor rollout outputs and standalone ATIF v1.0–v1.8 trajectories can now be imported into Kitaru for inspection. Messages, tool calls/results, reasoning, model identity, recorded usage, and execution outcomes retain their source evidence.

Fixes #1070.

<img width="3032" height="2068" alt="CleanShot 2026-09-10 at 10 01 12@2x" src="https://github.com/user-attachments/assets/a2a94484-c4d5-486b-94c9-abd3e2afb342" />

[source](https://staging.cloud.zenml.io/kitaru-workspaces/eb381f84-52d0-47e5-a7e2-c222cc45e5a4/sessions/01a08a4b-8862-71a0-883f-2b6b309c9509)

## Why?

Harbor exports already contain the agent execution history needed for trace inspection. A dedicated importer avoids manual conversion while preserving the distinctions between execution failures, benchmark rewards, copied context, and aggregate metrics.

## Release context

New `kitaru-atif-importer` distribution, with initial version `0.1.0` and published core floor `kitaru>=0.24.0`, intended for the next applicable plugin release after review. First publication needs its Trusted Publisher/environment setup. This PR supports manual script registration and does not add a default-catalog entry or claim Harbor replay support.

## Reviewer Notes

Follow `parse()` through record validation and normalization. Invalid records fail independently before ingestion; stable source IDs support duplicate skipping. Copied context must not add historical calls or usage again. Final cost is used only when descendant costs are absent, and a zero benchmark reward must not turn a completed execution into a failure.

The local Harbor helper collects selected trial results without reading referenced files or following symlinked directories. It excludes configuration and agent-result metadata; trajectory content remains intact. Bundle output uses exclusive creation and removes partial output after a failed write.

## Reproduction

From the checkout, prepare a Harbor job, then register and import on a test server with an importer-capable worker:

```bash
uv sync --project plugins --frozen --all-packages
uv run --project plugins python -m kitaru_atif_importer.harbor /path/to/harbor/job --output /tmp/harbor-import.json
uv run kitaru importer register dev-atif --server SERVER_URL --provider atif --script plugins/packages/atif-importer/src/kitaru_atif_importer/importer.py --entrypoint parse --display-version dev
uv run kitaru session import /tmp/harbor-import.json --server SERVER_URL --importer dev-atif@1 --agent AGENT@VERSION --wait
```

Use a dedicated existing agent version. Inspect the resulting sessions, then repeat the import: the second run should skip the same source identities. The CLI requires a new importer name if `dev-atif` is already registered.

Live staging validation imported three real Claude Code/Codex trajectories with 151 nodes. Direct API reads matched normalized content, reasoning, metadata, token usage, cost, and call counts. One source execution failure remained failed. Reimporting created zero sessions, skipped all three, and produced no import failures. Temporary workers stopped after their jobs completed.

## Local checks run

- All 214 available Harbor trajectories parsed locally, producing 11,914 nodes; recorded tool counts, costs, and token usage matched the exports.
- 56 focused ATIF tests passed against published Kitaru 0.24.0.
- Full plugin suite, release inventory tests, plugin format/lint/type checks, `just check`, and `just plugin-artifact-smoke` passed after updating the branch onto `develop`.
- Independent local and cross-model review completed; the partial bundle-write cleanup regression is covered.
