### PR TITLE
Support renamed Langfuse observation model field

### DIFF
--- a/plugins/packages/langfuse-importer/CHANGELOG.md
+++ b/plugins/packages/langfuse-importer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Support Langfuse SDK 4.15.2's renamed observation model field while retaining support for earlier SDK versions.
 - Standardize source identity precedence as `source_instance`, then `project_id`, then embedded project identity; trim strings, reject other types, and reject embedded conflicts even with overrides.
 - Require an explicit source identity when an export has no project ID instead of deriving one from the filename; accept `project_id` as an alias for `source_instance` and include a CLI remedy in the error.
 - Remove the importer payload size cap. Uploads are bounded by the server blob limit only.

--- a/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/api.py
+++ b/plugins/packages/langfuse-importer/src/kitaru_langfuse_importer/api.py
@@ -164,11 +164,10 @@ def _serialize_observation(observation: ObservationV2) -> dict[str, Any]:
         Observation payload dict.
     """
     payload = observation.model_dump(mode="json", by_alias=True)
-    # The v2 listing exposes the raw model string as providedModelName. The
-    # parser looks for a plain "model" key first, so carry it across under
-    # that name too instead of falling through to modelId, which names a
-    # matched catalog entry rather than the model string itself.
-    payload["model"] = observation.provided_model_name
+    # Langfuse 4.15.2 renamed providedModelName to model. Normalize the wire
+    # payload so either SDK shape preserves the model name rather than using
+    # modelId, which identifies a matched catalog entry.
+    payload.setdefault("model", payload.get("providedModelName"))
     return payload
 
 

--- a/plugins/tests/adapters/langfuse/fixtures.py
+++ b/plugins/tests/adapters/langfuse/fixtures.py
@@ -95,7 +95,6 @@ def build_observation_v2(
         "output": None,
         "metadata": None,
         "model_parameters": None,
-        "provided_model_name": None,
         **extra,
     }
     if end_time is not None:

--- a/plugins/tests/adapters/langfuse/test_api.py
+++ b/plugins/tests/adapters/langfuse/test_api.py
@@ -14,7 +14,9 @@
 """Focused contract tests for the Langfuse fetch entrypoint."""
 
 import asyncio
+import json
 from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 from langfuse.api.core import ApiError
@@ -37,6 +39,44 @@ from .fixtures import (
 def _flatten(nodes: list[ImportedNode]) -> list[ImportedNode]:
     """Flatten imported nodes depth-first for assertions."""
     return [node for root in nodes for node in (root, *_flatten(root.children))]
+
+
+@pytest.mark.parametrize(
+    ("model_fields", "expected"),
+    [
+        ({"model": "gpt-5-nano"}, "gpt-5-nano"),
+        ({"providedModelName": "gpt-5-nano"}, "gpt-5-nano"),
+        ({"model": "current", "providedModelName": "legacy"}, "current"),
+        ({"model": None}, None),
+        ({"model": None, "providedModelName": "legacy"}, None),
+        ({}, None),
+    ],
+)
+async def test_fetch_preserves_model_across_sdk_field_rename(
+    fake_langfuse: FakeLangfuseClient,
+    model_fields: dict[str, Any],
+    expected: str | None,
+) -> None:
+    """Accept both wire field names without requiring an SDK-specific attribute."""
+    fake_langfuse.trace_builders = [build_complete_trace]
+    fake_langfuse.observation_pages = {
+        "trace-1": [
+            build_observations_page(
+                [
+                    build_observation_v2(
+                        "obs-llm",
+                        "trace-1",
+                        observation_type="GENERATION",
+                        **model_fields,
+                    )
+                ]
+            )
+        ]
+    }
+
+    payloads = await collect_payloads(fetch({"trace_ids": ["trace-1"]}))
+
+    assert json.loads(payloads[0])[0]["observations"][0]["model"] == expected
 
 
 async def test_fetch_with_trace_ids_fetches_exactly_those_in_order(


### PR DESCRIPTION
## What changed?

Langfuse API imports support SDK 4.15.2's `model` field and the earlier `providedModelName` field without pinning the SDK.

## Why?

Langfuse 4.15.2, released September 9, renamed the observation field. Imports crashed with `AttributeError: 'ObservationV2' object has no attribute 'provided_model_name'`. Normalizing the serialized response preserves the model name across both SDK shapes.

## Release context

Include `kitaru-langfuse-importer` in its next applicable release. This PR leaves package versions and server catalog pins unchanged; release preparation must publish the fix before hosted workers can consume it. No cluster or Modal changes were made.

## Reviewer Notes

An explicit `model` value takes precedence, including null. The legacy field supplies the value only when `model` is absent. The shared fixture no longer injects the removed attribute, which previously masked the SDK incompatibility.

## Reproduction

Run the focused fetch regression against the new SDK:

```bash
uv sync --project plugins --frozen --all-packages
uv run --project plugins --no-sync --exclude-newer 2026-09-11T00:00:00Z --with 'langfuse==4.15.2' pytest -q -c plugins/pyproject.toml plugins/tests/adapters/langfuse/test_api.py -k field_rename
```

All six cases should pass: new and legacy fields, precedence, explicit null, and missing model. Before the fix, SDK 4.15.2 raises the reported `AttributeError`. Repeat with `langfuse==4.15.1` to verify backward compatibility. These tests use real SDK observation models with a fake API and need no provider credentials.

## Local checks run

- Langfuse adapter/API tests against SDK 4.15.1 and 4.15.2: 27 passed on each.
- Full plugin suite plus default-plugin tests: 1,804 passed, 1 skipped.
- Plugin format, lint, and type checks passed.
- `UV_NO_SYNC=1 just check` passed after installing all root extras and dependency groups.
