### PR TITLE
Strengthen LangGraph capture accounting

### DIFF
--- a/changelog.d/langgraph-capture-budget.fixed.md
+++ b/changelog.d/langgraph-capture-budget.fixed.md
@@ -1,0 +1,1 @@
+- Fixed LangGraph capture so enum values consume their field byte budget once.

--- a/plugins/packages/langgraph/CHANGELOG.md
+++ b/plugins/packages/langgraph/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed capture byte-budget accounting for enum values while retaining bounded unwrapping.
+
 ## 0.1.2
 
 - Mark captured mapping-key coercion and collisions as non-replayable, preserve nested tuples in tool results, and reject malformed stored outcomes without executing the live tool.

--- a/plugins/packages/langgraph/src/kitaru_langgraph/capture.py
+++ b/plugins/packages/langgraph/src/kitaru_langgraph/capture.py
@@ -195,6 +195,20 @@ def _convert(
     if depth > policy.max_depth:
         reasons.append("max_depth")
         return {"__kitaru_capture__": "max_depth"}
+    if isinstance(value, Enum):
+        seen_enums: set[int] = set()
+        while isinstance(value, Enum):
+            identity = id(value)
+            if identity in seen_enums:
+                reasons.append("cycle")
+                return {"__kitaru_capture__": "cycle"}
+            if seen_enums:
+                if work_remaining[0] <= 0:
+                    reasons.append("max_field_bytes")
+                    return {"__kitaru_capture__": "max_field_bytes"}
+                work_remaining[0] -= 1
+            seen_enums.add(identity)
+            value = value.value
     if value is None or isinstance(value, (str, bool, int)):
         return value
     if isinstance(value, float):
@@ -204,15 +218,6 @@ def _convert(
         return value
     if isinstance(value, (UUID, datetime, date, Decimal)):
         return str(value)
-    if isinstance(value, Enum):
-        return _convert(
-            value.value,
-            policy=policy,
-            depth=depth,
-            reasons=reasons,
-            active_ids=active_ids,
-            work_remaining=work_remaining,
-        )
     if isinstance(value, BaseModel):
         value = value.model_dump(mode="python", warnings=False)
     elif is_dataclass(value) and not isinstance(value, type):

--- a/plugins/tests/adapters/langgraph/test_capture.py
+++ b/plugins/tests/adapters/langgraph/test_capture.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, overload
 
 import pytest
@@ -94,6 +95,64 @@ def test_capture_preserves_ordinary_string_mapping() -> None:
     assert captured.value == value
     assert captured.replayable
     assert not captured.reasons
+
+
+def test_enum_value_uses_its_encoded_byte_budget_once() -> None:
+    class Status(Enum):
+        ZERO = 0
+
+    captured = capture_value(Status.ZERO, CapturePolicy(max_field_bytes=1))
+
+    assert captured.value == 0
+    assert captured.encoded_bytes == 1
+    assert captured.replayable
+    assert not captured.reasons
+
+
+def test_nested_enum_unwrapping_is_bounded() -> None:
+    value: Any = 0
+    for index in range(1_100):
+        value = next(iter(Enum(f"Status{index}", {"VALUE": value})))
+
+    within_limit = capture_value(value, CapturePolicy(max_field_bytes=1_100))
+    over_limit = capture_value(value, CapturePolicy(max_field_bytes=1_099))
+
+    assert within_limit.value == 0
+    assert within_limit.encoded_bytes == 1
+    assert within_limit.replayable
+    assert not within_limit.reasons
+    assert over_limit.value == {"__kitaru_capture__": "max_field_bytes"}
+    assert over_limit.reasons == ("max_field_bytes",)
+    assert over_limit.lossy and over_limit.truncated and not over_limit.replayable
+
+
+def test_cyclic_enum_value_is_contained() -> None:
+    class Cyclic(Enum):
+        VALUE = 0
+
+    Cyclic.VALUE._value_ = Cyclic.VALUE
+
+    captured = capture_value(Cyclic.VALUE, CapturePolicy())
+
+    assert captured.value == {"__kitaru_capture__": "cycle"}
+    assert captured.reasons == ("cycle",)
+    assert captured.lossy and not captured.truncated and not captured.replayable
+
+
+def test_cyclic_enum_markers_consume_shared_work_budget() -> None:
+    class Cyclic(Enum):
+        VALUE = 0
+
+    Cyclic.VALUE._value_ = Cyclic.VALUE
+
+    captured = capture_value(
+        [Cyclic.VALUE, Cyclic.VALUE], CapturePolicy(max_field_bytes=2)
+    )
+
+    assert captured.value == {"__kitaru_capture__": "max_field_bytes"}
+    assert set(captured.reasons) == {"cycle", "max_field_bytes"}
+    assert len(captured.reasons) == 2
+    assert captured.lossy and captured.truncated and not captured.replayable
 
 
 @dataclass

--- a/plugins/tests/adapters/langgraph/test_capture_properties.py
+++ b/plugins/tests/adapters/langgraph/test_capture_properties.py
@@ -13,6 +13,8 @@
 #  permissions and limitations under the License.
 """Property tests for LangGraph value capture."""
 
+import copy
+import json
 from typing import Any
 
 from hypothesis import given
@@ -44,6 +46,40 @@ _values = st.recursive(
     max_leaves=10,
 )
 
+_json_text = st.text(alphabet=st.characters(blacklist_categories=("Cs",)), max_size=23)
+_json_strings = st.one_of(
+    _json_text,
+    st.tuples(
+        st.sampled_from(['"', "\\", "\b", "\f", "\n", "\r", "\t", "\x00", "é", "😀"]),
+        _json_text,
+    ).map(lambda parts: "".join(parts)),
+)
+_json_keys = _json_strings.map(lambda value: f"field:{value}")
+_json_values = st.recursive(
+    st.none()
+    | st.booleans()
+    | st.integers(min_value=-(10**30), max_value=10**30)
+    | st.floats(allow_nan=False, allow_infinity=False)
+    | _json_strings,
+    lambda children: (
+        st.lists(children, max_size=4)
+        | st.dictionaries(_json_keys, children, max_size=4)
+    ),
+    max_leaves=12,
+)
+
+
+def _get_json_size(value: Any) -> int:
+    """Return the independent compact JSON UTF-8 byte count."""
+    return len(
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    )
+
 
 @given(value=st.dictionaries(st.text(max_size=8), _values, max_size=6))
 def test_string_keyed_mapping_is_captured_exactly_or_flagged(
@@ -65,3 +101,91 @@ def test_key_collapse_is_reported_as_lossy(value: dict[Any, Any]) -> None:
 def test_colliding_keys_example() -> None:
     result = capture_value({1: "a", "1": "b"}, CapturePolicy())
     assert len(result.value) == 2 or result.lossy
+
+
+@given(value=_json_values)
+def test_json_native_values_have_exact_byte_receipts(value: Any) -> None:
+    original = copy.deepcopy(value)
+
+    result = capture_value(value, CapturePolicy())
+
+    assert result.value == value
+    assert result.encoded_bytes == _get_json_size(value)
+    assert result.replayable
+    assert not result.lossy
+    assert not result.truncated
+    assert not result.reasons
+    assert value == original
+
+
+@given(value=_json_values)
+def test_field_byte_limit_is_inclusive(value: Any) -> None:
+    encoded_bytes = _get_json_size(value)
+
+    at = capture_value(value, CapturePolicy(max_field_bytes=encoded_bytes))
+    above = capture_value(value, CapturePolicy(max_field_bytes=encoded_bytes + 1))
+
+    if encoded_bytes > 1:
+        below = capture_value(value, CapturePolicy(max_field_bytes=encoded_bytes - 1))
+        assert below.value == {"__kitaru_capture__": "max_field_bytes"}
+        assert below.encoded_bytes == _get_json_size(below.value)
+        assert below.reasons == ("max_field_bytes",)
+        assert below.lossy and below.truncated and not below.replayable
+
+    for result in (at, above):
+        assert result.value == value
+        assert result.encoded_bytes == encoded_bytes
+        assert result.replayable
+        assert not result.reasons
+
+
+@given(max_field_bytes=st.integers(min_value=1, max_value=16))
+def test_tiny_budget_reports_final_marker_size(max_field_bytes: int) -> None:
+    result = capture_value(
+        "value-too-large-for-the-generated-budget",
+        CapturePolicy(max_field_bytes=max_field_bytes),
+    )
+
+    assert result.value == {"__kitaru_capture__": "max_field_bytes"}
+    assert result.encoded_bytes == _get_json_size(result.value)
+    assert result.encoded_bytes > max_field_bytes
+    assert result.reasons == ("max_field_bytes",)
+    assert result.lossy and result.truncated and not result.replayable
+
+
+@given(
+    prefix=_json_strings,
+    surrogate=st.integers(min_value=0xD800, max_value=0xDFFF).map(chr),
+    suffix=_json_strings,
+)
+def test_unencodable_strings_use_serialization_marker(
+    prefix: str, surrogate: str, suffix: str
+) -> None:
+    value = f"{prefix}{surrogate}{suffix}"
+
+    result = capture_value(value, CapturePolicy())
+
+    assert result.value == {
+        "__kitaru_capture__": "serialization_failed",
+        "type": "str",
+    }
+    assert result.encoded_bytes == _get_json_size(result.value)
+    assert result.reasons == ("serialization_failed",)
+    assert result.lossy and not result.truncated and not result.replayable
+
+
+@given(value=_json_values, max_field_bytes=st.integers(min_value=1, max_value=128))
+def test_loss_flags_and_receipts_remain_consistent(
+    value: Any, max_field_bytes: int
+) -> None:
+    original = copy.deepcopy(value)
+
+    result = capture_value(value, CapturePolicy(max_field_bytes=max_field_bytes))
+
+    assert result.encoded_bytes == _get_json_size(result.value)
+    assert result.lossy == bool(result.reasons)
+    assert result.replayable == (not result.lossy)
+    assert result.truncated == any(
+        reason.startswith("max_") for reason in result.reasons
+    )
+    assert value == original


### PR DESCRIPTION
## Summary

LangGraph capture now accepts an enum when its encoded value fits exactly at the field-byte limit, while nested and cyclic enum wrappers remain bounded by the shared work budget. The existing scheduled capture fuzz suite now verifies exact compact UTF-8 JSON receipts, inclusive thresholds, fallback markers, input immutability, and replayability decisions over generated values.

This is U3 of the nightly fuzzing expansion. U1 and U2 cover importer normalization and deterministic evaluators; database filter, lifecycle, scheduling, and optional-engine work remain separate follow-up units.

## Reviewer Notes

The main behavior change is in enum conversion: one wrapper and its encoded value consume one work unit, each additional wrapper consumes another, and a repeated wrapper reports a contained cycle. The test oracle uses `json.dumps(..., ensure_ascii=False, sort_keys=True, separators=(",", ":"))` independently of the production byte counter.

### Reproduction

```bash
HYPOTHESIS_PROFILE=nightly uv run --project plugins pytest -q -c plugins/pyproject.toml plugins/tests/adapters/langgraph/test_capture_properties.py plugins/tests/adapters/langgraph/test_capture.py --hypothesis-show-statistics
just fuzz-importers
```

The focused nightly suite passes 35 tests with 2,000 examples per generated property. The shared scheduled recipe passes all 46 tests in 14m48s.

Additional validation: `just check` passed; plugin format, lint, and type checks passed; the complete plugin suite passed 1,813 tests with 1 skip and 4 existing dependency deprecation warnings.

Review completed with correctness, testing, project-standards, and independent Claude Opus 5 passes. The completed receipt is `20260912-190018-ccefc6e2`; all code findings were resolved before the final validation runs.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This changes only bounded local capture of enum-valued inputs; exact-fit values now remain replayable, while over-budget and cyclic values continue to produce explicit non-replayable markers.

Related: #907

Session-settled decisions carried from planning: extend the existing Hypothesis and nightly infrastructure, keep optional engine work independent, and require no separately licensed tooling.
