### PR TITLE
Add isolated API sequence fuzzing

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -115,6 +115,10 @@ fuzz-filters:
 fuzz-api:
     HYPOTHESIS_PROFILE=nightly KITARU_FUZZ=1 KITARU_FUZZ_RANDOM=1 KITARU_FUZZ_MAX_EXAMPLES=400 uv run --extra server --group fuzz pytest tests/server/test_fuzz_api.py -p no:randomly --hypothesis-show-statistics
 
+# Run isolated successful agent/version API sequences against PostgreSQL
+fuzz-api-sequences MAX_EXAMPLES="25" MAX_ACTIONS="15":
+    KITARU_FUZZ_API_SEQUENCES=1 KITARU_TEST_REQUIRE_POSTGRES=1 KITARU_FUZZ_API_SEQUENCE_MAX_EXAMPLES={{ MAX_EXAMPLES }} KITARU_FUZZ_API_SEQUENCE_MAX_ACTIONS={{ MAX_ACTIONS }} uv run --extra server --group fuzz pytest tests/server/test_fuzz_api_sequences.py -p no:randomly --hypothesis-show-statistics
+
 # Check Alembic migrations against the ORM schema (requires docker compose up -d db)
 migration-check:
     uv run python scripts/check_migrations.py

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -50,7 +50,7 @@ For local reproduction, prefix the normal base pytest command with `KITARU_TEST_
 
 ## Property-based tests
 
-Hypothesis tests live next to the surface they cover: `plugins/tests/importers/test_fuzz_parse.py` (importer `parse()` contract), `tests/mcp/test_fuzz_tools.py` (MCP tool boundary, requests generated from each tool's JSON schema), `tests/cli/test_redaction_properties.py`, `tests/server/test_fuzz_filters.py` (recursive JSON list filters), and `plugins/tests/adapters/langgraph/test_capture_properties.py`.
+Hypothesis tests live next to the surface they cover: `plugins/tests/importers/test_fuzz_parse.py` (importer `parse()` contract), `tests/mcp/test_fuzz_tools.py` (MCP tool boundary, requests generated from each tool's JSON schema), `tests/cli/test_redaction_properties.py`, `tests/server/test_fuzz_filters.py` (recursive JSON list filters), `tests/server/test_fuzz_api_sequences.py` (isolated successful agent/version API sequences), and `plugins/tests/adapters/langgraph/test_capture_properties.py`.
 
 Three profiles are registered in each root's `conftest.py` and selected with `HYPOTHESIS_PROFILE`: `dev` (100 examples, default locally), `ci` (50 examples, fixed seed; default when `CI` is set, so PR runs are deterministic), and `nightly` (2000 examples, random; used by `just fuzz` and the `fuzz-nightly` workflow — `fuzz-importers`, `fuzz-mcp`, and `fuzz-filters` cover their named property-test surfaces). `@given` tests are sync; call async code with `asyncio.run` inside the body.
 
@@ -71,3 +71,5 @@ The only assertion is that the server never answers 5xx. One database is shared 
 Known defects are listed in `KNOWN_FAILURES` keyed by method and path, with the issue number as the reason, and skip rather than mask everything behind them in the same operation. Delete an entry as part of closing its issue.
 
 `KITARU_FUZZ_MAX_EXAMPLES` sets depth (default 25) and `KITARU_FUZZ_RANDOM=1` turns off `derandomize` so a nightly explores fresh inputs; the default stays derandomized so a failure reproduces. `KITARU_FUZZ_CAPTURE` writes captured tracebacks to a JSONL file. Findings scale steeply with depth, so prefer nightly depth over a shallow gate.
+
+`tests/server/test_fuzz_api_sequences.py` gives each complete generated action list a fresh PostgreSQL database, application lifespan, and authenticated client. It records symbolic resource IDs and credential roles so a shrunk failure can be replayed without retaining database IDs or tokens. Schemathesis validates observed responses against the committed OpenAPI schema; ordinary Hypothesis action lists keep prerequisites valid and isolation explicit. Opt in with `just fuzz-api-sequences`, or pass smaller bounds such as `just fuzz-api-sequences 5 5` for a smoke run. The explicit suite fails rather than skips when PostgreSQL is unavailable.

--- a/tests/server/fuzz_sequences.py
+++ b/tests/server/fuzz_sequences.py
@@ -1,0 +1,325 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Reusable isolation and failure receipts for generated API sequences."""
+
+import re
+import uuid
+from collections.abc import AsyncGenerator, AsyncIterator, Iterable, Iterator
+from contextlib import AbstractAsyncContextManager, asynccontextmanager, contextmanager
+from enum import StrEnum
+from types import TracebackType
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from conftest import lifespan_client, local_settings
+
+_ACCOUNT_PASSWORD = "sequence-secret"
+_SECRET_FIELDS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "authorization",
+        "key",
+        "password",
+        "task_token",
+        "token",
+    }
+)
+_UUID_PATTERN = re.compile(
+    r"(?<![0-9a-f])[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+    r"[0-9a-f]{4}-[0-9a-f]{12}(?![0-9a-f])",
+    re.IGNORECASE,
+)
+
+
+class CredentialRole(StrEnum):
+    """Symbolic credential roles understood by a generated sequence."""
+
+    ACCOUNT = "account"
+    WORKER = "worker"
+
+
+class SequenceAction(BaseModel):
+    """One replayable operation expressed without live ids or credentials."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    target: str | None = None
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+class SequenceStepReceipt(BaseModel):
+    """Sanitized result and checked invariants for one sequence operation."""
+
+    action: SequenceAction
+    credential_role: CredentialRole
+    status: int
+    response: Any = None
+    invariants: list[str] = Field(default_factory=list)
+
+
+class SequenceReceipt(BaseModel):
+    """Sanitized evidence needed to understand and replay a sequence."""
+
+    steps: list[SequenceStepReceipt] = Field(default_factory=list)
+    successful_operations: int = 0
+
+    def record_step(
+        self,
+        *,
+        action: SequenceAction,
+        credential_role: CredentialRole,
+        status: int,
+        response: Any = None,
+        invariants: Iterable[str] = (),
+    ) -> None:
+        """Record one sanitized operation result.
+
+        Args:
+            action: Symbolic operation that was executed.
+            credential_role: Role used for the request.
+            status: Observed HTTP status.
+            response: Sanitized response summary.
+            invariants: Names of the invariants checked after the response.
+        """
+        self.steps.append(
+            SequenceStepReceipt(
+                action=action,
+                credential_role=credential_role,
+                status=status,
+                response=response,
+                invariants=list(invariants),
+            )
+        )
+        if 200 <= status < 300:
+            self.successful_operations += 1
+
+    def assert_accepted(self) -> None:
+        """Reject an empty sequence or one without a successful prerequisite."""
+        if not self.steps:
+            raise AssertionError("Sequence receipt contains no operations")
+        has_prerequisite = any(
+            step.action.name.startswith("create_") and 200 <= step.status < 300
+            for step in self.steps
+        )
+        if not has_prerequisite:
+            raise AssertionError("Sequence contains no successful prerequisite")
+
+    def serialize(self) -> str:
+        """Serialize the receipt as stable, readable JSON."""
+        return self.model_dump_json(indent=2)
+
+
+class SequenceCleanupError(RuntimeError):
+    """Report cleanup separately from any failure raised by the sequence."""
+
+    def __init__(
+        self,
+        *,
+        sequence_error: BaseException | None,
+        cleanup_error: BaseException,
+    ) -> None:
+        sequence_summary = (
+            "none"
+            if sequence_error is None
+            else f"{type(sequence_error).__name__}: {sequence_error}"
+        )
+        super().__init__(
+            "Sequence cleanup failed "
+            f"after sequence error {sequence_summary}; "
+            f"cleanup error {type(cleanup_error).__name__}: {cleanup_error}"
+        )
+        self.sequence_error = sequence_error
+        self.cleanup_error = cleanup_error
+
+
+class SequenceRuntime:
+    """Keep live ids and credentials outside the replayable receipt."""
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        receipt: SequenceReceipt,
+        *,
+        database_name: str | None = None,
+    ) -> None:
+        self.client = client
+        self.receipt = receipt
+        self.database_name = database_name
+        self._ids: dict[str, str] = {}
+        self._credentials: dict[CredentialRole, str] = {}
+
+    def bind_id(self, symbol: str, value: str | uuid.UUID) -> None:
+        """Bind a symbolic resource name to one id from the current database."""
+        raw_value = str(value)
+        if symbol in self._ids:
+            raise AssertionError(f"Symbolic id is already bound: {symbol}")
+        if raw_value in self._ids.values():
+            raise AssertionError("Live id is already bound to another symbol")
+        self._ids[symbol] = raw_value
+
+    def resolve_id(self, symbol: str) -> str:
+        """Resolve a symbolic resource name for the current sequence run."""
+        try:
+            return self._ids[symbol]
+        except KeyError as exc:
+            raise AssertionError(f"Symbolic id is not bound: {symbol}") from exc
+
+    def set_credential(self, role: CredentialRole, value: str) -> None:
+        """Bind one live credential to a symbolic role."""
+        self._credentials[role] = value
+
+    def get_headers(self, role: CredentialRole) -> dict[str, str]:
+        """Build request headers for one bound credential role."""
+        try:
+            credential = self._credentials[role]
+        except KeyError as exc:
+            raise AssertionError(f"Credential role is not bound: {role}") from exc
+        return {"Authorization": f"Bearer {credential}"}
+
+    def sanitize(self, value: Any) -> Any:
+        """Replace live ids and secrets with replayable symbolic values."""
+        if isinstance(value, uuid.UUID):
+            value = str(value)
+        if isinstance(value, str):
+            for symbol, live_id in sorted(
+                self._ids.items(), key=lambda item: len(item[1]), reverse=True
+            ):
+                if value == live_id:
+                    return {"$ref": symbol}
+                value = value.replace(live_id, f"<$ref:{symbol}>")
+            for role, credential in sorted(
+                self._credentials.items(), key=lambda item: len(item[1]), reverse=True
+            ):
+                if value == credential or value == f"Bearer {credential}":
+                    return {"$credential": role.value}
+                value = value.replace(
+                    f"Bearer {credential}", f"<$credential:{role.value}>"
+                )
+                value = value.replace(credential, f"<$credential:{role.value}>")
+            return _UUID_PATTERN.sub("<unbound-uuid>", value)
+        if isinstance(value, dict):
+            return {
+                str(key): (
+                    "<redacted>"
+                    if str(key).lower() in _SECRET_FIELDS
+                    else self.sanitize(item)
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [self.sanitize(item) for item in value]
+        return value
+
+    def record_response(
+        self,
+        *,
+        action: SequenceAction,
+        credential_role: CredentialRole,
+        response: httpx.Response,
+        invariants: Iterable[str] = (),
+    ) -> None:
+        """Record one HTTP response without retaining live secrets or ids."""
+        try:
+            body = response.json()
+        except ValueError:
+            body = response.text or None
+        self.receipt.record_step(
+            action=SequenceAction(
+                name=action.name,
+                target=action.target,
+                arguments=self.sanitize(action.arguments),
+            ),
+            credential_role=credential_role,
+            status=response.status_code,
+            response=self.sanitize(body),
+            invariants=invariants,
+        )
+
+
+@asynccontextmanager
+async def report_cleanup_failures(
+    manager: AbstractAsyncContextManager[httpx.AsyncClient],
+) -> AsyncIterator[httpx.AsyncClient]:
+    """Preserve a sequence failure when its context cleanup also fails."""
+    client = await manager.__aenter__()
+    sequence_error: BaseException | None = None
+    sequence_traceback: TracebackType | None = None
+    try:
+        yield client
+    except BaseException as exc:
+        sequence_error = exc
+        sequence_traceback = exc.__traceback__
+
+    try:
+        suppressed = await manager.__aexit__(
+            type(sequence_error) if sequence_error is not None else None,
+            sequence_error,
+            sequence_traceback,
+        )
+    except BaseException as cleanup_error:
+        raise SequenceCleanupError(
+            sequence_error=sequence_error,
+            cleanup_error=cleanup_error,
+        ) from cleanup_error
+
+    if sequence_error is not None and not suppressed:
+        raise sequence_error.with_traceback(sequence_traceback)
+
+
+@asynccontextmanager
+async def isolate_sequence(
+    receipt: SequenceReceipt,
+) -> AsyncGenerator[SequenceRuntime, None]:
+    """Run one API sequence in one fresh database and authenticated lifespan."""
+    settings = local_settings(
+        use_db=True,
+        DEFAULT_ACCOUNT_PASSWORD=_ACCOUNT_PASSWORD,
+        TASK_SWEEP_INTERVAL_SECONDS=0,
+    )
+    manager = lifespan_client(settings)
+    async with report_cleanup_failures(manager) as client:
+        response = await client.post(
+            "/api/v1/login",
+            data={"username": "default", "password": _ACCOUNT_PASSWORD},
+        )
+        if response.status_code != 200:
+            raise AssertionError(
+                f"Sequence login returned HTTP {response.status_code}: {response.text}"
+            )
+        runtime = SequenceRuntime(
+            client,
+            receipt,
+            database_name=settings.DB_NAME,
+        )
+        runtime.set_credential(
+            CredentialRole.ACCOUNT,
+            response.json()["access_token"],
+        )
+        yield runtime
+
+
+@contextmanager
+def annotate_sequence_failure(receipt: SequenceReceipt) -> Iterator[None]:
+    """Attach a sanitized receipt to an assertion without replacing it."""
+    try:
+        yield
+    except BaseException as exc:
+        if isinstance(exc, (GeneratorExit, KeyboardInterrupt, SystemExit)):
+            raise
+        exc.add_note(f"Sequence receipt:\n{receipt.serialize()}")
+        raise

--- a/tests/server/test_fuzz_api_sequences.py
+++ b/tests/server/test_fuzz_api_sequences.py
@@ -1,0 +1,801 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Isolated agent and agent-version API sequence properties.
+
+The broad API fuzzer deliberately shares one database and tests independent
+requests. This opt-in suite instead runs every complete action list in a fresh
+PostgreSQL database, carries symbolic ids through successful prerequisites,
+and emits a sanitized receipt when an invariant fails.
+"""
+
+import asyncio
+import importlib
+import os
+import re
+import uuid
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fuzz_sequences import (
+    CredentialRole,
+    SequenceAction,
+    SequenceReceipt,
+    SequenceRuntime,
+    annotate_sequence_failure,
+    isolate_sequence,
+)
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from conftest import db_settings
+from kitaru.server.database.service import DatabaseService
+
+_SEQUENCES_ENABLED = os.environ.get("KITARU_FUZZ_API_SEQUENCES") == "1"
+if not _SEQUENCES_ENABLED:
+    pytest.skip(
+        "API sequence fuzzing is opt-in; set KITARU_FUZZ_API_SEQUENCES=1 "
+        "(needs docker compose up -d db)",
+        allow_module_level=True,
+    )
+
+try:
+    schemathesis = importlib.import_module("schemathesis")
+    response_schema_conformance = importlib.import_module(
+        "schemathesis.specs.openapi.checks"
+    ).response_schema_conformance
+except ImportError as exc:
+    raise pytest.UsageError(
+        "API sequence fuzzing requires the fuzz dependency group"
+    ) from exc
+
+SPEC_PATH = Path(__file__).parents[2] / "openapi" / "openapi.json"
+SCHEMA = schemathesis.openapi.from_path(str(SPEC_PATH))
+UUID_PATTERN = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+    r"[0-9a-f]{4}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+
+
+def _get_positive_int(name: str, default: int, *, maximum: int | None = None) -> int:
+    """Read a positive bounded integer from the environment."""
+    raw_value = os.environ.get(name, str(default))
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise pytest.UsageError(f"{name} must be a positive integer") from exc
+    if value < 1 or (maximum is not None and value > maximum):
+        bound = f" no greater than {maximum}" if maximum is not None else ""
+        raise pytest.UsageError(f"{name} must be a positive integer{bound}")
+    return value
+
+
+MAX_EXAMPLES = _get_positive_int("KITARU_FUZZ_API_SEQUENCE_MAX_EXAMPLES", 25)
+MAX_ACTIONS = _get_positive_int("KITARU_FUZZ_API_SEQUENCE_MAX_ACTIONS", 15, maximum=15)
+if MAX_ACTIONS < 2:
+    raise pytest.UsageError("KITARU_FUZZ_API_SEQUENCE_MAX_ACTIONS must be at least 2")
+
+SEQUENCE_SETTINGS = settings(
+    max_examples=MAX_EXAMPLES,
+    deadline=None,
+    derandomize=os.environ.get("KITARU_FUZZ_RANDOM") is None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+
+SAFE_DESCRIPTION = st.one_of(
+    st.none(),
+    st.text(
+        alphabet=(
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ._-é漢🙂"
+        ),
+        min_size=0,
+        max_size=32,
+    ),
+)
+SAFE_VERSION = st.one_of(
+    st.none(),
+    st.text(
+        alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.+/",
+        min_size=1,
+        max_size=24,
+    ).filter(lambda value: value[0].isalnum() and value[-1].isalnum()),
+)
+
+
+def _action(
+    operation: str,
+    target: str | None = None,
+    **arguments: Any,
+) -> SequenceAction:
+    """Build one symbolic sequence action."""
+    return SequenceAction(name=operation, target=target, arguments=arguments)
+
+
+@st.composite
+def _successful_crud_sequences(
+    draw: st.DrawFn,
+) -> list[SequenceAction]:
+    """Generate bounded chains whose prerequisites always exist when needed."""
+    action_count = draw(st.integers(min_value=2, max_value=MAX_ACTIONS))
+    agent_name = draw(
+        st.text(
+            alphabet="abcdefghijklmnopqrstuvwxyz0123456789-", min_size=1, max_size=24
+        )
+        .filter(lambda value: value[0] != "-" and value[-1] != "-")
+        .map(lambda value: f"fuzz-{value}")
+    )
+    description = draw(SAFE_DESCRIPTION)
+    actions = [
+        _action("create_agent", "agent_0", name=agent_name, description=description)
+    ]
+    agent_alive = True
+    live_versions: list[str] = []
+    deleted_versions: list[str] = []
+    version_count = 0
+
+    while len(actions) < action_count:
+        if agent_alive:
+            choices = ["get_agent", "list_agents", "update_agent", "create_version"]
+            if live_versions or deleted_versions:
+                choices.append("get_version")
+            if live_versions:
+                choices.extend(["list_versions", "update_version", "delete_version"])
+            choices.append("delete_agent")
+        else:
+            choices = ["get_agent", "delete_agent", "create_version"]
+            if live_versions or deleted_versions:
+                choices.append("get_version")
+            if live_versions:
+                choices.append("delete_version")
+
+        action_name = draw(st.sampled_from(choices))
+        if action_name == "update_agent":
+            updated = draw(SAFE_DESCRIPTION)
+            actions.append(_action(action_name, "agent_0", description=updated))
+        elif action_name == "create_version":
+            symbol = f"version_{version_count}"
+            display_version = draw(SAFE_VERSION)
+            version_description = draw(SAFE_DESCRIPTION)
+            actions.append(
+                _action(
+                    action_name,
+                    symbol,
+                    agent="agent_0",
+                    display_version=display_version,
+                    description=version_description,
+                )
+            )
+            if agent_alive:
+                live_versions.append(symbol)
+                version_count += 1
+        elif action_name in {"get_version", "update_version", "delete_version"}:
+            candidates = (
+                [*live_versions, *deleted_versions]
+                if action_name == "get_version"
+                else live_versions
+            )
+            symbol = draw(st.sampled_from(candidates))
+            if action_name == "update_version":
+                updated = draw(SAFE_DESCRIPTION)
+                actions.append(_action(action_name, symbol, description=updated))
+            else:
+                actions.append(_action(action_name, symbol))
+            if action_name == "delete_version":
+                live_versions.remove(symbol)
+                deleted_versions.append(symbol)
+        elif action_name == "list_versions":
+            actions.append(_action(action_name, "agent_0"))
+        else:
+            actions.append(_action(action_name, "agent_0"))
+            if action_name == "delete_agent":
+                agent_alive = False
+
+    return actions
+
+
+def _validate_response(
+    *,
+    method: str,
+    path: str,
+    response: httpx.Response,
+    path_parameters: dict[str, str] | None = None,
+    body: dict[str, Any] | None = None,
+) -> None:
+    """Validate an actual response against its checked-in OpenAPI operation."""
+    case_arguments: dict[str, Any] = {}
+    if path_parameters is not None:
+        case_arguments["path_parameters"] = path_parameters
+    if body is not None:
+        case_arguments["body"] = body
+    case = SCHEMA[path][method.upper()].Case(**case_arguments)
+    case.validate_response(response, checks=[response_schema_conformance])
+
+
+async def _prepare_runtime(runtime: SequenceRuntime) -> None:
+    """Bind the account id so response receipts contain no live UUIDs."""
+    response = await runtime.client.get(
+        "/api/v1/accounts/me",
+        headers=runtime.get_headers(CredentialRole.ACCOUNT),
+    )
+    assert response.status_code == 200
+    runtime.bind_id("account", response.json()["id"])
+
+
+async def _check_database_exists(name: str) -> bool:
+    """Check one disposable database name through PostgreSQL's admin database."""
+    engine = create_async_engine(
+        DatabaseService.generate_database_uri(db_settings(), use_default_db=True)
+    )
+    try:
+        async with engine.connect() as connection:
+            row = await connection.execute(
+                text("SELECT 1 FROM pg_database WHERE datname = :name"),
+                {"name": name},
+            )
+            return row.first() is not None
+    finally:
+        await engine.dispose()
+
+
+def _bind_created_id(
+    runtime: SequenceRuntime,
+    target: str,
+    response: httpx.Response,
+) -> AssertionError | None:
+    """Bind a valid created UUID, deferring any collision until after recording."""
+    if response.status_code != 201:
+        return None
+    try:
+        response_id = response.json().get("id")
+    except (AttributeError, ValueError):
+        return None
+    if not isinstance(response_id, str):
+        return None
+    try:
+        uuid.UUID(response_id)
+    except ValueError:
+        return None
+    try:
+        runtime.bind_id(target, response_id)
+    except AssertionError as exc:
+        return exc
+    return None
+
+
+async def _execute_action(
+    runtime: SequenceRuntime,
+    action: SequenceAction,
+    state: dict[str, dict[str, Any]],
+) -> None:
+    """Execute one symbolic action and check the modeled API state."""
+    role = CredentialRole.ACCOUNT
+    headers = runtime.get_headers(role)
+    target = action.target
+    arguments = action.arguments
+    invariants: list[str] = ["response_schema"]
+
+    if action.name == "create_agent":
+        assert target is not None
+        path = "/api/v1/agents"
+        method = "POST"
+        body = {"name": arguments["name"], "description": arguments["description"]}
+        response = await runtime.client.post(path, json=body, headers=headers)
+        binding_error = _bind_created_id(runtime, target, response)
+        runtime.record_response(
+            action=action,
+            credential_role=role,
+            response=response,
+            invariants=[*invariants, "created_values"],
+        )
+        if binding_error is not None:
+            raise binding_error
+        _validate_response(method=method, path=path, response=response, body=body)
+        assert response.status_code == 201
+        payload = response.json()
+        assert payload["name"] == body["name"]
+        assert payload["description"] == body["description"]
+        assert payload["latest_version"] == 0
+        state[target] = {
+            "kind": "agent",
+            "alive": True,
+            "name": body["name"],
+            "description": body["description"],
+            "versions": [],
+            "next_version": 1,
+        }
+        return
+
+    if action.name in {"get_agent", "update_agent", "delete_agent"}:
+        assert target is not None
+        model = state[target]
+        agent_id = runtime.resolve_id(target)
+        path = "/api/v1/agents/{agent_id}"
+        concrete_path = f"/api/v1/agents/{agent_id}"
+        path_parameters = {"agent_id": agent_id}
+        method = {
+            "get_agent": "GET",
+            "update_agent": "PATCH",
+            "delete_agent": "DELETE",
+        }[action.name]
+        body = (
+            {"description": arguments["description"]}
+            if action.name == "update_agent"
+            else None
+        )
+        response = await runtime.client.request(
+            method, concrete_path, json=body, headers=headers
+        )
+        expected_status = 200 if model["alive"] else 404
+        if action.name == "delete_agent":
+            expected_status = 204 if model["alive"] else 404
+        runtime.record_response(
+            action=action,
+            credential_role=role,
+            response=response,
+            invariants=[*invariants, "agent_lifecycle"],
+        )
+        _validate_response(
+            method=method,
+            path=path,
+            response=response,
+            path_parameters=path_parameters,
+            body=body,
+        )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            payload = response.json()
+            if action.name == "update_agent":
+                model["description"] = arguments["description"]
+            assert payload["id"] == agent_id
+            assert payload["name"] == model["name"]
+            assert payload["description"] == model["description"]
+            assert payload["latest_version"] == model["next_version"] - 1
+        if action.name == "delete_agent" and response.status_code == 204:
+            model["alive"] = False
+        return
+
+    if action.name == "list_agents":
+        path = "/api/v1/agents"
+        response = await runtime.client.get(path, headers=headers)
+        runtime.record_response(
+            action=action,
+            credential_role=role,
+            response=response,
+            invariants=[*invariants, "agent_collection"],
+        )
+        _validate_response(method="GET", path=path, response=response)
+        assert response.status_code == 200
+        live_ids = [
+            runtime.resolve_id(symbol)
+            for symbol, model in reversed(state.items())
+            if model["kind"] == "agent" and model["alive"]
+        ]
+        assert [item["id"] for item in response.json()["items"]] == live_ids
+        return
+
+    if action.name == "create_version":
+        assert target is not None
+        agent_symbol = str(arguments["agent"])
+        agent = state[agent_symbol]
+        agent_id = runtime.resolve_id(agent_symbol)
+        path = "/api/v1/agents/{agent_id}/versions"
+        concrete_path = f"/api/v1/agents/{agent_id}/versions"
+        path_parameters = {"agent_id": agent_id}
+        body = {
+            "display_version": arguments["display_version"],
+            "description": arguments["description"],
+        }
+        response = await runtime.client.post(concrete_path, json=body, headers=headers)
+        binding_error = _bind_created_id(runtime, target, response)
+        runtime.record_response(
+            action=action,
+            credential_role=role,
+            response=response,
+            invariants=[*invariants, "version_parent"],
+        )
+        if binding_error is not None:
+            raise binding_error
+        _validate_response(
+            method="POST",
+            path=path,
+            response=response,
+            path_parameters=path_parameters,
+            body=body,
+        )
+        expected_status = 201 if agent["alive"] else 404
+        assert response.status_code == expected_status
+        if response.status_code == 201:
+            payload = response.json()
+            assert payload["agent_id"] == agent_id
+            assert payload["version"] == agent["next_version"]
+            assert payload["display_version"] == body["display_version"]
+            assert payload["description"] == body["description"]
+            state[target] = {
+                "kind": "version",
+                "alive": True,
+                "agent": agent_symbol,
+                "version": agent["next_version"],
+                "display_version": body["display_version"],
+                "description": body["description"],
+            }
+            agent["versions"].append(target)
+            agent["next_version"] += 1
+            persisted_parent = await runtime.client.get(
+                f"/api/v1/agents/{agent_id}", headers=headers
+            )
+            _validate_response(
+                method="GET",
+                path="/api/v1/agents/{agent_id}",
+                response=persisted_parent,
+                path_parameters={"agent_id": agent_id},
+            )
+            assert persisted_parent.status_code == 200
+            assert persisted_parent.json()["latest_version"] == payload["version"]
+        return
+
+    if action.name in {"get_version", "update_version", "delete_version"}:
+        assert target is not None
+        model = state[target]
+        version_id = runtime.resolve_id(target)
+        path = "/api/v1/agent-versions/{agent_version_id}"
+        concrete_path = f"/api/v1/agent-versions/{version_id}"
+        path_parameters = {"agent_version_id": version_id}
+        method = {
+            "get_version": "GET",
+            "update_version": "PATCH",
+            "delete_version": "DELETE",
+        }[action.name]
+        body = (
+            {"description": arguments["description"]}
+            if action.name == "update_version"
+            else None
+        )
+        response = await runtime.client.request(
+            method, concrete_path, json=body, headers=headers
+        )
+        expected_status = 200 if model["alive"] else 404
+        if action.name == "delete_version":
+            expected_status = 204 if model["alive"] else 404
+        checked_invariants = [*invariants, "version_lifecycle"]
+        if action.name == "delete_version":
+            checked_invariants.append("version_high_water")
+        runtime.record_response(
+            action=action,
+            credential_role=role,
+            response=response,
+            invariants=checked_invariants,
+        )
+        _validate_response(
+            method=method,
+            path=path,
+            response=response,
+            path_parameters=path_parameters,
+            body=body,
+        )
+        assert response.status_code == expected_status
+        if response.status_code == 200:
+            if action.name == "update_version":
+                model["description"] = arguments["description"]
+            payload = response.json()
+            assert payload["id"] == version_id
+            assert payload["agent_id"] == runtime.resolve_id(model["agent"])
+            assert payload["version"] == model["version"]
+            assert payload["description"] == model["description"]
+        if action.name == "delete_version" and response.status_code == 204:
+            model["alive"] = False
+            parent = state[model["agent"]]
+            if parent["alive"]:
+                parent_id = runtime.resolve_id(model["agent"])
+                persisted_parent = await runtime.client.get(
+                    f"/api/v1/agents/{parent_id}", headers=headers
+                )
+                _validate_response(
+                    method="GET",
+                    path="/api/v1/agents/{agent_id}",
+                    response=persisted_parent,
+                    path_parameters={"agent_id": parent_id},
+                )
+                assert persisted_parent.status_code == 200
+                assert (
+                    persisted_parent.json()["latest_version"]
+                    == parent["next_version"] - 1
+                )
+        return
+
+    if action.name == "list_versions":
+        assert target is not None
+        agent = state[target]
+        agent_id = runtime.resolve_id(target)
+        path = "/api/v1/agents/{agent_id}/versions"
+        concrete_path = f"/api/v1/agents/{agent_id}/versions"
+        response = await runtime.client.get(concrete_path, headers=headers)
+        runtime.record_response(
+            action=action,
+            credential_role=role,
+            response=response,
+            invariants=[*invariants, "version_collection"],
+        )
+        _validate_response(
+            method="GET",
+            path=path,
+            response=response,
+            path_parameters={"agent_id": agent_id},
+        )
+        assert response.status_code == 200
+        expected = [
+            runtime.resolve_id(symbol)
+            for symbol in reversed(agent["versions"])
+            if state[symbol]["alive"]
+        ]
+        assert [item["id"] for item in response.json()["items"]] == expected
+        return
+
+    raise AssertionError(f"Unknown sequence action: {action.name}")
+
+
+async def _run_crud_sequence(actions: list[SequenceAction]) -> SequenceReceipt:
+    """Run one complete action list in one isolated database."""
+    receipt = SequenceReceipt()
+    with annotate_sequence_failure(receipt):
+        async with isolate_sequence(receipt) as runtime:
+            await _prepare_runtime(runtime)
+            state: dict[str, dict[str, Any]] = {}
+            for action in actions:
+                await _execute_action(runtime, action, state)
+        receipt.assert_accepted()
+    return receipt
+
+
+def _receipt_shape(receipt: SequenceReceipt) -> list[tuple[Any, ...]]:
+    """Return stable replay evidence, excluding timestamps in response bodies."""
+    return [
+        (
+            step.action,
+            step.credential_role,
+            step.status,
+            step.invariants,
+        )
+        for step in receipt.steps
+    ]
+
+
+def test_fixed_crud_chain_replays_on_fresh_databases() -> None:
+    """Replay create/read/update/list/delete behavior from symbolic actions."""
+    actions = [
+        _action("create_agent", "agent_0", name="receipt-agent", description="one"),
+        _action("get_agent", "agent_0"),
+        _action("update_agent", "agent_0", description="two"),
+        _action("get_agent", "agent_0"),
+        _action(
+            "create_version",
+            "version_0",
+            agent="agent_0",
+            display_version="v1",
+            description="first",
+        ),
+        _action("get_version", "version_0"),
+        _action("update_version", "version_0", description="revised"),
+        _action("get_version", "version_0"),
+        _action("list_versions", "agent_0"),
+        _action("delete_version", "version_0"),
+        _action("get_version", "version_0"),
+        _action("delete_agent", "agent_0"),
+        _action("get_agent", "agent_0"),
+        _action("delete_agent", "agent_0"),
+    ]
+
+    first = asyncio.run(_run_crud_sequence(actions))
+    serialized = first.serialize()
+    recorded = SequenceReceipt.model_validate_json(serialized)
+    second = asyncio.run(_run_crud_sequence([step.action for step in recorded.steps]))
+
+    assert first.successful_operations == second.successful_operations == 11
+    assert _receipt_shape(first) == _receipt_shape(second)
+    assert not UUID_PATTERN.search(serialized)
+
+
+def test_deleted_agent_retains_its_version() -> None:
+    """Keep a version readable after its parent agent is deleted."""
+    actions = [
+        _action("create_agent", "agent_0", name="retained-agent", description=None),
+        _action(
+            "create_version",
+            "version_0",
+            agent="agent_0",
+            display_version=None,
+            description="retained",
+        ),
+        _action("delete_agent", "agent_0"),
+        _action("get_version", "version_0"),
+        _action(
+            "create_version",
+            "version_1",
+            agent="agent_0",
+            display_version=None,
+            description=None,
+        ),
+        _action("delete_version", "version_0"),
+        _action("get_version", "version_0"),
+    ]
+
+    receipt = asyncio.run(_run_crud_sequence(actions))
+
+    assert [step.status for step in receipt.steps] == [
+        201,
+        201,
+        204,
+        200,
+        404,
+        204,
+        404,
+    ]
+
+
+def test_versions_stay_isolated_to_their_parent_collection() -> None:
+    """List each created version only through its correct parent agent."""
+    actions = [
+        _action("create_agent", "agent_0", name="first-agent", description=None),
+        _action("create_agent", "agent_1", name="second-agent", description=None),
+        _action("list_agents"),
+        _action(
+            "create_version",
+            "version_0",
+            agent="agent_0",
+            display_version="v1",
+            description=None,
+        ),
+        _action("list_versions", "agent_0"),
+        _action("list_versions", "agent_1"),
+    ]
+
+    receipt = asyncio.run(_run_crud_sequence(actions))
+
+    assert receipt.successful_operations == len(actions)
+
+
+async def test_schema_failure_carries_the_failing_response_receipt() -> None:
+    """Record a malformed create response before schema validation raises."""
+
+    async def return_malformed_response(request: httpx.Request) -> httpx.Response:
+        _ = request
+        response = httpx.Response(
+            201,
+            json={"id": "not-a-uuid", "name": "incomplete"},
+        )
+        response.elapsed = timedelta()
+        return response
+
+    receipt = SequenceReceipt()
+    transport = httpx.MockTransport(return_malformed_response)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://test",
+    ) as client:
+        runtime = SequenceRuntime(client, receipt)
+        runtime.set_credential(CredentialRole.ACCOUNT, "test-token")
+        with (
+            pytest.raises(BaseExceptionGroup) as raised,
+            annotate_sequence_failure(receipt),
+        ):
+            await _execute_action(
+                runtime,
+                _action(
+                    "create_agent",
+                    "agent_0",
+                    name="schema-agent",
+                    description=None,
+                ),
+                {},
+            )
+
+    assert receipt.steps[0].status == 201
+    notes = "\n".join(raised.value.__notes__)
+    assert "Sequence receipt:\n{" in notes
+    assert "not-a-uuid" in notes
+
+
+async def test_duplicate_created_id_is_recorded_without_leaking_uuid() -> None:
+    """Retain the conflicting response before reporting a sanitized id collision."""
+    raw_id = "018f7777-1234-7abc-8123-123456789abc"
+
+    async def return_duplicate_id(request: httpx.Request) -> httpx.Response:
+        _ = request
+        return httpx.Response(201, json={"id": raw_id})
+
+    receipt = SequenceReceipt()
+    transport = httpx.MockTransport(return_duplicate_id)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://test",
+    ) as client:
+        runtime = SequenceRuntime(client, receipt)
+        runtime.set_credential(CredentialRole.ACCOUNT, "test-token")
+        runtime.bind_id("agent_0", raw_id)
+        with pytest.raises(
+            AssertionError,
+            match="Live id is already bound to another symbol",
+        ) as raised:
+            await _execute_action(
+                runtime,
+                _action(
+                    "create_agent",
+                    "agent_1",
+                    name="duplicate",
+                    description=None,
+                ),
+                {},
+            )
+
+    assert raw_id not in str(raised.value)
+    serialized = receipt.serialize()
+    assert len(receipt.steps) == 1
+    assert receipt.steps[0].response == {"id": {"$ref": "agent_0"}}
+    assert raw_id not in serialized
+
+
+@given(actions=_successful_crud_sequences())
+@SEQUENCE_SETTINGS
+def test_generated_successful_crud_sequences(actions: list[SequenceAction]) -> None:
+    """Preserve agent and version invariants across generated action lists."""
+    receipt = asyncio.run(_run_crud_sequence(actions))
+    assert len(receipt.steps) == len(actions)
+
+
+async def test_consecutive_isolated_sequences_share_no_rows() -> None:
+    """Create a fresh database for each complete sequence context."""
+    for _ in range(2):
+        receipt = SequenceReceipt()
+        async with isolate_sequence(receipt) as runtime:
+            await _prepare_runtime(runtime)
+            response = await runtime.client.get(
+                "/api/v1/agents", headers=runtime.get_headers(CredentialRole.ACCOUNT)
+            )
+            assert response.status_code == 200
+            assert response.json()["items"] == []
+            response = await runtime.client.post(
+                "/api/v1/agents",
+                json={"name": "same-name"},
+                headers=runtime.get_headers(CredentialRole.ACCOUNT),
+            )
+            assert response.status_code == 201
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        pytest.param(AssertionError("controlled failure"), id="assertion"),
+        pytest.param(KeyboardInterrupt(), id="interruption"),
+    ],
+)
+async def test_body_failure_drops_the_sequence_database(
+    failure: BaseException,
+) -> None:
+    """Drop the real disposable database after a body failure or interruption."""
+    receipt = SequenceReceipt()
+    database_name: str | None = None
+    with pytest.raises(type(failure)) as raised:
+        async with isolate_sequence(receipt) as runtime:
+            database_name = runtime.database_name
+            assert database_name is not None
+            assert await _check_database_exists(database_name)
+            raise failure
+
+    assert raised.value is failure
+    assert database_name is not None
+    assert not await _check_database_exists(database_name)

--- a/tests/server/test_fuzz_sequences.py
+++ b/tests/server/test_fuzz_sequences.py
@@ -1,0 +1,155 @@
+#  Copyright (c) ZenML GmbH 2026. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+"""Fast contract tests for generated API sequence receipts and cleanup."""
+
+from contextlib import AbstractAsyncContextManager
+from types import TracebackType
+
+import httpx
+import pytest
+from fuzz_sequences import (
+    CredentialRole,
+    SequenceAction,
+    SequenceCleanupError,
+    SequenceReceipt,
+    SequenceRuntime,
+    annotate_sequence_failure,
+    report_cleanup_failures,
+)
+
+
+def test_receipt_acceptance_rejects_empty_and_read_only_sequences() -> None:
+    """Require at least one successful prerequisite before accepting a run."""
+    empty = SequenceReceipt()
+    with pytest.raises(AssertionError, match="no operations"):
+        empty.assert_accepted()
+
+    read_only = SequenceReceipt()
+    read_only.record_step(
+        action=SequenceAction(name="list_agents"),
+        credential_role=CredentialRole.ACCOUNT,
+        status=200,
+    )
+    with pytest.raises(AssertionError, match="no successful prerequisite"):
+        read_only.assert_accepted()
+
+
+async def test_failure_note_redacts_nested_ids_and_credentials() -> None:
+    """Attach replay evidence without leaking embedded ids or credentials."""
+    raw_id = "018f7777-1234-7abc-8123-123456789abc"
+    other_id = "018f8888-5678-7def-9234-abcdef123456"
+    raw_token = "live-worker-token"
+    receipt = SequenceReceipt()
+    async with httpx.AsyncClient() as client:
+        runtime = SequenceRuntime(client, receipt)
+        runtime.bind_id("agent_0", raw_id)
+        runtime.set_credential(CredentialRole.WORKER, raw_token)
+        runtime.record_response(
+            action=SequenceAction(
+                name="create_agent",
+                target="agent_0",
+                arguments={
+                    "resource": f"/agents/{raw_id}",
+                    "authorization": f"prefix Bearer {raw_token} suffix",
+                },
+            ),
+            credential_role=CredentialRole.WORKER,
+            response=httpx.Response(
+                404,
+                json={
+                    "detail": f"Agent {raw_id} was not found; related {other_id}",
+                    "diagnostic": f"authentication failed for Bearer {raw_token}",
+                },
+            ),
+            invariants=["forced_failure"],
+        )
+
+    with (
+        pytest.raises(RuntimeError, match="forced") as raised,
+        annotate_sequence_failure(receipt),
+    ):
+        raise RuntimeError("forced")
+
+    notes = "\n".join(raised.value.__notes__)
+    assert "Sequence receipt:\n{" in notes
+    assert '"credential_role": "worker"' in notes
+    assert "<$ref:agent_0>" in notes
+    assert "<unbound-uuid>" in notes
+    assert "<$credential:worker>" in notes
+    assert raw_id not in notes
+    assert other_id not in notes
+    assert raw_token not in notes
+
+
+def test_failure_note_does_not_intercept_interrupt() -> None:
+    """Propagate an interruption without turning it into a receipt failure."""
+    receipt = SequenceReceipt()
+    interruption = KeyboardInterrupt()
+    with pytest.raises(KeyboardInterrupt) as raised, annotate_sequence_failure(receipt):
+        raise interruption
+    assert raised.value is interruption
+    assert not getattr(raised.value, "__notes__", [])
+
+
+class _ControlledManager(AbstractAsyncContextManager[httpx.AsyncClient]):
+    """Expose entry and exit behavior for cleanup reporting tests."""
+
+    def __init__(self, cleanup_error: BaseException | None = None) -> None:
+        self.client = httpx.AsyncClient()
+        self.cleanup_error = cleanup_error
+        self.exited = False
+
+    async def __aenter__(self) -> httpx.AsyncClient:
+        return self.client
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        _ = exc_type, exc_value, traceback
+        self.exited = True
+        await self.client.aclose()
+        if self.cleanup_error is not None:
+            raise self.cleanup_error
+        return None
+
+
+async def test_assertion_and_interruption_enter_cleanup() -> None:
+    """Exit the sequence context for assertion failures and interruptions."""
+    for failure in (AssertionError("broken invariant"), KeyboardInterrupt()):
+        manager = _ControlledManager()
+        with pytest.raises(type(failure)):
+            async with report_cleanup_failures(manager):
+                raise failure
+        assert manager.exited
+
+
+async def test_cleanup_failure_preserves_the_sequence_failure() -> None:
+    """Distinguish teardown failure with or without an earlier body failure."""
+    for sequence_error in (None, AssertionError("broken invariant")):
+        cleanup_error = RuntimeError("database drop failed")
+        manager = _ControlledManager(cleanup_error)
+
+        with pytest.raises(
+            SequenceCleanupError, match="database drop failed"
+        ) as raised:
+            async with report_cleanup_failures(manager):
+                if sequence_error is not None:
+                    raise sequence_error
+
+        assert raised.value.sequence_error is sequence_error
+        assert raised.value.cleanup_error is cleanup_error
+        assert manager.exited


### PR DESCRIPTION
## What changed?

Agent and agent-version fuzzing can now exercise dependent CRUD chains inside a fresh PostgreSQL database and authenticated application lifespan for every generated sequence. The harness validates each observed response against the committed OpenAPI schema, checks persisted lifecycle state after every action, and emits a sanitized symbolic receipt that can be replayed without retaining live IDs or credentials.

This is U5 of the nightly fuzzing expansion in #907. It establishes the isolation and receipt contract that the task-attempt lifecycle work in U6 will build on; scheduling remains deferred to U7 after the local suites have accepted receipts.

## Why?

The existing broad API fuzzer sends independent requests through one shared database. It cannot prove create/read/update/delete dependencies, parent-child version rules, clean-state replay, or teardown after a shrunk sequence fails.

The installed Schemathesis version does not expose explicit stateful links for these operations. Following the plan's fallback, this uses bounded Hypothesis action lists to preserve prerequisites while Schemathesis validates the real responses.

## Release context

Test infrastructure only. No runtime, API, schema, packaging, or release follow-up is required.

## Reviewer Notes

Start with the generated action strategy and `_execute_action`: together they define the independent state model for agent/version creation, updates, deletion, collection ordering, parent association, and the `latest_version` high-water mark. Then inspect `fuzz_sequences.py` for the fresh-database lifespan and receipt boundary. The important failure behavior is that malformed responses, duplicate created IDs, and application-handler exceptions are recorded and sanitized before the assertion or exception escapes, while assertion failures and interruptions still drop the disposable database.

## Reproduction

With PostgreSQL running via `docker compose up -d db`, run:

```bash
just fuzz-api-sequences 25 15
```

The command must collect ten tests, execute 25 generated sequences with up to 15 actions each, and finish without skipped required tests. `just fuzz-api-sequences 5 5` provides a faster smoke run. An unavailable PostgreSQL instance is an explicit failure rather than a green skip.

## Local checks run

- `just check`
- `just test`: 5,192 passed, 345 skipped, 16 expected xfails
- `just fuzz-api-sequences 25 15`: 10 passed; 25 generated sequences
- Three independent randomized 25-case runs: passed
- Existing agent/version PostgreSQL API tests: 19 passed
- Receipt and cleanup contract tests: 5 passed

## New concepts

**Symbolic sequence receipts:** failure evidence records stable resource names such as `agent_0` and credential roles such as `account`. A clean replay binds those symbols to new database IDs and tokens, so shrinking and reproduction do not depend on stale state or expose live credentials.
